### PR TITLE
[browser] Conditional access to DOM when searching for hotreload script

### DIFF
--- a/src/mono/browser/runtime/loader/config.ts
+++ b/src/mono/browser/runtime/loader/config.ts
@@ -333,7 +333,7 @@ async function loadBootConfig (module: DotnetModuleInternal): Promise<void> {
         loaderHelpers.config.applicationEnvironment = "Production";
     }
 
-    if (loaderHelpers.config.debugLevel !== 0 && document.querySelector("script[src*='aspnetcore-browser-refresh']")) {
+    if (loaderHelpers.config.debugLevel !== 0 && globalThis.window?.document?.querySelector("script[src*='aspnetcore-browser-refresh']")) {
         loaderHelpers.config.environmentVariables = loaderHelpers.config.environmentVariables || {};
         if (!loaderHelpers.config.environmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"]) {
             loaderHelpers.config.environmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";


### PR DESCRIPTION
For scenarios where we don't have access to DOM, expect it can be undefined.
Caused by https://github.com/dotnet/runtime/pull/113374.
Contributes to https://github.com/dotnet/performance/issues/4782.