### PR TITLE
Delete vestiges of unused assembly formats

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -103,21 +103,6 @@ namespace Internal.Reflection.Augments
                 return RuntimeAssemblyInfo.GetRuntimeAssemblyIfExists(assemblyRef.ToRuntimeAssemblyName());
         }
 
-        public static Assembly Load(ReadOnlySpan<byte> rawAssembly, ReadOnlySpan<byte> pdbSymbolStore)
-        {
-            if (rawAssembly.IsEmpty)
-                throw new ArgumentNullException(nameof(rawAssembly));
-
-            return RuntimeAssemblyInfo.GetRuntimeAssemblyFromByteArray(rawAssembly, pdbSymbolStore);
-        }
-
-        public static Assembly Load(string assemblyPath)
-        {
-            ArgumentNullException.ThrowIfNull(assemblyPath);
-
-            return RuntimeAssemblyInfo.GetRuntimeAssemblyFromPath(assemblyPath);
-        }
-
         //
         // This overload of GetMethodForHandle only accepts handles for methods declared on non-generic types (the method, however,
         // can be an instance of a generic method.) To resolve handles for methods declared on generic types, you must pass

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/AssemblyBinder.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/AssemblyBinder.cs
@@ -19,7 +19,6 @@ namespace Internal.Reflection.Core
     {
         public MetadataReader Reader;
         public ScopeDefinitionHandle ScopeDefinitionHandle;
-        public IEnumerable<QScopeDefinition> OverflowScopes;
     }
 
     //
@@ -32,10 +31,6 @@ namespace Internal.Reflection.Core
     public abstract class AssemblyBinder
     {
         public abstract bool Bind(RuntimeAssemblyName refName, bool cacheMissedLookups, out AssemblyBindResult result, out Exception exception);
-
-        public abstract bool Bind(ReadOnlySpan<byte> rawAssembly, ReadOnlySpan<byte> rawSymbolStore, out AssemblyBindResult result, out Exception exception);
-
-        public abstract bool Bind(string assemblyPath, out AssemblyBindResult bindResult, out Exception exception);
 
         public abstract IList<AssemblyBindResult> GetLoadedAssemblies();
     }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.GetTypeCore.CaseSensitive.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/Assemblies/NativeFormat/NativeFormatRuntimeAssembly.GetTypeCore.CaseSensitive.cs
@@ -21,15 +21,12 @@ namespace System.Reflection.Runtime.Assemblies.NativeFormat
                 namespaceParts[numNamespaceParts - i - 1] = parts[i];
             string name = parts[numNamespaceParts];
 
-            foreach (QScopeDefinition scopeDefinition in AllScopes)
+            MetadataReader reader = Scope.Reader;
+            ScopeDefinitionHandle scopeDefinitionHandle = Scope.Handle;
+
+            NamespaceDefinition namespaceDefinition;
+            if (TryResolveNamespaceDefinitionCaseSensitive(reader, namespaceParts, scopeDefinitionHandle, out namespaceDefinition))
             {
-                MetadataReader reader = scopeDefinition.Reader;
-                ScopeDefinitionHandle scopeDefinitionHandle = scopeDefinition.Handle;
-
-                NamespaceDefinition namespaceDefinition;
-                if (!TryResolveNamespaceDefinitionCaseSensitive(reader, namespaceParts, scopeDefinitionHandle, out namespaceDefinition))
-                    continue;
-
                 // We've successfully drilled down the namespace chain. Now look for a top-level type matching the type name.
                 TypeDefinitionHandleCollection candidateTypes = namespaceDefinition.TypeDefinitions;
                 foreach (TypeDefinitionHandle candidateType in candidateTypes)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -43,17 +43,7 @@ namespace System.Reflection.Runtime.Assemblies
         /// </summary>
         internal static RuntimeAssembly GetRuntimeAssemblyFromByteArray(ReadOnlySpan<byte> rawAssembly, ReadOnlySpan<byte> pdbSymbolStore)
         {
-            AssemblyBinder binder = ReflectionCoreExecution.ExecutionEnvironment.AssemblyBinder;
-            if (!binder.Bind(rawAssembly, pdbSymbolStore, out AssemblyBindResult bindResult, out Exception exception))
-            {
-                if (exception != null)
-                    throw exception;
-                else
-                    throw new BadImageFormatException();
-            }
-
-            RuntimeAssembly result = GetRuntimeAssembly(bindResult);
-            return result;
+            throw new PlatformNotSupportedException();
         }
 
         /// <summary>
@@ -61,17 +51,7 @@ namespace System.Reflection.Runtime.Assemblies
         /// </summary>
         internal static RuntimeAssembly GetRuntimeAssemblyFromPath(string assemblyPath)
         {
-            AssemblyBinder binder = ReflectionCoreExecution.ExecutionEnvironment.AssemblyBinder;
-            if (!binder.Bind(assemblyPath, out AssemblyBindResult bindResult, out Exception exception))
-            {
-                if (exception != null)
-                    throw exception;
-                else
-                    throw new BadImageFormatException();
-            }
-
-            RuntimeAssembly result = GetRuntimeAssembly(bindResult, assemblyPath);
-            return result;
+            throw new PlatformNotSupportedException();
         }
 
         /// <summary>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -39,22 +39,6 @@ namespace System.Reflection.Runtime.Assemblies
         }
 
         /// <summary>
