### PR TITLE
[Bounds Checks] Make union/intersect operations more precise

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -996,8 +996,9 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
                     return l2;
                 }
 
-                // Otherwise, prefer the BinOpArray(preferredBound) over the constant.
-                return l1;
+                // Otherwise, prefer the BinOpArray(preferredBound) over the constant for the upper bound
+                // and the constant for the lower bound.
+                return isLower ? l2 : l1;
             }
             unreached();
         };

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -518,6 +518,7 @@ struct RangeOps
         // This is correct if k >= 0 and n >= k, since $bnd always >= 0
         // ($bnd + n) could overflow, but the result ($bnd + n) also
         // preserves the overflow.
+        //
         if (r1hi.IsConstant() && r1hi.GetConstant() >= 0 && r2hi.IsBinOpArray() &&
             r2hi.GetConstant() >= r1hi.GetConstant())
         {
@@ -542,26 +543,13 @@ struct RangeOps
             result.lLimit = Limit(Limit::keConstant, min(r2lo.cns, r1lo.cns));
         }
 
-        // Rule: <$bnd + cns1, ...> U <cns2, ...> = <$bnd + cns1, ...> when cns1 >= cns2
-        //
-        // Example: <$bnd + 10, ...> U <1, ...> = <$bnd + 10, ...>
-        //
-        if (r1lo.IsBinOpArray() && r2lo.IsConstant() && (r1lo.cns >= r2lo.cns))
-        {
-            result.lLimit = r1lo;
-        }
-        if (r2lo.IsBinOpArray() && r1lo.IsConstant() && (r2lo.cns >= r1lo.cns))
-        {
-            result.lLimit = r2lo;
-        }
-
         // Rule: <..., $bnd + cns1> U <..., $bnd + cns2> = <..., $bnd + max(cns1, cns2)>
         //
         // Example: <..., $bnd + 10> U <..., $bnd + 20> = <..., $bnd + 20>
         //
         if (r1hi.IsBinOpArray() && r2hi.IsBinOpArray() && r1hi.vn == r2hi.vn)
         {
-            result.uLimit     = r1hi;
+            result.uLimit     = r1hi; // copy $bnd and kind info
             result.uLimit.cns = max(r1hi.cns, r2hi.cns);
         }
 
@@ -571,7 +559,7 @@ struct RangeOps
         //
         if (r1lo.IsBinOpArray() && r2lo.IsBinOpArray() && r1lo.vn == r2lo.vn)
         {
-            result.lLimit     = r1hi;
+            result.lLimit     = r1hi; // copy $bnd and kind info
             result.lLimit.cns = min(r1lo.cns, r2lo.cns);
         }
         return result;

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -558,6 +558,7 @@ struct RangeOps
         // Example: <..., $bnd + 10> U <..., $bnd + 20> = <..., $bnd + 20>
         if (r1hi.IsBinOpArray() && r2hi.IsBinOpArray() && r1hi.vn == r2hi.vn)
         {
+            result.uLimit = r1hi;
             result.uLimit.cns = max(r1hi.cns, r2hi.cns);
         }
 
@@ -566,6 +567,7 @@ struct RangeOps
         // Example: <$bnd + 10, ...> U <$bnd + 20, ...> = <$bnd + 10, ...>
         if (r1lo.IsBinOpArray() && r2lo.IsBinOpArray() && r1lo.vn == r2lo.vn)
         {
+            result.lLimit = r1hi;
             result.lLimit.cns = min(r1lo.cns, r2lo.cns);
         }
         return result;

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -559,7 +559,7 @@ struct RangeOps
         //
         if (r1lo.IsBinOpArray() && r2lo.IsBinOpArray() && r1lo.vn == r2lo.vn)
         {
-            result.lLimit     = r1hi; // copy $bnd and kind info
+            result.lLimit     = r1lo; // copy $bnd and kind info
             result.lLimit.cns = min(r1lo.cns, r2lo.cns);
         }
         return result;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/113809
Partially addresses https://github.com/dotnet/runtime/issues/104890 (removes bounds check)

```cs
public static int UnrolledSum(Span<int> arr)
{
    int sum = 0;
    int i = 0;
    for (; i < arr.Length - 3; i += 4)
    {
        sum += arr[i + 0];
        sum += arr[i + 1];
        sum += arr[i + 2];
        sum += arr[i + 3];
    }

    // Handle the remaining elements
    for (; i < arr.Length; i++)
        sum += arr[i];
    return sum;
}
```
We are now able to drop bounds checks completely here:
```diff
; Method Tests:UnrolledSum(System.Span`1[int]):int (FullOpts)
-      sub      rsp, 40
       mov      rax, bword ptr [rcx]
       mov      ecx, dword ptr [rcx+0x08]
       xor      edx, edx
       xor      r8d, r8d
       lea      r10d, [rcx-0x03]
       test     r10d, r10d
       jle      SHORT G_M39394_IG05
       align    [0 bytes for IG03]
G_M39394_IG03:
       mov      r9d, r8d
       add      edx, dword ptr [rax+4*r9]
       lea      r9d, [r8+0x01]
       add      edx, dword ptr [rax+4*r9]
       lea      r9d, [r8+0x02]
       add      edx, dword ptr [rax+4*r9]
       lea      r9d, [r8+0x03]
       add      edx, dword ptr [rax+4*r9]
       add      r8d, 4
       cmp      r8d, r10d
       jl       SHORT G_M39394_IG03
       jmp      SHORT G_M39394_IG05
-      align    [0 bytes for IG04]
+      align    [2 bytes for IG04]
G_M39394_IG04:
-      cmp      r8d, ecx
-      jae      SHORT G_M39394_IG08
       mov      r10d, r8d
       add      edx, dword ptr [rax+4*r10]
       inc      r8d
G_M39394_IG05:
       cmp      r8d, ecx
       jl       SHORT G_M39394_IG04
       mov      eax, edx
-      add      rsp, 40
       ret      
-G_M39394_IG08:
-      call     CORINFO_HELP_RNGCHKFAIL
-      int3     
-; Total bytes of code: 99
+; Total bytes of code: 82
```
