### PR TITLE
JIT: Introduce `LclVarDsc::lvIsMultiRegDest`

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7749,7 +7749,7 @@ void CodeGen::genMultiRegStoreToLocal(GenTreeLclVar* lclNode)
     if (actualOp1->OperIs(GT_CALL))
     {
         assert(regCount <= MAX_RET_REG_COUNT);
-        noway_assert(varDsc->lvIsMultiRegRet);
+        noway_assert(varDsc->lvIsMultiRegDest);
     }
 
 #ifdef FEATURE_SIMD

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -609,8 +609,9 @@ public:
     unsigned char lvIsStructField : 1; // Is this local var a field of a promoted struct local?
     unsigned char lvContainsHoles : 1; // Is this a promoted struct whose fields do not cover the struct local?
 
-    unsigned char lvIsMultiRegArg : 1; // true if this is a multireg LclVar struct used in an argument context
-    unsigned char lvIsMultiRegRet : 1; // true if this is a multireg LclVar struct assigned from a multireg call
+    unsigned char lvIsMultiRegArg  : 1; // true if this is a multireg LclVar struct used in an argument context
+    unsigned char lvIsMultiRegRet  : 1; // true if this is a multireg LclVar struct assigned from a multireg call
+    unsigned char lvIsMultiRegDest : 1; // true if this is a multireg LclVar struct that is stored from a multireg node
 
 #ifdef DEBUG
     unsigned char lvHiddenBufferStructArg : 1; // True when this struct (or its field) are passed as hidden buffer
@@ -701,6 +702,13 @@ public:
     bool lvIsMultiRegArgOrRet()
     {
         return lvIsMultiRegArg || lvIsMultiRegRet;
+    }
+
+    void SetIsMultiRegDest()
+    {
+        lvIsMultiRegDest = true;
+        // TODO-Quirk: Set the old lvIsMultiRegRet, which is used for heuristics
+        lvIsMultiRegRet = true;
     }
 
     bool IsStackAllocatedObject() const

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -2052,13 +2052,13 @@ GenTree* DecomposeLongs::StoreNodeToVar(LIR::Use& use)
     if (user->OperGet() == GT_STORE_LCL_VAR)
     {
         // If parent is already a STORE_LCL_VAR, just mark it lvIsMultiRegRet.
-        m_compiler->lvaGetDesc(user->AsLclVar())->lvIsMultiRegRet = true;
+        m_compiler->lvaGetDesc(user->AsLclVar())->SetIsMultiRegDest();
         return tree->gtNext;
     }
 
     // Otherwise, we need to force var = call()
-    unsigned lclNum                              = use.ReplaceWithLclVar(m_compiler);
-    m_compiler->lvaTable[lclNum].lvIsMultiRegRet = true;
+    unsigned lclNum = use.ReplaceWithLclVar(m_compiler);
+    m_compiler->lvaGetDesc(lclNum)->SetIsMultiRegDest();
 
     if (m_compiler->lvaEnregMultiRegVars)
     {

--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -784,8 +784,8 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
         unsigned const   dstLclNum = parentNode->AsLclVar()->GetLclNum();
         LclVarDsc* const dstVarDsc = lvaGetDesc(dstLclNum);
 
-        JITDUMP(" [marking V%02u as multi-reg-ret]", dstLclNum);
-        dstVarDsc->lvIsMultiRegRet = true;
+        JITDUMP(" [marking V%02u as multi-reg-dest]", dstLclNum);
+        dstVarDsc->SetIsMultiRegDest();
     }
 
     // If a method returns a multi-reg type, only forward sub locals,
@@ -835,6 +835,7 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
             LclVarDsc* const fwdVarDsc = lvaGetDesc(fwdLclNum);
 
             JITDUMP(" [marking V%02u as multi-reg-ret]", fwdLclNum);
+            // TODO-Quirk: Only needed for heuristics
             fwdVarDsc->lvIsMultiRegRet = true;
             fwdSubNodeLocal->gtFlags |= GTF_DONT_CSE;
         }

