### PR TITLE
ML-KEM: Overloads

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -137,10 +137,10 @@ namespace System.Security.Cryptography
         /// <param name="sharedSecret">
         ///   The buffer to receive the shared secret.
         /// </param>
-        /// <param name="ciphertextWritten">
+        /// <param name="ciphertextBytesWritten">
         ///   When this method returns, the total number of bytes written into <paramref name="ciphertext"/>.
         /// </param>
-        /// <param name="sharedSecretWritten">
+        /// <param name="sharedSecretBytesWritten">
         ///   When this method returns, the total number of bytes written into <paramref name="sharedSecret"/>.
         /// </param>
         /// <exception cref="CryptographicException">
@@ -157,8 +157,8 @@ namespace System.Security.Cryptography
         public void Encapsulate(
             Span<byte> ciphertext,
             Span<byte> sharedSecret,
-            out int ciphertextWritten,
-            out int sharedSecretWritten)
+            out int ciphertextBytesWritten,
+            out int sharedSecretBytesWritten)
         {
             if (ciphertext.Length < Algorithm.CiphertextSizeInBytes)
                 throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(ciphertext));
@@ -176,8 +176,8 @@ namespace System.Security.Cryptography
 
             ThrowIfDisposed();
             EncapsulateCore(ciphertextExact, sharedSecretExact);
-            ciphertextWritten = ciphertextExact.Length;
-            sharedSecretWritten = sharedSecretExact.Length;
+            ciphertextBytesWritten = ciphertextExact.Length;
+            sharedSecretBytesWritten = sharedSecretExact.Length;
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace System.Security.Cryptography
         /// <param name="sharedSecret">
         ///   The buffer to receive the shared secret.
         /// </param>
-        /// <param name="sharedSecretWritten">
+        /// <param name="sharedSecretBytesWritten">
         ///   When this method returns, the total number of bytes written into <paramref name="sharedSecret"/>.
         /// </param>
         /// <exception cref="CryptographicException">
@@ -278,7 +278,7 @@ namespace System.Security.Cryptography
         ///   <para><paramref name="sharedSecret" /> is too small to hold the shared secret.</para>
         /// </exception>
         /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
-        public void Decapsulate(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret, out int sharedSecretWritten)
+        public void Decapsulate(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret, out int sharedSecretBytesWritten)
         {
             if (ciphertext.Length != Algorithm.CiphertextSizeInBytes)
                 throw new ArgumentException(SR.Argument_KemInvalidCiphertextLength, nameof(ciphertext));
@@ -290,7 +290,7 @@ namespace System.Security.Cryptography
 
             Span<byte> sharedSecretExact = sharedSecret.Slice(0, Algorithm.SharedSecretSizeInBytes);
             DecapsulateCore(ciphertext, sharedSecretExact);
-            sharedSecretWritten = sharedSecretExact.Length;
+            sharedSecretBytesWritten = sharedSecretExact.Length;
         }
 
         /// <summary>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -449,6 +449,28 @@ namespace System.Security.Cryptography
             return MLKemImplementation.ImportPrivateSeedImpl(algorithm, source);
         }
 
+        /// <summary>
+        /// Imports an ML-KEM key from its private seed value.
+        /// </summary>
+        /// <param name="algorithm">The specific ML-KEM algorithm for this key.</param>
+        /// <param name="source">The private seed.</param>
+        /// <returns>The imported key.</returns>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="source"/> has a length that is not the
+        ///   <see cref="MLKemAlgorithm.PrivateSeedSizeInBytes" /> from <paramref name="algorithm" />.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <para><paramref name="algorithm" /> is <see langword="null" /></para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="source" /> is <see langword="null" /></para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while importing the key.
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The platform does not support ML-KEM. Callers can use the <see cref="IsSupported" /> property
+        ///   to determine if the platform supports MK-KEM.
+        /// </exception>
         public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, byte[] source)
         {
             if (source is null)

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -3,8 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-
-#pragma warning disable CA1510, CA1513
+using System.Runtime.CompilerServices;
 
 namespace System.Security.Cryptography
 {
@@ -54,11 +53,7 @@ namespace System.Security.Cryptography
         /// </exception>
         protected MLKem(MLKemAlgorithm algorithm)
         {
-            if (algorithm is null)
-            {
-                throw new ArgumentNullException(nameof(algorithm));
-            }
-
+            ThrowIfNull(algorithm);
             Algorithm = algorithm;
         }
 
@@ -83,11 +78,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static MLKem GenerateKey(MLKemAlgorithm algorithm)
         {
-            if (algorithm is null)
-            {
-                throw new ArgumentNullException(nameof(algorithm));
-            }
-
+            ThrowIfNull(algorithm);
             ThrowIfNotSupported();
             return MLKemImplementation.GenerateKeyImpl(algorithm);
         }
@@ -323,8 +314,7 @@ namespace System.Security.Cryptography
         /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
         public byte[] Decapsulate(byte[] ciphertext)
         {
-            if (ciphertext is null)
-                throw new ArgumentNullException(nameof(ciphertext));
+            ThrowIfNull(ciphertext);
 
             if (ciphertext.Length != Algorithm.CiphertextSizeInBytes)
                 throw new ArgumentException(SR.Argument_KemInvalidCiphertextLength, nameof(ciphertext));
@@ -355,10 +345,15 @@ namespace System.Security.Cryptography
         /// </summary>
         protected void ThrowIfDisposed()
         {
+#if NET
+            ObjectDisposedException.ThrowIf(_disposed, typeof(MLKem));
+#else
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(MLKem));
+                throw new ObjectDisposedException(typeof(MLKem).FullName);
             }
+#endif
+
         }
 
         /// <summary>
@@ -439,8 +434,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            if (algorithm is null)
-                throw new ArgumentNullException(nameof(algorithm));
+            ThrowIfNull(algorithm);
 
             if (source.Length != algorithm.PrivateSeedSizeInBytes)
                 throw new ArgumentException(SR.Argument_KemInvalidSeedLength, nameof(source));
@@ -473,8 +467,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, byte[] source)
         {
-            if (source is null)
-                throw new ArgumentNullException(nameof(source));
+            ThrowIfNull(source);
 
             return ImportPrivateSeed(algorithm, new ReadOnlySpan<byte>(source));
         }
