### PR TITLE
[RuntimeAsync] Docs: Add Await overloads for configured task awaitables.

### DIFF
--- a/docs/design/specs/runtime-async.md
+++ b/docs/design/specs/runtime-async.md
@@ -49,6 +49,15 @@ Async methods support suspension using one of the following methods:
           public static T Await<T>(Task<T> task);
           [MethodImpl(MethodImplOptions.Async)]
           public static T Await<T>(ValueTask<T> task);
+
+          [MethodImpl(MethodImplOptions.Async)]
+          public static void Await(ConfiguredTaskAwaitable configuredAwaitable);
+          [MethodImpl(MethodImplOptions.Async)]
+          public static void Await(ConfiguredValueTaskAwaitable configuredAwaitable);
+          [MethodImpl(MethodImplOptions.Async)]
+          public static T Await<T>(ConfiguredTaskAwaitable<T> configuredAwaitable);
+          [MethodImpl(MethodImplOptions.Async)]
+          public static T Await<T>(ConfiguredValueTaskAwaitable<T> configuredAwaitable);
       }
   }
   ```


### PR DESCRIPTION
Add Await overloads for configured task awaitables.

The purpose is to make the common subsets of the following pattern optimizable into direct `async2`->`async2` calls.

```cs
   await SomethingAsync().ConfigureAwait(false);
```

The new overloads:  
```cs
  namespace System.Runtime.CompilerServices
  {
      public static class RuntimeHelpers
      {
. . .
. . .
          [MethodImpl(MethodImplOptions.Async)]
          public static void Await(ConfiguredTaskAwaitable configuredAwaitable);
          [MethodImpl(MethodImplOptions.Async)]
          public static void Await(ConfiguredValueTaskAwaitable configuredAwaitable);
          [MethodImpl(MethodImplOptions.Async)]
          public static T Await<T>(ConfiguredTaskAwaitable<T> configuredAwaitable);
          [MethodImpl(MethodImplOptions.Async)]
          public static T Await<T>(ConfiguredValueTaskAwaitable<T> configuredAwaitable);
      }
  }
```

The idea is that JIT/AOT can detect the following pattern:

```
call[virt] SomethingAsync()
ldc.i4.0                    
call[virt] ConfigureAwait()
call RuntimeHelpers.Await(ConfiguredTaskAwaitable)
```

and emit the equivalent of

```
async_call_no_context SomethingAsync_async2_variant()
```

`async_call_no_context` basically means a `CORINFO_CALLCONV_ASYNCCALL` call with additional bit passed somehow (TBD), indicating no interest in synchronization context capture when suspending/resuming.

The variant of the above IL with `ldc.i4.1` can also be detected, for completeness, and interpreted as `async_call` with the default "do flow the context, if not default" semantics
