### PR TITLE
Fix targets for using the NativeAOT runtime pack as the "target ILC" pack

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -158,7 +158,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == 'true'">
       <PrivateSdkAssemblies Include="$(IlcSdkPath)*.dll"/>
       <FrameworkAssemblies Include="@(RuntimePackAsset)" Condition="'$(PublishAotUsingRuntimePack)' == 'true' and '%(Extension)' == '.dll'" />
-      <FrameworkAssemblies Include="$(_NETCoreAppRuntimePackPath)" Condition="'$(PublishAotUsingRuntimePack)' != 'true' and '%(Extension)' == '.dll'" />
+      <FrameworkAssemblies Include="$(_NETCoreAppRuntimePackPath)lib/**/*.dll" Condition="'$(PublishAotUsingRuntimePack)' != 'true'" />
       <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
     </ItemGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -157,7 +157,8 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup Condition="'$(IlcUseNativeAOTRuntimePackLayout)' == 'true'">
       <PrivateSdkAssemblies Include="$(IlcSdkPath)*.dll"/>
-      <FrameworkAssemblies Include="@(RuntimePackAsset)" Condition="'%(Extension)' == '.dll'" />
+      <FrameworkAssemblies Include="@(RuntimePackAsset)" Condition="'$(PublishAotUsingRuntimePack)' == 'true' and '%(Extension)' == '.dll'" />
+      <FrameworkAssemblies Include="$(_NETCoreAppRuntimePackPath)" Condition="'$(PublishAotUsingRuntimePack)' != 'true' and '%(Extension)' == '.dll'" />
       <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
     </ItemGroup>
 


### PR DESCRIPTION
Change how we select the assets as we aren't using this package as a runtime pack.

Unblocks https://github.com/dotnet/sdk/pull/46611
