### PR TITLE
Simplify RID model and handle Linux libc flavors in orchestrated builds

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -1,12 +1,5 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
-  <PropertyGroup>
-    <!-- TEMP: These changes should be upstreamed to Arcade -->
-    <RestoreEmbedFilesInBinlog>true</RestoreEmbedFilesInBinlog>
-    <RestoreStaticGraphEnableBinaryLogger>true</RestoreStaticGraphEnableBinaryLogger>
-    <RestoreStaticGraphBinaryLoggerParameters>LogFile=$(ArtifactsLogDir)Restore-Build.proj.binlog</RestoreStaticGraphBinaryLoggerParameters>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(RestoreToolsetOnly)' != 'true'">
     <!-- Subsets are already imported by Directory.Build.props. -->
     <ProjectReference Include="@(ProjectToBuild)" />

--- a/Build.proj
+++ b/Build.proj
@@ -1,5 +1,12 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
+  <PropertyGroup>
+    <!-- TEMP: These changes should be upstreamed to Arcade -->
+    <RestoreEmbedFilesInBinlog>true</RestoreEmbedFilesInBinlog>
+    <RestoreStaticGraphEnableBinaryLogger>true</RestoreStaticGraphEnableBinaryLogger>
+    <RestoreStaticGraphBinaryLoggerParameters>LogFile=$(ArtifactsLogDir)Restore-Build.proj.binlog</RestoreStaticGraphBinaryLoggerParameters>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(RestoreToolsetOnly)' != 'true'">
     <!-- Subsets are already imported by Directory.Build.props. -->
     <ProjectReference Include="@(ProjectToBuild)" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -169,11 +169,6 @@
   <Import Project="$(RepositoryEngineeringDir)RuntimeIdentifier.props" />
 
   <PropertyGroup>
-    <!-- Microsoft.NET.Sdk.IL SDK defaults to the portable host rid. Match it to the SDK RID (so source-build scenarios use the same RID as the host SDK). -->
-    <MicrosoftNetCoreIlasmPackageRuntimeId>$(NETCoreSdkRuntimeIdentifier)</MicrosoftNetCoreIlasmPackageRuntimeId>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <MicrosoftNetCoreAppRefPackDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'microsoft.netcore.app.ref'))</MicrosoftNetCoreAppRefPackDir>
     <MicrosoftNetCoreAppRefPackRefDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRefPackDir)', 'ref', '$(NetCoreAppCurrent)'))</MicrosoftNetCoreAppRefPackRefDir>
     <MicrosoftNetCoreAppRefPackDataDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRefPackDir)', 'data'))</MicrosoftNetCoreAppRefPackDataDir>
@@ -371,6 +366,7 @@
   <PropertyGroup>
     <CustomBeforeNoTargets>$(RepositoryEngineeringDir)NoTargetsSdk.BeforeTargets.targets</CustomBeforeNoTargets>
     <CustomAfterTraversalTargets>$(RepositoryEngineeringDir)TraversalSdk.AfterTargets.targets</CustomAfterTraversalTargets>
+    <BeforeMicrosoftNETSdkTargets Condition="'$(MSBuildProjectExtension)' == '.ilproj'">$(BeforeMicrosoftNETSdkTargets);$(RepositoryEngineeringDir)ILSdk.BeforeTargets.targets</BeforeMicrosoftNETSdkTargets>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -169,6 +169,11 @@
   <Import Project="$(RepositoryEngineeringDir)RuntimeIdentifier.props" />
 
   <PropertyGroup>
+    <!-- Microsoft.NET.Sdk.IL SDK defaults to the portable host rid. Match it to the SDK RID (so source-build scenarios use the same RID as the host SDK). -->
+    <MicrosoftNetCoreIlasmPackageRuntimeId>$(NETCoreSdkRuntimeIdentifier)</MicrosoftNetCoreIlasmPackageRuntimeId>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <MicrosoftNetCoreAppRefPackDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'microsoft.netcore.app.ref'))</MicrosoftNetCoreAppRefPackDir>
     <MicrosoftNetCoreAppRefPackRefDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRefPackDir)', 'ref', '$(NetCoreAppCurrent)'))</MicrosoftNetCoreAppRefPackRefDir>
     <MicrosoftNetCoreAppRefPackDataDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRefPackDir)', 'data'))</MicrosoftNetCoreAppRefPackDataDir>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,11 +25,11 @@
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <KnownFrameworkReference Update="Microsoft.NETCore.App">
       <RuntimePackRuntimeIdentifiers
-        Condition="'%(TargetFramework)' == '$(NetCoreAppCurrent)'">%(RuntimePackRuntimeIdentifiers);$(PackageRID)</RuntimePackRuntimeIdentifiers>
+        Condition="'%(TargetFramework)' == '$(NetCoreAppCurrent)'">%(RuntimePackRuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier)</RuntimePackRuntimeIdentifiers>
     </KnownFrameworkReference>
     <KnownCrossgen2Pack Update="Microsoft.NETCore.App.Crossgen2">
       <Crossgen2RuntimeIdentifiers
-        Condition="'%(TargetFramework)' == '$(NetCoreAppCurrent)'" >%(Crossgen2RuntimeIdentifiers);$(PackageRID)</Crossgen2RuntimeIdentifiers>
+        Condition="'%(TargetFramework)' == '$(NetCoreAppCurrent)'" >%(Crossgen2RuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier)</Crossgen2RuntimeIdentifiers>
     </KnownCrossgen2Pack>
     <!-- Avoid references to Microsoft.AspNetCore.App.Runtime.<rid> -->
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,6 +1,6 @@
 <!-- When altering this file, include @dotnet/product-construction as a reviewer. -->
 
-<Project>
+<Project TreatAsLocalProperty="TargetOS;TargetRid">
 
   <PropertyGroup>
     <GitHubRepositoryName>runtime</GitHubRepositoryName>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -16,6 +16,7 @@
     <_targetRidPlatformIndex>$(TargetRid.LastIndexOf('-'))</_targetRidPlatformIndex>
     <TargetArch>$(TargetRid.Substring($(_targetRidPlatformIndex)).TrimStart('-'))</TargetArch>
     <TargetOS>$(TargetRid.Substring(0, $(_targetRidPlatformIndex)))</TargetOS>
