### PR TITLE
Support Activity Events and Links trace out of proc output

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -87,6 +87,7 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <Compile Include="$(CommonPath)Internal\Padding.cs" Link="Common\Internal\Padding.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs" Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Diagnostics\DiagnosticsHelper.cs" Link="Common\System\Diagnostics\DiagnosticsHelper.cs" />
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs" Link="CoreLib\System\Text\ValueStringBuilder.cs" />
 
     <None Include="DiagnosticSourceUsersGuide.md" />
     <None Include="ActivityUserGuide.md" />
@@ -107,7 +108,6 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <Compile Include="System\Diagnostics\Metrics\TagList.netcore.cs" />
     <Compile Include="System\Diagnostics\System.Diagnostics.DiagnosticSource.Typeforwards.netcoreapp.cs" />
     <Compile Include="$(CommonPath)System\LocalAppContextSwitches.Common.cs" Link="Common\System\LocalAppContextSwitches.Common.cs" />
-    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs" Link="Common\System\Text\ValueStringBuilder.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -58,8 +58,8 @@ namespace System.Diagnostics
 #pragma warning disable CA1825 // Array.Empty<T>() doesn't exist in all configurations
         private static readonly IEnumerable<KeyValuePair<string, string?>> s_emptyBaggageTags = new KeyValuePair<string, string?>[0];
         private static readonly IEnumerable<KeyValuePair<string, object?>> s_emptyTagObjects = new KeyValuePair<string, object?>[0];
-        private static readonly IEnumerable<ActivityLink> s_emptyLinks = new ActivityLink[0];
-        private static readonly IEnumerable<ActivityEvent> s_emptyEvents = new ActivityEvent[0];
+        private static readonly IEnumerable<ActivityLink> s_emptyLinks = new DiagLinkedList<ActivityLink>();
+        private static readonly IEnumerable<ActivityEvent> s_emptyEvents = new DiagLinkedList<ActivityEvent>();
 #pragma warning restore CA1825
         private static readonly ActivitySource s_defaultSource = new ActivitySource(string.Empty);
         private static readonly AsyncLocal<Activity?> s_current = new AsyncLocal<Activity?>();

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -59,21 +59,18 @@ namespace System.Diagnostics
 
             s_activeSources.Add(this);
 
-            if (s_allListeners.Count > 0)
+            s_allListeners.EnumWithAction((listener, source) =>
             {
-                s_allListeners.EnumWithAction((listener, source) =>
+                Func<ActivitySource, bool>? shouldListenTo = listener.ShouldListenTo;
+                if (shouldListenTo != null)
                 {
-                    Func<ActivitySource, bool>? shouldListenTo = listener.ShouldListenTo;
-                    if (shouldListenTo != null)
+                    var activitySource = (ActivitySource)source;
+                    if (shouldListenTo(activitySource))
                     {
-                        var activitySource = (ActivitySource)source;
-                        if (shouldListenTo(activitySource))
-                        {
-                            activitySource.AddListener(listener);
-                        }
+                        activitySource.AddListener(listener);
                     }
-                }, this);
-            }
+                }
+            }, this);
 
             GC.KeepAlive(DiagnosticSourceEventSource.Log);
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagLinkedList.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagLinkedList.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 
 namespace System.Diagnostics
 {
@@ -149,6 +150,121 @@ namespace System.Diagnostics
         public DiagEnumerator<T> GetEnumerator() => new DiagEnumerator<T>(_first);
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private static void ActivityLinkToString(ref ActivityLink al, ref ValueStringBuilder vsb)
+        {
+            ActivityContext ac = al.Context;
+
+            vsb.Append("(");
+            vsb.Append(ac.TraceId.ToHexString());
+            vsb.Append(", ");
+            vsb.Append(ac.SpanId.ToHexString());
+            vsb.Append(", ");
+            vsb.Append(ac.TraceFlags.ToString());
+            vsb.Append(", ");
+            vsb.Append(ac.TraceState ?? "null");
+            vsb.Append(", ");
+            vsb.Append(ac.IsRemote ? "true" : "false");
+
+            if (al.Tags is not null)
+            {
+                vsb.Append(", [");
+                string sep = "";
+                foreach (KeyValuePair<string, object?> kvp in al.EnumerateTagObjects())
+                {
+                    vsb.Append(sep);
+                    vsb.Append(kvp.Key);
+                    vsb.Append(": ");
+                    vsb.Append(kvp.Value?.ToString() ?? "null");
+                    sep = ", ";
+                }
+
+                vsb.Append("]");
+            }
+            vsb.Append(")");
+        }
+
+        private static void ActivityEventToString(ref ActivityEvent ae, ref ValueStringBuilder vsb)
+        {
+            vsb.Append("(");
+            vsb.Append(ae.Name);
+            vsb.Append(", ");
+            vsb.Append(ae.Timestamp.ToString("o"));
+
+            if (ae.Tags is not null)
+            {
+                vsb.Append(", [");
+                string sep = "";
+                foreach (KeyValuePair<string, object?> kvp in ae.EnumerateTagObjects())
+                {
+                    vsb.Append(sep);
+                    vsb.Append(kvp.Key);
+                    vsb.Append(": ");
+                    vsb.Append(kvp.Value?.ToString() ?? "null");
+                    sep = ", ";
+                }
+
+                vsb.Append("]");
+            }
+            vsb.Append(")");
+        }
+
+        public override string ToString()
+        {
+            lock (this)
+            {
+                DiagNode<T>? current = _first;
+                if (current is null)
+                {
+                    return "[]";
+                }
+
+                var vsb = new ValueStringBuilder(stackalloc char[256]);
+                vsb.Append("[");
+
+                if (typeof(T) == typeof(ActivityLink))
+                {
+                    while (current is not null)
+                    {
+                        ActivityLink al = (ActivityLink)(object)current.Value!;
+                        ActivityLinkToString(ref al, ref vsb);
+                        current = current.Next;
+                        if (current is not null)
+                        {
+                            vsb.Append(", ");
+                        }
+                    }
+                }
+                else if (typeof(T) == typeof(ActivityEvent))
+                {
+                    while (current is not null)
+                    {
+                        ActivityEvent ae = (ActivityEvent)(object)current.Value!;
+                        ActivityEventToString(ref ae, ref vsb);
+                        current = current.Next;
+                        if (current is not null)
+                        {
+                            vsb.Append(", ");
+                        }
+                    }
+                }
+                else
+                {
+                    while (current is not null)
+                    {
+                        vsb.Append(current.Value?.ToString() ?? "null");
+                        current = current.Next;
+                        if (current is not null)
+                        {
+                            vsb.Append(", ");
+                        }
+                    }
+                }
+
+                vsb.Append("]");
+                return vsb.ToString();
+            }
+        }
     }
 
     internal struct DiagEnumerator<T> : IEnumerator<T>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagLinkedList.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagLinkedList.cs
