### PR TITLE
Replace `Unsafe.As` with `Unsafe.Read{Write}Unaligned`

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -600,7 +600,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else
                 {
-                    Unsafe.As<byte, bool>(ref destPtr) = true;
+                    Unsafe.WriteUnaligned(ref destPtr, true);
                     ref byte dst = ref Unsafe.Add(ref destPtr, typeMT->NullableValueAddrOffset);
                     uint valueSize = typeMT->NullableValueSize;
                     ref byte src = ref RuntimeHelpers.GetRawData(obj);
@@ -620,7 +620,7 @@ namespace System.Runtime.CompilerServices
             ref byte nullableData = ref src.GetRawData();
 
             // If 'hasValue' is false, return null.
-            if (!Unsafe.As<byte, bool>(ref nullableData))
+            if (!Unsafe.ReadUnaligned<bool>(ref nullableData))
                 return null;
 
             // Allocate a new instance of the T in Nullable<T>.

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.BoxCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.BoxCache.cs
@@ -69,7 +69,7 @@ namespace System
                 {
                     // If the allocator is null, then we shouldn't allocate and make a copy,
                     // we should return the data as the object it currently is.
-                    return Unsafe.As<byte, object>(ref data);
+                    return Unsafe.ReadUnaligned<object>(ref data);
                 }
 
                 ref byte source = ref data;

--- a/src/coreclr/System.Private.CoreLib/src/System/TypedReference.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/TypedReference.CoreCLR.cs
@@ -66,7 +66,7 @@ namespace System
             }
             else
             {
-                result = Unsafe.As<byte, object>(ref value._value);
+                result = Unsafe.ReadUnaligned<object>(ref value._value);
             }
 
             return result;

--- a/src/coreclr/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ValueType.cs
@@ -123,15 +123,15 @@ namespace System
                 switch (GetHashCodeStrategy(pMT, ObjectHandleOnStack.Create(ref thisRef), out uint fieldOffset, out uint fieldSize, out MethodTable* fieldMT))
                 {
                     case ValueTypeHashCodeStrategy.ReferenceField:
-                        hashCode.Add(Unsafe.As<byte, object>(ref Unsafe.AddByteOffset(ref rawData, fieldOffset)).GetHashCode());
+                        hashCode.Add(Unsafe.ReadUnaligned<object>(ref Unsafe.AddByteOffset(ref rawData, fieldOffset)).GetHashCode());
                         break;
 
                     case ValueTypeHashCodeStrategy.DoubleField:
-                        hashCode.Add(Unsafe.As<byte, double>(ref Unsafe.AddByteOffset(ref rawData, fieldOffset)).GetHashCode());
+                        hashCode.Add(Unsafe.ReadUnaligned<double>(ref Unsafe.AddByteOffset(ref rawData, fieldOffset)).GetHashCode());
                         break;
 
                     case ValueTypeHashCodeStrategy.SingleField:
-                        hashCode.Add(Unsafe.As<byte, float>(ref Unsafe.AddByteOffset(ref rawData, fieldOffset)).GetHashCode());
+                        hashCode.Add(Unsafe.ReadUnaligned<float>(ref Unsafe.AddByteOffset(ref rawData, fieldOffset)).GetHashCode());
                         break;
 
                     case ValueTypeHashCodeStrategy.FastGetHashCode:

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -246,7 +246,7 @@ namespace Internal.Runtime.Augments
             if (fieldType.ToMethodTable()->IsFunctionPointer)
                 return RuntimeExports.RhBox(MethodTable.Of<IntPtr>(), ref address);
 
-            return ReflectionPointer.Box((void*)Unsafe.As<byte, IntPtr>(ref address), Type.GetTypeFromHandle(fieldType));
+            return ReflectionPointer.Box((void*)Unsafe.ReadUnaligned<IntPtr>(ref address), Type.GetTypeFromHandle(fieldType));
         }
 
         public static unsafe void StoreReferenceTypeField(IntPtr address, object fieldValue)
@@ -268,7 +268,7 @@ namespace Internal.Runtime.Augments
         public static object LoadReferenceTypeField(object obj, int fieldOffset)
         {
             ref byte address = ref Unsafe.AddByteOffset(ref obj.GetRawData(), new IntPtr(fieldOffset - ObjectHeaderSize));
-            return Unsafe.As<byte, object>(ref address);
+            return Unsafe.ReadUnaligned<object>(ref address);
         }
 
         [CLSCompliant(false)]
@@ -293,7 +293,7 @@ namespace Internal.Runtime.Augments
         {
             Debug.Assert(TypedReference.TargetTypeToken(typedReference).ToMethodTable()->IsValueType);
 
-            Unsafe.As<byte, object>(ref Unsafe.Add<byte>(ref typedReference.Value, fieldOffset)) = fieldValue;
+            Unsafe.WriteUnaligned(ref Unsafe.Add<byte>(ref typedReference.Value, fieldOffset), fieldValue);
         }
 
         [CLSCompliant(false)]
@@ -301,7 +301,7 @@ namespace Internal.Runtime.Augments
         {
             Debug.Assert(TypedReference.TargetTypeToken(typedReference).ToMethodTable()->IsValueType);
 
-            return Unsafe.As<byte, object>(ref Unsafe.Add<byte>(ref typedReference.Value, fieldOffset));
+            return Unsafe.ReadUnaligned<object>(ref Unsafe.Add<byte>(ref typedReference.Value, fieldOffset));
         }
 
         [CLSCompliant(false)]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
@@ -773,7 +773,7 @@ namespace System
             else
             {
                 Debug.Assert(!pElementEEType->IsPointer && !pElementEEType->IsFunctionPointer);
-                return Unsafe.As<byte, object>(ref element);
+                return Unsafe.ReadUnaligned<object>(ref element);
             }
         }
 
@@ -809,7 +809,7 @@ namespace System
                 {
                     throw new InvalidCastException(SR.InvalidCast_StoreArrayElement);
                 }
