### PR TITLE
Allow embeded ICU data with StaticICULinking

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -356,7 +356,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <Output TaskParameter="ExitCode" PropertyName="_DsymUtilOutput" />
     </Exec>
 
-    <Exec Command="CC=&quot;$(CppLinker)&quot; &quot;$(IlcHostPackagePath)/native/src/libs/build-local.sh&quot; &quot;$(IlcHostPackagePath)/&quot; &quot;$(IntermediateOutputPath)&quot; System.Globalization.Native"
+    <Exec Command="CC=&quot;$(CppLinker)&quot; &quot;$(IlcHostPackagePath)/native/src/libs/build-local.sh&quot; &quot;$(IlcHostPackagePath)/&quot; &quot;$(MSBuildProjectDirectory)/$(IntermediateOutputPath)&quot; System.Globalization.Native &quot;$(EmbedIcuDataPath)&quot;"
         Condition="'$(StaticICULinking)' == 'true' and '$(InvariantGlobalization)' != 'true'" />
 
     <Exec Command="CC=&quot;$(CppLinker)&quot; &quot;$(IlcHostPackagePath)/native/src/libs/build-local.sh&quot; &quot;$(IlcHostPackagePath)/&quot; &quot;$(IntermediateOutputPath)&quot; System.Security.Cryptography.Native"

--- a/src/coreclr/nativeaot/docs/compiling.md
+++ b/src/coreclr/nativeaot/docs/compiling.md
@@ -74,8 +74,28 @@ You can use this feature by adding the `StaticICULinking` property to your proje
 ```xml
 <PropertyGroup>
   <StaticICULinking>true</StaticICULinking>
+
+  <!-- Optional: Embeds ICU data into the binary, making it fully standalone when system ICU
+       libraries are not installed on the target machine.
+       Update path to match your ICU version and variant: l(arge), b(ig endian), s(mall) or full. -->
+  <EmbedIcuDataPath>/usr/share/icu/74.2/icudt74l.dat</EmbedIcuDataPath>
 </PropertyGroup>
 ```
+
+> [!NOTE]
+> Some distros, such as Alpine and Gentoo, currently package ICU data as a `icudt*.dat` archive,
+> while others, like Ubuntu, do not.
+> To use `EmbedIcuDataPath` on a distro that does not provide the `.dat` file,
+> you may need to build ICU with `--with-data-packaging=archive` to generate it.
+> See https://unicode-org.github.io/icu/userguide/icu_data#building-and-linking-against-icu-data.
+> ```sh
+> # e.g. to obtain icudt*.dat on Ubuntu
+> $ curl -sSL https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-src.tgz | tar xzf -
+> $ cd icu/source
+> $ ./configure --with-data-packaging=archive --enable-static --disable-shared --disable-samples
+> $ make -j
+> $ find . -path *out/* -name icudt*.dat -exec echo $(pwd)/{} \;
+> ```
 
 This feature is only supported on Linux. This feature is not supported when crosscompiling.
 

--- a/src/native/libs/System.Globalization.Native/pal_icushim_static.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim_static.c
@@ -216,6 +216,15 @@ int32_t GlobalizationNative_LoadICU(void)
     }
 #endif
 
+#if defined(EMBEDDED_ICU_DATA_HEADER)
+    #include EMBEDDED_ICU_DATA_HEADER
+
+    if (!load_icu_data(icu_data))
+    {
+        return 0;
+    }
+#endif
+
     UErrorCode status = 0;
     UVersionInfo version;
     // Request the CLDR version to perform basic ICU initialization and find out

--- a/src/native/libs/build-local.sh
+++ b/src/native/libs/build-local.sh
@@ -13,6 +13,24 @@
 SHIM_SOURCE_DIR="$1"/native/src
 INTERMEDIATE_OUTPUT_PATH="$2"
 TARGET_LIBRARY="$3"
+EMBED_ICU_DATA_PATH="$4"
+
+if [ -n "$EMBED_ICU_DATA_PATH" ]; then
+    header="${INTERMEDIATE_OUTPUT_PATH}embedded_icu_data.h"
+
+    cat <<EOF > "$header"
+#ifndef EMBEDDED_ICU_DATA
+#define EMBEDDED_ICU_DATA
+
+static const unsigned char icu_data[] __attribute__((aligned(16))) = {
+$(od -An -vtx1 "$EMBED_ICU_DATA_PATH" | tr -d ' \n' | sed 's/\(..\)/0x\1, /g')
+};
+
+#endif // EMBEDDED_ICU_DATA
+EOF
+
+    CMAKE_EXTRA_ARGS=-DCMAKE_C_FLAGS="-DEMBEDDED_ICU_DATA_HEADER='\"$header\"'"
+fi
 
 if [ -d "$SHIM_SOURCE_DIR" ]; then
     LOCAL_SHIM_DIR="$INTERMEDIATE_OUTPUT_PATH"/libs/$TARGET_LIBRARY/build
@@ -22,7 +40,7 @@ if [ -d "$SHIM_SOURCE_DIR" ]; then
         exit 1
     fi
 
-    if ! cmake -S "$SHIM_SOURCE_DIR/libs/$TARGET_LIBRARY/" -DLOCAL_BUILD:STRING=1 -DCLR_CMAKE_TARGET_UNIX:STRING=1; then
+    if ! cmake -S "$SHIM_SOURCE_DIR/libs/$TARGET_LIBRARY/" -DLOCAL_BUILD:STRING=1 -DCLR_CMAKE_TARGET_UNIX:STRING=1 $CMAKE_EXTRA_ARGS; then
         echo "local_build.sh::ERROR: cmake failed"
         exit 1
     fi


### PR DESCRIPTION
When using StaticICULinking, there is one moving part which we have to carry to the production environment (or the exported container layer). Since we already allow (16-byte aligned) ICU data embedding for wasm, android and other mono targets, PR reuses the same mechanism with a tiny bit of infra using POSIX-y tools like `od`, `tr` and `sed` which are guaranteed to be available in the context where built-local.sh is called.

This makes statically linked executable requiring globalization run in scratch container without copying the icudt.dat.

Example usage `dotnet publish -p:StaticExecutable=true -p:InvariantGlobalization=false -p:StaticICULinking=true -p:EmbedIcuDataPath=/usr/share/icu/74.2/icudt74l.dat`