### PR TITLE
Add `DOTNET_JitBypassAPXCheck` configuration

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9862,7 +9862,7 @@ public:
     //
     bool canUseApxEncoding() const
     {
-        return compOpportunisticallyDependsOn(InstructionSet_APX);
+        return compOpportunisticallyDependsOn(InstructionSet_APX) || (JitConfig.JitBypassAPXCheck() != 0);
     }
 
 private:

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -372,6 +372,7 @@ RELEASE_CONFIG_INTEGER(JitNoInline, "JitNoInline", 0)
 CONFIG_INTEGER(JitStressRex2Encoding, "JitStressRex2Encoding", 0) // Enable rex2 encoding for compatible instructions.
 CONFIG_INTEGER(JitStressPromotedEvexEncoding, "JitStressPromotedEvexEncoding", 0) // Enable promoted EVEX encoding for
                                                                                   // compatible instructions.
+CONFIG_INTEGER(JitBypassAPXCheck, "JitBypassAPXCheck", 0)                         // Bypass APX CPUID check.
 #endif
 
 // clang-format off


### PR DESCRIPTION
Setting this to `1` allows APX instructions to be generated, without doing a CPUID check.

The intention is to use this to do SuperPMI testing of APX.

Alternative implementations:
1. `JitBypassAPXCheck` is checked in the only location where `InstructionSet_APX` is checked. Possibly, the config should just set `InstructionSet_APX` someplace instead.
2. AltJits are configured so if `DOTNET_EnableAPX=1` is set (currently the default is `0`), then `InstructionSet_APX` is added to the set of ISAs. However, this leads to more asserts than those that are APX-specific (perhaps those should also be examined, but they look like artifacts of AltJit instruction set mismatch with the VM).