### PR TITLE
Allow specifying SDK search paths in global.json

### DIFF
--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -60,6 +60,11 @@
       File="$(OutDir)TestContextVariables.txt"
       Overwrite="true"
       Lines="@(TestContextVariable)" />
+
+    <WriteLinesToFile
+      File="$(OutDir)global.json"
+      Lines="{}"
+      WriteOnlyWhenDifferent="true" />
   </Target>
 
   <Target Name="DetermineTestOutputDirectory">

--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -61,6 +61,7 @@
       Overwrite="true"
       Lines="@(TestContextVariable)" />
 
+    <!-- Write an empty global.json to the output, such that running the test -->
     <WriteLinesToFile
       File="$(OutDir)global.json"
       Lines="{}"

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -451,7 +451,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Expected: no SDKs found
             RunTest()
                 .Should().Fail()
-                .And.FindAnySdk(false);
+                .And.FindAnySdk(false)
+                .And.HaveStdErrContaining($"Empty search paths specified in global.json file: {globalJsonPath}");
 
             sdk.Paths = [ GlobalJson.HostSdkPath ];
             globalJsonPath = GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -453,7 +453,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Should().Fail()
                 .And.FindAnySdk(false);
 
-            sdk.Paths = [ "$host$" ];
+            sdk.Paths = [ GlobalJson.HostSdkPath ];
             globalJsonPath = GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
 
             // Paths: $host$
@@ -483,7 +483,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             using TestArtifact custom = TestArtifact.Create("sdkPath");
             AddSdkToCustomPath(custom.Location, "9999.0.0");
 
-            GlobalJson.Sdk sdk = new() { Paths = [ custom.Location, "$host$" ] };
+            GlobalJson.Sdk sdk = new() { Paths = [ custom.Location, GlobalJson.HostSdkPath ] };
             GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
 
             // Add SDK versions
@@ -542,7 +542,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             AddSdkToCustomPath(custom2.Location, "9999.0.2");
             AddAvailableSdkVersions("9999.0.1");
 
-            GlobalJson.Sdk sdk = new() { Version = "9999.0.1", Paths = [ custom1.Location, custom2.Location, "$host$" ] };
+            GlobalJson.Sdk sdk = new() { Version = "9999.0.1", Paths = [ custom1.Location, custom2.Location, GlobalJson.HostSdkPath ] };
             GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
 
             // Specified SDK
@@ -562,6 +562,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOutContaining($"9999.0.0 [{custom1.Location}")
                 .And.HaveStdOutContaining($"9999.0.2 [{custom2.Location}")
                 .And.HaveStdOutContaining($"9999.0.1 [{ExecutableDotNet.BinPath}");
