### PR TITLE
JIT: Avoid rare self-edge in register homing

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -3391,7 +3391,10 @@ void CodeGen::genSpillOrAddNonStandardRegisterParam(unsigned lclNum, regNumber s
     {
         RegNode* sourceRegNode = graph->GetOrAdd(sourceReg);
         RegNode* destRegNode   = graph->GetOrAdd(varDsc->GetRegNum());
-        graph->AddEdge(sourceRegNode, destRegNode, TYP_I_IMPL, 0);
+        if (sourceRegNode != destRegNode)
+        {
+            graph->AddEdge(sourceRegNode, destRegNode, TYP_I_IMPL, 0);
+        }
     }
 }
 


### PR DESCRIPTION
Only the secret stub parameter goes through this path to create an edge in the graph, and it was missing a check for whether it was going into the same register as it was in. This would cause register homing to generate unnecessary moves into a temporary register because it thought there was a conflict.

Usually the secret stub parameter has to be allocated to a callee saved variable, so we typically do not see this inefficiency.