### PR TITLE
[10.0/preview2] JIT: make array stack disable work in release builds

### DIFF
--- a/src/coreclr/jit/objectalloc.h
+++ b/src/coreclr/jit/objectalloc.h
@@ -340,8 +340,8 @@ inline bool ObjectAllocator::CanAllocateLclVarOnStack(unsigned int         lclNu
 #ifdef DEBUG
     enableBoxedValueClasses = (JitConfig.JitObjectStackAllocationBoxedValueClass() != 0);
     enableRefClasses        = (JitConfig.JitObjectStackAllocationRefClass() != 0);
-    enableArrays            = (JitConfig.JitObjectStackAllocationArray() != 0);
 #endif
+    enableArrays            = (JitConfig.JitObjectStackAllocationArray() != 0);
 
     unsigned classSize = 0;
 


### PR DESCRIPTION
Despite this being a release config setting, it was only impacting checked/debug builds.