### PR TITLE
Use dotnet-install script directly from CDN instead of dot.net

### DIFF
--- a/eng/docker/libraries-sdk.linux.Dockerfile
+++ b/eng/docker/libraries-sdk.linux.Dockerfile
@@ -20,7 +20,7 @@ ENV _DOTNET_INSTALL_CHANNEL=$VERSION
 RUN rm -rf /usr/share/dotnet
 
 # Install latest daily SDK:
-RUN wget https://dot.net/v1/dotnet-install.sh
+RUN wget https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh
 RUN bash ./dotnet-install.sh --channel $_DOTNET_INSTALL_CHANNEL --quality daily --install-dir /usr/share/dotnet
 
 # Collect the following artifacts under /live-runtime-artifacts,

--- a/eng/docker/libraries-sdk.windows.Dockerfile
+++ b/eng/docker/libraries-sdk.windows.Dockerfile
@@ -14,7 +14,7 @@ USER ContainerAdministrator
 # remove the existing ASP.NET SDK, we want to keep only the latest one we download later
 RUN Remove-Item -Force -Recurse 'C:/Program Files/dotnet/shared/Microsoft.AspNetCore.App/*'
 
-RUN Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile .\dotnet-install.ps1
+RUN Invoke-WebRequest -Uri https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1 -OutFile .\dotnet-install.ps1
 RUN & .\dotnet-install.ps1 -Channel $env:_DOTNET_INSTALL_CHANNEL -Quality daily -InstallDir 'C:/Program Files/dotnet'
 
 USER ContainerUser

--- a/src/libraries/Common/tests/System/Net/StressTests/build-local.ps1
+++ b/src/libraries/Common/tests/System/Net/StressTests/build-local.ps1
@@ -49,7 +49,7 @@ if (-not (Test-Path -Path $TestHostRoot)) {
 if (-not (Test-Path -Path $DailyDotnetRoot)) {
     Write-Host "Downloading daily SDK to: $DailyDotnetRoot"
     New-Item -ItemType Directory -Path $DailyDotnetRoot
-    Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile "$DailyDotnetRoot\dotnet-install.ps1"
+    Invoke-WebRequest -Uri https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1 -OutFile "$DailyDotnetRoot\dotnet-install.ps1"
     & "$DailyDotnetRoot\dotnet-install.ps1" -NoPath -Channel $Version -Quality daily -InstallDir $DailyDotnetRoot
 } else {
     Write-Host "Daily SDK found in $DailyDotnetRoot"

--- a/src/libraries/Common/tests/System/Net/StressTests/build-local.sh
+++ b/src/libraries/Common/tests/System/Net/StressTests/build-local.sh
@@ -48,7 +48,7 @@ fi
 if [[ ! -d $daily_dotnet_root ]]; then
     echo "Downloading daily SDK to $daily_dotnet_root"
     mkdir $daily_dotnet_root
-    wget https://dot.net/v1/dotnet-install.sh -O $daily_dotnet_root/dotnet-install.sh
+    wget https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh -O $daily_dotnet_root/dotnet-install.sh
     bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version --quality daily --install-dir $daily_dotnet_root
 else
     echo "Daily SDK found in $daily_dotnet_root"

--- a/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
@@ -79,7 +79,7 @@
     <RemoveDir Directories="$(_SdkWithNoWorkloadPath)" />
     <MakeDir Directories="$(_SdkWithNoWorkloadPath)" />
 
-    <DownloadFile SourceUrl="https://dot.net/v1/$(_DotNetInstallScriptName)"
+    <DownloadFile SourceUrl="https://builds.dotnet.microsoft.com/dotnet/scripts/v1/$(_DotNetInstallScriptName)"
                   DestinationFolder="$(ArtifactsObjDir)"
                   Retries="3"
                   Condition="!Exists($(_DotNetInstallScriptPath))"/>


### PR DESCRIPTION
The dot.net redirector is currently having issues, we should be using the script directly from the CDN anyway.