@@ -157,26 +157,26 @@ namespace System.Diagnostics
 
             vsb.Append("(");
             vsb.Append(ac.TraceId.ToHexString());
-            vsb.Append(", ");
+            vsb.Append(",\u200B");
             vsb.Append(ac.SpanId.ToHexString());
-            vsb.Append(", ");
+            vsb.Append(",\u200B");
             vsb.Append(ac.TraceFlags.ToString());
-            vsb.Append(", ");
+            vsb.Append(",\u200B");
             vsb.Append(ac.TraceState ?? "null");
-            vsb.Append(", ");
+            vsb.Append(",\u200B");
             vsb.Append(ac.IsRemote ? "true" : "false");
 
             if (al.Tags is not null)
             {
-                vsb.Append(", [");
+                vsb.Append(",\u200B[");
                 string sep = "";
                 foreach (KeyValuePair<string, object?> kvp in al.EnumerateTagObjects())
                 {
                     vsb.Append(sep);
                     vsb.Append(kvp.Key);
-                    vsb.Append(": ");
+                    vsb.Append(":\u200B");
                     vsb.Append(kvp.Value?.ToString() ?? "null");
-                    sep = ", ";
+                    sep = ",\u200B";
                 }
 
                 vsb.Append("]");
@@ -188,20 +188,20 @@ namespace System.Diagnostics
         {
             vsb.Append("(");
             vsb.Append(ae.Name);
-            vsb.Append(", ");
+            vsb.Append(",\u200B");
             vsb.Append(ae.Timestamp.ToString("o"));
 
             if (ae.Tags is not null)
             {
-                vsb.Append(", [");
+                vsb.Append(",\u200B[");
                 string sep = "";
                 foreach (KeyValuePair<string, object?> kvp in ae.EnumerateTagObjects())
                 {
                     vsb.Append(sep);
                     vsb.Append(kvp.Key);
-                    vsb.Append(": ");
+                    vsb.Append(":\u200B");
                     vsb.Append(kvp.Value?.ToString() ?? "null");
-                    sep = ", ";
+                    sep = ",\u200B";
                 }
 
                 vsb.Append("]");
@@ -231,7 +231,7 @@ namespace System.Diagnostics
                         current = current.Next;
                         if (current is not null)
                         {
-                            vsb.Append(", ");
+                            vsb.Append(",\u200B");
                         }
                     }
                 }
@@ -244,7 +244,7 @@ namespace System.Diagnostics
                         current = current.Next;
                         if (current is not null)
                         {
-                            vsb.Append(", ");
+                            vsb.Append(",\u200B");
                         }
                     }
                 }
