### PR TITLE
Add IInitializationOptions to allow developer to define the initialization of options by themselves

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/src/IInitializationOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IInitializationOptions.cs
@@ -3,8 +3,20 @@
 
 namespace Microsoft.Extensions.Options
 {
+    /// <summary>
+    /// Represents something that initialize the <typeparamref name="TOptions"/> type.
+    /// </summary>
+    /// <typeparam name="TOptions">Options type being initialized.</typeparam>
+    /// <remarks>
+    /// This is run before all <see cref="IConfigureOptions{TOptions}"/>.
+    /// </remarks>
     public interface IInitializationOptions<out TOptions> where TOptions : class
     {
+        /// <summary>
+        /// Creates a new instance of type <typeparamref name="TOptions"/>.
+        /// </summary>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
+        /// <returns>The created <typeparamref name="TOptions"/> instance.</returns>
         TOptions Initialize(string name);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/IInitializationOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IInitializationOptions.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Options
+{
+    public interface IInitializationOptions<out TOptions> where TOptions : class
+    {
+        TOptions Initialize(string name);
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Options/src/InitializationOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/InitializationOptions.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Implements <see cref="IInitializationOptions{TOptions}"/>.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type.</typeparam>
+    public class InitializationOptions<[DynamicallyAccessedMembers(Options.DynamicallyAccessedMembers)] TOptions> :
+        IInitializationOptions<TOptions>
+        where TOptions : class
+    {
+        /// <summary>
+        /// Creates a new instance of type <typeparamref name="TOptions"/>.
+        /// </summary>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
+        /// <returns>The created <typeparamref name="TOptions"/> instance.</returns>
+        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
+        public TOptions Initialize(string name)
+        {
+            return Activator.CreateInstance<TOptions>();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             ThrowHelper.ThrowIfNull(services);
 
+            services.TryAdd(ServiceDescriptor.Singleton(typeof(IInitializationOptions<>), typeof(InitializationOptions<>)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(UnnamedOptionsManager<>)));
             services.TryAdd(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(OptionsManager<>)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsMonitor<>), typeof(OptionsMonitor<>)));

--- a/src/libraries/Microsoft.Extensions.Options/src/PostConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/PostConfigureOptions.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Extensions.Options
         /// <param name="action">The action to register.</param>
         public PostConfigureOptions(string? name, Action<TOptions>? action)
         {
-            // test
             Name = name;
             Action = action;
         }

--- a/src/libraries/Microsoft.Extensions.Options/src/PostConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/PostConfigureOptions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.Options
         /// <param name="action">The action to register.</param>
         public PostConfigureOptions(string? name, Action<TOptions>? action)
         {
+            // test
             Name = name;
             Action = action;
         }


### PR DESCRIPTION
Developers can implement the interface IInitializationOptions and defined the action of initializing options by themselves.