### PR TITLE
Fix missing ServiceCallSite.Key causing an unkeyed cache entry to be overwritten by a keyed instance

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 ResultCache resultCache = (cacheLocation == CallSiteResultCacheLocation.Scope || cacheLocation == CallSiteResultCacheLocation.Root)
                     ? new ResultCache(cacheLocation, callSiteKey)
                     : new ResultCache(CallSiteResultCacheLocation.None, callSiteKey);
-                return _callSiteCache[callSiteKey] = new IEnumerableCallSite(resultCache, itemType, callSites);
+                return _callSiteCache[callSiteKey] = new IEnumerableCallSite(resultCache, itemType, callSites, serviceIdentifier.ServiceKey);
             }
             finally
             {
@@ -381,7 +381,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 var lifetime = new ResultCache(descriptor.Lifetime, serviceIdentifier, slot);
                 if (descriptor.HasImplementationInstance())
                 {
-                    callSite = new ConstantCallSite(descriptor.ServiceType, descriptor.GetImplementationInstance());
+                    callSite = new ConstantCallSite(descriptor.ServiceType, descriptor.GetImplementationInstance(), descriptor.ServiceKey);
                 }
                 else if (!descriptor.IsKeyedService && descriptor.ImplementationFactory != null)
                 {
@@ -399,7 +399,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 {
                     throw new InvalidOperationException(SR.InvalidServiceDescriptor);
                 }
-                callSite.Key = descriptor.ServiceKey;
 
                 return _callSiteCache[callSiteKey] = callSite;
             }
@@ -478,7 +477,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     ParameterInfo[] parameters = constructor.GetParameters();
                     if (parameters.Length == 0)
                     {
-                        return new ConstructorCallSite(lifetime, serviceIdentifier.ServiceType, constructor);
+                        return new ConstructorCallSite(lifetime, serviceIdentifier.ServiceType, constructor, serviceIdentifier.ServiceKey);
                     }
 
                     parameterCallSites = CreateArgumentCallSites(
@@ -488,7 +487,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         parameters,
                         throwIfCallSiteNotFound: true)!;
 
-                    return new ConstructorCallSite(lifetime, serviceIdentifier.ServiceType, constructor, parameterCallSites);
+                    return new ConstructorCallSite(lifetime, serviceIdentifier.ServiceType, constructor, parameterCallSites, serviceIdentifier.ServiceKey);
                 }
 
                 Array.Sort(constructors,
@@ -552,7 +551,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 else
                 {
                     Debug.Assert(parameterCallSites != null);
-                    return new ConstructorCallSite(lifetime, serviceIdentifier.ServiceType, bestConstructor, parameterCallSites);
+                    return new ConstructorCallSite(lifetime, serviceIdentifier.ServiceType, bestConstructor, parameterCallSites, serviceIdentifier.ServiceKey);
                 }
             }
             finally

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private readonly Type _serviceType;
         internal object? DefaultValue => Value;
 
-        public ConstantCallSite(Type serviceType, object? defaultValue) : base(ResultCache.None(serviceType))
+        public ConstantCallSite(Type serviceType, object? defaultValue, object? serviceKey = null) : base(ResultCache.None(serviceType), serviceKey)
         {
             _serviceType = serviceType ?? throw new ArgumentNullException(nameof(serviceType));
             if (defaultValue != null && !serviceType.IsInstanceOfType(defaultValue))

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstructorCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstructorCallSite.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         internal ConstructorInfo ConstructorInfo { get; }
         internal ServiceCallSite[] ParameterCallSites { get; }
 
-        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo) : this(cache, serviceType, constructorInfo, Array.Empty<ServiceCallSite>())
+        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo, object? serviceKey) : this(cache, serviceType, constructorInfo, Array.Empty<ServiceCallSite>(), serviceKey)
         {
         }
 
