### PR TITLE
JIT/x86: Fix reported kill regs for varargs prologs

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5924,11 +5924,11 @@ void CodeGen::genFnProlog()
 
         // MOV EAX, <VARARGS HANDLE>
         assert(compiler->lvaVarargsHandleArg == compiler->info.compArgsCount - 1);
-        GetEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_EAX, compiler->lvaVarargsHandleArg, 0);
-        regSet.verifyRegUsed(REG_EAX);
+        GetEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_SCRATCH, compiler->lvaVarargsHandleArg, 0);
+        regSet.verifyRegUsed(REG_SCRATCH);
 
         // MOV EAX, [EAX]
-        GetEmitter()->emitIns_R_AR(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_EAX, REG_EAX, 0);
+        GetEmitter()->emitIns_R_AR(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_SCRATCH, REG_SCRATCH, 0);
 
         // EDX might actually be holding something here.  So make sure to only use EAX for this code
         // sequence.
@@ -5940,16 +5940,16 @@ void CodeGen::genFnProlog()
         noway_assert(lastArg->lvFramePointerBased);
 
         // LEA EAX, &<VARARGS HANDLE> + EAX
-        GetEmitter()->emitIns_R_ARR(INS_lea, EA_PTRSIZE, REG_EAX, genFramePointerReg(), REG_EAX, offset);
+        GetEmitter()->emitIns_R_ARR(INS_lea, EA_PTRSIZE, REG_SCRATCH, genFramePointerReg(), REG_SCRATCH, offset);
 
         if (varDsc->lvIsInReg())
         {
-            GetEmitter()->emitIns_Mov(INS_mov, EA_PTRSIZE, varDsc->GetRegNum(), REG_EAX, /* canSkip */ true);
+            GetEmitter()->emitIns_Mov(INS_mov, EA_PTRSIZE, varDsc->GetRegNum(), REG_SCRATCH, /* canSkip */ true);
             regSet.verifyRegUsed(varDsc->GetRegNum());
         }
         else
         {
-            GetEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_EAX, argsStartVar, 0);
+            GetEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SCRATCH, argsStartVar, 0);
         }
     }
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2443,6 +2443,15 @@ void LinearScan::buildIntervals()
             // assert(block->isRunRarely());
         }
 
+#ifdef TARGET_X86
+        // On x86 w/ varargs CodeGen::genFnProlog trashs eax register which happens
+        // to be the hidden stub parameter, so mark it as killed here.
+        if ((block == compiler->fgFirstBB) && compiler->info.compIsVarArgs)
+        {
+            addKillForRegs(RBM_EAX, currentLoc + 1);
+        }
+#endif
+
         // For Swift calls there can be an arbitrary amount of codegen related
         // to homing of decomposed struct parameters passed on stack. We cannot
         // do that in the prolog. We handle registers in the prolog and the


### PR DESCRIPTION
PR #100823 stopped the hidden stub arg on x86 from being `do-not-enregister`. There's a code specifically for varargs prologs that depended on that behavior and trashes the EAX register (the same register used for the hidden arg):

https://github.com/dotnet/runtime/blob/1f76c1f47b6a635ceb39f2735f84b0eba8a4bf5c/src/coreclr/jit/codegencommon.cpp#L5925-L5931

Luckily, the bug doesn't manifest because we currenly never pair varargs with `JIT_FLAG_USE_PINVOKE_HELPERS`. This meant that we always emitted call to `CORINFO_HELP_INIT_PINVOKE_FRAME` helper call which also killed the EAX register.