### PR TITLE
Reapply "Refactor `external_assembly_probe` to be separate from single-file bundle probing"

### DIFF
--- a/src/coreclr/binder/inc/assembly.hpp
+++ b/src/coreclr/binder/inc/assembly.hpp
@@ -25,7 +25,6 @@
 #include "customassemblybinder.h"
 #endif // !defined(DACCESS_COMPILE)
 
-#include "bundle.h"
 #include <assemblybinderutil.h>
 
 namespace BINDER_SPACE

--- a/src/coreclr/binder/inc/assemblybindercommon.hpp
+++ b/src/coreclr/binder/inc/assemblybindercommon.hpp
@@ -16,7 +16,7 @@
 
 #include "bindertypes.hpp"
 #include "bindresult.hpp"
-#include "bundle.h"
+#include <assemblyprobeextension.h>
 
 class AssemblyBinder;
 class DefaultAssemblyBinder;
@@ -28,7 +28,7 @@ namespace BINDER_SPACE
     class AssemblyBinderCommon
     {
     public:
-        static HRESULT BindAssembly(/* in */  AssemblyBinder      *pBinder, 
+        static HRESULT BindAssembly(/* in */  AssemblyBinder      *pBinder,
                                     /* in */  AssemblyName        *pAssemblyName,
                                     /* in */  bool                 excludeAppPaths,
                                     /* out */ Assembly           **ppAssembly);
@@ -44,7 +44,7 @@ namespace BINDER_SPACE
         static HRESULT GetAssembly(/* in */  SString     &assemblyPath,
                                    /* in */  BOOL         fIsInTPA,
                                    /* out */ Assembly   **ppAssembly,
-                                   /* in */  BundleFileLocation bundleFileLocation = BundleFileLocation::Invalid());
+                                   /* in */  ProbeExtensionResult probeExtensionResult = ProbeExtensionResult::Invalid());
 
 #if !defined(DACCESS_COMPILE)
         static HRESULT BindUsingHostAssemblyResolver (/* in */ INT_PTR pManagedAssemblyLoadContextToBindWithin,

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -288,12 +288,9 @@ int coreclr_initialize(
     hr = CorHost2::CreateObject(IID_ICLRRuntimeHost4, (void**)&host);
     IfFailRet(hr);
 
-    ConstWStringHolder appDomainFriendlyNameW = StringToUnicode(appDomainFriendlyName);
-
-    ExternalAssemblyProbeFn* externalAssemblyProbe = hostContract != nullptr ? hostContract->external_assembly_probe : nullptr;
-    if (bundleProbe != nullptr || externalAssemblyProbe != nullptr)
+    if (bundleProbe != nullptr)
     {
-        static Bundle bundle(exePath, bundleProbe, externalAssemblyProbe);
+        static Bundle bundle(exePath, bundleProbe);
         Bundle::AppBundle = &bundle;
     }
 
@@ -309,6 +306,7 @@ int coreclr_initialize(
     hr = host->Start();
     IfFailRet(hr);
 
+    ConstWStringHolder appDomainFriendlyNameW = StringToUnicode(appDomainFriendlyName);
     hr = host->CreateAppDomainWithManager(
         appDomainFriendlyNameW,
         0,

--- a/src/coreclr/inc/assemblyprobeextension.h
+++ b/src/coreclr/inc/assemblyprobeextension.h
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef HAVE_ASSEMBLY_PROBE_EXTENSIONS_H
+#define HAVE_ASSEMBLY_PROBE_EXTENSIONS_H
+
+#include <sstring.h>
+#include "bundle.h"
+
+class ProbeExtensionResult
+{
+public:
+    enum class Type
+    {
+        Invalid,
+        Bundle,
+        External,
+    };
+
+    Type Type;
+    union
+    {
+        BundleFileLocation BundleLocation;
+        struct
+        {
+            void* Data;
+            int64_t Size;
+        } ExternalData;
+    };
+
+    ProbeExtensionResult()
+        : Type{Type::Invalid}
+    { }
+
+    static ProbeExtensionResult Bundle(BundleFileLocation location)
+    {
+        return ProbeExtensionResult(location);
+    }
+
+    static ProbeExtensionResult External(void* data, int64_t size)
+    {
+        return ProbeExtensionResult(data, size);
+    }
+
+    static ProbeExtensionResult Invalid() { LIMITED_METHOD_CONTRACT; return ProbeExtensionResult(); }
+
+    bool IsValid() const { return Type != Type::Invalid; }
+
+private:
+    ProbeExtensionResult(BundleFileLocation location)
+        : Type{Type::Bundle}
+        , BundleLocation{location}
+    { }
+
+    ProbeExtensionResult(void* data, int64_t size)
+        : Type{Type::External}
+        , ExternalData{data, size}
+    { }
+};
+
+class AssemblyProbeExtension
+{
+public:
+    static bool IsEnabled();
+    static ProbeExtensionResult Probe(const SString& path, bool pathIsBundleRelative = false);
+};
+
+#endif // HAVE_ASSEMBLY_PROBE_EXTENSIONS_H

--- a/src/coreclr/inc/bundle.h
+++ b/src/coreclr/inc/bundle.h
@@ -18,31 +18,29 @@ class Bundle;
 struct BundleFileLocation
 {
     INT64 Size;
-    void* DataStart;
     INT64 Offset;
-    INT64 UncompresedSize;
+    INT64 UncompressedSize;
 
     BundleFileLocation()
     {
         LIMITED_METHOD_CONTRACT;
 
         Size = 0;
-        DataStart = nullptr;
         Offset = 0;
-        UncompresedSize = 0;
+        UncompressedSize = 0;
     }
 
     static BundleFileLocation Invalid() { LIMITED_METHOD_CONTRACT; return BundleFileLocation(); }
 
     const SString &Path() const;
 
-    bool IsValid() const { LIMITED_METHOD_CONTRACT; return DataStart != nullptr || Offset != 0; }
+    bool IsValid() const { LIMITED_METHOD_CONTRACT; return Offset != 0; }
 };
 
 class Bundle
 {
 public:
-    Bundle(LPCSTR bundlePath, BundleProbeFn *probe, ExternalAssemblyProbeFn* externalAssemblyProbe = nullptr);
+    Bundle(LPCSTR bundlePath, BundleProbeFn *probe);
     BundleFileLocation Probe(const SString& path, bool pathIsBundleRelative = false) const;
 
     const SString &Path() const { LIMITED_METHOD_CONTRACT; return m_path; }
@@ -53,9 +51,8 @@ public:
     static BundleFileLocation ProbeAppBundle(const SString& path, bool pathIsBundleRelative = false);
 
 private:
-    SString m_path; // The path to single-file executable or package name/id on Android
+    SString m_path; // The path to single-file executable
     BundleProbeFn *m_probe;
-    ExternalAssemblyProbeFn *m_externalAssemblyProbe;
 
     SString m_basePath; // The prefix to denote a path within the bundle
     COUNT_T m_basePathLength;

--- a/src/coreclr/inc/hostinformation.h
+++ b/src/coreclr/inc/hostinformation.h
@@ -11,6 +11,9 @@ class HostInformation
 public:
     static void SetContract(_In_ host_runtime_contract* hostContract);
     static bool GetProperty(_In_z_ const char* name, SString& value);
+
+    static bool HasExternalProbe();
+    static bool ExternalAssemblyProbe(_In_ const SString& path, _Out_ void** data, _Out_ int64_t* size);
 };
 
 #endif // _HOSTINFORMATION_H_

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -293,6 +293,7 @@ set(VM_SOURCES_WKS
     ${VM_SOURCES_DAC_AND_WKS_COMMON}
     appdomainnative.cpp
     assemblynative.cpp
+    assemblyprobeextension.cpp
     assemblyspec.cpp
     baseassemblyspec.cpp
     ${RUNTIME_DIR}/CachedInterfaceDispatch.cpp
@@ -390,6 +391,7 @@ set(VM_HEADERS_WKS
     ../inc/jithelpers.h
     appdomainnative.hpp
     assemblynative.hpp
+    ../inc/assemblyprobeextension.h
     assemblyspec.hpp
     assemblyspecbase.h
     baseassemblyspec.h

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -191,9 +191,7 @@ extern "C" void QCALLTYPE AssemblyNative_LoadFromPath(INT_PTR ptrNativeAssemblyB
 
     if (pwzILPath != NULL)
     {
-        pILImage = PEImage::OpenImage(pwzILPath,
-                                      MDInternalImport_Default,
-                                      BundleFileLocation::Invalid());
+        pILImage = PEImage::OpenImage(pwzILPath);
 
         // Need to verify that this is a valid CLR assembly.
         if (!pILImage->CheckILFormat())

--- a/src/coreclr/vm/assemblyprobeextension.cpp
+++ b/src/coreclr/vm/assemblyprobeextension.cpp
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "common.h"
+#include <bundle.h>
+#include <hostinformation.h>
+#include <sstring.h>
+
+/*static*/
+bool AssemblyProbeExtension::IsEnabled()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return Bundle::AppIsBundle() || HostInformation::HasExternalProbe();
+}
+
+/*static*/
+ProbeExtensionResult AssemblyProbeExtension::Probe(const SString& path, bool pathIsBundleRelative)
+{
+    STANDARD_VM_CONTRACT;
+
+    if (!Bundle::AppIsBundle() && !HostInformation::HasExternalProbe())
+        return ProbeExtensionResult::Invalid();
+
+    if (Bundle::AppIsBundle())
+    {
+        BundleFileLocation bundleLocation = Bundle::AppBundle->Probe(path, pathIsBundleRelative);
+        if (bundleLocation.IsValid())
+        {
+            return ProbeExtensionResult::Bundle(bundleLocation);
+        }
+    }
+
+    void* data;
+    int64_t size;
+    if (HostInformation::ExternalAssemblyProbe(path, &data, &size))
+    {
+        return ProbeExtensionResult::External(data, size);
+    }
+
+    return ProbeExtensionResult::Invalid();
+}

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -433,7 +433,7 @@ Assembly *AssemblySpec::LoadAssembly(LPCWSTR pFilePath)
 
     pILImage = PEImage::OpenImage(pFilePath,
         MDInternalImport_Default,
-        Bundle::ProbeAppBundle(SString{ SString::Literal, pFilePath }));
+        AssemblyProbeExtension::Probe(SString{ SString::Literal, pFilePath }));
 
     // Need to verify that this is a valid CLR assembly.
     if (!pILImage->CheckILFormat())

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -17,7 +17,7 @@
 #include "peimagelayout.inl"
 #include "domainassembly.h"
 #include "holder.h"
-#include "bundle.h"
+#include <assemblyprobeextension.h>
 #include "strongnameinternal.h"
 
 #include "../binder/inc/assemblyidentity.hpp"
@@ -76,9 +76,9 @@ HRESULT  AssemblySpec::Bind(AppDomain *pAppDomain, BINDER_SPACE::Assembly** ppAs
 }
 
 
-STDAPI BinderAcquirePEImage(LPCWSTR             wszAssemblyPath,
-                            PEImage           **ppPEImage,
-                            BundleFileLocation  bundleFileLocation)
+STDAPI BinderAcquirePEImage(LPCWSTR                 wszAssemblyPath,
+                            PEImage               **ppPEImage,
+                            ProbeExtensionResult    probeExtensionResult)
 {
     HRESULT hr = S_OK;
 
@@ -86,7 +86,7 @@ STDAPI BinderAcquirePEImage(LPCWSTR             wszAssemblyPath,
 
     EX_TRY
     {
-        PEImageHolder pImage = PEImage::OpenImage(wszAssemblyPath, MDInternalImport_Default, bundleFileLocation);
+        PEImageHolder pImage = PEImage::OpenImage(wszAssemblyPath, MDInternalImport_Default, probeExtensionResult);
 
         // Make sure that the IL image can be opened.
         if (pImage->IsFile())

--- a/src/coreclr/vm/hostinformation.cpp
+++ b/src/coreclr/vm/hostinformation.cpp
@@ -40,3 +40,18 @@ bool HostInformation::GetProperty(_In_z_ const char* name, SString& value)
 
     return lenActual > 0 && lenActual <= len;
 }
+
+bool HostInformation::HasExternalProbe()
+{
+    return s_hostContract != nullptr && s_hostContract->external_assembly_probe != nullptr;
+}
+
+bool HostInformation::ExternalAssemblyProbe(_In_ const SString& path, _Out_ void** data, _Out_ int64_t* size)
+{
+    if (!HasExternalProbe())
+        return false;
+
+    StackSString utf8Path;
+    utf8Path.SetAndConvertToUTF8(path.GetUnicode());
+    return s_hostContract->external_assembly_probe(utf8Path.GetUTF8(), data, size);
+}

--- a/src/coreclr/vm/hostinformation.cpp
+++ b/src/coreclr/vm/hostinformation.cpp
@@ -6,23 +6,25 @@
 
 namespace
 {
-    host_runtime_contract* s_hostContract = nullptr;
+    host_runtime_contract s_hostContract = {};
 }
 
 void HostInformation::SetContract(_In_ host_runtime_contract* hostContract)
 {
-    _ASSERTE(s_hostContract == nullptr);
-    s_hostContract = hostContract;
+    _ASSERTE(s_hostContract.size == 0 && hostContract != nullptr);
+
+    // Copy the contract values
+    s_hostContract = *hostContract;
 }
 
 bool HostInformation::GetProperty(_In_z_ const char* name, SString& value)
 {
-    if (s_hostContract == nullptr || s_hostContract->get_runtime_property == nullptr)
+    if (s_hostContract.get_runtime_property == nullptr)
         return false;
 
     size_t len = MAX_PATH + 1;
     char* dest = value.OpenUTF8Buffer(static_cast<COUNT_T>(len));
-    size_t lenActual = s_hostContract->get_runtime_property(name, dest, len, s_hostContract->context);
+    size_t lenActual = s_hostContract.get_runtime_property(name, dest, len, s_hostContract.context);
     value.CloseBuffer();
 
     // Doesn't exist or failed to get property
@@ -35,7 +37,7 @@ bool HostInformation::GetProperty(_In_z_ const char* name, SString& value)
     // Buffer was not large enough
     len = lenActual;
     dest = value.OpenUTF8Buffer(static_cast<COUNT_T>(len));
-    lenActual = s_hostContract->get_runtime_property(name, dest, len, s_hostContract->context);
+    lenActual = s_hostContract.get_runtime_property(name, dest, len, s_hostContract.context);
     value.CloseBuffer();
 
     return lenActual > 0 && lenActual <= len;
@@ -43,7 +45,7 @@ bool HostInformation::GetProperty(_In_z_ const char* name, SString& value)
 
 bool HostInformation::HasExternalProbe()
 {
-    return s_hostContract != nullptr && s_hostContract->external_assembly_probe != nullptr;
+    return s_hostContract.external_assembly_probe != nullptr;
 }
 
 bool HostInformation::ExternalAssemblyProbe(_In_ const SString& path, _Out_ void** data, _Out_ int64_t* size)
@@ -53,5 +55,5 @@ bool HostInformation::ExternalAssemblyProbe(_In_ const SString& path, _Out_ void
 
     StackSString utf8Path;
     utf8Path.SetAndConvertToUTF8(path.GetUnicode());
-    return s_hostContract->external_assembly_probe(utf8Path.GetUTF8(), data, size);
+    return s_hostContract.external_assembly_probe(utf8Path.GetUTF8(), data, size);
 }

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -148,13 +148,13 @@ NativeImage *NativeImage::Open(
 
     PEImageLayoutHolder peLoadedImage;
 
-    BundleFileLocation bundleFileLocation = Bundle::ProbeAppBundle(fullPath, /*pathIsBundleRelative */ true);
-    if (bundleFileLocation.IsValid())
+    ProbeExtensionResult probeExtensionResult = AssemblyProbeExtension::Probe(fullPath, /*pathIsBundleRelative */ true);
+    if (probeExtensionResult.IsValid())
     {
         // No need to use cache for this PE image.
         // Composite r2r PE image is not a part of anyone's identity.
         // We only need it to obtain the native image, which will be cached at AppDomain level.
-        PEImageHolder pImage = PEImage::OpenImage(fullPath, MDInternalImport_NoCache, bundleFileLocation);
+        PEImageHolder pImage = PEImage::OpenImage(fullPath, MDInternalImport_NoCache, probeExtensionResult);
         PEImageLayout* loaded = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_LOADED);
         // We will let pImage instance be freed after exiting this scope, but we will keep the layout,
         // thus the layout needs an AddRef, or it will be gone together with pImage.

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -850,7 +850,7 @@ PEAssembly *PEAssembly::Create(IMetaDataAssemblyEmit *pAssemblyEmit)
 #ifndef DACCESS_COMPILE
 
 // Supports implementation of the legacy Assembly.CodeBase property.
-// Returns false if the assembly was loaded from a bundle, true otherwise
+// Returns false if the assembly was loaded via reflection emit or from a probe extension, true otherwise
 BOOL PEAssembly::GetCodeBase(SString &result)
 {
     CONTRACTL
@@ -864,7 +864,7 @@ BOOL PEAssembly::GetCodeBase(SString &result)
     CONTRACTL_END;
 
     PEImage* ilImage = GetPEImage();
-    if (ilImage != NULL && !ilImage->IsInBundle())
+    if (ilImage != NULL && !ilImage->IsInBundle() && !ilImage->IsExternalData())
     {
         // All other cases use the file path.
         result.Set(ilImage->GetPath());

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -150,7 +150,7 @@ inline const SString& PEAssembly::GetPath()
     }
     CONTRACTL_END;
 
-    if (IsReflectionEmit() || m_PEImage->IsInBundle ())
+    if (IsReflectionEmit() || m_PEImage->IsInBundle() || m_PEImage->IsExternalData())
     {
         return SString::Empty();
     }

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -240,9 +240,10 @@ BOOL PEImage::CompareImage(UPTR u1, UPTR u2)
     PEImage *pImage = (PEImage *) u2;
 
     if (pLocator->m_bIsInBundle != pImage->IsInBundle())
-    {
         return FALSE;
-    }
+
+    if (pLocator->m_bIsExternalData != pImage->IsExternalData())
+        return FALSE;
 
     BOOL ret = FALSE;
     HRESULT hr;
@@ -547,7 +548,7 @@ PEImage::PEImage(const WCHAR* path):
     m_pathHash(0),
     m_refCount(1),
     m_bInHashMap(FALSE),
-    m_bundleFileLocation(),
+    m_probeExtensionResult(),
     m_hFile(INVALID_HANDLE_VALUE),
     m_dwPEKind(0),
     m_dwMachine(0),
@@ -627,7 +628,7 @@ PTR_PEImageLayout PEImage::GetOrCreateLayoutInternal(DWORD imageLayoutMask)
 
 #ifdef TARGET_WINDOWS
         // on Windows we prefer to just load the file using OS loader
-        if (!IsInBundle() && bIsLoadedLayoutSuitable)
+        if (!IsInBundle() && IsFile() && bIsLoadedLayoutSuitable)
         {
             bIsLoadedLayoutPreferred = TRUE;
         }

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -36,7 +36,7 @@ inline const SString& PEImage::GetPathToLoad()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    return IsInBundle() ? m_bundleFileLocation.Path() : m_path;
+    return IsInBundle() ? m_probeExtensionResult.BundleLocation.Path() : m_path;
 }
 
 inline void* PEImage::GetExternalData(INT64* size)
@@ -44,35 +44,57 @@ inline void* PEImage::GetExternalData(INT64* size)
     LIMITED_METHOD_CONTRACT;
 
     _ASSERTE(size != nullptr);
+    if (!IsExternalData())
+    {
+        *size = 0;
+        return nullptr;
+    }
 
-    *size = m_bundleFileLocation.Size;
-    return m_bundleFileLocation.DataStart;
+    *size = m_probeExtensionResult.ExternalData.Size;
+    return m_probeExtensionResult.ExternalData.Data;
 }
 
 inline INT64 PEImage::GetOffset() const
 {
     LIMITED_METHOD_CONTRACT;
 
-    return m_bundleFileLocation.Offset;
+    return IsInBundle() ? m_probeExtensionResult.BundleLocation.Offset : 0;
 }
 
 inline BOOL PEImage::IsInBundle() const
 {
     LIMITED_METHOD_CONTRACT;
 
-    return m_bundleFileLocation.IsValid();
+    return m_probeExtensionResult.Type == ProbeExtensionResult::Type::Bundle;
+}
+
+inline BOOL PEImage::IsExternalData() const
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return m_probeExtensionResult.Type == ProbeExtensionResult::Type::External;
 }
 
 inline INT64 PEImage::GetSize() const
 {
-    LIMITED_METHOD_CONTRACT;
-    return m_bundleFileLocation.Size;
+    if (IsInBundle())
+        return m_probeExtensionResult.BundleLocation.Size;
+
+    if (IsExternalData())
+        return m_probeExtensionResult.ExternalData.Size;
+
+    // Size is not specified
+    return 0;
 }
 
-inline INT64 PEImage::GetUncompressedSize() const
+inline BOOL PEImage::IsCompressed(INT64* uncompressedSize) const
 {
     LIMITED_METHOD_CONTRACT;
-    return m_bundleFileLocation.UncompresedSize;
+
+    if (uncompressedSize != NULL)
+        *uncompressedSize = IsInBundle() ? m_probeExtensionResult.BundleLocation.UncompressedSize : 0;
+
+    return IsInBundle() && m_probeExtensionResult.BundleLocation.UncompressedSize != 0;
 }
 
 inline void PEImage::SetModuleFileNameHintForDAC()
@@ -108,7 +130,7 @@ inline const SString &PEImage::GetModuleFileNameHintForDAC()
 inline BOOL PEImage::IsFile()
 {
     WRAPPER_NO_CONTRACT;
-    return m_bundleFileLocation.DataStart == nullptr && !GetPathToLoad().IsEmpty();
+    return !IsExternalData() && !GetPathToLoad().IsEmpty();
 }
 
 //
@@ -281,7 +303,7 @@ inline CHECK PEImage::CheckFormat()
     CHECK_OK;
 }
 
-inline void  PEImage::Init(BundleFileLocation bundleFileLocation)
+inline void  PEImage::Init(ProbeExtensionResult probeExtensionResult)
 {
     CONTRACTL
     {
@@ -292,14 +314,14 @@ inline void  PEImage::Init(BundleFileLocation bundleFileLocation)
     CONTRACTL_END;
 
     m_pathHash = m_path.HashCaseInsensitive();
-    m_bundleFileLocation = bundleFileLocation;
+    m_probeExtensionResult = probeExtensionResult;
     SetModuleFileNameHintForDAC();
 }
 #ifndef DACCESS_COMPILE
 
 
 /*static*/
-inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle)
+inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle, BOOL isExternalData)
 {
     CONTRACTL
     {
@@ -307,31 +329,32 @@ inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle)
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pPath));
+        PRECONDITION(!(isInBundle && isExternalData));
         PRECONDITION(s_hashLock.OwnedByCurrentThread());
     }
     CONTRACTL_END;
 
     int CaseHashHelper(const WCHAR *buffer, COUNT_T count);
 
-    PEImageLocator locator(pPath, isInBundle);
+    PEImageLocator locator(pPath, isInBundle, isExternalData);
     DWORD dwHash = CaseHashHelper(pPath, (COUNT_T) u16_strlen(pPath));
     return (PEImage *) s_Images->LookupValue(dwHash, &locator);
 }
 
 /* static */
-inline PTR_PEImage PEImage::OpenImage(LPCWSTR pPath, MDInternalImportFlags flags /* = MDInternalImport_Default */, BundleFileLocation bundleFileLocation /* = BundleFileLocation::Invalid() */)
+inline PTR_PEImage PEImage::OpenImage(LPCWSTR pPath, MDInternalImportFlags flags /* = MDInternalImport_Default */, ProbeExtensionResult probeExtensionResult /* = ProbeExtensionResult::Invalid() */)
 {
     BOOL forbidCache = (flags & MDInternalImport_NoCache);
     if (forbidCache)
     {
         PEImageHolder pImage(new PEImage{pPath});
-        pImage->Init(bundleFileLocation);
+        pImage->Init(probeExtensionResult);
         return dac_cast<PTR_PEImage>(pImage.Extract());
     }
 
     CrstHolder holder(&s_hashLock);
 
-    PEImage* found = FindByPath(pPath, bundleFileLocation.IsValid());
+    PEImage* found = FindByPath(pPath, probeExtensionResult.Type == ProbeExtensionResult::Type::Bundle, probeExtensionResult.Type == ProbeExtensionResult::Type::External);
     if (found == (PEImage*) INVALIDENTRY)
     {
         // We did not find the entry in the Cache, and we've been asked to only use the cache.
@@ -341,7 +364,7 @@ inline PTR_PEImage PEImage::OpenImage(LPCWSTR pPath, MDInternalImportFlags flags
         }
 
         PEImageHolder pImage(new PEImage{pPath});
-        pImage->Init(bundleFileLocation);
+        pImage->Init(probeExtensionResult);
 
         pImage->AddToHashMap();
         return dac_cast<PTR_PEImage>(pImage.Extract());

--- a/src/native/corehost/host_runtime_contract.h
+++ b/src/native/corehost/host_runtime_contract.h
@@ -23,6 +23,7 @@
 #define HOST_PROPERTY_PLATFORM_RESOURCE_ROOTS "PLATFORM_RESOURCE_ROOTS"
 #define HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES "TRUSTED_PLATFORM_ASSEMBLIES"
 
+// Any callbacks set on this contract are expected to be valid for the lifetime of the process
 struct host_runtime_contract
 {
     size_t size;


### PR DESCRIPTION
Undo the revert in https://github.com/dotnet/runtime/pull/113738

https://github.com/dotnet/runtime/commit/0d3c85285b463efb34ac24cfa2a0ab119df2a7cd is the change on top of the original that should address https://github.com/dotnet/source-build/issues/4952.

Make a copy of the host contract information on initialization instead of just operating on a pointer to the struct. This should address intermittent failures on shutdown where a thread is still running after `coreclr_shutdown` has completed and the actual contract struct provided by a host may be cleaned up. The assumption is that any function pointers provided on the host contract at initialization should remain valid for the process lifetime.