-                Unsafe.As<byte, object?>(ref element) = value;
+                Unsafe.WriteUnaligned(ref element, value);
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Enum.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Enum.NativeAot.cs
@@ -101,39 +101,39 @@ namespace System
             switch (elementType)
             {
                 case EETypeElementType.Char:
-                    result = (ulong)(long)Unsafe.As<byte, char>(ref pValue);
+                    result = (ulong)(long)Unsafe.ReadUnaligned<char>(ref pValue);
                     return true;
 
                 case EETypeElementType.SByte:
-                    result = (ulong)(long)Unsafe.As<byte, sbyte>(ref pValue);
+                    result = (ulong)(long)Unsafe.ReadUnaligned<sbyte>(ref pValue);
                     return true;
 
                 case EETypeElementType.Byte:
-                    result = (ulong)(long)Unsafe.As<byte, byte>(ref pValue);
+                    result = (ulong)(long)Unsafe.ReadUnaligned<byte>(ref pValue);
                     return true;
 
                 case EETypeElementType.Int16:
-                    result = (ulong)(long)Unsafe.As<byte, short>(ref pValue);
+                    result = (ulong)(long)Unsafe.ReadUnaligned<short>(ref pValue);
                     return true;
 
                 case EETypeElementType.UInt16:
-                    result = (ulong)(long)Unsafe.As<byte, ushort>(ref pValue);
+                    result = (ulong)(long)Unsafe.ReadUnaligned<ushort>(ref pValue);
                     return true;
 
                 case EETypeElementType.Int32:
-                    result = (ulong)(long)Unsafe.As<byte, int>(ref pValue);
+                    result = (ulong)(long)Unsafe.ReadUnaligned<int>(ref pValue);
                     return true;
 
                 case EETypeElementType.UInt32:
-                    result = (ulong)(long)Unsafe.As<byte, uint>(ref pValue);
+                    result = (ulong)(long)Unsafe.ReadUnaligned<uint>(ref pValue);
                     return true;
 
                 case EETypeElementType.Int64:
-                    result = (ulong)(long)Unsafe.As<byte, long>(ref pValue);
+                    result = (ulong)(long)Unsafe.ReadUnaligned<long>(ref pValue);
                     return true;
 
                 case EETypeElementType.UInt64:
-                    result = (ulong)(long)Unsafe.As<byte, ulong>(ref pValue);
+                    result = (ulong)(long)Unsafe.ReadUnaligned<ulong>(ref pValue);
                     return true;
 
                 default:

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -161,23 +161,23 @@ namespace System
                     switch (dstType)
                     {
                         case EETypeElementType.Single:
-                            Unsafe.As<byte, float>(ref dstValue) = srcValue;
+                            Unsafe.WriteUnaligned(ref dstValue, (float)srcValue);
                             break;
                         case EETypeElementType.Double:
-                            Unsafe.As<byte, double>(ref dstValue) = srcValue;
+                            Unsafe.WriteUnaligned(ref dstValue, (double)srcValue);
                             break;
                         case EETypeElementType.Char:
                         case EETypeElementType.Int16:
                         case EETypeElementType.UInt16:
-                            Unsafe.As<byte, short>(ref dstValue) = srcValue;
+                            Unsafe.WriteUnaligned(ref dstValue, (short)srcValue);
                             break;
                         case EETypeElementType.Int32:
                         case EETypeElementType.UInt32:
-                            Unsafe.As<byte, int>(ref dstValue) = srcValue;
+                            Unsafe.WriteUnaligned(ref dstValue, (int)srcValue);
                             break;
                         case EETypeElementType.Int64:
                         case EETypeElementType.UInt64:
-                            Unsafe.As<byte, long>(ref dstValue) = srcValue;
+                            Unsafe.WriteUnaligned(ref dstValue, (long)srcValue);
                             break;
                         default:
                             Debug.Fail("Expected to be unreachable");
@@ -189,19 +189,19 @@ namespace System
                     switch (dstType)
                     {
                         case EETypeElementType.Int16:
-                            Unsafe.As<byte, short>(ref dstValue) = Unsafe.As<byte, sbyte>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (short)(sbyte)srcValue);
                             break;
                         case EETypeElementType.Int32:
-                            Unsafe.As<byte, int>(ref dstValue) = Unsafe.As<byte, sbyte>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (int)(sbyte)srcValue);
                             break;
                         case EETypeElementType.Int64:
-                            Unsafe.As<byte, long>(ref dstValue) = Unsafe.As<byte, sbyte>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (long)(sbyte)srcValue);
                             break;
                         case EETypeElementType.Single:
-                            Unsafe.As<byte, float>(ref dstValue) = Unsafe.As<byte, sbyte>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (float)(sbyte)srcValue);
                             break;
                         case EETypeElementType.Double:
-                            Unsafe.As<byte, double>(ref dstValue) = Unsafe.As<byte, sbyte>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (double)(sbyte)srcValue);
                             break;
                         default:
                             Debug.Fail("Expected to be unreachable");
@@ -214,22 +214,22 @@ namespace System
                     switch (dstType)
                     {
                         case EETypeElementType.Single:
-                            Unsafe.As<byte, float>(ref dstValue) = Unsafe.As<byte, ushort>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (float)Unsafe.ReadUnaligned<ushort>(ref srcValue));
                             break;
                         case EETypeElementType.Double:
-                            Unsafe.As<byte, double>(ref dstValue) = Unsafe.As<byte, ushort>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (double)Unsafe.ReadUnaligned<ushort>(ref srcValue));
                             break;
                         case EETypeElementType.UInt16:
                         case EETypeElementType.Char:
-                            Unsafe.As<byte, ushort>(ref dstValue) = Unsafe.As<byte, ushort>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (char)Unsafe.ReadUnaligned<ushort>(ref srcValue));
                             break;
                         case EETypeElementType.Int32:
                         case EETypeElementType.UInt32:
-                            Unsafe.As<byte, uint>(ref dstValue) = Unsafe.As<byte, ushort>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (uint)Unsafe.ReadUnaligned<ushort>(ref srcValue));
                             break;
                         case EETypeElementType.Int64:
                         case EETypeElementType.UInt64:
-                            Unsafe.As<byte, ulong>(ref dstValue) = Unsafe.As<byte, ushort>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (ulong)Unsafe.ReadUnaligned<ushort>(ref srcValue));
                             break;
                         default:
                             Debug.Fail("Expected to be unreachable");
@@ -241,16 +241,16 @@ namespace System
                     switch (dstType)
                     {
                         case EETypeElementType.Int32:
-                            Unsafe.As<byte, int>(ref dstValue) = Unsafe.As<byte, short>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (int)Unsafe.ReadUnaligned<short>(ref srcValue));
                             break;
                         case EETypeElementType.Int64:
-                            Unsafe.As<byte, long>(ref dstValue) = Unsafe.As<byte, short>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (long)Unsafe.ReadUnaligned<short>(ref srcValue));
                             break;
                         case EETypeElementType.Single:
-                            Unsafe.As<byte, float>(ref dstValue) = Unsafe.As<byte, short>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (float)Unsafe.ReadUnaligned<short>(ref srcValue));
                             break;
                         case EETypeElementType.Double:
-                            Unsafe.As<byte, double>(ref dstValue) = Unsafe.As<byte, short>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (double)Unsafe.ReadUnaligned<short>(ref srcValue));
                             break;
                         default:
                             Debug.Fail("Expected to be unreachable");
@@ -262,13 +262,13 @@ namespace System
                     switch (dstType)
                     {
                         case EETypeElementType.Int64:
-                            Unsafe.As<byte, long>(ref dstValue) = Unsafe.As<byte, int>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (long)Unsafe.ReadUnaligned<int>(ref srcValue));
                             break;
                         case EETypeElementType.Single:
-                            Unsafe.As<byte, float>(ref dstValue) = (float)Unsafe.As<byte, int>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (float)Unsafe.ReadUnaligned<int>(ref srcValue));
                             break;
                         case EETypeElementType.Double:
-                            Unsafe.As<byte, double>(ref dstValue) = Unsafe.As<byte, int>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (double)Unsafe.ReadUnaligned<int>(ref srcValue));
                             break;
                         default:
                             Debug.Fail("Expected to be unreachable");
@@ -281,13 +281,13 @@ namespace System
                     {
                         case EETypeElementType.Int64:
                         case EETypeElementType.UInt64:
-                            Unsafe.As<byte, long>(ref dstValue) = Unsafe.As<byte, uint>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (ulong)Unsafe.ReadUnaligned<uint>(ref srcValue));
                             break;
                         case EETypeElementType.Single:
