### PR TITLE
Fix AltJit and VectorT ISA specification

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -6012,10 +6012,13 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
         // needing to have the hardware in question.
 
 #if defined(TARGET_ARM64)
-        // Keep the existing VectorT* ISAs.
-        if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT128))
+        if (info.compMatchedVM)
         {
-            instructionSetFlags.AddInstructionSet(InstructionSet_VectorT128);
+            // Keep the existing VectorT* ISAs.
+            if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT128))
+            {
+                instructionSetFlags.AddInstructionSet(InstructionSet_VectorT128);
+            }
         }
 
         if (JitConfig.EnableHWIntrinsic() != 0)
@@ -6073,18 +6076,21 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
             instructionSetFlags.AddInstructionSet(InstructionSet_Sve);
         }
 #elif defined(TARGET_XARCH)
-        // Keep the existing VectorT* ISAs.
-        if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT128))
+        if (info.compMatchedVM)
         {
-            instructionSetFlags.AddInstructionSet(InstructionSet_VectorT128);
-        }
-        if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT256))
-        {
-            instructionSetFlags.AddInstructionSet(InstructionSet_VectorT256);
-        }
-        if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT512))
-        {
-            instructionSetFlags.AddInstructionSet(InstructionSet_VectorT512);
+            // Keep the existing VectorT* ISAs.
+            if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT128))
+            {
+                instructionSetFlags.AddInstructionSet(InstructionSet_VectorT128);
+            }
+            if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT256))
+            {
+                instructionSetFlags.AddInstructionSet(InstructionSet_VectorT256);
+            }
+            if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT512))
+            {
+                instructionSetFlags.AddInstructionSet(InstructionSet_VectorT512);
+            }
         }
 
         if (JitConfig.EnableHWIntrinsic() != 0)

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5998,6 +5998,7 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
 
     if (enableAvailableIsas)
     {
+        CORINFO_InstructionSetFlags currentInstructionSetFlags = compileFlags->GetInstructionSetFlags();
         CORINFO_InstructionSetFlags instructionSetFlags;
 
         // We need to assume, by default, that all flags coming from the VM are invalid.
@@ -6011,6 +6012,12 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
         // needing to have the hardware in question.
 
 #if defined(TARGET_ARM64)
+        // Keep the existing VectorT* ISAs.
+        if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT128))
+        {
+            instructionSetFlags.AddInstructionSet(InstructionSet_VectorT128);
+        }
+
         if (JitConfig.EnableHWIntrinsic() != 0)
         {
             instructionSetFlags.AddInstructionSet(InstructionSet_ArmBase);
@@ -6066,6 +6073,20 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
             instructionSetFlags.AddInstructionSet(InstructionSet_Sve);
         }
 #elif defined(TARGET_XARCH)
+        // Keep the existing VectorT* ISAs.
+        if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT128))
+        {
+            instructionSetFlags.AddInstructionSet(InstructionSet_VectorT128);
+        }
+        if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT256))
+        {
+            instructionSetFlags.AddInstructionSet(InstructionSet_VectorT256);
+        }
+        if (currentInstructionSetFlags.HasInstructionSet(InstructionSet_VectorT512))
+        {
+            instructionSetFlags.AddInstructionSet(InstructionSet_VectorT512);
+        }
+
         if (JitConfig.EnableHWIntrinsic() != 0)
         {
             instructionSetFlags.AddInstructionSet(InstructionSet_X86Base);
@@ -9355,6 +9376,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  * The following don't require a Compiler* to work:
  *      dRegMask                    : Display a regMaskTP (call dspRegMask(mask)).
  *      dBlockList                  : Display a BasicBlockList*.
+ *      dIsa                        : Display a CORINFO_InstructionSet
+ *      dIsaFlags                   : Display a CORINFO_InstructionSetFlags
  *
  * The following find an object in the IR and return it, as well as setting a global variable with the value that can
  * be used in the debugger (e.g., in the watch window, or as a way to get an address for data breakpoints).
@@ -9438,6 +9461,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // Functions which don't require a Compiler*
 #pragma comment(linker, "/include:dRegMask")
 #pragma comment(linker, "/include:dBlockList")
+#pragma comment(linker, "/include:dIsa")
+#pragma comment(linker, "/include:dIsaFlags")
 
 // Functions which search for objects in the IR
 #pragma comment(linker, "/include:dFindTreeInTree")
@@ -10318,6 +10343,41 @@ JITDBGAPI void __cdecl dBlockList(BasicBlockList* list)
     {
         printf(FMT_BB " ", list->block->bbNum);
         list = list->next;
+    }
+    printf("\n");
+}
+
+JITDBGAPI void __cdecl dIsa(const CORINFO_InstructionSet isa)
+{
+    static unsigned sequenceNumber = 0; // separate calls with a number to indicate this function has been called
+    printf("===================================================================== dIsa %u\n", sequenceNumber++);
+    printf("%s\n", InstructionSetToString(isa));
+}
+
+JITDBGAPI void __cdecl dIsaFlags(const CORINFO_InstructionSetFlags& isaFlags)
+{
+    static unsigned sequenceNumber = 0; // separate calls with a number to indicate this function has been called
+    printf("===================================================================== dIsaFlags %u\n", sequenceNumber++);
+    if (isaFlags.IsEmpty())
+    {
+        printf("<empty>\n");
+    }
+    else
+    {
+        bool first = true;
+        // The flags start at '1'. We don't know the last flag, so compute the maximum.
+        // It would be better if CORINFO_InstructionSet defined InstructionSet_FIRST and InstructionSet_LAST,
+        // or even better, if CORINFO_InstructionSetFlags defined an iterator over the instruction sets in the flags.
+        CORINFO_InstructionSet isaFirst = (CORINFO_InstructionSet)1;
+        CORINFO_InstructionSet isaLast  = (CORINFO_InstructionSet)(sizeof(CORINFO_InstructionSetFlags) * 8 - 1);
+        for (CORINFO_InstructionSet isa = isaFirst; isa <= isaLast; isa = (CORINFO_InstructionSet)((int)isa + 1))
+        {
+            if (isaFlags.HasInstructionSet(isa))
+            {
+                printf("%s%s", first ? "" : " ", InstructionSetToString(isa));
+                first = false;
+            }
+        }
     }
     printf("\n");
 }


### PR DESCRIPTION
When running as an AltJit when the generated code will not be used (either because of a mismatched VM, or because RunAltJitCode=0), the JIT overwrites the passed in ISAs. When it does so, it zeros out the VectorT* ISA flags.

Instead of this, carry over the existing ISA flags. This should work for same-architecture SPMI replays.

I'm not sure if additional logic for specifically setting the VectorT* ISA is required for other scenarios, or if incorporating similar logic to `EEJitManager::SetCpuInfo()` into `Compiler::compCompile()` is required.

Adds new JIT debugging helpers `dIsa()` and `dIsaFlags()` to dump out string representations of `CORINFO_InstructionSet` and `CORINFO_InstructionSetFlags`.

Fixes #113869