### PR TITLE
Fix CAS mustExpand assertions in checked build

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -4123,8 +4123,8 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                     break;
                 }
 #if defined(TARGET_RISCV64)
-                // CAS for small types is natively supported starting with the Zacas extension in Linux 6.8; however, hardware support
-                // for RVA23 profile is not available at the time of writing.
+                // CAS for small types is natively supported starting with the Zacas extension in Linux 6.8; however,
+                // hardware support for RVA23 profile is not available at the time of writing.
                 else if (genTypeSize(retType) < 4)
                 {
                     mustExpand = false;
@@ -4168,8 +4168,8 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                     break;
                 }
 #if defined(TARGET_RISCV64)
-                // CAS for small types is natively supported starting with the Zacas extension in Linux 6.8; however, hardware support
-                // for RVA23 profile is not available at the time of writing.
+                // CAS for small types is natively supported starting with the Zacas extension in Linux 6.8; however,
+                // hardware support for RVA23 profile is not available at the time of writing.
                 else if (genTypeSize(retType) < 4)
                 {
                     mustExpand = false;

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -4123,7 +4123,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                     break;
                 }
 #if defined(TARGET_RISCV64)
-                // CAS for small types is natively supported starting with the Zacas extension in Linux 6.8; however,
+                // CAS for small types is natively supported starting with the Zabha extension in Linux 6.8; however,
                 // hardware support for RVA23 profile is not available at the time of writing.
                 else if (genTypeSize(retType) < 4)
                 {
@@ -4168,7 +4168,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                     break;
                 }
 #if defined(TARGET_RISCV64)
-                // CAS for small types is natively supported starting with the Zacas extension in Linux 6.8; however,
+                // CAS for small types is natively supported starting with the Zabha extension in Linux 6.8; however,
                 // hardware support for RVA23 profile is not available at the time of writing.
                 else if (genTypeSize(retType) < 4)
                 {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -4112,7 +4112,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
             }
 #endif // defined(TARGET_ARM64) || defined(TARGET_RISCV64)
 
-#if defined(TARGET_XARCH) || defined(TARGET_ARM64) || defined(TARGET_RISCV64)
+#if defined(TARGET_64BIT)
             // TODO-ARM-CQ: reenable treating InterlockedCmpXchg32 operation as intrinsic
             case NI_System_Threading_Interlocked_CompareExchange:
             {
@@ -4122,12 +4122,15 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                 {
                     break;
                 }
-#if !defined(TARGET_XARCH) && !defined(TARGET_ARM64)
+#if defined(TARGET_RISCV64)
+                // CAS for small types is natively supported starting with the Zacas extension in Linux 6.8; however, hardware support
+                // for RVA23 profile is not available at the time of writing.
                 else if (genTypeSize(retType) < 4)
                 {
+                    mustExpand = false;
                     break;
                 }
-#endif // !defined(TARGET_XARCH) && !defined(TARGET_ARM64)
+#endif // defined(TARGET_RISCV64)
 
                 if ((retType == TYP_REF) &&
                     (impStackTop(1).val->IsIntegralConst(0) || impStackTop(1).val->IsIconHandle(GTF_ICON_OBJ_HDL)))
@@ -4164,12 +4167,15 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                 {
                     break;
                 }
-#if !defined(TARGET_XARCH) && !defined(TARGET_ARM64)
+#if defined(TARGET_RISCV64)
+                // CAS for small types is natively supported starting with the Zacas extension in Linux 6.8; however, hardware support
+                // for RVA23 profile is not available at the time of writing.
                 else if (genTypeSize(retType) < 4)
                 {
+                    mustExpand = false;
                     break;
                 }
-#endif // !defined(TARGET_XARCH) && !defined(TARGET_ARM64)
+#endif // defined(TARGET_RISCV64)
 
                 if ((retType == TYP_REF) &&
                     (impStackTop().val->IsIntegralConst(0) || impStackTop().val->IsIconHandle(GTF_ICON_OBJ_HDL)))
@@ -4199,7 +4205,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                                           callType, op1, op2);
                 break;
             }
-#endif // defined(TARGET_XARCH) || defined(TARGET_ARM64) || defined(TARGET_RISCV64)
+#endif // defined(TARGET_64BIT)
 
             case NI_System_Threading_Interlocked_MemoryBarrier:
             {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -4112,7 +4112,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
             }
 #endif // defined(TARGET_ARM64) || defined(TARGET_RISCV64)
 
-#if defined(TARGET_64BIT)
+#if defined(TARGET_64BIT) || defined(TARGET_X86)
             // TODO-ARM-CQ: reenable treating InterlockedCmpXchg32 operation as intrinsic
             case NI_System_Threading_Interlocked_CompareExchange:
             {
@@ -4205,7 +4205,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                                           callType, op1, op2);
                 break;
             }
-#endif // defined(TARGET_64BIT)
+#endif // defined(TARGET_64BIT) || defined(TARGET_X86)
 
             case NI_System_Threading_Interlocked_MemoryBarrier:
             {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -4116,6 +4116,12 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
             // TODO-ARM-CQ: reenable treating InterlockedCmpXchg32 operation as intrinsic
             case NI_System_Threading_Interlocked_CompareExchange:
             {
+#if defined(TARGET_LOONGARCH64)
+                // GT_CMPXCHG is NYI in lsraloongarch64
+                mustExpand = false;
+                break;
+#endif
+
                 var_types retType = JITtype2varType(sig->retType);
 
                 if (genTypeSize(retType) > TARGET_POINTER_SIZE)
@@ -4161,6 +4167,12 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
             case NI_System_Threading_Interlocked_Exchange:
             case NI_System_Threading_Interlocked_ExchangeAdd:
             {
+#if defined(TARGET_LOONGARCH64)
+                // GT_XADD and GT_XCHG are NYI in lsraloongarch64
+                mustExpand = false;
+                break;
+#endif
+
                 var_types retType = JITtype2varType(sig->retType);
 
                 if (genTypeSize(retType) > TARGET_POINTER_SIZE)

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -4123,7 +4123,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                     break;
                 }
 #if defined(TARGET_RISCV64)
-                // CAS for small types is natively supported starting with the Zabha extension in Linux 6.8; however,
+                // CAS for small types is natively supported starting with the Zabha extension; however,
                 // hardware support for RVA23 profile is not available at the time of writing.
                 else if (genTypeSize(retType) < 4)
                 {
@@ -4168,7 +4168,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                     break;
                 }
 #if defined(TARGET_RISCV64)
-                // CAS for small types is natively supported starting with the Zabha extension in Linux 6.8; however,
+                // CAS for small types is natively supported starting with the Zabha extension; however,
                 // hardware support for RVA23 profile is not available at the time of writing.
                 else if (genTypeSize(retType) < 4)
                 {


### PR DESCRIPTION
On community platforms, clrjit checked builds are running into:

```
ILC: /root/dotnet/runtime/src/coreclr/jit/importercalls.cpp:4857
ILC: Assertion failed '!"Unhandled must expand intrinsic, throwing PlatformNotSupportedException"' in 'System.Threading.Interlocked:Exchange(byref,ushort):ushort' during 'Importation' (IL size 8; hash 0x23160c7c; MinOpts)
```

https://godbolt.org/z/5Wxz89W4r (@fuad1502's example from https://github.com/dotnet/runtime/pull/113250)
Note that this is NativeAOT specific issue, crossgen2 and regular corehost apps don't seem to have this problem https://godbolt.org/z/M7eaaT7aT