### PR TITLE
Do not throw for `Marshal.SizeOf(typeof(delegate*<void>))`

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NativeAot.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.InteropServices
         {
             Debug.Assert(throwIfNotMarshalable);
 
-            if (t.IsPointer /* or IsFunctionPointer */)
+            if (t.IsPointer || t.IsFunctionPointer)
                 return IntPtr.Size;
 
             if (t.IsByRef || t.IsArray || t.ContainsGenericParameters)

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
@@ -32,6 +32,12 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
+        public unsafe void SizeOf_FunctionPointer_ReturnsExpected()
+        {
+            Assert.Equal(IntPtr.Size, Marshal.SizeOf(typeof(delegate*<void>)));
+        }
+
+        [Fact]
         public void SizeOf_Pointer_ReturnsExpected()
         {
             Assert.Equal(IntPtr.Size, Marshal.SizeOf(typeof(int).MakePointerType()));


### PR DESCRIPTION
Noticed as I was looking at this code.