### PR TITLE
Fix ThrowControlForThread on x86 funclet platforms

### DIFF
--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -369,9 +369,9 @@ void SetupTLSForThread();
 // When we resume a thread at a new location, to get an exception thrown, we have to
 // pretend the exception originated elsewhere.
 EXTERN_C void ThrowControlForThread(
-#ifdef FEATURE_EH_FUNCLETS
+#if !defined(TARGET_X86)
         FaultingExceptionFrame *pfef
-#endif // FEATURE_EH_FUNCLETS
+#endif // !TARGET_X86
 #if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
         , TADDR ssp
 #endif // TARGET_AMD64 && TARGET_WINDOWS

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -3757,7 +3757,6 @@ ThrowControlForThread(
             STRESS_LOG0(LF_SYNC, LL_INFO100, "ThrowControlForThread resume\n");
             pThread->ResetThrowControlForThread();
             // Thread abort is not allowed at this point
-            // Thread abort is not allowed at this point
             __asan_handle_no_return();
 #if defined(TARGET_WINDOWS) && defined(TARGET_X86)
             RedirectedThrowControl();


### PR DESCRIPTION
`ThrowControlForThread` on x86 is directly injected into context with no extra parameter. This was correctly handled on win-x86 but not on linux-x86. Fix that and adjust the code conditions to actually reflect the platform differences to also get this correct for win-x86/funclets.