### PR TITLE
JIT: Don't skip non-funclet try regions with handlers in `fgFindTryRegionEnds`

### DIFF
--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -1339,8 +1339,8 @@ void Compiler::fgFindTryRegionEnds()
     // Null out try end pointers to signify the given clause hasn't been visited yet.
     for (EHblkDsc* const HBtab : EHClauses(this))
     {
-        // Ignore try regions inside handler regions.
-        if (!HBtab->ebdTryLast->hasHndIndex())
+        // Ignore try regions inside funclet regions.
+        if (!UsesFunclets() || !HBtab->ebdTryLast->hasHndIndex())
         {
             HBtab->ebdTryLast = nullptr;
             unsetTryEnds++;


### PR DESCRIPTION
Fixes #113417 ([comment](https://github.com/dotnet/runtime/issues/113417#issuecomment-2718580254)).