### PR TITLE
Fix stack overflow caused by very deep parent/child Task chains

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2141,10 +2141,10 @@ namespace System.Threading.Tasks
 
         internal void NotifyParentIfPotentiallyAttachedTask()
         {
-            if (Interlocked.Increment(ref s_notificationDepth) > MaxNotificationDepth)
+            if (++s_notificationDepth > MaxNotificationDepth)
             {
                 if (TplEventSource.Log.IsEnabled()) TplEventSource.Log.Write("TaskNotifyParentIfChildComplete: Notification recursion detected and limited at depth " + s_notificationDepth);
-                Interlocked.Decrement(ref s_notificationDepth);
+                --s_notificationDepth;
                 return;
             }
 
@@ -2164,7 +2164,7 @@ namespace System.Threading.Tasks
             }
             finally
             {
-                Interlocked.Decrement(ref s_notificationDepth);
+                --s_notificationDepth;
             }
         }
 


### PR DESCRIPTION
Defensive code has been added to prevent a stack oferflow recursion involving the call chain FinishStageTwo->FinishStageThree->NotifyParentIfPotentiallyAttachedTask->ProcessChildCompletion->FinishStageTwo.

Tests revealed that the recursion counter did easily get greater than 100, but the current 500 limit was never reached.

Amend is not final and requires someone with better knowledge of the platform to codify the correct fix.
Due to emergency situation, we had to create this patch.

#113189