@@ -500,8 +493,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            if (algorithm is null)
-                throw new ArgumentNullException(nameof(algorithm));
+            ThrowIfNull(algorithm);
 
             if (source.Length != algorithm.DecapsulationKeySizeInBytes)
                 throw new ArgumentException(SR.Argument_KemInvalidDecapsulationKeyLength, nameof(source));
@@ -533,9 +525,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, byte[] source)
         {
-            if (source is null)
-                throw new ArgumentNullException(nameof(source));
-
+            ThrowIfNull(source);
             return ImportDecapsulationKey(algorithm, new ReadOnlySpan<byte>(source));
         }
 
@@ -560,8 +550,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            if (algorithm is null)
-                throw new ArgumentNullException(nameof(algorithm));
+            ThrowIfNull(algorithm);
 
             if (source.Length != algorithm.EncapsulationKeySizeInBytes)
                 throw new ArgumentException(SR.Argument_KemInvalidEncapsulationKeyLength, nameof(source));
@@ -593,8 +582,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, byte[] source)
         {
-            if (source is null)
-                throw new ArgumentNullException(nameof(source));
+            ThrowIfNull(source);
 
             return ImportEncapsulationKey(algorithm, new ReadOnlySpan<byte>(source));
         }
@@ -738,6 +726,20 @@ namespace System.Security.Cryptography
             {
                 throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(MLKem)));
             }
+        }
+
+        private static void ThrowIfNull(
+            [NotNull] object? argument,
+            [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        {
+#if NET
+            ArgumentNullException.ThrowIfNull(argument, paramName);
+#else
+            if (argument is null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+#endif
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -501,17 +501,42 @@ namespace System.Security.Cryptography
         public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             if (algorithm is null)
-            {
                 throw new ArgumentNullException(nameof(algorithm));
-            }
 
             if (source.Length != algorithm.DecapsulationKeySizeInBytes)
-            {
                 throw new ArgumentException(SR.Argument_KemInvalidDecapsulationKeyLength, nameof(source));
-            }
 
             ThrowIfNotSupported();
             return MLKemImplementation.ImportDecapsulationKeyImpl(algorithm, source);
+        }
+
+        /// <summary>
+        /// Imports an ML-KEM key from a decapsulation key.
+        /// </summary>
+        /// <param name="algorithm">The specific ML-KEM algorithm for this key.</param>
+        /// <param name="source">The decapsulation key.</param>
+        /// <returns>The imported key.</returns>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="source"/> has a length that is not valid for the ML-KEM algorithm.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <para><paramref name="algorithm" /> is <see langword="null" /></para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="source" /> is <see langword="null" /></para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while importing the key.
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The platform does not support ML-KEM. Callers can use the <see cref="IsSupported" /> property
+        ///   to determine if the platform supports MK-KEM.
+        /// </exception>
+        public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, byte[] source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            return ImportDecapsulationKey(algorithm, new ReadOnlySpan<byte>(source));
         }
 
         /// <summary>
@@ -536,17 +561,42 @@ namespace System.Security.Cryptography
         public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             if (algorithm is null)
-            {
                 throw new ArgumentNullException(nameof(algorithm));
-            }
 
             if (source.Length != algorithm.EncapsulationKeySizeInBytes)
-            {
                 throw new ArgumentException(SR.Argument_KemInvalidEncapsulationKeyLength, nameof(source));
-            }
 
             ThrowIfNotSupported();
             return MLKemImplementation.ImportEncapsulationKeyImpl(algorithm, source);
+        }
+
+        /// <summary>
+        /// Imports an ML-KEM key from a encapsulation key.
+        /// </summary>
+        /// <param name="algorithm">The specific ML-KEM algorithm for this key.</param>
+        /// <param name="source">The encapsulation key.</param>
+        /// <returns>The imported key.</returns>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="source"/> has a length that is not valid for the ML-KEM algorithm.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <para><paramref name="algorithm" /> is <see langword="null" /></para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="source" /> is <see langword="null" /></para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while importing the key.
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The platform does not support ML-KEM. Callers can use the <see cref="IsSupported" /> property
+        ///   to determine if the platform supports MK-KEM.
+        /// </exception>
+        public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, byte[] source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            return ImportEncapsulationKey(algorithm, new ReadOnlySpan<byte>(source));
         }
 
         /// <summary>
@@ -578,6 +628,26 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
+        ///   Exports the decapsulation key.
+        /// </summary>
+        /// <returns>
+        ///   The decapsulation key.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   <para>The current instance cannot export a decapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while importing the key.</para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public byte[] ExportDecapsulationKey()
+        {
+            ThrowIfDisposed();
+            byte[] decapsulationKey = new byte[Algorithm.DecapsulationKeySizeInBytes];
+            ExportDecapsulationKeyCore(decapsulationKey);
+            return decapsulationKey;
+        }
+
+        /// <summary>
         ///   When overridden in a derived class, exports the decapsulation key into the provided buffer.
         /// </summary>
         /// <param name="destination">
@@ -594,6 +664,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="destination"/> is the incorrect length to receive the encapsulation key.
         /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred exporting the encapsulation key.
+        /// </exception>
         /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
         public void ExportEncapsulationKey(Span<byte> destination)
         {
@@ -606,6 +679,24 @@ namespace System.Security.Cryptography
 
             ThrowIfDisposed();
             ExportEncapsulationKeyCore(destination);
+        }
+
+        /// <summary>
+        ///   Exports the encapsulation key.
+        /// </summary>
+        /// <returns>
+        ///   The encapsulation key.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred exporting the encapsulation key.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public byte[] ExportEncapsulationKey()
+        {
+            ThrowIfDisposed();
+            byte[] encapsulationKey = new byte[Algorithm.EncapsulationKeySizeInBytes];
+            ExportEncapsulationKeyCore(encapsulationKey);
+            return encapsulationKey;
         }
 
         /// <summary>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -207,6 +207,38 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