-                            Unsafe.As<byte, float>(ref dstValue) = (float)Unsafe.As<byte, uint>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (float)Unsafe.ReadUnaligned<uint>(ref srcValue));
                             break;
                         case EETypeElementType.Double:
-                            Unsafe.As<byte, double>(ref dstValue) = Unsafe.As<byte, uint>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (double)Unsafe.ReadUnaligned<uint>(ref srcValue));
                             break;
                         default:
                             Debug.Fail("Expected to be unreachable");
@@ -299,10 +299,10 @@ namespace System
                     switch (dstType)
                     {
                         case EETypeElementType.Single:
-                            Unsafe.As<byte, float>(ref dstValue) = (float)Unsafe.As<byte, long>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (float)Unsafe.ReadUnaligned<long>(ref srcValue));
                             break;
                         case EETypeElementType.Double:
-                            Unsafe.As<byte, double>(ref dstValue) = (double)Unsafe.As<byte, long>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (double)Unsafe.ReadUnaligned<long>(ref srcValue));
                             break;
                         default:
                             Debug.Fail("Expected to be unreachable");
@@ -314,10 +314,10 @@ namespace System
                     switch (dstType)
                     {
                         case EETypeElementType.Single:
-                            Unsafe.As<byte, float>(ref dstValue) = (float)Unsafe.As<byte, ulong>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (float)Unsafe.ReadUnaligned<ulong>(ref srcValue));
                             break;
                         case EETypeElementType.Double:
-                            Unsafe.As<byte, double>(ref dstValue) = (double)Unsafe.As<byte, ulong>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (double)Unsafe.ReadUnaligned<ulong>(ref srcValue));
                             break;
                         default:
                             Debug.Fail("Expected to be unreachable");
@@ -329,7 +329,7 @@ namespace System
                     switch (dstType)
                     {
                         case EETypeElementType.Double:
-                            Unsafe.As<byte, double>(ref dstValue) = Unsafe.As<byte, float>(ref srcValue);
+                            Unsafe.WriteUnaligned(ref dstValue, (double)Unsafe.ReadUnaligned<float>(ref srcValue));
                             break;
                         default:
                             Debug.Fail("Expected to be unreachable");

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
@@ -779,7 +779,7 @@ namespace System.Reflection
                     {
                         Type type = Type.GetTypeFromMethodTable(argumentInfo.Type);
                         Debug.Assert(type.IsPointer);
-                        obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref obj.GetRawData()), type);
+                        obj = Pointer.Box((void*)Unsafe.ReadUnaligned<IntPtr>(ref obj.GetRawData()), type);
                     }
                     else
                     {
@@ -814,7 +814,7 @@ namespace System.Reflection
                     {
                         Type type = Type.GetTypeFromMethodTable(argumentInfo.Type);
                         Debug.Assert(type.IsPointer);
-                        obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref obj.GetRawData()), type);
+                        obj = Pointer.Box((void*)Unsafe.ReadUnaligned<IntPtr>(ref obj.GetRawData()), type);
                     }
                     else
                     {
@@ -844,7 +844,7 @@ namespace System.Reflection
             {
                 Type type = Type.GetTypeFromMethodTable(_returnType);
                 Debug.Assert(type.IsPointer);
-                obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref byref), type);
+                obj = Pointer.Box((void*)Unsafe.ReadUnaligned<IntPtr>(ref byref), type);
             }
             else if ((_returnTransform & Transform.FunctionPointer) != 0)
             {
@@ -854,7 +854,7 @@ namespace System.Reflection
             else if ((_returnTransform & Transform.Reference) != 0)
             {
                 Debug.Assert((_returnTransform & Transform.ByRef) != 0);
-                obj = Unsafe.As<byte, object>(ref byref);
+                obj = Unsafe.ReadUnaligned<object>(ref byref);
             }
             else
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -374,7 +374,7 @@ namespace System.Runtime.CompilerServices
 
             if (!mt->IsValueType)
             {
-                return Unsafe.As<byte, object>(ref target);
+                return Unsafe.ReadUnaligned<object>(ref target);
             }
 
             if (mt->IsByRefLike)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
@@ -127,11 +127,11 @@ namespace System
 
                 if (fieldType->ElementType == EETypeElementType.Single)
                 {
-                    hashCode.Add(Unsafe.As<byte, float>(ref fieldData));
+                    hashCode.Add(Unsafe.ReadUnaligned<float>(ref fieldData));
                 }
                 else if (fieldType->ElementType == EETypeElementType.Double)
                 {
-                    hashCode.Add(Unsafe.As<byte, double>(ref fieldData));
+                    hashCode.Add(Unsafe.ReadUnaligned<double>(ref fieldData));
                 }
                 else if (fieldType->IsPrimitive)
                 {
@@ -159,7 +159,7 @@ namespace System
                 }
                 else
                 {
-                    object fieldValue = Unsafe.As<byte, object>(ref fieldData);
+                    object fieldValue = Unsafe.ReadUnaligned<object>(ref fieldData);
                     if (fieldValue != null)
                     {
                         hashCode.Add(fieldValue);

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -949,7 +949,7 @@ namespace System
                         return (result >= 0) ? (index + result) : ~(index + ~result);
 
                         static int GenericBinarySearch<T>(Array array, int adjustedIndex, int length, object value) where T : struct, IComparable<T>
-                            => UnsafeArrayAsSpan<T>(array, adjustedIndex, length).BinarySearch(Unsafe.As<byte, T>(ref value.GetRawData()));
+                            => UnsafeArrayAsSpan<T>(array, adjustedIndex, length).BinarySearch(Unsafe.ReadUnaligned<T>(ref value.GetRawData()));
                     }
                 }
             }
@@ -1445,7 +1445,7 @@ namespace System
                     return (result >= 0 ? startIndex : lb) + result;
 
                     static int GenericIndexOf<T>(Array array, object value, int adjustedIndex, int length) where T : struct, IEquatable<T>
-                        => UnsafeArrayAsSpan<T>(array, adjustedIndex, length).IndexOf(Unsafe.As<byte, T>(ref value.GetRawData()));
+                        => UnsafeArrayAsSpan<T>(array, adjustedIndex, length).IndexOf(Unsafe.ReadUnaligned<T>(ref value.GetRawData()));
                 }
             }
 
@@ -1521,7 +1521,7 @@ namespace System
                 {
                     int result = SpanHelpers.IndexOfValueType(
                         ref Unsafe.Add(ref Unsafe.As<T, short>(ref MemoryMarshal.GetArrayDataReference(array)), startIndex),
-                        Unsafe.As<T, short>(ref value),
+                        Unsafe.ReadUnaligned<short>(ref Unsafe.As<T, byte>(ref value)),
                         count);
                     return (result >= 0 ? startIndex : 0) + result;
                 }
