### PR TITLE
Enable SuperPMI replay for APX ISA testing

### DIFF
--- a/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -30,6 +30,7 @@ parameters:
   runtimeVariant: ''
   shouldContinueOnError: false
   SuperPmiCollect: ''
+  SuperPmiReplayType: ''
   SuperPmiDiffType: ''
   SuperPmiBaseJitOptions: ''
   SuperPmiDiffJitOptions: ''
@@ -65,6 +66,7 @@ steps:
       RuntimeFlavor: ${{ parameters.runtimeFlavor }}
       _RuntimeVariant: ${{ parameters.runtimeVariant }}
       _SuperPmiCollect: ${{ parameters.SuperPmiCollect }}
+      _SuperPmiReplayType: ${{ parameters.SuperPmiReplayType }}
       _SuperPmiDiffType: ${{ parameters.SuperPmiDiffType }}
       _SuperPmiBaseJitOptions: ${{ parameters.SuperPmiBaseJitOptions }}
       _SuperPmiDiffJitOptions: ${{ parameters.SuperPmiDiffJitOptions }}

--- a/eng/pipelines/coreclr/superpmi-replay-apx.yml
+++ b/eng/pipelines/coreclr/superpmi-replay-apx.yml
@@ -16,5 +16,4 @@ extends:
   parameters:
     platforms:
     - windows_x64
-    - windows_x86
-    replayType: standard
+    replayType: apx