+        ///   Creates an encapsulation ciphertext and shared secret, writing the shared secret into a buffer.
+        /// </summary>
+        /// <param name="sharedSecret">
+        ///   When this method returns, the shared secret.
+        /// </param>
+        /// <returns>
+        ///   The ciphertext.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="sharedSecret" /> is not the correct size.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>An error occurred during encapsulation.</para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public byte[] Encapsulate(Span<byte> sharedSecret)
+        {
+            ThrowIfDisposed();
+
+            if (sharedSecret.Length != Algorithm.SharedSecretSizeInBytes)
+            {
+                throw new ArgumentException(
+                    SR.Format(SR.Argument_DestinationImprecise, Algorithm.SharedSecretSizeInBytes),
+                    nameof(sharedSecret));
+            }
+
+            byte[] ciphertext = new byte[Algorithm.CiphertextSizeInBytes];
+            EncapsulateCore(ciphertext, sharedSecret);
+            return ciphertext;
+        }
+
+        /// <summary>
         ///   When overridden in a derived class, creates an encapsulation ciphertext and shared secret, writing them
         ///   into the provided buffers.
         /// </summary>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -440,17 +440,21 @@ namespace System.Security.Cryptography
         public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             if (algorithm is null)
-            {
                 throw new ArgumentNullException(nameof(algorithm));
-            }
 
             if (source.Length != algorithm.PrivateSeedSizeInBytes)
-            {
                 throw new ArgumentException(SR.Argument_KemInvalidSeedLength, nameof(source));
-            }
 
             ThrowIfNotSupported();
             return MLKemImplementation.ImportPrivateSeedImpl(algorithm, source);
+        }
+
+        public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, byte[] source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            return ImportPrivateSeed(algorithm, new ReadOnlySpan<byte>(source));
         }
 
         /// <summary>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -375,6 +375,7 @@ namespace System.Security.Cryptography
         ///   <para>-or-</para>
         ///   <para>An error occurred while exporting the key.</para>
         /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
         public void ExportPrivateSeed(Span<byte> destination)
         {
             if (destination.Length != Algorithm.PrivateSeedSizeInBytes)
@@ -386,6 +387,26 @@ namespace System.Security.Cryptography
 
             ThrowIfDisposed();
             ExportPrivateSeedCore(destination);
+        }
+
+        /// <summary>
+        ///   Exports the private seed.
+        /// </summary>
+        /// <returns>
+        ///   The private seed.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   <para>The current instance cannot export a seed.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public byte[] ExportPrivateSeed()
+        {
+            ThrowIfDisposed();
+            byte[] seed = new byte[Algorithm.PrivateSeedSizeInBytes];
+            ExportPrivateSeedCore(seed);
+            return seed;
         }
 
         /// <summary>

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
@@ -255,9 +255,26 @@ namespace System.Security.Cryptography.Tests
                 new byte[MLKemAlgorithm.MLKem512.CiphertextSizeInBytes],
                 new byte[MLKemAlgorithm.MLKem512.SharedSecretSizeInBytes]));
 
+            Assert.Throws<ObjectDisposedException>(() =>  kem.Encapsulate(
+                new byte[MLKemAlgorithm.MLKem512.CiphertextSizeInBytes],
+                new byte[MLKemAlgorithm.MLKem512.SharedSecretSizeInBytes],
+                out _,
+                out _));
+
+            Assert.Throws<ObjectDisposedException>(() =>  kem.Encapsulate(
+                out _));
+
             Assert.Throws<ObjectDisposedException>(() =>  kem.Decapsulate(
                 new byte[MLKemAlgorithm.MLKem512.CiphertextSizeInBytes],
                 new byte[MLKemAlgorithm.MLKem512.SharedSecretSizeInBytes]));
+
+            Assert.Throws<ObjectDisposedException>(() =>  kem.Decapsulate(
+                new byte[MLKemAlgorithm.MLKem512.CiphertextSizeInBytes],
+                new byte[MLKemAlgorithm.MLKem512.SharedSecretSizeInBytes],
+                out _));
+
+            Assert.Throws<ObjectDisposedException>(() =>  kem.Decapsulate(
+                new byte[MLKemAlgorithm.MLKem512.CiphertextSizeInBytes]));
 
             Assert.Throws<ObjectDisposedException>(() => kem.ExportPrivateSeed(
                 new byte[MLKemAlgorithm.MLKem512.PrivateSeedSizeInBytes]));

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
@@ -21,11 +21,21 @@ namespace System.Security.Cryptography.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("algorithm", static () =>
                 MLKem.ImportPrivateSeed(null, new byte[MLKemAlgorithm.MLKem512.PrivateSeedSizeInBytes]));
+
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () =>
+                MLKem.ImportPrivateSeed(null, new ReadOnlySpan<byte>(new byte[MLKemAlgorithm.MLKem512.PrivateSeedSizeInBytes])));
+        }
+
+        [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]
+        public static void ImportPrivateSeed_NullSource()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("source", static () =>
+                MLKem.ImportPrivateSeed(MLKemAlgorithm.MLKem512, null));
         }
 
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
         [MemberData(nameof(MLKemAlgorithms))]
-        public static void ImportPrivateSeed_WrongSize(MLKemAlgorithm algorithm)
+        public static void ImportPrivateSeed_WrongSize_Array(MLKemAlgorithm algorithm)
         {
             AssertExtensions.Throws<ArgumentException>("source", () =>
                 MLKem.ImportPrivateSeed(algorithm, new byte[algorithm.PrivateSeedSizeInBytes + 1]));
@@ -34,7 +44,23 @@ namespace System.Security.Cryptography.Tests
                 MLKem.ImportPrivateSeed(algorithm, new byte[algorithm.PrivateSeedSizeInBytes - 1]));
 
             AssertExtensions.Throws<ArgumentException>("source", () =>
-                MLKem.ImportPrivateSeed(algorithm, []));
+                MLKem.ImportPrivateSeed(algorithm, Array.Empty<byte>()));
+        }
+
+        [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
+        [MemberData(nameof(MLKemAlgorithms))]
+        public static void ImportPrivateSeed_WrongSize_Span(MLKemAlgorithm algorithm)
+        {
+            byte[] seed = new byte[algorithm.PrivateSeedSizeInBytes + 1];
+
+            AssertExtensions.Throws<ArgumentException>("source", () =>
+                MLKem.ImportPrivateSeed(algorithm, seed.AsSpan()));
+
+            AssertExtensions.Throws<ArgumentException>("source", () =>
+                MLKem.ImportPrivateSeed(algorithm, seed.AsSpan(0..^2)));
+
+            AssertExtensions.Throws<ArgumentException>("source", () =>
+                MLKem.ImportPrivateSeed(algorithm, ReadOnlySpan<byte>.Empty));
         }
 
         [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.Tests
                 MLKem.ImportPrivateSeed(algorithm, seed.AsSpan()));
 
             AssertExtensions.Throws<ArgumentException>("source", () =>
-                MLKem.ImportPrivateSeed(algorithm, seed.AsSpan(0..^2)));
+                MLKem.ImportPrivateSeed(algorithm, seed.AsSpan(0, seed.Length - 2)));
 
             AssertExtensions.Throws<ArgumentException>("source", () =>
                 MLKem.ImportPrivateSeed(algorithm, ReadOnlySpan<byte>.Empty));
