### PR TITLE
Fix break in DirectoryServices SearchResultCollection

### DIFF
--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SearchResultCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SearchResultCollection.cs
@@ -214,21 +214,21 @@ namespace System.DirectoryServices
             InnerList.CopyTo(array, index);
         }
 
-        /// <devdoc>
-        /// Supports a simple type-specific wrapper for the underlying cached list
-        /// </devdoc>
+        /// <summary>Provides an enumerator implementation for the array of <see cref="SearchResult"/>.</summary>
         private struct AlreadyReadResultsEnumerator : IEnumerator
         {
             private readonly IEnumerator _innerEnumerator;
 
+            /// <summary>Initialize the enumerator.</summary>
+            /// <param name="innerList">The ArrayList to enumerate.</param>
             internal AlreadyReadResultsEnumerator(ArrayList innerList)
             {
                 _innerEnumerator = innerList.GetEnumerator();
             }
 
-            /// <devdoc>
-            /// Gets the current element in the collection.
-            /// </devdoc>
+            /// <summary>
+            /// Current <see cref="SearchResult"/> value of the <see cref="IEnumerator"/>
+            /// </summary>
             public SearchResult Current
             {
                 get
@@ -237,23 +237,25 @@ namespace System.DirectoryServices
                 }
             }
 
-            /// <devdoc>
-            /// Advances the enumerator to the next element of the collection
-            /// and returns a Boolean value indicating whether a valid element is available.
-            /// </devdoc>
+            /// <summary>
+            /// Advances the enumerator to the next <see cref="SearchResult"/> element of the arrray.
+            /// </summary>
             public bool MoveNext()
             {
                 return _innerEnumerator.MoveNext();
             }
 
-            /// <devdoc>
-            /// Resets the enumerator back to its initial position before the first element in the collection.
-            /// </devdoc>
+            /// <summary>
+            /// Resets the enumerator to the beginning of the array.
+            /// </summary>
             public void Reset()
             {
                 _innerEnumerator.Reset();
             }
 
+            /// <summary>
+            /// Current <see cref="object"/> of the <see cref="IEnumerator"/>
+            /// </summary>
             object IEnumerator.Current => Current;
         }
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SearchResultCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SearchResultCollection.cs
@@ -217,7 +217,7 @@ namespace System.DirectoryServices
         /// <devdoc>
         /// Supports a simple type-specific wrapper for the underlying cached list
         /// </devdoc>
