### PR TITLE
[cDAC] Resolve breaking change caused by removing ThunkHeap descriptor

### DIFF
--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -44,7 +44,6 @@ public interface ILoader : IContract
     public virtual string GetFileName(ModuleHandle handle) => throw new NotImplementedException();
 
     public virtual TargetPointer GetLoaderAllocator(ModuleHandle handle) => throw new NotImplementedException();
-    public virtual TargetPointer GetThunkHeap(ModuleHandle handle) => throw new NotImplementedException();
     public virtual TargetPointer GetILBase(ModuleHandle handle) => throw new NotImplementedException();
     public virtual ModuleLookupTables GetLookupTables(ModuleHandle handle) => throw new NotImplementedException();
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -56,12 +56,6 @@ internal readonly struct Loader_1 : ILoader
         return module.LoaderAllocator;
     }
 
-    TargetPointer ILoader.GetThunkHeap(ModuleHandle handle)
-    {
-        Data.Module module = _target.ProcessedData.GetOrAdd<Data.Module>(handle.Address);
-        return module.ThunkHeap;
-    }
-
     TargetPointer ILoader.GetILBase(ModuleHandle handle)
     {
         Data.Module module = _target.ProcessedData.GetOrAdd<Data.Module>(handle.Address);

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Module.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Module.cs
@@ -21,7 +21,6 @@ internal sealed class Module : IData<Module>
         Assembly = target.ReadPointer(address + (ulong)type.Fields[nameof(Assembly)].Offset);
         Base = target.ReadPointer(address + (ulong)type.Fields[nameof(Base)].Offset);
         LoaderAllocator = target.ReadPointer(address + (ulong)type.Fields[nameof(LoaderAllocator)].Offset);
-        ThunkHeap = target.ReadPointer(address + (ulong)type.Fields[nameof(ThunkHeap)].Offset);
         DynamicMetadata = target.ReadPointer(address + (ulong)type.Fields[nameof(DynamicMetadata)].Offset);
         Path = target.ReadPointer(address + (ulong)type.Fields[nameof(Path)].Offset);
         FileName = target.ReadPointer(address + (ulong)type.Fields[nameof(FileName)].Offset);
@@ -40,7 +39,6 @@ internal sealed class Module : IData<Module>
     public uint Flags { get; init; }
     public TargetPointer Base { get; init; }
     public TargetPointer LoaderAllocator { get; init; }
-    public TargetPointer ThunkHeap { get; init; }
     public TargetPointer DynamicMetadata { get; init; }
     public TargetPointer Path { get; init; }
     public TargetPointer FileName { get; init; }

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -844,7 +844,6 @@ internal sealed unsafe partial class SOSDacImpl
             data->metadataSize = readOnlyMetadata.Size;
 
             data->LoaderAllocator = contract.GetLoaderAllocator(handle);
-            data->ThunkHeap = contract.GetThunkHeap(handle);
 
             Target.TypeInfo lookupMapTypeInfo = _target.GetTypeInfo(DataType.ModuleLookupMap);
             ulong tableDataOffset = (ulong)lookupMapTypeInfo.Fields[Constants.FieldNames.ModuleLookupMap.TableData].Offset;

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -844,7 +844,6 @@ internal sealed unsafe partial class SOSDacImpl
             data->metadataSize = readOnlyMetadata.Size;
 
             data->LoaderAllocator = contract.GetLoaderAllocator(handle);
-            data->ThunkHeap = 0; // No longer used. DAC does not set this value
 
             Target.TypeInfo lookupMapTypeInfo = _target.GetTypeInfo(DataType.ModuleLookupMap);
             ulong tableDataOffset = (ulong)lookupMapTypeInfo.Fields[Constants.FieldNames.ModuleLookupMap.TableData].Offset;
@@ -861,6 +860,7 @@ internal sealed unsafe partial class SOSDacImpl
             data->dwModuleID = 0;
             data->dwBaseClassIndex = 0;
             data->dwModuleIndex = 0;
+            data->ThunkHeap = 0;
         }
         catch (global::System.Exception e)
         {

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -844,6 +844,7 @@ internal sealed unsafe partial class SOSDacImpl
             data->metadataSize = readOnlyMetadata.Size;
 
             data->LoaderAllocator = contract.GetLoaderAllocator(handle);
+            data->ThunkHeap = 0; // No longer used. DAC does not set this value
 
             Target.TypeInfo lookupMapTypeInfo = _target.GetTypeInfo(DataType.ModuleLookupMap);
             ulong tableDataOffset = (ulong)lookupMapTypeInfo.Fields[Constants.FieldNames.ModuleLookupMap.TableData].Offset;

--- a/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.cs
+++ b/src/native/managed/cdacreader/tests/MockDescriptors/MockDescriptors.cs
@@ -132,7 +132,6 @@ internal partial class MockDescriptors
             new(nameof(Data.Module.Flags), DataType.uint32),
             new(nameof(Data.Module.Base), DataType.pointer),
             new(nameof(Data.Module.LoaderAllocator), DataType.pointer),
-            new(nameof(Data.Module.ThunkHeap), DataType.pointer),
             new(nameof(Data.Module.DynamicMetadata), DataType.pointer),
             new(nameof(Data.Module.Path), DataType.pointer),
             new(nameof(Data.Module.FileName), DataType.pointer),


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/112460 removed `m_pThunkHeap` from `Module` and the associated datadescriptor.

This value is used in a single DAC api which was changed in the same PR. 

Modified cDAC api to match new DAC api.

This is a breaking change and could be fixed with a new contract version. However, I think we can ignore this field given the cDAC hasn't really shipped yet.