@@ -101,7 +101,7 @@ namespace System.Security.Cryptography.Tests
                 MLKem.ImportDecapsulationKey(algorithm, destination.AsSpan()));
 
             AssertExtensions.Throws<ArgumentException>("source", () =>
-                MLKem.ImportDecapsulationKey(algorithm, destination.AsSpan(0..^2)));
+                MLKem.ImportDecapsulationKey(algorithm, destination.AsSpan(0, destination.Length - 2)));
 
             AssertExtensions.Throws<ArgumentException>("source", () =>
                 MLKem.ImportDecapsulationKey(algorithm, ReadOnlySpan<byte>.Empty));
@@ -145,7 +145,7 @@ namespace System.Security.Cryptography.Tests
                 MLKem.ImportEncapsulationKey(algorithm, destination.AsSpan()));
 
             AssertExtensions.Throws<ArgumentException>("source", () =>
-                MLKem.ImportEncapsulationKey(algorithm, destination.AsSpan(0..^2)));
+                MLKem.ImportEncapsulationKey(algorithm, destination.AsSpan(0, destination.Length - 2)));
 
             AssertExtensions.Throws<ArgumentException>("source", () =>
                 MLKem.ImportEncapsulationKey(algorithm, ReadOnlySpan<byte>.Empty));

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
@@ -112,6 +112,25 @@ namespace System.Security.Cryptography.Tests
 
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
         [MemberData(nameof(MLKemAlgorithms))]
+        public static void Encapsulate_DestinationTooSmall(MLKemAlgorithm algorithm)
+        {
+            using MLKem kem = MLKem.GenerateKey(algorithm);
+
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Encapsulate(
+                new byte[algorithm.CiphertextSizeInBytes - 1],
+                new byte[algorithm.SharedSecretSizeInBytes],
+                out _,
+                out _));
+
+            AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Encapsulate(
+                new byte[algorithm.CiphertextSizeInBytes],
+                new byte[algorithm.SharedSecretSizeInBytes - 1],
+                out _,
+                out _));
+        }
+
+        [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
+        [MemberData(nameof(MLKemAlgorithms))]
         public static void Decapsulate_WrongSize(MLKemAlgorithm algorithm)
         {
             using MLKem kem = MLKem.GenerateKey(algorithm);
@@ -128,6 +147,22 @@ namespace System.Security.Cryptography.Tests
                 [],
                 new byte[algorithm.SharedSecretSizeInBytes]));
 
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(
+                new byte[algorithm.CiphertextSizeInBytes - 1],
+                new byte[algorithm.SharedSecretSizeInBytes],
+                out _));
+
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(
+                new byte[algorithm.CiphertextSizeInBytes + 1],
+                new byte[algorithm.SharedSecretSizeInBytes],
+                out _));
+
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(
+                new byte[algorithm.CiphertextSizeInBytes - 1]));
+
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(
+                new byte[algorithm.CiphertextSizeInBytes + 1]));
+
             AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Decapsulate(
                 new byte[algorithm.CiphertextSizeInBytes],
                 new byte[algorithm.SharedSecretSizeInBytes + 1]));
@@ -139,6 +174,26 @@ namespace System.Security.Cryptography.Tests
             AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Decapsulate(
                 new byte[algorithm.CiphertextSizeInBytes],
                 []));
+        }
+
+        [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
+        [MemberData(nameof(MLKemAlgorithms))]
+        public static void Decapsulate_DestinationTooSmall(MLKemAlgorithm algorithm)
+        {
+            using MLKem kem = MLKem.GenerateKey(algorithm);
+
+            AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Decapsulate(
+                new byte[algorithm.CiphertextSizeInBytes],
+                new byte[algorithm.SharedSecretSizeInBytes - 1],
+                out _));
+        }
+
+        [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
+        [MemberData(nameof(MLKemAlgorithms))]
+        public static void Decapsulate_NullArg(MLKemAlgorithm algorithm)
+        {
+            using MLKem kem = MLKem.GenerateKey(algorithm);
+            AssertExtensions.Throws<ArgumentNullException>("ciphertext", () => kem.Decapsulate(null));
         }
 
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
@@ -70,9 +70,16 @@ namespace System.Security.Cryptography.Tests
                 MLKem.ImportDecapsulationKey(null, new byte[MLKemAlgorithm.MLKem512.DecapsulationKeySizeInBytes]));
         }
 
+        [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]
+        public static void ImportDecapsulationKey_NullSource()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("source", static () =>
+                MLKem.ImportDecapsulationKey(MLKemAlgorithm.MLKem512, null));
+        }
+
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
         [MemberData(nameof(MLKemAlgorithms))]
