### PR TITLE
Add runtime-nativeaot-outerloop to build analysis

### DIFF
--- a/eng/build-analysis-configuration.json
+++ b/eng/build-analysis-configuration.json
@@ -15,6 +15,10 @@
        {
          "PipelineId": 157,
          "PipelineName": "runtime-llvm"
+       },
+       {
+         "PipelineId": 265,
+         "PipelineName": "runtime-nativeaot-outerloop"
        }
     ]
 }


### PR DESCRIPTION
We don't collect stats on these pipelines so the hit count on issues like https://github.com/dotnet/runtime/issues/29383 don't get updated with hits in nativeaot runs.

At this point `runtime-nativeaot-outerloop` is more reliable than e.g. `runtime-libraries-coreclr outerloop` that hasn't seen a successful run in years.

Cc @dotnet/ilc-contrib 