### PR TITLE
Disable `this` variable deoptimization on x86/funclets

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3068,15 +3068,6 @@ void Compiler::lvaSortByRefCount()
         {
             lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::NoRegVars));
         }
-#if defined(JIT32_GCENCODER)
-        if (UsesFunclets() && lvaIsOriginalThisArg(lclNum) &&
-            (info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0)
-        {
-            // For x86/Linux, we need to track "this".
-            // However we cannot have it in tracked variables, so we set "this" pointer always untracked
-            varDsc->lvTracked = 0;
-        }
-#endif
 
         // No benefit in tracking the PSPSym (if any)
         //


### PR DESCRIPTION
We already get the necessary semantics with existing checks in `LinearScan::allocateRegisters` and `Compiler::lvaSetVarLiveInOutOfHandler`. They both specifically handle `JIT32_GCENCODER` and `lvaKeepAliveAndReportThis()` case.

This caused unnecessary spilling of `this` to stack for small methods like `get_Count` property accessors.

Referenced code:

https://github.com/dotnet/runtime/blob/32299f4b6aa148fd6ee0da222b01334a88414a25/src/coreclr/jit/lsra.cpp#L6670-L6674

https://github.com/dotnet/runtime/blob/32299f4b6aa148fd6ee0da222b01334a88414a25/src/coreclr/jit/lclvars.cpp#L2110-L2118