--- a/eng/pipelines/coreclr/templates/jit-replay-pipeline.yml
+++ b/eng/pipelines/coreclr/templates/jit-replay-pipeline.yml
@@ -1,0 +1,58 @@
+parameters:
+  - name: platforms
+    type: object
+  - name: replayType
+    type: string
+    default: standard
+
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    stages:
+    # Don't run if the JIT-EE GUID has changed,
+    # since there won't be any SuperPMI collections with the new GUID until the collection
+    # pipeline completes after this PR is merged.
+    - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      - stage: EvaluatePaths
+        displayName: Evaluate Paths
+        jobs:
+        - template: /eng/pipelines/common/evaluate-paths-job.yml
+          parameters:
+            paths:
+            - subset: jiteeversionguid
+              include:
+              - src/coreclr/inc/jiteeversionguid.h
+
+    - stage: Build
+      jobs:
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: checked
+          platforms: ${{ parameters.platforms }}
+          jobParameters:
+            buildArgs: -s clr.alljits+clr.spmi -c $(_BuildConfig)
+            postBuildSteps:
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr
+                  includeRootFolder: false
+                  archiveType: $(archiveType)
+                  tarCompression: $(tarCompression)
+                  archiveExtension: $(archiveExtension)
+                  artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+                  displayName: Build Assets
+            condition: not(eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_jiteeversionguid.containsChange'], true))
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/superpmi-replay-job.yml
+          buildConfig: checked
+          platforms: ${{ parameters.platforms }}
+          helixQueueGroup: ci
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            condition: not(eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_jiteeversionguid.containsChange'], true))
+            replayType: ${{ parameters.replayType }}
+            unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)

--- a/eng/pipelines/coreclr/templates/run-superpmi-replay-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-replay-job.yml
@@ -16,6 +16,7 @@ parameters:
   enableTelemetry: false          # optional -- enable for telemetry
   liveLibrariesBuildConfig: ''    # optional -- live-live libraries configuration to use for the run
   helixQueues: ''                 # required -- Helix queues
+  replayType: 'standard'          # required -- 'standard', 'apx'
 
 jobs:
 - template: /eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -47,6 +48,9 @@ jobs:
     - ${{ each variable in parameters.variables }}:
       - ${{insert}}: ${{ variable }}
 
+    - name: replayType
+      value: ${{ parameters.replayType }}
+
     - template: /eng/pipelines/coreclr/templates/jit-python-variables.yml
       parameters:
         osGroup: ${{ parameters.osGroup }}
@@ -74,8 +78,8 @@ jobs:
         mkdir $(SpmiLogsLocation)
       displayName: Create directories
 
-    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi_replay_setup.py -source_directory $(Build.SourcesDirectory) -product_directory $(buildProductRootFolderPath) -arch $(archType)
-      displayName: ${{ format('SuperPMI replay setup ({0})', parameters.archType) }}
+    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/superpmi_replay_setup.py -source_directory $(Build.SourcesDirectory) -product_directory $(buildProductRootFolderPath) -type $(replayType) -arch $(archType)
+      displayName: ${{ format('SuperPMI replay setup ({0} {1})', parameters.replayType, parameters.archType) }}
 
       # Run superpmi replay in helix
     - template: /eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -93,6 +97,7 @@ jobs:
         BuildConfig: ${{ parameters.buildConfig }}
         osGroup: ${{ parameters.osGroup }}
         archType: ${{ parameters.archType }}
+        SuperPmiReplayType: ${{ parameters.replayType }}
 
       # Always upload the available logs for diagnostics
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/superpmi-replay-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-replay-job.yml
@@ -9,12 +9,14 @@ parameters:
   variables: {}
   helixQueues: ''
   runJobTemplate: '/eng/pipelines/coreclr/templates/run-superpmi-replay-job.yml'
+  replayType: 'standard'
+  unifiedArtifactsName: ''
 
 jobs:
 - template: ${{ parameters.runJobTemplate }}
   parameters:
-    jobName: ${{ format('superpmi_replay_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-    displayName: ${{ format('SuperPMI replay {0}{1} {2} {3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    jobName: ${{ format('superpmi_replay_{0}_{1}{2}_{3}_{4}', parameters.replayType, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    displayName: ${{ format('SuperPMI replay {0} {1}{2} {3} {4}', parameters.replayType, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
     pool: ${{ parameters.pool }}
     buildConfig: ${{ parameters.buildConfig }}
     archType: ${{ parameters.archType }}
@@ -23,6 +25,7 @@ jobs:
     condition: ${{ parameters.condition }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     helixQueues: ${{ parameters.helixQueues }}
+    replayType: ${{ parameters.replayType }}
     dependsOn:
       - 'build_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_'
 
@@ -30,11 +33,11 @@ jobs:
 
     steps:
 
-    # Download jit builds
+    # Download builds
     - template: /eng/pipelines/common/download-artifact-step.yml
       parameters:
         unpackFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr
-        artifactFileName: 'CheckedJIT_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)'
-        artifactName: 'CheckedJIT_$(osGroup)$(osSubgroup)_$(archType)'
-        displayName: 'JIT checked build'
+        artifactFileName: '${{ parameters.unifiedArtifactsName }}$(archiveExtension)'
+        artifactName: '${{ parameters.unifiedArtifactsName }}'
+        displayName: 'unified artifacts'
         cleanUnpackFolder: false

--- a/src/coreclr/scripts/superpmi-replay.proj
+++ b/src/coreclr/scripts/superpmi-replay.proj
@@ -25,10 +25,16 @@
   </Target> -->
 
   <PropertyGroup>
+    <!-- Default to standard type -->
+    <SuperPmiReplayType Condition=" '$(_SuperPmiReplayType)' == '' ">standard</SuperPmiReplayType>
+    <SuperPmiReplayType Condition=" '$(_SuperPmiReplayType)' != '' ">$(_SuperPmiReplayType)</SuperPmiReplayType>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <Python>%HELIX_PYTHONPATH%</Python>
     <ProductDirectory>%HELIX_CORRELATION_PAYLOAD%</ProductDirectory>
     <SuperpmiLogsLocation>%HELIX_WORKITEM_UPLOAD_ROOT%</SuperpmiLogsLocation>
-    <WorkItemCommand>$(Python) $(ProductDirectory)\superpmi_replay.py -jit_directory $(ProductDirectory)</WorkItemCommand>
+    <WorkItemCommand>$(Python) $(ProductDirectory)\superpmi_replay.py -type $(SuperPmiReplayType) -jit_directory $(ProductDirectory)</WorkItemCommand>
     <WorkItemTimeout>3:15</WorkItemTimeout>
   </PropertyGroup>
 
@@ -49,7 +55,7 @@
     </HelixCorrelationPayload>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Architecture)' == 'x64'">
+  <ItemGroup Condition="'$(SuperPmiReplayType)' == 'standard' and '$(Architecture)' == 'x64'">
     <SPMI_Partition Include="windows-x64-1" Platform="windows" Architecture="x64" Partition="1" PartitionCount="9"/>
     <SPMI_Partition Include="windows-x64-2" Platform="windows" Architecture="x64" Partition="2" PartitionCount="9"/>
     <SPMI_Partition Include="windows-x64-3" Platform="windows" Architecture="x64" Partition="3" PartitionCount="9"/>
@@ -97,7 +103,7 @@
     <SPMI_Partition Include="osx-arm64-9" Platform="osx" Architecture="arm64" Partition="9" PartitionCount="9"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Architecture)' == 'x86'">
+  <ItemGroup Condition="'$(SuperPmiReplayType)' == 'standard' and '$(Architecture)' == 'x86'">
     <SPMI_Partition Include="windows-x86-1" Platform="windows" Architecture="x86" Partition="1" PartitionCount="9"/>
     <SPMI_Partition Include="windows-x86-2" Platform="windows" Architecture="x86" Partition="2" PartitionCount="9"/>
     <SPMI_Partition Include="windows-x86-3" Platform="windows" Architecture="x86" Partition="3" PartitionCount="9"/>
@@ -118,11 +124,26 @@
     <SPMI_Partition Include="linux-arm-9" Platform="linux" Architecture="arm" Partition="9" PartitionCount="9"/>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SuperPmiReplayType)' == 'apx' and '$(Architecture)' == 'x64'">
+    <SPMI_Partition Include="windows-x64-1" Platform="windows" Architecture="x64" Partition="1" PartitionCount="6"/>
+    <SPMI_Partition Include="windows-x64-2" Platform="windows" Architecture="x64" Partition="2" PartitionCount="6"/>
+    <SPMI_Partition Include="windows-x64-3" Platform="windows" Architecture="x64" Partition="3" PartitionCount="6"/>
+    <SPMI_Partition Include="windows-x64-4" Platform="windows" Architecture="x64" Partition="4" PartitionCount="6"/>
+    <SPMI_Partition Include="windows-x64-5" Platform="windows" Architecture="x64" Partition="5" PartitionCount="6"/>
+    <SPMI_Partition Include="windows-x64-6" Platform="windows" Architecture="x64" Partition="6" PartitionCount="6"/>
+    <SPMI_Partition Include="linux-x64-1" Platform="linux" Architecture="x64" Partition="1" PartitionCount="6"/>
+    <SPMI_Partition Include="linux-x64-2" Platform="linux" Architecture="x64" Partition="2" PartitionCount="6"/>
+    <SPMI_Partition Include="linux-x64-3" Platform="linux" Architecture="x64" Partition="3" PartitionCount="6"/>
+    <SPMI_Partition Include="linux-x64-4" Platform="linux" Architecture="x64" Partition="4" PartitionCount="6"/>
+    <SPMI_Partition Include="linux-x64-5" Platform="linux" Architecture="x64" Partition="5" PartitionCount="6"/>
+    <SPMI_Partition Include="linux-x64-6" Platform="linux" Architecture="x64" Partition="6" PartitionCount="6"/>
+  </ItemGroup>
+
   <ItemGroup>
     <HelixWorkItem Include="@(SPMI_Partition)">
       <Command>$(WorkItemCommand) -arch %(HelixWorkItem.Architecture) -platform %(HelixWorkItem.Platform) -partition %(HelixWorkItem.Partition) -partition_count %(HelixWorkItem.PartitionCount) -log_directory $(SuperpmiLogsLocation)</Command>
       <Timeout>$(WorkItemTimeout)</Timeout>
-      <DownloadFilesFromResults>superpmi_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture)_%(HelixWorkItem.Partition).log</DownloadFilesFromResults>
+      <DownloadFilesFromResults>superpmi_final_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture)_%(HelixWorkItem.Partition).log</DownloadFilesFromResults>
     </HelixWorkItem>
   </ItemGroup>
   </Project>

--- a/src/coreclr/scripts/superpmi_replay_setup.py
+++ b/src/coreclr/scripts/superpmi_replay_setup.py
@@ -22,8 +22,9 @@ from jitutil import copy_directory, copy_files, set_pipeline_variable
 parser = argparse.ArgumentParser(description="description")
 
 parser.add_argument("-arch", help="Architecture")
-parser.add_argument("-source_directory", help="path to the directory containing binaries")
-parser.add_argument("-product_directory", help="path to the directory containing binaries")
+parser.add_argument("-type", required=True, help="Type of diff (standard, apx)")
+parser.add_argument("-source_directory", required=True, help="Path to the root directory of the dotnet/runtime source tree")
+parser.add_argument("-product_directory", required=True, help="path to the directory containing binaries")
 
 
 def setup_args(args):
@@ -53,6 +54,11 @@ def setup_args(args):
                         "product_directory",
                         lambda product_directory: os.path.isdir(product_directory),
                         "product_directory doesn't exist")
+
+    coreclr_args.verify(args,
+                        "type",
+                        lambda type: type in ["standard", "apx"],
+                        "Invalid type \"{}\"".format)
 
     return coreclr_args
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -7499,7 +7499,7 @@ MethodContext::Environment MethodContext::cloneEnvironment()
     }
     if (GetStringConfigValue != nullptr)
     {
-        env.getStingConfigValue = new LightWeightMap<DWORD, DWORD>(*GetStringConfigValue);
+        env.getStringConfigValue = new LightWeightMap<DWORD, DWORD>(*GetStringConfigValue);
     }
     return env;
 }
@@ -7525,7 +7525,7 @@ bool MethodContext::IsEnvironmentHeaderEqual(const Environment& prevEnv)
     {
         return false;
     }
-    if (!AreLWMHeadersEqual(prevEnv.getStingConfigValue, GetStringConfigValue))
+    if (!AreLWMHeadersEqual(prevEnv.getStringConfigValue, GetStringConfigValue))
     {
         return false;
     }
@@ -7539,7 +7539,7 @@ bool MethodContext::IsEnvironmentContentEqual(const Environment& prevEnv)
     {
         return false;
     }
-    if (!IsStringContentEqual(prevEnv.getStingConfigValue, GetStringConfigValue))
+    if (!IsStringContentEqual(prevEnv.getStringConfigValue, GetStringConfigValue))
     {
         return false;
     }

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.h
@@ -915,12 +915,12 @@ public:
 
     struct Environment
     {
-        Environment() : getIntConfigValue(nullptr), getStingConfigValue(nullptr)
+        Environment() : getIntConfigValue(nullptr), getStringConfigValue(nullptr)
         {
         }
 
         LightWeightMap<Agnostic_ConfigIntInfo, DWORD>* getIntConfigValue;
-        LightWeightMap<DWORD, DWORD>*                  getStingConfigValue;
+        LightWeightMap<DWORD, DWORD>*                  getStringConfigValue;
     };
 
     Environment cloneEnvironment();

--- a/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
@@ -1544,16 +1544,7 @@ void MyICJI::updateEntryPointForTailCall(CORINFO_CONST_LOOKUP* entryPoint)
 uint32_t MyICJI::getJitFlags(CORJIT_FLAGS* jitFlags, uint32_t sizeInBytes)
 {
     jitInstance->mc->cr->AddCall("getJitFlags");
-    uint32_t ret = jitInstance->mc->repGetJitFlags(jitFlags, sizeInBytes);
-    if (jitInstance->forceClearAltJitFlag)
-    {
-        jitFlags->Clear(CORJIT_FLAGS::CORJIT_FLAG_ALT_JIT);
-    }
-    else if (jitInstance->forceSetAltJitFlag)
-    {
-        jitFlags->Set(CORJIT_FLAGS::CORJIT_FLAG_ALT_JIT);
-    }
-    return ret;
+    return jitInstance->getJitFlags(jitFlags, sizeInBytes);
 }
 
 // Runs the given function with the given parameter under an error trap

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -56,8 +56,8 @@ JitInstance* JitInstance::InitJit(char*                         nameOfJit,
         }
     }
 
-    jit->environment.getIntConfigValue   = nullptr;
-    jit->environment.getStingConfigValue = nullptr;
+    jit->environment.getIntConfigValue    = nullptr;
+    jit->environment.getStringConfigValue = nullptr;
 
     if (st1 != nullptr)
         st1->Start();
@@ -244,7 +244,7 @@ ReplayResults JitInstance::CompileMethod(MethodContext* MethodToCompile, int mcI
 
         pParam->pThis->mc->repCompileMethod(&pParam->info, &pParam->flags, &os);
         CORJIT_FLAGS jitFlags;
-        pParam->pThis->mc->repGetJitFlags(&jitFlags, sizeof(jitFlags));
+        pParam->pThis->getJitFlags(&jitFlags, sizeof(jitFlags));
 
         pParam->results.IsMinOpts =
             jitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE) ||
@@ -308,6 +308,17 @@ ReplayResults JitInstance::CompileMethod(MethodContext* MethodToCompile, int mcI
             if (!matchesTargetArch)
             {
                 jitResult = CORJIT_OK;
+            }
+            else
+            {
+                // If the target matches, but the JIT is an altjit and the user specified RunAltJitCode=0,
+                // then the JIT will also return CORJIT_SKIPPED, to prevent the generated code from being used.
+                // However, we don't want to treat that as a replay failure.
+                if (jitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_ALT_JIT) &&
+                    (pParam->pThis->jitHost->getIntConfigValue("RunAltJitCode", 1) == 0))
+                {
+                    jitResult = CORJIT_OK;
+                }
             }
         }
 
@@ -445,6 +456,22 @@ const char* JitInstance::getOption(const char* key, LightWeightMap<DWORD, DWORD>
     return (const char*)options->GetBuffer(options->Get(keyIndex));
 }
 
+// Returns extended flags for a particular compilation instance, adjusted for altjit.
+// This is a helper call; it does not record the call in the CompileResult.
+uint32_t JitInstance::getJitFlags(CORJIT_FLAGS* jitFlags, uint32_t sizeInBytes)
+{
+    uint32_t ret = mc->repGetJitFlags(jitFlags, sizeInBytes);
+    if (forceClearAltJitFlag)
+    {
+        jitFlags->Clear(CORJIT_FLAGS::CORJIT_FLAG_ALT_JIT);
+    }
+    else if (forceSetAltJitFlag)
+    {
+        jitFlags->Set(CORJIT_FLAGS::CORJIT_FLAG_ALT_JIT);
+    }
+    return ret;
+}
+
 // Used to allocate memory that needs to handed to the EE.
 // For eg, use this to allocated memory for reporting debug info,
 // which will be handed to the EE by setVars() and setBoundaries()
@@ -507,7 +534,7 @@ bool JitInstance::callJitStartup(ICorJitHost* jithost)
     }
     PAL_ENDTRY
 
-    Assert(environment.getIntConfigValue == nullptr && environment.getStingConfigValue == nullptr);
+    Assert(environment.getIntConfigValue == nullptr && environment.getStringConfigValue == nullptr);
     environment = mc->cloneEnvironment();
 
     return param.result;
@@ -527,10 +554,10 @@ bool JitInstance::resetConfig(MethodContext* firstContext)
         environment.getIntConfigValue = nullptr;
     }
 