@@ -256,7 +256,7 @@ namespace System.Diagnostics
                         current = current.Next;
                         if (current is not null)
                         {
-                            vsb.Append(", ");
+                            vsb.Append(",\u200B");
                         }
                     }
                 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -2440,32 +2440,32 @@ namespace System.Diagnostics.Tests
 
                 formattedLinks += $"{linkSep}(";
                 formattedLinks += ac.TraceId.ToHexString();
-                formattedLinks += ", ";
+                formattedLinks += ",\u200B";
                 formattedLinks += ac.SpanId.ToHexString();
-                formattedLinks += ", ";
+                formattedLinks += ",\u200B";
                 formattedLinks += ac.TraceFlags.ToString();
-                formattedLinks += ", ";
+                formattedLinks += ",\u200B";
                 formattedLinks += ac.TraceState ?? "null";
-                formattedLinks += ", ";
+                formattedLinks += ",\u200B";
                 formattedLinks += ac.IsRemote ? "true" : "false";
 
                 if (link.Tags is not null)
                 {
-                    formattedLinks += ", [";
+                    formattedLinks += ",\u200B[";
                     string sep = "";
                     foreach (KeyValuePair<string, object?> kvp in link.EnumerateTagObjects())
                     {
                         formattedLinks += sep;
                         formattedLinks += kvp.Key;
-                        formattedLinks += ": ";
+                        formattedLinks += ":\u200B";
                         formattedLinks += kvp.Value?.ToString() ?? "null";
-                        sep = ", ";
+                        sep = ",\u200B";
                     }
 
                     formattedLinks += "]";
                 }
                 formattedLinks += ")";
-                linkSep = ", ";
+                linkSep = ",\u200B";
             }
             formattedLinks += "]";
 
@@ -2489,27 +2489,27 @@ namespace System.Diagnostics.Tests
             {
                 formattedEvents += $"{linkSep}(";
                 formattedEvents += e.Name;
-                formattedEvents += ", ";
+                formattedEvents += ",\u200B";
                 formattedEvents += e.Timestamp.ToString("o");
 
                 if (e.Tags is not null)
                 {
-                    formattedEvents += ", [";
+                    formattedEvents += ",\u200B[";
                     string sep = "";
                     foreach (KeyValuePair<string, object?> kvp in e.EnumerateTagObjects())
                     {
                         formattedEvents += sep;
                         formattedEvents += kvp.Key;
-                        formattedEvents += ": ";
+                        formattedEvents += ":\u200B";
                         formattedEvents += kvp.Value?.ToString() ?? "null";
-                        sep = ", ";
+                        sep = ",\u200B";
                     }
 
                     formattedEvents += "]";
                 }
 
                 formattedEvents += ")";
-                linkSep = ", ";
+                linkSep = ",\u200B";
             }
 
             formattedEvents += "]";

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -977,7 +977,7 @@ namespace System
         // "TimeZoneInfo"           := TimeZoneInfo Data;[AdjustmentRule Data 1];...;[AdjustmentRule Data N]
         //
         // "TimeZoneInfo Data"      := <_id>;<_baseUtcOffset>;<_displayName>;
-        //                          <_standardDisplayName>;<_daylightDispayName>;
+        //                          <_standardDisplayName>;<_daylightDisplayName>;
         //
         // "AdjustmentRule Data" := <DateStart>;<DateEnd>;<DaylightDelta>;
         //                          [TransitionTime Data DST Start]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/102924?reload=1
- https://github.com/dotnet/runtime/issues/102924?reload=1


This change supports formatting the Events and Links embedded in the `Activity` object to allow getting such formatted data when the activity data gets serialized out of proc. The Events and Links will show up like the following example in the ETW serialized data:

```
Events->"[(TestEvent1,​2025-03-27T23:34:10.6225721+00:00,​[E11:​EV1,​E12:​EV2]),​(TestEvent2,​2025-03-27T23:34:11.6276895+00:00,​[E21:​EV21,​E22:​EV22])]"
Links->"[(19b6e8ea216cb2ba36dd5d957e126d9f,​98f7abcb3418f217,​Recorded,​null,​false,​[alk1:​alv1,​alk2:​alv2]),​(2d409549aadfdbdf5d1892584a5f2ab2,​4f3526086a350f50,​None,​null,​false)]"
```

**Note:** the Events and Links will have the zero width space `\u200B` embedded after `,` and `:`.
![image](https://github.com/user-attachments/assets/ecfc4f3c-cc1d-42d5-afce-ae7289940763)


