### PR TITLE
Assertprop: Remove more useless assertions + cleanup

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1335,7 +1335,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, optAsser
                 {
                     if (!optLocalAssertionProp)
                     {
-                        // Currently not useful for global assertion prop
+                        // O2K_LCLVAR_COPY is not useful for global assertion prop
                         goto DONE_ASSERTION;
                     }
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1123,13 +1123,9 @@ ssize_t Compiler::optCastConstantSmall(ssize_t iconVal, var_types smallType)
 //    Assertion creation may fail either because the provided assertion
 //    operands aren't supported or because the assertion table is full.
 //
-AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
-                                            GenTree*         op2,
-                                            optAssertionKind assertionKind,
-                                            bool             helperCallArgs)
+AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, optAssertionKind assertionKind)
 {
     assert(op1 != nullptr);
-    assert(!helperCallArgs || (op2 != nullptr));
 
     AssertionDsc assertion = {OAK_INVALID};
     assert(assertion.assertionKind == OAK_INVALID);
@@ -1237,46 +1233,6 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             goto DONE_ASSERTION; // Don't make an assertion
         }
 
-        if (helperCallArgs)
-        {
-            if (optLocalAssertionProp)
-            {
-                // O1K_SUBTYPE is not useful for local assertion prop
-                goto DONE_ASSERTION;
-            }
-
-            //
-            // Must either be an OAK_EQUAL or an OAK_NOT_EQUAL assertion
-            //
-            if ((assertionKind != OAK_EQUAL) && (assertionKind != OAK_NOT_EQUAL))
-            {
-                goto DONE_ASSERTION; // Don't make an assertion
-            }
-
-            if (op2->gtOper != GT_CNS_INT)
-            {
-                goto DONE_ASSERTION; // Don't make an assertion
-            }
-            assertion.op2.kind = O2K_CONST_INT;
-
-            //
-            // TODO-CQ: Check for Sealed class and change kind to O1K_EXACT_TYPE
-            //          And consider the special cases, like CORINFO_FLG_SHAREDINST or CORINFO_FLG_VARIANCE
-            //          where a class can be sealed, but they don't behave as exact types because casts to
-            //          non-base types sometimes still succeed.
-            //
-            assertion.op1.kind       = O1K_SUBTYPE;
-            assertion.op1.vn         = optConservativeNormalVN(op1);
-            assertion.op2.u1.iconVal = op2->AsIntCon()->gtIconVal;
-            assertion.op2.vn         = optConservativeNormalVN(op2);
-            assertion.op2.SetIconFlag(op2->GetIconHandleFlag());
-
-            //
-            // Ok everything has been set and the assertion looks good
-            //
-            assertion.assertionKind = assertionKind;
-        }
-        else // !helperCallArgs
         {
             /* Skip over a GT_COMMA node(s), if necessary */
             while (op2->gtOper == GT_COMMA)
@@ -1462,35 +1418,6 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     assertion.assertionKind = OAK_SUBRANGE;
                     assertion.op2.u2        = nodeRange;
                 }
-            }
-        }
-    }
-
-    //
-    // Are we making an IsType assertion?
-    //
-    else if (op1->OperIs(GT_IND) && !optLocalAssertionProp)
-    {
-        op1 = op1->AsOp()->gtOp1;
-        //
-        // Is this an indirection of a local variable?
-        //
-        if (op1->TypeIs(TYP_REF))
-        {
-            ssize_t      cnsValue  = 0;
-            GenTreeFlags iconFlags = GTF_EMPTY;
-            if (optIsTreeKnownIntValue(!optLocalAssertionProp, op2, &cnsValue, &iconFlags))
-            {
-                assertion.assertionKind  = assertionKind;
-                assertion.op1.kind       = O1K_EXACT_TYPE;
-                assertion.op1.vn         = optConservativeNormalVN(op1);
-                assertion.op2.kind       = O2K_CONST_INT;
-                assertion.op2.u1.iconVal = cnsValue;
-                assertion.op2.vn         = optConservativeNormalVN(op2);
-
-                /* iconFlags should only contain bits in GTF_ICON_HDL_MASK */
-                assert((iconFlags & ~GTF_ICON_HDL_MASK) == 0);
-                assertion.op2.SetIconFlag(iconFlags);
             }
         }
     }
