### PR TITLE
Disable some named synchronization object tests on Windows Server Core

### DIFF
--- a/src/libraries/System.Threading/tests/EventWaitHandleTests.cs
+++ b/src/libraries/System.Threading/tests/EventWaitHandleTests.cs
@@ -260,7 +260,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Windows Nano Server apparently uses the same namespace for the Local\ and Global\ prefixes
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // Windows Nano Server and Server Core apparently use the same namespace for the Local\ and Global\ prefixes
         [MemberData(nameof(MutexTests.NameNamespaceTests_MemberData), MemberType = typeof(MutexTests))]
         [PlatformSpecific(TestPlatforms.Windows)] // names aren't supported on Unix
         public void NameNamespaceTest(

--- a/src/libraries/System.Threading/tests/MutexTests.cs
+++ b/src/libraries/System.Threading/tests/MutexTests.cs
@@ -476,7 +476,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Windows Nano Server apparently uses the same namespace for the Local\ and Global\ prefixes
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // Windows Nano Server and Server Core apparently use the same namespace for the Local\ and Global\ prefixes
         [MemberData(nameof(NameNamespaceTests_MemberData))]
         public void NameNamespaceTest(
             bool create_currentUserOnly,

--- a/src/libraries/System.Threading/tests/SemaphoreTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreTests.cs
@@ -493,7 +493,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Windows Nano Server apparently uses the same namespace for the Local\ and Global\ prefixes
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // Windows Nano Server and Server Core apparently use the same namespace for the Local\ and Global\ prefixes
         [MemberData(nameof(MutexTests.NameNamespaceTests_MemberData), MemberType = typeof(MutexTests))]
         [PlatformSpecific(TestPlatforms.Windows)] // names aren't supported on Unix
         public void NameNamespaceTest(


### PR DESCRIPTION
The new failing tests were added in https://github.com/dotnet/runtime/pull/112213. It looks like Windows Server Core also does not use different namespaces for local and global named synchronization objects.