### PR TITLE
ILLink: Respect DisableRuntimeMarshalling

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -3362,6 +3362,9 @@ namespace Mono.Linker.Steps
 				}
 			}
 
+			if (method.AssemblyHasDisableRuntimeMarshalling ())
+				return;
+
 			TypeDefinition? returnTypeDefinition = Context.TryResolve (method.ReturnType);
 
 			const bool includeStaticFields = false;

--- a/src/tools/illink/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -35,6 +35,21 @@ namespace Mono.Linker
 			return false;
 		}
 
+		public static bool AssemblyHasDisableRuntimeMarshalling (this MethodDefinition method)
+		{
+			var assembly = method.Module.Assembly;
+			if (!assembly.HasCustomAttributes)
+				return false;
+
+			foreach (var ca in assembly.CustomAttributes) {
+				var caType = ca.AttributeType;
+				if (caType.Name == "DisableRuntimeMarshallingAttribute" && caType.Namespace == "System.Runtime.CompilerServices")
+					return true;
+			}
+
+			return false;
+		}
+
 		public static bool IsPropertyMethod (this MethodDefinition md)
 		{
 			return (md.SemanticsAttributes & MethodSemanticsAttributes.Getter) != 0 ||

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/Interop/PInvoke/PInvokeTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/Interop/PInvoke/PInvokeTests.cs
@@ -46,5 +46,11 @@ namespace ILLink.RoslynAnalyzer.Tests.Interop
 		{
 			return RunTest ();
 		}
+
+		[Fact]
+		public Task RespectsDisableRuntimeMarshalling ()
+		{
+			return RunTest ();
+		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Dependencies/AssemblyWithoutDisableRuntimeMarshalling.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Dependencies/AssemblyWithoutDisableRuntimeMarshalling.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace Mono.Linker.Tests.Cases.Interop.PInvoke.Dependencies;
+
+public class AssemblyWithoutDisableRuntimeMarshalling
+{
+	[DllImport ("Unused")]
+	public static extern B SomeMethod ();
+
+	public class B;
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/PInvoke/RespectsDisableRuntimeMarshalling.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/PInvoke/RespectsDisableRuntimeMarshalling.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Interop.PInvoke.Dependencies;
+
+#if INCLUDE_DISABLE_RUNTIME_MARSHALLING_ATTRIBUTE
+[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
+#endif
+
+[assembly: KeptAttributeAttribute(typeof(DisableRuntimeMarshallingAttribute))]
+
+namespace Mono.Linker.Tests.Cases.Interop.PInvoke;
+
+[SetupCompileBefore ("WithoutDisable.dll", new [] { typeof(AssemblyWithoutDisableRuntimeMarshalling) })]
+[Define ("INCLUDE_DISABLE_RUNTIME_MARSHALLING_ATTRIBUTE")]
+[KeptModuleReference ("Unused")]
+[KeptMemberInAssembly ("WithoutDisable.dll", typeof (AssemblyWithoutDisableRuntimeMarshalling.B), ".ctor()")]
+public class RespectsDisableRuntimeMarshalling
+{
+	public static void Main ()
+	{
+		var a = SomeMethod ();
+		var b = AssemblyWithoutDisableRuntimeMarshalling.SomeMethod ();
+	}
+
+	// The .ctor() will not be marked due to DisableRuntimeMarshalling
+	[Kept]
+	class A;
+
+	[Kept]
+	[DllImport ("Unused")]
+	static extern A SomeMethod ();
+}


### PR DESCRIPTION
The linker will no longer do additional marking in `ProcessInteropMethod` when the methods owning assembly has `[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]`


As requested https://github.com/dotnet/runtime/pull/113437#issuecomment-2722824229