### PR TITLE
Fix the ParallelCrash test

### DIFF
--- a/src/tests/baseservices/exceptions/simple/ParallelCrashTester.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrashTester.csproj
@@ -12,6 +12,7 @@
     <Compile Include="ParallelCrashTester.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <ProjectReference Include="ParallelCrash.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>


### PR DESCRIPTION
My recent change has broken this test. For some reason, the TestLibrary project needs to be referenced from the parent process csproj as well, otherwise the TestLibrary won't end up in the test directory.

Close #113763