-        public static void ImportDecapsulationKey_WrongSize(MLKemAlgorithm algorithm)
+        public static void ImportDecapsulationKey_WrongSize_Array(MLKemAlgorithm algorithm)
         {
             AssertExtensions.Throws<ArgumentException>("source", () =>
                 MLKem.ImportDecapsulationKey(algorithm, new byte[algorithm.DecapsulationKeySizeInBytes + 1]));
@@ -81,7 +88,23 @@ namespace System.Security.Cryptography.Tests
                 MLKem.ImportDecapsulationKey(algorithm, new byte[algorithm.DecapsulationKeySizeInBytes - 1]));
 
             AssertExtensions.Throws<ArgumentException>("source", () =>
-                MLKem.ImportDecapsulationKey(algorithm, []));
+                MLKem.ImportDecapsulationKey(algorithm, Array.Empty<byte>()));
+        }
+
+        [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
+        [MemberData(nameof(MLKemAlgorithms))]
+        public static void ImportDecapsulationKey_WrongSize_Span(MLKemAlgorithm algorithm)
+        {
+            byte[] destination = new byte[algorithm.DecapsulationKeySizeInBytes + 1];
+
+            AssertExtensions.Throws<ArgumentException>("source", () =>
+                MLKem.ImportDecapsulationKey(algorithm, destination.AsSpan()));
+
+            AssertExtensions.Throws<ArgumentException>("source", () =>
+                MLKem.ImportDecapsulationKey(algorithm, destination.AsSpan(0..^2)));
+
+            AssertExtensions.Throws<ArgumentException>("source", () =>
+                MLKem.ImportDecapsulationKey(algorithm, ReadOnlySpan<byte>.Empty));
         }
 
         [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]
@@ -91,9 +114,16 @@ namespace System.Security.Cryptography.Tests
                 MLKem.ImportEncapsulationKey(null, new byte[MLKemAlgorithm.MLKem512.EncapsulationKeySizeInBytes]));
         }
 
+        [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]
+        public static void ImportEncapsulationKey_NullSource()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("source", static () =>
+                MLKem.ImportEncapsulationKey(MLKemAlgorithm.MLKem512, null));
+        }
+
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
         [MemberData(nameof(MLKemAlgorithms))]
-        public static void ImportEncapsulationKey_WrongSize(MLKemAlgorithm algorithm)
+        public static void ImportEncapsulationKey_WrongSize_Array(MLKemAlgorithm algorithm)
         {
             AssertExtensions.Throws<ArgumentException>("source", () =>
                 MLKem.ImportEncapsulationKey(algorithm, new byte[algorithm.EncapsulationKeySizeInBytes + 1]));
@@ -103,6 +133,22 @@ namespace System.Security.Cryptography.Tests
 
             AssertExtensions.Throws<ArgumentException>("source", () =>
                 MLKem.ImportEncapsulationKey(algorithm, []));
+        }
+
+        [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
+        [MemberData(nameof(MLKemAlgorithms))]
+        public static void ImportEncapsulationKey_WrongSize_Span(MLKemAlgorithm algorithm)
+        {
+            byte[] destination = new byte[algorithm.EncapsulationKeySizeInBytes + 1];
+
+            AssertExtensions.Throws<ArgumentException>("source", () =>
+                MLKem.ImportEncapsulationKey(algorithm, destination.AsSpan()));
+
+            AssertExtensions.Throws<ArgumentException>("source", () =>
+                MLKem.ImportEncapsulationKey(algorithm, destination.AsSpan(0..^2)));
+
+            AssertExtensions.Throws<ArgumentException>("source", () =>
+                MLKem.ImportEncapsulationKey(algorithm, ReadOnlySpan<byte>.Empty));
         }
 
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
@@ -310,8 +356,12 @@ namespace System.Security.Cryptography.Tests
             Assert.Throws<ObjectDisposedException>(() => kem.ExportDecapsulationKey(
                 new byte[MLKemAlgorithm.MLKem512.DecapsulationKeySizeInBytes]));
 
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportDecapsulationKey());
+
             Assert.Throws<ObjectDisposedException>(() => kem.ExportEncapsulationKey(
                 new byte[MLKemAlgorithm.MLKem512.EncapsulationKeySizeInBytes]));
+
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportEncapsulationKey());
         }
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
@@ -279,6 +279,8 @@ namespace System.Security.Cryptography.Tests
             Assert.Throws<ObjectDisposedException>(() => kem.ExportPrivateSeed(
                 new byte[MLKemAlgorithm.MLKem512.PrivateSeedSizeInBytes]));
 
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportPrivateSeed());
+
             Assert.Throws<ObjectDisposedException>(() => kem.ExportDecapsulationKey(
                 new byte[MLKemAlgorithm.MLKem512.DecapsulationKeySizeInBytes]));
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.ArgValidation.cs
@@ -178,8 +178,10 @@ namespace System.Security.Cryptography.Tests
                 new byte[algorithm.SharedSecretSizeInBytes - 1]));
 
             AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Encapsulate(
-                new byte[algorithm.CiphertextSizeInBytes],
-                []));
+                new byte[algorithm.SharedSecretSizeInBytes + 1]));
+
+            AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Encapsulate(
+                new byte[algorithm.SharedSecretSizeInBytes - 1]));
         }
 
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
@@ -335,6 +337,9 @@ namespace System.Security.Cryptography.Tests
 
             Assert.Throws<ObjectDisposedException>(() =>  kem.Encapsulate(
                 out _));
+
+            Assert.Throws<ObjectDisposedException>(() =>  kem.Encapsulate(
+                new byte[MLKemAlgorithm.MLKem512.SharedSecretSizeInBytes]));
 
             Assert.Throws<ObjectDisposedException>(() =>  kem.Decapsulate(
                 new byte[MLKemAlgorithm.MLKem512.CiphertextSizeInBytes],

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.Encapsulation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.Encapsulation.cs
@@ -25,15 +25,28 @@ namespace System.Security.Cryptography.Tests
 
                 byte[] sharedSecretBuffer = new byte[vector.Algorithm.SharedSecretSizeInBytes];
                 byte[] expectedSharedSecret = vector.SharedSecret.HexToByteArray();
-                kem.Decapsulate(vector.Ciphertext.HexToByteArray(), sharedSecretBuffer);
+                byte[] ciphertextBytes = vector.Ciphertext.HexToByteArray();
 
+                // Exact buffers
+                kem.Decapsulate(ciphertextBytes, sharedSecretBuffer);
                 AssertExtensions.SequenceEqual(expectedSharedSecret, sharedSecretBuffer);
+
+                // Large enough buffers
+                sharedSecretBuffer.AsSpan().Clear();
+                kem.Decapsulate(ciphertextBytes, sharedSecretBuffer, out int sharedSecretWritten);
+                AssertExtensions.SequenceEqual(expectedSharedSecret, sharedSecretBuffer);
+                Assert.Equal(vector.Algorithm.SharedSecretSizeInBytes, sharedSecretWritten);
+
+                // Allocating return
+                byte[] sharedSecret = kem.Decapsulate(ciphertextBytes);
+                AssertExtensions.SequenceEqual(expectedSharedSecret, sharedSecret);
             }
         }