@@ -1529,7 +1529,7 @@ namespace System
                 {
                     int result = SpanHelpers.IndexOfValueType(
                         ref Unsafe.Add(ref Unsafe.As<T, int>(ref MemoryMarshal.GetArrayDataReference(array)), startIndex),
-                        Unsafe.As<T, int>(ref value),
+                        Unsafe.ReadUnaligned<int>(ref Unsafe.As<T, byte>(ref value)),
                         count);
                     return (result >= 0 ? startIndex : 0) + result;
                 }
@@ -1537,7 +1537,7 @@ namespace System
                 {
                     int result = SpanHelpers.IndexOfValueType(
                         ref Unsafe.Add(ref Unsafe.As<T, long>(ref MemoryMarshal.GetArrayDataReference(array)), startIndex),
-                        Unsafe.As<T, long>(ref value),
+                        Unsafe.ReadUnaligned<long>(ref Unsafe.As<T, byte>(ref value)),
                         count);
                     return (result >= 0 ? startIndex : 0) + result;
                 }
@@ -1672,7 +1672,7 @@ namespace System
                     return (result >= 0 ? endIndex : lb) + result;
 
                     static int GenericLastIndexOf<T>(Array array, object value, int adjustedIndex, int length) where T : struct, IEquatable<T>
-                        => UnsafeArrayAsSpan<T>(array, adjustedIndex, length).LastIndexOf(Unsafe.As<byte, T>(ref value.GetRawData()));
+                        => UnsafeArrayAsSpan<T>(array, adjustedIndex, length).LastIndexOf(Unsafe.ReadUnaligned<T>(ref value.GetRawData()));
                 }
             }
 
@@ -1768,7 +1768,7 @@ namespace System
                     int endIndex = startIndex - count + 1;
                     int result = SpanHelpers.LastIndexOfValueType(
                         ref Unsafe.Add(ref Unsafe.As<T, short>(ref MemoryMarshal.GetArrayDataReference(array)), endIndex),
-                        Unsafe.As<T, short>(ref value),
+                        Unsafe.ReadUnaligned<short>(ref Unsafe.As<T, byte>(ref value)),
                         count);
 
                     return (result >= 0 ? endIndex : 0) + result;
@@ -1778,7 +1778,7 @@ namespace System
                     int endIndex = startIndex - count + 1;
                     int result = SpanHelpers.LastIndexOfValueType(
                         ref Unsafe.Add(ref Unsafe.As<T, int>(ref MemoryMarshal.GetArrayDataReference(array)), endIndex),
-                        Unsafe.As<T, int>(ref value),
+                        Unsafe.ReadUnaligned<int>(ref Unsafe.As<T, byte>(ref value)),
                         count);
 
                     return (result >= 0 ? endIndex : 0) + result;
@@ -1788,7 +1788,7 @@ namespace System
                     int endIndex = startIndex - count + 1;
                     int result = SpanHelpers.LastIndexOfValueType(
                         ref Unsafe.Add(ref Unsafe.As<T, long>(ref MemoryMarshal.GetArrayDataReference(array)), endIndex),
-                        Unsafe.As<T, long>(ref value),
+                        Unsafe.ReadUnaligned<long>(ref Unsafe.As<T, byte>(ref value)),
                         count);
 
                     return (result >= 0 ? endIndex : 0) + result;

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -418,22 +418,22 @@ namespace System
                 case CorElementType.ELEMENT_TYPE_I2:
                 case CorElementType.ELEMENT_TYPE_U2:
                     {
-                        ushort flagsValue = Unsafe.As<byte, ushort>(ref pFlagsValue);
-                        return (Unsafe.As<byte, ushort>(ref pThisValue) & flagsValue) == flagsValue;
+                        ushort flagsValue = Unsafe.ReadUnaligned<ushort>(ref pFlagsValue);
+                        return (Unsafe.ReadUnaligned<ushort>(ref pThisValue) & flagsValue) == flagsValue;
                     }
 
                 case CorElementType.ELEMENT_TYPE_I4:
                 case CorElementType.ELEMENT_TYPE_U4:
                     {
-                        uint flagsValue = Unsafe.As<byte, uint>(ref pFlagsValue);
-                        return (Unsafe.As<byte, uint>(ref pThisValue) & flagsValue) == flagsValue;
+                        uint flagsValue = Unsafe.ReadUnaligned<uint>(ref pFlagsValue);
+                        return (Unsafe.ReadUnaligned<uint>(ref pThisValue) & flagsValue) == flagsValue;
                     }
 
                 case CorElementType.ELEMENT_TYPE_I8:
                 case CorElementType.ELEMENT_TYPE_U8:
                     {
-                        ulong flagsValue = Unsafe.As<byte, ulong>(ref pFlagsValue);
-                        return (Unsafe.As<byte, ulong>(ref pThisValue) & flagsValue) == flagsValue;
+                        ulong flagsValue = Unsafe.ReadUnaligned<ulong>(ref pFlagsValue);
+                        return (Unsafe.ReadUnaligned<ulong>(ref pThisValue) & flagsValue) == flagsValue;
                     }
 
 #if RARE_ENUMS
@@ -1166,21 +1166,21 @@ namespace System
             ref byte data = ref this.GetRawData();
             return InternalGetCorElementType() switch
             {
-                CorElementType.ELEMENT_TYPE_I1 => Unsafe.As<byte, sbyte>(ref data),
+                CorElementType.ELEMENT_TYPE_I1 => Unsafe.ReadUnaligned<sbyte>(ref data),
                 CorElementType.ELEMENT_TYPE_U1 => data,
-                CorElementType.ELEMENT_TYPE_I2 => Unsafe.As<byte, short>(ref data),
-                CorElementType.ELEMENT_TYPE_U2 => Unsafe.As<byte, ushort>(ref data),
-                CorElementType.ELEMENT_TYPE_I4 => Unsafe.As<byte, int>(ref data),
-                CorElementType.ELEMENT_TYPE_U4 => Unsafe.As<byte, uint>(ref data),
-                CorElementType.ELEMENT_TYPE_I8 => Unsafe.As<byte, long>(ref data),
-                CorElementType.ELEMENT_TYPE_U8 => Unsafe.As<byte, ulong>(ref data),
+                CorElementType.ELEMENT_TYPE_I2 => Unsafe.ReadUnaligned<short>(ref data),
+                CorElementType.ELEMENT_TYPE_U2 => Unsafe.ReadUnaligned<ushort>(ref data),
+                CorElementType.ELEMENT_TYPE_I4 => Unsafe.ReadUnaligned<int>(ref data),
+                CorElementType.ELEMENT_TYPE_U4 => Unsafe.ReadUnaligned<uint>(ref data),
+                CorElementType.ELEMENT_TYPE_I8 => Unsafe.ReadUnaligned<long>(ref data),
+                CorElementType.ELEMENT_TYPE_U8 => Unsafe.ReadUnaligned<ulong>(ref data),
 #if RARE_ENUMS
-                CorElementType.ELEMENT_TYPE_R4 => Unsafe.As<byte, float>(ref data),
-                CorElementType.ELEMENT_TYPE_R8 => Unsafe.As<byte, double>(ref data),
-                CorElementType.ELEMENT_TYPE_I => Unsafe.As<byte, IntPtr>(ref data),
-                CorElementType.ELEMENT_TYPE_U => Unsafe.As<byte, UIntPtr>(ref data),
-                CorElementType.ELEMENT_TYPE_CHAR => Unsafe.As<byte, char>(ref data),
-                CorElementType.ELEMENT_TYPE_BOOLEAN => Unsafe.As<byte, bool>(ref data),
+                CorElementType.ELEMENT_TYPE_R4 => Unsafe.ReadUnaligned<float>(ref data),
+                CorElementType.ELEMENT_TYPE_R8 => Unsafe.ReadUnaligned<double>(ref data),
+                CorElementType.ELEMENT_TYPE_I => Unsafe.ReadUnaligned<IntPtr>(ref data),
+                CorElementType.ELEMENT_TYPE_U => Unsafe.ReadUnaligned<UIntPtr>(ref data),
+                CorElementType.ELEMENT_TYPE_CHAR => Unsafe.ReadUnaligned<char>(ref data),
+                CorElementType.ELEMENT_TYPE_BOOLEAN => Unsafe.ReadUnaligned<bool>(ref data),
 #endif
                 _ => throw CreateUnknownEnumTypeException(),
             };