-        private sealed class AlreadyReadResultsEnumerator : IEnumerator
+        private struct AlreadyReadResultsEnumerator : IEnumerator
         {
             private readonly IEnumerator _innerEnumerator;
 

--- a/src/libraries/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
+++ b/src/libraries/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
@@ -8,8 +8,8 @@
     <Compile Include="System\DirectoryServices\ActiveDirectorySecurityTests.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectory\DomainControllerTests.cs" />
     <Compile Include="System\DirectoryServices\DirectoryEntryTests.cs" />
-    <Compile Include="System\DirectoryServices\DirectoryServicesPermissionTests.cs" />
     <Compile Include="System\DirectoryServices\DirectorySearcherTests.cs" />
+    <Compile Include="System\DirectoryServices\DirectoryServicesPermissionTests.cs" />
     <Compile Include="System\DirectoryServices\DirectoryServicesTests.cs" />
     <Compile Include="System\DirectoryServices\DirectorySynchronizationTests.cs" />
     <Compile Include="System\DirectoryServices\DirectoryVirtualListViewContextTests.cs" />

--- a/src/libraries/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
+++ b/src/libraries/System.DirectoryServices/tests/System.DirectoryServices.Tests.csproj
@@ -9,6 +9,7 @@
     <Compile Include="System\DirectoryServices\ActiveDirectory\DomainControllerTests.cs" />
     <Compile Include="System\DirectoryServices\DirectoryEntryTests.cs" />
     <Compile Include="System\DirectoryServices\DirectoryServicesPermissionTests.cs" />
+    <Compile Include="System\DirectoryServices\DirectorySearcherTests.cs" />
     <Compile Include="System\DirectoryServices\DirectoryServicesTests.cs" />
     <Compile Include="System\DirectoryServices\DirectorySynchronizationTests.cs" />
     <Compile Include="System\DirectoryServices\DirectoryVirtualListViewContextTests.cs" />
@@ -20,8 +21,7 @@
     <Compile Include="System\DirectoryServices\ActiveDirectory\ForestTests.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectory\ActiveDirectoryTests.cs" />
     <Compile Include="System\DirectoryServices\ActiveDirectory\TrustHelperTests.cs" />
-    <Compile Include="$(CommonTestPath)System\DirectoryServices\LdapConfiguration.cs"
-             Link="Common\DirectoryServices\LdapConfiguration.cs" />
+    <Compile Include="$(CommonTestPath)System\DirectoryServices\LdapConfiguration.cs" Link="Common\DirectoryServices\LdapConfiguration.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(CommonTestPath)System\DirectoryServices\LDAP.Configuration.xml">

--- a/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectorySearcherTests.cs
+++ b/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectorySearcherTests.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System.Collections;
+using Xunit;
+using Xunit.Sdk;
+using System.Reflection;
+
+namespace System.DirectoryServices.Tests
+{
+    public partial class DirectorySearcherTests
+    {
+        internal static bool IsLdapConfigurationExist => LdapConfiguration.Configuration != null;
+        internal static bool IsActiveDirectoryServer => IsLdapConfigurationExist && LdapConfiguration.Configuration.IsActiveDirectoryServer;
+
+        private const int ADS_SYSTEMFLAG_CR_NTDS_NC = 0x1;
+        private const int ADS_SYSTEMFLAG_CR_NTDS_DOMAIN = 0x2;
+
+        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        public void DirectorySearch_IteratesCorrectly_SimpleEnumeration()
+        {
+            var e = GetDomains();
+            Assert.NotNull(e);
+
+            foreach (var result in e)
+            {
+                Assert.NotNull(result);
+            }
+        }
+
+        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        public void DirectorySearch_IteratesCorrectly_AfterCount()
+        {
+            var e = GetDomains();
+            Assert.NotNull(e);
+            Assert.NotEqual(0, e.Count);
+
+            foreach (var result in e)
+            {
+                Assert.NotNull(result);
+            }
+        }
+
+
+        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        public void DirectorySearch_IteratesCorrectly_MixedCount()
+        {
+            var e = GetDomains();
+            Assert.NotNull(e);
+            Assert.NotEqual(0, e.Count);
+
+            foreach (var result in e)
+            {
+                Assert.NotEqual(0, e.Count);
+                Assert.NotNull(result);
+            }
+        }
+
+        private static SearchResultCollection GetDomains()
+        {
+            using var entry = new DirectoryEntry("LDAP://rootDSE");
+            var namingContext = entry.Properties["configurationNamingContext"][0]!.ToString();
+            using var searchRoot = new DirectoryEntry($"LDAP://CN=Partitions,{namingContext}");
+            using var ds = new DirectorySearcher(searchRoot)
+            {
+                PageSize = 1000,
+                CacheResults = false
+            };
+            ds.SearchScope = SearchScope.OneLevel;
+            ds.PropertiesToLoad.Add("distinguishedName");
+            ds.PropertiesToLoad.Add("nETBIOSName");
+            ds.PropertiesToLoad.Add("nCName");
+            ds.PropertiesToLoad.Add("dnsRoot");
+            ds.PropertiesToLoad.Add("trustParent");
+            ds.PropertiesToLoad.Add("objectSid");
+            ds.Filter = string.Format("(&(objectCategory=crossRef)(systemFlags={0}))", ADS_SYSTEMFLAG_CR_NTDS_DOMAIN | ADS_SYSTEMFLAG_CR_NTDS_NC);
+
+            return ds.FindAll();
+        }
+    }
+}

--- a/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectorySearcherTests.cs
+++ b/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectorySearcherTests.cs
@@ -21,18 +21,23 @@ namespace System.DirectoryServices.Tests
         [ConditionalFact(nameof(IsLdapConfigurationExist))]
         public void DirectorySearch_IteratesCorrectly_SimpleEnumeration()
         {
+            bool seen = false;
             var e = GetDomains();
             Assert.NotNull(e);
 
             foreach (var result in e)
             {
                 Assert.NotNull(result);
+                seen = true;
             }
+
+            Assert.True(seen);
         }
 
         [ConditionalFact(nameof(IsLdapConfigurationExist))]
         public void DirectorySearch_IteratesCorrectly_AfterCount()
         {
+            bool seen = false;
             var e = GetDomains();
             Assert.NotNull(e);
             Assert.NotEqual(0, e.Count);
@@ -40,22 +45,10 @@ namespace System.DirectoryServices.Tests
             foreach (var result in e)
             {
                 Assert.NotNull(result);
+                seen = true;
             }
-        }
 
-
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
-        public void DirectorySearch_IteratesCorrectly_MixedCount()
-        {
-            var e = GetDomains();
-            Assert.NotNull(e);
-            Assert.NotEqual(0, e.Count);
-
-            foreach (var result in e)
-            {
-                Assert.NotEqual(0, e.Count);
-                Assert.NotNull(result);
-            }
+            Assert.True(seen);
         }
 
         private static SearchResultCollection GetDomains()

--- a/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectorySearcherTests.cs
+++ b/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectorySearcherTests.cs
@@ -22,7 +22,7 @@ namespace System.DirectoryServices.Tests
         public void DirectorySearch_IteratesCorrectly_SimpleEnumeration()
         {
             bool seen = false;
-            var e = GetDomains();
+            SearchResultCollection e = GetDomains();
             Assert.NotNull(e);
 
             foreach (var result in e)
@@ -38,7 +38,7 @@ namespace System.DirectoryServices.Tests
         public void DirectorySearch_IteratesCorrectly_AfterCount()
         {
             bool seen = false;
-            var e = GetDomains();
+            SearchResultCollection e = GetDomains();
             Assert.NotNull(e);
             Assert.NotEqual(0, e.Count);
 

--- a/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectorySearcherTests.cs
+++ b/src/libraries/System.DirectoryServices/tests/System/DirectoryServices/DirectorySearcherTests.cs
@@ -53,10 +53,10 @@ namespace System.DirectoryServices.Tests
 
         private static SearchResultCollection GetDomains()
         {
-            using var entry = new DirectoryEntry("LDAP://rootDSE");
-            var namingContext = entry.Properties["configurationNamingContext"][0]!.ToString();
-            using var searchRoot = new DirectoryEntry($"LDAP://CN=Partitions,{namingContext}");
-            using var ds = new DirectorySearcher(searchRoot)
+            using DirectoryEntry entry = new DirectoryEntry("LDAP://rootDSE");
+            string namingContext = entry.Properties["configurationNamingContext"][0]!.ToString();
+            using DirectoryEntry searchRoot = new DirectoryEntry($"LDAP://CN=Partitions,{namingContext}");
+            using DirectorySearcher ds = new DirectorySearcher(searchRoot)
             {
                 PageSize = 1000,
                 CacheResults = false


### PR DESCRIPTION
Added enumeration handling when the internal ArrayList has already been loaded but an enumeration follows. This fixes the issue with 9.x Linq statements against the collection caused by the access of the .Count

Fixes #113265

I am not entirely sure the best way to test this, as we never had tests for this class until now so I created a new DirectorySearcherTests.cs (conditionally run when LDAP is available) using the setup shown in the bug report.