+
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
         [InlineData(true)]
         [InlineData(false)]
-        public static void DecapsulateVectors_OverlappingBuffers(bool partial)
+        public static void DecapsulateVectors_OverlappingBuffers_ExactBuffers(bool partial)
         {
             foreach (MLKemTestDecapsulationVector vector in MLKemDecapsulationTestVectors)
             {
@@ -52,6 +65,27 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void DecapsulateVectors_OverlappingBuffers_LargeEnoughBuffers(bool partial)
+        {
+            foreach (MLKemTestDecapsulationVector vector in MLKemDecapsulationTestVectors)
+            {
+                byte[] decapsulationKeyBytes = vector.DecapsulationKey.HexToByteArray();
+                byte[] ciphertextBytes = vector.Ciphertext.HexToByteArray();
+                using MLKem kem = MLKem.ImportDecapsulationKey(vector.Algorithm, decapsulationKeyBytes);
+
+                Span<byte> sharedSecretBuffer = ciphertextBytes.AsSpan(partial ? 1 : 0);
+
+                ReadOnlySpan<byte> expectedSharedSecret = vector.SharedSecret.HexToByteArray();
+
+                kem.Decapsulate(ciphertextBytes, sharedSecretBuffer, out int sharedSecretWritten);
+                Assert.Equal(vector.Algorithm.SharedSecretSizeInBytes, sharedSecretWritten);
+                AssertExtensions.SequenceEqual(expectedSharedSecret, sharedSecretBuffer.Slice(0, sharedSecretWritten));
+            }
+        }
+
         [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]
         public static void Decapsulate_OnlyEncapsulationKey()
         {
@@ -61,9 +95,19 @@ namespace System.Security.Cryptography.Tests
                 using MLKem kem = MLKem.ImportEncapsulationKey(vector.Algorithm, encapsulationKeyBytes);
                 byte[] sharedSecretBuffer = new byte[vector.Algorithm.SharedSecretSizeInBytes];
 
+                // Exact buffer
                 Assert.ThrowsAny<CryptographicException>(() => kem.Decapsulate(
                     vector.Ciphertext.HexToByteArray(),
                     sharedSecretBuffer));
+
+                // Large enough buffer
+                Assert.ThrowsAny<CryptographicException>(() => kem.Decapsulate(
+                    vector.Ciphertext.HexToByteArray(),
+                    sharedSecretBuffer,
+                    out _));
+
+                // Allocating
+                Assert.ThrowsAny<CryptographicException>(() => kem.Decapsulate(vector.Ciphertext.HexToByteArray()));
             }
         }
 
@@ -75,20 +119,32 @@ namespace System.Security.Cryptography.Tests
                 byte[] decapsulationKeyBytes = vector.DecapsulationKey.HexToByteArray();
                 using MLKem kem = MLKem.ImportDecapsulationKey(vector.Algorithm, decapsulationKeyBytes);
 
-                byte[] sharedSecretBuffer = new byte[vector.Algorithm.SharedSecretSizeInBytes];
+                byte[] sharedSecretBuffer = new byte[vector.Algorithm.SharedSecretSizeInBytes + 10];
                 byte[] expectedSharedSecret = vector.SharedSecret.HexToByteArray();
                 byte[] ciphertext = vector.Ciphertext.HexToByteArray();
 
                 Tamper(ciphertext);
-                kem.Decapsulate(ciphertext, sharedSecretBuffer);
 
-                AssertExtensions.SequenceNotEqual(expectedSharedSecret, sharedSecretBuffer);
+                // Exact buffer
+                Span<byte> sharedSecretExact = sharedSecretBuffer.AsSpan(0, vector.Algorithm.SharedSecretSizeInBytes);
+                kem.Decapsulate(ciphertext, sharedSecretExact);
+                AssertExtensions.SequenceNotEqual(expectedSharedSecret, sharedSecretExact);
+
+                // Large enough buffer
+                sharedSecretBuffer.AsSpan().Clear();
+                kem.Decapsulate(ciphertext, sharedSecretBuffer, out int sharedSecretWritten);
+                Assert.Equal(vector.Algorithm.SharedSecretSizeInBytes, sharedSecretWritten);
+                AssertExtensions.SequenceNotEqual(expectedSharedSecret, sharedSecretBuffer.AsSpan(0, sharedSecretWritten));
+
+                // Allocating
+                byte[] sharedSecret = kem.Decapsulate(ciphertext);
+                AssertExtensions.SequenceNotEqual(expectedSharedSecret, sharedSecret);
             }
         }
 
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
         [MemberData(nameof(MLKemAlgorithms))]
