### PR TITLE
Remove most usages of the macro-based "don't return in this block" hack

### DIFF
--- a/src/coreclr/inc/clrhost.h
+++ b/src/coreclr/inc/clrhost.h
@@ -44,16 +44,6 @@ private:
     DWORD m_dwLastError;
 };
 
-
-#define BEGIN_PRESERVE_LAST_ERROR \
-    { \
-        PreserveLastErrorHolder __preserveLastErrorHolder; \
-        {
-
-#define END_PRESERVE_LAST_ERROR \
-        } \
-    }
-
 //
 // TRASH_LASTERROR macro sets bogus last error in debug builds to help find places that fail to save it
 //

--- a/src/coreclr/inc/clrhost.h
+++ b/src/coreclr/inc/clrhost.h
@@ -29,16 +29,29 @@ using std::nothrow;
 #define _DEBUG_IMPL 1
 #endif
 
+struct PreserveLastErrorHolder
+{
+    PreserveLastErrorHolder()
+    {
+        m_dwLastError = ::GetLastError();
+    }
+
+    ~PreserveLastErrorHolder()
+    {
+        ::SetLastError(m_dwLastError);
+    }
+private:
+    DWORD m_dwLastError;
+};
+
+
 #define BEGIN_PRESERVE_LAST_ERROR \
     { \
-        DWORD __dwLastError = ::GetLastError(); \
-        DEBUG_ASSURE_NO_RETURN_BEGIN(PRESERVE_LAST_ERROR); \
-            {
+        PreserveLastErrorHolder __preserveLastErrorHolder; \
+        {
 
 #define END_PRESERVE_LAST_ERROR \
-            } \
-        DEBUG_ASSURE_NO_RETURN_END(PRESERVE_LAST_ERROR); \
-        ::SetLastError(__dwLastError); \
+        } \
     }
 
 //

--- a/src/coreclr/inc/contract.h
+++ b/src/coreclr/inc/contract.h
@@ -1160,7 +1160,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
     Contract::RanPostconditions ___ran(__FUNCTION__);                   \
     Contract::Operation ___op = Contract::Setup;                        \
     BOOL ___contract_enabled = FALSE;                                   \
-    DEBUG_ASSURE_NO_RETURN_BEGIN(CONTRACT)                              \
     ___contract_enabled = Contract::EnforceContract();                  \
     enum {___disabled = 0};                                             \
     if (!___contract_enabled)                                           \
@@ -1181,10 +1180,8 @@ typedef __SafeToUsePostCondition __PostConditionOK;
             }                                                           \
             else                                                        \
             {                                                           \
-                DEBUG_OK_TO_RETURN_BEGIN(CONTRACT)                      \
               ___run_return:                                            \
                 return _returnexp;                                      \
-                DEBUG_OK_TO_RETURN_END(CONTRACT)                        \
             }                                                           \
         }                                                               \
         if (0)                                                          \
@@ -1226,7 +1223,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
         Contract::Returner<_returntype> ___returner(RETVAL);                \
         Contract::RanPostconditions ___ran(__FUNCTION__);                   \
         Contract::Operation ___op = Contract::Setup;                        \
-        DEBUG_ASSURE_NO_RETURN_BEGIN(CONTRACT)                              \
         BOOL ___contract_enabled = Contract::EnforceContract();             \
         enum {___disabled = 0};                                             \
         {                                                                   \
@@ -1244,10 +1240,8 @@ typedef __SafeToUsePostCondition __PostConditionOK;
                 }                                                           \
                 else                                                        \
                 {                                                           \
-                    DEBUG_OK_TO_RETURN_BEGIN(CONTRACT)                      \
                   ___run_return:                                            \
                     return _returnexp;                                      \
-                    DEBUG_OK_TO_RETURN_END(CONTRACT)                        \
                 }                                                           \
             }                                                               \
             if (0)                                                          \