+    <TargetOS Condition="'$(TargetOS)' == 'win'">windows</TargetOS>
 
     <_hostRidPlatformIndex>$(_hostRid.LastIndexOf('-'))</_hostRidPlatformIndex>
     <_hostArch>$(_hostRid.Substring($(_hostRidPlatformIndex)).TrimStart('-'))</_hostArch>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -42,9 +42,6 @@
       <InnerBuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)usemonoruntime</InnerBuildArgs>
       <!-- TODO: This parameter is only available on the Unix script. Intentional? -->
       <InnerBuildArgs Condition="'$(OS)' != 'Windows_NT'">$(InnerBuildArgs) --outputrid $(OutputRID)</InnerBuildArgs>
-      <!-- PackageOS and ToolsOS control the rids of prebuilts consumed by the build.
-           They are set to RuntimeOS so they match with the build SDK rid. -->
-      <InnerBuildArgs Condition="'$(RuntimeOS)' != ''">$(InnerBuildArgs) /p:PackageOS=$(RuntimeOS)</InnerBuildArgs>
       <!-- BaseOS is an expected known rid in the graph that OutputRID is compatible with.
            It's used to add OutputRID in the graph if the parent can't be detected. -->
       <InnerBuildArgs>$(InnerBuildArgs) /p:AdditionalRuntimeIdentifierParent=$(BaseOS) /p:BaseOS=$(BaseOS)</InnerBuildArgs>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,6 +1,13 @@
 <!-- When altering this file, include @dotnet/product-construction as a reviewer. -->
 
-<Project TreatAsLocalProperty="TargetOS;TargetRid">
+<Project>
+  <PropertyGroup>
+    <!-- TargetRid can be set by the orchestrator, so we need to set OutputRID to that as a default. -->
+    <OutputRID Condition="'$(OutputRID)' == ''">$(TargetRid)</OutputRID>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)OSArch.props" />
+  <Import Project="$(MSBuildThisFileDirectory)RuntimeIdentifier.props" />
 
   <PropertyGroup>
     <GitHubRepositoryName>runtime</GitHubRepositoryName>
@@ -8,48 +15,7 @@
     <BaseInnerSourceBuildCommand Condition="'$(OS)' == 'Windows_NT'">.\build.cmd</BaseInnerSourceBuildCommand>
     <BaseInnerSourceBuildCommand Condition="'$(OS)' != 'Windows_NT'">./build.sh</BaseInnerSourceBuildCommand>
 
-    <_hostRid>$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</_hostRid>
-    <!-- TargetRid names what gets built. -->
-    <TargetRid Condition="'$(TargetRid)' == ''">$(_hostRid)</TargetRid>
-
-    <!-- Split e.g. 'fedora.33-x64' into 'fedora.33' and 'x64'. -->
-    <_targetRidPlatformIndex>$(TargetRid.LastIndexOf('-'))</_targetRidPlatformIndex>
-    <TargetArch>$(TargetRid.Substring($(_targetRidPlatformIndex)).TrimStart('-'))</TargetArch>
-    <TargetOS>$(TargetRid.Substring(0, $(_targetRidPlatformIndex)))</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == 'win'">windows</TargetOS>
-
-    <_hostRidPlatformIndex>$(_hostRid.LastIndexOf('-'))</_hostRidPlatformIndex>
-    <_hostArch>$(_hostRid.Substring($(_hostRidPlatformIndex)).TrimStart('-'))</_hostArch>
-
     <LogVerbosity Condition="'$(LogVerbosity)' == ''">minimal</LogVerbosity>
-  </PropertyGroup>
-
-  <!-- Keep this list in sync with https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/Directory.Build.props#L23 -->
-  <PropertyGroup Label="ShortStacks">
-    <ShortStack Condition="'$(TargetOS)' == 'wasi'">true</ShortStack>
-    <ShortStack Condition="'$(TargetOS)' == 'browser'">true</ShortStack>
-    <ShortStack Condition="'$(TargetOS)' == 'ios'">true</ShortStack>
-    <ShortStack Condition="'$(TargetOS)' == 'iossimulator'">true</ShortStack>
-    <ShortStack Condition="'$(TargetOS)' == 'tvos'">true</ShortStack>
-    <ShortStack Condition="'$(TargetOS)' == 'tvossimulator'">true</ShortStack>
-    <ShortStack Condition="'$(TargetOS)' == 'maccatalyst'">true</ShortStack>
-    <ShortStack Condition="'$(TargetOS)' == 'android'">true</ShortStack>
-    <ShortStack Condition="'$(TargetOS)' == 'linux-bionic'">true</ShortStack>
-    <!-- Mono LLVM builds are short -->
-    <ShortStack Condition="'$(DotNetBuildMonoEnableLLVM)' == 'true' or '$(DotNetBuildMonoAOTEnableLLVM)' == 'true'">true</ShortStack>
-  </PropertyGroup>
-
-  <!--
-    Allow the VMR orchestrator to control whether or not to build rid-specific artifacts,
-    but provide defaults until the VMR orchestrator provides controls in all scenarios.
-  -->
-  <PropertyGroup Condition="'$(EnableDefaultRidSpecificArtifacts)' == ''">
-    <!-- Source-build always needs all artifacts to be published. -->
-    <EnableDefaultRidSpecificArtifacts Condition="'$(DotNetBuildSourceOnly)' != ''">false</EnableDefaultRidSpecificArtifacts>
-    <!-- Short-stack builds should always only publish RID-specific artifacts. -->
-    <EnableDefaultRidSpecificArtifacts Condition="'$(ShortStack)' == 'true'">true</EnableDefaultRidSpecificArtifacts>
-    <!-- If no override is specified, don't use RID-specific publishing. Instead, publish everything. -->
-    <EnableDefaultRidSpecificArtifacts Condition="'$(EnableDefaultRidSpecificArtifacts)' == ''">false</EnableDefaultRidSpecificArtifacts>
   </PropertyGroup>
 
   <Target Name="GetRuntimeSourceBuildCommandConfiguration"
@@ -64,21 +30,23 @@
       <InnerBuildArgs Condition="'$(DotNetBuildOrchestrator)' == 'true' and '$(Sign)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)sign</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)pack</InnerBuildArgs>
 
-      <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)arch $(TargetArch)</InnerBuildArgs>
-      <InnerBuildArgs Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)os $(TargetOS)</InnerBuildArgs>
-      <InnerBuildArgs Condition="'$(CrossBuild)' == 'true' or ('$(TargetArch)' != '$(_hostArch)' and '$(ShortStack)' != 'true')">$(InnerBuildArgs) $(FlagParameterPrefix)cross</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)arch $(TargetArchitecture)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(_portableOS)' == 'win'">$(InnerBuildArgs) $(FlagParameterPrefix)os windows</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)os $(_portableOS)</InnerBuildArgs>
+      <!-- Mobile builds are never "cross" builds as they don't have a rootfs-based filesystem build. -->
+      <InnerBuildArgs Condition="'$(CrossBuild)' == 'true' or ('$(TargetArchitecture)' != '$(BuildArchitecture)' and '$(TargetsMobile)' != 'true')">$(InnerBuildArgs) $(FlagParameterPrefix)cross</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)configuration $(Configuration)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)verbosity $(LogVerbosity)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)usemonoruntime</InnerBuildArgs>
       <!-- TODO: This parameter is only available on the Unix script. Intentional? -->
