### PR TITLE
[APX] Make sure KMOV is not encoded in EVEX when JitStressEvexEncoding is set.

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -141,6 +141,38 @@ bool emitter::IsPermuteVar2xInstruction(instruction ins)
     }
 }
 
+//------------------------------------------------------------------------
+// IsPermuteVar2xInstruction: Is this an Avx512 KMOV instruction?
+//
+// Arguments:
+//    ins - The instruction to check.
+//
+// Returns:
+//    `true` if it is a KMOV instruction.
+//
+bool emitter::IsKMOVInstruction(instruction ins)
+{
+    switch (ins)
+    {
+        case INS_kmovb_gpr:
+        case INS_kmovw_gpr:
+        case INS_kmovd_gpr:
+        case INS_kmovq_gpr:
+        case INS_kmovb_msk:
+        case INS_kmovw_msk:
+        case INS_kmovd_msk:
+        case INS_kmovq_msk:
+        {
+            return true;
+        }
+
+        default:
+        {
+            return false;
+        }
+    }
+}
+
 regNumber emitter::getBmiRegNumber(instruction ins)
 {
     switch (ins)
@@ -1717,8 +1749,7 @@ bool emitter::TakesEvexPrefix(const instrDesc* id) const
         // Requires the EVEX encoding due to used registers
         // A special case here is KMOV, the original KMOV introduced in Avx512 can only be encoded in VEX, APX promoted
         // them to EVEX, so only return true when APX is available.
-        if ((ins == INS_kmovb_msk) || (ins == INS_kmovw_msk) || (ins == INS_kmovd_msk) || (ins == INS_kmovq_msk) ||
-            (ins == INS_kmovb_gpr) || (ins == INS_kmovw_gpr) || (ins == INS_kmovd_gpr) || (ins == INS_kmovq_gpr))
+        if (IsKMOVInstruction(ins))
         {
             // Use EVEX only when needed.
             return HasExtendedGPReg(id);
@@ -1757,6 +1788,13 @@ bool emitter::TakesEvexPrefix(const instrDesc* id) const
             return false;
         }
 
+        if (IsKMOVInstruction(ins))
+        {
+            // KMOV should not be encoded in EVEX when stressing EVEX, as they are supposed to encded in EVEX only
+            // when APX is available, only stressing EVEX is not enough making the encoding valid.
+            return false;
+        }
+
         // Requires the EVEX encoding due to STRESS mode and no change in semantics
         //
         // Some instructions, like VCMPEQW return the value in a SIMD register for
@@ -1769,7 +1807,17 @@ bool emitter::TakesEvexPrefix(const instrDesc* id) const
     if (IsApxExtendedEvexInstruction(ins) && emitComp->DoJitStressPromotedEvexEncoding())
     {
         // This path will be hit when we stress APX-EVEX and encode VEX with Extended EVEX.
-        return (IsBMIInstruction(ins) && HasApxNf(ins));
+        if (IsKMOVInstruction(ins))
+        {
+            return true;
+        }
+
+        if (IsBMIInstruction(ins))
+        {
+            return HasApxNf(ins);
+        }
+
+        return false;
     }
 #endif // DEBUG
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -142,7 +142,7 @@ bool emitter::IsPermuteVar2xInstruction(instruction ins)
 }
 
 //------------------------------------------------------------------------
-// IsPermuteVar2xInstruction: Is this an Avx512 KMOV instruction?
+// IsKMOVInstruction: Is this an Avx512 KMOV instruction?
 //
 // Arguments:
 //    ins - The instruction to check.

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -124,6 +124,7 @@ static bool IsAVXOnlyInstruction(instruction ins);
 static bool IsAvx512OnlyInstruction(instruction ins);
 static bool IsFMAInstruction(instruction ins);
 static bool IsPermuteVar2xInstruction(instruction ins);
+static bool IsKMOVInstruction(instruction ins);
 static bool IsAVXVNNIInstruction(instruction ins);
 static bool IsBMIInstruction(instruction ins);
 static bool IsKInstruction(instruction ins);


### PR DESCRIPTION
Fix #113814

`KMOV` instructions will be able to be encoded in EVEX on APX enabled machine to address EGPRs, but on Avx512 machine, they can only be encoded in VEX.

we should ensure KMOV has the right prefix under different cases, essentially in the bug, we are stressing original EVEX encoding by `JitStressEvexEncoding`. So `KMOV` should not be impacted and stay VEX-encoded.