### PR TITLE
[release/8.0-staging] [HttpStress] [SslStress] Run stress tests nightly against staging branches 

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -8,12 +8,11 @@ pr:
 schedules:
 - cron: "0 13 * * *" # 1PM UTC => 5 AM PST
   displayName: HttpStress nightly run
+  always: true
   branches:
     include:
     - main
-    - release/6.0
-    - release/7.0
-    - release/8.0
+    - release/*-staging
 
 variables:
   - template: ../variables.yml

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -8,12 +8,11 @@ pr:
 schedules:
 - cron: "0 13 * * *" # 1PM UTC => 5 AM PST
   displayName: SslStress nightly run
+  always: true
   branches:
     include:
     - main
-    - release/6.0
-    - release/7.0
-    - release/8.0
+    - release/*-staging
 
 variables:
   - template: ../variables.yml


### PR DESCRIPTION
Backport of #113432 to release/8.0-staging

Contributes to #113372.

/cc @antonfirsov

## Customer Impact

N/A Test-only change

## Regression

N/A Test-only change

## Testing

This change is needed to ensure HttpStress and SslStress run nightly against `release/9.0-staging`.

## Risk

None. Test-only change