-      <InnerBuildArgs Condition="'$(OS)' != 'Windows_NT'">$(InnerBuildArgs) --outputrid $(TargetRid)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(OS)' != 'Windows_NT'">$(InnerBuildArgs) --outputrid $(OutputRID)</InnerBuildArgs>
       <!-- PackageOS and ToolsOS control the rids of prebuilts consumed by the build.
            They are set to RuntimeOS so they match with the build SDK rid. -->
-      <InnerBuildArgs Condition="'$(RuntimeOS)' != ''">$(InnerBuildArgs) /p:PackageOS=$(RuntimeOS) /p:ToolsOS=$(RuntimeOS)</InnerBuildArgs>
-      <!-- BaseOS is an expected known rid in the graph that TargetRid is compatible with.
-           It's used to add TargetRid in the graph if the parent can't be detected. -->
+      <InnerBuildArgs Condition="'$(RuntimeOS)' != ''">$(InnerBuildArgs) /p:PackageOS=$(RuntimeOS)</InnerBuildArgs>
+      <!-- BaseOS is an expected known rid in the graph that OutputRID is compatible with.
+           It's used to add OutputRID in the graph if the parent can't be detected. -->
       <InnerBuildArgs>$(InnerBuildArgs) /p:AdditionalRuntimeIdentifierParent=$(BaseOS) /p:BaseOS=$(BaseOS)</InnerBuildArgs>
       <!-- Pass through special build modes controlled by properties -->
       <InnerBuildArgs Condition="'$(DotNetBuildRuntimeWasmEnableThreads)' == 'true'">$(InnerBuildArgs) /p:WasmEnableThreads=true</InnerBuildArgs>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -6,8 +6,8 @@
     <OutputRID Condition="'$(OutputRID)' == ''">$(TargetRid)</OutputRID>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)OSArch.props" />
-  <Import Project="$(MSBuildThisFileDirectory)RuntimeIdentifier.props" />
+  <Import Project="$(MSBuildThisFileDirectory)OSArch.props" Condition="'$(_ImportedOSArchProps)' != 'true'" />
+  <Import Project="$(MSBuildThisFileDirectory)RuntimeIdentifier.props" Condition="'$(_ImportedRuntimeIdentifierProps)' != 'true'" />
 
   <PropertyGroup>
     <GitHubRepositoryName>runtime</GitHubRepositoryName>

--- a/eng/ILSdk.BeforeTargets.targets
+++ b/eng/ILSdk.BeforeTargets.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Microsoft.NET.Sdk.IL SDK defaults to the portable host rid. Match it to the SDK RID (so source-build scenarios use the same RID as the host SDK). -->
+    <MicrosoftNetCoreIlasmPackageRuntimeId>$(NETCoreSdkRuntimeIdentifier)</MicrosoftNetCoreIlasmPackageRuntimeId>
+  </PropertyGroup>
+</Project>

--- a/eng/OSArch.props
+++ b/eng/OSArch.props
@@ -32,4 +32,8 @@
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
     <Platform Condition="'$(Platform)' == '' and '$(InferPlatformFromTargetArchitecture)' == 'true'">$(TargetArchitecture)</Platform>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <_ImportedOSArchProps>true</_ImportedOSArchProps>
+  </PropertyGroup>
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -78,7 +78,7 @@
     but we do produce them in both the VMR and the runtime official build.
   -->
   <PropertyGroup Condition="'$(DotNetBuildOrchestrator)' == 'true'">
-    <ShouldGenerateProductVersionFiles Condition="'$(PackageRID)' == 'win-x64' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">true</ShouldGenerateProductVersionFiles>
+    <ShouldGenerateProductVersionFiles Condition="'$(OutputRID)' == 'win-x64' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">true</ShouldGenerateProductVersionFiles>
     <ShouldGenerateProductVersionFiles Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</ShouldGenerateProductVersionFiles>
   </PropertyGroup>
 

--- a/eng/RuntimeIdentifier.props
+++ b/eng/RuntimeIdentifier.props
@@ -65,4 +65,7 @@
     <TargetsWindows Condition="'$(TargetOS)' == 'windows'">true</TargetsWindows>
     <TargetsUnix Condition="'$(TargetsFreeBSD)' == 'true' or '$(Targetsillumos)' == 'true' or '$(TargetsSolaris)' == 'true' or '$(TargetsHaiku)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsNetBSD)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetsMacCatalyst)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetsAndroid)' == 'true'">true</TargetsUnix>
   </PropertyGroup>
+  <PropertyGroup>
+    <_ImportedRuntimeIdentifierProps>true</_ImportedRuntimeIdentifierProps>
+  </PropertyGroup>
 </Project>

--- a/eng/RuntimeIdentifier.props
+++ b/eng/RuntimeIdentifier.props
@@ -36,26 +36,6 @@
     <PackageRID Condition="'$(PackageRID)' == ''">$(_packageOS)-$(TargetArchitecture)</PackageRID>
   </PropertyGroup>
 
-  <!-- ToolsRID is used for packages needed on the build host. -->
-  <PropertyGroup Label="CalculateToolsRID">
-    <!-- _portableHostOS is the portable rid-OS corresponding to the build host platform.
-
-         To determine _portableHostOS we use _hostOS, similar to how _portableOS is calculated from TargetOS.
-
-         When we're not cross-building we can detect linux flavors by looking at _portableOS
-         because the target platform and the build host platform are the same.
-         For cross-builds, we're currently unable to detect the flavors. -->
-    <_portableHostOS>$(_hostOS)</_portableHostOS>
-    <_portableHostOS Condition="'$(_portableHostOS)' == 'windows'">win</_portableHostOS>
-    <_portableHostOS Condition="'$(CrossBuild)' != 'true' and '$(_portableOS)' == 'linux-musl'">linux-musl</_portableHostOS>
-
-    <!-- source-build sets ToolsOS to build with non-portable rid packages that were source-built previously. -->
-    <ToolsRID Condition="'$(ToolsOS)' != ''">$(ToolsOS)-$(_hostArch)</ToolsRID>
-    <ToolsRID Condition="'$(ToolsRID)' == ''">$(_portableHostOS)-$(_hostArch)</ToolsRID>
-
-    <!-- Microsoft.NET.Sdk.IL SDK defaults to the portable host rid. Match it to ToolsRID (for source-build). -->
-    <MicrosoftNetCoreIlasmPackageRuntimeId>$(ToolsRID)</MicrosoftNetCoreIlasmPackageRuntimeId>
-  </PropertyGroup>
 
   <!-- OutputRID is used to name the target platform.
        For portable builds, OutputRID matches _portableOS.

