### PR TITLE
[mono] Add a few bridge tests

### DIFF
--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -659,11 +659,11 @@ compute_low_index (ScanData *data, GCObject *obj)
 	obj = bridge_object_forward (obj);
 	other = find_data (obj);
 
-#if DUMP_GRAPH
-	printf ("\tcompute low %p ->%p (%s) %p (%d / %d, color %p)\n", data->obj, obj, safe_name_bridge (obj), other, other ? other->index : -2, other ? other->low_index : -2, other->color);
-#endif
 	if (!other)
 		return;
+#if DUMP_GRAPH
+	printf ("\tcompute low %p ->%p (%s) %p (%d / %d, color %p)\n", data->obj, obj, safe_name_bridge (obj), other, other ? other->index : -2, other->low_index, other->color);
+#endif
 
 	g_assert (other->state != INITIAL);
 
@@ -797,10 +797,12 @@ create_scc (ScanData *data)
 	g_assert (found);
 
 #if DUMP_GRAPH
-	printf ("\tpoints-to-colors: ");
-	for (i = 0; i < dyn_array_ptr_size (&color_data->other_colors); i++)
-		printf ("%p ", dyn_array_ptr_get (&color_data->other_colors, i));
-	printf ("\n");
+    if (color_data) {
+        printf ("\tpoints-to-colors: ");
+        for (i = 0; i < dyn_array_ptr_size (&color_data->other_colors); i++)
+            printf ("%p ", dyn_array_ptr_get (&color_data->other_colors, i));
+        printf ("\n");
+    }
 #endif
 }
 

--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -370,15 +370,6 @@ safe_name_bridge (GCObject *obj)
 	GCVTable vt = SGEN_LOAD_VTABLE (obj);
 	return m_class_get_name (vt->klass);
 }
-
-static ScanData*
-find_or_create_data (GCObject *obj)
-{
-	ScanData *entry = find_data (obj);
-	if (!entry)
-		entry = create_data (obj);
-	return entry;
-}
 #endif
 
 //----------
@@ -934,8 +925,11 @@ dump_color_table (const char *why, gboolean do_index)
 				printf (" bridges: ");
 				for (j = 0; j < dyn_array_ptr_size (&cd->bridges); ++j) {
 					GCObject *obj = dyn_array_ptr_get (&cd->bridges, j);
-					ScanData *data = find_or_create_data (obj);
-					printf ("%d ", data->index);
+					ScanData *data = find_data (obj);
+					if (!data)
+						printf ("%p ", obj);
+					else
+						printf ("%p(%d) ", obj, data->index);
 				}
 			}
 			printf ("\n");

--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -368,7 +368,7 @@ static const char*
 safe_name_bridge (GCObject *obj)
 {
 	GCVTable vt = SGEN_LOAD_VTABLE (obj);
-	return vt->klass->name;
+	return m_class_get_name (vt->klass);
 }
 
 static ScanData*
@@ -762,7 +762,7 @@ create_scc (ScanData *data)
 #if DUMP_GRAPH
 	printf ("|SCC %p rooted in %s (%p) has bridge %d\n", color_data, safe_name_bridge (data->obj), data->obj, found_bridge);
 	printf ("\tloop stack: ");
