### PR TITLE
JIT: fix issue in cloning loops with trys in handlers

### DIFF
--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2680,8 +2680,8 @@ BasicBlock* Compiler::fgCloneTryRegion(BasicBlock* tryEntry, CloneTryInfo& info,
                 if (bbIsTryBeg(block))
                 {
                     assert(added);
-                    JITDUMP("==> found try entry for EH#%02u nested in handler at " FMT_BB "\n", block->bbNum,
-                            block->getTryIndex());
+                    JITDUMP("==> found try entry for EH#%02u nested in handler at " FMT_BB "\n", block->getTryIndex(),
+                            block->bbNum);
                     regionsToProcess.Push(block->getTryIndex());
                 }
             }
@@ -2759,6 +2759,12 @@ BasicBlock* Compiler::fgCloneTryRegion(BasicBlock* tryEntry, CloneTryInfo& info,
     {
         JITDUMP("Cloned EH clauses will go before enclosing try region EH#%02u\n", enclosingTryIndex);
         assert(insertBeforeIndex == enclosingTryIndex);
+    }
+
+    if (insertBeforeIndex != compHndBBtabCount)
+    {
+        JITDUMP("Existing EH region(s) EH#%02u...EH#%02u will become EH#%02u...EH#%02u\n", insertBeforeIndex,
+                compHndBBtabCount - 1, insertBeforeIndex + regionCount, compHndBBtabCount + regionCount - 1);
     }
 
     // Once we call fgTryAddEHTableEntries with deferCloning = false,
@@ -2860,7 +2866,7 @@ BasicBlock* Compiler::fgCloneTryRegion(BasicBlock* tryEntry, CloneTryInfo& info,
         //
         if (ebd->ebdEnclosingTryIndex != EHblkDsc::NO_ENCLOSING_INDEX)
         {
-            if (XTnum < clonedOutermostRegionIndex)
+            if (ebd->ebdEnclosingTryIndex < clonedOutermostRegionIndex)
             {
                 ebd->ebdEnclosingTryIndex += (unsigned short)indexShift;
             }
@@ -2873,7 +2879,7 @@ BasicBlock* Compiler::fgCloneTryRegion(BasicBlock* tryEntry, CloneTryInfo& info,
 
         if (ebd->ebdEnclosingHndIndex != EHblkDsc::NO_ENCLOSING_INDEX)
         {
-            if (XTnum < clonedOutermostRegionIndex)
+            if (ebd->ebdEnclosingHndIndex < clonedOutermostRegionIndex)
             {
                 ebd->ebdEnclosingHndIndex += (unsigned short)indexShift;
             }

--- a/src/tests/JIT/opt/Cloning/loops_with_eh.cs
+++ b/src/tests/JIT/opt/Cloning/loops_with_eh.cs
@@ -17,6 +17,7 @@ using Xunit;
 // g   - giant finally (TF will remain try finally)
 // p   - regions are serial, not nested
 // TFi - try finally with what follows in the finally
+// I   - inlining
 // 
 // x: we currently cannot clone loops where the try is the first thing
 // as the header and preheader are different regions
@@ -1123,6 +1124,143 @@ public class LoopsWithEH
             {
                 sum += 1;
             }
+        }
+
+        return sum;
+    }
+
+    [Fact]
+    public static int Test_LTFiTF() => Sum_LTFiTF(data, n) - 130;
+
+    public static int Sum_LTFiTF(int[] data, int n)
+    {
+        int sum = 0;
+
+        for (int i = 0; i < n; i++)
+        {
+            sum += data[i];
+            try
+            {
+                SideEffect();
+            }
+            finally
+            {
+                try
+                {
+                    SideEffect();
+                }
+                finally
+                {
+                    sum += 1;
+                }
+
+                sum += 1;
+            }
+        }
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int SomeEH()
+    {
+        int sum = 0;
+
+        try
+        {
+            SideEffect();
+        }
+        finally
+        {
+            try
+            {
+                SideEffect();
+            }
+            finally
+            {
+                sum += 1;
+            }
+
+            sum += 1;
+        }
+
+        return sum;
+    }
+
+    [Fact]
+    public static int Test_LITFiTF() => Sum_LITFiTF(data, n) - 130;
+
+    public static int Sum_LITFiTF(int[] data, int n)
+    {
+        int sum = 0;
+
+        for (int i = 0; i < n; i++)
+        {
+            sum += data[i];
+            sum += SomeEH();
+        }
+
+        return sum;
+    }
+
+    [Fact]
+    public static int Test_TFLTFiTF() => Sum_TFLTFiTF(data, n) - 131;
+
+    public static int Sum_TFLTFiTF(int[] data, int n)
+    {
+        int sum = 0;
+
+        try
+        {
+            for (int i = 0; i < n; i++)
+            {
+                sum += data[i];
+                try
+                {
+                    SideEffect();
+                }
+                finally
+                {
+                    try
+                    {
+                        SideEffect();
+                    }
+                    finally
+                    {
+                        sum += 1;
+                    }
+
+                    sum += 1;
+                }
+            }
+        }
+        finally
+        {
+            SideEffect();
+            sum += 1;
+        }
+        return sum;
+    }
+
+    // [Fact]
+    public static int Test_TFLITFiTF() => Sum_TFLITFiTF(data, n) - 131;
+
+    public static int Sum_TFLITFiTF(int[] data, int n)
+    {
+        int sum = 0;
+
+        try
+        {
+            for (int i = 0; i < n; i++)
+            {
+                sum += data[i];
+                sum += SomeEH();
+            }
+        }
+        finally
+        {
+            SideEffect();
+            sum += 1;
         }
 
         return sum;


### PR DESCRIPTION
Loop cloning with EH had a bug when:
* the loop contained a try T0 that was within a handler H1
* the associated try T1 was also within the loop
* the entire loop was within another try T2

Here T0's containing try is T2, and its enclosing try index was properly adjusted when the EH table expands as part of cloning. We were doing another index adjustment later which lead to an out of bounds index.

Also cleaned up the code that detects which try regions need cloning as in the above we only need to consider T1. When we go to clone it we also will clone H1
 and hence T2.

Also fixed/added some more dumping, and some new test cases.

This fix addresses a problem that came up stress testing #112998. Since the underlying bug does not require inlining to create the EH setup above, I am fixing it separately.