### PR TITLE
Tensor<T> - Fixed missing memory offset from ReadOnlyTensorSpan

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.Factory.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.Factory.cs
@@ -64,7 +64,7 @@ namespace System.Numerics.Tensors
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static Tensor<T> Create<T>(T[] values, scoped ReadOnlySpan<nint> lengths, scoped ReadOnlySpan<nint> strides, bool pinned = false)
         {
-            return new Tensor<T>(values, lengths, strides, 0, pinned);
+            return new Tensor<T>(values, lengths, strides, memoryOffset: 0, pinned);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace System.Numerics.Tensors
         public static Tensor<T> Create<T>(IEnumerable<T> values, scoped ReadOnlySpan<nint> lengths, bool pinned = false)
         {
             T[] data = values.ToArray();
-            return new Tensor<T>(data, lengths.IsEmpty ? [data.Length] : lengths, 0, pinned);
+            return new Tensor<T>(data, lengths.IsEmpty ? [data.Length] : lengths, memoryOffset: 0, pinned);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace System.Numerics.Tensors
         public static Tensor<T> Create<T>(IEnumerable<T> values, scoped ReadOnlySpan<nint> lengths, scoped ReadOnlySpan<nint> strides, bool pinned = false)
         {
             T[] data = values.ToArray();
-            return new Tensor<T>(data, lengths.IsEmpty ? [data.Length] : lengths, strides, 0, pinned);
+            return new Tensor<T>(data, lengths.IsEmpty ? [data.Length] : lengths, strides, memoryOffset: 0, pinned);
         }
 
         #region Normal
@@ -115,7 +115,7 @@ namespace System.Numerics.Tensors
             nint linearLength = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = new T[linearLength];
             GaussianDistribution<T>(values, linearLength, random);
-            return new Tensor<T>(values, lengths, 0, false);
+            return new Tensor<T>(values, lengths, memoryOffset: 0, isPinned: false);
         }
 
         private static void GaussianDistribution<T>(in Span<T> values, nint linearLength, Random random)
@@ -154,7 +154,7 @@ namespace System.Numerics.Tensors
             for (int i = 0; i < values.Length; i++)
                 values[i] = T.CreateChecked(random.NextDouble());
 
-            return new Tensor<T>(values, lengths, 0, false);
+            return new Tensor<T>(values, lengths, memoryOffset: 0, isPinned: false);
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace System.Numerics.Tensors
         {
             nint linearLength = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = GC.AllocateUninitializedArray<T>((int)linearLength, pinned);
-            return new Tensor<T>(values, lengths, strides, 0, pinned);
+            return new Tensor<T>(values, lengths, strides, memoryOffset: 0, pinned);
         }
 
         /// <summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.Factory.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.Factory.cs
@@ -64,7 +64,7 @@ namespace System.Numerics.Tensors
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static Tensor<T> Create<T>(T[] values, scoped ReadOnlySpan<nint> lengths, scoped ReadOnlySpan<nint> strides, bool pinned = false)
         {
-            return new Tensor<T>(values, lengths, strides, pinned);
+            return new Tensor<T>(values, lengths, strides, 0, pinned);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace System.Numerics.Tensors
         public static Tensor<T> Create<T>(IEnumerable<T> values, scoped ReadOnlySpan<nint> lengths, bool pinned = false)
         {
             T[] data = values.ToArray();
-            return new Tensor<T>(data, lengths.IsEmpty ? [data.Length] : lengths, pinned);
+            return new Tensor<T>(data, lengths.IsEmpty ? [data.Length] : lengths, 0, pinned);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace System.Numerics.Tensors
         public static Tensor<T> Create<T>(IEnumerable<T> values, scoped ReadOnlySpan<nint> lengths, scoped ReadOnlySpan<nint> strides, bool pinned = false)
         {
             T[] data = values.ToArray();
-            return new Tensor<T>(data, lengths.IsEmpty ? [data.Length] : lengths, strides, pinned);
+            return new Tensor<T>(data, lengths.IsEmpty ? [data.Length] : lengths, strides, 0, pinned);
         }
 
         #region Normal
@@ -115,7 +115,7 @@ namespace System.Numerics.Tensors
             nint linearLength = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = new T[linearLength];
             GaussianDistribution<T>(values, linearLength, random);
-            return new Tensor<T>(values, lengths, false);
+            return new Tensor<T>(values, lengths, 0, false);
         }
 
         private static void GaussianDistribution<T>(in Span<T> values, nint linearLength, Random random)
@@ -154,7 +154,7 @@ namespace System.Numerics.Tensors
             for (int i = 0; i < values.Length; i++)
                 values[i] = T.CreateChecked(random.NextDouble());
 
-            return new Tensor<T>(values, lengths, false);
+            return new Tensor<T>(values, lengths, 0, false);
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace System.Numerics.Tensors
         {
             nint linearLength = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = GC.AllocateUninitializedArray<T>((int)linearLength, pinned);
-            return new Tensor<T>(values, lengths, strides, pinned);
+            return new Tensor<T>(values, lengths, strides, 0, pinned);
         }
 
         /// <summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -69,7 +69,7 @@ namespace System.Numerics.Tensors
             _lengths = lengths.IsEmpty ? [values.Length] : lengths.ToArray();
             _memoryOffset = memoryOffset;
 
-            if (_memoryOffset < 0 || _memoryOffset >= values.Length)
+            if (_memoryOffset < 0 || (_memoryOffset >= values.Length && values.Length != 0 ))
                 ThrowHelper.ThrowIndexOutOfRangeException();
 
             _flattenedLength = TensorSpanHelpers.CalculateTotalLength(_lengths);

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -69,6 +69,9 @@ namespace System.Numerics.Tensors
             _lengths = lengths.IsEmpty ? [values.Length] : lengths.ToArray();
             _memoryOffset = memoryOffset;
 
+            if (_memoryOffset < 0 || _memoryOffset >= values.Length)
+                ThrowHelper.ThrowIndexOutOfRangeException();
+
             _flattenedLength = TensorSpanHelpers.CalculateTotalLength(_lengths);
             _strides = strides.IsEmpty ? TensorSpanHelpers.CalculateStrides(_lengths, _flattenedLength) : strides.ToArray();
             TensorSpanHelpers.ValidateStrides(_strides, _lengths);
@@ -77,12 +80,12 @@ namespace System.Numerics.Tensors
             if (Environment.Is64BitProcess)
             {
                 // See comment in Span<T>.Slice for how this works.
-                if ((ulong)(uint)maxElements >= (ulong)(uint)values.Length && values.Length != 0)
+                if ((ulong)(uint)maxElements >= (ulong)(uint)(values.Length - memoryOffset) && values.Length != 0)
                     ThrowHelper.ThrowArgument_InvalidStridesAndLengths();
             }
             else
             {
-                if (((uint)maxElements >= (uint)(values.Length)) && values.Length != 0)
+                if (((uint)maxElements >= (uint)(values.Length - memoryOffset)) && values.Length != 0)
                     ThrowHelper.ThrowArgument_InvalidStridesAndLengths();
             }
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -99,7 +99,7 @@ namespace System.Numerics.Tensors
         {
             nint linearLength = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = pinned ? GC.AllocateArray<T>((int)linearLength, pinned) : (new T[linearLength]);
-            return new Tensor<T>(values, lengths.ToArray(), 0, pinned);
+            return new Tensor<T>(values, lengths.ToArray(), memoryOffset: 0, pinned);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace System.Numerics.Tensors
         {
             nint linearLength = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = pinned ? GC.AllocateArray<T>((int)linearLength, pinned) : (new T[linearLength]);
-            return new Tensor<T>(values, lengths.ToArray(), strides.ToArray(), 0, pinned);
+            return new Tensor<T>(values, lengths.ToArray(), strides.ToArray(), memoryOffset: 0, pinned);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace System.Numerics.Tensors
         {
             nint linearLength = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = GC.AllocateUninitializedArray<T>((int)linearLength, pinned);
-            return new Tensor<T>(values, lengths.ToArray(), 0, pinned);
+            return new Tensor<T>(values, lengths.ToArray(), memoryOffset: 0, pinned);
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace System.Numerics.Tensors
         {
             nint linearLength = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = GC.AllocateUninitializedArray<T>((int)linearLength, pinned);
-            return new Tensor<T>(values, lengths.ToArray(), strides.ToArray(), 0, pinned);
+            return new Tensor<T>(values, lengths.ToArray(), strides.ToArray(), memoryOffset: 0, pinned);
         }
 
         // ITensor
@@ -381,7 +381,7 @@ namespace System.Numerics.Tensors
         /// <summary>
         /// Defines an implicit conversion of an array to a <see cref="Tensor{T}"/>.
         /// </summary>
-        public static implicit operator Tensor<T>(T[] array) => new Tensor<T>(array, [array.Length], 0);
+        public static implicit operator Tensor<T>(T[] array) => new Tensor<T>(array, [array.Length], memoryOffset: 0);
 
         /// <summary>
         /// Defines an implicit conversion of a <see cref="Tensor{T}"/> to a <see cref="TensorSpan{T}"/>.

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -218,7 +218,7 @@ namespace System.Numerics.Tensors
         internal static Tensor<T> LazyBroadcast<T>(Tensor<T> input, ReadOnlySpan<nint> lengths)
         {
             if (input.Lengths.SequenceEqual(lengths))
-                return new Tensor<T>(input._values, lengths, false);
+                return new Tensor<T>(input._values, lengths, input._memoryOffset, false);
 
             if (!TensorHelpers.IsBroadcastableTo(input.Lengths, lengths))
                 ThrowHelper.ThrowArgument_LengthsNotBroadcastCompatible();
@@ -244,7 +244,7 @@ namespace System.Numerics.Tensors
                 }
             }
 
-            Tensor<T> output = new Tensor<T>(input._values, lengths, strides);
+            Tensor<T> output = new Tensor<T>(input._values, lengths, strides, input._memoryOffset);
 
             return output;
         }
@@ -2660,7 +2660,7 @@ namespace System.Numerics.Tensors
                         lengths[i] = tensor.Lengths[dimensions[i]];
                     permutation = dimensions.ToArray();
                 }
-                outTensor = new Tensor<T>(values, lengths, Array.Empty<nint>(), tensor._isPinned);
+                outTensor = new Tensor<T>(values, lengths, Array.Empty<nint>(), tensor._memoryOffset, tensor._isPinned);
 
                 ospan = outTensor.AsTensorSpan();
                 ispan = tensor.AsTensorSpan();
@@ -2771,7 +2771,7 @@ namespace System.Numerics.Tensors
             else
                 strides = TensorSpanHelpers.CalculateStrides(arrLengths);
 
-            return new Tensor<T>(tensor._values, arrLengths, strides);
+            return new Tensor<T>(tensor._values, arrLengths, strides, tensor._memoryOffset);
         }
 
         /// <summary>
@@ -2926,7 +2926,7 @@ namespace System.Numerics.Tensors
         {
             nint newSize = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = tensor.IsPinned ? GC.AllocateArray<T>((int)newSize) : (new T[newSize]);
-            Tensor<T> output = new Tensor<T>(values, lengths, false);
+            Tensor<T> output = new Tensor<T>(values, lengths, tensor._memoryOffset, false);
             ReadOnlySpan<T> span = MemoryMarshal.CreateSpan(ref tensor.AsTensorSpan()._reference, (int)tensor._values.Length);
             Span<T> ospan = MemoryMarshal.CreateSpan(ref output.AsTensorSpan()._reference, (int)output.FlattenedLength);
             if (newSize > tensor._values.Length)
@@ -3217,7 +3217,7 @@ namespace System.Numerics.Tensors
             for (int i = 0; i < outputs.Length; i++)
             {
                 T[] values = new T[(int)totalToCopy];
-                outputs[i] = new Tensor<T>(values, newShape);
+                outputs[i] = new Tensor<T>(values, newShape, 0);
                 oIndices.Clear();
                 iIndices.Clear();
 
@@ -3299,7 +3299,7 @@ namespace System.Numerics.Tensors
                 strides = TensorSpanHelpers.CalculateStrides(lengths);
             }
 
-            return new Tensor<T>(tensor._values, lengths, strides);
+            return new Tensor<T>(tensor._values, lengths, strides, tensor._memoryOffset);
         }
 
         /// <summary>
@@ -3661,7 +3661,7 @@ namespace System.Numerics.Tensors
                 strides[dimension] = tensor.Strides[dimension] * tensor.Lengths[dimension];
             }
 
