### PR TITLE
JIT: Re-introduce late `fgOptimizeBranch` pass

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2412,6 +2412,18 @@ PhaseStatus Compiler::optOptimizePreLayout()
         modified |= fgExpandRarelyRunBlocks();
     }
 
+    // Run a late pass of unconditional-to-conditional branch optimization, skipping handler blocks.
+    for (BasicBlock* block = fgFirstBB; block != fgFirstFuncletBB; block = block->Next())
+    {
+        if (!UsesFunclets() && block->hasHndIndex())
+        {
+            block = ehGetDsc(block->getHndIndex())->ebdHndLast;
+            continue;
+        }
+
+        modified |= fgOptimizeBranch(block);
+    }
+
     return modified ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
 


### PR DESCRIPTION
Part of #107749. `fgReorderBlocks` runs `fgOptimizeBranch` when it decides not to reorder a particular block. Turning off the old layout in favor of RPO layout in .NET 9 had the unintended consequence of also disabling the later `fgOptimizeBranch` pass the JIT used to do. After finding cases in #113108 ([comment](https://github.com/dotnet/runtime/issues/113108#issuecomment-2722492800)) that benefit from cloning and hoisting loop tests, I decided to reintroduce this late pass. These regressions also highlight that `fgOptimizeBranch` can create compaction opportunities inside loop bodies that we don't currently take advantage of; I've added a check to handle this.