### PR TITLE
ILLink: Fix instantiation tracking bug with `[Intrinsic]` methods.

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Interop.IntrinsicTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Interop.IntrinsicTests.g.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests.Interop
+{
+	public sealed partial class IntrinsicTests : LinkerTestBase
+	{
+
+		protected override string TestSuiteName => "Interop.Intrinsic";
+
+		[Fact]
+		public Task OutTypesAreMarkedInstantiated ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/Intrinsic/OutTypesAreMarkedInstantiated.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/Intrinsic/OutTypesAreMarkedInstantiated.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Interop.Intrinsic;
+
+public class OutTypesAreMarkedInstantiated
+{
+	public static void Main ()
+	{
+		FooRefParameter refParmaeter = null;
+		FakeIntrinsicMethod (null, ref refParmaeter, out FooOutParameter outParameter);
+		UsedToMarkMethods (null, null, null, null);
+	}
+
+	[Kept]
+	[KeptAttributeAttribute (typeof(IntrinsicAttribute))]
+	[Intrinsic]
+	public static FooReturn FakeIntrinsicMethod (FooNormalParameter normal, ref FooRefParameter @ref, out FooOutParameter @out)
+	{
+		@out = null;
+		return null;
+	}
+
+	[Kept]
+	static void UsedToMarkMethods (FooReturn f, FooNormalParameter n, FooRefParameter r, FooOutParameter o)
+	{
+		f.Method ();
+		n.Method ();
+		r.Method ();
+		o.Method ();
+	}
+}
+
+public class FooReturn
+{
+	// This method should not have it's body modified because the linker should consider it as instantiated
+	[Kept]
+	public void Method ()
+	{
+		throw new System.NotImplementedException ();
+	}
+}
+
+public class FooOutParameter
+{
+	// This method should not have it's body modified because the linker should consider it as instantiated
+	[Kept]
+	public void Method ()
+	{
+		throw new System.NotImplementedException ();
+	}
+}
+
+public class FooRefParameter
+{
+	// This method should not have it's body modified because the linker should consider it as instantiated
+	[Kept]
+	public void Method ()
+	{
+		throw new System.NotImplementedException ();
+	}
+}
+
+public class FooNormalParameter
+{
+	[Kept]
+	// This parameter will not be marked as instantiated because it is not an out or ref parameter.  This will lead to the linker applying the
+	// unreachable bodies optimization
+	[ExpectBodyModified]
+	public void Method ()
+	{
+		throw new System.NotImplementedException ();
+	}
+}


### PR DESCRIPTION
I found it while getting the linker tests running on a mono based .NET 8 BCL build.  The following test code
```
    public static void Main ()
    {
        Helper(null);
    }
    [Kept]
    static void Helper (object[] maybetypes)
    {
        Type[] types = new Type[] { maybetypes[0] as Type };
    }
```
Will have `Helper` modified to be essentially
```
Type[] types = new Type[] { null };
```
What's happening is, `System.Type` is not marked as instantied which leads to `ProcessPendingTypeChecks` kicking in.  This problem doesn't happen with a normal CoreCLR .NET 8 BCL.  Here's why. With CoreCLR, `System.Object` has
```
[MethodImpl(MethodImplOptions.InternalCall)]
[Intrinsic]
public extern Type GetType();
```
The icall flag leads to `ProcessInteropMethod` being called.  Which will then mark the default constructor of the return type, which then leads to `System.Type` being marked as instantiated. With the mono based BCL, `GetType` looks like
```
    [Intrinsic]
    public Type GetType()
    {
        return GetType();
    }
```

The fix is to have the linker record the return type and any out parameters as instantiated.