-            return new Tensor<T>(tensor._values, lengths, strides);
+            return new Tensor<T>(tensor._values, lengths, strides, tensor._memoryOffset);
         }
 
         /// <summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorExtensions.cs
@@ -218,7 +218,7 @@ namespace System.Numerics.Tensors
         internal static Tensor<T> LazyBroadcast<T>(Tensor<T> input, ReadOnlySpan<nint> lengths)
         {
             if (input.Lengths.SequenceEqual(lengths))
-                return new Tensor<T>(input._values, lengths, input._memoryOffset, false);
+                return new Tensor<T>(input._values, lengths, input._memoryOffset, isPinned: false);
 
             if (!TensorHelpers.IsBroadcastableTo(input.Lengths, lengths))
                 ThrowHelper.ThrowArgument_LengthsNotBroadcastCompatible();
@@ -2926,7 +2926,7 @@ namespace System.Numerics.Tensors
         {
             nint newSize = TensorSpanHelpers.CalculateTotalLength(lengths);
             T[] values = tensor.IsPinned ? GC.AllocateArray<T>((int)newSize) : (new T[newSize]);
-            Tensor<T> output = new Tensor<T>(values, lengths, tensor._memoryOffset, false);
+            Tensor<T> output = new Tensor<T>(values, lengths, tensor._memoryOffset, isPinned: false);
             ReadOnlySpan<T> span = MemoryMarshal.CreateSpan(ref tensor.AsTensorSpan()._reference, (int)tensor._values.Length);
             Span<T> ospan = MemoryMarshal.CreateSpan(ref output.AsTensorSpan()._reference, (int)output.FlattenedLength);
             if (newSize > tensor._values.Length)
@@ -3217,7 +3217,7 @@ namespace System.Numerics.Tensors
             for (int i = 0; i < outputs.Length; i++)
             {
                 T[] values = new T[(int)totalToCopy];
-                outputs[i] = new Tensor<T>(values, newShape, 0);
+                outputs[i] = new Tensor<T>(values, newShape, memoryOffset: 0);
                 oIndices.Clear();
                 iIndices.Clear();
 

--- a/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
@@ -1168,6 +1168,12 @@ namespace System.Numerics.Tensors.Tests
             t1 = t0.Slice(new NRange(new NIndex(0), new NIndex(2)), new NRange(new NIndex(2), new NIndex(3)));
             sum = Tensor.Sum<float>(t1);
             Assert.Equal(9, sum);
+
+            Assert.Throws<IndexOutOfRangeException>(()=> new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6 }, [2, 3], -1));
+            Assert.Throws<IndexOutOfRangeException>(()=> new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6 }, [2, 3], 100));
+            Assert.Throws<IndexOutOfRangeException>(()=> new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6 }, [2, 3], int.MinValue));
+            Assert.Throws<IndexOutOfRangeException>(()=> new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6 }, [2, 3], int.MaxValue));
+            Assert.Throws<ArgumentException>(()=> new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6 }, [2, 3], 2));
         }
 
         public static float StdDev(float[] values)

