### PR TITLE
Reword HostAbortedException docs

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostAbortedException.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostAbortedException.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization;
 namespace Microsoft.Extensions.Hosting
 {
     /// <summary>
-    /// The exception that is thrown upon <see cref="IHost"/> abortion.
+    /// The exception that is thrown when an <see cref="IHost"/> is stopped to indicate the Host is stopping gracefully.  This exception should not be thrown or handled by user code.
     /// </summary>
     [Serializable]
     public sealed class HostAbortedException : Exception


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/60600 or https://github.com/dotnet/runtime/pull/69404 for reference.

@carlossanlop - should I port this to [dotnet-api-docs](https://github.com/dotnet/dotnet-api-docs/blob/17a1a93359457a3554b6e8a57c53710a68076ebf/xml/Microsoft.Extensions.Hosting/HostAbortedException.xml#L31) manually after merging, or will our process do that?