### PR TITLE
[RISC-V] Utilize `Zba` extension

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1433,10 +1433,6 @@ AGAIN:
 #endif
 
 FOUND_AM:
-#ifdef TARGET_RISCV64
-    assert(mul == 0 || mul == 1);
-#endif
-
     if (rv2)
     {
         // Make sure a GC address doesn't end up in 'rv2'

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5450,41 +5450,6 @@ void CodeGen::genScaledAdd(
         // target = base + index
         emit->emitIns_R_R_R(ins, attr, targetReg, baseReg, indexReg);
     }
-    // TODO: Use emitComp->compOpportunisticallyDependsOn(InstructionSet_Zba)
-    else if (0 < scale && scale <= 3)
-    {
-        instruction ins;
-        if (attr == EA_4BYTE)
-        {
-            switch (scale)
-            {
-                case 1:
-                    ins = INS_sh1add_uw;
-                    break;
-                case 2:
-                    ins = INS_sh2add_uw;
-                    break;
-                case 3:
-                    ins = INS_sh3add_uw;
-                    break;
-            }
-        }
-        else
-        {
-            switch (scale)
-            {
-                case 1:
-                    ins = INS_sh1add;
-                    break;
-                case 2:
-                    ins = INS_sh2add;
-                    break;
-                case 3:
-                    ins = INS_sh3add;
-            }
-        }
-        emit->emitIns_R_R_R(ins, attr, targetReg, indexReg, baseReg);
-    }
     else
     {
         instruction ins;
@@ -6350,7 +6315,14 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
         genIntCastOverflowCheck(cast, desc, srcReg);
     }
 
-    if ((desc.ExtendKind() != GenIntCastDesc::COPY) || (srcReg != dstReg))
+    if ((cast->gtFlags & GTF_CAST_DEFER_TO_SHXADD_UW) != 0)
+    {
+        if (srcReg != dstReg)
+        {
+            emit->emitIns_R_R_I(INS_addi, EA_PTRSIZE, dstReg, srcReg, 0);
+        }
+    }
+    else if ((desc.ExtendKind() != GenIntCastDesc::COPY) || (srcReg != dstReg))
     {
         switch (desc.ExtendKind())
         {

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5450,6 +5450,41 @@ void CodeGen::genScaledAdd(
         // target = base + index
         emit->emitIns_R_R_R(ins, attr, targetReg, baseReg, indexReg);
     }
+    // TODO: Use emitComp->compOpportunisticallyDependsOn(InstructionSet_Zba)
+    else if (0 < scale && scale <= 3)
+    {
+        instruction ins;
+        if (attr == EA_4BYTE)
+        {
+            switch (scale)
+            {
+                case 1:
+                    ins = INS_sh1add_uw;
+                    break;
+                case 2:
+                    ins = INS_sh2add_uw;
+                    break;
+                case 3:
+                    ins = INS_sh3add_uw;
+                    break;
+            }
+        }
+        else
+        {
+            switch (scale)
+            {
+                case 1:
+                    ins = INS_sh1add;
+                    break;
+                case 2:
+                    ins = INS_sh2add;
+                    break;
+                case 3:
+                    ins = INS_sh3add;
+            }
+        }
+        emit->emitIns_R_R_R(ins, attr, targetReg, indexReg, baseReg);
+    }
     else
     {
         instruction ins;

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -253,6 +253,17 @@ inline bool jitIsScaleIndexMul(size_t val, unsigned naturalMul)
     }
 #elif defined(TARGET_ARM64)
     return val == naturalMul;
+#elif defined(TARGET_RISCV64)
+    switch (val)
+    {
+        case 1:
+        case 2:
+        case 4:
+        case 8:
+            return true;
+        default:
+            return false;
+    }
 #else
     return false;
 #endif

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -4616,7 +4616,23 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
 
                 if (isValidSimm12(offset))
                 {
-                    if (lsl > 0)
+                    // TODO: Use emitComp->compOpportunisticallyDependsOn(InstructionSet_Zba)
+                    if (0 < lsl && lsl <= 3)
+                    {
+                        switch (lsl)
+                        {
+                            case 1:
+                                emitIns_R_R_R(INS_sh1add, addType, tmpReg, index->GetRegNum(), memBase->GetRegNum());
+                                break;
+                            case 2:
+                                emitIns_R_R_R(INS_sh2add, addType, tmpReg, index->GetRegNum(), memBase->GetRegNum());
+                                break;
+                            case 3:
+                                emitIns_R_R_R(INS_sh3add, addType, tmpReg, index->GetRegNum(), memBase->GetRegNum());
+                                break;
+                        }
+                    }
+                    else if (lsl > 0)
                     {
                         // Generate code to set tmpReg = base + index*scale
                         emitIns_R_R_I(INS_slli, addType, tmpReg, index->GetRegNum(), lsl);
@@ -4714,7 +4730,27 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                         NO_WAY("illegal ins within emitInsLoadStoreOp!");
                 }
 
-                if (lsl > 0)
+                // TODO: Use emitComp->compOpportunisticallyDependsOn(InstructionSet_Zba)
+                if (0 < lsl && lsl <= 3)
+                {
+                    switch (lsl)
+                    {
+                        case 1:
+                            emitIns_R_R_R(INS_sh1add, addType, codeGen->rsGetRsvdReg(), index->GetRegNum(),
+                                          memBase->GetRegNum());
+                            break;
+                        case 2:
+                            emitIns_R_R_R(INS_sh2add, addType, codeGen->rsGetRsvdReg(), index->GetRegNum(),
+                                          memBase->GetRegNum());
+                            break;
+                        case 3:
+                            emitIns_R_R_R(INS_sh3add, addType, codeGen->rsGetRsvdReg(), index->GetRegNum(),
+                                          memBase->GetRegNum());
+                            break;
+                    }
+                    emitIns_R_R_I(ins, attr, dataReg, codeGen->rsGetRsvdReg(), 0);
+                }
+                else if (lsl > 0)
                 {
                     // Then load/store dataReg from/to [memBase + index*scale]
                     emitIns_R_R_I(INS_slli, emitActualTypeSize(index->TypeGet()), codeGen->rsGetRsvdReg(),

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -4651,8 +4651,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
 
                 if (isValidSimm12(offset))
                 {
-                    // TODO: Use emitComp->compOpportunisticallyDependsOn(InstructionSet_Zba)
-                    if (0 < lsl && lsl <= 3)
+                    if (canUseShxaddIns(lsl, emitComp))
                     {
                         instruction shxaddIns = getShxaddVariant(lsl, useUnsignedShxaddVariant);
                         emitIns_R_R_R(shxaddIns, addType, tmpReg, index->GetRegNum(), memBase->GetRegNum());
@@ -4687,8 +4686,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                     noway_assert(tmpReg != index->GetRegNum());
 
                     // Then load/store dataReg from/to [tmpReg + index*scale]
-                    // TODO: Use emitComp->compOpportunisticallyDependsOn(InstructionSet_Zba)
-                    if (0 < lsl && lsl <= 3)
+                    if (canUseShxaddIns(lsl, emitComp))
                     {
                         instruction shxaddIns = getShxaddVariant(lsl, useUnsignedShxaddVariant);
                         emitIns_R_R_R(shxaddIns, addType, tmpReg, index->GetRegNum(), tmpReg);
@@ -4768,8 +4766,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                         NO_WAY("illegal ins within emitInsLoadStoreOp!");
                 }
 
-                // TODO: Use emitComp->compOpportunisticallyDependsOn(InstructionSet_Zba)
-                if (0 < lsl && lsl <= 3)
+                if (canUseShxaddIns(lsl, emitComp))
                 {
                     instruction shxaddIns = getShxaddVariant(lsl, useUnsignedShxaddVariant);
                     emitIns_R_R_R(shxaddIns, addType, codeGen->rsGetRsvdReg(), index->GetRegNum(),
@@ -4845,6 +4842,11 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
         // Then load/store dataReg from/to [addrReg]
         emitIns_R_R_I(ins, attr, dataReg, addr->GetRegNum(), 0);
     }
+}
+
+bool emitter::canUseShxaddIns(int scale, Compiler* comp)
+{
+    return comp->compOpportunisticallyDependsOn(InstructionSet_Zba) && jitIsScaleIndexShift(scale);
 }
 
 // The callee must call genConsumeReg() for any non-contained srcs

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -4704,11 +4704,15 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                         instruction shxaddIns = getShxaddVariant(lsl, useUnsignedShxaddVariant);
                         emitIns_R_R_R(shxaddIns, addType, tmpReg, index->GetRegNum(), tmpReg);
                     }
-                    else
+                    else if (lsl > 0)
                     {
                         regNumber scaleReg = codeGen->internalRegisters.GetSingle(indir);
                         emitIns_R_R_I(INS_slli, addType, scaleReg, index->GetRegNum(), lsl);
                         emitIns_R_R_R(INS_add, addType, tmpReg, tmpReg, scaleReg);
+                    }
+                    else
+                    {
+                        emitIns_R_R_R(INS_add, addType, tmpReg, memBase->GetRegNum(), index->GetRegNum());
                     }
                     emitIns_R_R_I(ins, attr, dataReg, tmpReg, 0);
                 }

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -824,7 +824,8 @@ void emitter::emitIns_R_R_R(
     if ((INS_add <= ins && ins <= INS_and) || (INS_mul <= ins && ins <= INS_remuw) ||
         (INS_addw <= ins && ins <= INS_sraw) || (INS_fadd_s <= ins && ins <= INS_fmax_s) ||
         (INS_fadd_d <= ins && ins <= INS_fmax_d) || (INS_feq_s <= ins && ins <= INS_fle_s) ||
-        (INS_feq_d <= ins && ins <= INS_fle_d) || (INS_lr_w <= ins && ins <= INS_amomaxu_d))
+        (INS_feq_d <= ins && ins <= INS_fle_d) || (INS_lr_w <= ins && ins <= INS_amomaxu_d) ||
+        (INS_sh1add <= ins && ins <= INS_slli_uw))
     {
 #ifdef DEBUG
         switch (ins)
@@ -913,6 +914,15 @@ void emitter::emitIns_R_R_R(
             case INS_amominu_d:
             case INS_amomaxu_w:
             case INS_amomaxu_d:
+
+            case INS_sh1add:
+            case INS_sh2add:
+            case INS_sh3add:
+            case INS_add_uw:
+            case INS_sh1add_uw:
+            case INS_sh2add_uw:
+            case INS_sh3add_uw:
+            case INS_slli_uw:
                 break;
             default:
                 NYI_RISCV64("illegal ins within emitIns_R_R_R!");

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -4579,44 +4579,33 @@ void emitter::emitDispFrameRef(int varx, int disp, int offs, bool asmfm)
 
 #endif // DEBUG
 
-instruction getShxaddVariant(int scale, bool useUnsignedVariant)
+instruction emitter::getShxaddVariant(int scale, bool useUnsignedVariant)
 {
-    assert((1 <= scale) && (scale <= 3));
-
-    instruction shxaddIns;
-
     if (useUnsignedVariant)
     {
         switch (scale)
         {
             case 1:
-                shxaddIns = INS_sh1add_uw;
-                break;
+                return INS_sh1add_uw;
             case 2:
-                shxaddIns = INS_sh2add_uw;
-                break;
+                return INS_sh2add_uw;
             case 3:
-                shxaddIns = INS_sh3add_uw;
-                break;
+                return INS_sh3add_uw;
         }
     }
     else
     {
-
         switch (scale)
         {
             case 1:
-                shxaddIns = INS_sh1add;
-                break;
+                return INS_sh1add;
             case 2:
-                shxaddIns = INS_sh2add;
-                break;
+                return INS_sh2add;
             case 3:
-                shxaddIns = INS_sh3add;
-                break;
+                return INS_sh3add;
         }
     }
-    return shxaddIns;
+    return INS_none;
 }
 
 // Generate code for a load or store operation with a potentially complex addressing mode

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3677,6 +3677,11 @@ void emitter::emitDispInsName(
                     {
                         printf("slliw          %s, %s, %d\n", rd, rs1, imm12 & 0x1f); // 5 BITS for SHAMT in RISCV64
                     }
+                    // SLLI.UW's instruction code's upper 6 bits have to be equal to 0x2
+                    else if (((imm12 >> 6) & 0x3f) == 0x2)
+                    {
+                        printf("slli.uw        %s, %s, %d\n", rd, rs1, imm12 & 0x3f); // 6 BITS for SHAMT in RISCV64
+                    }
                     else
                     {
                         emitDispIllegalInstruction(code);
@@ -3792,6 +3797,20 @@ void emitter::emitDispInsName(
                             return emitDispIllegalInstruction(code);
                     }
                     return;
+                case 0b0010000:
+                    switch (opcode3)
+                    {
+                        case 0x2: // SH1ADD
+                            printf("sh1add         %s, %s, %s\n", rd, rs1, rs2);
+                            return;
+                        case 0x4: // SH2ADD
+                            printf("sh2add         %s, %s, %s\n", rd, rs1, rs2);
+                            return;
+                        case 0x6: // SH3ADD
+                            printf("sh3add         %s, %s, %s\n", rd, rs1, rs2);
+                            return;
+                    }
+                    return;
                 default:
                     return emitDispIllegalInstruction(code);
             }
@@ -3855,6 +3874,20 @@ void emitter::emitDispInsName(
                             return;
                         default:
                             return emitDispIllegalInstruction(code);
+                    }
+                    return;
+                case 0b0010000:
+                    switch (opcode3)
+                    {
+                        case 0x2: // SH1ADD.UW
+                            printf("sh1add.uw           %s, %s, %s\n", rd, rs1, rs2);
+                            return;
+                        case 0x4: // SH2ADD.UW
+                            printf("sh2add.uw           %s, %s, %s\n", rd, rs1, rs2);
+                            return;
+                        case 0x6: // SH3ADD.UW
+                            printf("sh3add.uw           %s, %s, %s\n", rd, rs1, rs2);
+                            return;
                     }
                     return;
                 default:

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3880,13 +3880,13 @@ void emitter::emitDispInsName(
                     switch (opcode3)
                     {
                         case 0x2: // SH1ADD.UW
-                            printf("sh1add.uw           %s, %s, %s\n", rd, rs1, rs2);
+                            printf("sh1add.uw      %s, %s, %s\n", rd, rs1, rs2);
                             return;
                         case 0x4: // SH2ADD.UW
-                            printf("sh2add.uw           %s, %s, %s\n", rd, rs1, rs2);
+                            printf("sh2add.uw      %s, %s, %s\n", rd, rs1, rs2);
                             return;
                         case 0x6: // SH3ADD.UW
-                            printf("sh3add.uw           %s, %s, %s\n", rd, rs1, rs2);
+                            printf("sh3add.uw      %s, %s, %s\n", rd, rs1, rs2);
                             return;
                     }
                     return;

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -267,6 +267,8 @@ inline static bool isFloatReg(regNumber reg)
     return (reg >= REG_FP_FIRST && reg <= REG_FP_LAST);
 }
 
+static bool canUseShxaddIns(int scale, Compiler* comp);
+
 /************************************************************************/
 /*                   Output target-independent instructions             */
 /************************************************************************/

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -75,6 +75,8 @@ emitter::code_t emitInsCode(instruction ins /*, insFormat fmt*/) const;
 // Generate code for a load or store operation and handle the case of contained GT_LEA op1 with [base + offset]
 void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir);
 
+static instruction getShxaddVariant(int scale, bool useUnsignedVariant);
+
 // Emit the 32-bit RISCV64 instruction 'code' into the 'dst'  buffer
 unsigned emitOutput_Instr(BYTE* dst, code_t code) const;
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -554,6 +554,9 @@ enum GenTreeFlags : unsigned int
     GTF_HW_EM_OP                  = 0x10000000, // GT_HWINTRINSIC -- node is used as an operand to an embedded mask
     GTF_HW_USER_CALL              = 0x20000000, // GT_HWINTRINSIC -- node is implemented via a user call
 #endif // FEATURE_HW_INTRINSICS
+#ifdef TARGET_RISCV64
+    GTF_CAST_DEFER_TO_SHXADD_UW = 0x80000000, // GT_CAST -- Cast can be skipped if it's an index for SH(X)ADD_UW instruction.
+#endif
 };
 
 inline constexpr GenTreeFlags operator ~(GenTreeFlags a)

--- a/src/coreclr/jit/instrsriscv64.h
+++ b/src/coreclr/jit/instrsriscv64.h
@@ -260,6 +260,23 @@ INST(amominu_w,     "amominu.w",      0,   0xc000202f) // funct5:11000
 INST(amominu_d,     "amominu.d",      0,   0xc000302f) // funct5:11000
 INST(amomaxu_w,     "amomaxu.w",      0,   0xe000202f) // funct5:11100
 INST(amomaxu_d,     "amomaxu.d",      0,   0xe000302f) // funct5:11100
+
+// Zba extension (RV64 + RV32)
+
+//// R_R_R
+INST(sh1add,        "sh1add",         0,   0x20002033)
+INST(sh2add,        "sh2add",         0,   0x20004033)
+INST(sh3add,        "sh3add",         0,   0x20006033)
+
+// Zba extension (RV64)
+
+//// R_R_R
+INST(add_uw,        "add.uw",         0,   0x0800003b)
+INST(sh1add_uw,     "sh1add_uw",      0,   0x2000203b)
+INST(sh2add_uw,     "sh2add_uw",      0,   0x2000403b)
+INST(sh3add_uw,     "sh3add_uw",      0,   0x2000603b)
+INST(slli_uw,       "slli_uw",        0,   0x0800101b)
+
 // clang-format on
 /*****************************************************************************/
 #undef INST

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -10045,23 +10045,30 @@ GenTree* Lowering::LowerIndir(GenTreeIndir* ind)
 #ifdef TARGET_RISCV64
     // Defer cast to SH(X)ADD_UW instruction.
     // TODO: Use emitComp->compOpportunisticallyDependsOn(InstructionSet_Zba)
-    if (ind->HasIndex() && ind->Index()->OperGet() == GT_CAST)
+    GenTree* addr = ind->Addr();
+    if (ind->HasIndex() && ind->Index()->OperGet() == GT_CAST && addr->isContained() && addr->OperIsAddrMode())
     {
-        GenTree* const     index        = ind->Index();
-        GenTreeCast* const cast         = index->AsCast();
-        GenTree* const     src          = cast->CastOp();
-        const var_types    srcType      = genActualType(src);
-        const bool         srcUnsigned  = cast->IsUnsigned();
-        const unsigned     srcSize      = genTypeSize(srcType);
-        const var_types    castType     = cast->gtCastType;
-        const bool         castUnsigned = varTypeIsUnsigned(castType);
-        const unsigned     castSize     = genTypeSize(castType);
+        DWORD lsl;
+        BitScanForward(&lsl, addr->AsAddrMode()->gtScale);
 
-        bool isZeroExtendIntToLong = srcSize == 4 && castSize == 8 && (castUnsigned || srcUnsigned);
-
-        if (isZeroExtendIntToLong)
+        if (lsl > 0 && lsl <= 3)
         {
-            index->gtFlags |= GTF_CAST_DEFER_TO_SHXADD_UW;
+            GenTree* const     index        = ind->Index();
+            GenTreeCast* const cast         = index->AsCast();
+            GenTree* const     src          = cast->CastOp();
+            const var_types    srcType      = genActualType(src);
+            const bool         srcUnsigned  = cast->IsUnsigned();
+            const unsigned     srcSize      = genTypeSize(srcType);
+            const var_types    castType     = cast->gtCastType;
+            const bool         castUnsigned = varTypeIsUnsigned(castType);
+            const unsigned     castSize     = genTypeSize(castType);
+
+            bool isZeroExtendIntToLong = srcSize == 4 && castSize > 4 && (castUnsigned || srcUnsigned);
+
+            if (isZeroExtendIntToLong)
+            {
+                index->gtFlags |= GTF_CAST_DEFER_TO_SHXADD_UW;
+            }
         }
     }
 #endif

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -403,6 +403,9 @@ private:
     void     LowerPutArgStk(GenTreePutArgStk* putArgStk);
     GenTree* TryLowerMulWithConstant(GenTreeOp* node);
 #endif // TARGET_XARCH
+#ifdef TARGET_RISCV64
+    bool TrySetDeferCastToShxaddUwFlag(GenTreeAddrMode* addr);
+#endif // TARGET_RISCV64
 
     bool TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* parent);
 

--- a/src/coreclr/jit/lowerriscv64.cpp
+++ b/src/coreclr/jit/lowerriscv64.cpp
@@ -229,6 +229,41 @@ GenTree* Lowering::LowerStoreLoc(GenTreeLclVarCommon* storeLoc)
 GenTree* Lowering::LowerStoreIndir(GenTreeStoreInd* node)
 {
     ContainCheckStoreIndir(node);
+
+    if (!node->Addr()->isContained() || !node->Addr()->OperIsAddrMode())
+    {
+        return node->gtNext;
+    }
+    GenTreeAddrMode* addr = node->Addr()->AsAddrMode();
+
+    // Defer cast to SH(X)ADD_UW instruction.
+    // TODO: Use emitComp->compOpportunisticallyDependsOn(InstructionSet_Zba)
+    if (addr->HasIndex() && addr->Index()->OperGet() == GT_CAST && isPow2(addr->gtScale))
+    {
+        DWORD lsl;
+        BitScanForward(&lsl, addr->gtScale);
+
+        if (lsl > 0 && lsl <= 3)
+        {
+            GenTree* const     index        = addr->Index();
+            GenTreeCast* const cast         = index->AsCast();
+            GenTree* const     src          = cast->CastOp();
+            const var_types    srcType      = genActualType(src);
+            const bool         srcUnsigned  = cast->IsUnsigned();
+            const unsigned     srcSize      = genTypeSize(srcType);
+            const var_types    castType     = cast->gtCastType;
+            const bool         castUnsigned = varTypeIsUnsigned(castType);
+            const unsigned     castSize     = genTypeSize(castType);
+
+            bool isZeroExtendIntToLong = srcSize == 4 && castSize > 4 && (castUnsigned || srcUnsigned);
+
+            if (isZeroExtendIntToLong)
+            {
+                index->gtFlags |= GTF_CAST_DEFER_TO_SHXADD_UW;
+            }
+        }
+    }
+
     return node->gtNext;
 }
 

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -679,7 +679,7 @@ int LinearScan::BuildNode(GenTree* tree)
             {
                 DWORD scale;
                 BitScanForward(&scale, lea->gtScale);
-                if (scale > 3)
+                if (scale > 0 && !emitter::canUseShxaddIns(scale, compiler))
                     buildInternalIntRegisterDefForNode(tree); // scaleTempReg
             }
 

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -679,7 +679,7 @@ int LinearScan::BuildNode(GenTree* tree)
             {
                 DWORD scale;
                 BitScanForward(&scale, lea->gtScale);
-                if (scale > 0)
+                if (scale > 3)
                     buildInternalIntRegisterDefForNode(tree); // scaleTempReg
             }
 


### PR DESCRIPTION
With the following C# code:
```cs
public static int Fun(int[] arr, int i) {
    return arr[i];
}
```

Before patch:
```asm
slli   a1, a1, 32
srli   a1, a1, 32
slli   a1, a1, 2
add    a2, a0, a1
lw     a0, 16(a2)
```

After patch:
```asm
sh2add.uw a2, a1, a0
lw        a0, 16(a2)
```

TODO:
- [x] Wait for https://github.com/dotnet/runtime/pull/113676 to get merged in, and use `compOpportunisticallyDependsOn`.
- [x] Remove zero extension by utilizing `shxadd.uw`.
- [ ] Detect shift + add and turn it into `SHXADD` GenTree.

Part of #84834, cc @dotnet/samsung