### PR TITLE
Cut off deep recursion over arrays

### DIFF
--- a/src/coreclr/tools/Common/Compiler/GenericCycleDetection/ModuleCycleInfo.cs
+++ b/src/coreclr/tools/Common/Compiler/GenericCycleDetection/ModuleCycleInfo.cs
@@ -142,7 +142,20 @@ namespace ILCompiler
                 {
                     case TypeFlags.Array:
                     case TypeFlags.SzArray:
-                        return IsDeepPossiblyCyclicInstantiation(((ParameterizedType)type).ParameterType, ref breadthCounter, seenTypes);
+                        TypeDesc parameterType = type;
+                        int arrayNesting = 0;
+                        do
+                        {
+                            parameterType = ((ParameterizedType)parameterType).ParameterType;
+                            arrayNesting++;
+                        } while (parameterType.IsArray);
+
+                        if (arrayNesting > _depthCutoff)
+                        {
+                            return true;
+                        }
+
+                        return IsDeepPossiblyCyclicInstantiation(parameterType, ref breadthCounter, seenTypes);
                     default:
                         TypeDesc typeDef = type.GetTypeDefinition();
                         if (type != typeDef)

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -3284,6 +3284,7 @@ class Generics
 
         class GenClass<T> { }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static object RecurseOverStruct<T>(int count) where T : new()
         {
             if (count > 0)
@@ -3292,6 +3293,7 @@ class Generics
             return new T();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static object RecurseOverClass<T>(int count) where T : new()
         {
             if (count > 0)
@@ -3299,6 +3301,9 @@ class Generics
 
             return new T();
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int RecurseOverArray<T>(int iter) => iter > 0 ? RecurseOverArray<T[]>(iter - 1) : 0;
 
         public static void Run()
         {
@@ -3324,6 +3329,8 @@ class Generics
 
             if (!caughtException)
                 throw new Exception();
+
+            RecurseOverArray<object>(2);
         }
     }
 


### PR DESCRIPTION
When we hit a generic recursion over arrays, we detect it, but there was no cutoff logic to cut off the expansion. The result is a compile time OOM. This adds a cutoff, using the same cutoff number we use to look for deep generics.

Cc @dotnet/ilc-contrib 