### PR TITLE
Move macro definition to give better out-of-the-box VSCode experience on Windows

### DIFF
--- a/src/coreclr/inc/debugmacros.h
+++ b/src/coreclr/inc/debugmacros.h
@@ -13,6 +13,7 @@
 #include "stacktrace.h"
 #include "debugmacrosext.h"
 #include "palclr.h"
+#include <minipal/utils.h>
 
 #undef _ASSERTE
 #undef VERIFY

--- a/src/coreclr/inc/palclr.h
+++ b/src/coreclr/inc/palclr.h
@@ -48,8 +48,6 @@
 #endif // !_MSC_VER
 #endif // !NOINLINE
 
-#define ANALYZER_NORETURN
-
 #ifdef _MSC_VER
 #define EMPTY_BASES_DECL __declspec(empty_bases)
 #else

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -132,12 +132,6 @@ extern bool g_arm64_atomics_present;
 
 #define DECLSPEC_NORETURN   PAL_NORETURN
 
-#ifdef __clang_analyzer__
-#define ANALYZER_NORETURN __attribute((analyzer_noreturn))
-#else
-#define ANALYZER_NORETURN
-#endif
-
 #define EMPTY_BASES_DECL
 
 #if !defined(_MSC_VER) || defined(SOURCE_FORMATTING)
@@ -1552,7 +1546,7 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
         M512 Zmm30;
         M512 Zmm31;
     };
-    
+
     struct
     {
         DWORD64 Egpr16;
@@ -1572,7 +1566,7 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
         DWORD64 Egpr30;
         DWORD64 Egpr31;
     };
-    
+
 } CONTEXT, *PCONTEXT, *LPCONTEXT;
 
 //

--- a/src/native/minipal/utils.h
+++ b/src/native/minipal/utils.h
@@ -9,6 +9,12 @@
 // Number of characters in a string literal. Excludes terminating NULL.
 #define STRING_LENGTH(str) (ARRAY_SIZE(str) - 1)
 
+#ifdef __clang_analyzer__
+#define ANALYZER_NORETURN __attribute((analyzer_noreturn))
+#else
+#define ANALYZER_NORETURN
+#endif
+
 #ifndef __has_builtin
 #define __has_builtin(x) 0
 #endif


### PR DESCRIPTION
Today, the default experience when opening the runtime repo in VSCode and editing C++ code in the CoreCLR VM leads to red squiggles under every `_ASSERTE` usage. This comes from the `ANALYZER_NORETURN` macro being defined under a `HOST_WINDOWS` define in `palclr.h`. By moving the definition out of the PAL headers (which is technically correct anyway if we were to ever run clang-analyzer on Windows), the default VSCode experience can now parse the forward declaration of `DbgAssertDialog`, removing a significantly large group of the red squiggles that show up when developing the VM in VSCode. 