### PR TITLE
Fix resetting for JIT retry

### DIFF
--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -621,7 +621,7 @@ public:
             freeArrayInternal(m_pNativeVarInfo);
     }
 
-    void ResetForJitRetry()
+    virtual void ResetForJitRetry()
     {
         CONTRACTL {
             NOTHROW;
@@ -825,7 +825,7 @@ public:
     void BackoutJitData(EECodeGenManager * jitMgr) override;
     void SetDebugInfo(PTR_BYTE pDebugInfo) override;
 
-    void ResetForJitRetry()
+    void ResetForJitRetry() override
     {
         CONTRACTL {
             NOTHROW;
@@ -1084,16 +1084,6 @@ public:
 
     void BackoutJitData(EECodeGenManager * jitMgr) override;
     void SetDebugInfo(PTR_BYTE pDebugInfo) override;
-
-    void ResetForJitRetry()
-    {
-        CONTRACTL {
-            NOTHROW;
-            GC_NOTRIGGER;
-        } CONTRACTL_END;
-
-        CEECodeGenInfo::ResetForJitRetry();
-    }
 };
 #endif // FEATURE_INTERPRETER
 


### PR DESCRIPTION
I've made a mistake in my recent PR where the `ResetForJitRetry` method on a new base class was not marked as virtual by accident. So the JIT specific version was not executed and part of the state was not reset.

Close #113840