@@ -1928,18 +1855,12 @@ void Compiler::optDebugCheckAssertions(AssertionIndex index)
 //    assertionIndex - the index of the assertion
 //    op1 - the first assertion operand
 //    op2 - the second assertion operand
-//    helperCallArgs - when true this indicates that the assertion operands
-//                     are the arguments of a type cast helper call such as
-//                     CORINFO_HELP_ISINSTANCEOFCLASS
 //
 // Notes:
 //    The created complementary assertion is associated with the original
 //    assertion such that it can be found by optFindComplementary.
 //
-void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex,
-                                               GenTree*       op1,
-                                               GenTree*       op2,
-                                               bool           helperCallArgs)
+void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex, GenTree* op1, GenTree* op2)
 {
     if (assertionIndex == NO_ASSERTION_INDEX)
     {
@@ -1983,12 +1904,12 @@ void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex,
             return;
         }
 
-        AssertionIndex index = optCreateAssertion(op1, op2, OAK_NOT_EQUAL, helperCallArgs);
+        AssertionIndex index = optCreateAssertion(op1, op2, OAK_NOT_EQUAL);
         optMapComplementary(index, assertionIndex);
     }
     else if (candidateAssertion.assertionKind == OAK_NOT_EQUAL)
     {
-        AssertionIndex index = optCreateAssertion(op1, op2, OAK_EQUAL, helperCallArgs);
+        AssertionIndex index = optCreateAssertion(op1, op2, OAK_EQUAL);
         optMapComplementary(index, assertionIndex);
     }
 }
@@ -2053,9 +1974,7 @@ AssertionIndex Compiler::optAssertionGenCast(GenTreeCast* cast)
 //    op1 - the first assertion operand
 //    op2 - the second assertion operand
 //    assertionKind - the assertion kind
-//    helperCallArgs - when true this indicates that the assertion operands
-//                     are the arguments of a type cast helper call such as
-//                     CORINFO_HELP_ISINSTANCEOFCLASS
+//
 // Return Value:
 //    The new assertion index or NO_ASSERTION_INDEX if a new assertion
 //    was not created.
@@ -2067,17 +1986,14 @@ AssertionIndex Compiler::optAssertionGenCast(GenTreeCast* cast)
 //    create a second, complementary assertion. This may too fail, for the
 //    same reasons as the first one.
 //
-AssertionIndex Compiler::optCreateJtrueAssertions(GenTree*                   op1,
-                                                  GenTree*                   op2,
-                                                  Compiler::optAssertionKind assertionKind,
-                                                  bool                       helperCallArgs)
+AssertionIndex Compiler::optCreateJtrueAssertions(GenTree* op1, GenTree* op2, optAssertionKind assertionKind)
 {
-    AssertionIndex assertionIndex = optCreateAssertion(op1, op2, assertionKind, helperCallArgs);
+    AssertionIndex assertionIndex = optCreateAssertion(op1, op2, assertionKind);
     // Don't bother if we don't have an assertion on the JTrue False path. Current implementation
     // allows for a complementary only if there is an assertion on the False path (tree->HasAssertion()).
     if (assertionIndex != NO_ASSERTION_INDEX)
     {
-        optCreateComplementaryAssertion(assertionIndex, op1, op2, helperCallArgs);
+        optCreateComplementaryAssertion(assertionIndex, op1, op2);
     }
     return assertionIndex;
 }
@@ -2254,6 +2170,38 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
         return NO_ASSERTION_INDEX;
     }
 
