### PR TITLE
[release/9.0-staging] Use minipal_getcpufeatures to detect for AVX (#113032)

### DIFF
--- a/src/coreclr/gc/CMakeLists.txt
+++ b/src/coreclr/gc/CMakeLists.txt
@@ -93,6 +93,10 @@ if(CLR_CMAKE_TARGET_ARCH_AMD64)
     list(APPEND GC_LINK_LIBRARIES
         gc_vxsort
     )
+    list(APPEND GC_SOURCES
+      ${CLR_SRC_NATIVE_DIR}/minipal/cpufeatures.c
+    )
+    include(${CLR_SRC_NATIVE_DIR}/minipal/configure.cmake)
 endif(CLR_CMAKE_TARGET_ARCH_AMD64)
 
 

--- a/src/coreclr/gc/sample/CMakeLists.txt
+++ b/src/coreclr/gc/sample/CMakeLists.txt
@@ -36,6 +36,7 @@ if (CLR_CMAKE_TARGET_ARCH_AMD64 AND CLR_CMAKE_TARGET_WIN32)
     ../vxsort/smallsort/bitonic_sort.AVX512.int64_t.generated.cpp
     ../vxsort/smallsort/bitonic_sort.AVX512.int32_t.generated.cpp
     ../vxsort/smallsort/avx2_load_mask_tables.cpp
+    ${CLR_SRC_NATIVE_DIR}/minipal/cpufeatures.c
 )
 endif (CLR_CMAKE_TARGET_ARCH_AMD64 AND CLR_CMAKE_TARGET_WIN32)
 


### PR DESCRIPTION
Backport of # to release/9.0-staging

/cc @cshung

## Customer Impact

@Typhon226 reported on #112897 that, on some machines, buggy behavior in `__builtin_cpu_supports` for Unix platforms could lie to us that it supports AVX512 when it doesn't. This could lead to runtime crashes.

## Regression

- [x] Yes
- [ ] No

The regression was introduced in PR #98712, commit 68cf2dd23a0d64bfb59ffc418ed53a856f7c965a when I enabled VxSort for unix platforms, but this is not the root cause.

## Testing

Local testing is done on various machines, but none of them hit the  `__builtin_cpu_supports` buggy behavior, so it worked both before and after the changes.
https://github.com/dotnet/runtime/pull/113032#issuecomment-2695967106

Customer testing is done on the machines that hit the issue, and the fixed version works as expected, for both https://github.com/dotnet/runtime/issues/112897#issuecomment-2728479871 (9.0 binaries) and https://github.com/dotnet/runtime/issues/112897#issuecomment-2720061622 (10.0 binaries)

## Risk

The risk is low, the same function is used by the JIT to determine if the CPU supports AVX512. 