-	for (int i = 0; i < dyn_array_ptr_size (&loop_stack); ++i) {
+	for (i = 0; i < dyn_array_ptr_size (&loop_stack); ++i) {
 		ScanData *other = dyn_array_ptr_get (&loop_stack, i);
 		printf ("(%d/%d)", other->index, other->low_index);
 	}
@@ -807,7 +807,7 @@ create_scc (ScanData *data)
 
 #if DUMP_GRAPH
 	printf ("\tpoints-to-colors: ");
-	for (int i = 0; i < dyn_array_ptr_size (&color_data->other_colors); i++)
+	for (i = 0; i < dyn_array_ptr_size (&color_data->other_colors); i++)
 		printf ("%p ", dyn_array_ptr_get (&color_data->other_colors, i));
 	printf ("\n");
 #endif
@@ -995,7 +995,7 @@ processing_stw_step (void)
 #if defined (DUMP_GRAPH)
 	printf ("----summary----\n");
 	printf ("bridges:\n");
-	for (int i = 0; i < bridge_count; ++i) {
+	for (i = 0; i < bridge_count; ++i) {
 		ScanData *sd = find_data (dyn_array_ptr_get (&registered_bridges, i));
 		printf ("\t%s (%p) index %d color %p\n", safe_name_bridge (sd->obj), sd->obj, sd->index, sd->color);
 	}

--- a/src/tests/GC/Features/Bridge/Bridge.cs
+++ b/src/tests/GC/Features/Bridge/Bridge.cs
@@ -1,0 +1,392 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+// False pinning cases are still possible. For example the thread can die
+// and its stack reused by another thread. It also seems that a thread that
+// does a GC can keep on the stack references to objects it encountered
+// during the collection which are never released afterwards. This would
+// be more likely to happen with the interpreter which reuses more stack.
+public static class FinalizerHelpers
+{
+    private static IntPtr aptr;
+
+    private static unsafe void NoPinActionHelper(int depth, Action act)
+    {
+        // Avoid tail calls
+        int* values = stackalloc int[20];
+        aptr = new IntPtr(values);
+
+        if (depth <= 0)
+        {
+            //
+            // When the action is called, this new thread might have not allocated
+            // anything yet in the nursery. This means that the address of the first
+            // object that would be allocated would be at the start of the tlab and
+            // implicitly the end of the previous tlab (address which can be in use
+            // when allocating on another thread, at checking if an object fits in
+            // this other tlab). We allocate a new dummy object to avoid this type
+            // of false pinning for most common cases.
+            //
+            new object();
+            act();
+            ClearStack();
+        }
+        else
+        {
+            NoPinActionHelper(depth - 1, act);
+        }
+    }
+
+    private static unsafe void ClearStack()
+    {
+        int* values = stackalloc int[25000];
+        for (int i = 0; i < 25000; i++)
+            values[i] = 0;
+    }
+
+    public static void PerformNoPinAction(Action act)
+    {
+        Thread thr = new Thread(() => NoPinActionHelper (128, act));
+        thr.Start();
+        thr.Join();
+    }
+}
+
+public class BridgeBase
+{
+    public static int fin_count;
+
+    ~BridgeBase()
+    {
+        fin_count++;
+    }
+}
+
+public class Bridge : BridgeBase
+{
+    public List<object> Links = new List<object>();
+    public int __test;
+
+    ~Bridge()
+    {
+        Links = null;
+    }
+}
+
+public class Bridge1 : BridgeBase
+{
+    public object Link;
+    ~Bridge1()
+    {
+        Link = null;
+    }
+}
+
+// 128 size
+public class Bridge14 : BridgeBase
+{
+    public object a,b,c,d,e,f,g,h,i,j,k,l,m,n;
+}
+
+public class NonBridge
+{
+    public object Link;
+}
+
+public class NonBridge2 : NonBridge
+{
+    public object Link2;
+}
+
+public class NonBridge14
+{
+    public object a,b,c,d,e,f,g,h,i,j,k,l,m,n;
+}
+
+
+public class BridgeTest
+{
+    const int OBJ_COUNT = 100 * 1000;
+    const int LINK_COUNT = 2;
+    const int EXTRAS_COUNT = 0;
+    const double survival_rate = 0.1;
+
+    // Pathological case for the original old algorithm.  Goes
+    // away when merging is replaced by appending with flag
+    // checking.
+    static void SetupLinks()
+    {
+        var list = new List<Bridge>();
+        for (int i = 0; i < OBJ_COUNT; ++i)
+        {
+            var bridge = new Bridge();
+            list.Add(bridge);
+        }
+
+        var r = new Random(100);
+        for (int i = 0; i < OBJ_COUNT; ++i)
+        {
+            var n = list[i];
+            for (int j = 0; j < LINK_COUNT; ++j)
+                n.Links.Add(list[r.Next (OBJ_COUNT)]);
+            for (int j = 0; j < EXTRAS_COUNT; ++j)
+                n.Links.Add(j);
+            if (r.NextDouble() <= survival_rate)
+                n.__test = 1;
+        }
+    }
+
+    const int LIST_LENGTH = 10000;
+    const int FAN_OUT = 10000;
+
+    // Pathological case for the new algorithm.  Goes away with
+    // the single-node elimination optimization, but will still
+    // persist if modified by using a ladder instead of the single
+    // list.
+    static void SetupLinkedFan()
+    {
+        var head = new Bridge();
+        var tail = new NonBridge();
+        head.Links.Add(tail);
+        for (int i = 0; i < LIST_LENGTH; ++i)
+        {
+            var obj = new NonBridge ();
+            tail.Link = obj;
+            tail = obj;
+        }
+        var list = new List<Bridge>();
+        tail.Link = list;
+        for (int i = 0; i < FAN_OUT; ++i)
+            list.Add (new Bridge());
+    }
+
+    // Pathological case for the improved old algorithm.  Goes
+    // away with copy-on-write DynArrays, but will still persist
+    // if modified by using a ladder instead of the single list.
+    static void SetupInverseFan()
+    {
+        var tail = new Bridge();
+        object list = tail;
+        for (int i = 0; i < LIST_LENGTH; ++i)
+        {
+            var obj = new NonBridge();
+            obj.Link = list;
+            list = obj;
+        }
+        var heads = new Bridge[FAN_OUT];
+        for (int i = 0; i < FAN_OUT; ++i)
+        {
+            var obj = new Bridge();
+            obj.Links.Add(list);
+            heads[i] = obj;
+        }
+    }
+
+    // Not necessarily a pathology, but a special case of where we
+    // generate lots of "dead" SCCs.  A non-bridge object that
+    // can't reach a bridge object can safely be removed from the
+    // graph.  In this special case it's a linked list hanging off
+    // a bridge object.  We can handle this by "forwarding" edges
+    // going to non-bridge nodes that have only a single outgoing
+    // edge.  That collapses the whole list into a single node.
+    // We could remove that node, too, by removing non-bridge
+    // nodes with no outgoing edges.
+    static void SetupDeadList()
+    {
+        var head = new Bridge();
+        var tail = new NonBridge();
+        head.Links.Add(tail);
+        for (int i = 0; i < LIST_LENGTH; ++i)
+        {
+            var obj = new NonBridge();
+            tail.Link = obj;
+            tail = obj;
+        }
+    }
+
+    // Triggered a bug in the forwarding mechanic.
+    static void SetupSelfLinks()
+    {
+        var head = new Bridge();
+        var tail = new NonBridge();
+        head.Links.Add(tail);
+        tail.Link = tail;
+    }
+
+    const int L0_COUNT = 50000;
+    const int L1_COUNT = 50000;
+    const int EXTRA_LEVELS = 4;
+
+    // Set a complex graph from one bridge to a couple.
+    // The graph is designed to expose naive coloring on
+    // tarjan and SCC explosion on classic.
+    static void Spider()
+    {
+        Bridge a = new Bridge();
+        Bridge b = new Bridge();
+
+        var l1 = new List<object>();
+        for (int i = 0; i < L0_COUNT; ++i) {
+            var l0 = new List<object>();
+            l0.Add(a);
+            l0.Add(b);
+            l1.Add(l0);
+        }
+        var last_level = l1;
+        for (int l = 0; l < EXTRA_LEVELS; ++l) {
+            int j = 0;
+            var l2 = new List<object>();
+            for (int i = 0; i < L1_COUNT; ++i) {
+                var tmp = new List<object>();
+                tmp.Add(last_level [j++ % last_level.Count]);
+                tmp.Add(last_level [j++ % last_level.Count]);
+                l2.Add(tmp);
+            }
+            last_level = l2;
+        }
+        Bridge c = new Bridge();
+        c.Links.Add(last_level);
+    }
+
+    // Simulates a graph with two nested cycles that is produces by
+    // the async state machine when `async Task M()` method gets its
+    // continuation rooted by an Action held by RunnableImplementor
+    // (ie. the task continuation is hooked through the SynchronizationContext
+    // implentation and rooted only by Android bridge objects).
+    static void NestedCycles()
+    {
+        Bridge runnableImplementor = new Bridge ();
+        Bridge byteArrayOutputStream = new Bridge ();
+        NonBridge2 action = new NonBridge2 ();
+        NonBridge displayClass = new NonBridge ();
+        NonBridge2 asyncStateMachineBox = new NonBridge2 ();
+        NonBridge2 asyncStreamWriter = new NonBridge2 ();
+
+        runnableImplementor.Links.Add(action);
+        action.Link = displayClass;
+        action.Link2 = asyncStateMachineBox;
+        displayClass.Link = action;
+        asyncStateMachineBox.Link = asyncStreamWriter;
+        asyncStateMachineBox.Link2 = action;
+        asyncStreamWriter.Link = byteArrayOutputStream;
+        asyncStreamWriter.Link2 = asyncStateMachineBox;
+    }
+
+    static void RunGraphTest(Action test)
+    {
+        Console.WriteLine("Start test {0}", test.Method.Name);
+        FinalizerHelpers.PerformNoPinAction(test);
+        Console.WriteLine("-graph built-");
+        for (int i = 0; i < 5; i++)
+        {
+            Console.WriteLine("-GC {0}/5-", i);
+            GC.Collect ();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Console.WriteLine("Finished test {0}, finalized {1}", test.Method.Name, Bridge.fin_count);
+    }
+
+    static void TestLinkedList()
+    {
+        int count = Environment.ProcessorCount + 2;
+        var th = new Thread [count];
+        for (int i = 0; i < count; ++i)
+        {
+            th [i] = new Thread( _ =>
+            {
+                var lst = new ArrayList();
+                for (var j = 0; j < 500 * 1000; j++)
+                {
+                    lst.Add (new object());
+                    if ((j % 999) == 0)
+                        lst.Add (new BridgeBase());
+                    if ((j % 1000) == 0)
+                        new BridgeBase();
+                    if ((j % 50000) == 0)
+                        lst = new ArrayList();
+                }
+            });
+
+            th [i].Start();
+        }
+
+        for (int i = 0; i < count; ++i)
+            th [i].Join();
+
+        GC.Collect(2);
+        Console.WriteLine("Finished test LinkedTest, finalized {0}", BridgeBase.fin_count);
+    }
+
+    //we fill 16Mb worth of stuff, eg, 256k objects
+    const int major_fill = 1024 * 256;
+
+    //4mb nursery with 64 bytes objects -> alloc half
+    const int nursery_obj_count = 16 * 1024;
+
+    static void SetupFragmentation<TBridge, TNonBridge>()
+            where TBridge : new()
+            where TNonBridge : new()
+    {
+        const int loops = 4;
+        for (int k = 0; k < loops; k++)
+        {
+            Console.WriteLine("[{0}] CrashLoop {1}/{2}", DateTime.Now, k + 1, loops);
+            var arr = new object[major_fill];
+            for (int i = 0; i < major_fill; i++)
+                arr[i] = new TNonBridge();
+            GC.Collect(1);
+            Console.WriteLine("[{0}] major fill done", DateTime.Now);
+
+            //induce massive fragmentation
+            for (int i = 0; i < major_fill; i += 4)
+            {
+                arr[i + 1] = null;
+                arr[i + 2] = null;
+                arr[i + 3] = null;
+            }
+            GC.Collect (1);
+            Console.WriteLine("[{0}] fragmentation done", DateTime.Now);
+
+            //since 50% is garbage, do 2 fill passes
+            for (int j = 0; j < 2; ++j)
+            {
+                for (int i = 0; i < major_fill; i++)
+                {
+                    if ((i % 1000) == 0)
+                        new TBridge();
+                    else
+                        arr[i] = new TBridge();
+                }
+            }
+            Console.WriteLine("[{0}] done spewing bridges", DateTime.Now);
+
+            for (int i = 0; i < major_fill; i++)
+                arr[i] = null;
+            GC.Collect ();
+        }
+    }
+
+    public static int Main(string[] args)
+    {
+//        TestLinkedList(); // Crashes, but only in this multithreaded variant
+        RunGraphTest(SetupFragmentation<Bridge14, NonBridge14>); // This passes but the following crashes ??
+//        RunGraphTest(SetupFragmentation<Bridge, NonBridge>);
+        RunGraphTest(SetupLinks);
+        RunGraphTest(SetupLinkedFan);
+        RunGraphTest(SetupInverseFan);
+
+        RunGraphTest(SetupDeadList);
+        RunGraphTest(SetupSelfLinks);
+//        RunGraphTest(NestedCycles); // Fixed by Filip
+//        RunGraphTest(Spider); // Crashes
+        return 100;
+    }
+}

--- a/src/tests/GC/Features/Bridge/Bridge.csproj
+++ b/src/tests/GC/Features/Bridge/Bridge.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- This is a separate app launched by the actual test in BridgeTester.csproj -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Bridge.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/GC/Features/Bridge/BridgeTester.cs
+++ b/src/tests/GC/Features/Bridge/BridgeTester.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime;
+using System.Text;
+
+using Xunit;
+
+public class BridgeTester
+{
+    [Fact]
+    public static void RunTests()
+    {
+        string corerun = TestLibrary.Utilities.IsWindows ? "corerun.exe" : "corerun";
+        string coreRoot = Environment.GetEnvironmentVariable("CORE_ROOT");
+        string bridgeTestApp = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Bridge.dll");
+
+        var startInfo = new ProcessStartInfo(Path.Combine(coreRoot, corerun), bridgeTestApp);
+        startInfo.EnvironmentVariables["MONO_GC_DEBUG"] = "bridge=BridgeBase,bridge-compare-to=new";
+        startInfo.EnvironmentVariables["MONO_GC_PARAMS"] = "bridge-implementation=tarjan,bridge-require-precise-merge";
+
+        using (Process p = Process.Start(startInfo))
+        {
+            p.WaitForExit();
+            Console.WriteLine ("Bridge Test App returned {0}", p.ExitCode);
+            if (p.ExitCode != 100)
+                throw new Exception("Bridge Test App failed execution");
+        }
+    }
+}

--- a/src/tests/GC/Features/Bridge/BridgeTester.csproj
+++ b/src/tests/GC/Features/Bridge/BridgeTester.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' != 'Mono'">true</DisableProjectBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="BridgeTester.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Bridge.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </ProjectReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR ports over some bridge tests that we had in mono/mono. In order to enforce finalization of some objects that are logically dead, we reuse the `FinalizerHelpers.PerformNoPinAction`, which runs an Action while ensuring objects allocated by it are seen dead by the GC. Because mono GC is conservative, we go through extra lengths to ensure no pinning occurs.

Mono currently has two algorithms for building the SCC/xref set over the dead bridge objects: `new` and `tarjan`. The `new` bridge is the legacy one which should be more stable and this PR attempts to reuse the bridge output compare functionality to catch potential bugs with the `tarjan` bridge (which is the default used bridge). When using the bridge compare functionality, the GC will randomly keep alive half of the bridge objects (since we don't have a java counterpart that responds with the liveness). We also pass the additional debug flag `bridge=BridgeBase` which means that all objects that are instances of `BridgeBase` or a derived type are treated as a bridge object and they take part in the SCC construction.

This testing approach is very cheap but it has some potential pitfalls: maybe the `new` bridge itself has some bugs, the output between the bridges differs for benign reasons and the `tarjan` bridge needs to have some functionality disabled in order for this comparison to work (`scc_precise_merge` and `disable_non_bridge_scc`, which are optimizations meant to speed up the bridge processing, even if they don't produce the theoretical correct set of SCCs/xrefs).

Currently there are quite a bit of tests crashing that need investigation. In the future we could also add more complex random graph generators for stress testing.

This PR also fixes a few logging issues in the `tarjan` bridge due to bitrot.