### PR TITLE
new System.Net.Http.EnableMetrics switch

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
@@ -21,6 +21,14 @@ namespace System.Net.Http
                 false);
         }
 
+        internal static class MetricsHandler
+        {
+            public static bool EnableMetrics { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
+                "System.Net.Http.EnableMetrics",
+                "DOTNET_SYSTEM_NET_HTTP_ENABLEMETRICS",
+                true);
+        }
+
         internal static class SocketsHttpHandler
         {
 #if !TARGET_BROWSER && !TARGET_WASI

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -45,7 +45,10 @@ namespace System.Net.Http
 
                         // MetricsHandler should be descendant of DiagnosticsHandler in the handler chain to make sure the 'http.request.duration'
                         // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
-                        handler = new MetricsHandler(handler, _nativeMeterFactory, out _);
+                        if (MetricsHandler.IsGloballyEnabled())
+                        {
+                            handler = new MetricsHandler(handler, _nativeMeterFactory, out _);
+                        }
                         if (DiagnosticsHandler.IsGloballyEnabled())
                         {
                             handler = new DiagnosticsHandler(handler, DistributedContextPropagator.Current);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -45,7 +45,10 @@ namespace System.Net.Http
 
                 // MetricsHandler should be descendant of DiagnosticsHandler in the handler chain to make sure the 'http.request.duration'
                 // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
-                handler = new MetricsHandler(handler, _meterFactory, out _);
+                if (MetricsHandler.IsGloballyEnabled())
+                {
+                    handler = new MetricsHandler(handler, _meterFactory, out _);
+                }
                 if (DiagnosticsHandler.IsGloballyEnabled())
                 {
                     handler = new DiagnosticsHandler(handler, DistributedContextPropagator.Current);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -17,6 +17,7 @@ namespace System.Net.Http.Metrics
 
         public MetricsHandler(HttpMessageHandler innerHandler, IMeterFactory? meterFactory, out Meter meter)
         {
+            Debug.Assert(IsGloballyEnabled());
             _innerHandler = innerHandler;
 
             meter = meterFactory?.Create("System.Net.Http") ?? SharedMeter.Instance;
@@ -32,6 +33,8 @@ namespace System.Net.Http.Metrics
                 description: "Duration of HTTP client requests.",
                 advice: DiagnosticsHelper.ShortHistogramAdvice);
         }
+
+        internal static bool IsGloballyEnabled() => GlobalHttpSettings.MetricsHandler.EnableMetrics;
 
         internal override ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -531,8 +531,11 @@ namespace System.Net.Http
 
             // MetricsHandler should be descendant of DiagnosticsHandler in the handler chain to make sure the 'http.request.duration'
             // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
-            handler = new MetricsHandler(handler, settings._meterFactory, out Meter meter);
-            settings._metrics = new SocketsHttpHandlerMetrics(meter);
+            if (MetricsHandler.IsGloballyEnabled())
+            {
+                handler = new MetricsHandler(handler, settings._meterFactory, out Meter meter);
+                settings._metrics = new SocketsHttpHandlerMetrics(meter);
+            }
 
             // DiagnosticsHandler is inserted before RedirectHandler so that trace propagation is done on redirects as well
             if (DiagnosticsHandler.IsGloballyEnabled() && settings._activityHeadersPropagator is DistributedContextPropagator propagator)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -28,6 +28,8 @@
     <!-- This WASM test is slow on NodeJS. This sets the xharness timeout but there is also override in sendtohelix-browser.targets -->
     <WasmXHarnessTestsTimeout>01:15:00</WasmXHarnessTestsTimeout>
     <XunitShowProgress Condition="'$(FeatureWasmManagedThreads)' == 'true'">true</XunitShowProgress>
+    <EventSourceSupport>true</EventSourceSupport>
+    <MetricsSupport>true</MetricsSupport>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'wasi'">
@@ -47,6 +49,9 @@
     <NodeNpmModule Include="ws" />
     <NodeNpmModule Include="node-fetch" />
     <NodeNpmModule Include="node-abort-controller" />
+
+    <RuntimeHostConfigurationOption Include="System.Net.Http.EnableActivityPropagation" Value="true" Trim="true" />
+    <RuntimeHostConfigurationOption Include="System.Net.Http.EnableMetrics" Value="true" Trim="true" />
 
   </ItemGroup>
 


### PR DESCRIPTION
Motivation: in browser/wasm the diagnostics and metrics are usually not usable in production deployment. They are making IL donwload bigger.

- new switch `System.Net.Http.EnableMetrics` and use it in HTTP client to make `MetricsHandler` optional

TODO
- unit test with metrics disabled
- [fix](https://github.com/dotnet/runtime/pull/113524#discussion_r1995438656) `settings._metrics` usage
- make both `System.Net.Http.EnableMetrics` and `System.Net.Http.EnableActivityPropagation` opt-in for browser
- make it into linker switch, so that it could be trimmed out