### PR TITLE
Remove FileExtensionSignInfos for .deb, .rpm, & .pkg

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -58,16 +58,6 @@
     <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="3PartySHA2" />
 
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
-
-    <!--
-      Removal is temporarily needed as we integrate support for these extensions into SignTool.
-      Should be cleaned up after https://github.com/dotnet/arcade/issues/14432,
-      https://github.com/dotnet/arcade/issues/14433, and
-      https://github.com/dotnet/arcade/issues/14435 are completed.
-     -->
-    <FileExtensionSignInfo Remove=".deb;.rpm;.pkg" />
-    <FileExtensionSignInfo Include=".pkg" CertificateName="8003" />
-    <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
`LinuxSign` is the default for debs and rpms, and MacDeveloper should be used for pkgs.

See [arcade defaults](https://github.com/dotnet/arcade/blob/ea4e870f76d853a521cda6067d30245d42b31402/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props#L79-L96)