--- a/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorTests.cs
@@ -1136,6 +1136,40 @@ namespace System.Numerics.Tensors.Tests
             Assert.Equal(0f, Tensor.StdDev(upperLeft));
         }
 
+        [Fact]
+        public static void TensorSumTests()
+        {
+            float[] values = new float[] { 1, 2, 3, 4, 5, 6 };
+            Tensor<float> t0 = Tensor.Create<float>(new float[] { 1, 2, 3, 4, 5, 6 }, [2, 3]);
+            float sum = Tensor.Sum<float>(t0);
+            Assert.Equal(21, sum);
+
+            // Slice first row of 2 x 2 for sum
+            Tensor<float> t1 = t0.Slice(new NRange(new NIndex(0), new NIndex(1)), new NRange(new NIndex(0), new NIndex(0, true)));
+            sum = Tensor.Sum<float>(t1);
+            Assert.Equal(6, sum);
+
+            // Slice second row of 2 x 2 for sum.
+            t1 = t0.Slice(new NRange(new NIndex(1), new NIndex(2)), new NRange(new NIndex(0), new NIndex(0, true)));
+            sum = Tensor.Sum<float>(t1);
+            Assert.Equal(15, sum);
+
+            // Slice first column of 2 x 2 for sum.
+            t1 = t0.Slice(new NRange(new NIndex(0), new NIndex(2)), new NRange(new NIndex(0), new NIndex(1)));
+            sum = Tensor.Sum<float>(t1);
+            Assert.Equal(5, sum);
+
+            // Slice second column of 2 x 2 for sum.
+            t1 = t0.Slice(new NRange(new NIndex(0), new NIndex(2)), new NRange(new NIndex(1), new NIndex(2)));
+            sum = Tensor.Sum<float>(t1);
+            Assert.Equal(7, sum);
+
+            // Slice Third column of 2 x 2 for sum.
+            t1 = t0.Slice(new NRange(new NIndex(0), new NIndex(2)), new NRange(new NIndex(2), new NIndex(3)));
+            sum = Tensor.Sum<float>(t1);
+            Assert.Equal(9, sum);
+        }
+
         public static float StdDev(float[] values)
         {
             float mean = Mean(values);
@@ -2649,7 +2683,7 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public void TensorObjectFillTests()
         {
-            ITensor tensor = (ITensor)new Tensor<int>(new int[4], new nint[] { 2, 2 });
+            ITensor tensor = (ITensor)new Tensor<int>(new int[4], new nint[] { 2, 2 }, 0);
             tensor.Fill(5);
 
             Assert.Equal(5, tensor[0, 0]);
@@ -2670,7 +2704,7 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public void TensorObjectIndexerTests()
         {
-            ITensor tensor = new Tensor<int>(new int[] { 1, 2, 3, 4 }, new nint[] { 2, 2 });
+            ITensor tensor = new Tensor<int>(new int[] { 1, 2, 3, 4 }, new nint[] { 2, 2 }, 0);
 
             Assert.Equal(1, tensor[new nint[] { 0, 0 }]);
             Assert.Equal(2, tensor[new nint[] { 0, 1 }]);
@@ -2701,7 +2735,7 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public void TensorGetPinnedHandleTests()
         {
-            Tensor<int> tensor = new Tensor<int>(new int[] { 1, 2, 3, 4 }, new nint[] { 2, 2 });
+            Tensor<int> tensor = new Tensor<int>(new int[] { 1, 2, 3, 4 }, new nint[] { 2, 2 }, 0);
 
             using MemoryHandle handle = tensor.GetPinnedHandle();
             unsafe


### PR DESCRIPTION
When creating #113166 I didn't have any testing for the implicit conversions and so missed a few places where the memory offset was not being passed through. This fixes that, and makes the memory offset no longer have a default value on the internal constructor so it has to be manually specified every time to not miss it anymore. It also adds testing to catch this case moving forward.