### PR TITLE
Avoid infinite loop in recursive type hierarchies

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
@@ -139,6 +139,7 @@ namespace System.Reflection.Emit
             // Maybe we are lucky that they are equal in the first place
             if (t1 == t2)
                 return true;
+
             RuntimeTypeBuilder? tb1 = null;
             RuntimeTypeBuilder? tb2 = null;
             Type? runtimeType1;
@@ -171,7 +172,7 @@ namespace System.Reflection.Emit
             if (tb1 != null && tb2 != null && ReferenceEquals(tb1, tb2))
                 return true;
 
-            // if the runtimetype view is eqaul than it is equal
+            // if the runtimetype view is equal than it is equal
             if (runtimeType1 != null && runtimeType2 != null && runtimeType1 == runtimeType2)
                 return true;
 
@@ -945,6 +946,10 @@ namespace System.Reflection.Emit
 
             while (p != null)
             {
+                // We can't use IsTypeEqual(p, this) because it would be recursive at least for Enums.
+                if (ReferenceEquals(p, this))
+                    throw new ArgumentException(SR.Argument_RecursiveTypeHierarchy, nameof(c));
+
                 if (IsTypeEqual(p, c))
                     return true;
 

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1540,6 +1540,9 @@
   <data name="Argument_RecursiveFallbackBytes" xml:space="preserve">
     <value>Recursive fallback not allowed for bytes {0}.</value>
   </data>
+  <data name="Argument_RecursiveTypeHierarchy" xml:space="preserve">
+    <value>The type hierarchy must not be recursive.</value>
+  </data>  
   <data name="Argument_RedefinedLabel" xml:space="preserve">
     <value>Label defined multiple times.</value>
   </data>

--- a/src/libraries/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderSetParent.cs
+++ b/src/libraries/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderSetParent.cs
@@ -134,5 +134,29 @@ namespace System.Reflection.Emit.Tests
 
             Assert.Throws<BadImageFormatException>(() => type.CreateTypeInfo());
         }
+
+        [Fact]
+        public static void RecursiveTypeBuilder_Self()
+        {
+            AssemblyBuilder assembly = Helpers.DynamicAssembly();
+            ModuleBuilder module = assembly.DefineDynamicModule("TestModule");
+
+            TypeBuilder type = module.DefineType("TestType", TypeAttributes.Class | TypeAttributes.Public);
+            type.SetParent(type);
+            Assert.Throws<ArgumentException>(() => type.CreateType());
+        }
+
+        [Fact]
+        public static void RecursiveTypeBuilder_Base()
+        {
+            AssemblyBuilder assembly = Helpers.DynamicAssembly();
+            ModuleBuilder module = assembly.DefineDynamicModule("TestModule");
+
+            TypeBuilder typeBase = module.DefineType("BaseType", TypeAttributes.Class | TypeAttributes.Public);
+            TypeBuilder typeDerived = module.DefineType("DerivedType", TypeAttributes.Class | TypeAttributes.Public);
+            typeBase.SetParent(typeDerived);
+            typeDerived.SetParent(typeBase);
+            Assert.Throws<ArgumentException>(() => typeBase.CreateType());
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/112072

We have a somewhat high bar for adding error detection to the builder classes, but this one causes an infinite loop.