### PR TITLE
Build ILAsm dependencies with secure source hashing enabled in MSVC

### DIFF
--- a/src/coreclr/ilasm/CMakeLists.txt
+++ b/src/coreclr/ilasm/CMakeLists.txt
@@ -51,6 +51,10 @@ if(CLR_CMAKE_TARGET_WIN32)
 
   set(ILASM_RESOURCES Native.rc)
   add_definitions(-DFX_VER_INTERNALNAME_STR=ilasm.exe)
+
+  # Ensure secure source code hashing is enabled when building asmparse.cpp
+  # to avoid BinSkim BA2004 warnings.
+  set_source_files_properties( prebuilt/asmparse.cpp PROPERTIES COMPILE_FLAGS "/ZH:SHA_256" )
 endif(CLR_CMAKE_TARGET_WIN32)
 
 


### PR DESCRIPTION
BinSkim flagged the parser ILAsm directly links in for not being built with secure source hashing enabled in MSVC ([issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2418875)). Modern MSVC versions should default to using SHA-256 to compute source file checksums, though older versions default to MD5, according to the feature's [documentation](https://learn.microsoft.com/en-us/cpp/build/reference/zh?view=msvc-170). To ensure we aren't dependent on the compiler version used to pass BinSkim's `BA2004` check, set the build to always use SHA-256.