### PR TITLE
Disable SendAsync_ReuseRequestInHandler_ResetsHeadersForEachReuse on WASM

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -1543,7 +1543,7 @@ namespace System.Net.Http.Functional.Tests
             }   
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
         public async Task SendAsync_ReuseRequestInHandler_ResetsHeadersForEachReuse()
         {
             Activity parent0 = new Activity("parent0");


### PR DESCRIPTION
I merged #113342 too eagerly. The mentioned test is not expected to pass on WASM, see https://dev.azure.com/dnceng-public/public/_build/results?buildId=979131&view=ms.vss-test-web.build-test-results-tab&runId=26097406&resultId=183007&paneView=dotnet-dnceng.dnceng-build-release-tasks.helix-test-information-tab.