+        }
+
+        [Fact]
+        public void GlobalJson_ErrorMessage()
+        {
+            GlobalJson.Sdk sdk = new() { ErrorMessage = "Custom SDK resolution error" };
+            GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
+
+            RunTest()
+                .Should().Fail()
+                .And.HaveStdErrContaining(sdk.ErrorMessage);
         }
 
         public static IEnumerable<object[]> InvalidGlobalJsonData

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void SdkLookup_Global_Json_Single_Digit_Patch_Rollup()
+        public void GlobalJson_SingleDigitPatch()
         {
             // Set specified SDK version = 9999.3.4-global-dummy
             string requestedVersion = "9999.3.4-global-dummy";
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void SdkLookup_Global_Json_Two_Part_Patch_Rollup()
+        public void GlobalJson_TwoPartPatch()
         {
             // Set specified SDK version = 9999.3.304-global-dummy
             string requestedVersion = "9999.3.304-global-dummy";
@@ -226,7 +226,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void SdkLookup_Negative_Version()
+        public void NegativeVersion()
         {
             GlobalJson.CreateEmpty(SharedState.CurrentWorkingDir);
 
@@ -257,7 +257,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void SdkLookup_Must_Pick_The_Highest_Semantic_Version()
+        public void PickHighestSemanticVersion()
         {
             GlobalJson.CreateEmpty(SharedState.CurrentWorkingDir);
 
@@ -355,7 +355,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [InlineData("Latestfeature")]
         [InlineData("latestMINOR")]
         [InlineData("latESTMajor")]
-        public void It_allows_case_insensitive_roll_forward_policy_names(string rollForward)
+        public void RollForwardPolicy_CaseInsensitive(string rollForward)
         {
             const string Requested = "9999.0.100";
             AddAvailableSdkVersions(Requested);
@@ -369,7 +369,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
         [Theory]
         [MemberData(nameof(InvalidGlobalJsonData))]
-        public void It_falls_back_to_latest_sdk_for_invalid_global_json(string globalJsonContents, string[] messages)
+        public void InvalidGlobalJson_FallsBackToLatestSdk(string globalJsonContents, string[] messages)
         {
             AddAvailableSdkVersions("9999.0.100", "9999.0.300-dummy.9", "9999.1.402");
 
@@ -387,7 +387,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
         [Theory]
         [MemberData(nameof(SdkRollForwardData))]
-        public void It_rolls_forward_as_expected(string policy, string requested, bool allowPrerelease, string expected, string[] installed)
+        public void RollForward(string policy, string requested, bool allowPrerelease, string expected, string[] installed)
         {
             AddAvailableSdkVersions(installed);
 
@@ -409,7 +409,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void It_uses_latest_stable_sdk_if_allow_prerelease_is_false()
+        public void AllowPrereleaseFalse_UseLatestRelease()
         {
             var installed = new string[] {
                     "9999.1.702",
@@ -435,6 +435,120 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var result = RunTest()
                 .Should().Pass()
                 .And.HaveStdErrContaining($"SDK path resolved to [{Path.Combine(ExecutableDotNet.BinPath, "sdk", ExpectedVersion)}]");
+        }
+
+        [Fact]
+        public void GlobalJson_Paths()
+        {
+            GlobalJson.Sdk sdk = new() { Paths = [] };
+            string globalJsonPath = GlobalJson.Write(SharedState.CurrentWorkingDir, sdk );
+
+            // Add SDK versions
+            AddAvailableSdkVersions("9999.0.4");
+
+            // Paths: none
+            // Exe: 9999.0.4
+            // Expected: no SDKs found
+            RunTest()
+                .Should().Fail()
+                .And.FindAnySdk(false);
+
+            sdk.Paths = [ "$host$" ];
+            globalJsonPath = GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
+
+            // Paths: $host$
+            // Exe: 9999.0.4
+            // Expected: 9999.0.4 from exe dir
+            RunTest()
+                .Should().Pass()
+                .And.HaveStdErrContaining(ExpectedResolvedSdkOutput("9999.0.4"));
+
+            using TestArtifact custom = TestArtifact.Create("sdkPath");
+            AddSdkToCustomPath(custom.Location, "9999.0.4");
+            sdk.Paths = [ custom.Location ];
+            globalJsonPath = GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
+
+            // Paths: custom
+            // Custom: 9999.0.4
+            // Exe: 9999.0.4
+            // Expected: 9999.0.4 from custom dir
+            RunTest()
+                .Should().Pass()
+                .And.HaveStdErrContaining(ExpectedResolvedSdkOutput("9999.0.4", custom.Location));
+        }
+
+        [Fact]
+        public void GlobalJson_Paths_Multiple()
+        {
+            using TestArtifact custom = TestArtifact.Create("sdkPath");
+            AddSdkToCustomPath(custom.Location, "9999.0.0");
+
+            GlobalJson.Sdk sdk = new() { Paths = [ custom.Location, "$host$" ] };
+            GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
+
+            // Add SDK versions
+            AddAvailableSdkVersions("9999.0.4");
+
+            // Specified SDK
+            //   version: none
+            //   paths: custom, $host$
+            // Custom: 9999.0.0
+            // Exe: 9999.0.4
+            // Expected: 9999.0.0 from custom dir
+            RunTest()
+                .Should().Pass()
+                .And.HaveStdErrContaining(ExpectedResolvedSdkOutput("9999.0.0", custom.Location));
+
+            sdk.Version = "9999.0.3";
+            GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
+
+            // Specified SDK
+            //   version: 9999.0.3
+            //   paths: custom, $host$
+            // Custom: 9999.0.0
+            // Exe: 9999.0.4
+            // Expected: 9999.0.4 from exe dir
+            RunTest()
+                .Should().Pass()
+                .And.HaveStdErrContaining(ExpectedResolvedSdkOutput("9999.0.4"));
+
+            sdk.Version = "9999.0.5";
+            string globalJsonPath = GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
+
+            // Specified SDK
+            //   version: 9999.0.5
+            //   paths: custom, $host$
+            // Custom: 9999.0.0
+            // Exe: 9999.0.4
+            // Expected: no compatible version
+            RunTest()
+                .Should().Fail()
+                .And.NotFindCompatibleSdk(globalJsonPath, sdk.Version)
+                .And.FindAnySdk(true);
+        }
+
+        [Fact]
+        public void GlobalJson_Paths_FirstMatch()
+        {
+            using TestArtifact custom1 = TestArtifact.Create("sdkPath1");
+            AddSdkToCustomPath(custom1.Location, "9999.0.0");
+            using TestArtifact custom2 = TestArtifact.Create("sdkPath2");
+            AddSdkToCustomPath(custom2.Location, "9999.0.2");
+            AddAvailableSdkVersions("9999.0.1");
+
+            GlobalJson.Sdk sdk = new() { Version = "9999.0.1", Paths = [ custom1.Location, custom2.Location, "$host$" ] };
+            GlobalJson.Write(SharedState.CurrentWorkingDir, sdk);
+
+            // Specified SDK
+            //   version: none
+            //   paths: custom1, custom2, $host$
+            // Custom1: 9999.0.0
+            // Custom2: 9999.0.2
+            // Exe: 9999.0.1
+            // Expected: 9999.0.2 from custom2 - first match is used, not best match (which would be exe which is an exact match)
+            RunTest()
+                .Should().Pass()
+                .And.HaveStdErrContaining(ExpectedResolvedSdkOutput("9999.0.2", custom2.Location));
         }
 
         public static IEnumerable<object[]> InvalidGlobalJsonData
@@ -472,7 +586,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 // Use an invalid version value
                 yield return new object[] {
-                    GlobalJson.FormatVersionSettings(version: "invalid"),
+                    GlobalJson.FormatSettings(new GlobalJson.Sdk() { Version = "invalid" }),
                     new[] {
                         "Version 'invalid' is not valid for the 'sdk/version' value",
                         IgnoringSDKSettings
@@ -490,7 +604,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 // Use a policy but no version
                 yield return new object[] {
-                    GlobalJson.FormatVersionSettings(policy: "latestPatch"),
+                    GlobalJson.FormatSettings(new GlobalJson.Sdk() { RollForward = "latestPatch" }),
                     new[] {
                         "The roll-forward policy 'latestPatch' requires a 'sdk/version' value",
                         IgnoringSDKSettings
@@ -499,7 +613,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 // Use an invalid policy value
                 yield return new object[] {
-                    GlobalJson.FormatVersionSettings(policy: "invalid"),
+                    GlobalJson.FormatSettings(new GlobalJson.Sdk() { RollForward = "invalid" }),
                     new[] {
                         "The roll-forward policy 'invalid' is not supported for the 'sdk/rollForward' value",
                         IgnoringSDKSettings
@@ -517,7 +631,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 // Use a prerelease version and allowPrerelease = false
                 yield return new object[] {
-                    GlobalJson.FormatVersionSettings(version: "9999.1.402-preview1", allowPrerelease: false),
+                    GlobalJson.FormatSettings(new GlobalJson.Sdk() { Version = "9999.1.402-preview1", AllowPrerelease = false }),
                     new[] { "Ignoring the 'sdk/allowPrerelease' value" }
                 };
             }
@@ -992,6 +1106,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             }
         }
 
+        private static void AddSdkToCustomPath(string sdkRoot, string version)
+        {
+            DotNetBuilder.AddMockSDK(sdkRoot, version, version);
+
+            // Add a mock framework matching the runtime version for the mock SDK
+            // This allows the host to successfully resolve frameworks for the SDK at the custom location
+            DotNetBuilder.AddMicrosoftNETCoreAppFrameworkMockHostPolicy(sdkRoot, version);
+        }
+
         // This method adds a list of new sdk version folders in the specified directory.
         // The actual contents are 'fake' and the minimum required for SDK discovery.
         // The dotnet.runtimeconfig.json created uses a dummy framework version (9999.0.0)
@@ -1003,8 +1126,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             }
         }
 
-        private string ExpectedResolvedSdkOutput(string expectedVersion)
-            => Path.Combine("Using .NET SDK dll=[", ExecutableDotNet.BinPath, "sdk", expectedVersion, "dotnet.dll]");
+        private string ExpectedResolvedSdkOutput(string expectedVersion, string rootPath = null)
+            => $"Using .NET SDK dll=[{Path.Combine(rootPath == null ? ExecutableDotNet.BinPath : rootPath, "sdk", expectedVersion, "dotnet.dll")}]";
 
         private CommandResult RunTest() => RunTest("help");
 

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -525,6 +525,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Should().Fail()
                 .And.NotFindCompatibleSdk(globalJsonPath, sdk.Version)
                 .And.FindAnySdk(true);
+
+            // Verify we have the expected SDK versions
+            RunTest("--list-sdks")
+                .Should().Pass()
+                .And.HaveStdOutContaining($"9999.0.0 [{custom.Location}")
+                .And.HaveStdOutContaining($"9999.0.4 [{ExecutableDotNet.BinPath}");
         }
 
         [Fact]
@@ -549,6 +555,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             RunTest()
                 .Should().Pass()
                 .And.HaveStdErrContaining(ExpectedResolvedSdkOutput("9999.0.2", custom2.Location));
+
+            // Verify we have the expected SDK versions
+            RunTest("--list-sdks")
+                .Should().Pass()
+                .And.HaveStdOutContaining($"9999.0.0 [{custom1.Location}")
+                .And.HaveStdOutContaining($"9999.0.2 [{custom2.Location}")
+                .And.HaveStdOutContaining($"9999.0.1 [{ExecutableDotNet.BinPath}");
         }
 
         public static IEnumerable<object[]> InvalidGlobalJsonData

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -487,7 +487,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Expected: 9999.0.4 from custom dir
             RunTest()
                 .Should().Pass()
-                .And.HaveStdErrContaining(ExpectedResolvedSdkOutput("9999.0.4", Path.Combine(SharedState.CurrentWorkingDir, relativePath)));
+                .And.HaveStdErrContaining(ExpectedResolvedSdkOutput("9999.0.4", custom.Location));
 
             string underCurrent = SharedState.CurrentWorkingDirArtifact.GetUniqueSubdirectory("sdkPath");
             AddSdkToCustomPath(underCurrent, "9999.0.4");

--- a/src/installer/tests/TestUtils/DotNetBuilder.cs
+++ b/src/installer/tests/TestUtils/DotNetBuilder.cs
@@ -49,16 +49,27 @@ namespace Microsoft.DotNet.CoreSetup.Test
         /// </remarks>
         public DotNetBuilder AddMicrosoftNETCoreAppFrameworkMockHostPolicy(string version)
         {
+            AddMicrosoftNETCoreAppFrameworkMockHostPolicy(_path, version);
+            return this;
+        }
+
+        /// <summary>
+        /// Add a mock of the Microsoft.NETCore.App framework with the specified version to the specified directory
+        /// </summary>
+        /// <param name="version">Version to add</param>
+        /// <remarks>
+        /// Product runtime binaries are not added. All the added mock framework will contain is a mock version of host policy.
+        /// </remarks>
+        public static void AddMicrosoftNETCoreAppFrameworkMockHostPolicy(string directory, string version)
+        {
             // ./shared/Microsoft.NETCore.App/<version> - create a mock of the root framework
-            string netCoreAppPath = AddFramework(Constants.MicrosoftNETCoreApp, version);
+            string netCoreAppPath = AddFramework(directory, Constants.MicrosoftNETCoreApp, version);
 
             // ./shared/Microsoft.NETCore.App/<version>/hostpolicy.dll - this is a mock, will not actually load CoreCLR
             File.Copy(
                 Binaries.HostPolicy.MockPath,
                 Path.Combine(netCoreAppPath, Binaries.HostPolicy.FileName),
                 true);
-
-            return this;
         }
 
         /// <summary>
@@ -175,7 +186,16 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string sdkVersion,
             string runtimeVersion)
         {
-            string path = Path.Combine(_path, "sdk", sdkVersion);
+            AddMockSDK(_path, sdkVersion, runtimeVersion);
+            return this;
+        }
+
+        public static void AddMockSDK(
+            string directory,
+            string sdkVersion,
+            string runtimeVersion)
+        {
+            string path = Path.Combine(directory, "sdk", sdkVersion);
             Directory.CreateDirectory(path);
 
             using var _ = File.Create(Path.Combine(path, "dotnet.dll"));
@@ -183,12 +203,13 @@ namespace Microsoft.DotNet.CoreSetup.Test
             RuntimeConfig dotnetRuntimeConfig = new RuntimeConfig(Path.Combine(path, "dotnet.runtimeconfig.json"));
             dotnetRuntimeConfig.WithFramework(new RuntimeConfig.Framework("Microsoft.NETCore.App", runtimeVersion));
             dotnetRuntimeConfig.Save();
-
-            return this;
         }
 
+        private string AddFramework(string name, string version)
+            => AddFramework(_path, name, version);
+
         /// <summary>
-        /// Add a minimal mock framework with the specified framework name and version
+        /// Add a minimal mock framework with the specified framework name and version to the specified directory
         /// </summary>
         /// <param name="name">Framework name</param>
         /// <param name="version">Framework version</param>
@@ -196,10 +217,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
         /// <remarks>
         /// The added mock framework will only contain a deps.json.
         /// </remarks>
-        private string AddFramework(string name, string version)
+        private static string AddFramework(string directory, string name, string version)
         {
             // ./shared/<name>/<version> - create a mock of effectively the framework
-            string path = Path.Combine(_path, "shared", name, version);
+            string path = Path.Combine(directory, "shared", name, version);
             Directory.CreateDirectory(path);
 
             // ./shared/<name>/<version>/<name>.deps.json - empty file

--- a/src/installer/tests/TestUtils/GlobalJson.cs
+++ b/src/installer/tests/TestUtils/GlobalJson.cs
@@ -27,6 +27,8 @@ namespace Microsoft.DotNet.TestUtils
             public string ErrorMessage { get; set; }
         }
 
+        public const string HostSdkPath = "$host$";
+
         public static string CreateEmpty(string directory)
             => Write(directory, "{}");
 

--- a/src/installer/tests/TestUtils/GlobalJson.cs
+++ b/src/installer/tests/TestUtils/GlobalJson.cs
@@ -2,30 +2,42 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.DotNet.TestUtils
 {
     public static class GlobalJson
     {
+        public class Sdk
+        {
+            [JsonPropertyName("version")]
+            public string Version { get; set; }
+
+            [JsonPropertyName("rollForward")]
+            public string RollForward { get; set; }
+
+            [JsonPropertyName("allowPrerelease")]
+            public bool? AllowPrerelease { get; set; }
+
+            [JsonPropertyName("paths")]
+            public string[] Paths { get; set; }
+
+            [JsonPropertyName("errorMessage")]
+            public string ErrorMessage { get; set; }
+        }
+
         public static string CreateEmpty(string directory)
             => Write(directory, "{}");
 
         public static string CreateWithVersion(string directory, string version)
-            => Write(directory, @$"{{ ""sdk"": {{ ""version"": ""{version}"" }} }}");
+            => Write(directory, new Sdk { Version = version });
 
         public static string CreateWithVersionSettings(string directory, string version = null, string policy = null, bool? allowPrerelease = null)
-            => Write(directory, FormatVersionSettings(version, policy, allowPrerelease));
+            => Write(directory, new Sdk { Version = version, RollForward = policy, AllowPrerelease = allowPrerelease });
 
-        public static string FormatVersionSettings(string version = null, string policy = null, bool? allowPrerelease = null)
-            => $$"""
-                {
-                    "sdk": {
-                        "version": {{(version != null ? $"\"{version}\"" : "null")}},
-                        "rollForward": {{(policy != null ? $"\"{policy}\"" : "null")}},
-                        "allowPrerelease": {{(allowPrerelease.HasValue ? $"{allowPrerelease.Value.ToString().ToLowerInvariant()}" : "null")}}
-                    }
-                }
-                """;
+        public static string FormatSettings(Sdk sdk)
+            => JsonSerializer.Serialize(new { sdk = sdk }, new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault });
 
         public static string Write(string directory, string contents)
         {
@@ -34,5 +46,7 @@ namespace Microsoft.DotNet.TestUtils
             return file;
         }
 
+        public static string Write(string directory, Sdk sdk)
+            => Write(directory, FormatSettings(sdk));
     }
 }

--- a/src/installer/tests/TestUtils/TestContext.cs
+++ b/src/installer/tests/TestUtils/TestContext.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.TestUtils;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
@@ -44,6 +45,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
             TestAssetsOutput = GetTestContextVariable("TEST_ASSETS_OUTPUT");
             TestArtifactsPath = GetTestContextVariable("TEST_ARTIFACTS");
             Directory.CreateDirectory(TestArtifactsPath);
+
+            // Create an empty global.json, so running tests from test artifacts is not affected
+            // by any global.json in parent directiers
+            GlobalJson.CreateEmpty(TestArtifactsPath);
 
             BuiltDotNet = new DotNetCli(Path.Combine(TestAssetsOutput, "sharedFrameworkPublish"));
         }

--- a/src/native/corehost/fxr/framework_info.cpp
+++ b/src/native/corehost/fxr/framework_info.cpp
@@ -39,7 +39,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
     std::vector<framework_info>* framework_infos)
 {
     std::vector<pal::string_t> hive_dir;
-    get_framework_and_sdk_locations(own_dir, disable_multilevel_lookup, &hive_dir);
+    get_framework_locations(own_dir, disable_multilevel_lookup, &hive_dir);
 
     int32_t hive_depth = 0;
 

--- a/src/native/corehost/fxr/fx_resolver.cpp
+++ b/src/native/corehost/fxr/fx_resolver.cpp
@@ -203,7 +203,7 @@ namespace
             fx_ref.get_fx_name().c_str(), fx_ref.get_fx_version().c_str());
 
         std::vector<pal::string_t> hive_dir;
-        get_framework_and_sdk_locations(dotnet_dir, disable_multilevel_lookup, &hive_dir);
+        get_framework_locations(dotnet_dir, disable_multilevel_lookup, &hive_dir);
 
         pal::string_t selected_fx_dir;
         pal::string_t selected_fx_version;

--- a/src/native/corehost/fxr/sdk_info.h
+++ b/src/native/corehost/fxr/sdk_info.h
@@ -22,10 +22,10 @@ struct sdk_info
         std::function<void(const fx_ver_t&, const pal::string_t&, const pal::string_t&)> callback);
 
     static void get_all_sdk_infos(
-        const pal::string_t& own_dir,
+        const pal::string_t& dotnet_dir,
         std::vector<sdk_info>* sdk_infos);
 
-    static bool print_all_sdks(const pal::string_t& own_dir, const pal::string_t& leading_whitespace);
+    static bool print_all_sdks(const pal::string_t& dotnet_dir, const pal::string_t& leading_whitespace);
 
     pal::string_t base_path;
     pal::string_t full_path;

--- a/src/native/corehost/fxr/sdk_resolver.cpp
+++ b/src/native/corehost/fxr/sdk_resolver.cpp
@@ -79,6 +79,11 @@ pal::string_t sdk_resolver::resolve(const pal::string_t& dotnet_root, bool print
     for (auto&& dir : locations)
     {
         append_path(&dir, _X("sdk"));
+        if (!pal::fullpath(&dir, true))
+        {
+            trace::verbose(_X("SDK path [%s] does not exist"), dir.c_str());
+            continue;
+        }
 
         // Search paths are in priority order. We take the first match and do not
         // look in any remaining locations.

--- a/src/native/corehost/fxr/sdk_resolver.cpp
+++ b/src/native/corehost/fxr/sdk_resolver.cpp
@@ -100,18 +100,7 @@ pal::string_t sdk_resolver::resolve(const pal::string_t& dotnet_root, bool print
     }
 
     if (print_errors)
-    {
-        if (error_message.empty())
-        {
-            // Default resolution error message
-            print_resolution_error(dotnet_root, _X(""));
-        }
-        else
-        {
-            // Custom error message specified in the global.json
-            trace::error(error_message.c_str());
-        }
-    }
+        print_resolution_error(dotnet_root, _X(""));
 
     return {};
 }
@@ -153,6 +142,13 @@ std::vector<pal::string_t> sdk_resolver::get_search_paths(const pal::string_t& d
 
 void sdk_resolver::print_resolution_error(const pal::string_t& dotnet_root, const pal::char_t *main_error_prefix) const
 {
+    if (!error_message.empty())
+    {
+        // Custom error message specified in the global.json
+        trace::error(_X("%s%s"), main_error_prefix, error_message.c_str());
+        return;
+    }
+
     bool sdk_exists = false;
     const pal::char_t *no_sdk_message = _X("No .NET SDKs were found.");
     if (!requested_version.is_empty())

--- a/src/native/corehost/fxr/sdk_resolver.cpp
+++ b/src/native/corehost/fxr/sdk_resolver.cpp
@@ -28,15 +28,16 @@ namespace
     };
 }
 
-sdk_resolver::sdk_resolver(bool allow_prerelease) :
-    sdk_resolver({}, sdk_roll_forward_policy::latest_major, allow_prerelease)
+sdk_resolver::sdk_resolver(bool allow_prerelease)
+    : sdk_resolver({}, sdk_roll_forward_policy::latest_major, allow_prerelease)
 {
 }
 
-sdk_resolver::sdk_resolver(fx_ver_t version, sdk_roll_forward_policy roll_forward, bool allow_prerelease) :
-    requested_version(std::move(version)),
-    roll_forward(roll_forward),
-    allow_prerelease(allow_prerelease)
+sdk_resolver::sdk_resolver(fx_ver_t version, sdk_roll_forward_policy roll_forward, bool allow_prerelease)
+    : requested_version(std::move(version))
+    , roll_forward(roll_forward)
+    , allow_prerelease(allow_prerelease)
+    , has_custom_paths(false)
 {
 }
 
@@ -50,7 +51,7 @@ const fx_ver_t& sdk_resolver::get_requested_version() const
     return requested_version;
 }
 
-pal::string_t sdk_resolver::resolve(const pal::string_t& dotnet_root, bool print_errors) const
+pal::string_t sdk_resolver::resolve(const pal::string_t& dotnet_root, bool print_errors, pal::string_t* out_resolved_root) const
 {
     if (trace::is_enabled())
     {
@@ -60,20 +61,34 @@ pal::string_t sdk_resolver::resolve(const pal::string_t& dotnet_root, bool print
             requested.empty() ? _X("latest") : requested.c_str(),
             to_policy_name(roll_forward),
             allow_prerelease ? _X("true") : _X("false"));
+        if (has_custom_paths)
+        {
+            trace::verbose(_X("  paths = ["));
+            for (const pal::string_t& path : paths)
+            {
+                trace::verbose(_X("    %s"), path.c_str());
+            }
+            trace::verbose(_X("  ]"));
+        }
     }
 
     pal::string_t resolved_sdk_path;
     fx_ver_t resolved_version;
 
-    vector<pal::string_t> locations;
-    get_framework_and_sdk_locations(dotnet_root, /*disable_multilevel_lookup*/ true, &locations);
-
+    std::vector<pal::string_t> locations = get_search_paths(dotnet_root);
     for (auto&& dir : locations)
     {
         append_path(&dir, _X("sdk"));
 
+        // Search paths are in priority order. We take the first match and do not
+        // look in any remaining locations.
         if (resolve_sdk_path_and_version(dir, resolved_sdk_path, resolved_version))
         {
+            if (out_resolved_root != nullptr)
+            {
+                out_resolved_root->assign(get_directory(dir));
+            }
+
             break;
         }
     }
@@ -85,9 +100,55 @@ pal::string_t sdk_resolver::resolve(const pal::string_t& dotnet_root, bool print
     }
 
     if (print_errors)
-        print_resolution_error(dotnet_root, _X(""));
+    {
+        if (error_message.empty())
+        {
+            // Default resolution error message
+            print_resolution_error(dotnet_root, _X(""));
+        }
+        else
+        {
+            // Custom error message specified in the global.json
+            trace::error(error_message.c_str());
+        }
+    }
 
     return {};
+}
+
+std::vector<pal::string_t> sdk_resolver::get_search_paths(const pal::string_t& dotnet_root) const
+{
+    std::vector<pal::string_t> locations;
+    if (!has_custom_paths)
+    {
+        if (!dotnet_root.empty())
+            locations.push_back(dotnet_root);
+    }
+    else
+    {
+        // Use custom paths specified in the global.json
+        pal::string_t json_dir = get_directory(global_file);
+        for (const pal::string_t& path : paths)
+        {
+            if (path == _X("$host$"))
+            {
+                locations.push_back(dotnet_root);
+            }
+            else if (pal::is_path_rooted(path))
+            {
+                locations.push_back(path);
+            }
+            else
+            {
+                // Path is relative to the global.json
+                pal::string_t full_path = json_dir;
+                append_path(&full_path, path.c_str());
+                locations.push_back(full_path);
+            }
+        }
+    }
+
+    return locations;
 }
 
 void sdk_resolver::print_resolution_error(const pal::string_t& dotnet_root, const pal::char_t *main_error_prefix) const
@@ -106,7 +167,17 @@ void sdk_resolver::print_resolution_error(const pal::string_t& dotnet_root, cons
 
         bool has_global_file = !global_file.empty();
         if (has_global_file)
+        {
             trace::error(_X("global.json file: %s"), global_file.c_str());
+            if (has_custom_paths)
+            {
+                trace::error(_X("  Search paths:"));
+                for (const pal::string_t& path : paths)
+                {
+                    trace::error(_X("    %s"), path.c_str());
+                }
+            }
+        }
 
         trace::error(_X("\nInstalled SDKs:"));
         sdk_exists = sdk_info::print_all_sdks(dotnet_root, _X(""));
@@ -353,6 +424,36 @@ bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
         }
     }
 
+    const auto& paths_value = sdk->value.FindMember(_X("paths"));
+    if (paths_value != sdk->value.MemberEnd() && !paths_value->value.IsNull())
+    {
+        if (!paths_value->value.IsArray())
+        {
+            trace::warning(_X("Expected an array for 'sdk/paths' value in [%s]"), global_file_path.c_str());
+            return false;
+        }
+
+        has_custom_paths = true;
+        const auto& paths_array = paths_value->value.GetArray();
+        paths.reserve(paths_array.Size());
+        for (const auto& path : paths_array)
+        {
+            paths.push_back(path.GetString());
+        }
+    }
+
+    const auto& error_message_value = sdk->value.FindMember(_X("errorMessage"));
+    if (error_message_value != sdk->value.MemberEnd() && !error_message_value->value.IsNull())
+    {
+        if (!error_message_value->value.IsString())
+        {
+            trace::warning(_X("Expected a string for the 'sdk/errorMessage' value in [%s]"), global_file_path.c_str());
+            return false;
+        }
+
+        error_message = error_message_value->value.GetString();
+    }
+
     global_file = std::move(global_file_path);
     return true;
 }