--- a/eng/RuntimeIdentifier.props
+++ b/eng/RuntimeIdentifier.props
@@ -25,18 +25,6 @@
     <_portableOS Condition="'$(HostOS)' == 'win' and '$(TargetsMobile)' != 'true'">win</_portableOS>
   </PropertyGroup>
 
-  <!-- PackageRID is used for packages needed for the target. -->
-  <PropertyGroup Label="CalculatePackageRID">
-    <_packageOS>$(_portableOS)</_packageOS>
-
-    <_packageOS Condition="'$(CrossBuild)' == 'true' and '$(_portableOS)' != 'linux-musl' and '$(_portableOS)' != 'linux-bionic' and '$(_portableOS)' != 'android'">$(_hostOS)</_packageOS>
-
-    <!-- source-build sets PackageOS to build with non-portable rid packages that were source-built previously. -->
-    <PackageRID Condition="'$(PackageOS)' != ''">$(PackageOS)-$(TargetArchitecture)</PackageRID>
-    <PackageRID Condition="'$(PackageRID)' == ''">$(_packageOS)-$(TargetArchitecture)</PackageRID>
-  </PropertyGroup>
-
-
   <!-- OutputRID is used to name the target platform.
        For portable builds, OutputRID matches _portableOS.
        For non-portable builds, it uses __DistroRid (from the native build script), or falls back to RuntimeInformation.RuntimeIdentifier.

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -14,7 +14,7 @@
         We have specific jobs that produce RID-agnostic packages or packages for multiple RIDs set this property.
       - Mono AOT LLVM builds only publish LLVM-specific packages always.
 
-      VMR jobs can control whether or not a vertical has EnableDefaultRidSpecificArtifacts set to true or false in DotNetBuild.props.
+      The VMR orchestrator will set EnableDefaultRidSpecificArtifacts=true as a global property based on its configuration.
 
       Packages that do not meet the above rules are added with Vertical visibility in the VMR and excluded in non-VMR builds.
     -->
@@ -27,7 +27,7 @@
 
     <!-- The final stage of the runtime official build should publish everything. -->
     <EnableDefaultRidSpecificArtifacts Condition="'$(DotNetFinalPublish)' != ''">false</EnableDefaultRidSpecificArtifacts>
-    <EnableDefaultRidSpecificArtifacts Condition="'$(EnableDefaultRidSpecificArtifacts)' == ''">true</EnableDefaultRidSpecificArtifacts>
+    <EnableDefaultRidSpecificArtifacts Condition="'$(EnableDefaultRidSpecificArtifacts)' == '' and '$(DotNetBuildOrchestrator)' != 'true'">true</EnableDefaultRidSpecificArtifacts>
 
     <UseDotNetCertificate>true</UseDotNetCertificate>
   </PropertyGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -22,8 +22,8 @@
     <EnableBlobArtifacts>true</EnableBlobArtifacts>
     <EnableBlobArtifacts Condition="'$(MonoAOTEnableLLVM)' == 'true'">false</EnableBlobArtifacts>
 
-    <!-- Set the TargetRid property to our PackageRID, which is the right RID to use for selecting packages from our repo. -->
-    <TargetRid>$(PackageRID)</TargetRid>
+    <!-- Set the TargetRid property to our OutputRID, which is the right RID to use for selecting packages from our repo. -->
+    <TargetRid>$(OutputRID)</TargetRid>
 
     <!-- The final stage of the runtime official build should publish everything. -->
     <EnableDefaultRidSpecificArtifacts Condition="'$(DotNetFinalPublish)' != ''">false</EnableDefaultRidSpecificArtifacts>
@@ -119,29 +119,29 @@
   <Choose>
     <When Condition="'$(MonoAOTEnableLLVM)' == 'true'">
       <ItemGroup>
-        <PackageArtifacts Include="$(ArtifactsPackagesDir)**\*.LLVM.AOT.$(PackageRID).*.nupkg" />
+        <PackageArtifacts Include="$(ArtifactsPackagesDir)**\*.LLVM.AOT.$(OutputRID).*.nupkg" />
         <Artifact Include="@(PackageArtifacts)"
                   IsShipping="$([System.String]::Copy('%(RecursiveDir)').StartsWith('Shipping'))"
                   Kind="Package" />
       </ItemGroup>
     </When>
     <When Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">
-      <ItemGroup Condition="'$(PackageRID)' == 'ios-arm64'">
+      <ItemGroup Condition="'$(OutputRID)' == 'ios-arm64'">
         <PackageArtifacts
           Include="$(ArtifactsPackagesDir)**\Microsoft.NET.Runtime.iOS.Sample.Mono.*.nupkg;
                   $(ArtifactsPackagesDir)**\Microsoft.NET.Runtime.LibraryBuilder.Sdk.*.nupkg;
                   $(ArtifactsPackagesDir)**\Microsoft.NET.Runtime.MonoAOTCompiler.Task.*.nupkg;
                   $(ArtifactsPackagesDir)**\Microsoft.NET.Runtime.MonoTargets.Sdk.*.nupkg" />
       </ItemGroup>
-      <ItemGroup Condition="'$(PackageRID)' == 'android-arm64'">
+      <ItemGroup Condition="'$(OutputRID)' == 'android-arm64'">
         <PackageArtifacts
           Include="$(ArtifactsPackagesDir)**\Microsoft.NET.Runtime.Android.Sample.Mono.*.nupkg" />
       </ItemGroup>
-      <ItemGroup Condition="'$(PackageRID)' == 'wasi-wasm'">
+      <ItemGroup Condition="'$(OutputRID)' == 'wasi-wasm'">
         <PackageArtifacts
           Include="$(ArtifactsPackagesDir)**\Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk.*.nupkg" />
       </ItemGroup>