-        public static void Encapsulate_NonDeterministic(MLKemAlgorithm algorithm)
+        public static void Encapsulate_NonDeterministic_Exact(MLKemAlgorithm algorithm)
         {
             using MLKem kem = MLKem.GenerateKey(algorithm);
 
@@ -103,9 +159,43 @@ namespace System.Security.Cryptography.Tests
         }
 
         [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
+        [MemberData(nameof(MLKemAlgorithms))]
+        public static void Encapsulate_NonDeterministic_LargeEnough(MLKemAlgorithm algorithm)
+        {
+            using MLKem kem = MLKem.GenerateKey(algorithm);
+
+            byte[] ciphertext1 = new byte[algorithm.CiphertextSizeInBytes + 10];
+            byte[] sharedSecret1 = new byte[algorithm.SharedSecretSizeInBytes + 10];
+            byte[] ciphertext2 = new byte[algorithm.CiphertextSizeInBytes + 10];
+            byte[] sharedSecret2 = new byte[algorithm.SharedSecretSizeInBytes + 10];
+            kem.Encapsulate(ciphertext1, sharedSecret1, out int ciphertext1Written, out int sharedSecret1Written);
+            kem.Encapsulate(ciphertext2, sharedSecret2, out int ciphertext2Written, out int sharedSecret2Written);
+
+            AssertExtensions.SequenceNotEqual(
+                ciphertext1.AsSpan(0, ciphertext1Written),
+                ciphertext2.AsSpan(0, ciphertext2Written));
+
+            AssertExtensions.SequenceNotEqual(
+                sharedSecret1.AsSpan(0, sharedSecret1Written),
+                sharedSecret2.AsSpan(0, sharedSecret2Written));
+        }
+
+        [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
+        [MemberData(nameof(MLKemAlgorithms))]
+        public static void Encapsulate_NonDeterministic_Allocating(MLKemAlgorithm algorithm)
+        {
+            using MLKem kem = MLKem.GenerateKey(algorithm);
+
+            byte[] ciphertext1 = kem.Encapsulate(out byte[] sharedSecret1);
+            byte[] ciphertext2 = kem.Encapsulate(out byte[] sharedSecret2);
+            AssertExtensions.SequenceNotEqual(ciphertext1, ciphertext2);
+            AssertExtensions.SequenceNotEqual(sharedSecret1, sharedSecret2);
+        }
+
+        [ConditionalTheory(typeof(MLKem), nameof(MLKem.IsSupported))]
         [InlineData(false)]
         [InlineData(true)]
-        public static void Encapsulate_Overlaps(bool partial)
+        public static void Encapsulate_Overlaps_Fail(bool partial)
         {
             using MLKem kem = MLKem.GenerateKey(MLKemAlgorithm.MLKem512);
             byte[] buffer = new byte[MLKemAlgorithm.MLKem512.CiphertextSizeInBytes];
@@ -116,6 +206,54 @@ namespace System.Security.Cryptography.Tests
                 Span<byte> ciphertext = buffer.AsSpan(0, MLKemAlgorithm.MLKem512.CiphertextSizeInBytes);
                 kem.Encapsulate(ciphertext, sharedSecret);
             });
+
+            Assert.Throws<CryptographicException>(() =>
+            {
+                Span<byte> sharedSecret = buffer.AsSpan(partial ? 1 : 0, MLKemAlgorithm.MLKem512.SharedSecretSizeInBytes);
+                Span<byte> ciphertext = buffer.AsSpan(0, MLKemAlgorithm.MLKem512.CiphertextSizeInBytes);
+                kem.Encapsulate(ciphertext, sharedSecret, out _, out _);
+            });
+        }
+
+        [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]
+        public static void Encapsulate_Overlaps_SameBuffer_Works()
+        {
+            MLKemAlgorithm algorithm = MLKemAlgorithm.MLKem512;
+            using MLKem kem = MLKem.GenerateKey(algorithm);
+            byte[] buffer = new byte[algorithm.SharedSecretSizeInBytes + algorithm.CiphertextSizeInBytes];
+            Span<byte> sharedSecret = buffer.AsSpan(0, algorithm.SharedSecretSizeInBytes);
+            Span<byte> ciphertext = buffer.AsSpan(algorithm.SharedSecretSizeInBytes);
+
+            kem.Encapsulate(ciphertext, sharedSecret, out int ciphertextWritten, out int sharedSecretWritten);
+            Assert.Equal(algorithm.CiphertextSizeInBytes, ciphertextWritten);
+            Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecretWritten);
+
+            Span<byte> decapsulated = new byte[algorithm.SharedSecretSizeInBytes];
+            kem.Decapsulate(ciphertext, decapsulated);
+            AssertExtensions.SequenceEqual(sharedSecret, decapsulated);
+        }
+
+        [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]
+        public static void Encapsulate_Overlaps_WhenTrimmed_Works()
+        {
+            MLKemAlgorithm algorithm = MLKemAlgorithm.MLKem512;
+            using MLKem kem = MLKem.GenerateKey(algorithm);
+
+            // sharedSecret does overlap ciphertext in this test. However, the part that overlaps will never
+            // be written to because it is trimmed to the exact size, which ends up with the buffers beside each
+            // other, which should work.
+            byte[] buffer = new byte[algorithm.SharedSecretSizeInBytes + algorithm.CiphertextSizeInBytes + 10];
+            Span<byte> sharedSecret = buffer.AsSpan(0, algorithm.SharedSecretSizeInBytes + 10);
+            Span<byte> ciphertext = buffer.AsSpan(algorithm.SharedSecretSizeInBytes);
+            Assert.True(sharedSecret.Overlaps(ciphertext), "sharedSecret.Overlaps(ciphertext)");
+
+            kem.Encapsulate(ciphertext, sharedSecret, out int ciphertextWritten, out int sharedSecretWritten);
+            Assert.Equal(algorithm.CiphertextSizeInBytes, ciphertextWritten);
+            Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecretWritten);
+
+            Span<byte> decapsulated = new byte[algorithm.SharedSecretSizeInBytes];
+            kem.Decapsulate(ciphertext.Slice(0, ciphertextWritten), decapsulated);
+            AssertExtensions.SequenceEqual(sharedSecret.Slice(0, sharedSecretWritten), decapsulated);
         }
 
         private static void Tamper(Span<byte> buffer)

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.Keys.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.Keys.cs
@@ -22,12 +22,16 @@ namespace System.Security.Cryptography.Tests
             Span<byte> seed = new byte[algorithm.PrivateSeedSizeInBytes];
 
             kem.ExportPrivateSeed(seed);
+            byte[] allocatedSeed1 = kem.ExportPrivateSeed();
             Assert.True(seed.ContainsAnyExcept((byte)0));
+            AssertExtensions.SequenceEqual(seed, allocatedSeed1.AsSpan());
 
             using MLKem kem2 = MLKem.ImportPrivateSeed(algorithm, seed);
             Span<byte> seed2 = new byte[algorithm.PrivateSeedSizeInBytes];
             kem2.ExportPrivateSeed(seed2);
+            byte[] allocatedSeed2 = kem2.ExportPrivateSeed();
             AssertExtensions.SequenceEqual(seed, seed2);
+            AssertExtensions.SequenceEqual(seed2, allocatedSeed2.AsSpan());
         }
 
         [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]
@@ -116,8 +120,10 @@ namespace System.Security.Cryptography.Tests
                 vector.Algorithm,
                 vector.DecapsulationKey.HexToByteArray());
 