@@ -481,13 +582,11 @@ bool sdk_resolver::resolve_sdk_path_and_version(const pal::string_t& dir, pal::s
         }
     }
 
+    // No match - we did not find and exact match and roll forward is disabled
     if (roll_forward == sdk_roll_forward_policy::disable)
-    {
-        // Not yet fully resolved
         return false;
-    }
 
-    bool changed = false;
+    bool found = false;
     pal::string_t resolved_version_str = resolved_version.is_empty() ? pal::string_t{} : resolved_version.as_str();
     sdk_info::enumerate_sdk_paths(
         dir,
@@ -519,17 +618,16 @@ bool sdk_resolver::resolve_sdk_path_and_version(const pal::string_t& dir, pal::s
                 resolved_version_str.empty() ? _X("none") : resolved_version_str.c_str()
             );
 
-            changed = true;
+            found = true;
             resolved_version = version;
             resolved_version_str = std::move(version_str);
         });
 
-    if (changed)
+    if (found)
     {
         sdk_path = dir;
         append_path(&sdk_path, resolved_version_str.c_str());
     }
 
-    // Not yet fully resolved
-    return false;
+    return found;
 }

--- a/src/native/corehost/fxr/sdk_resolver.h
+++ b/src/native/corehost/fxr/sdk_resolver.h
@@ -41,7 +41,9 @@ public:
 
     const fx_ver_t& get_requested_version() const;
 
