### PR TITLE
Host: fix Cancellation not aborting Start in some cases

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -338,6 +338,10 @@ namespace Microsoft.Extensions.Hosting.Internal
                         {
                             exceptions.AddRange(task.Exception.InnerExceptions); // Log exception from async method.
                         }
+                        else if (task.IsCanceled)
+                        {
+                            exceptions.Add(new TaskCanceledException(task));
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #113495 

If `ServicesStartConcurrently` is enabled and a hosted service returns an already completed, cancelled task in e.g. `StartAsync`, this is currently ignored by the host and startup is not aborted.

Fix this by adding a `TaskCanceledException` to the exception list in this case.