### PR TITLE
[9.0] Update openssl dependency for openSUSE

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-opensuse.42.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-opensuse.42.proj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <LinuxPackageDependency Include="libopenssl1_0_0;libicu;krb5" />
+    <LinuxPackageDependency Include="libopenssl3;libicu;krb5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates openssl dependency to `libopenssl3` as it is present in openSUSE Leap 15.6 and openSUSE Tumbleweed images.

Dependency was updated in .NET 10 with https://github.com/dotnet/runtime/pull/112671