-    pal::string_t resolve(const pal::string_t& dotnet_root, bool print_errors = true) const;
+    pal::string_t resolve(const pal::string_t& dotnet_root, bool print_errors = true, pal::string_t* out_resolved_root = nullptr) const;
+
+    std::vector<pal::string_t> get_search_paths(const pal::string_t& dotnet_root) const;
 
     void print_resolution_error(const pal::string_t& dotnet_root, const pal::char_t *prefix) const;
 
@@ -60,10 +62,15 @@ private:
     bool is_better_match(const fx_ver_t& current, const fx_ver_t& previous) const;
     bool exact_match_preferred() const;
     bool is_policy_use_latest() const;
+
+    // Returns true and sets sdk_path/resolved_version if a matching SDK was found
     bool resolve_sdk_path_and_version(const pal::string_t& dir, pal::string_t& sdk_path, fx_ver_t& resolved_version) const;
 
     pal::string_t global_file;
     fx_ver_t requested_version;
     sdk_roll_forward_policy roll_forward;
     bool allow_prerelease;
+    bool has_custom_paths;
+    std::vector<pal::string_t> paths;
+    pal::string_t error_message;
 };

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -277,7 +277,7 @@ bool multilevel_lookup_enabled()
     return multilevel_lookup;
 }
 
