### PR TITLE
Fix a synchronization bug in System.Diagnostics.ActivitySource

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -59,7 +59,7 @@ namespace System.Diagnostics
 
             s_activeSources.Add(this);
 
-            lock(s_allListeners)
+            lock (s_allListeners)
             {
                 if (s_allListeners.Count > 0)
                 {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -59,20 +59,23 @@ namespace System.Diagnostics
 
             s_activeSources.Add(this);
 
-            if (s_allListeners.Count > 0)
+            lock(s_allListeners)
             {
-                s_allListeners.EnumWithAction((listener, source) =>
+                if (s_allListeners.Count > 0)
                 {
-                    Func<ActivitySource, bool>? shouldListenTo = listener.ShouldListenTo;
-                    if (shouldListenTo != null)
+                    s_allListeners.EnumWithAction((listener, source) =>
                     {
-                        var activitySource = (ActivitySource)source;
-                        if (shouldListenTo(activitySource))
+                        Func<ActivitySource, bool>? shouldListenTo = listener.ShouldListenTo;
+                        if (shouldListenTo != null)
                         {
-                            activitySource.AddListener(listener);
+                            var activitySource = (ActivitySource)source;
+                            if (shouldListenTo(activitySource))
+                            {
+                                activitySource.AddListener(listener);
+                            }
                         }
-                    }
-                }, this);
+                    }, this);
+                }
             }
 
             GC.KeepAlive(DiagnosticSourceEventSource.Log);


### PR DESCRIPTION
I don't know if this is the preferred solution.

I'm not actually sure if this is a synchronization bug, or if the check for the size of the list should be removed.

It's clear that there's a race between the size check and the enumeration, but looking at the enumeration code, it tries to be thread-safe.

It definitely enumerates the list without a lock, but given the mechanics in `Remove` etc. It's not clear to me if that enumeration is problematic.

It hinges on whether `foreach` should be considered thread-safe. I couldn't find this documented anywhere.

If it is thread-safe then it seems like the size check should be removed for clarity. If the size check is important, then this lock should be inserted.

Let me know what is preferred (or if I'm wrong)

Thanks!