### PR TITLE
Revert "Reenable ClientDisableTlsResume_Succeeds test"

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowTlsResumeTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowTlsResumeTests.cs
@@ -34,6 +34,7 @@ namespace System.Net.Security.Tests
         [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/103449", TestPlatforms.Windows)]
         public async Task ClientDisableTlsResume_Succeeds(bool testClient)
         {
             SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions


### PR DESCRIPTION
Reverts dotnet/runtime#113604

The test still seems to fail, see https://github.com/dotnet/runtime/issues/103449#issuecomment-2740352019