+            Assert.Throws<CryptographicException>(() => kem.ExportPrivateSeed());
             Assert.Throws<CryptographicException>(() => kem.ExportPrivateSeed(
                 new byte[vector.Algorithm.PrivateSeedSizeInBytes]));
+
         }
 
         [ConditionalFact(typeof(MLKem), nameof(MLKem.IsSupported))]
@@ -128,6 +134,7 @@ namespace System.Security.Cryptography.Tests
                 vector.Algorithm,
                 vector.EncapsulationKey.HexToByteArray());
 
+            Assert.Throws<CryptographicException>(() => kem.ExportPrivateSeed());
             Assert.Throws<CryptographicException>(() => kem.ExportPrivateSeed(
                 new byte[vector.Algorithm.PrivateSeedSizeInBytes]));
         }

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
@@ -63,6 +63,9 @@
   <data name="Argument_DestinationImprecise" xml:space="preserve">
     <value>Destination must be exactly {0} bytes.</value>
   </data>
+  <data name="Argument_DestinationTooShort" xml:space="preserve">
+    <value>Destination is too short.</value>
+  </data>
   <data name="Argument_InvalidOffLen" xml:space="preserve">
     <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1801,11 +1801,15 @@ namespace System.Security.Cryptography
         protected MLKem(System.Security.Cryptography.MLKemAlgorithm algorithm) { }
         public System.Security.Cryptography.MLKemAlgorithm Algorithm { get { throw null; } }
         public static bool IsSupported { get { throw null; } }
+        public byte[] Decapsulate(byte[] ciphertext) { throw null; }
         public void Decapsulate(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret) { }
+        public void Decapsulate(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret, out int sharedSecretWritten) { throw null; }
         protected abstract void DecapsulateCore(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret);
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public byte[] Encapsulate(out byte[] sharedSecret) { throw null; }
         public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret) { }
+        public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret, out int ciphertextWritten, out int sharedSecretWritten) { throw null; }
         protected abstract void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret);
         public void ExportDecapsulationKey(System.Span<byte> destination) { }
         protected abstract void ExportDecapsulationKeyCore(System.Span<byte> destination);

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1803,13 +1803,13 @@ namespace System.Security.Cryptography
         public static bool IsSupported { get { throw null; } }
         public byte[] Decapsulate(byte[] ciphertext) { throw null; }
         public void Decapsulate(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret) { }
-        public void Decapsulate(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret, out int sharedSecretWritten) { throw null; }
+        public void Decapsulate(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret, out int sharedSecretBytesWritten) { throw null; }
         protected abstract void DecapsulateCore(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret);
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public byte[] Encapsulate(out byte[] sharedSecret) { throw null; }
         public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret) { }
-        public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret, out int ciphertextWritten, out int sharedSecretWritten) { throw null; }
+        public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret, out int ciphertextBytesWritten, out int sharedSecretBytesWritten) { throw null; }
         protected abstract void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret);
         public byte[] ExportDecapsulationKey() { throw null; }
         public void ExportDecapsulationKey(System.Span<byte> destination) { }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1811,15 +1811,19 @@ namespace System.Security.Cryptography
         public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret) { }
         public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret, out int ciphertextWritten, out int sharedSecretWritten) { throw null; }
         protected abstract void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret);
+        public byte[] ExportDecapsulationKey() { throw null; }
         public void ExportDecapsulationKey(System.Span<byte> destination) { }
         protected abstract void ExportDecapsulationKeyCore(System.Span<byte> destination);
+        public byte[] ExportEncapsulationKey() { throw null; }
         public void ExportEncapsulationKey(System.Span<byte> destination) { }
         protected abstract void ExportEncapsulationKeyCore(System.Span<byte> destination);
         public byte[] ExportPrivateSeed() { throw null; }
         public void ExportPrivateSeed(System.Span<byte> destination) { }
         protected abstract void ExportPrivateSeedCore(System.Span<byte> destination);
         public static System.Security.Cryptography.MLKem GenerateKey(System.Security.Cryptography.MLKemAlgorithm algorithm) { throw null; }
+        public static System.Security.Cryptography.MLKem ImportDecapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, byte[] source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportDecapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.MLKem ImportEncapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, byte[] source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportEncapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportPrivateSeed(System.Security.Cryptography.MLKemAlgorithm algorithm, byte[] source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportPrivateSeed(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1815,6 +1815,7 @@ namespace System.Security.Cryptography
         protected abstract void ExportDecapsulationKeyCore(System.Span<byte> destination);
         public void ExportEncapsulationKey(System.Span<byte> destination) { }
         protected abstract void ExportEncapsulationKeyCore(System.Span<byte> destination);
+        public byte[] ExportPrivateSeed() { throw null; }
         public void ExportPrivateSeed(System.Span<byte> destination) { }
         protected abstract void ExportPrivateSeedCore(System.Span<byte> destination);
         public static System.Security.Cryptography.MLKem GenerateKey(System.Security.Cryptography.MLKemAlgorithm algorithm) { throw null; }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1821,6 +1821,7 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.MLKem GenerateKey(System.Security.Cryptography.MLKemAlgorithm algorithm) { throw null; }
         public static System.Security.Cryptography.MLKem ImportDecapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportEncapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.MLKem ImportPrivateSeed(System.Security.Cryptography.MLKemAlgorithm algorithm, byte[] source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportPrivateSeed(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
         protected void ThrowIfDisposed() { }
     }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1808,6 +1808,7 @@ namespace System.Security.Cryptography
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public byte[] Encapsulate(out byte[] sharedSecret) { throw null; }
+        public byte[] Encapsulate(System.Span<byte> sharedSecret) { throw null; }
         public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret) { }
         public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret, out int ciphertextBytesWritten, out int sharedSecretBytesWritten) { throw null; }
         protected abstract void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret);


### PR DESCRIPTION
In #113719 we added the APIs for span-writing buffers in `MLKem`. This rounds out the existing APIs with overloads that:

* Allocate buffers for the caller
* Provide additional information about amount of data written to the buffer
* Offer array-as-input overloads for platforms that avoid spans.

Separately, this cleans up some exception throwing.

Contributes to #113508 