-    if (environment.getStingConfigValue != nullptr)
+    if (environment.getStringConfigValue != nullptr)
     {
-        delete environment.getStingConfigValue;
-        environment.getStingConfigValue = nullptr;
+        delete environment.getStringConfigValue;
+        environment.getStringConfigValue = nullptr;
     }
 
     mc                   = firstContext;

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.h
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.h
@@ -72,6 +72,8 @@ public:
     const char* getOption(const char* key);
     const char* getOption(const char* key, LightWeightMap<DWORD, DWORD>* options);
 
+    uint32_t getJitFlags(CORJIT_FLAGS* jitFlags, uint32_t sizeInBytes);
+
     const MethodContext::Environment& getEnvironment();
 
     void* allocateArray(size_t size);


### PR DESCRIPTION
Create a new `runtime-coreclr superpmi-replay-apx` pipeline that
does SuperPMI replay using AltJit with various APX enabling configuration
options set. This enables some amount of APX testing even without
hardware available to run the generated code.

Notes:
1. Create a new jit-replay-pipeline.yml template to share the
   superpmi-replay pipeline implementation with the existing pipeline.
2. The existing pipeline is designated the "standard" replay type and
   the new pipeline the "apx" replay type.
3. The APX pipeline does replays for Windows x64 and Linux x64.
4. The configurations tested are:
```
a. "EnableAPX=1"
b. "EnableAPX=1", "EnableApxNDD=1"
c. "EnableAPX=1", "JitStressRex2Encoding=1"
d. "EnableAPX=1", "JitStressPromotedEvexEncoding=1"
e. "EnableAPX=1", "JitStressRegs=4000"
f. "EnableAPX=1", "EnableApxNDD=1", "JitStressRex2Encoding=1", "JitStressPromotedEvexEncoding=1", "JitStressRegs=4000"
```
All configurations pass `--altjit` to superpmi.py to set the AltJit variables, as well as
setting "RunAltJitCode=0" which causes all enabled ISAs to be enabled.
5. Change superpmi to no fail altjit compiles when RunAltJitCode=0 is set. With RunAltJitCode=0, the JIT returns CORJIT_SKIPPED. We don't want superpmi to fail these compiles.
6. nit: fixed typo in superpmi of getStingConfigValue => getStringConfigValue
