### PR TITLE
Disable LongProcessNamesAreSupported on OSX

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2267,6 +2267,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52852", TestPlatforms.MacCatalyst)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/53095", TestPlatforms.Android)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/29383", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void LongProcessNamesAreSupported()
         {
             string sleepPath;

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2267,7 +2267,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52852", TestPlatforms.MacCatalyst)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/53095", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/29383", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/29383", TestPlatforms.OSX)]
         public void LongProcessNamesAreSupported()
         {
             string sleepPath;


### PR DESCRIPTION
This is consistently failing on osx after updating Helix to osx13.