### PR TITLE
[release/9.0-staging] [HttpStress] Fix Linux HttpStress build

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -37,7 +37,7 @@ extends:
           DUMPS_SHARE_MOUNT_ROOT: "/dumps-share"
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-ubuntu-1804-open
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
         steps:
         - checkout: self

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update -y && \
 RUN git clone --depth 1 --single-branch --branch v2.3.5 --recursive https://github.com/microsoft/msquic
 RUN cd msquic/ && \
     mkdir build && \
-    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3 -DQUIC_ENABLE_SANITIZERS=on && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3 && \
+      # -DQUIC_ENABLE_SANITIZERS=on && \
     cd build && \
     cmake --build . --config Debug
 RUN cd msquic/build/bin/Debug && \
@@ -41,8 +42,8 @@ ENV DOTNET_DbgMiniDumpName="/dumps-share/coredump.%p"
 EXPOSE 5001
 
 # configure adress sanitizer
-ENV ASAN_OPTIONS='detect_leaks=0'
-ENV LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/12/libasan.so
+# ENV ASAN_OPTIONS='detect_leaks=0'
+# ENV LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/12/libasan.so
 
 ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3' # Although the version attribute is obsolete and should be ignored, it's seemingly not the case on Build.Ubuntu.2204.Amd64.Open
 services:
   client:
     build:


### PR DESCRIPTION
Backport of #111664 to release/9.0-staging

Fixes #111660.

## Customer Impact

N/A Test-only change

## Regression

N/A Test-only change

## Testing

This fixes the Linux build and restores HttpStress execution against `release/9.0-staging`.

## Risk

None. Test-only change