### PR TITLE
[browser] Soft fingerprint for boot config

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -401,12 +401,13 @@ Copyright (c) .NET Foundation. All rights reserved.
         Include="$(_WasmBuildBootJsonPath)"
         RelativePath="_framework/$(_WasmBootConfigFileName)" />
 
-      <_WasmBuildBootConfigFingerprintPatterns Include="WasmBootConfigFiles" Pattern="*%(_WasmBuildBootConfigCandidate.Extension)" Expression="#[.{fingerprint}]!" />
+      <_WasmBuildBootConfigFingerprintPatterns Include="WasmBootConfigFiles" Pattern="*%(_WasmBuildBootConfigCandidate.Extension)" Expression="#[.{fingerprint}]!" Condition="'$(_WasmFingerprintBootConfig)' == 'true'" />
+      <_WasmBuildBootConfigFingerprintPatterns Include="WasmBootConfigFiles" Pattern="*%(_WasmBuildBootConfigCandidate.Extension)" Expression="#[.{fingerprint}]?" Condition="'$(_WasmFingerprintBootConfig)' != 'true'" />
     </ItemGroup>
 
     <DefineStaticWebAssets
       CandidateAssets="@(_WasmBuildBootConfigCandidate)"
-      FingerprintCandidates="$(_WasmFingerprintBootConfig)"
+      FingerprintCandidates="$(_WasmFingerprintAssets)"
       FingerprintPatterns="@(_WasmBuildBootConfigFingerprintPatterns)"
       SourceId="$(PackageId)"
       SourceType="Computed"
@@ -598,12 +599,13 @@ Copyright (c) .NET Foundation. All rights reserved.
         Include="$(IntermediateOutputPath)$(_WasmPublishBootConfigFileName)"
         RelativePath="_framework/$(_WasmBootConfigFileName)" />
 
-      <_WasmPublishBootConfigFingerprintPatterns Include="WasmBootConfigFiles" Pattern="*%(_WasmPublishBootConfigCandidate.Extension)" Expression="#[.{fingerprint}]!" />
+      <_WasmPublishBootConfigFingerprintPatterns Include="WasmBootConfigFiles" Pattern="*%(_WasmPublishBootConfigCandidate.Extension)" Expression="#[.{fingerprint}]!" Condition="'$(_WasmFingerprintBootConfig)' == 'true'" />
+      <_WasmPublishBootConfigFingerprintPatterns Include="WasmBootConfigFiles" Pattern="*%(_WasmPublishBootConfigCandidate.Extension)" Expression="#[.{fingerprint}]?" Condition="'$(_WasmFingerprintBootConfig)' != 'true'" />
     </ItemGroup>
 
     <DefineStaticWebAssets
       CandidateAssets="@(_WasmPublishBootConfigCandidate)"
-      FingerprintCandidates="$(_WasmFingerprintBootConfig)"
+      FingerprintCandidates="$(_WasmFingerprintAssets)"
       FingerprintPatterns="@(_WasmPublishBootConfigFingerprintPatterns)"
       SourceId="$(PackageId)"
       SourceType="Computed"

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -188,12 +188,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_BlazorWebAssemblyStartupMemoryCache>$(BlazorWebAssemblyStartupMemoryCache)</_BlazorWebAssemblyStartupMemoryCache>
       <_BlazorWebAssemblyJiterpreter>$(BlazorWebAssemblyJiterpreter)</_BlazorWebAssemblyJiterpreter>
       <_BlazorWebAssemblyRuntimeOptions>$(BlazorWebAssemblyRuntimeOptions)</_BlazorWebAssemblyRuntimeOptions>
+      <!-- true = wasm assets will have hard fingerprint; false = wasm assets won't have even soft fingerprint -->
       <_WasmFingerprintAssets>$(WasmFingerprintAssets)</_WasmFingerprintAssets>
       <_WasmFingerprintAssets Condition="'$(_WasmFingerprintAssets)' == '' and '$(_TargetingNET90OrLater)' == 'true'">true</_WasmFingerprintAssets>
       <_WasmFingerprintAssets Condition="'$(_WasmFingerprintAssets)' == ''">false</_WasmFingerprintAssets>
+      <!-- true = dotnet.js will have hard fingerprint; false = dotnet.js will have soft fingerprint -->
       <_WasmFingerprintDotnetJs>$(WasmFingerprintDotnetJs)</_WasmFingerprintDotnetJs>
       <_WasmFingerprintDotnetJs Condition="'$(_WasmFingerprintDotnetJs)' == ''">$(WriteImportMapToHtml)</_WasmFingerprintDotnetJs>
       <_WasmFingerprintDotnetJs Condition="'$(_WasmFingerprintDotnetJs)' == ''">false</_WasmFingerprintDotnetJs>
+      <!-- true = boot config will have hard fingerprint; false = boot config will have soft fingerprint -->
       <_WasmFingerprintBootConfig>$(WasmFingerprintBootConfig)</_WasmFingerprintBootConfig>
       <_WasmFingerprintBootConfig Condition="'$(_WasmFingerprintBootConfig)' == ''">$(WriteImportMapToHtml)</_WasmFingerprintBootConfig>
       <_WasmFingerprintBootConfig Condition="'$(_WasmFingerprintBootConfig)' == ''">false</_WasmFingerprintBootConfig>


### PR DESCRIPTION
Before this change we apply only hard fingerprint on boot config if users opt-in (`WasmFingerprintBootConfig` or `WriteImportMapToHtml`).
This means that hosted blazor won't have soft fingerprint on boot config.

This PR adds soft fingerprint if wasm assets are to be fingerprinted (default behavior) and hard fingerprint if users opt-in.

Added comments
- `WasmFingerprintAssets`
  - true = wasm assets will have hard fingerprint
  - false = wasm assets won't have even soft fingerprint
- `WasmFingerprintBootConfig`
  - true = boot config will have hard fingerprint
  - false = boot config will have soft fingerprint
- `WasmFingerprintDotnetJs`
  - true = dotnet.js will have hard fingerprint
  - false = dotnet.js will have soft fingerprint

Contributes to https://github.com/dotnet/aspnetcore/issues/59456