-      <ItemGroup Condition="'$(PackageRID)' == 'browser-wasm' and '$(WasmEnableThreads)' != 'true'">
+      <ItemGroup Condition="'$(OutputRID)' == 'browser-wasm' and '$(WasmEnableThreads)' != 'true'">
         <PackageArtifacts
           Include="$(ArtifactsPackagesDir)**\Microsoft.NET.Runtime.wasm.Sample.Mono.*.nupkg;
                   $(ArtifactsPackagesDir)**\Microsoft.NET.Runtime.WorkloadTesting.Internal.*.nupkg;

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -52,7 +52,7 @@
 
     <!-- Determine if AOT tools can run on the specified target -->
     <_AotToolsSupportedOS Condition="'$(TargetsMobile)' != 'true' and '$(TargetsLinuxBionic)' != 'true' and '$(StageOneBuild)' != 'true'">true</_AotToolsSupportedOS>
-    <_AotToolsSupportedArch>true</_AotToolsSupportedArch>
+    <_AotToolsSupportedArch Condition="'$(TargetArchitecture)' != 'armel'">true</_AotToolsSupportedArch>
     <AotToolsSupported Condition="'$(_AotToolsSupportedOS)' == 'true' and '$(_AotToolsSupportedArch)' == 'true'">true</AotToolsSupported>
   </PropertyGroup>
 
@@ -169,7 +169,6 @@
   <PropertyGroup>
     <_IsCommunityCrossArchitecture Condition="'$(CrossBuild)' == 'true' and ('$(TargetArchitecture)' == 'loongarch64' or '$(TargetArchitecture)' == 'riscv64')">true</_IsCommunityCrossArchitecture>
     <UseNativeAotForComponents Condition="'$(NativeAotSupported)' == 'true' and '$(TargetOS)' == '$(HostOS)' and '$(TargetsLinuxBionic)' != 'true' and '$(_IsCommunityCrossArchitecture)' != 'true'">true</UseNativeAotForComponents>
-
     <!-- If we're building clr.nativeaotlibs and not building the CLR runtime, compile libraries against NativeAOT CoreLib -->
     <UseNativeAotCoreLib Condition="'$(TestNativeAot)' == 'true' or ($(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr.native+')) and !$(_subset.Contains('+clr.runtime+')) and !$(_subset.Contains('+clr.corelib+')))">true</UseNativeAotCoreLib>
   </PropertyGroup>
@@ -440,7 +439,8 @@
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2_publish.csproj" Condition="'$(AotToolsSupported)' == 'true'" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.Build.Tasks\ILCompiler.Build.Tasks.csproj" Category="clr" Condition="'$(AotToolsSupported)' == 'true'" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler_publish.csproj" Category="clr" Condition="'$(AotToolsSupported)' == 'true'" />
-    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\BuildIntegration\BuildIntegration.proj" Category="clr" Condition="'$(AotToolsSupported)' == 'true'" />
+    <!-- We may use these targets with the in-build ILCompiler or with the shipping ILCompiler. Produce them whenever we may use them. -->
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\BuildIntegration\BuildIntegration.proj" Category="clr" Condition="'$(AotToolsSupported)' == 'true' or '$(NativeAotSupported)' == 'true'" />
 
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler.csproj" Condition="'$(AotToolsSupported)' == 'true'" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2.csproj" Condition="'$(AotToolsSupported)' == 'true'" Category="clr" />

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -99,7 +99,7 @@
 
   <PropertyGroup>
     <DefaultCoreClrSubsets>clr.native+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools+host.native</DefaultCoreClrSubsets>