--- a/src/coreclr/jit/gschecks.cpp
+++ b/src/coreclr/jit/gschecks.cpp
@@ -418,8 +418,9 @@ void Compiler::gsParamsToShadows()
             // We don't need unsafe value cls check here since we are copying the params and this flag
             // would have been set on the original param before reaching here.
             lvaSetStruct(shadowVarNum, varDsc->GetLayout(), false);
-            shadowVarDsc->lvIsMultiRegArg = varDsc->lvIsMultiRegArg;
-            shadowVarDsc->lvIsMultiRegRet = varDsc->lvIsMultiRegRet;
+            shadowVarDsc->lvIsMultiRegArg  = varDsc->lvIsMultiRegArg;
+            shadowVarDsc->lvIsMultiRegRet  = varDsc->lvIsMultiRegRet;
+            shadowVarDsc->lvIsMultiRegDest = varDsc->lvIsMultiRegDest;
         }
         shadowVarDsc->lvIsUnsafeBuffer = varDsc->lvIsUnsafeBuffer;
         shadowVarDsc->lvIsPtr          = varDsc->lvIsPtr;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1060,7 +1060,7 @@ GenTree* Compiler::impStoreStruct(GenTree*         store,
 
     if (store->OperIs(GT_STORE_LCL_VAR) && src->IsMultiRegNode())
     {
-        lvaGetDesc(store->AsLclVar())->lvIsMultiRegRet = true;
+        lvaGetDesc(store->AsLclVar())->SetIsMultiRegDest();
     }
 
     return store;
@@ -11004,8 +11004,7 @@ GenTree* Compiler::impStoreMultiRegValueToVar(GenTree*                    op,
 
     LclVarDsc* varDsc = lvaGetDesc(tmpNum);
 
-    // Set "lvIsMultiRegRet" to block promotion under "!lvaEnregMultiRegVars".
-    varDsc->lvIsMultiRegRet = true;
+    varDsc->SetIsMultiRegDest();
 
     GenTreeLclVar* ret = gtNewLclvNode(tmpNum, varDsc->lvType);
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -6447,6 +6447,10 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
         {
             printf("R");
         }
+        if (varDsc->lvIsMultiRegDest)
+        {
+            printf("M");
+        }
 #ifdef JIT32_GCENCODER
         if (varDsc->lvPinned)
             printf("P");
@@ -6461,6 +6465,10 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     if (varDsc->lvIsMultiRegRet)
     {
         printf(" multireg-ret");
+    }
+    if (varDsc->lvIsMultiRegDest)
+    {
+        printf(" multireg-dest");
     }
     if (varDsc->lvMustInit)
     {

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8416,7 +8416,7 @@ void Lowering::CheckNode(Compiler* compiler, GenTree* node)
 #endif // FEATURE_SIMD && TARGET_64BIT
             if (varDsc->lvPromoted)
             {
-                assert(varDsc->lvDoNotEnregister || varDsc->lvIsMultiRegRet);
+                assert(varDsc->lvDoNotEnregister || (node->OperIs(GT_STORE_LCL_VAR) && varDsc->lvIsMultiRegDest));
             }
         }
         break;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1818,9 +1818,9 @@ void LinearScan::identifyCandidates()
             if (varDsc->lvIsStructField)
             {
                 LclVarDsc* parentVarDsc = compiler->lvaGetDesc(varDsc->lvParentLcl);
-                if (parentVarDsc->lvIsMultiRegRet && !parentVarDsc->lvDoNotEnregister)
+                if (parentVarDsc->lvIsMultiRegDest && !parentVarDsc->lvDoNotEnregister)
                 {
-                    JITDUMP("Setting multi-reg struct V%02u as not enregisterable:", varDsc->lvParentLcl);
+                    JITDUMP("Setting multi-reg-dest struct V%02u as not enregisterable:", varDsc->lvParentLcl);
                     compiler->lvaSetVarDoNotEnregister(varDsc->lvParentLcl DEBUGARG(DoNotEnregisterReason::BlockOp));
                     for (unsigned int i = 0; i < parentVarDsc->lvFieldCnt; i++)
                     {

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -679,7 +679,7 @@ void MorphCopyBlockHelper::TrySpecialCases()
     {
         assert(m_store->OperIs(GT_STORE_LCL_VAR));
 
-        m_dstVarDsc->lvIsMultiRegRet = true;
+        m_dstVarDsc->SetIsMultiRegDest();
 
         JITDUMP("Not morphing a multireg node return\n");
         m_transformationDecision = BlockTransformation::SkipMultiRegSrc;


### PR DESCRIPTION
With recent work to expand returned promoted locals into `FIELD_LIST` the only "whole references" of promoted locals we should see is when stored from a multi-reg node. This is the only knowledge the backend should need for correctness purposes, so introduce a bit to track this property, and switch the backend to check this instead.

The existing `lvIsMultiRegRet` is essentially this + whether the local is returned. We should be able to remove this, but it is currently used for some outdated correctness checks in old promotion, so keep it around for now.

This makes the new bitwise combination of returns kick in much more often for multireg returns. For example on win-arm64:

```csharp
static Memory<int> ToMemory(int[] arr)
{
    return arr.AsMemory();
}
```

```diff
 G_M45070_IG01:  ;; offset=0x0000
-            stp     fp, lr, [sp, #-0x20]!
+            stp     fp, lr, [sp, #-0x10]!
             mov     fp, sp
-            str     xzr, [fp, #0x10]    // [V03 tmp2]
-                                                ;; size=12 bbWeight=1 PerfScore 2.50
-G_M45070_IG02:  ;; offset=0x000C
-            cbz     x0, G_M45070_IG04
-                                                ;; size=4 bbWeight=1 PerfScore 1.00
-G_M45070_IG03:  ;; offset=0x0010
-            str     x0, [fp, #0x10]     // [V07 tmp6]
-            str     wzr, [fp, #0x18]    // [V08 tmp7]
-            ldr     x0, [fp, #0x10]     // [V07 tmp6]
-            ldr     w0, [x0, #0x08]
-            str     w0, [fp, #0x1C]     // [V09 tmp8]
-            b       G_M45070_IG05
-                                                ;; size=24 bbWeight=0.50 PerfScore 4.50
-G_M45070_IG04:  ;; offset=0x0028
-            str     xzr, [fp, #0x10]    // [V07 tmp6]
-            str     xzr, [fp, #0x18]
-                                                ;; size=8 bbWeight=0.50 PerfScore 1.00
-G_M45070_IG05:  ;; offset=0x0030
-            ldp     x0, x1, [fp, #0x10] // [V03 tmp2], [V03 tmp2+0x08]
-                                                ;; size=4 bbWeight=1 PerfScore 3.00
-G_M45070_IG06:  ;; offset=0x0034
-            ldp     fp, lr, [sp], #0x20
+						;; size=8 bbWeight=1 PerfScore 1.50
+G_M45070_IG02:  ;; offset=0x0008
+            cbz     x0, G_M45070_IG06
+						;; size=4 bbWeight=1 PerfScore 1.00
+G_M45070_IG03:  ;; offset=0x000C
+            ldr     w1, [x0, #0x08]
+						;; size=4 bbWeight=0.80 PerfScore 2.40
+G_M45070_IG04:  ;; offset=0x0010
+            mov     w1, w1
+            mov     x2, xzr
+            orr     x1, x2, x1,  LSL #32
+						;; size=12 bbWeight=1 PerfScore 2.00
+G_M45070_IG05:  ;; offset=0x001C
+            ldp     fp, lr, [sp], #0x10
             ret     lr
-                                                ;; size=8 bbWeight=1 PerfScore 2.00
+						;; size=8 bbWeight=1 PerfScore 2.00
+G_M45070_IG06:  ;; offset=0x0024
+            mov     x0, xzr
+            mov     w1, wzr
+            b       G_M45070_IG04
+						;; size=12 bbWeight=0.20 PerfScore 0.40
 
-; Total bytes of code 60, prolog size 12, PerfScore 14.00, instruction count 15, allocated bytes for code 60 (MethodHash=b2994ff1) for method Program:ToMemory(int[]):System.Memory`1[int] (FullOpts)
+; Total bytes of code 48, prolog size 8, PerfScore 9.30, instruction count 12, allocated bytes for code 48 (MethodHash=b2994ff1) for method Program:ToMemory(int[]):System.Memory`1[int] (FullOpts)
```
(which still can be improved)