### PR TITLE
Move "switch recognition" phase to be before "optimize bools"

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4946,6 +4946,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     if (opts.OptimizationEnabled())
     {
+        // Conditional to switch conversion, and switch peeling
+        //
+        DoPhase(this, PHASE_SWITCH_RECOGNITION, &Compiler::optRecognizeAndOptimizeSwitchJumps);
+
         // Optimize boolean conditions
         //
         DoPhase(this, PHASE_OPTIMIZE_BOOLS, &Compiler::optOptimizeBools);
@@ -4953,10 +4957,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         // If conversion
         //
         DoPhase(this, PHASE_IF_CONVERSION, &Compiler::optIfConversion);
-
-        // Conditional to switch conversion, and switch peeling
-        //
-        DoPhase(this, PHASE_SWITCH_RECOGNITION, &Compiler::optRecognizeAndOptimizeSwitchJumps);
 
         // Run flow optimizations before reordering blocks
         //

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1715,7 +1715,7 @@ bool Compiler::fgFoldCondToReturnBlock(BasicBlock* block)
         modified = true;
     }
     // Same here - bail out if the block is no longer BBJ_COND after compacting.
-    if (!block->KindIs(BBJ_COND))
+    if (block->HasFlag(BBF_REMOVED) || !block->KindIs(BBJ_COND))
     {
         return modified;
     }

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -33,11 +33,11 @@ PhaseStatus Compiler::optRecognizeAndOptimizeSwitchJumps()
         }
 
         // Before we start, let's optimize possible fallthrough blocks for BBJ_COND's successors.
-        /*if (block->KindIs(BBJ_COND))
+        if (block->KindIs(BBJ_COND) && block->hasSingleStmt())
         {
             BasicBlock* retFalseBb = block->GetFalseTarget();
             BasicBlock* retTrueBb  = block->GetTrueTarget();
-            if (fgCanCompactBlock(retTrueBb))
+            if (fgCanCompactBlock(retTrueBb) && retTrueBb->isEmpty())
             {
                 fgCompactBlock(retTrueBb);
                 modified = true;
@@ -53,7 +53,7 @@ PhaseStatus Compiler::optRecognizeAndOptimizeSwitchJumps()
             {
                 continue;
             }
-        }*/
+        }
 
 // Limit to XARCH, ARM is already doing a great job with such comparisons using
 // a series of ccmp instruction (see ifConvert phase).

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -33,7 +33,7 @@ PhaseStatus Compiler::optRecognizeAndOptimizeSwitchJumps()
         }
 
         // Before we start, let's optimize possible fallthrough blocks for BBJ_COND's successors.
-        if (block->KindIs(BBJ_COND))
+        /*if (block->KindIs(BBJ_COND))
         {
             BasicBlock* retFalseBb = block->GetFalseTarget();
             BasicBlock* retTrueBb  = block->GetTrueTarget();
@@ -53,7 +53,7 @@ PhaseStatus Compiler::optRecognizeAndOptimizeSwitchJumps()
             {
                 continue;
             }
-        }
+        }*/
 
 // Limit to XARCH, ARM is already doing a great job with such comparisons using
 // a series of ccmp instruction (see ifConvert phase).

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -51,7 +51,7 @@ PhaseStatus Compiler::optRecognizeAndOptimizeSwitchJumps()
             }
             if (block->HasFlag(BBF_REMOVED))
             {
-                block = block->Next();
+                continue;
             }
         }
 


### PR DESCRIPTION
We should try to recognize jump tables before `PHASE_OPTIMIZE_BOOLS` and `PHASE_IF_CONVERSION`  phases which may transform BBJ_COND blocks (e.g. BBJ_COND<cond> to BBJ_RETURN<cond>)