### PR TITLE
[browser] Remove experimental args from NodeJS WBT runner (part2)

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
@@ -41,7 +41,6 @@ namespace Wasm.Build.Tests
             Assert.DoesNotContain("Compiling native assets with emcc", output);
 
             RunAndTestWasmApp(buildArgs,
-                                extraXHarnessArgs: host == RunHost.NodeJS ? "--engine-arg=--experimental-wasm-simd --engine-arg=--experimental-wasm-eh" : "",
                                 expectedExitCode: 42,
                                 test: output =>
                                 {


### PR DESCRIPTION
Remove args from 1 missed test from https://github.com/dotnet/runtime/pull/111655.
Contributes to https://github.com/dotnet/runtime/issues/111753