@@ -1679,7 +1673,6 @@ public:
     {                                                                       \
         ContractViolationHolder<violationmask> __violationHolder_onlyOneAllowedPerScope;   \
         __violationHolder_onlyOneAllowedPerScope.Enter();                   \
-        DEBUG_ASSURE_NO_RETURN_BEGIN(CONTRACT)                              \
 
 // Use this to jump out prematurely from a violation.  Used for EH
 // when the function might not return

--- a/src/coreclr/inc/contract.h
+++ b/src/coreclr/inc/contract.h
@@ -1454,8 +1454,7 @@ typedef __SafeToUsePostCondition __PostConditionOK;
 
 #endif // __FORCE_NORUNTIME_CONTRACTS__
 
-#define CONTRACT_END   CONTRACTL_END                                                        \
-   DEBUG_ASSURE_NO_RETURN_END(CONTRACT)                                                     \
+#define CONTRACT_END   CONTRACTL_END
 
 
 // The final expression in the RETURN macro deserves special explanation (or something.)
@@ -1680,7 +1679,6 @@ public:
         __violationHolder_onlyOneAllowedPerScope.Leave();                   \
 
 #define END_CONTRACT_VIOLATION                                              \
-        DEBUG_ASSURE_NO_RETURN_END(CONTRACT)                                \
         __violationHolder_onlyOneAllowedPerScope.Leave();                   \
     }                                                                       \
 

--- a/src/coreclr/inc/debugreturn.h
+++ b/src/coreclr/inc/debugreturn.h
@@ -18,9 +18,6 @@
 #define DEBUG_ASSURE_NO_RETURN_BEGIN(arg)    { char* __noReturnInThisBlock_##arg = ::new (nothrow) char[1];
 #define DEBUG_ASSURE_NO_RETURN_END(arg)      ::delete[] __noReturnInThisBlock_##arg; }
 
-#define DEBUG_OK_TO_RETURN_BEGIN(arg)        { ::delete[] __noReturnInThisBlock_##arg;
-#define DEBUG_OK_TO_RETURN_END(arg)          __noReturnInThisBlock_##arg = ::new (nothrow) char[1]; }
-
 #define DEBUG_ASSURE_SAFE_TO_RETURN TRUE
 #define return return
 
@@ -104,18 +101,12 @@ typedef __SafeToReturn __ReturnOK;
 #define DEBUG_ASSURE_NO_RETURN_BEGIN(arg) { typedef __YouCannotUseAReturnStatementHere __ReturnOK; if (0 && __ReturnOK::used()) { } else {
 #define DEBUG_ASSURE_NO_RETURN_END(arg)   } }
 
-#define DEBUG_OK_TO_RETURN_BEGIN(arg) { typedef __SafeToReturn __ReturnOK; if (0 && __ReturnOK::used()) { } else {
-#define DEBUG_OK_TO_RETURN_END(arg) } }
-
 #else // defined(_DEBUG) && !defined(JIT_BUILD) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024315)
 
 #define DEBUG_ASSURE_SAFE_TO_RETURN TRUE
 
 #define DEBUG_ASSURE_NO_RETURN_BEGIN(arg) {
 #define DEBUG_ASSURE_NO_RETURN_END(arg) }
-
-#define DEBUG_OK_TO_RETURN_BEGIN(arg) {
-#define DEBUG_OK_TO_RETURN_END(arg) }
 
 #endif // defined(_DEBUG) && !defined(JIT_BUILD) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024315)
 

--- a/src/coreclr/vm/FrameTypes.h
+++ b/src/coreclr/vm/FrameTypes.h
@@ -47,8 +47,5 @@ FRAME_TYPE_NAME(DebuggerClassInitMarkFrame)
 FRAME_TYPE_NAME(DebuggerExitFrame)
 FRAME_TYPE_NAME(DebuggerU2MCatchHandlerFrame)
 FRAME_TYPE_NAME(ExceptionFilterFrame)
-#if defined(_DEBUG)
-FRAME_TYPE_NAME(AssumeByrefFromJITStackFrame)
-#endif // _DEBUG
 
 #undef FRAME_TYPE_NAME