+    // See if we have IND(obj) ==/!= TypeHandle
+    //
+    if (!optLocalAssertionProp && op1->OperIs(GT_IND))
+    {
+        ssize_t      cnsValue  = 0;
+        GenTreeFlags iconFlags = GTF_EMPTY;
+        if (op1->gtGetOp1()->TypeIs(TYP_REF) &&
+            optIsTreeKnownIntValue(!optLocalAssertionProp, op2, &cnsValue, &iconFlags))
+        {
+            AssertionDsc assertion;
+            assertion.assertionKind  = OAK_EQUAL;
+            assertion.op1.kind       = O1K_EXACT_TYPE;
+            assertion.op1.vn         = optConservativeNormalVN(op1->gtGetOp1());
+            assertion.op2.kind       = O2K_CONST_INT;
+            assertion.op2.u1.iconVal = cnsValue;
+            assertion.op2.vn         = optConservativeNormalVN(op2);
+            assertion.op2.SetIconFlag(iconFlags);
+            AssertionIndex index = optAddAssertion(&assertion);
+
+            // We don't need to create a complementary assertion here. We're only interested
+            // in the assertion that the object is of a certain type. The opposite assertion
+            // (that the object is not of a certain type) is not useful (at least not yet).
+            //
+            // So if we have "if (obj->pMT != CNS) then create the assertion for the "else" edge.
+            if (relop->OperIs(GT_NE))
+            {
+                return AssertionInfo::ForNextEdge(index);
+            }
+            return index;
+        }
+    }
+
     // Check for op1 or op2 to be lcl var and if so, keep it in op1.
     if ((op1->gtOper != GT_LCL_VAR) && (op2->gtOper == GT_LCL_VAR))
     {
@@ -2317,6 +2265,12 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
         return NO_ASSERTION_INDEX;
     }
 
+    if (optLocalAssertionProp)
+    {
+        // O1K_SUBTYPE is Global Assertion Prop only
+        return NO_ASSERTION_INDEX;
+    }
+
     GenTreeCall* const call = op1->AsCall();
 
     // Note CORINFO_HELP_READYTORUN_ISINSTANCEOF does not have the same argument pattern.
@@ -2324,26 +2278,44 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
     //
     // Also note The CASTCLASS helpers won't appear in predicates as they throw on failure.
     // So the helper list here is smaller than the one in optAssertionProp_Call.
+    //
     if ((call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFINTERFACE)) ||
         (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFARRAY)) ||
         (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFCLASS)) ||
         (call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_ISINSTANCEOFANY)))
     {
-        GenTree* objectNode      = call->gtArgs.GetArgByIndex(1)->GetNode();
-        GenTree* methodTableNode = call->gtArgs.GetArgByIndex(0)->GetNode();
+        GenTree* objectNode      = call->gtArgs.GetUserArgByIndex(1)->GetNode();
+        GenTree* methodTableNode = call->gtArgs.GetUserArgByIndex(0)->GetNode();
 
         // objectNode can be TYP_I_IMPL in case if it's a constant handle
         // (e.g. a string literal from frozen segments)
+        //
         assert(objectNode->TypeIs(TYP_REF, TYP_I_IMPL));
         assert(methodTableNode->TypeIs(TYP_I_IMPL));
 
-        // Reverse the assertion
-        assert((assertionKind == OAK_EQUAL) || (assertionKind == OAK_NOT_EQUAL));
-        assertionKind = (assertionKind == OAK_EQUAL) ? OAK_NOT_EQUAL : OAK_EQUAL;
-
-        if (objectNode->OperIs(GT_LCL_VAR))
+        if (methodTableNode->OperIs(GT_CNS_INT))
         {
-            return optCreateJtrueAssertions(objectNode, methodTableNode, assertionKind, /* helperCallArgs */ true);
+            AssertionDsc assertion;
+            assertion.op1.kind       = O1K_SUBTYPE;
+            assertion.op1.vn         = optConservativeNormalVN(objectNode);
+            assertion.op2.kind       = O2K_CONST_INT;
+            assertion.op2.u1.iconVal = methodTableNode->AsIntCon()->IconValue();
+            assertion.op2.vn         = optConservativeNormalVN(methodTableNode);
+            assertion.op2.SetIconFlag(op2->GetIconHandleFlag());
+            assertion.assertionKind = OAK_EQUAL;
+            AssertionIndex index    = optAddAssertion(&assertion);
+
+            // We don't need to create a complementary assertion here. We're only interested
+            // in the assertion that the object is of a certain type. The opposite assertion
+            // (that the object is not of a certain type) is not useful (at least not yet).
+            //
+            // So if we have "if (ISINST(obj, pMT) == null) then create the assertion for the "else" edge.
+            //
+            if (relop->OperIs(GT_EQ))
+            {
+                return AssertionInfo::ForNextEdge(index);
+            }
+            return index;
         }
     }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8044,10 +8044,7 @@ public:
     AssertionIndex optAssertionGenCast(GenTreeCast* cast);
     AssertionInfo  optCreateJTrueBoundsAssertion(GenTree* tree);
     AssertionInfo  optAssertionGenJtrue(GenTree* tree);