-    <DefaultCoreClrSubsets Condition="'$(PackageRID)' == 'linux-armel'">clr.native+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets Condition="'$(OutputRID)' == 'linux-armel'">clr.native+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools</DefaultCoreClrSubsets>
     <DefaultCoreClrSubsets Condition="'$(TargetsAndroid)' == 'true'">clr.native+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools</DefaultCoreClrSubsets>
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(RuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -49,6 +49,11 @@
     <_NativeAotSupportedOS Condition="'$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'maccatalyst' or '$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvossimulator' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'freebsd'">true</_NativeAotSupportedOS>
     <_NativeAotSupportedArch Condition="'$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'loongarch64' or '$(TargetArchitecture)' == 'riscv64' or ('$(TargetOS)' == 'windows' and '$(TargetArchitecture)' == 'x86')">true</_NativeAotSupportedArch>
     <NativeAotSupported Condition="'$(_NativeAotSupportedOS)' == 'true' and '$(_NativeAotSupportedArch)' == 'true'">true</NativeAotSupported>
+
+    <!-- Determine if AOT tools can run on the specified target -->
+    <_AotToolsSupportedOS Condition="'$(TargetsMobile)' != 'true' and '$(TargetsLinuxBionic)' != 'true' and '$(StageOneBuild)' != 'true'">true</_AotToolsSupportedOS>
+    <_AotToolsSupportedArch>true</_AotToolsSupportedArch>
+    <AotToolsSupported Condition="'$(_AotToolsSupportedOS)' == 'true' and '$(_AotToolsSupportedArch)' == 'true'">true</AotToolsSupported>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -432,13 +437,13 @@
                              $(CoreClrProjectRoot)tools\AssemblyChecker\AssemblyChecker.csproj;
                              $(ToolsProjectRoot)StressLogAnalyzer\src\StressLogAnalyzer.csproj" Category="clr" Condition="'$(DotNetBuildSourceOnly)' != 'true'"/>
     <!-- skip the architectures that don't have LKG runtime packs -->
-    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2_publish.csproj" Condition="'$(NativeAotSupported)' == 'true' and '$(StageOneBuild)' != 'true'" Category="clr" />
-    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.Build.Tasks\ILCompiler.Build.Tasks.csproj" Category="clr" Condition="'$(NativeAotSupported)' == 'true'" />
-    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler_publish.csproj" Category="clr" Condition="'$(NativeAotSupported)' == 'true' and '$(StageOneBuild)' != 'true'" />
-    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\BuildIntegration\BuildIntegration.proj" Category="clr" Condition="'$(NativeAotSupported)' == 'true'" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2_publish.csproj" Condition="'$(AotToolsSupported)' == 'true'" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.Build.Tasks\ILCompiler.Build.Tasks.csproj" Category="clr" Condition="'$(AotToolsSupported)' == 'true'" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler_publish.csproj" Category="clr" Condition="'$(AotToolsSupported)' == 'true'" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\BuildIntegration\BuildIntegration.proj" Category="clr" Condition="'$(AotToolsSupported)' == 'true'" />
 
-    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler.csproj" Condition="'$(NativeAotSupported)' == 'true' and '$(StageOneBuild)' != 'true'" Category="clr" />
-    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2.csproj" Condition="'$(NativeAotSupported)' == 'true' and '$(StageOneBuild)' != 'true'" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler.csproj" Condition="'$(AotToolsSupported)' == 'true'" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2.csproj" Condition="'$(AotToolsSupported)' == 'true'" Category="clr" />
 
     <!--
       Always build the in-build variants of these tools. They run on the host machine, which we always have LKG packs for.

--- a/eng/native/naming.props
+++ b/eng/native/naming.props
@@ -30,16 +30,16 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  
+
   <Choose>
-    <When Condition="$(PackageRID.StartsWith('win'))">
+    <When Condition="$(OutputRID.StartsWith('win'))">
       <PropertyGroup>
         <LibSuffix>.dll</LibSuffix>
         <StaticLibSuffix>.lib</StaticLibSuffix>
         <SymbolsSuffix>.pdb</SymbolsSuffix>
       </PropertyGroup>
     </When>
-    <When Condition="$(PackageRID.StartsWith('osx')) or $(PackageRID.StartsWith('maccatalyst')) or $(PackageRID.StartsWith('ios')) or $(PackageRID.StartsWith('tvos'))">
+    <When Condition="$(OutputRID.StartsWith('osx')) or $(OutputRID.StartsWith('maccatalyst')) or $(OutputRID.StartsWith('ios')) or $(OutputRID.StartsWith('tvos'))">
       <PropertyGroup>
         <LibPrefix>lib</LibPrefix>
         <LibSuffix>.dylib</LibSuffix>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -21,8 +21,8 @@
   <Target Name="GetTestConsoleApps">
     <ItemGroup>
       <TestConsoleAppSourceFiles>
-        <ProjectDir>$([MSBuild]::NormalizeDirectory('$(TrimmingTestProjectsDir)', '$(MSBuildProjectName)', '%(Filename)', '$(PackageRID)'))</ProjectDir>
-        <TestRuntimeIdentifier>$(PackageRID)</TestRuntimeIdentifier>
+        <ProjectDir>$([MSBuild]::NormalizeDirectory('$(TrimmingTestProjectsDir)', '$(MSBuildProjectName)', '%(Filename)', '$(OutputRID)'))</ProjectDir>
+        <TestRuntimeIdentifier>$(OutputRID)</TestRuntimeIdentifier>
         <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
         <TargetFramework Condition="'%(TestConsoleAppSourceFiles.TargetOS)' != ''">$(NetCoreAppCurrent)-%(TestConsoleAppSourceFiles.TargetOS)</TargetFramework>
       </TestConsoleAppSourceFiles>
@@ -36,8 +36,8 @@
       </TestConsoleAppSourceFiles>
     </ItemGroup>
 
-    <ItemGroup Condition="!$(SkipOnTestRuntimes.Contains('$(PackageRID)'))">
-      <_SkippedAppSourceFiles Include="@(TestConsoleAppSourceFiles)" Condition="$([System.String]::Copy('%(TestConsoleAppSourceFiles.SkipOnTestRuntimes)').Contains('$(PackageRID)'))" />
+    <ItemGroup Condition="!$(SkipOnTestRuntimes.Contains('$(OutputRID)'))">
+      <_SkippedAppSourceFiles Include="@(TestConsoleAppSourceFiles)" Condition="$([System.String]::Copy('%(TestConsoleAppSourceFiles.SkipOnTestRuntimes)').Contains('$(OutputRID)'))" />
 
       <_SkippedAppSourceFiles Include="@(TestConsoleAppSourceFiles)" Condition="'$(RunNativeAotTestApps)' == 'true' and '%(TestConsoleAppSourceFiles.NativeAotIncompatible)' == 'true'" />
 

--- a/eng/toolAot.targets
+++ b/eng/toolAot.targets
@@ -19,7 +19,7 @@
 
   <ItemGroup Condition="'$(UseNativeAotForComponents)' == 'true' and '$(PublishAot)' == 'true' and '$(MicrosoftDotNetILCompilerVersion)' != ''">
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
-    <PackageReference Include="runtime.$(ToolsRID).Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
+    <PackageReference Include="runtime.$(NETCoreSdkRuntimeIdentifier).Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputPath>$(RuntimeBinDir)ilc/</OutputPath>
-    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
   </PropertyGroup>
 
   <Import Project="ILCompiler.props" />

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
@@ -7,6 +7,7 @@
     <NoWarn>8002,NU1701</NoWarn>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendTargetFrameworkToOutputPath Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</AppendTargetFrameworkToOutputPath>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -17,12 +18,6 @@
 
   <Import Project="../AotCompilerCommon.props" />
   <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(StageTwoBuild)' == 'true'" />
-
-  <PropertyGroup>
-    <SelfContained>true</SelfContained>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <UseAppHost>true</UseAppHost>
-  </PropertyGroup>
 
   <PropertyGroup>
     <!-- CoreDisTools are used in debugging visualizers. -->

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj
@@ -2,7 +2,7 @@
   <!-- This project is publishes a self-contained copy of ILCompiler. -->
   <PropertyGroup>
     <_IsPublishing>true</_IsPublishing>
-    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
     <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <_IsPublishing>true</_IsPublishing>
     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifier>
     <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
@@ -2,7 +2,7 @@
   <!-- This project is publishes a self-contained copy of crossgen2. -->
   <PropertyGroup>
     <_IsPublishing>true</_IsPublishing>
-    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
     <PublishDir>$(RuntimeBinDir)crossgen2-published/</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <_IsPublishing>true</_IsPublishing>
     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifier>
     <PublishDir>$(RuntimeBinDir)crossgen2-published/</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>

--- a/src/installer/pkg/projects/Directory.Build.props
+++ b/src/installer/pkg/projects/Directory.Build.props
@@ -72,7 +72,7 @@
   <Import Project="$(RIDPropsFile)" />
 
   <ItemGroup>
-    <_buildingOnRID Include="$(PackageRID)" Condition="'$(BuildOnUnknownPlatforms)' != 'false'">
+    <_buildingOnRID Include="$(NETCoreSdkRuntimeIdentifier)" Condition="'$(BuildOnUnknownPlatforms)' != 'false'">
       <Platform>$(Platform)</Platform>
     </_buildingOnRID>
     <!-- Ensure we have a RID-specific package for the current build, even if it isn't in our official set -->

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
@@ -9,6 +9,8 @@
     <DnneGenRollForward>Major</DnneGenRollForward>
     <!-- To integrate with DNNE's architecture calculation, we need to set the RID for this project. -->
     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
+    <!-- Set the apphost RID so we download the apphost pack if needed. -->
+    <AppHostRuntimeIdentifier>$(OutputRID)</AppHostRuntimeIdentifier>
     <UseLocalAppHostPack>true</UseLocalAppHostPack>
     <!-- Don't use the local apphost pack on Windows as matching linker configurations is difficult. -->
     <UseLocalAppHostPack Condition="'$(TargetOS)' == 'windows'">false</UseLocalAppHostPack>

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
@@ -120,5 +120,8 @@
                             GetAppleBuildArgumentsForDNNE;
                             GetUnixCrossBuildArgumentsForDNNE"
           BeforeTargets="DnneBuildNativeExports">
+    <PropertyGroup>
+      <DnneNetHostDir>$([System.IO.Path]::GetDirectoryName('$(AppHostSourcePath)'))</DnneNetHostDir>
+    </PropertyGroup>
   </Target>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
@@ -8,6 +8,7 @@
     <DnneAddGeneratedBinaryToProject>true</DnneAddGeneratedBinaryToProject>
     <DnneGenRollForward>Major</DnneGenRollForward>
     <!-- To integrate with DNNE's architecture calculation, we need to set the RID for this project. -->
+    <UseLocalAppHostPack>true</UseLocalAppHostPack>
     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
     <_TargetsAppleOS Condition="'$(TargetOS)' == 'osx' or '$(TargetOS)' == 'maccatalyst' or
       '$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'iossimulator' or

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
@@ -8,8 +8,10 @@
     <DnneAddGeneratedBinaryToProject>true</DnneAddGeneratedBinaryToProject>
     <DnneGenRollForward>Major</DnneGenRollForward>
     <!-- To integrate with DNNE's architecture calculation, we need to set the RID for this project. -->
-    <UseLocalAppHostPack>true</UseLocalAppHostPack>
     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
+    <UseLocalAppHostPack>true</UseLocalAppHostPack>
+    <!-- Don't use the local apphost pack on Windows as matching linker configurations is difficult. -->
+    <UseLocalAppHostPack Condition="'$(TargetOS)' == 'windows'">false</UseLocalAppHostPack>
     <_TargetsAppleOS Condition="'$(TargetOS)' == 'osx' or '$(TargetOS)' == 'maccatalyst' or
       '$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'iossimulator' or
       '$(TargetOS)' == 'tvossimulator'">true</_TargetsAppleOS>
@@ -18,6 +20,11 @@
   <ItemGroup>
     <Compile Include="..\..\TestAssets\SharedTypes\ComInterfaces\**\*.cs" Link="ComInterfaceGenerator\ComInterfaces\%(RecursiveDir)\%(FileName).cs" />
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs" Link="Common\DisableRuntimeMarshalling.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalAppHostPack)' != 'true' and '$(NetCoreAppToolCurrent)' != '$(NetCoreAppCurrent)'">
+    <KnownAppHostPack Include="@(KnownAppHostPack->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', '$(NetCoreAppToolCurrent)'))"
+                      TargetFramework="$(NetCoreAppCurrent)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -113,10 +120,5 @@
                             GetAppleBuildArgumentsForDNNE;
                             GetUnixCrossBuildArgumentsForDNNE"
           BeforeTargets="DnneBuildNativeExports">
