### PR TITLE
Fix double dispose of GCHandle in BrowserWebSocket

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -550,13 +550,12 @@ namespace System.Net.WebSockets
             }
         }
 
-        private async Task CancellationHelper(Task promise, CancellationToken cancellationToken, WebSocketState previousState, IDisposable? disposable = null)
+        private async Task CancellationHelper(Task promise, CancellationToken cancellationToken, WebSocketState previousState)
         {
             try
             {
                 if (promise.IsCompletedSuccessfully)
                 {
-                    disposable?.Dispose();
                     return;
                 }
                 if (promise.IsCompleted)
@@ -601,10 +600,6 @@ namespace System.Net.WebSockets
                     }
                     throw new WebSocketException(WebSocketError.NativeError, ex);
                 }
-            }
-            finally
-            {
-                disposable?.Dispose();
             }
         }
 

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -399,7 +399,7 @@ namespace System.Net.WebSockets
 
                 if (sendTask != null)  // this is optimization for single-threaded build, see resolvedPromise() in web-socket.ts. Null means synchronously resolved.
                 {
-                    await CancellationHelper(sendTask, cancellationToken, previousState, pinBuffer).ConfigureAwait(false);
+                    await CancellationHelper(sendTask, cancellationToken, previousState).ConfigureAwait(false);
                 }
             }
             catch (JSException ex)
@@ -442,7 +442,7 @@ namespace System.Net.WebSockets
 
                 if (receiveTask != null)  // this is optimization for single-threaded build, see resolvedPromise() in web-socket.ts. Null means synchronously resolved.
                 {
-                    await CancellationHelper(receiveTask, cancellationToken, previousState, pinBuffer).ConfigureAwait(false);
+                    await CancellationHelper(receiveTask, cancellationToken, previousState).ConfigureAwait(false);
                 }
 
                 return ConvertResponse();


### PR DESCRIPTION
MemoryHandle is a struct, so passing it into an IDisposable parameter creates a box. This causes two copies of GCHandle to exist which are no longer synchronized and can be double disposed.

This happened when passing pinBuffer into CancellationHelper in ReceiveAsyncCore and SendAsyncCore. In both cases the caller does the Dispose itself inside a finally, so there's no need to pass the pinBuffer to CancellationHelper at all.