### PR TITLE
Prevent OS core dump creation for intentionally crashing tests

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
@@ -504,7 +504,7 @@ namespace TestLibrary
         // Ensure that the OS doesn't generate core dump for the current process
         public static void DisableOSCoreDump()
         {
-            if ((Environment.OSVersion.Platform == PlatformID.Unix) || (Environment.OSVersion.Platform == PlatformID.MacOSX))
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
                 RLimit rlimit = new RLimit
                 {

--- a/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
@@ -504,6 +504,8 @@ namespace TestLibrary
         // Ensure that the OS doesn't generate core dump for the current process
         public static void DisableOSCoreDump()
         {
+            // At present, RLimit is defined in a way where the fields are always 64-bit.
+            // Before adding support for a new platform, its definition of rlimit should be confirmed.
             if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
                 RLimit rlimit = new RLimit

--- a/src/tests/baseservices/exceptions/simple/ParallelCrash.cs
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrash.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using TestLibrary;
 
 // Runtime stability in the presence of concurrent fatal errors
 
@@ -20,6 +21,9 @@ public class ParallelCrash
 
     public static int Main(string[] args)
     {
+        // Ensure that the OS doesn't generate core dump for this intentionally crashing process
+        Utilities.DisableOSCoreDump();
+
         s_crashMainThread = true;
         s_crashWorkerThreads = true;
         if (args.Length > 0)

--- a/src/tests/baseservices/exceptions/simple/ParallelCrash.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrash.csproj
@@ -8,4 +8,7 @@
   <ItemGroup>
     <Compile Include="ParallelCrash.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/exceptions/simple/ParallelCrashTester.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrashTester.csproj
@@ -18,4 +18,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/exceptions/simple/ParallelCrashTester.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrashTester.csproj
@@ -18,7 +18,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflow.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflow.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Threading;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TestLibrary;
 
 namespace TestStackOverflow
 {
@@ -136,6 +138,9 @@ namespace TestStackOverflow
 
         static void Main(string[] args)
         {
+            // Ensure that the OS doesn't generate core dump for this intentionally crashing process
+            Utilities.DisableOSCoreDump();
+
             bool smallframe = (args[0] == "smallframe");
             if (args[1] == "secondary")
             {

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflow.csproj
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflow.csproj
@@ -10,5 +10,8 @@
   <ItemGroup>
     <Compile Include="stackoverflow.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>
 

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflow3.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflow3.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using System.Runtime.InteropServices;
+using TestLibrary;
 
 namespace TestStackOverflow3
 {
@@ -11,6 +13,9 @@ namespace TestStackOverflow3
 
         public static void Main()
         {
+            // Ensure that the OS doesn't generate core dump for this intentionally crashing process
+            Utilities.DisableOSCoreDump();
+
             Program ex = new Program();
             ex.Execute();
         }

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflow3.csproj
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflow3.csproj
@@ -11,5 +11,8 @@
   <ItemGroup>
     <Compile Include="stackoverflow3.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>
 

--- a/src/tests/baseservices/exceptions/unhandled/unhandled.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandled.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using TestLibrary;
 
 namespace TestUnhandledException
 {
@@ -40,6 +41,9 @@ namespace TestUnhandledException
 
         static void Main(string[] args)
         {
+            // Ensure that the OS doesn't generate core dump for this intentionally crashing process
+            Utilities.DisableOSCoreDump();
+
             if (args[0] == "main")
             {
                 throw new Exception("Test");


### PR DESCRIPTION
There are three coreclr tests that intentionally run a crashing secondary process. While the CreateDump invocation on crash for these tests was already disabled, the OS core dump creation was still happening. In the CI this was causing test machines getting out of disk space. This change disables OS core dump creation for those tests.

Close #113652