-    <PropertyGroup>
-      <DnneNetHostDir>$([System.IO.Path]::GetDirectoryName('$(AppHostSourcePath)'))</DnneNetHostDir>
-      <!-- Build the native component in release always to avoid CRT conflicts. -->
-      <Configuration>Release</Configuration>
-    </PropertyGroup>
   </Target>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
@@ -115,6 +115,8 @@
           BeforeTargets="DnneBuildNativeExports">
     <PropertyGroup>
       <DnneNetHostDir>$([System.IO.Path]::GetDirectoryName('$(AppHostSourcePath)'))</DnneNetHostDir>
+      <!-- Build the native component in release always to avoid CRT conflicts. -->
+      <Configuration>Release</Configuration>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
@@ -7,12 +7,8 @@
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <DnneAddGeneratedBinaryToProject>true</DnneAddGeneratedBinaryToProject>
     <DnneGenRollForward>Major</DnneGenRollForward>
-    <!-- NativeExports should use the live built apphost. We need to define a dependency
-         to the apphost to make sure that it is built before this project invokes DNNE. -->
-    <UseLocalAppHostPack>false</UseLocalAppHostPack>
     <!-- To integrate with DNNE's architecture calculation, we need to set the RID for this project. -->
     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
-    <AppHostRuntimeIdentifier>$(PackageRID)</AppHostRuntimeIdentifier>
     <_TargetsAppleOS Condition="'$(TargetOS)' == 'osx' or '$(TargetOS)' == 'maccatalyst' or
       '$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'iossimulator' or
       '$(TargetOS)' == 'tvossimulator'">true</_TargetsAppleOS>
@@ -21,13 +17,6 @@
   <ItemGroup>
     <Compile Include="..\..\TestAssets\SharedTypes\ComInterfaces\**\*.cs" Link="ComInterfaceGenerator\ComInterfaces\%(RecursiveDir)\%(FileName).cs" />
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs" Link="Common\DisableRuntimeMarshalling.cs" />
-  </ItemGroup>
-
-  <!-- Until we use the live app host, use a prebuilt from the SDK.
-       Issue: https://github.com/dotnet/runtime/issues/58109. -->
-  <ItemGroup Condition="'$(UseLocalAppHostPack)' != 'true' and '$(NetCoreAppToolCurrent)' != '$(NetCoreAppCurrent)'">
-    <KnownAppHostPack Include="@(KnownAppHostPack->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', '$(NetCoreAppToolCurrent)'))"
-                      TargetFramework="$(NetCoreAppCurrent)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <!-- FIXME: clean up the duplication with libraries Directory.Build.props -->
-    <PackageRID>browser-wasm</PackageRID>
     <NativeBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)'))</NativeBinDir>
     <!-- only use for files that are not configuration dependent -->
     <NativeGeneratedFilesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', 'generated'))</NativeGeneratedFilesDir>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -97,21 +97,21 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NeedEmscriptenPackages)' == 'true'">
-    <PackageReference Include="Microsoft.NET.Runtime.Emscripten.$(EmsdkVersion).Cache.$(_portableHostOS)-$(BuildArchitecture)"
+    <PackageReference Include="Microsoft.NET.Runtime.Emscripten.$(EmsdkVersion).Cache.$(NETCoreSdkPortableRuntimeIdentifier)"
                       PrivateAssets="all"
                       Version="$(EmsdkPackageVersion)"
                       PackageArch="$(BuildArchitecture)" />