@@ -1209,15 +1209,15 @@ namespace System
 
                 case CorElementType.ELEMENT_TYPE_I2:
                 case CorElementType.ELEMENT_TYPE_U2:
-                    return Unsafe.As<byte, ushort>(ref pThisValue) == Unsafe.As<byte, ushort>(ref pOtherValue);
+                    return Unsafe.ReadUnaligned<ushort>(ref pThisValue) == Unsafe.ReadUnaligned<ushort>(ref pOtherValue);
 
                 case CorElementType.ELEMENT_TYPE_I4:
                 case CorElementType.ELEMENT_TYPE_U4:
-                    return Unsafe.As<byte, uint>(ref pThisValue) == Unsafe.As<byte, uint>(ref pOtherValue);
+                    return Unsafe.ReadUnaligned<uint>(ref pThisValue) == Unsafe.ReadUnaligned<uint>(ref pOtherValue);
 
                 case CorElementType.ELEMENT_TYPE_I8:
                 case CorElementType.ELEMENT_TYPE_U8:
-                    return Unsafe.As<byte, ulong>(ref pThisValue) == Unsafe.As<byte, ulong>(ref pOtherValue);
+                    return Unsafe.ReadUnaligned<ulong>(ref pThisValue) == Unsafe.ReadUnaligned<ulong>(ref pOtherValue);
 
 #if RARE_ENUMS
                 case CorElementType.ELEMENT_TYPE_BOOLEAN:
@@ -1256,21 +1256,21 @@ namespace System
             ref byte data = ref this.GetRawData();
             return InternalGetCorElementType() switch
             {
-                CorElementType.ELEMENT_TYPE_I1 => Unsafe.As<byte, sbyte>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_I1 => Unsafe.ReadUnaligned<sbyte>(ref data).GetHashCode(),
                 CorElementType.ELEMENT_TYPE_U1 => data.GetHashCode(),
-                CorElementType.ELEMENT_TYPE_I2 => Unsafe.As<byte, short>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_U2 => Unsafe.As<byte, ushort>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_I4 => Unsafe.As<byte, int>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_U4 => Unsafe.As<byte, uint>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_I8 => Unsafe.As<byte, long>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_U8 => Unsafe.As<byte, ulong>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_I2 => Unsafe.ReadUnaligned<short>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_U2 => Unsafe.ReadUnaligned<ushort>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_I4 => Unsafe.ReadUnaligned<int>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_U4 => Unsafe.ReadUnaligned<uint>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_I8 => Unsafe.ReadUnaligned<long>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_U8 => Unsafe.ReadUnaligned<ulong>(ref data).GetHashCode(),
 #if RARE_ENUMS
-                CorElementType.ELEMENT_TYPE_R4 => Unsafe.As<byte, float>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_R8 => Unsafe.As<byte, double>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_I => Unsafe.As<byte, IntPtr>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_U => Unsafe.As<byte, UIntPtr>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_CHAR => Unsafe.As<byte, char>(ref data).GetHashCode(),
-                CorElementType.ELEMENT_TYPE_BOOLEAN => Unsafe.As<byte, bool>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_R4 => Unsafe.ReadUnaligned<float>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_R8 => Unsafe.ReadUnaligned<double>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_I => Unsafe.ReadUnaligned<IntPtr>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_U => Unsafe.ReadUnaligned<UIntPtr>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_CHAR => Unsafe.ReadUnaligned<char>(ref data).GetHashCode(),
+                CorElementType.ELEMENT_TYPE_BOOLEAN => Unsafe.ReadUnaligned<bool>(ref data).GetHashCode(),
 #endif
                 _ => throw CreateUnknownEnumTypeException(),
             };