-        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo, ServiceCallSite[] parameterCallSites) : base(cache)
+        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo, ServiceCallSite[] parameterCallSites, object? serviceKey) : base(cache, serviceKey)
         {
             if (!serviceType.IsAssignableFrom(constructorInfo.DeclaringType))
             {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/FactoryCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/FactoryCallSite.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     {
         public Func<IServiceProvider, object> Factory { get; }
 
-        public FactoryCallSite(ResultCache cache, Type serviceType, Func<IServiceProvider, object> factory) : base(cache)
+        public FactoryCallSite(ResultCache cache, Type serviceType, Func<IServiceProvider, object> factory) : base(cache, null)
         {
             Factory = factory;
             ServiceType = serviceType;
         }
 
-        public FactoryCallSite(ResultCache cache, Type serviceType, object serviceKey, Func<IServiceProvider, object, object> factory) : base(cache)
+        public FactoryCallSite(ResultCache cache, Type serviceType, object serviceKey, Func<IServiceProvider, object, object> factory) : base(cache, serviceKey)
         {
             Factory = sp => factory(sp, serviceKey);
             ServiceType = serviceType;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/IEnumerableCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/IEnumerableCallSite.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         internal Type ItemType { get; }
         internal ServiceCallSite[] ServiceCallSites { get; }
 
-        public IEnumerableCallSite(ResultCache cache, Type itemType, ServiceCallSite[] serviceCallSites) : base(cache)
+        public IEnumerableCallSite(ResultCache cache, Type itemType, ServiceCallSite[] serviceCallSites, object? serviceKey = null) : base(cache, serviceKey)
         {
             Debug.Assert(!ServiceProvider.VerifyAotCompatibility || !itemType.IsValueType, "If VerifyAotCompatibility=true, an IEnumerableCallSite should not be created with a ValueType.");
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCallSite.cs
@@ -10,9 +10,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     /// </summary>
     internal abstract class ServiceCallSite
     {
-        protected ServiceCallSite(ResultCache cache)
+        protected ServiceCallSite(ResultCache cache, object? key)
         {
             Cache = cache;
+            Key = key;
         }
 
         public abstract Type ServiceType { get; }
@@ -20,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public abstract CallSiteKind Kind { get; }
         public ResultCache Cache { get; }
         public object? Value { get; set; }
-        public object? Key { get; set; }
+        public object? Key { get; }
 
         public bool CaptureDisposable =>
             ImplementationType == null ||

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderCallSite.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal sealed class ServiceProviderCallSite : ServiceCallSite
     {
-        public ServiceProviderCallSite() : base(ResultCache.None(typeof(IServiceProvider)))
+        public ServiceProviderCallSite() : base(ResultCache.None(typeof(IServiceProvider)), null)
         {
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderServiceExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderServiceExtensionsTest.cs
@@ -278,6 +278,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
+        [OuterLoop] // Includes a long Task.Delay
         public async Task GetService_ReturnsGenericUnkeyedInstance_AfterUsingGetKeyedService()
         {
             // Arrange
@@ -302,6 +303,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
+        [OuterLoop] // Includes a long Task.Delay
         public async Task GetServices_ReturnsExpectedNumberOfGenericKeyedAndUnkeyedInstances_AfterUsingGetKeyedServices()
         {
             // Arrange
@@ -330,6 +332,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
+        [OuterLoop] // Includes a long Task.Delay
         public async Task GetService_ReturnsNonGenericUnkeyedInstance_AfterUsingGetKeyedService()
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderServiceExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderServiceExtensionsTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection.Tests;
 using Xunit;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -285,7 +286,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient(typeof(IGenericService<>), typeof(UnkeyedGenericService<>));
             services.AddKeyedTransient(typeof(IGenericService<>), "someKey", typeof(PrimaryKeyedGenericService<>));
 
-            await using var serviceProvider = services.BuildServiceProvider();
+            await using var serviceProvider = services.BuildServiceProvider(ServiceProviderMode.Dynamic);
 
             // Act
             _ = serviceProvider.GetKeyedService<IGenericService<object>>("someKey");
@@ -310,7 +311,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddKeyedTransient<IGenericService<object>, PrimaryKeyedGenericService<object>>("someKey");
             services.AddKeyedTransient<IGenericService<object>, SecondaryKeyedGenericService<object>>("someKey");
 
-            await using var serviceProvider = services.BuildServiceProvider();
+            await using var serviceProvider = services.BuildServiceProvider(ServiceProviderMode.Dynamic);
 
             // Act
             _ = serviceProvider.GetKeyedServices<IGenericService<object>>("someKey");
@@ -337,7 +338,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient(typeof(SomeService));
             services.AddKeyedTransient(typeof(SomeService), "someKey", typeof(SomeOtherService));
 
-            await using var serviceProvider = services.BuildServiceProvider();
+            await using var serviceProvider = services.BuildServiceProvider(ServiceProviderMode.Dynamic);
 
             // Act
             _ = serviceProvider.GetKeyedService<SomeService>("someKey");


### PR DESCRIPTION
Fix missing `ServiceCallSite.Key` causing an unkeyed cache entry to be overwritten by a keyed instance when using `DynamicServiceProviderEngine` and cover all cases (Generic ([TryCreateOpenGeneric](https://github.com/dotnet/runtime/blob/6e2274c87c699f6749473b83969f12949e48ec7d/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs#L202)) and Enumerable ([TryCreateEnumerable](https://github.com/dotnet/runtime/blob/6e2274c87c699f6749473b83969f12949e48ec7d/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs#L203)) and the basic one ([TryCreateExact](https://github.com/dotnet/runtime/blob/6e2274c87c699f6749473b83969f12949e48ec7d/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs#L201C45-L201C59)) ) with unit tests.

Fixes #111795