--- a/src/coreclr/vm/callcounting.cpp
+++ b/src/coreclr/vm/callcounting.cpp
@@ -760,7 +760,7 @@ PCODE CallCountingManager::OnCallCountThresholdReached(TransitionBlock *transiti
 
     PCODE codeEntryPoint = 0;
 
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
     MAKE_CURRENT_THREAD_AVAILABLE();
 
@@ -822,8 +822,6 @@ PCODE CallCountingManager::OnCallCountThresholdReached(TransitionBlock *transiti
     UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
 
     frame->Pop(CURRENT_THREAD);
-
-    END_PRESERVE_LAST_ERROR;
 
     return codeEntryPoint;
 }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2522,7 +2522,7 @@ extern "C" PT_RUNTIME_FUNCTION GetRuntimeFunctionCallback(IN ULONG     ControlPc
     PT_RUNTIME_FUNCTION prf = NULL;
 
     // We must preserve this so that GCStress=4 eh processing doesnt kill last error.
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
 #ifdef ENABLE_CONTRACTS
     // Some 64-bit OOM tests use the hosting interface to re-enter the CLR via
@@ -2544,8 +2544,6 @@ extern "C" PT_RUNTIME_FUNCTION GetRuntimeFunctionCallback(IN ULONG     ControlPc
         prf = codeInfo.GetFunctionEntry();
 
     LOG((LF_EH, LL_INFO1000000, "GetRuntimeFunctionCallback(%p) returned %p\n", ControlPc, prf));
-
-    END_PRESERVE_LAST_ERROR;
 
     return  prf;
 }
@@ -4379,7 +4377,7 @@ extern "C" void GetRuntimeStackWalkInfo(IN  ULONG64   ControlPc,
 
     WRAPPER_NO_CONTRACT;
 
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
     if (pModuleBase)
         *pModuleBase = 0;
@@ -4392,7 +4390,7 @@ extern "C" void GetRuntimeStackWalkInfo(IN  ULONG64   ControlPc,
 #if defined(DACCESS_COMPILE)
         GetUnmanagedStackWalkInfo(ControlPc, pModuleBase, pFuncEntry);
 #endif // DACCESS_COMPILE
-        goto Exit;
+        return;
     }
 
     if (pModuleBase)
@@ -4404,10 +4402,6 @@ extern "C" void GetRuntimeStackWalkInfo(IN  ULONG64   ControlPc,
     {
         *pFuncEntry = (UINT_PTR)(PT_RUNTIME_FUNCTION)codeInfo.GetFunctionEntry();
     }
-
-Exit:
-    ;
-    END_PRESERVE_LAST_ERROR;
 }
 #endif // FEATURE_EH_FUNCLETS
 

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -5828,7 +5828,7 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
 {
     LPVOID ret = NULL;
 
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
     CONTRACTL
     {
@@ -5879,8 +5879,6 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
     UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
     UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
 
-    END_PRESERVE_LAST_ERROR;
-
     return ret;
 }
 
@@ -5891,7 +5889,7 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
 
 EXTERN_C void STDCALL VarargPInvokeStubWorker(TransitionBlock * pTransitionBlock, VASigCookie *pVASigCookie, MethodDesc *pMD)
 {
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
@@ -5915,13 +5913,11 @@ EXTERN_C void STDCALL VarargPInvokeStubWorker(TransitionBlock * pTransitionBlock
     GetILStubForCalli(pVASigCookie, pMD);
 
     pFrame->Pop(CURRENT_THREAD);
-
-    END_PRESERVE_LAST_ERROR;
 }
 
 EXTERN_C void STDCALL GenericPInvokeCalliStubWorker(TransitionBlock * pTransitionBlock, VASigCookie * pVASigCookie, PCODE pUnmanagedTarget)
 {
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
@@ -5944,8 +5940,6 @@ EXTERN_C void STDCALL GenericPInvokeCalliStubWorker(TransitionBlock * pTransitio
     GetILStubForCalli(pVASigCookie, NULL);
 
     pFrame->Pop(CURRENT_THREAD);
-
-    END_PRESERVE_LAST_ERROR;
 }
 
 PCODE GetILStubForCalli(VASigCookie *pVASigCookie, MethodDesc *pMD)

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -5896,9 +5896,10 @@ bool IsGcMarker(CONTEXT* pContext, EXCEPTION_RECORD *pExceptionRecord)
         {
             // GCStress processing can disturb last error, so preserve it.
             BOOL res;
-            BEGIN_PRESERVE_LAST_ERROR;
-            res = OnGcCoverageInterrupt(pContext);
-            END_PRESERVE_LAST_ERROR;
+            {
+                PreserveLastErrorHolder preserveLastError;
+                res = OnGcCoverageInterrupt(pContext);
+            }
             if (res)
             {
                 return true;

--- a/src/coreclr/vm/exceptmacros.h
+++ b/src/coreclr/vm/exceptmacros.h
@@ -501,6 +501,7 @@ void COMPlusCooperativeTransitionHandler(Frame* pFrame);
         CoopTransitionHolder __CoopTransition(CURRENT_THREAD);
 
 #define COOPERATIVE_TRANSITION_END()                \
+        __CoopTransition.SuppressRelease();         \
     }                                               \
     END_GCX_ASSERT_PREEMP;                          \
   }

--- a/src/coreclr/vm/exceptmacros.h
+++ b/src/coreclr/vm/exceptmacros.h
@@ -500,12 +500,11 @@ void COMPlusCooperativeTransitionHandler(Frame* pFrame);
   {                                                 \
     MAKE_CURRENT_THREAD_AVAILABLE();                \
     BEGIN_GCX_ASSERT_PREEMP;                        \
-    CoopTransitionHolder __CoopTransition(CURRENT_THREAD); \
-    DEBUG_ASSURE_NO_RETURN_BEGIN(COOP_TRANSITION)
+    {                                               \
+        CoopTransitionHolder __CoopTransition(CURRENT_THREAD);
 
 #define COOPERATIVE_TRANSITION_END()                \
-    DEBUG_ASSURE_NO_RETURN_END(COOP_TRANSITION)     \
-    __CoopTransition.SuppressRelease();             \
+    }                                               \
     END_GCX_ASSERT_PREEMP;                          \
   }
 

--- a/src/coreclr/vm/exceptmacros.h
+++ b/src/coreclr/vm/exceptmacros.h
@@ -342,8 +342,7 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
         bool       __fExceptionCaught = false;                                             \
         SCAN_EHMARKER();                                                                    \
         if (true) PAL_CPP_TRY {                                                             \
-            SCAN_EHMARKER_TRY();                                                            \
-            DEBUG_ASSURE_NO_RETURN_BEGIN(IUACH)
+            SCAN_EHMARKER_TRY();
 
 #define INSTALL_UNWIND_AND_CONTINUE_HANDLER                                                 \
     INSTALL_UNWIND_AND_CONTINUE_HANDLER_EX                                            \
@@ -358,11 +357,9 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
         bool       __fExceptionCaught = false;                                             \
         SCAN_EHMARKER();                                                                    \
         if (true) PAL_CPP_TRY {                                                             \
-            SCAN_EHMARKER_TRY();                                                            \
-            DEBUG_ASSURE_NO_RETURN_BEGIN(IUACH);
+            SCAN_EHMARKER_TRY();
 
 #define UNINSTALL_UNWIND_AND_CONTINUE_HANDLER_EX(nativeRethrow)                      \
-            DEBUG_ASSURE_NO_RETURN_END(IUACH)                                               \
             SCAN_EHMARKER_END_TRY();                                                        \
         }                                                                                   \
         PAL_CPP_CATCH_NON_DERIVED_NOARG (const std::bad_alloc&)                             \

--- a/src/coreclr/vm/fcall.h
+++ b/src/coreclr/vm/fcall.h
@@ -542,13 +542,9 @@ LPVOID __FCThrow(LPVOID me, enum RuntimeExceptionKind reKind, UINT resID, LPCWST
 #if defined(_PREFAST_)
   #define FORLAZYMACHSTATE_BEGINLOOP(x) x
   #define FORLAZYMACHSTATE_ENDLOOP(x)
-  #define FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_BEGIN
-  #define FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_END
 #else
   #define FORLAZYMACHSTATE_BEGINLOOP(x) x do
   #define FORLAZYMACHSTATE_ENDLOOP(x) while(x)
-  #define FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_BEGIN  DEBUG_OK_TO_RETURN_BEGIN(LAZYMACHSTATE)
-  #define FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_END    DEBUG_OK_TO_RETURN_END(LAZYMACHSTATE)
 #endif
 
 // BEGIN: before gcpoll
@@ -558,10 +554,6 @@ LPVOID __FCThrow(LPVOID me, enum RuntimeExceptionKind reKind, UINT resID, LPCWST
 // END: after gcpoll
 //__fcallGcCanTrigger.Leave(__FUNCTION__, __FILE__, __LINE__);
 
-// We have to put DEBUG_OK_TO_RETURN_BEGIN around the FORLAZYMACHSTATE
-// to allow the HELPER_FRAME to be installed inside an SO_INTOLERANT region
-// which does not allow a return.  The return is used by FORLAZYMACHSTATE
-// to capture the state, but is not an actual return, so it is ok.
 #define HELPER_METHOD_FRAME_BEGIN_EX_BODY(ret, helperFrame, gcpoll, allowGC)  \
         FORLAZYMACHSTATE_BEGINLOOP(int alwaysZero = 0;)         \
         {                                                       \
@@ -569,9 +561,7 @@ LPVOID __FCThrow(LPVOID me, enum RuntimeExceptionKind reKind, UINT resID, LPCWST
             PERMIT_HELPER_METHOD_FRAME_BEGIN();                 \
             CHECK_HELPER_METHOD_FRAME_PERMITTED();              \
             helperFrame;                                        \
-            FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_BEGIN;          \
             FORLAZYMACHSTATE(CAPTURE_STATE(__helperframe.MachineState(), ret);) \
-            FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_END;            \
             INDEBUG(__helperframe.SetAddrOfHaveCheckedRestoreState(&__haveCheckedRestoreState)); \
             DEBUG_ASSURE_NO_RETURN_BEGIN(HELPER_METHOD_FRAME);  \
             INCONTRACT(FCallGCCanTrigger::Enter());

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2819,36 +2819,6 @@ public:
 #endif
 };
 
-#ifdef _DEBUG
-// We use IsProtectedByGCFrame to check if some OBJECTREF pointers are protected
-// against GC. That function doesn't know if a byref is from managed stack thus
-// protected by JIT. AssumeByrefFromJITStackFrame is used to bypass that check if an
-// OBJECTRef pointer is passed from managed code to an FCall and it's in stack.
-
-typedef DPTR(class AssumeByrefFromJITStackFrame) PTR_AssumeByrefFromJITStackFrame;
-
-class AssumeByrefFromJITStackFrame : public Frame
-{
-public:
-#ifndef DACCESS_COMPILE
-    AssumeByrefFromJITStackFrame(OBJECTREF *pObjRef) : Frame(FrameIdentifier::AssumeByrefFromJITStackFrame)
-    {
-        m_pObjRef      = pObjRef;
-    }
-#endif
-
-    BOOL Protects_Impl(OBJECTREF *ppORef)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return ppORef == m_pObjRef;
-    }
-
-private:
-    OBJECTREF *m_pObjRef;
-}; //AssumeByrefFromJITStackFrame
-
-#endif //_DEBUG
-
 //------------------------------------------------------------------------
 // These macros GC-protect OBJECTREF pointers on the EE's behalf.
 // In between these macros, the GC can move but not discard the protected
@@ -2976,27 +2946,6 @@ private:
 
 
 #define ASSERT_ADDRESS_IN_STACK(address) _ASSERTE (Thread::IsAddressInCurrentStack (address));
-
-#if defined (_DEBUG) && !defined (DACCESS_COMPILE)
-#define ASSUME_BYREF_FROM_JIT_STACK_BEGIN(__objRef)                                      \
-                /* make sure we are only called inside an FCall */                       \
-                if (__me == 0) {};                                                       \
-                /* make sure the address is in stack. If the address is an interior */   \
-                /*pointer points to GC heap, the FCall still needs to protect it explicitly */             \
-                ASSERT_ADDRESS_IN_STACK (__objRef);                                      \
-                do {                                                                     \
-                AssumeByrefFromJITStackFrame __dummyAssumeByrefFromJITStackFrame ((__objRef));       \
-                __dummyAssumeByrefFromJITStackFrame.Push ();                                  \
-                /* work around unreachable code warning */                               \
-                if (true) { DEBUG_ASSURE_NO_RETURN_BEGIN(GC_PROTECT)
-
-#define ASSUME_BYREF_FROM_JIT_STACK_END()                                          \
-                DEBUG_ASSURE_NO_RETURN_END(GC_PROTECT) }                                            \
-                __dummyAssumeByrefFromJITStackFrame.Pop(); } while(0)
-#else //defined (_DEBUG) && !defined (DACCESS_COMPILE)
-#define ASSUME_BYREF_FROM_JIT_STACK_BEGIN(__objRef)
-#define ASSUME_BYREF_FROM_JIT_STACK_END()
-#endif //defined (_DEBUG) && !defined (DACCESS_COMPILE)
 
 void ComputeCallRefMap(MethodDesc* pMD,
                        GCRefMapBuilder * pBuilder,

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2889,8 +2889,7 @@ public:
                         (OBJECTREF*)&(ObjRefStruct),                    \
                         sizeof(ObjRefStruct)/sizeof(OBJECTREF),         \
                         FALSE);                                         \
-                /* work around unreachable code warning */              \
-                if (true) { DEBUG_ASSURE_NO_RETURN_BEGIN(GCPROTECT)
+                {
 
 #define GCPROTECT_BEGIN_THREAD(pThread, ObjRefStruct)           do {    \
                 GCFrame __gcframe(                                      \
@@ -2898,16 +2897,14 @@ public:
                         (OBJECTREF*)&(ObjRefStruct),                    \
                         sizeof(ObjRefStruct)/sizeof(OBJECTREF),         \
                         FALSE);                                         \
-                /* work around unreachable code warning */              \
-                if (true) { DEBUG_ASSURE_NO_RETURN_BEGIN(GCPROTECT)
+                {
 
 #define GCPROTECT_ARRAY_BEGIN(ObjRefArray,cnt) do {                     \
                 GCFrame __gcframe(                                      \
                         (OBJECTREF*)&(ObjRefArray),                     \
                         cnt * sizeof(ObjRefArray) / sizeof(OBJECTREF),  \
                         FALSE);                                         \
-                /* work around unreachable code warning */              \
-                if (true) { DEBUG_ASSURE_NO_RETURN_BEGIN(GCPROTECT)
+                {
 
 #define GCPROTECT_BEGININTERIOR(ObjRefStruct)           do {            \
                 /* work around Wsizeof-pointer-div warning as we */     \
@@ -2917,20 +2914,18 @@ public:
                         (OBJECTREF*)&(ObjRefStruct),                    \
                         subjectSize/sizeof(OBJECTREF),                  \
                         TRUE);                                          \
-                /* work around unreachable code warning */              \
-                if (true) { DEBUG_ASSURE_NO_RETURN_BEGIN(GCPROTECT)
+                {
 
 #define GCPROTECT_BEGININTERIOR_ARRAY(ObjRefArray,cnt) do {             \
                 GCFrame __gcframe(                                      \
                         (OBJECTREF*)&(ObjRefArray),                     \
                         cnt,                                            \
                         TRUE);                                          \
-                /* work around unreachable code warning */              \
-                if (true) { DEBUG_ASSURE_NO_RETURN_BEGIN(GCPROTECT)
+                {
 
 
 #define GCPROTECT_END()                                                 \
-                DEBUG_ASSURE_NO_RETURN_END(GCPROTECT) }                 \
+                }                                                       \
                 } while(0)
 
 

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2622,7 +2622,7 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
 {
     PCODE pbRetVal = (PCODE)NULL;
 
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
@@ -2734,8 +2734,6 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
     }
 
     POSTCONDITION(pbRetVal != NULL);
-
-    END_PRESERVE_LAST_ERROR;
 
     return pbRetVal;
 }
@@ -3163,7 +3161,7 @@ EXTERN_C PCODE STDCALL ExternalMethodFixupWorker(TransitionBlock * pTransitionBl
 
     PCODE         pCode   = (PCODE)NULL;
 
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
     MAKE_CURRENT_THREAD_AVAILABLE();
 
@@ -3489,8 +3487,6 @@ EXTERN_C PCODE STDCALL ExternalMethodFixupWorker(TransitionBlock * pTransitionBl
     UNINSTALL_MANAGED_EXCEPTION_DISPATCHER_EX(propagateExceptionToNativeCode);
 
     pEMFrame->Pop(CURRENT_THREAD);          // Pop the ExternalMethodFrame from the frame stack
-
-    END_PRESERVE_LAST_ERROR;
 
     return pCode;
 }

--- a/src/coreclr/vm/stubhelpers.cpp
+++ b/src/coreclr/vm/stubhelpers.cpp
@@ -420,7 +420,7 @@ FCIMPL1(void*, StubHelpers::GetDelegateTarget, DelegateObject *pThisUNSAFE)
     PCODE pEntryPoint = (PCODE)NULL;
 
 #ifdef _DEBUG
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 #endif
 
     CONTRACTL
@@ -441,10 +441,6 @@ FCIMPL1(void*, StubHelpers::GetDelegateTarget, DelegateObject *pThisUNSAFE)
 #endif // HOST_64BIT
 
     pEntryPoint = orefThis->GetMethodPtrAux();
-
-#ifdef _DEBUG
-    END_PRESERVE_LAST_ERROR;
-#endif
 
     return (PVOID)pEntryPoint;
 }
@@ -485,7 +481,7 @@ extern "C" void QCALLTYPE StubHelpers_ThrowInteropParamException(INT resID, INT 
 #ifdef PROFILING_SUPPORTED
 extern "C" void* QCALLTYPE StubHelpers_ProfilerBeginTransitionCallback(MethodDesc* pTargetMD)
 {
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
     QCALL_CONTRACT;
 
@@ -495,14 +491,12 @@ extern "C" void* QCALLTYPE StubHelpers_ProfilerBeginTransitionCallback(MethodDes
 
     END_QCALL;
 
-    END_PRESERVE_LAST_ERROR;
-
     return pTargetMD;
 }
 
 extern "C" void QCALLTYPE StubHelpers_ProfilerEndTransitionCallback(MethodDesc* pTargetMD)
 {
-    BEGIN_PRESERVE_LAST_ERROR;
+    PreserveLastErrorHolder preserveLastError;
 
     QCALL_CONTRACT;
 
@@ -511,8 +505,6 @@ extern "C" void QCALLTYPE StubHelpers_ProfilerEndTransitionCallback(MethodDesc* 
     ProfilerUnmanagedToManagedTransitionMD(pTargetMD, COR_PRF_TRANSITION_RETURN);
 
     END_QCALL;
-
-    END_PRESERVE_LAST_ERROR;
 }
 #endif // PROFILING_SUPPORTED
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -5235,14 +5235,22 @@ public:
         : m_pFrame(pThread->m_pFrame)
     {
         LIMITED_METHOD_CONTRACT;
-        _ASSERTE(!std::uncaught_exception());
     }
 
     ~CoopTransitionHolder()
     {
         WRAPPER_NO_CONTRACT;
-        if (std::uncaught_exception())
+        _ASSERTE(m_pFrame == nullptr || std::uncaught_exception());
+        if (m_pFrame != nullptr)
             COMPlusCooperativeTransitionHandler(m_pFrame);
+    }
+
+    void SuppressRelease()
+    {
+        LIMITED_METHOD_CONTRACT;
+        // FRAME_TOP and NULL must be distinct values.
+        // static_assert_no_msg(FRAME_TOP_VALUE != NULL);
+        m_pFrame = nullptr;
     }
 };
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -111,6 +111,7 @@
 #ifndef __threads_h__
 #define __threads_h__
 
+#include <exception>
 #include "vars.hpp"
 #include "util.hpp"
 #include "eventstore.hpp"
@@ -5239,16 +5240,8 @@ public:
     ~CoopTransitionHolder()
     {
         WRAPPER_NO_CONTRACT;
-        if (m_pFrame != NULL)
+        if (std::uncaught_exception())
             COMPlusCooperativeTransitionHandler(m_pFrame);
-    }
-
-    void SuppressRelease()
-    {
-        LIMITED_METHOD_CONTRACT;
-        // FRAME_TOP and NULL must be distinct values.
-        // static_assert_no_msg(FRAME_TOP_VALUE != NULL);
-        m_pFrame = NULL;
     }
 };
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -5235,6 +5235,7 @@ public:
         : m_pFrame(pThread->m_pFrame)
     {
         LIMITED_METHOD_CONTRACT;
+        _ASSERTE(!std::uncaught_exception());
     }
 
     ~CoopTransitionHolder()

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -5240,7 +5240,7 @@ public:
     ~CoopTransitionHolder()
     {
         WRAPPER_NO_CONTRACT;
-        _ASSERTE(m_pFrame == nullptr || std::uncaught_exception());
+        _ASSERTE_MSG(m_pFrame == nullptr || std::uncaught_exception(), "Early return from JIT/EE interface method");
         if (m_pFrame != nullptr)
             COMPlusCooperativeTransitionHandler(m_pFrame);
     }

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2264,7 +2264,8 @@ Exit: ;
 
 void Thread::HandleThreadAbort ()
 {
-    BEGIN_PRESERVE_LAST_ERROR;
+    // Only preserve the last error when we aren't throwing an exception for ThreadAbort.
+    DWORD lastError = GetLastError();
 
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
@@ -2322,7 +2323,7 @@ void Thread::HandleThreadAbort ()
         }
     }
 
-    END_PRESERVE_LAST_ERROR;
+    ::SetLastError(lastError);
 }
 
 void Thread::PreWorkForThreadAbort()
@@ -5731,7 +5732,7 @@ BOOL CheckActivationSafePoint(SIZE_T ip)
 
     // The criteria for safe activation is to be running managed code.
     // Also we are not interested in handling interruption if we are already in preemptive mode nor if we are single stepping
-    BOOL isActivationSafePoint = pThread != NULL && 
+    BOOL isActivationSafePoint = pThread != NULL &&
         (pThread->m_StateNC & Thread::TSNC_DebuggerIsStepping) == 0 &&
         pThread->PreemptiveGCDisabled() &&
         ExecutionManager::IsManagedCode(ip);


### PR DESCRIPTION
We have hack in the CoreCLR codebase where we define the `return` keyword as a macro with a `for` loop that depends on typedefs to enable blocking returns from within specific blocks of code.

This has caused issues that have had to be fixed in the following PRs:

https://github.com/dotnet/runtime/pull/67464
https://github.com/dotnet/runtime/pull/109756
https://github.com/dotnet/runtime/pull/113279

Many of these blocks of code can be adjusted slightly to not require this mechanism to act correctly or already do not require it. Also, some usages are just dead code entirely.

This PR does not remove the mechanism as it does not remove all usages of it. The final usage (as mentioned in https://github.com/dotnet/runtime/issues/67470) is in the support logic for HelperMethodFrames. As we are removing HMFs from the runtime (https://github.com/dotnet/runtime/issues/95695), I figure that we can remove this mechanism after we remove HMFs instead of trying to figure out how to re-implement the HMF logic such that returns are safe.