-    AssertionIndex optCreateJtrueAssertions(GenTree*                   op1,
-                                            GenTree*                   op2,
-                                            Compiler::optAssertionKind assertionKind,
-                                            bool                       helperCallArgs = false);
+    AssertionIndex optCreateJtrueAssertions(GenTree* op1, GenTree* op2, optAssertionKind assertionKind);
     AssertionIndex optFindComplementary(AssertionIndex assertionIndex);
     void           optMapComplementary(AssertionIndex assertionIndex, AssertionIndex index);
 
@@ -8056,19 +8053,13 @@ public:
     ssize_t optCastConstantSmall(ssize_t iconVal, var_types smallType);
 
     // Assertion creation functions.
-    AssertionIndex optCreateAssertion(GenTree*         op1,
-                                      GenTree*         op2,
-                                      optAssertionKind assertionKind,
-                                      bool             helperCallArgs = false);
+    AssertionIndex optCreateAssertion(GenTree* op1, GenTree* op2, optAssertionKind assertionKind);
 
     AssertionIndex optFinalizeCreatingAssertion(AssertionDsc* assertion);
 
     bool optTryExtractSubrangeAssertion(GenTree* source, IntegralRange* pRange);
 
-    void optCreateComplementaryAssertion(AssertionIndex assertionIndex,
-                                         GenTree*       op1,
-                                         GenTree*       op2,
-                                         bool           helperCallArgs = false);
+    void optCreateComplementaryAssertion(AssertionIndex assertionIndex, GenTree* op1, GenTree* op2);
 
     bool           optAssertionVnInvolvesNan(AssertionDsc* assertion);
     AssertionIndex optAddAssertion(AssertionDsc* assertion);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7704,7 +7704,7 @@ public:
     ASSERT_TP     apLocal;
     ASSERT_TP     apLocalIfTrue;
 
-    enum optAssertionKind
+    enum optAssertionKind : uint8_t
     {
         OAK_INVALID,
         OAK_EQUAL,
@@ -7714,7 +7714,7 @@ public:
         OAK_COUNT
     };
 
-    enum optOp1Kind
+    enum optOp1Kind : uint8_t
     {
         O1K_INVALID,
         O1K_LCLVAR,
@@ -7727,13 +7727,14 @@ public:
         O1K_EXACT_TYPE,
         O1K_SUBTYPE,
         O1K_COUNT
+        // NOTE: as of today, only LCLVAR is used by both Local and Global assertion prop
+        // the rest are used only by Global assertion prop.
     };
 
-    enum optOp2Kind : uint16_t
+    enum optOp2Kind : uint8_t
     {
         O2K_INVALID,
         O2K_LCLVAR_COPY,
-        O2K_IND_CNS_INT,
         O2K_CONST_INT,
         O2K_CONST_LONG,
         O2K_CONST_DOUBLE,
@@ -7923,7 +7924,6 @@ public:
 
             switch (op2.kind)
             {
-                case O2K_IND_CNS_INT:
                 case O2K_CONST_INT:
                     return ((op2.u1.iconVal == that->op2.u1.iconVal) && (op2.GetIconFlag() == that->op2.GetIconFlag()));
 


### PR DESCRIPTION
This PR does:

1) `O1K_SUBTYPE` and `O1K_EXACT_TYPE` are now Global Prop only. They also rely only on `op1.vn`, `op1.lcl` is not used.
2) `O1K_SUBTYPE` and `O1K_EXACT_TYPE` are now created direcly in `optAssertionGenJtrue` - this allows us to create them only for needed edges + remove weird `helperCallArgs` param.
3) `O2K_IND_CNS_INT` is removed as unused
4) `O2K_LCLVAR_COPY` is now Local Prop only, almost no diffs in Global Prop.
5) Assertions with NoVN are not added to the table in Global Prop


[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=973485&view=ms.vss-build-web.run-extensions-tab) are improvements mostly because there is more room for more useful assertions now + my PR in fact creates more `O1K_EXACT_TYPE` assertions.