-        /// Returns non-null or throws.
-        /// </summary>
-        internal static RuntimeAssembly GetRuntimeAssemblyFromByteArray(ReadOnlySpan<byte> rawAssembly, ReadOnlySpan<byte> pdbSymbolStore)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        /// <summary>
-        /// Returns non-null or throws.
-        /// </summary>
-        internal static RuntimeAssembly GetRuntimeAssemblyFromPath(string assemblyPath)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        /// <summary>
         /// Returns null if no assembly matches the assemblyRefName. Throws for other error cases.
         /// </summary>
         internal static RuntimeAssemblyInfo GetRuntimeAssemblyIfExists(RuntimeAssemblyName assemblyRefName)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.NativeAot.cs
@@ -43,18 +43,21 @@ namespace System.Runtime.Loader
 
         private static Assembly InternalLoadFromPath(string? assemblyPath, string? nativeImagePath)
         {
-            // TODO: This is not passing down the AssemblyLoadContext,
-            // so it won't actually work properly when multiple assemblies with the same identity get loaded.
-            return ReflectionAugments.Load(assemblyPath);
+            ArgumentNullException.ThrowIfNull(assemblyPath);
+
+            throw new PlatformNotSupportedException();
         }
 #pragma warning restore IDE0060
 
-#pragma warning disable CA1822
-        internal Assembly InternalLoad(ReadOnlySpan<byte> arrAssembly, ReadOnlySpan<byte> arrSymbols)
+#pragma warning disable CA1822, IDE0060
+        internal Assembly InternalLoad(ReadOnlySpan<byte> rawAssembly, ReadOnlySpan<byte> rawSymbols)
         {
-            return ReflectionAugments.Load(arrAssembly, arrSymbols);
+            if (rawAssembly.IsEmpty)
+                throw new ArgumentNullException(nameof(rawAssembly));
+
+            throw new PlatformNotSupportedException();
         }
-#pragma warning restore CA1822
+#pragma warning restore CA1822, IDE0060
 
         private void ReferenceUnreferencedEvents()
         {

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
@@ -90,12 +90,6 @@ namespace Internal.Reflection.Execution
                     out isFlags);
                 return;
             }
-#if ECMA_METADATA_SUPPORT
-            if (qTypeDefinition.IsEcmaFormatMetadataBased)
-            {
-                return EcmaFormatEnumInfo.Create<TUnderlyingValue>(typeHandle, qTypeDefinition.EcmaFormatReader, qTypeDefinition.EcmaFormatHandle);
-            }
-#endif
             names = Array.Empty<string>();
             values = Array.Empty<object>();
             isFlags = false;

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/MethodInvokerWithMethodInvokeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/MethodInvokerWithMethodInvokeInfo.cs
@@ -42,17 +42,6 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 if (0 != (methodAttributes & MethodAttributes.Static))
                     isStatic = true;
             }
-#if ECMA_METADATA_SUPPORT
-            if (methodHandle.IsEcmaFormatMetadataBased)
-            {
-                var reader = methodHandle.EcmaFormatReader;
-                var method = reader.GetMethodDefinition(methodHandle.EcmaFormatHandle);
-                var blobReader = reader.GetBlobReader(method.Signature);
-                byte sigByte = blobReader.ReadByte();
-                if ((sigByte & (byte)System.Reflection.Metadata.SignatureAttributes.Instance) == 0)
-                    isStatic = true;
-            }
-#endif
 
             if (isStatic)
                 return new StaticMethodInvoker(methodInvokeInfo);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
