### PR TITLE
Fix AcquireCredentialHandle parameter lifetime

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -445,7 +445,7 @@ namespace System.Net.Security
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info($"flags=({flags}), ProtocolFlags=({protocolFlags}), EncryptionPolicy={policy}");
 
-            Interop.SspiCli.TLS_PARAMETERS tlsParameters = default;
+            Interop.SspiCli.TLS_PARAMETERS tlsParameters;
             if (protocolFlags != 0)
             {
                 // If we were asked to do specific protocol we need to fill TLS_PARAMETERS.

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -353,10 +353,11 @@ namespace System.Net.Security
                 secureCredential.dwSessionLifespan = -1;
             }
 
+            Interop.Crypt32.CERT_CONTEXT* certificateHandle;
             if (certificate != null)
             {
                 secureCredential.cCreds = 1;
-                Interop.Crypt32.CERT_CONTEXT* certificateHandle = (Interop.Crypt32.CERT_CONTEXT*)certificate.Handle;
+                certificateHandle = (Interop.Crypt32.CERT_CONTEXT*)certificate.Handle;
                 secureCredential.paCred = &certificateHandle;
             }
 
@@ -434,19 +435,20 @@ namespace System.Net.Security
                 credential.dwSessionLifespan = -1;
             }
 
+            Interop.Crypt32.CERT_CONTEXT* certificateHandle;
             if (certificate != null)
             {
                 credential.cCreds = 1;
-                Interop.Crypt32.CERT_CONTEXT* certificateHandle = (Interop.Crypt32.CERT_CONTEXT*)certificate.Handle;
+                certificateHandle = (Interop.Crypt32.CERT_CONTEXT*)certificate.Handle;
                 credential.paCred = &certificateHandle;
             }
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info($"flags=({flags}), ProtocolFlags=({protocolFlags}), EncryptionPolicy={policy}");
 
+            Interop.SspiCli.TLS_PARAMETERS tlsParameters = default;
             if (protocolFlags != 0)
             {
                 // If we were asked to do specific protocol we need to fill TLS_PARAMETERS.
-                Interop.SspiCli.TLS_PARAMETERS tlsParameters = default;
                 tlsParameters.grbitDisabledProtocols = (uint)protocolFlags ^ uint.MaxValue;
 
                 credential.cTlsParameters = 1;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -449,6 +449,7 @@ namespace System.Net.Security
             if (protocolFlags != 0)
             {
                 // If we were asked to do specific protocol we need to fill TLS_PARAMETERS.
+                tlsParameters = default;
                 tlsParameters.grbitDisabledProtocols = (uint)protocolFlags ^ uint.MaxValue;
 
                 credential.cTlsParameters = 1;


### PR DESCRIPTION
I randomly noticed this while reading the code. I don't ever recall seeing an issue with this, so maybe the compiler treats the new and previous code the same way, but this makes the lifetime scope of few variables reflect actual runtime usage.