-    <PackageReference Include="runtime.$(_portableHostOS)-$(BuildArchitecture).Microsoft.NETCore.Runtime.Wasm.Node.Transport"
+    <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.NETCore.Runtime.Wasm.Node.Transport"
                       Version="$(NodePackageVersion)"
                       PackageArch="$(BuildArchitecture)" />
-    <PackageReference Include="Microsoft.NET.Runtime.Emscripten.$(EmsdkVersion).Sdk.$(_portableHostOS)-$(BuildArchitecture)"
+    <PackageReference Include="Microsoft.NET.Runtime.Emscripten.$(EmsdkVersion).Sdk.$(NETCoreSdkPortableRuntimeIdentifier)"
                       PrivateAssets="all"
                       Version="$(EmsdkPackageVersion)"
                       PackageArch="$(BuildArchitecture)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MonoUseCrossTool)' == 'true'">
-    <PackageReference Include="runtime.$(_portableHostOS)-$(BuildArchitecture).Microsoft.NETCore.Runtime.Mono.LLVM.Libclang"
+    <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.NETCore.Runtime.Mono.LLVM.Libclang"
                       PrivateAssets="all"
                       Version="$(MonoLLVMLibclangVersion)"
                       PackageArch="$(BuildArchitecture)"
@@ -277,10 +277,10 @@ JS_ENGINES = [NODE_JS]
     <RemoveDir Directories="$(EMSDK_PATH)" />
 
     <ItemGroup>
-      <EmsdkFiles   Condition="'%(PackageReference.Identity)' != 'runtime.$(_portableHostOS)-$(BuildArchitecture).Microsoft.NETCore.Runtime.Wasm.Node.Transport' and '%(PackageReference.Identity)' != 'Microsoft.NET.Runtime.Emscripten.$(EmsdkVersion).Python.win-$(BuildArchitecture)'"
+      <EmsdkFiles   Condition="'%(PackageReference.Identity)' != 'runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.NETCore.Runtime.Wasm.Node.Transport' and '%(PackageReference.Identity)' != 'Microsoft.NET.Runtime.Emscripten.$(EmsdkVersion).Python.win-$(BuildArchitecture)'"
                     Include="$(NuGetPackageRoot)\$([System.String]::Copy(%(PackageReference.Identity)).ToLowerInvariant())\%(PackageReference.Version)\tools\**" />
-      <NodeFiles    Condition="'%(PackageReference.Identity)' == 'runtime.$(_portableHostOS)-$(BuildArchitecture).Microsoft.NETCore.Runtime.Wasm.Node.Transport'"
-                    Include="$(NuGetPackageRoot)\$([System.String]::Copy(%(PackageReference.Identity)).ToLowerInvariant())\%(PackageReference.Version)\tools\$(_portableHostOS)-$(BuildArchitecture)\**" />
+      <NodeFiles    Condition="'%(PackageReference.Identity)' == 'runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.NETCore.Runtime.Wasm.Node.Transport'"
+                    Include="$(NuGetPackageRoot)\$([System.String]::Copy(%(PackageReference.Identity)).ToLowerInvariant())\%(PackageReference.Version)\tools\$(NETCoreSdkPortableRuntimeIdentifier)\**" />
       <PythonFiles  Condition="'$(HostOS)' == 'windows' and '%(PackageReference.Identity)' == 'Microsoft.NET.Runtime.Emscripten.$(EmsdkVersion).Python.win-$(BuildArchitecture)'"
                     Include="$(NuGetPackageRoot)\$([System.String]::Copy(%(PackageReference.Identity)).ToLowerInvariant())\%(PackageReference.Version)\tools\**" />
     </ItemGroup>
@@ -915,7 +915,7 @@ JS_ENGINES = [NODE_JS]
     </PropertyGroup>
 
     <ItemGroup Condition="'$(MonoUseCrossTool)' == 'true'">
-      <_LibclangPackageReferencePathPropertyName Include="Pkgruntime_$(_portableHostOS)-$(BuildArchitecture)_Microsoft_NETCore_Runtime_Mono_LLVM_Libclang" />
+      <_LibclangPackageReferencePathPropertyName Include="Pkgruntime_$()NETCoreSdkPortableRuntimeIdentifier)_Microsoft_NETCore_Runtime_Mono_LLVM_Libclang" />
     </ItemGroup>
     <PropertyGroup Condition="'$(MonoUseCrossTool)' == 'true'">
       <_LibclangPackageReferencePath>$(%(_LibclangPackageReferencePathPropertyName.Identity))</_LibclangPackageReferencePath>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -915,7 +915,7 @@ JS_ENGINES = [NODE_JS]
     </PropertyGroup>
 
     <ItemGroup Condition="'$(MonoUseCrossTool)' == 'true'">
-      <_LibclangPackageReferencePathPropertyName Include="Pkgruntime_$()NETCoreSdkPortableRuntimeIdentifier)_Microsoft_NETCore_Runtime_Mono_LLVM_Libclang" />
+      <_LibclangPackageReferencePathPropertyName Include="Pkgruntime_$(NETCoreSdkPortableRuntimeIdentifier)_Microsoft_NETCore_Runtime_Mono_LLVM_Libclang" />
     </ItemGroup>
     <PropertyGroup Condition="'$(MonoUseCrossTool)' == 'true'">
       <_LibclangPackageReferencePath>$(%(_LibclangPackageReferencePathPropertyName.Identity))</_LibclangPackageReferencePath>

--- a/src/mono/wasi/wasi.proj
+++ b/src/mono/wasi/wasi.proj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <!-- FIXME: clean up the duplication with libraries Directory.Build.props -->
-    <PackageRID>wasi-wasm</PackageRID>
     <NativeBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)'))</NativeBinDir>
   </PropertyGroup>
 
@@ -216,7 +215,7 @@
       <CMakeConfigurationLinkFlags Condition="'$(Configuration)' == 'Debug'"  >$(CMakeConfigurationWasiFlags)</CMakeConfigurationLinkFlags>
       <CMakeConfigurationLinkFlags Condition="'$(Configuration)' == 'Release'">-O2</CMakeConfigurationLinkFlags>
 
-      <!-- 
+      <!--
       this together with some DLLImports makes dependency on wasi:http@0.2.0
       it will get trimmed when HTTP is not used and using publish + native rebuild
       but the default dotnet.wasm and requires -S http argument to wasmtime


### PR DESCRIPTION
This is needed to fix the linux-bionic builds in the VMR.

Contributes to https://github.com/dotnet/source-build/issues/4955