### PR TITLE
Loop cloning for Span

### DIFF
--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -266,6 +266,7 @@ Documentation for VS debugger format specifiers: https://learn.microsoft.com/vis
     <Expand>
       <ExpandedItem Condition="optType == LcOptInfo::OptType::LcJaggedArray">(LcJaggedArrayOptInfo*)this,nd</ExpandedItem>
       <ExpandedItem Condition="optType == LcOptInfo::OptType::LcMdArray">(LcMdArrayOptInfo*)this,nd</ExpandedItem>
+      <ExpandedItem Condition="optType == LcOptInfo::OptType::LcSpan">(LcSpanOptInfo*)this,nd</ExpandedItem>
     </Expand>
   </Type>
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8185,6 +8185,7 @@ public:
 
     bool optIsStackLocalInvariant(FlowGraphNaturalLoop* loop, unsigned lclNum);
     bool optExtractArrIndex(GenTree* tree, ArrIndex* result, unsigned lhsNum, bool* topLevelIsFinal);
+    bool optExtractSpanIndex(GenTree* tree, SpanIndex* result);
     bool optReconstructArrIndexHelp(GenTree* tree, ArrIndex* result, unsigned lhsNum, bool* topLevelIsFinal);
     bool optReconstructArrIndex(GenTree* tree, ArrIndex* result);
     bool optIdentifyLoopOptInfo(FlowGraphNaturalLoop* loop, LoopCloneContext* context);

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3671,6 +3671,8 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
             case NI_System_Span_get_Item:
             case NI_System_ReadOnlySpan_get_Item:
             {
+                optMethodFlags |= OMF_HAS_ARRAYREF;
+
                 // Have index, stack pointer-to Span<T> s on the stack. Expand to:
                 //
                 // For Span<T>

--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -211,6 +211,28 @@ struct ArrIndex
 #endif
 };
 
+// SpanIndex represents a span element access and associated bounds check.
+struct SpanIndex
+{
+    unsigned    lenLcl;   // The Span length local num
+    unsigned    indLcl;   // The index local num
+    GenTree*    bndsChk;  // The bounds check node
+    BasicBlock* useBlock; // Block where the [] occurs
+
+    SpanIndex()
+        : lenLcl(BAD_VAR_NUM)
+        , indLcl(BAD_VAR_NUM)
+        , bndsChk(nullptr)
+        , useBlock(nullptr)
+    {
+    }
+
+#ifdef DEBUG
+    void Print();
+    void PrintBoundsCheckNode();
+#endif
+};
+
 // Forward declarations
 #define LC_OPT(en) struct en##OptInfo;
 #include "loopcloningopts.h"
@@ -312,6 +334,21 @@ struct LcJaggedArrayOptInfo : public LcOptInfo
         : LcOptInfo(LcJaggedArray)
         , dim(dim)
         , arrIndex(arrIndex)
+        , stmt(stmt)
+    {
+    }
+};
+
+// Optimization info for a Span
+//
+struct LcSpanOptInfo : public LcOptInfo
+{
+    SpanIndex  spanIndex; // SpanIndex representation of the Span.
+    Statement* stmt;      // "stmt" where the optimization opportunity occurs.
+
+    LcSpanOptInfo(SpanIndex& spanIndex, Statement* stmt)
+        : LcOptInfo(LcSpan)
+        , spanIndex(spanIndex)
         , stmt(stmt)
     {
     }
@@ -481,6 +518,38 @@ struct LC_Array
     GenTree* ToGenTree(Compiler* comp, BasicBlock* bb);
 };
 
+// Symbolic representation of Span.Length
+struct LC_Span
+{
+    SpanIndex* spanIndex;
+
+#ifdef DEBUG
+    void Print()
+    {
+        spanIndex->Print();
+    }
+#endif
+
+    LC_Span()
+        : spanIndex(nullptr)
+    {
+    }
+
+    LC_Span(SpanIndex* arrIndex)
+        : spanIndex(arrIndex)
+    {
+    }
+
+    // Equality operator
+    bool operator==(const LC_Span& that) const
+    {
+        return (spanIndex->lenLcl == that.spanIndex->lenLcl) && (spanIndex->indLcl == that.spanIndex->indLcl);
+    }
+
+    // Get a tree representation for this symbolic Span.Length
+    GenTree* ToGenTree(Compiler* comp);
+};
+
 //------------------------------------------------------------------------
 // LC_Ident: symbolic representation of "a value"
 //
@@ -492,6 +561,7 @@ struct LC_Ident
         Const,
         Var,
         ArrAccess,