@@ -1294,35 +1294,35 @@ namespace System
             switch (InternalGetCorElementType())
             {
                 case CorElementType.ELEMENT_TYPE_I1:
-                    return Unsafe.As<byte, sbyte>(ref pThisValue).CompareTo(Unsafe.As<byte, sbyte>(ref pTargetValue));
+                    return Unsafe.ReadUnaligned<sbyte>(ref pThisValue).CompareTo(Unsafe.ReadUnaligned<sbyte>(ref pTargetValue));
 
                 case CorElementType.ELEMENT_TYPE_U1:
                     return pThisValue.CompareTo(pTargetValue);
 
                 case CorElementType.ELEMENT_TYPE_I2:
-                    return Unsafe.As<byte, short>(ref pThisValue).CompareTo(Unsafe.As<byte, short>(ref pTargetValue));
+                    return Unsafe.ReadUnaligned<short>(ref pThisValue).CompareTo(Unsafe.ReadUnaligned<short>(ref pTargetValue));
 
                 case CorElementType.ELEMENT_TYPE_U2:
-                    return Unsafe.As<byte, ushort>(ref pThisValue).CompareTo(Unsafe.As<byte, ushort>(ref pTargetValue));
+                    return Unsafe.ReadUnaligned<ushort>(ref pThisValue).CompareTo(Unsafe.ReadUnaligned<ushort>(ref pTargetValue));
 
                 case CorElementType.ELEMENT_TYPE_I4:
-                    return Unsafe.As<byte, int>(ref pThisValue).CompareTo(Unsafe.As<byte, int>(ref pTargetValue));
+                    return Unsafe.ReadUnaligned<int>(ref pThisValue).CompareTo(Unsafe.ReadUnaligned<int>(ref pTargetValue));
 
                 case CorElementType.ELEMENT_TYPE_U4:
-                    return Unsafe.As<byte, uint>(ref pThisValue).CompareTo(Unsafe.As<byte, uint>(ref pTargetValue));
+                    return Unsafe.ReadUnaligned<uint>(ref pThisValue).CompareTo(Unsafe.ReadUnaligned<uint>(ref pTargetValue));
 
                 case CorElementType.ELEMENT_TYPE_I8:
-                    return Unsafe.As<byte, long>(ref pThisValue).CompareTo(Unsafe.As<byte, long>(ref pTargetValue));
+                    return Unsafe.ReadUnaligned<long>(ref pThisValue).CompareTo(Unsafe.ReadUnaligned<long>(ref pTargetValue));
 
                 case CorElementType.ELEMENT_TYPE_U8:
-                    return Unsafe.As<byte, ulong>(ref pThisValue).CompareTo(Unsafe.As<byte, ulong>(ref pTargetValue));
+                    return Unsafe.ReadUnaligned<ulong>(ref pThisValue).CompareTo(Unsafe.ReadUnaligned<ulong>(ref pTargetValue));
 
 #if RARE_ENUMS
                 case CorElementType.ELEMENT_TYPE_R4:
-                    return Unsafe.As<byte, float>(ref pThisValue).CompareTo(Unsafe.As<byte, float>(ref pTargetValue));
+                    return Unsafe.ReadUnaligned<float>(ref pThisValue).CompareTo(Unsafe.ReadUnaligned<float>(ref pTargetValue));
 
                 case CorElementType.ELEMENT_TYPE_R8:
-                    return Unsafe.As<byte, double>(ref pThisValue).CompareTo(Unsafe.As<byte, double>(ref pTargetValue));
+                    return Unsafe.ReadUnaligned<double>(ref pThisValue).CompareTo(Unsafe.ReadUnaligned<double>(ref pTargetValue));
 
                 case CorElementType.ELEMENT_TYPE_BOOLEAN:
                     goto case CorElementType.ELEMENT_TYPE_U1;
@@ -1466,7 +1466,7 @@ namespace System
         {
             AssertValidGenerics<TUnderlying, TStorage>();
 
-            TStorage value = Unsafe.As<byte, TStorage>(ref rawData);
+            TStorage value = Unsafe.ReadUnaligned<TStorage>(ref rawData);
 
             EnumInfo<TStorage> enumInfo = GetEnumInfo<TStorage>(enumType);
             string? result = enumInfo.HasFlagsAttribute ?
@@ -1496,7 +1496,7 @@ namespace System
         {
             AssertValidGenerics<TUnderlying, TStorage>();
 
-            TStorage value = Unsafe.As<byte, TStorage>(ref rawData);
+            TStorage value = Unsafe.ReadUnaligned<TStorage>(ref rawData);
 
             string? result;
             switch (format | 0x20)
@@ -1563,7 +1563,7 @@ namespace System
                          typeof(TStorage) == typeof(short) ||
                          typeof(TStorage) == typeof(char))
                 {
-                    ushort value = Unsafe.As<byte, ushort>(ref data);
+                    ushort value = Unsafe.ReadUnaligned<ushort>(ref data);
                     HexConverter.ToCharsBuffer((byte)(value >> 8), destination);
                     HexConverter.ToCharsBuffer((byte)value, destination, 2);
                 }
@@ -1574,7 +1574,7 @@ namespace System
 #endif
                          typeof(TStorage) == typeof(int))
                 {
-                    uint value = Unsafe.As<byte, uint>(ref data);
+                    uint value = Unsafe.ReadUnaligned<uint>(ref data);
                     HexConverter.ToCharsBuffer((byte)(value >> 24), destination);
                     HexConverter.ToCharsBuffer((byte)(value >> 16), destination, 2);
                     HexConverter.ToCharsBuffer((byte)(value >> 8), destination, 4);
@@ -1587,7 +1587,7 @@ namespace System
 #endif
                          typeof(TStorage) == typeof(long))
                 {
-                    ulong value = Unsafe.As<byte, ulong>(ref data);
+                    ulong value = Unsafe.ReadUnaligned<ulong>(ref data);
                     HexConverter.ToCharsBuffer((byte)(value >> 56), destination);
                     HexConverter.ToCharsBuffer((byte)(value >> 48), destination, 2);
                     HexConverter.ToCharsBuffer((byte)(value >> 40), destination, 4);
@@ -1694,20 +1694,20 @@ namespace System
             {
                 return corElementType switch
                 {
-                    CorElementType.ELEMENT_TYPE_I1 => TryFormatPrimitiveDefault<sbyte, byte>(enumType, (sbyte)rawData, destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_I1 => TryFormatPrimitiveDefault<sbyte, byte>(enumType, Unsafe.ReadUnaligned<sbyte>(ref rawData), destination, out charsWritten),
                     CorElementType.ELEMENT_TYPE_U1 => TryFormatPrimitiveDefault<byte, byte>(enumType, rawData, destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_I2 => TryFormatPrimitiveDefault<short, ushort>(enumType, Unsafe.As<byte, short>(ref rawData), destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_U2 => TryFormatPrimitiveDefault<ushort, ushort>(enumType, Unsafe.As<byte, ushort>(ref rawData), destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_I4 => TryFormatPrimitiveDefault<int, uint>(enumType, Unsafe.As<byte, int>(ref rawData), destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_U4 => TryFormatPrimitiveDefault<uint, uint>(enumType, Unsafe.As<byte, uint>(ref rawData), destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_I8 => TryFormatPrimitiveDefault<long, ulong>(enumType, Unsafe.As<byte, long>(ref rawData), destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_U8 => TryFormatPrimitiveDefault<ulong, ulong>(enumType, Unsafe.As<byte, ulong>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_I2 => TryFormatPrimitiveDefault<short, ushort>(enumType, Unsafe.ReadUnaligned<short>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_U2 => TryFormatPrimitiveDefault<ushort, ushort>(enumType, Unsafe.ReadUnaligned<ushort>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_I4 => TryFormatPrimitiveDefault<int, uint>(enumType, Unsafe.ReadUnaligned<int>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_U4 => TryFormatPrimitiveDefault<uint, uint>(enumType, Unsafe.ReadUnaligned<uint>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_I8 => TryFormatPrimitiveDefault<long, ulong>(enumType, Unsafe.ReadUnaligned<long>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_U8 => TryFormatPrimitiveDefault<ulong, ulong>(enumType, Unsafe.ReadUnaligned<ulong>(ref rawData), destination, out charsWritten),
 #if RARE_ENUMS
-                    CorElementType.ELEMENT_TYPE_R4 => TryFormatPrimitiveDefault<float, float>(enumType, Unsafe.As<byte, float>(ref rawData), destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_R8 => TryFormatPrimitiveDefault<double, double>(enumType, Unsafe.As<byte, double>(ref rawData), destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_I => TryFormatPrimitiveDefault<nint, nuint>(enumType, Unsafe.As<byte, nint>(ref rawData), destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_U => TryFormatPrimitiveDefault<nuint, nuint>(enumType, Unsafe.As<byte, nuint>(ref rawData), destination, out charsWritten),
-                    CorElementType.ELEMENT_TYPE_CHAR => TryFormatPrimitiveDefault<char, char>(enumType, Unsafe.As<byte, char>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_R4 => TryFormatPrimitiveDefault<float, float>(enumType, Unsafe.ReadUnaligned<float>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_R8 => TryFormatPrimitiveDefault<double, double>(enumType, Unsafe.ReadUnaligned<double>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_I => TryFormatPrimitiveDefault<nint, nuint>(enumType, Unsafe.ReadUnaligned<nint>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_U => TryFormatPrimitiveDefault<nuint, nuint>(enumType, Unsafe.ReadUnaligned<nuint>(ref rawData), destination, out charsWritten),
+                    CorElementType.ELEMENT_TYPE_CHAR => TryFormatPrimitiveDefault<char, char>(enumType, Unsafe.ReadUnaligned<char>(ref rawData), destination, out charsWritten),
 #endif
                     _ => throw CreateUnknownEnumTypeException(),
                 };
@@ -1718,18 +1718,18 @@ namespace System
                 {
                     CorElementType.ELEMENT_TYPE_I1 => TryFormatPrimitiveNonDefault<sbyte, byte>(enumType, (sbyte)rawData, destination, out charsWritten, format),
                     CorElementType.ELEMENT_TYPE_U1 => TryFormatPrimitiveNonDefault<byte, byte>(enumType, rawData, destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_I2 => TryFormatPrimitiveNonDefault<short, ushort>(enumType, Unsafe.As<byte, short>(ref rawData), destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_U2 => TryFormatPrimitiveNonDefault<ushort, ushort>(enumType, Unsafe.As<byte, ushort>(ref rawData), destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_I4 => TryFormatPrimitiveNonDefault<int, uint>(enumType, Unsafe.As<byte, int>(ref rawData), destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_U4 => TryFormatPrimitiveNonDefault<uint, uint>(enumType, Unsafe.As<byte, uint>(ref rawData), destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_I8 => TryFormatPrimitiveNonDefault<long, ulong>(enumType, Unsafe.As<byte, long>(ref rawData), destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_U8 => TryFormatPrimitiveNonDefault<ulong, ulong>(enumType, Unsafe.As<byte, ulong>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_I2 => TryFormatPrimitiveNonDefault<short, ushort>(enumType, Unsafe.ReadUnaligned<short>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_U2 => TryFormatPrimitiveNonDefault<ushort, ushort>(enumType, Unsafe.ReadUnaligned<ushort>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_I4 => TryFormatPrimitiveNonDefault<int, uint>(enumType, Unsafe.ReadUnaligned<int>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_U4 => TryFormatPrimitiveNonDefault<uint, uint>(enumType, Unsafe.ReadUnaligned<uint>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_I8 => TryFormatPrimitiveNonDefault<long, ulong>(enumType, Unsafe.ReadUnaligned<long>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_U8 => TryFormatPrimitiveNonDefault<ulong, ulong>(enumType, Unsafe.ReadUnaligned<ulong>(ref rawData), destination, out charsWritten, format),
 #if RARE_ENUMS
-                    CorElementType.ELEMENT_TYPE_R4 => TryFormatPrimitiveNonDefault<float, float>(enumType, Unsafe.As<byte, float>(ref rawData), destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_R8 => TryFormatPrimitiveNonDefault<double, double>(enumType, Unsafe.As<byte, double>(ref rawData), destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_I => TryFormatPrimitiveNonDefault<nint, nuint>(enumType, Unsafe.As<byte, nint>(ref rawData), destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_U => TryFormatPrimitiveNonDefault<nuint, nuint>(enumType, Unsafe.As<byte, nuint>(ref rawData), destination, out charsWritten, format),
-                    CorElementType.ELEMENT_TYPE_CHAR => TryFormatPrimitiveNonDefault<char, char>(enumType, Unsafe.As<byte, char>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_R4 => TryFormatPrimitiveNonDefault<float, float>(enumType, Unsafe.ReadUnaligned<float>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_R8 => TryFormatPrimitiveNonDefault<double, double>(enumType, Unsafe.ReadUnaligned<double>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_I => TryFormatPrimitiveNonDefault<nint, nuint>(enumType, Unsafe.ReadUnaligned<nint>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_U => TryFormatPrimitiveNonDefault<nuint, nuint>(enumType, Unsafe.ReadUnaligned<nuint>(ref rawData), destination, out charsWritten, format),
+                    CorElementType.ELEMENT_TYPE_CHAR => TryFormatPrimitiveNonDefault<char, char>(enumType, Unsafe.ReadUnaligned<char>(ref rawData), destination, out charsWritten, format),
 #endif
                     _ => throw CreateUnknownEnumTypeException(),
                 };

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -243,7 +243,7 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly Guid ToGuid()
             {
-                return Unsafe.As<GuidResult, Guid>(ref Unsafe.AsRef(in this));
+                return Unsafe.ReadUnaligned<Guid>(ref Unsafe.As<GuidResult, byte>(ref Unsafe.AsRef(in this)));
             }
 
             public void ReverseAbcEndianness()
@@ -1425,7 +1425,7 @@ namespace System
                 (byte)'8', (byte)'9', (byte)'a', (byte)'b',
                 (byte)'c', (byte)'d', (byte)'e', (byte)'f');
 
-            Vector128<byte> srcVec = Unsafe.As<Guid, Vector128<byte>>(ref value);
+            Vector128<byte> srcVec = Vector128.LoadUnsafe(ref Unsafe.As<Guid, byte>(ref value));
             (Vector128<byte> hexLow, Vector128<byte> hexHigh) =
                 HexConverter.AsciiToHexVector128(srcVec, hexMap);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/FieldAccessor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/FieldAccessor.cs
@@ -145,7 +145,7 @@ namespace System.Reflection
                         VerifyTarget(obj);
                         Debug.Assert(obj != null);
                         return Pointer.Box(
-                            (void*)Unsafe.As<byte, IntPtr>(ref Unsafe.AddByteOffset(ref obj.GetRawData(), _addressOrOffset)),
+                            (void*)Unsafe.ReadUnaligned<IntPtr>(ref Unsafe.AddByteOffset(ref obj.GetRawData(), _addressOrOffset)),
                             _fieldInfo.FieldType);
 
                     case FieldAccessorType.StaticReferenceType:
@@ -237,7 +237,7 @@ namespace System.Reflection
                         Debug.Assert(obj != null);
                         Volatile.Write(
                             ref Unsafe.As<byte, short>(ref Unsafe.AddByteOffset(ref obj.GetRawData(), _addressOrOffset)),
-                            Unsafe.As<byte, short>(ref value!.GetRawData()));
+                            Unsafe.ReadUnaligned<short>(ref value!.GetRawData()));
                         return;
 
                     case FieldAccessorType.InstanceValueTypeSize4:
@@ -245,7 +245,7 @@ namespace System.Reflection
                         Debug.Assert(obj != null);
                         Volatile.Write(
                             ref Unsafe.As<byte, int>(ref Unsafe.AddByteOffset(ref obj.GetRawData(), _addressOrOffset)),
-                            Unsafe.As<byte, int>(ref value!.GetRawData()));
+                            Unsafe.ReadUnaligned<int>(ref value!.GetRawData()));
                         return;
 
                     case FieldAccessorType.InstanceValueTypeSize8:
@@ -253,7 +253,7 @@ namespace System.Reflection
                         Debug.Assert(obj != null);
                         Volatile.Write(
                             ref Unsafe.As<byte, long>(ref Unsafe.AddByteOffset(ref obj.GetRawData(), _addressOrOffset)),
-                            Unsafe.As<byte, long>(ref value!.GetRawData()));
+                            Unsafe.ReadUnaligned<long>(ref value!.GetRawData()));
                         return;
 
                     case FieldAccessorType.StaticReferenceType:
@@ -272,21 +272,21 @@ namespace System.Reflection
                         VerifyStaticField(ref value, invokeAttr, binder, culture);
                         Volatile.Write(
                             ref Unsafe.AsRef<short>(_addressOrOffset.ToPointer()),
-                            Unsafe.As<byte, short>(ref value!.GetRawData()));
+                            Unsafe.ReadUnaligned<short>(ref value!.GetRawData()));
                         return;
 
                     case FieldAccessorType.StaticValueTypeSize4:
                         VerifyStaticField(ref value, invokeAttr, binder, culture);
                         Volatile.Write(
                             ref Unsafe.AsRef<int>(_addressOrOffset.ToPointer()),
-                            Unsafe.As<byte, int>(ref value!.GetRawData()));
+                            Unsafe.ReadUnaligned<int>(ref value!.GetRawData()));
                         return;
 
                     case FieldAccessorType.StaticValueTypeSize8:
                         VerifyStaticField(ref value, invokeAttr, binder, culture);
                         Volatile.Write(
                             ref Unsafe.AsRef<long>(_addressOrOffset.ToPointer()),
-                            Unsafe.As<byte, long>(ref value!.GetRawData()));
+                            Unsafe.ReadUnaligned<long>(ref value!.GetRawData()));
                         return;
 
                     case FieldAccessorType.SlowPathUntilClassInitialized:

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
@@ -135,17 +135,17 @@ namespace System.Reflection
                         case CorElementType.ELEMENT_TYPE_CHAR:
                         case CorElementType.ELEMENT_TYPE_I2:
                         case CorElementType.ELEMENT_TYPE_U2:
-                            Unsafe.As<byte, ushort>(ref destElement) = srcElement; break;
+                            Unsafe.WriteUnaligned(ref destElement, (ushort)srcElement); break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-                            Unsafe.As<byte, uint>(ref destElement) = srcElement; break;
+                            Unsafe.WriteUnaligned(ref destElement, (uint)srcElement); break;
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-                            Unsafe.As<byte, ulong>(ref destElement) = srcElement; break;
+                            Unsafe.WriteUnaligned(ref destElement, (ulong)srcElement); break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = srcElement; break;
+                            Unsafe.WriteUnaligned(ref destElement, (float)srcElement); break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = srcElement; break;
+                            Unsafe.WriteUnaligned(ref destElement, (double)srcElement); break;
                         default:
                             Debug.Fail("Expected to be unreachable"); break;
                     }
@@ -155,15 +155,15 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_I2:
-                            Unsafe.As<byte, short>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (short)(sbyte)srcElement); break;
                         case CorElementType.ELEMENT_TYPE_I4:
-                            Unsafe.As<byte, int>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (int)(sbyte)srcElement); break;
                         case CorElementType.ELEMENT_TYPE_I8:
-                            Unsafe.As<byte, long>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (long)(sbyte)srcElement); break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (float)(sbyte)srcElement); break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (double)(sbyte)srcElement); break;
                         default:
                             Debug.Fail("Array.Copy from I1 to another type hit unsupported widening conversion"); break;
                     }
@@ -176,17 +176,17 @@ namespace System.Reflection
                         case CorElementType.ELEMENT_TYPE_U2:
                         case CorElementType.ELEMENT_TYPE_CHAR:
                             // U2 and CHAR are identical in conversion
-                            Unsafe.As<byte, ushort>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, Unsafe.ReadUnaligned<ushort>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-                            Unsafe.As<byte, uint>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (uint)Unsafe.ReadUnaligned<ushort>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-                            Unsafe.As<byte, ulong>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (ulong)Unsafe.ReadUnaligned<ushort>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (float)Unsafe.ReadUnaligned<ushort>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (double)Unsafe.ReadUnaligned<ushort>(ref srcElement)); break;
                         default:
                             Debug.Fail("Array.Copy from U2 to another type hit unsupported widening conversion"); break;
                     }
@@ -196,13 +196,13 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_I4:
-                            Unsafe.As<byte, int>(ref destElement) = Unsafe.As<byte, short>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (int)Unsafe.ReadUnaligned<short>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_I8:
-                            Unsafe.As<byte, long>(ref destElement) = Unsafe.As<byte, short>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (long)Unsafe.ReadUnaligned<short>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, short>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (float)Unsafe.ReadUnaligned<short>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, short>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (double)Unsafe.ReadUnaligned<short>(ref srcElement)); break;
                         default:
                             Debug.Fail("Array.Copy from I2 to another type hit unsupported widening conversion"); break;
                     }
@@ -213,11 +213,11 @@ namespace System.Reflection
                     {
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-                            Unsafe.As<byte, ulong>(ref destElement) = Unsafe.As<byte, uint>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (ulong)Unsafe.ReadUnaligned<uint>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, uint>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (float)Unsafe.ReadUnaligned<uint>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, uint>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (double)Unsafe.ReadUnaligned<uint>(ref srcElement)); break;
                         default:
                             Debug.Fail("Array.Copy from U4 to another type hit unsupported widening conversion"); break;
                     }
@@ -227,11 +227,11 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_I8:
-                            Unsafe.As<byte, long>(ref destElement) = Unsafe.As<byte, int>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (long)Unsafe.ReadUnaligned<int>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, int>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (float)Unsafe.ReadUnaligned<int>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, int>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (double)Unsafe.ReadUnaligned<int>(ref srcElement)); break;
                         default:
                             Debug.Fail("Array.Copy from I4 to another type hit unsupported widening conversion"); break;
                     }
@@ -241,9 +241,9 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, ulong>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (float)Unsafe.ReadUnaligned<ulong>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, ulong>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (double)Unsafe.ReadUnaligned<ulong>(ref srcElement)); break;
                         default:
                             Debug.Fail("Array.Copy from U8 to another type hit unsupported widening conversion"); break;
                     }
@@ -253,9 +253,9 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, long>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (float)Unsafe.ReadUnaligned<long>(ref srcElement)); break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, long>(ref srcElement); break;
+                            Unsafe.WriteUnaligned(ref destElement, (double)Unsafe.ReadUnaligned<long>(ref srcElement)); break;
                         default:
                             Debug.Fail("Array.Copy from I8 to another type hit unsupported widening conversion"); break;
                     }
@@ -263,7 +263,7 @@ namespace System.Reflection
 
                 case CorElementType.ELEMENT_TYPE_R4:
                     Debug.Assert(destElType == CorElementType.ELEMENT_TYPE_R8);
-                    Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, float>(ref srcElement); break;
+                    Unsafe.WriteUnaligned(ref destElement, (double)Unsafe.ReadUnaligned<float>(ref srcElement)); break;
 
                 default:
                     Debug.Fail("Fell through outer switch in PrimitiveWiden!  Unknown primitive type for source array!"); break;

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
@@ -246,7 +246,7 @@ namespace System.Runtime.CompilerServices
 
             if (!rtType.IsValueType)
             {
-                return Unsafe.As<byte, object?>(ref target);
+                return Unsafe.ReadUnaligned<object?>(ref target);
             }
 
             if (rtType.IsByRefLike)


### PR DESCRIPTION
Doesn't depend upon implementation specific behaviour, i.e. that data is properly aligned.

For `System.Private.CoreLib`
