### PR TITLE
Fix GetInterfaceMap with respect to generics

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
@@ -38,7 +38,7 @@ namespace Internal.Reflection.Execution
                     goto notFound;
                 }
 
-                MethodBase methodBase = ReflectionExecution.GetMethodBaseFromStartAddressIfAvailable(classRtMethodHandle);
+                MethodBase methodBase = ReflectionExecution.GetMethodBaseFromOriginalLdftnResult(classRtMethodHandle, instanceType.TypeHandle);
                 if (methodBase == null)
                 {
                     goto notFound;

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
@@ -94,6 +94,17 @@ namespace Internal.Reflection.Execution
             return ExecutionDomain.GetMethod(declaringTypeHandle, qMethodDefinition, genericMethodTypeArgumentHandles: null);
         }
 
+        public static MethodBase GetMethodBaseFromOriginalLdftnResult(IntPtr methodStartAddress, RuntimeTypeHandle declaringTypeHandle)
+        {
+            if (!ExecutionEnvironment.TryGetMethodForOriginalLdFtnResult(methodStartAddress,
+                ref declaringTypeHandle, out QMethodDefinition qMethodDefinition, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles))
+            {
+                return null;
+            }
+
+            return ExecutionDomain.GetMethod(declaringTypeHandle, qMethodDefinition, genericMethodTypeArgumentHandles);
+        }
+
         internal static ExecutionEnvironmentImplementation ExecutionEnvironment { get; private set; }
     }
 }


### PR DESCRIPTION
This API is still generally broken because the partial implementation from https://github.com/dotnet/corert/pull/8144 is still only partial, but this should either return correct result or throw. Here we can compute the correct result. Full fix still tracked at #89157.