+        SpanAccess,
         Null,
         ClassHandle,
         IndirOfLocal,
@@ -509,6 +579,7 @@ private:
             unsigned indirOffs;
         };
         LC_Array             arrAccess;
+        LC_Span              spanAccess;
         CORINFO_CLASS_HANDLE clsHnd;
         struct
         {
@@ -553,6 +624,8 @@ public:
                 return (lclNum == that.lclNum) && (indirOffs == that.indirOffs);
             case ArrAccess:
                 return (arrAccess == that.arrAccess);
+            case SpanAccess:
+                return (spanAccess == that.spanAccess);
             case Null:
                 return true;
             case MethodAddr:
@@ -597,6 +670,9 @@ public:
                 break;
             case ArrAccess:
                 arrAccess.Print();
+                break;
+            case SpanAccess:
+                spanAccess.Print();
                 break;
             case Null:
                 printf("null");
@@ -643,6 +719,13 @@ public:
     {
         LC_Ident id(ArrAccess);
         id.arrAccess = arrLen;
+        return id;
+    }
+
+    static LC_Ident CreateSpanAccess(const LC_Span& spanLen)
+    {
+        LC_Ident id(SpanAccess);
+        id.spanAccess = spanLen;
         return id;
     }
 

--- a/src/coreclr/jit/loopcloningopts.h
+++ b/src/coreclr/jit/loopcloningopts.h
@@ -13,5 +13,6 @@ LC_OPT(LcMdArray)
 LC_OPT(LcJaggedArray)
 LC_OPT(LcTypeTest)
 LC_OPT(LcMethodAddrTest)
+LC_OPT(LcSpan)
 
 #undef LC_OPT


### PR DESCRIPTION
This PR enables loop cloning for Spans
Closes https://github.com/dotnet/runtime/issues/82946
Closes https://github.com/dotnet/runtime/issues/110986
Closes https://github.com/dotnet/runtime/issues/112019

Example:
```cs
static void Test(Span<int> span, int len)
{
    for (int i = 0; i < len; i++)
        span[i] = 0;
}
```
Current codegen:
```asm
; Assembly listing for method Test(System.Span`1[int],int) (FullOpts)
       sub      rsp, 40
       xor      eax, eax
       test     edx, edx
       jle      SHORT G_M2065_IG04
       align    [0 bytes for IG03]
G_M2065_IG03:
       cmp      eax, dword ptr [rcx+0x08]    ;; <-- bounds check each iteration
       jae      SHORT G_M2065_IG05
       mov      r8, bword ptr [rcx]
       xor      r10d, r10d
       mov      dword ptr [r8+4*rax], r10d
       inc      eax
       cmp      eax, edx
       jl       SHORT G_M2065_IG03
G_M2065_IG04:
       add      rsp, 40
       ret    
  
G_M2065_IG05:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code 42, prolog size 4, PerfScore 38.00
```
New codegen:
```asm
; Assembly listing for method Test(System.Span`1[int],int) (FullOpts)
       sub      rsp, 40
       xor      eax, eax
       test     edx, edx
       jle      SHORT G_M2065_IG05
       cmp      edx, dword ptr [rcx+0x08]
       jg       SHORT G_M2065_IG06
       xor      eax, eax
       align    [15 bytes for IG04]
G_M2065_IG04:
       mov      r8, bword ptr [rcx]     ;; <-- no bounds checks (fast loop)
       xor      r10d, r10d
       mov      dword ptr [r8+rax], r10d
       add      rax, 4
       dec      edx
       jne      SHORT G_M2065_IG04
G_M2065_IG05:
       add      rsp, 40
       ret      

G_M2065_IG06:
       cmp      eax, dword ptr [rcx+0x08]  ;; slow loop (cloned)
       jae      SHORT G_M2065_IG07
       mov      r8, bword ptr [rcx]
       mov      r10d, eax
       xor      r9d, r9d
       mov      dword ptr [r8+4*r10], r9d
       inc      eax
       cmp      eax, edx
       jl       SHORT G_M2065_IG06
       jmp      SHORT G_M2065_IG05
G_M2065_IG07:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code 87, prolog size 4, PerfScore 23.38
```
Another example where this helps:
```cs
    void Test(Span<int> a, Span<int> b)
    {
        if (a.Length == b.Length)
        {
            for (int i = 0; i < a.Length; i++)
                a[i] = b[i];
        }
    }
```
previously, we couldn't optimize range check for ^

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=983876&view=ms.vss-build-web.run-extensions-tab)