### PR TITLE
Do not report inlining decision to runtime in DEBUG mode

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1165,7 +1165,7 @@ void Compiler::fgNoteNonInlineCandidate(Statement* stmt, GenTreeCall* call)
         return;
     }
 
-    InlineResult      inlineResult(this, call, nullptr, "fgNoteNonInlineCandidate", false);
+    InlineResult      inlineResult(this, call, nullptr, "fgNoteNonInlineCandidate", true);
     InlineObservation currentObservation = InlineObservation::CALLSITE_NOT_CANDIDATE;
 
     // Try and recover the reason left behind when the jit decided


### PR DESCRIPTION
We should report inlining decisions to the runtime only in non-DEBUG mode. If done in DEBUG mode, we can see discrepancies in inlining decisions that can further diverge the code produced in RELEASE vs. DEBUG mode. The inlining reporting happened at below code. The fix is to not report the inlining decision.

https://github.com/dotnet/runtime/blob/5e7d6817767ec1e313a66ce2027cbe55828c7cce/src/coreclr/jit/fginline.cpp#L862-L866

Fixes: https://github.com/dotnet/runtime/issues/113546