### PR TITLE
Ensure we keep metadata for fields

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldMetadataNode.cs
@@ -58,6 +58,8 @@ namespace ILCompiler.DependencyAnalysis
                         TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, sigData.type, "Modifier in a field signature");
             }
 
+            TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, _field.FieldType, "Type of the field");
+
             return dependencies;
         }
         protected override string GetName(NodeFactory factory)

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -74,7 +74,7 @@ internal static class ReflectionTest
         TestCompilerGeneratedCode.Run();
         Test105034Regression.Run();
         TestMethodsNeededFromNativeLayout.Run();
-
+        TestFieldAndParamMetadata.Run();
 
         //
         // Mostly functionality tests
@@ -830,6 +830,29 @@ internal static class ReflectionTest
             if (parameters[0].GetCustomAttributes(inherit: true).Length != 0)
                 throw new Exception("Attributes");
 #endif
+        }
+    }
+
+    class TestFieldAndParamMetadata
+    {
+        public class FieldType;
+
+        public FieldType TheField;
+
+        public class ParameterType;
+
+        public static void TheMethod(ParameterType p) { }
+
+        public static void Run()
+        {
+            Type fieldType = typeof(TestFieldAndParamMetadata).GetField(nameof(TheField)).FieldType;
+
+            if (fieldType.Name != nameof(FieldType))
+                throw new Exception();
+
+            Type parameterType = typeof(TestFieldAndParamMetadata).GetMethod(nameof(TheMethod)).GetParameters()[0].ParameterType;
+            if (parameterType.Name != nameof(ParameterType))
+                throw new Exception();
         }
     }
 


### PR DESCRIPTION
We already do this for methods but `FieldMetadataNode` was missing the matching logic (we'd only keep metadata for custom modifiers in the lines above those I'm touching).