@@ -25,48 +25,23 @@ namespace Internal.Reflection.Execution
     {
         private AssemblyBinderImplementation()
         {
-            _scopeGroups = Array.Empty<KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup>>();
-
+            ArrayBuilder<KeyValuePair<RuntimeAssemblyName, QScopeDefinition>> scopes = default;
             foreach (NativeFormatModuleInfo module in ModuleList.EnumerateModules())
-                RegisterModule(module);
+            {
+                MetadataReader reader = module.MetadataReader;
+                foreach (ScopeDefinitionHandle scopeDefinitionHandle in reader.ScopeDefinitions)
+                {
+                    scopes.Add(new KeyValuePair<RuntimeAssemblyName, QScopeDefinition>(
+                        scopeDefinitionHandle.ToRuntimeAssemblyName(reader),
+                        new QScopeDefinition(reader, scopeDefinitionHandle)
+                        ));
+                }
+            }
+
+            ScopeGroups = scopes.ToArray();
         }
 
         public static AssemblyBinderImplementation Instance { get; } = new AssemblyBinderImplementation();
-
-        partial void BindEcmaFilePath(string assemblyPath, ref AssemblyBindResult bindResult, ref Exception exception, ref bool? result);
-        partial void BindEcmaBytes(ReadOnlySpan<byte> rawAssembly, ReadOnlySpan<byte> rawSymbolStore, ref AssemblyBindResult bindResult, ref Exception exception, ref bool? result);
-        partial void BindEcmaAssemblyName(RuntimeAssemblyName refName, bool cacheMissedLookups, ref AssemblyBindResult result, ref Exception exception, ref Exception preferredException, ref bool resultBoolean);
-        partial void InsertEcmaLoadedAssemblies(List<AssemblyBindResult> loadedAssemblies);
-
-        public sealed override bool Bind(string assemblyPath, out AssemblyBindResult bindResult, out Exception exception)
-        {
-            bool? result = null;
-            exception = null;
-            bindResult = default(AssemblyBindResult);
-
-            BindEcmaFilePath(assemblyPath, ref bindResult, ref exception, ref result);
-
-            // If the Ecma assembly binder isn't linked in, simply throw PlatformNotSupportedException
-            if (!result.HasValue)
-                throw new PlatformNotSupportedException();
-            else
-                return result.Value;
-        }
-
-        public sealed override bool Bind(ReadOnlySpan<byte> rawAssembly, ReadOnlySpan<byte> rawSymbolStore, out AssemblyBindResult bindResult, out Exception exception)
-        {
-            bool? result = null;
-            exception = null;
-            bindResult = default(AssemblyBindResult);
-
-            BindEcmaBytes(rawAssembly, rawSymbolStore, ref bindResult, ref exception, ref result);
-
-            // If the Ecma assembly binder isn't linked in, simply throw PlatformNotSupportedException
-            if (!result.HasValue)
-                throw new PlatformNotSupportedException();
-            else
-                return result.Value;
-        }
 
         public sealed override bool Bind(RuntimeAssemblyName refName, bool cacheMissedLookups, out AssemblyBindResult result, out Exception exception)
         {
@@ -76,7 +51,7 @@ namespace Internal.Reflection.Execution
 
             Exception preferredException = null;
 
-            foreach (KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup> group in ScopeGroups)
+            foreach (KeyValuePair<RuntimeAssemblyName, QScopeDefinition> group in ScopeGroups)
             {
                 if (AssemblyNameMatches(refName, group.Key, ref preferredException))
                 {
@@ -87,17 +62,12 @@ namespace Internal.Reflection.Execution
                     }
 
                     foundMatch = true;
-                    ScopeDefinitionGroup scopeDefinitionGroup = group.Value;
+                    QScopeDefinition scopeDefinitionGroup = group.Value;
 
-                    result.Reader = scopeDefinitionGroup.CanonicalScope.Reader;
-                    result.ScopeDefinitionHandle = scopeDefinitionGroup.CanonicalScope.Handle;
-                    result.OverflowScopes = scopeDefinitionGroup.OverflowScopes;
+                    result.Reader = scopeDefinitionGroup.Reader;
+                    result.ScopeDefinitionHandle = scopeDefinitionGroup.Handle;
                 }
             }
-
-            BindEcmaAssemblyName(refName, cacheMissedLookups, ref result, ref exception, ref preferredException, ref foundMatch);
-            if (exception != null)
-                return false;
 
             if (!foundMatch)
             {
@@ -111,18 +81,15 @@ namespace Internal.Reflection.Execution
         public sealed override IList<AssemblyBindResult> GetLoadedAssemblies()
         {
             List<AssemblyBindResult> loadedAssemblies = new List<AssemblyBindResult>(ScopeGroups.Length);
-            foreach (KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup> group in ScopeGroups)
+            foreach (KeyValuePair<RuntimeAssemblyName, QScopeDefinition> group in ScopeGroups)
             {
-                ScopeDefinitionGroup scopeDefinitionGroup = group.Value;
+                QScopeDefinition scopeDefinitionGroup = group.Value;
 
                 AssemblyBindResult result = default(AssemblyBindResult);
-                result.Reader = scopeDefinitionGroup.CanonicalScope.Reader;
-                result.ScopeDefinitionHandle = scopeDefinitionGroup.CanonicalScope.Handle;
-                result.OverflowScopes = scopeDefinitionGroup.OverflowScopes;
+                result.Reader = scopeDefinitionGroup.Reader;
+                result.ScopeDefinitionHandle = scopeDefinitionGroup.Handle;
                 loadedAssemblies.Add(result);
             }
-
-            InsertEcmaLoadedAssemblies(loadedAssemblies);
 
             return loadedAssemblies;
         }
@@ -188,86 +155,6 @@ namespace Internal.Reflection.Execution
             return true;
         }
 
-        /// <summary>
-        /// This callback gets called whenever a module gets registered. It adds the metadata reader
-        /// for the new module to the available scopes. The lock in ExecutionEnvironmentImplementation ensures
-        /// that this function may never be called concurrently so that we can assume that two threads
-        /// never update the reader and scope list at the same time.
-        /// </summary>
-        /// <param name="nativeFormatModuleInfo">Module to register</param>
-        private void RegisterModule(NativeFormatModuleInfo nativeFormatModuleInfo)
-        {
-            LowLevelDictionaryWithIEnumerable<RuntimeAssemblyName, ScopeDefinitionGroup> scopeGroups = new LowLevelDictionaryWithIEnumerable<RuntimeAssemblyName, ScopeDefinitionGroup>();
-            foreach (KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup> oldGroup in _scopeGroups)
-            {
-                scopeGroups.Add(oldGroup.Key, oldGroup.Value);
-            }
-            AddScopesFromReaderToGroups(scopeGroups, nativeFormatModuleInfo.MetadataReader);
-
-            // Update reader and scope list
-            KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup>[] scopeGroupsArray = new KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup>[scopeGroups.Count];
-            int i = 0;
-            foreach (KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup> data in scopeGroups)
-            {
-                scopeGroupsArray[i] = data;
-                i++;
-            }
-
-            _scopeGroups = scopeGroupsArray;
-        }
-
-        private KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup>[] ScopeGroups
-        {
-            get
-            {
-                return _scopeGroups;
-            }
-        }
-
-        private static void AddScopesFromReaderToGroups(LowLevelDictionaryWithIEnumerable<RuntimeAssemblyName, ScopeDefinitionGroup> groups, MetadataReader reader)
-        {
-            foreach (ScopeDefinitionHandle scopeDefinitionHandle in reader.ScopeDefinitions)
-            {
-                RuntimeAssemblyName defName = scopeDefinitionHandle.ToRuntimeAssemblyName(reader);
-                ScopeDefinitionGroup scopeDefinitionGroup;
-                if (groups.TryGetValue(defName, out scopeDefinitionGroup))
-                {
-                    scopeDefinitionGroup.AddOverflowScope(new QScopeDefinition(reader, scopeDefinitionHandle));
-                }
-                else
-                {
-                    scopeDefinitionGroup = new ScopeDefinitionGroup(new QScopeDefinition(reader, scopeDefinitionHandle));
-                    groups.Add(defName, scopeDefinitionGroup);
-                }
-            }
-        }
-
-        private volatile KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup>[] _scopeGroups;
-
-        private class ScopeDefinitionGroup
-        {
-            public ScopeDefinitionGroup(QScopeDefinition canonicalScope)
-            {
-                _canonicalScope = canonicalScope;
-            }
-
-            public QScopeDefinition CanonicalScope { get { return _canonicalScope; } }
-
-            public IEnumerable<QScopeDefinition> OverflowScopes
-            {
-                get
-                {
-                    return _overflowScopes.ToArray();
-                }
-            }
-
-            public void AddOverflowScope(QScopeDefinition overflowScope)
-            {
-                _overflowScopes.Add(overflowScope);
-            }
-
-            private readonly QScopeDefinition _canonicalScope;
-            private ArrayBuilder<QScopeDefinition> _overflowScopes;
-        }
+        private KeyValuePair<RuntimeAssemblyName, QScopeDefinition>[] ScopeGroups { get; }
     }
 }


### PR DESCRIPTION
* Vestigial support for loading assemblies in IL format
* Vestigial support for "overflow scopes" in native metadata, which is something we had in .NET Native at some point I guess (ability to split metadata for a single assembly into multiple native modules?)