-void get_framework_and_sdk_locations(const pal::string_t& dotnet_dir, const bool disable_multilevel_lookup, std::vector<pal::string_t>* locations)
+void get_framework_locations(const pal::string_t& dotnet_dir, const bool disable_multilevel_lookup, std::vector<pal::string_t>* locations)
 {
     bool multilevel_lookup = disable_multilevel_lookup ? false : multilevel_lookup_enabled();
 

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -91,7 +91,7 @@ pal::string_t get_runtime_id();
 bool try_get_runtime_id_from_env(pal::string_t& out_rid);
 
 bool multilevel_lookup_enabled();
-void get_framework_and_sdk_locations(const pal::string_t& dotnet_dir, const bool disable_multilevel_lookup, std::vector<pal::string_t>* locations);
+void get_framework_locations(const pal::string_t& dotnet_dir, const bool disable_multilevel_lookup, std::vector<pal::string_t>* locations);
 bool get_file_path_from_env(const pal::char_t* env_key, pal::string_t* recv);
 size_t index_of_non_numeric(const pal::string_t& str, size_t i);
 bool try_stou(const pal::string_t& str, unsigned* num);


### PR DESCRIPTION
- Parse optional properties in global.json:
  ```json
  {
      "sdk": {
          "paths": [ "path/to/sdk/root", "$host$" ],
          "errorMessage": "<message>"
      }
  }
  ```
  - `paths` can be absolute or relative to the global.json. `$host$` is a special value indicating the running `dotnet` path
  - `errorMessage` is shown on SDK resolution failure (instead of the host's default SDK resolution error message).
- Make `hostfxr` search for SDKs with custom paths if specified and error out with custom message if specified
  - `dotnet <command>` - global.json based on process working directory, runs command using resolved SDK respecting global.json paths
  - `hostfxr_resolve_sdk2` - global.json based on working directory argument, returns resolved SDK respecting global.json paths
  - `--info` and `--list-sdks` - global.json based on process working directory, prints found SDKs respecting global.json paths
  - `hostfxr_get_available_sdks` and `hostfxr_get_dotnet_environment_info` - global.json based on process working directory, returns found SDKs respecting global.json paths
- Update error and tracing messages to include information about configured search paths

Part of https://github.com/dotnet/designs/blob/main/proposed/local-sdk-global-json.md.
SDK needs to be updated as well. It currently assumes that its process is the SDK root path, which would no longer be the case if the SDK is resolved via a custom path. It needs this for launching sub-processes for `build`, `run`, etc.

Contributes to https://github.com/dotnet/sdk/issues/8254

cc @dotnet/appmodel @jaredpar @rainersigwald 