### PR TITLE
Use `GetUninitializedObject` to marshal LayoutClass

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.Aot.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.Aot.cs
@@ -680,11 +680,9 @@ namespace Internal.TypeSystem.Interop
             LoadManagedValue(codeStream);
             codeStream.Emit(ILOpcode.brtrue, lNonNull);
 
-            MethodDesc ctor = ManagedType.GetParameterlessConstructor();
-            if (ctor == null)
-                throw new InvalidProgramException();
-
-            codeStream.Emit(ILOpcode.newobj, emitter.NewToken(ctor));
+            codeStream.Emit(ILOpcode.ldtoken, emitter.NewToken(ManagedType));
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(InteropTypes.GetType(Context).GetMethod("GetTypeFromHandle", null)));
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(InteropTypes.GetRuntimeHelpers(Context).GetKnownMethod("GetUninitializedObject", null)));
             StoreManagedValue(codeStream);
 
             codeStream.EmitLabel(lNonNull);
@@ -736,12 +734,9 @@ namespace Internal.TypeSystem.Interop
         protected override void AllocNativeToManaged(ILCodeStream codeStream)
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
-
-            MethodDesc ctor = ManagedType.GetParameterlessConstructor();
-            if (ctor == null)
-                throw new InvalidProgramException();
-
-            codeStream.Emit(ILOpcode.newobj, emitter.NewToken(ctor));
+            codeStream.Emit(ILOpcode.ldtoken, emitter.NewToken(ManagedType));
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(InteropTypes.GetType(Context).GetMethod("GetTypeFromHandle", null)));
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(InteropTypes.GetRuntimeHelpers(Context).GetKnownMethod("GetUninitializedObject", null)));
             StoreManagedValue(codeStream);
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/InteropTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/InteropTypes.cs
@@ -12,6 +12,11 @@ namespace Internal.TypeSystem.Interop
             return context.SystemModule.GetKnownType("System", "GC");
         }
 
+        public static MetadataType GetType(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System", "Type");
+        }
+
         public static MetadataType GetSafeHandle(TypeSystemContext context)
         {
             return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "SafeHandle");
@@ -30,6 +35,11 @@ namespace Internal.TypeSystem.Interop
         public static MetadataType GetPInvokeMarshal(TypeSystemContext context)
         {
             return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "PInvokeMarshal");
+        }
+
+        public static MetadataType GetRuntimeHelpers(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "RuntimeHelpers");
         }
 
         public static MetadataType GetMarshal(TypeSystemContext context)


### PR DESCRIPTION
The marshalling rule is that `Marshal.PtrToStructure` will use the parameterless constructor to create instance and refuse working if there isn't one, but p/invoke will use `GetUninitializedObject` and ignore any constructors.