### PR TITLE
JIT: Remove oldlayout test configs

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -540,7 +540,6 @@ jobs:
             - jitpartialcompilation_pgo
             - jitpartialcompilation_pgo_stress_random
             - jitoptrepeat
-            - jitoldlayout
           ${{ else }}:
             scenarios:
             - jitosr_stress
@@ -554,7 +553,6 @@ jobs:
             - jitphysicalpromotion_full
             - jitrlcse
             - jitoptrepeat
-            - jitoldlayout
         ${{ if in(parameters.testGroup, 'jit-cfg') }}:
           scenarios:
           - jitcfg

--- a/eng/pipelines/coreclr/libraries-pgo.yml
+++ b/eng/pipelines/coreclr/libraries-pgo.yml
@@ -71,4 +71,3 @@ extends:
                     - syntheticpgo
                     - syntheticpgo_blend
                     - jitrlcse
-                    - jitoldlayout

--- a/src/coreclr/ilasm/CMakeLists.txt
+++ b/src/coreclr/ilasm/CMakeLists.txt
@@ -51,6 +51,10 @@ if(CLR_CMAKE_TARGET_WIN32)
 
   set(ILASM_RESOURCES Native.rc)
   add_definitions(-DFX_VER_INTERNALNAME_STR=ilasm.exe)
+
+  # Ensure secure source code hashing is enabled when building asmparse.cpp
+  # to avoid BinSkim BA2004 warnings.
+  set_source_files_properties( prebuilt/asmparse.cpp PROPERTIES COMPILE_FLAGS "/ZH:SHA_256" )
 endif(CLR_CMAKE_TARGET_WIN32)
 
 

--- a/src/coreclr/ilasm/CMakeLists.txt
+++ b/src/coreclr/ilasm/CMakeLists.txt
@@ -51,10 +51,6 @@ if(CLR_CMAKE_TARGET_WIN32)
 
   set(ILASM_RESOURCES Native.rc)
   add_definitions(-DFX_VER_INTERNALNAME_STR=ilasm.exe)
-
-  # Ensure secure source code hashing is enabled when building asmparse.cpp
-  # to avoid BinSkim BA2004 warnings.
-  set_source_files_properties( prebuilt/asmparse.cpp PROPERTIES COMPILE_FLAGS "/ZH:SHA_256" )
 endif(CLR_CMAKE_TARGET_WIN32)
 
 

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -248,7 +248,6 @@
     <TestEnvironment Include="syntheticpgo_blend" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitSynthesizeCounts="3" JitCheckSynthesizedCounts="1" />
     <TestEnvironment Include="jitrlcse" JitRLCSEGreedy="1" />
     <TestEnvironment Include="jitoptrepeat" JitEnableOptRepeat="1" JitOptRepeat="*" JitOptRepeatCount="2"/>
-    <TestEnvironment Include="jitoldlayout" JitDoReversePostOrderLayout="0"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' == 'true'" GCName="clrgc.dll"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' != 'true'" GCName="libclrgc.so"/>
     <TestEnvironment Include="gcstandaloneserver" Condition="'$(TargetsWindows)' == 'true'" gcServer="1" GCName="clrgc.dll"/>


### PR DESCRIPTION
Follow-up to #113335. There is no longer any old layout implementation to test.

@dotnet/jit-contrib PTAL, thanks!