### PR TITLE
Remove ConfigureAwait(false) from AsyncEnumerable LINQ

### DIFF
--- a/src/libraries/System.Linq.AsyncEnumerable/src/System.Linq.AsyncEnumerable.csproj
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System.Linq.AsyncEnumerable.csproj
@@ -3,7 +3,13 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <NoWarn>$(NoWarn);CS1998</NoWarn> <!-- Various IAsyncEnumerable implementations that don't need to use await -->
+
+    <!-- Various IAsyncEnumerable implementations that don't need to use await -->
+    <NoWarn>$(NoWarn);CS1998</NoWarn>
+
+    <!-- Due to heavy use of callbacks, ConfigureAwait(false) should not be used.
+         The callbacks should be allowed to run in the original context. -->
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
 
     <!-- Disabling baseline validation since this is a brand new package.
          Once this package has shipped a stable version, the following line

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AggregateBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AggregateBy.cs
@@ -54,38 +54,32 @@ namespace System.Linq
                 IEqualityComparer<TKey>? keyComparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (!await e.MoveNextAsync())
                 {
-                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        yield break;
-                    }
+                    yield break;
+                }
 
-                    Dictionary<TKey, TAccumulate> dict = new(keyComparer);
+                Dictionary<TKey, TAccumulate> dict = new(keyComparer);
 
-                    do
-                    {
-                        TSource value = enumerator.Current;
-                        TKey key = keySelector(value);
+                do
+                {
+                    TSource value = e.Current;
+                    TKey key = keySelector(value);
 
 #if NET
-                        ref TAccumulate? acc = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out bool exists);
-                        acc = func(exists ? acc! : seed, value);
+                    ref TAccumulate? acc = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out bool exists);
+                    acc = func(exists ? acc! : seed, value);
 #else
-                        dict[key] = func(dict.TryGetValue(key, out TAccumulate? acc) ? acc : seed, value);
+                    dict[key] = func(dict.TryGetValue(key, out TAccumulate? acc) ? acc : seed, value);
 #endif
-                    }
-                    while (await enumerator.MoveNextAsync().ConfigureAwait(false));
-
-                    foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
-                    {
-                        yield return countBy;
-                    }
                 }
-                finally
+                while (await e.MoveNextAsync());
+
+                foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
                 {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                    yield return countBy;
                 }
             }
         }
@@ -131,33 +125,27 @@ namespace System.Linq
                 IEqualityComparer<TKey>? keyComparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (!await e.MoveNextAsync())
                 {
-                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        yield break;
-                    }
-
-                    Dictionary<TKey, TAccumulate> dict = new(keyComparer);
-
-                    do
-                    {
-                        TSource value = enumerator.Current;
-                        TKey key = await keySelector(value, cancellationToken).ConfigureAwait(false);
-
-                        dict[key] = await func(dict.TryGetValue(key, out TAccumulate? acc) ? acc : seed, value, cancellationToken).ConfigureAwait(false);
-                    }
-                    while (await enumerator.MoveNextAsync().ConfigureAwait(false));
-
-                    foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
-                    {
-                        yield return countBy;
-                    }
+                    yield break;
                 }
-                finally
+
+                Dictionary<TKey, TAccumulate> dict = new(keyComparer);
+
+                do
                 {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                    TSource value = e.Current;
+                    TKey key = await keySelector(value, cancellationToken);
+
+                    dict[key] = await func(dict.TryGetValue(key, out TAccumulate? acc) ? acc : seed, value, cancellationToken);
+                }
+                while (await e.MoveNextAsync());
+
+                foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
+                {
+                    yield return countBy;
                 }
             }
         }
@@ -204,38 +192,32 @@ namespace System.Linq
                 IEqualityComparer<TKey>? keyComparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (!await e.MoveNextAsync())
                 {
-                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        yield break;
-                    }
+                    yield break;
+                }
 
-                    Dictionary<TKey, TAccumulate> dict = new(keyComparer);
+                Dictionary<TKey, TAccumulate> dict = new(keyComparer);
 
-                    do
-                    {
-                        TSource value = enumerator.Current;
-                        TKey key = keySelector(value);
+                do
+                {
+                    TSource value = e.Current;
+                    TKey key = keySelector(value);
 
 #if NET
-                        ref TAccumulate? acc = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out bool exists);
-                        acc = func(exists ? acc! : seedSelector(key), value);
+                    ref TAccumulate? acc = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out bool exists);
+                    acc = func(exists ? acc! : seedSelector(key), value);
 #else
-                        dict[key] = func(dict.TryGetValue(key, out TAccumulate? acc) ? acc : seedSelector(key), value);
+                    dict[key] = func(dict.TryGetValue(key, out TAccumulate? acc) ? acc : seedSelector(key), value);
 #endif
-                    }
-                    while (await enumerator.MoveNextAsync().ConfigureAwait(false));
-
-                    foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
-                    {
-                        yield return countBy;
-                    }
                 }
-                finally
+                while (await e.MoveNextAsync());
+
+                foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
                 {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                    yield return countBy;
                 }
             }
         }
@@ -282,34 +264,28 @@ namespace System.Linq
                 IEqualityComparer<TKey>? keyComparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    Dictionary<TKey, TAccumulate> dict = new(keyComparer);
+
+                    do
                     {
-                        Dictionary<TKey, TAccumulate> dict = new(keyComparer);
+                        TSource value = e.Current;
+                        TKey key = await keySelector(value, cancellationToken);
 
-                        do
-                        {
-                            TSource value = enumerator.Current;
-                            TKey key = await keySelector(value, cancellationToken).ConfigureAwait(false);
-
-                            dict[key] = await func(
-                                dict.TryGetValue(key, out TAccumulate? acc) ? acc : await seedSelector(key, cancellationToken).ConfigureAwait(false),
-                                value,
-                                cancellationToken).ConfigureAwait(false);
-                        }
-                        while (await enumerator.MoveNextAsync().ConfigureAwait(false));
-
-                        foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
-                        {
-                            yield return countBy;
-                        }
+                        dict[key] = await func(
+                            dict.TryGetValue(key, out TAccumulate? acc) ? acc : await seedSelector(key, cancellationToken),
+                            value,
+                            cancellationToken);
                     }
-                }
-                finally
-                {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
+
+                    foreach (KeyValuePair<TKey, TAccumulate> countBy in dict)
+                    {
+                        yield return countBy;
+                    }
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AllAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AllAsync.cs
@@ -29,7 +29,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), predicate);
+            return Impl(source.WithCancellation(cancellationToken), predicate);
 
             static async ValueTask<bool> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -74,9 +74,9 @@ namespace System.Linq
                 Func<TSource, CancellationToken, ValueTask<bool>> predicate,
                 CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    if (!await predicate(element, cancellationToken).ConfigureAwait(false))
+                    if (!await predicate(element, cancellationToken))
                     {
                         return false;
                     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AnyAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AnyAsync.cs
@@ -28,15 +28,9 @@ namespace System.Linq
                 IAsyncEnumerable<TSource> source,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    return await enumerator.MoveNextAsync().ConfigureAwait(false);
-                }
-                finally
-                {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
-                }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                return await e.MoveNextAsync();
             }
         }
 
@@ -59,7 +53,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), predicate);
+            return Impl(source.WithCancellation(cancellationToken), predicate);
 
             static async ValueTask<bool> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -103,9 +97,9 @@ namespace System.Linq
                 Func<TSource, CancellationToken, ValueTask<bool>> predicate,
                 CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    if (await predicate(element, cancellationToken).ConfigureAwait(false))
+                    if (await predicate(element, cancellationToken))
                     {
                         return true;
                     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Append.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Append.cs
@@ -29,7 +29,7 @@ namespace System.Linq
                 TSource element,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken))
                 {
                     yield return item;
                 }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AverageAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AverageAsync.cs
@@ -23,7 +23,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<double> Impl(
                 ConfiguredCancelableAsyncEnumerable<int> source)
@@ -58,7 +58,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<double> Impl(
                 ConfiguredCancelableAsyncEnumerable<long> source)
@@ -91,7 +91,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<float> Impl(
                 ConfiguredCancelableAsyncEnumerable<float> source)
@@ -124,7 +124,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<double> Impl(
                 ConfiguredCancelableAsyncEnumerable<double> source)
@@ -157,7 +157,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<decimal> Impl(
                 ConfiguredCancelableAsyncEnumerable<decimal> source)
@@ -191,7 +191,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<double?> Impl(
                 ConfiguredCancelableAsyncEnumerable<int?> source)
@@ -223,7 +223,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<double?> Impl(
                 ConfiguredCancelableAsyncEnumerable<long?> source)
@@ -254,7 +254,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<float?> Impl(
                 ConfiguredCancelableAsyncEnumerable<float?> source)
@@ -285,7 +285,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<double?> Impl(
                 ConfiguredCancelableAsyncEnumerable<double?> source)
@@ -316,7 +316,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<decimal?> Impl(
                 ConfiguredCancelableAsyncEnumerable<decimal?> source)

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Cast.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Cast.cs
@@ -35,7 +35,7 @@ namespace System.Linq
                 IAsyncEnumerable<object?> source,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (object? item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (object? item in source.WithCancellation(cancellationToken))
                 {
                     yield return (TResult)item!;
                 }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Chunk.cs
@@ -39,64 +39,58 @@ namespace System.Linq
                 int size,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                // Before allocating anything, make sure there's at least one element.
+                if (await e.MoveNextAsync())
                 {
-                    // Before allocating anything, make sure there's at least one element.
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    // Now that we know we have at least one item, allocate an initial storage array. This is not
+                    // the array we'll yield.  It starts out small in order to avoid significantly overallocating
+                    // when the source has many fewer elements than the chunk size.
+                    int arraySize = Math.Min(size, 4);
+                    int i;
+                    do
                     {
-                        // Now that we know we have at least one item, allocate an initial storage array. This is not
-                        // the array we'll yield.  It starts out small in order to avoid significantly overallocating
-                        // when the source has many fewer elements than the chunk size.
-                        int arraySize = Math.Min(size, 4);
-                        int i;
-                        do
+                        var array = new TSource[arraySize];
+
+                        // Store the first item.
+                        array[0] = e.Current;
+                        i = 1;
+
+                        if (size != array.Length)
                         {
-                            var array = new TSource[arraySize];
-
-                            // Store the first item.
-                            array[0] = e.Current;
-                            i = 1;
-
-                            if (size != array.Length)
+                            // This is the first chunk. As we fill the array, grow it as needed.
+                            for (; i < size && await e.MoveNextAsync(); i++)
                             {
-                                // This is the first chunk. As we fill the array, grow it as needed.
-                                for (; i < size && await e.MoveNextAsync().ConfigureAwait(false); i++)
+                                if (i >= array.Length)
                                 {
-                                    if (i >= array.Length)
-                                    {
-                                        arraySize = (int)Math.Min((uint)size, 2 * (uint)array.Length);
-                                        Array.Resize(ref array, arraySize);
-                                    }
-
-                                    array[i] = e.Current;
+                                    arraySize = (int)Math.Min((uint)size, 2 * (uint)array.Length);
+                                    Array.Resize(ref array, arraySize);
                                 }
-                            }
-                            else
-                            {
-                                // For all but the first chunk, the array will already be correctly sized.
-                                // We can just store into it until either it's full or MoveNext returns false.
-                                TSource[] local = array; // avoid bounds checks by using cached local (`array` is lifted to iterator object as a field)
-                                Debug.Assert(local.Length == size);
-                                for (; (uint)i < (uint)local.Length && await e.MoveNextAsync().ConfigureAwait(false); i++)
-                                {
-                                    local[i] = e.Current;
-                                }
-                            }
 
-                            if (i != array.Length)
-                            {
-                                Array.Resize(ref array, i);
+                                array[i] = e.Current;
                             }
-
-                            yield return array;
                         }
-                        while (i >= size && await e.MoveNextAsync().ConfigureAwait(false));
+                        else
+                        {
+                            // For all but the first chunk, the array will already be correctly sized.
+                            // We can just store into it until either it's full or MoveNext returns false.
+                            TSource[] local = array; // avoid bounds checks by using cached local (`array` is lifted to iterator object as a field)
+                            Debug.Assert(local.Length == size);
+                            for (; (uint)i < (uint)local.Length && await e.MoveNextAsync(); i++)
+                            {
+                                local[i] = e.Current;
+                            }
+                        }
+
+                        if (i != array.Length)
+                        {
+                            Array.Resize(ref array, i);
+                        }
+
+                        yield return array;
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    while (i >= size && await e.MoveNextAsync());
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Concat.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Concat.cs
@@ -33,12 +33,12 @@ namespace System.Linq
                 IAsyncEnumerable<TSource> second,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource item in first.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in first.WithCancellation(cancellationToken))
                 {
                     yield return item;
                 }
 
-                await foreach (TSource item in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in second.WithCancellation(cancellationToken))
                 {
                     yield return item;
                 }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ContainsAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ContainsAsync.cs
@@ -26,7 +26,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), value, comparer ?? EqualityComparer<TSource>.Default);
+            return Impl(source.WithCancellation(cancellationToken), value, comparer ?? EqualityComparer<TSource>.Default);
 
             async static ValueTask<bool> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountAsync.cs
@@ -29,21 +29,15 @@ namespace System.Linq
                 IAsyncEnumerable<TSource> source,
                 CancellationToken cancellationToken = default)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    int count = 0;
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        checked { count++; }
-                    }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                    return count;
-                }
-                finally
+                int count = 0;
+                while (await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    checked { count++; }
                 }
+
+                return count;
             }
         }
 
@@ -63,7 +57,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), predicate);
+            return Impl(source.WithCancellation(cancellationToken), predicate);
 
             static async ValueTask<int> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -106,9 +100,9 @@ namespace System.Linq
                 CancellationToken cancellationToken = default)
             {
                 int count = 0;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    if (await predicate(element, cancellationToken).ConfigureAwait(false))
+                    if (await predicate(element, cancellationToken))
                     {
                         checked { count++; }
                     }
@@ -136,21 +130,15 @@ namespace System.Linq
                 IAsyncEnumerable<TSource> source,
                 CancellationToken cancellationToken = default)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    long count = 0;
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        count++;
-                    }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                    return count;
-                }
-                finally
+                long count = 0;
+                while (await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    count++;
                 }
+
+                return count;
             }
         }
 
@@ -169,7 +157,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), predicate);
+            return Impl(source.WithCancellation(cancellationToken), predicate);
 
             static async ValueTask<long> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -211,9 +199,9 @@ namespace System.Linq
                 CancellationToken cancellationToken = default)
             {
                 long count = 0;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    if (await predicate(element, cancellationToken).ConfigureAwait(false))
+                    if (await predicate(element, cancellationToken))
                     {
                         count++;
                     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountBy.cs
@@ -35,35 +35,29 @@ namespace System.Linq
             static async IAsyncEnumerable<KeyValuePair<TKey, int>> Impl(
                 IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? keyComparer, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    Dictionary<TKey, int> countsBy = new(keyComparer);
+                    do
                     {
-                        Dictionary<TKey, int> countsBy = new(keyComparer);
-                        do
-                        {
-                            TSource value = enumerator.Current;
-                            TKey key = keySelector(value);
+                        TSource value = e.Current;
+                        TKey key = keySelector(value);
 
 #if NET
-                            ref int currentCount = ref CollectionsMarshal.GetValueRefOrAddDefault(countsBy, key, out _);
-                            checked { currentCount++; }
+                        ref int currentCount = ref CollectionsMarshal.GetValueRefOrAddDefault(countsBy, key, out _);
+                        checked { currentCount++; }
 #else
-                            countsBy[key] = countsBy.TryGetValue(key, out int currentCount) ? checked(currentCount + 1) : 1;
+                        countsBy[key] = countsBy.TryGetValue(key, out int currentCount) ? checked(currentCount + 1) : 1;
 #endif
-                        }
-                        while (await enumerator.MoveNextAsync().ConfigureAwait(false));
-
-                        foreach (KeyValuePair<TKey, int> countBy in countsBy)
-                        {
-                            yield return countBy;
-                        }
                     }
-                }
-                finally
-                {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
+
+                    foreach (KeyValuePair<TKey, int> countBy in countsBy)
+                    {
+                        yield return countBy;
+                    }
                 }
             }
         }
@@ -92,35 +86,29 @@ namespace System.Linq
             static async IAsyncEnumerable<KeyValuePair<TKey, int>> Impl(
                 IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<TKey>> keySelector, IEqualityComparer<TKey>? keyComparer, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    Dictionary<TKey, int> countsBy = new(keyComparer);
+                    do
                     {
-                        Dictionary<TKey, int> countsBy = new(keyComparer);
-                        do
-                        {
-                            TSource value = enumerator.Current;
-                            TKey key = await keySelector(value, cancellationToken).ConfigureAwait(false);
+                        TSource value = e.Current;
+                        TKey key = await keySelector(value, cancellationToken);
 
 #if NET
-                            ref int currentCount = ref CollectionsMarshal.GetValueRefOrAddDefault(countsBy, key, out _);
-                            checked { currentCount++; }
+                        ref int currentCount = ref CollectionsMarshal.GetValueRefOrAddDefault(countsBy, key, out _);
+                        checked { currentCount++; }
 #else
-                            countsBy[key] = countsBy.TryGetValue(key, out int currentCount) ? checked(currentCount + 1) : 1;
+                        countsBy[key] = countsBy.TryGetValue(key, out int currentCount) ? checked(currentCount + 1) : 1;
 #endif
-                        }
-                        while (await enumerator.MoveNextAsync().ConfigureAwait(false));
-
-                        foreach (KeyValuePair<TKey, int> countBy in countsBy)
-                        {
-                            yield return countBy;
-                        }
                     }
-                }
-                finally
-                {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
+
+                    foreach (KeyValuePair<TKey, int> countBy in countsBy)
+                    {
+                        yield return countBy;
+                    }
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/DefaultIfEmpty.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/DefaultIfEmpty.cs
@@ -42,25 +42,19 @@ namespace System.Linq
                 TSource defaultValue,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    do
                     {
-                        do
-                        {
-                            yield return e.Current;
-                        }
-                        while (await e.MoveNextAsync().ConfigureAwait(false));
+                        yield return e.Current;
                     }
-                    else
-                    {
-                        yield return defaultValue;
-                    }
+                    while (await e.MoveNextAsync());
                 }
-                finally
+                else
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    yield return defaultValue;
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Distinct.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Distinct.cs
@@ -30,26 +30,20 @@ namespace System.Linq
                 IEqualityComparer<TSource>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    HashSet<TSource> set = new(comparer);
+                    do
                     {
-                        HashSet<TSource> set = new(comparer);
-                        do
+                        TSource element = e.Current;
+                        if (set.Add(element))
                         {
-                            TSource element = e.Current;
-                            if (set.Add(element))
-                            {
-                                yield return element;
-                            }
+                            yield return element;
                         }
-                        while (await e.MoveNextAsync().ConfigureAwait(false));
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/DistinctBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/DistinctBy.cs
@@ -42,26 +42,20 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    HashSet<TKey> set = new(comparer);
+                    do
                     {
-                        HashSet<TKey> set = new(comparer);
-                        do
+                        TSource element = e.Current;
+                        if (set.Add(keySelector(element)))
                         {
-                            TSource element = enumerator.Current;
-                            if (set.Add(keySelector(element)))
-                            {
-                                yield return element;
-                            }
+                            yield return element;
                         }
-                        while (await enumerator.MoveNextAsync().ConfigureAwait(false));
                     }
-                }
-                finally
-                {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
             }
         }
@@ -98,26 +92,20 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> enumerator = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    HashSet<TKey> set = new(comparer);
+                    do
                     {
-                        HashSet<TKey> set = new(comparer);
-                        do
+                        TSource element = e.Current;
+                        if (set.Add(await keySelector(element, cancellationToken)))
                         {
-                            TSource element = enumerator.Current;
-                            if (set.Add(await keySelector(element, cancellationToken).ConfigureAwait(false)))
-                            {
-                                yield return element;
-                            }
+                            yield return element;
                         }
-                        while (await enumerator.MoveNextAsync().ConfigureAwait(false));
                     }
-                }
-                finally
-                {
-                    await enumerator.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ElementAtAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ElementAtAsync.cs
@@ -111,22 +111,16 @@ namespace System.Linq
         {
             if (index >= 0)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        if (index == 0)
-                        {
-                            return e.Current;
-                        }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                        index--;
-                    }
-                }
-                finally
+                while (await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    if (index == 0)
+                    {
+                        return e.Current;
+                    }
+
+                    index--;
                 }
             }
 
@@ -146,33 +140,27 @@ namespace System.Linq
         {
             if (indexFromEnd > 0)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    Queue<TSource> queue = new();
+                    queue.Enqueue(e.Current);
+
+                    while (await e.MoveNextAsync())
                     {
-                        Queue<TSource> queue = new();
-                        queue.Enqueue(e.Current);
-
-                        while (await e.MoveNextAsync().ConfigureAwait(false))
-                        {
-                            if (queue.Count == indexFromEnd)
-                            {
-                                queue.Dequeue();
-                            }
-
-                            queue.Enqueue(e.Current);
-                        }
-
                         if (queue.Count == indexFromEnd)
                         {
-                            return queue.Dequeue();
+                            queue.Dequeue();
                         }
+
+                        queue.Enqueue(e.Current);
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+
+                    if (queue.Count == indexFromEnd)
+                    {
+                        return queue.Dequeue();
+                    }
                 }
             }
 

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ExceptBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ExceptBy.cs
@@ -44,35 +44,29 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
+
+                if (!await firstEnumerator.MoveNextAsync())
                 {
-                    if (!await firstEnumerator.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        yield break;
-                    }
-
-                    HashSet<TKey> set = new(comparer);
-
-                    await foreach (TKey key in second.WithCancellation(cancellationToken).ConfigureAwait(false))
-                    {
-                        set.Add(key);
-                    }
-
-                    do
-                    {
-                        TSource firstElement = firstEnumerator.Current;
-                        if (set.Add(keySelector(firstElement)))
-                        {
-                            yield return firstElement;
-                        }
-                    }
-                    while (await firstEnumerator.MoveNextAsync().ConfigureAwait(false));
+                    yield break;
                 }
-                finally
+
+                HashSet<TKey> set = new(comparer);
+
+                await foreach (TKey key in second.WithCancellation(cancellationToken))
                 {
-                    await firstEnumerator.DisposeAsync().ConfigureAwait(false);
+                    set.Add(key);
                 }
+
+                do
+                {
+                    TSource firstElement = firstEnumerator.Current;
+                    if (set.Add(keySelector(firstElement)))
+                    {
+                        yield return firstElement;
+                    }
+                }
+                while (await firstEnumerator.MoveNextAsync());
             }
         }
 
@@ -110,35 +104,29 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> firstEnumerator = first.GetAsyncEnumerator(cancellationToken);
+
+                if (!await firstEnumerator.MoveNextAsync())
                 {
-                    if (!await firstEnumerator.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        yield break;
-                    }
-
-                    HashSet<TKey> set = new(comparer);
-
-                    await foreach (TKey key in second.WithCancellation(cancellationToken).ConfigureAwait(false))
-                    {
-                        set.Add(key);
-                    }
-
-                    do
-                    {
-                        TSource firstElement = firstEnumerator.Current;
-                        if (set.Add(await keySelector(firstElement, cancellationToken).ConfigureAwait(false)))
-                        {
-                            yield return firstElement;
-                        }
-                    }
-                    while (await firstEnumerator.MoveNextAsync().ConfigureAwait(false));
+                    yield break;
                 }
-                finally
+
+                HashSet<TKey> set = new(comparer);
+
+                await foreach (TKey key in second.WithCancellation(cancellationToken))
                 {
-                    await firstEnumerator.DisposeAsync().ConfigureAwait(false);
+                    set.Add(key);
                 }
+
+                do
+                {
+                    TSource firstElement = firstEnumerator.Current;
+                    if (set.Add(await keySelector(firstElement, cancellationToken)))
+                    {
+                        yield return firstElement;
+                    }
+                }
+                while (await firstEnumerator.MoveNextAsync());
             }
         }
     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/FirstAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/FirstAsync.cs
@@ -29,20 +29,14 @@ namespace System.Linq
                 IAsyncEnumerable<TSource> source,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        ThrowHelper.ThrowNoElementsException();
-                    }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                    return e.Current;
-                }
-                finally
+                if (!await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    ThrowHelper.ThrowNoElementsException();
                 }
+
+                return e.Current;
             }
         }
 
@@ -66,7 +60,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), predicate);
+            return Impl(source.WithCancellation(cancellationToken), predicate);
 
             static async ValueTask<TSource> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -112,9 +106,9 @@ namespace System.Linq
                 Func<TSource, CancellationToken, ValueTask<bool>> predicate,
                 CancellationToken cancellationToken)
             {
-                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken))
                 {
-                    if (await predicate(item, cancellationToken).ConfigureAwait(false))
+                    if (await predicate(item, cancellationToken))
                     {
                         return item;
                     }
@@ -157,15 +151,9 @@ namespace System.Linq
                 TSource defaultValue,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    return await e.MoveNextAsync().ConfigureAwait(false) ? e.Current : defaultValue;
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                return await e.MoveNextAsync() ? e.Current : defaultValue;
             }
         }
 
@@ -221,7 +209,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), predicate, defaultValue);
+            return Impl(source.WithCancellation(cancellationToken), predicate, defaultValue);
 
             static async ValueTask<TSource> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -266,9 +254,9 @@ namespace System.Linq
                 TSource defaultValue,
                 CancellationToken cancellationToken)
             {
-                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken))
                 {
-                    if (await predicate(item, cancellationToken).ConfigureAwait(false))
+                    if (await predicate(item, cancellationToken))
                     {
                         return item;
                     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupBy.cs
@@ -42,7 +42,7 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                foreach (IGrouping<TKey, TSource> item in await ToLookupAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false))
+                foreach (IGrouping<TKey, TSource> item in await ToLookupAsync(source, keySelector, comparer, cancellationToken))
                 {
                     yield return item;
                 }
@@ -79,7 +79,7 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                foreach (IGrouping<TKey, TSource> item in await ToLookupAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false))
+                foreach (IGrouping<TKey, TSource> item in await ToLookupAsync(source, keySelector, comparer, cancellationToken))
                 {
                     yield return item;
                 }
@@ -126,7 +126,7 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                foreach (IGrouping<TKey, TElement> item in await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false))
+                foreach (IGrouping<TKey, TElement> item in await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken))
                 {
                     yield return item;
                 }
@@ -173,7 +173,7 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                foreach (IGrouping<TKey, TElement> item in await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false))
+                foreach (IGrouping<TKey, TElement> item in await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken))
                 {
                     yield return item;
                 }
@@ -219,7 +219,7 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                if (await ToLookupAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false) is AsyncLookup<TKey, TSource> lookup)
+                if (await ToLookupAsync(source, keySelector, comparer, cancellationToken) is AsyncLookup<TKey, TSource> lookup)
                 {
                     foreach (TResult item in lookup.ApplyResultSelector(resultSelector))
                     {
@@ -268,9 +268,9 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                if (await ToLookupAsync(source, keySelector, comparer, cancellationToken).ConfigureAwait(false) is AsyncLookup<TKey, TSource> lookup)
+                if (await ToLookupAsync(source, keySelector, comparer, cancellationToken) is AsyncLookup<TKey, TSource> lookup)
                 {
-                    await foreach (TResult item in lookup.ApplyResultSelector(resultSelector, cancellationToken).ConfigureAwait(false))
+                    await foreach (TResult item in lookup.ApplyResultSelector(resultSelector, cancellationToken))
                     {
                         yield return item;
                     }
@@ -322,7 +322,7 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                if (await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false) is AsyncLookup<TKey, TElement> lookup)
+                if (await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken) is AsyncLookup<TKey, TElement> lookup)
                 {
                     foreach (TResult item in lookup.ApplyResultSelector(resultSelector))
                     {
@@ -376,9 +376,9 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                if (await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false) is AsyncLookup<TKey, TElement> lookup)
+                if (await ToLookupAsync(source, keySelector, elementSelector, comparer, cancellationToken) is AsyncLookup<TKey, TElement> lookup)
                 {
-                    await foreach (TResult item in lookup.ApplyResultSelector(resultSelector, cancellationToken).ConfigureAwait(false))
+                    await foreach (TResult item in lookup.ApplyResultSelector(resultSelector, cancellationToken))
                     {
                         yield return item;
                     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupJoin.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/GroupJoin.cs
@@ -60,23 +60,17 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TOuter> e = outer.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TOuter> e = outer.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    AsyncLookup<TKey, TInner> lookup = await AsyncLookup<TKey, TInner>.CreateForJoinAsync(inner, innerKeySelector, comparer, cancellationToken);
+                    do
                     {
-                        AsyncLookup<TKey, TInner> lookup = await AsyncLookup<TKey, TInner>.CreateForJoinAsync(inner, innerKeySelector, comparer, cancellationToken).ConfigureAwait(false);
-                        do
-                        {
-                            TOuter item = e.Current;
-                            yield return resultSelector(item, lookup[outerKeySelector(item)]);
-                        }
-                        while (await e.MoveNextAsync().ConfigureAwait(false));
+                        TOuter item = e.Current;
+                        yield return resultSelector(item, lookup[outerKeySelector(item)]);
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
             }
         }
@@ -131,26 +125,20 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TOuter> e = outer.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TOuter> e = outer.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    AsyncLookup<TKey, TInner> lookup = await AsyncLookup<TKey, TInner>.CreateForJoinAsync(inner, innerKeySelector, comparer, cancellationToken);
+                    do
                     {
-                        AsyncLookup<TKey, TInner> lookup = await AsyncLookup<TKey, TInner>.CreateForJoinAsync(inner, innerKeySelector, comparer, cancellationToken).ConfigureAwait(false);
-                        do
-                        {
-                            TOuter item = e.Current;
-                            yield return await resultSelector(
-                                item,
-                                lookup[await outerKeySelector(item, cancellationToken).ConfigureAwait(false)],
-                                cancellationToken).ConfigureAwait(false);
-                        }
-                        while (await e.MoveNextAsync().ConfigureAwait(false));
+                        TOuter item = e.Current;
+                        yield return await resultSelector(
+                            item,
+                            lookup[await outerKeySelector(item, cancellationToken)],
+                            cancellationToken);
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Index.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Index.cs
@@ -29,7 +29,7 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     yield return (checked(++index), element);
                 }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Intersect.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Intersect.cs
@@ -37,10 +37,9 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 HashSet<TSource> set;
-                IAsyncEnumerator<TSource> e = second.GetAsyncEnumerator(cancellationToken);
-                try
+                await using (IAsyncEnumerator<TSource> e = second.GetAsyncEnumerator(cancellationToken))
                 {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
+                    if (!await e.MoveNextAsync())
                     {
                         yield break;
                     }
@@ -50,14 +49,10 @@ namespace System.Linq
                     {
                         set.Add(e.Current);
                     }
-                    while (await e.MoveNextAsync().ConfigureAwait(false));
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
 
-                await foreach (TSource element in first.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in first.WithCancellation(cancellationToken))
                 {
                     if (set.Remove(element))
                     {

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/IntersectBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/IntersectBy.cs
@@ -50,10 +50,9 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 HashSet<TKey> set;
-                IAsyncEnumerator<TKey> e = second.GetAsyncEnumerator(cancellationToken);
-                try
+                await using (IAsyncEnumerator<TKey> e = second.GetAsyncEnumerator(cancellationToken))
                 {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
+                    if (!await e.MoveNextAsync())
                     {
                         yield break;
                     }
@@ -63,14 +62,10 @@ namespace System.Linq
                     {
                         set.Add(e.Current);
                     }
-                    while (await e.MoveNextAsync().ConfigureAwait(false));
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
 
-                await foreach (TSource element in first.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in first.WithCancellation(cancellationToken))
                 {
                     if (set.Remove(keySelector(element)))
                     {
@@ -120,10 +115,9 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 HashSet<TKey> set;
-                IAsyncEnumerator<TKey> e = second.GetAsyncEnumerator(cancellationToken);
-                try
+                await using (IAsyncEnumerator<TKey> e = second.GetAsyncEnumerator(cancellationToken))
                 {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
+                    if (!await e.MoveNextAsync())
                     {
                         yield break;
                     }
@@ -133,16 +127,12 @@ namespace System.Linq
                     {
                         set.Add(e.Current);
                     }
-                    while (await e.MoveNextAsync().ConfigureAwait(false));
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
 
-                await foreach (TSource element in first.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in first.WithCancellation(cancellationToken))
                 {
-                    if (set.Remove(await keySelector(element, cancellationToken).ConfigureAwait(false)))
+                    if (set.Remove(await keySelector(element, cancellationToken)))
                     {
                         yield return element;
                     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Join.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Join.cs
@@ -56,35 +56,29 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TOuter> e = outer.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TOuter> e = outer.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    AsyncLookup<TKey, TInner> lookup = await AsyncLookup<TKey, TInner>.CreateForJoinAsync(inner, innerKeySelector, comparer, cancellationToken);
+                    if (lookup.Count != 0)
                     {
-                        AsyncLookup<TKey, TInner> lookup = await AsyncLookup<TKey, TInner>.CreateForJoinAsync(inner, innerKeySelector, comparer, cancellationToken).ConfigureAwait(false);
-                        if (lookup.Count != 0)
+                        do
                         {
-                            do
+                            TOuter item = e.Current;
+                            Grouping<TKey, TInner>? g = lookup.GetGrouping(outerKeySelector(item), create: false);
+                            if (g is not null)
                             {
-                                TOuter item = e.Current;
-                                Grouping<TKey, TInner>? g = lookup.GetGrouping(outerKeySelector(item), create: false);
-                                if (g is not null)
+                                int count = g._count;
+                                TInner[] elements = g._elements;
+                                for (int i = 0; i != count; ++i)
                                 {
-                                    int count = g._count;
-                                    TInner[] elements = g._elements;
-                                    for (int i = 0; i != count; ++i)
-                                    {
-                                        yield return resultSelector(item, elements[i]);
-                                    }
+                                    yield return resultSelector(item, elements[i]);
                                 }
                             }
-                            while (await e.MoveNextAsync().ConfigureAwait(false));
                         }
+                        while (await e.MoveNextAsync());
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
                 }
             }
         }
@@ -136,35 +130,29 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TOuter> e = outer.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TOuter> e = outer.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    AsyncLookup<TKey, TInner> lookup = await AsyncLookup<TKey, TInner>.CreateForJoinAsync(inner, innerKeySelector, comparer, cancellationToken);
+                    if (lookup.Count != 0)
                     {
-                        AsyncLookup<TKey, TInner> lookup = await AsyncLookup<TKey, TInner>.CreateForJoinAsync(inner, innerKeySelector, comparer, cancellationToken).ConfigureAwait(false);
-                        if (lookup.Count != 0)
+                        do
                         {
-                            do
+                            TOuter item = e.Current;
+                            Grouping<TKey, TInner>? g = lookup.GetGrouping(await outerKeySelector(item, cancellationToken), create: false);
+                            if (g is not null)
                             {
-                                TOuter item = e.Current;
-                                Grouping<TKey, TInner>? g = lookup.GetGrouping(await outerKeySelector(item, cancellationToken).ConfigureAwait(false), create: false);
-                                if (g is not null)
+                                int count = g._count;
+                                TInner[] elements = g._elements;
+                                for (int i = 0; i != count; ++i)
                                 {
-                                    int count = g._count;
-                                    TInner[] elements = g._elements;
-                                    for (int i = 0; i != count; ++i)
-                                    {
-                                        yield return await resultSelector(item, elements[i], cancellationToken).ConfigureAwait(false);
-                                    }
+                                    yield return await resultSelector(item, elements[i], cancellationToken);
                                 }
                             }
-                            while (await e.MoveNextAsync().ConfigureAwait(false));
                         }
+                        while (await e.MoveNextAsync());
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/LastAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/LastAsync.cs
@@ -28,27 +28,21 @@ namespace System.Linq
                 IAsyncEnumerable<TSource> source,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        ThrowHelper.ThrowNoElementsException();
-                    }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                    TSource result;
-                    do
-                    {
-                        result = e.Current;
-                    }
-                    while (await e.MoveNextAsync().ConfigureAwait(false));
-
-                    return result;
-                }
-                finally
+                if (!await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    ThrowHelper.ThrowNoElementsException();
                 }
+
+                TSource result;
+                do
+                {
+                    result = e.Current;
+                }
+                while (await e.MoveNextAsync());
+
+                return result;
             }
         }
 
@@ -79,36 +73,30 @@ namespace System.Linq
                 Func<TSource, bool> predicate,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                while (await e.MoveNextAsync())
                 {
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
+                    TSource element = e.Current;
+                    if (predicate(element))
                     {
-                        TSource element = e.Current;
-                        if (predicate(element))
+                        TSource result = element;
+
+                        while (await e.MoveNextAsync())
                         {
-                            TSource result = element;
-
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            element = e.Current;
+                            if (predicate(element))
                             {
-                                element = e.Current;
-                                if (predicate(element))
-                                {
-                                    result = element;
-                                }
+                                result = element;
                             }
-
-                            return result;
                         }
-                    }
 
-                    ThrowHelper.ThrowNoMatchException();
-                    return default!;
+                        return result;
+                    }
                 }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+
+                ThrowHelper.ThrowNoMatchException();
+                return default!;
             }
         }
 
@@ -139,36 +127,30 @@ namespace System.Linq
                 Func<TSource, CancellationToken, ValueTask<bool>> predicate,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                while (await e.MoveNextAsync())
                 {
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
+                    TSource element = e.Current;
+                    if (await predicate(element, cancellationToken))
                     {
-                        TSource element = e.Current;
-                        if (await predicate(element, cancellationToken).ConfigureAwait(false))
+                        TSource result = element;
+
+                        while (await e.MoveNextAsync())
                         {
-                            TSource result = element;
-
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            element = e.Current;
+                            if (await predicate(element, cancellationToken))
                             {
-                                element = e.Current;
-                                if (await predicate(element, cancellationToken).ConfigureAwait(false))
-                                {
-                                    result = element;
-                                }
+                                result = element;
                             }
-
-                            return result;
                         }
-                    }
 
-                    ThrowHelper.ThrowNoMatchException();
-                    return default!;
+                        return result;
+                    }
                 }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+
+                ThrowHelper.ThrowNoMatchException();
+                return default!;
             }
         }
 
@@ -205,25 +187,19 @@ namespace System.Linq
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source, TSource defaultValue, CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    TSource result = defaultValue;
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        do
-                        {
-                            result = e.Current;
-                        }
-                        while (await e.MoveNextAsync().ConfigureAwait(false));
-                    }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                    return result;
-                }
-                finally
+                TSource result = defaultValue;
+                if (await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    do
+                    {
+                        result = e.Current;
+                    }
+                    while (await e.MoveNextAsync());
                 }
+
+                return result;
             }
         }
 
@@ -281,36 +257,30 @@ namespace System.Linq
                 TSource defaultValue,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                TSource result = defaultValue;
+                while (await e.MoveNextAsync())
                 {
-                    TSource result = defaultValue;
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
+                    TSource element = e.Current;
+                    if (predicate(element))
                     {
-                        TSource element = e.Current;
-                        if (predicate(element))
+                        result = element;
+
+                        while (await e.MoveNextAsync())
                         {
-                            result = element;
-
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            element = e.Current;
+                            if (predicate(element))
                             {
-                                element = e.Current;
-                                if (predicate(element))
-                                {
-                                    result = element;
-                                }
+                                result = element;
                             }
-
-                            break;
                         }
-                    }
 
-                    return result;
+                        break;
+                    }
                 }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+
+                return result;
             }
         }
 
@@ -337,36 +307,30 @@ namespace System.Linq
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, TSource defaultValue, CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                TSource result = defaultValue;
+                while (await e.MoveNextAsync())
                 {
-                    TSource result = defaultValue;
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
+                    TSource element = e.Current;
+                    if (await predicate(element, cancellationToken))
                     {
-                        TSource element = e.Current;
-                        if (await predicate(element, cancellationToken).ConfigureAwait(false))
+                        result = element;
+
+                        while (await e.MoveNextAsync())
                         {
-                            result = element;
-
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            element = e.Current;
+                            if (await predicate(element, cancellationToken))
                             {
-                                element = e.Current;
-                                if (await predicate(element, cancellationToken).ConfigureAwait(false))
-                                {
-                                    result = element;
-                                }
+                                result = element;
                             }
-
-                            break;
                         }
-                    }
 
-                    return result;
+                        break;
+                    }
                 }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+
+                return result;
             }
         }
     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MaxAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MaxAsync.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -62,27 +61,45 @@ namespace System.Linq
                 IComparer<TSource> comparer,
                 CancellationToken cancellationToken)
             {
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
                 TSource? value = default;
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                if (default(TSource) is null)
                 {
-                    if (default(TSource) is null)
+                    do
                     {
-                        do
+                        if (!await e.MoveNextAsync())
                         {
-                            if (!await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                return value;
-                            }
-
-                            value = e.Current;
+                            return value;
                         }
-                        while (value is null);
 
-                        while (await e.MoveNextAsync().ConfigureAwait(false))
+                        value = e.Current;
+                    }
+                    while (value is null);
+
+                    while (await e.MoveNextAsync())
+                    {
+                        TSource next = e.Current;
+                        if (next is not null && comparer.Compare(next, value) > 0)
+                        {
+                            value = next;
+                        }
+                    }
+                }
+                else
+                {
+                    if (!await e.MoveNextAsync())
+                    {
+                        ThrowHelper.ThrowNoElementsException();
+                    }
+
+                    value = e.Current;
+                    if (comparer == Comparer<TSource>.Default)
+                    {
+                        while (await e.MoveNextAsync())
                         {
                             TSource next = e.Current;
-                            if (next is not null && comparer.Compare(next, value) > 0)
+                            if (Comparer<TSource>.Default.Compare(next, value) > 0)
                             {
                                 value = next;
                             }
@@ -90,39 +107,15 @@ namespace System.Linq
                     }
                     else
                     {
-                        if (!await e.MoveNextAsync().ConfigureAwait(false))
+                        while (await e.MoveNextAsync())
                         {
-                            ThrowHelper.ThrowNoElementsException();
-                        }
-
-                        value = e.Current;
-                        if (comparer == Comparer<TSource>.Default)
-                        {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            TSource next = e.Current;
+                            if (comparer.Compare(next, value) > 0)
                             {
-                                TSource next = e.Current;
-                                if (Comparer<TSource>.Default.Compare(next, value) > 0)
-                                {
-                                    value = next;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                TSource next = e.Current;
-                                if (comparer.Compare(next, value) > 0)
-                                {
-                                    value = next;
-                                }
+                                value = next;
                             }
                         }
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
                 }
 
                 return value;
@@ -137,43 +130,37 @@ namespace System.Linq
             this IAsyncEnumerable<float> source,
             CancellationToken cancellationToken)
         {
-            IAsyncEnumerator<float> e = source.GetAsyncEnumerator(cancellationToken);
-            try
+            await using IAsyncEnumerator<float> e = source.GetAsyncEnumerator(cancellationToken);
+
+            if (!await e.MoveNextAsync())
             {
-                if (!await e.MoveNextAsync().ConfigureAwait(false))
-                {
-                    ThrowHelper.ThrowNoElementsException();
-                }
-
-                // NaN is ordered less than all other values. We need to do explicit checks to ensure this,
-                // but once we've found a value that is not NaN we need no longer worry about it,
-                // so first loop until such a value is found (or not, as the case may be).
-                float value = e.Current;
-                while (float.IsNaN(value))
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        return value;
-                    }
-
-                    value = e.Current;
-                }
-
-                while (await e.MoveNextAsync().ConfigureAwait(false))
-                {
-                    float x = e.Current;
-                    if (x > value)
-                    {
-                        value = x;
-                    }
-                }
-
-                return value;
+                ThrowHelper.ThrowNoElementsException();
             }
-            finally
+
+            // NaN is ordered less than all other values. We need to do explicit checks to ensure this,
+            // but once we've found a value that is not NaN we need no longer worry about it,
+            // so first loop until such a value is found (or not, as the case may be).
+            float value = e.Current;
+            while (float.IsNaN(value))
             {
-                await e.DisposeAsync().ConfigureAwait(false);
+                if (!await e.MoveNextAsync())
+                {
+                    return value;
+                }
+
+                value = e.Current;
             }
+
+            while (await e.MoveNextAsync())
+            {
+                float x = e.Current;
+                if (x > value)
+                {
+                    value = x;
+                }
+            }
+
+            return value;
         }
 
         /// <summary>Returns the maximum value in a sequence of values.</summary>
@@ -184,43 +171,37 @@ namespace System.Linq
             this IAsyncEnumerable<double> source,
             CancellationToken cancellationToken)
         {
-            IAsyncEnumerator<double> e = source.GetAsyncEnumerator(cancellationToken);
-            try
+            await using IAsyncEnumerator<double> e = source.GetAsyncEnumerator(cancellationToken);
+
+            if (!await e.MoveNextAsync())
             {
-                if (!await e.MoveNextAsync().ConfigureAwait(false))
-                {
-                    ThrowHelper.ThrowNoElementsException();
-                }
-
-                // NaN is ordered less than all other values. We need to do explicit checks to ensure this,
-                // but once we've found a value that is not NaN we need no longer worry about it,
-                // so first loop until such a value is found (or not, as the case may be).
-                double value = e.Current;
-                while (double.IsNaN(value))
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        return value;
-                    }
-
-                    value = e.Current;
-                }
-
-                while (await e.MoveNextAsync().ConfigureAwait(false))
-                {
-                    double x = e.Current;
-                    if (x > value)
-                    {
-                        value = x;
-                    }
-                }
-
-                return value;
+                ThrowHelper.ThrowNoElementsException();
             }
-            finally
+
+            // NaN is ordered less than all other values. We need to do explicit checks to ensure this,
+            // but once we've found a value that is not NaN we need no longer worry about it,
+            // so first loop until such a value is found (or not, as the case may be).
+            double value = e.Current;
+            while (double.IsNaN(value))
             {
-                await e.DisposeAsync().ConfigureAwait(false);
+                if (!await e.MoveNextAsync())
+                {
+                    return value;
+                }
+
+                value = e.Current;
             }
+
+            while (await e.MoveNextAsync())
+            {
+                double x = e.Current;
+                if (x > value)
+                {
+                    value = x;
+                }
+            }
+
+            return value;
         }
 
         /// <summary>Returns the maximum value in a sequence of nullable values.</summary>
@@ -230,7 +211,7 @@ namespace System.Linq
         private static async ValueTask<float?> MaxAsync(IAsyncEnumerable<float?> source, CancellationToken cancellationToken)
         {
             float? value = null;
-            await foreach (float? x in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+            await foreach (float? x in source.WithCancellation(cancellationToken))
             {
                 if (x is null)
                 {
@@ -253,7 +234,7 @@ namespace System.Linq
         private static async ValueTask<double?> MaxAsync(IAsyncEnumerable<double?> source, CancellationToken cancellationToken)
         {
             double? value = null;
-            await foreach (double? x in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+            await foreach (double? x in source.WithCancellation(cancellationToken))
             {
                 if (x is null)
                 {

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MaxByAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MaxByAsync.cs
@@ -39,47 +39,61 @@ namespace System.Linq
                 IComparer<TKey> comparer,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        if (default(TSource) is not null)
-                        {
-                            ThrowHelper.ThrowNoElementsException();
-                        }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                        return default;
+                if (!await e.MoveNextAsync())
+                {
+                    if (default(TSource) is not null)
+                    {
+                        ThrowHelper.ThrowNoElementsException();
                     }
 
-                    TSource value = e.Current;
-                    TKey key = keySelector(value);
+                    return default;
+                }
 
-                    if (default(TKey) is null)
+                TSource value = e.Current;
+                TKey key = keySelector(value);
+
+                if (default(TKey) is null)
+                {
+                    if (key is null)
                     {
-                        if (key is null)
+                        TSource firstValue = value;
+
+                        do
                         {
-                            TSource firstValue = value;
-
-                            do
+                            if (!await e.MoveNextAsync())
                             {
-                                if (!await e.MoveNextAsync().ConfigureAwait(false))
-                                {
-                                    // All keys are null, surface the first element.
-                                    return firstValue;
-                                }
-
-                                value = e.Current;
-                                key = keySelector(value);
+                                // All keys are null, surface the first element.
+                                return firstValue;
                             }
-                            while (key is null);
-                        }
 
-                        while (await e.MoveNextAsync().ConfigureAwait(false))
+                            value = e.Current;
+                            key = keySelector(value);
+                        }
+                        while (key is null);
+                    }
+
+                    while (await e.MoveNextAsync())
+                    {
+                        TSource nextValue = e.Current;
+                        TKey nextKey = keySelector(nextValue);
+                        if (nextKey is not null && comparer.Compare(nextKey, key) > 0)
+                        {
+                            key = nextKey;
+                            value = nextValue;
+                        }
+                    }
+                }
+                else
+                {
+                    if (comparer == Comparer<TKey>.Default)
+                    {
+                        while (await e.MoveNextAsync())
                         {
                             TSource nextValue = e.Current;
                             TKey nextKey = keySelector(nextValue);
-                            if (nextKey is not null && comparer.Compare(nextKey, key) > 0)
+                            if (Comparer<TKey>.Default.Compare(nextKey, key) > 0)
                             {
                                 key = nextKey;
                                 value = nextValue;
@@ -88,40 +102,20 @@ namespace System.Linq
                     }
                     else
                     {
-                        if (comparer == Comparer<TKey>.Default)
+                        while (await e.MoveNextAsync())
                         {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            TSource nextValue = e.Current;
+                            TKey nextKey = keySelector(nextValue);
+                            if (comparer.Compare(nextKey, key) > 0)
                             {
-                                TSource nextValue = e.Current;
-                                TKey nextKey = keySelector(nextValue);
-                                if (Comparer<TKey>.Default.Compare(nextKey, key) > 0)
-                                {
-                                    key = nextKey;
-                                    value = nextValue;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                TSource nextValue = e.Current;
-                                TKey nextKey = keySelector(nextValue);
-                                if (comparer.Compare(nextKey, key) > 0)
-                                {
-                                    key = nextKey;
-                                    value = nextValue;
-                                }
+                                key = nextKey;
+                                value = nextValue;
                             }
                         }
                     }
+                }
 
-                    return value;
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+                return value;
             }
         }
 
@@ -155,47 +149,61 @@ namespace System.Linq
                 IComparer<TKey> comparer,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        if (default(TSource) is not null)
-                        {
-                            ThrowHelper.ThrowNoElementsException();
-                        }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                        return default;
+                if (!await e.MoveNextAsync())
+                {
+                    if (default(TSource) is not null)
+                    {
+                        ThrowHelper.ThrowNoElementsException();
                     }
 
-                    TSource value = e.Current;
-                    TKey key = await keySelector(value, cancellationToken).ConfigureAwait(false);
+                    return default;
+                }
 
-                    if (default(TKey) is null)
+                TSource value = e.Current;
+                TKey key = await keySelector(value, cancellationToken);
+
+                if (default(TKey) is null)
+                {
+                    if (key is null)
                     {
-                        if (key is null)
+                        TSource firstValue = value;
+
+                        do
                         {
-                            TSource firstValue = value;
-
-                            do
+                            if (!await e.MoveNextAsync())
                             {
-                                if (!await e.MoveNextAsync().ConfigureAwait(false))
-                                {
-                                    // All keys are null, surface the first element.
-                                    return firstValue;
-                                }
-
-                                value = e.Current;
-                                key = await keySelector(value, cancellationToken).ConfigureAwait(false);
+                                // All keys are null, surface the first element.
+                                return firstValue;
                             }
-                            while (key is null);
-                        }
 
-                        while (await e.MoveNextAsync().ConfigureAwait(false))
+                            value = e.Current;
+                            key = await keySelector(value, cancellationToken);
+                        }
+                        while (key is null);
+                    }
+
+                    while (await e.MoveNextAsync())
+                    {
+                        TSource nextValue = e.Current;
+                        TKey nextKey = await keySelector(nextValue, cancellationToken);
+                        if (nextKey is not null && comparer.Compare(nextKey, key) > 0)
+                        {
+                            key = nextKey;
+                            value = nextValue;
+                        }
+                    }
+                }
+                else
+                {
+                    if (comparer == Comparer<TKey>.Default)
+                    {
+                        while (await e.MoveNextAsync())
                         {
                             TSource nextValue = e.Current;
-                            TKey nextKey = await keySelector(nextValue, cancellationToken).ConfigureAwait(false);
-                            if (nextKey is not null && comparer.Compare(nextKey, key) > 0)
+                            TKey nextKey = await keySelector(nextValue, cancellationToken);
+                            if (Comparer<TKey>.Default.Compare(nextKey, key) > 0)
                             {
                                 key = nextKey;
                                 value = nextValue;
@@ -204,40 +212,20 @@ namespace System.Linq
                     }
                     else
                     {
-                        if (comparer == Comparer<TKey>.Default)
+                        while (await e.MoveNextAsync())
                         {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            TSource nextValue = e.Current;
+                            TKey nextKey = await keySelector(nextValue, cancellationToken);
+                            if (comparer.Compare(nextKey, key) > 0)
                             {
-                                TSource nextValue = e.Current;
-                                TKey nextKey = await keySelector(nextValue, cancellationToken).ConfigureAwait(false);
-                                if (Comparer<TKey>.Default.Compare(nextKey, key) > 0)
-                                {
-                                    key = nextKey;
-                                    value = nextValue;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                TSource nextValue = e.Current;
-                                TKey nextKey = await keySelector(nextValue, cancellationToken).ConfigureAwait(false);
-                                if (comparer.Compare(nextKey, key) > 0)
-                                {
-                                    key = nextKey;
-                                    value = nextValue;
-                                }
+                                key = nextKey;
+                                value = nextValue;
                             }
                         }
                     }
+                }
 
-                    return value;
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+                return value;
             }
         }
     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MinAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MinAsync.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -59,27 +58,45 @@ namespace System.Linq
 
             static async ValueTask<TSource?> Impl(IAsyncEnumerable<TSource> source, IComparer<TSource> comparer, CancellationToken cancellationToken)
             {
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
                 TSource? value = default;
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                if (default(TSource) is null)
                 {
-                    if (default(TSource) is null)
+                    do
                     {
-                        do
+                        if (!await e.MoveNextAsync())
                         {
-                            if (!await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                return value;
-                            }
-
-                            value = e.Current;
+                            return value;
                         }
-                        while (value is null);
 
-                        while (await e.MoveNextAsync().ConfigureAwait(false))
+                        value = e.Current;
+                    }
+                    while (value is null);
+
+                    while (await e.MoveNextAsync())
+                    {
+                        TSource next = e.Current;
+                        if (next is not null && comparer.Compare(next, value) < 0)
+                        {
+                            value = next;
+                        }
+                    }
+                }
+                else
+                {
+                    if (!await e.MoveNextAsync())
+                    {
+                        ThrowHelper.ThrowNoElementsException();
+                    }
+
+                    value = e.Current;
+                    if (comparer == Comparer<TSource>.Default)
+                    {
+                        while (await e.MoveNextAsync())
                         {
                             TSource next = e.Current;
-                            if (next is not null && comparer.Compare(next, value) < 0)
+                            if (Comparer<TSource>.Default.Compare(next, value) < 0)
                             {
                                 value = next;
                             }
@@ -87,42 +104,18 @@ namespace System.Linq
                     }
                     else
                     {
-                        if (!await e.MoveNextAsync().ConfigureAwait(false))
+                        while (await e.MoveNextAsync())
                         {
-                            ThrowHelper.ThrowNoElementsException();
-                        }
-
-                        value = e.Current;
-                        if (comparer == Comparer<TSource>.Default)
-                        {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            TSource next = e.Current;
+                            if (comparer.Compare(next, value) < 0)
                             {
-                                TSource next = e.Current;
-                                if (Comparer<TSource>.Default.Compare(next, value) < 0)
-                                {
-                                    value = next;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                TSource next = e.Current;
-                                if (comparer.Compare(next, value) < 0)
-                                {
-                                    value = next;
-                                }
+                                value = next;
                             }
                         }
                     }
+                }
 
-                    return value;
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+                return value;
             }
         }
 
@@ -134,48 +127,41 @@ namespace System.Linq
             IAsyncEnumerable<float> source,
             CancellationToken cancellationToken)
         {
-            IAsyncEnumerator<float> e = source.GetAsyncEnumerator(cancellationToken);
-            try
+            await using IAsyncEnumerator<float> e = source.GetAsyncEnumerator(cancellationToken);
+
+            if (!await e.MoveNextAsync())
             {
-                if (!await e.MoveNextAsync().ConfigureAwait(false))
-                {
-                    ThrowHelper.ThrowNoElementsException();
-                }
+                ThrowHelper.ThrowNoElementsException();
+            }
 
-                float value = e.Current;
-                if (float.IsNaN(value))
-                {
-                    return value;
-                }
-
-                while (await e.MoveNextAsync().ConfigureAwait(false))
-                {
-                    float x = e.Current;
-                    if (x < value)
-                    {
-                        value = x;
-                    }
-
-                    // Normally NaN < anything is false, as is anything < NaN
-                    // However, this leads to some irksome outcomes in Min and Max.
-                    // If we use those semantics then Min(NaN, 5.0) is NaN, but
-                    // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
-                    // ordering where NaN is smaller than every value, including
-                    // negative infinity. Not testing for NaN therefore isn't an option, but since we
-                    // can't find a smaller value, we can short-circuit.
-                    else if (float.IsNaN(x))
-                    {
-                        return x;
-                    }
-                }
-
+            float value = e.Current;
+            if (float.IsNaN(value))
+            {
                 return value;
+            }
 
-            }
-            finally
+            while (await e.MoveNextAsync())
             {
-                await e.DisposeAsync().ConfigureAwait(false);
+                float x = e.Current;
+                if (x < value)
+                {
+                    value = x;
+                }
+
+                // Normally NaN < anything is false, as is anything < NaN
+                // However, this leads to some irksome outcomes in Min and Max.
+                // If we use those semantics then Min(NaN, 5.0) is NaN, but
+                // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
+                // ordering where NaN is smaller than every value, including
+                // negative infinity. Not testing for NaN therefore isn't an option, but since we
+                // can't find a smaller value, we can short-circuit.
+                else if (float.IsNaN(x))
+                {
+                    return x;
+                }
             }
+
+            return value;
         }
 
         /// <summary>Returns the minimum value in a sequence of values.</summary>
@@ -186,48 +172,41 @@ namespace System.Linq
             IAsyncEnumerable<double> source,
             CancellationToken cancellationToken)
         {
-            IAsyncEnumerator<double> e = source.GetAsyncEnumerator(cancellationToken);
-            try
+            await using IAsyncEnumerator<double> e = source.GetAsyncEnumerator(cancellationToken);
+
+            if (!await e.MoveNextAsync())
             {
-                if (!await e.MoveNextAsync().ConfigureAwait(false))
-                {
-                    ThrowHelper.ThrowNoElementsException();
-                }
+                ThrowHelper.ThrowNoElementsException();
+            }
 
-                double value = e.Current;
-                if (double.IsNaN(value))
-                {
-                    return value;
-                }
-
-                while (await e.MoveNextAsync().ConfigureAwait(false))
-                {
-                    double x = e.Current;
-                    if (x < value)
-                    {
-                        value = x;
-                    }
-
-                    // Normally NaN < anything is false, as is anything < NaN
-                    // However, this leads to some irksome outcomes in Min and Max.
-                    // If we use those semantics then Min(NaN, 5.0) is NaN, but
-                    // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
-                    // ordering where NaN is smaller than every value, including
-                    // negative infinity. Not testing for NaN therefore isn't an option, but since we
-                    // can't find a smaller value, we can short-circuit.
-                    else if (double.IsNaN(x))
-                    {
-                        return x;
-                    }
-                }
-
+            double value = e.Current;
+            if (double.IsNaN(value))
+            {
                 return value;
+            }
 
-            }
-            finally
+            while (await e.MoveNextAsync())
             {
-                await e.DisposeAsync().ConfigureAwait(false);
+                double x = e.Current;
+                if (x < value)
+                {
+                    value = x;
+                }
+
+                // Normally NaN < anything is false, as is anything < NaN
+                // However, this leads to some irksome outcomes in Min and Max.
+                // If we use those semantics then Min(NaN, 5.0) is NaN, but
+                // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
+                // ordering where NaN is smaller than every value, including
+                // negative infinity. Not testing for NaN therefore isn't an option, but since we
+                // can't find a smaller value, we can short-circuit.
+                else if (double.IsNaN(x))
+                {
+                    return x;
+                }
             }
+
+            return value;
         }
 
         /// <summary>Returns the minimum value in a sequence of nullable values.</summary>
@@ -239,7 +218,7 @@ namespace System.Linq
             CancellationToken cancellationToken)
         {
             float? value = null;
-            await foreach (float? x in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+            await foreach (float? x in source.WithCancellation(cancellationToken))
             {
                 if (x is null)
                 {
@@ -264,7 +243,7 @@ namespace System.Linq
             CancellationToken cancellationToken)
         {
             double? value = null;
-            await foreach (double? x in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+            await foreach (double? x in source.WithCancellation(cancellationToken))
             {
                 if (x is null)
                 {

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MinByAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MinByAsync.cs
@@ -39,47 +39,61 @@ namespace System.Linq
                 IComparer<TKey> comparer,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        if (default(TSource) is not null)
-                        {
-                            ThrowHelper.ThrowNoElementsException();
-                        }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                        return default;
+                if (!await e.MoveNextAsync())
+                {
+                    if (default(TSource) is not null)
+                    {
+                        ThrowHelper.ThrowNoElementsException();
                     }
 
-                    TSource value = e.Current;
-                    TKey key = keySelector(value);
+                    return default;
+                }
 
-                    if (default(TKey) is null)
+                TSource value = e.Current;
+                TKey key = keySelector(value);
+
+                if (default(TKey) is null)
+                {
+                    if (key is null)
                     {
-                        if (key is null)
+                        TSource firstValue = value;
+
+                        do
                         {
-                            TSource firstValue = value;
-
-                            do
+                            if (!await e.MoveNextAsync())
                             {
-                                if (!await e.MoveNextAsync().ConfigureAwait(false))
-                                {
-                                    // All keys are null, surface the first element.
-                                    return firstValue;
-                                }
-
-                                value = e.Current;
-                                key = keySelector(value);
+                                // All keys are null, surface the first element.
+                                return firstValue;
                             }
-                            while (key is null);
-                        }
 
-                        while (await e.MoveNextAsync().ConfigureAwait(false))
+                            value = e.Current;
+                            key = keySelector(value);
+                        }
+                        while (key is null);
+                    }
+
+                    while (await e.MoveNextAsync())
+                    {
+                        TSource nextValue = e.Current;
+                        TKey nextKey = keySelector(nextValue);
+                        if (nextKey is not null && comparer.Compare(nextKey, key) < 0)
+                        {
+                            key = nextKey;
+                            value = nextValue;
+                        }
+                    }
+                }
+                else
+                {
+                    if (comparer == Comparer<TKey>.Default)
+                    {
+                        while (await e.MoveNextAsync())
                         {
                             TSource nextValue = e.Current;
                             TKey nextKey = keySelector(nextValue);
-                            if (nextKey is not null && comparer.Compare(nextKey, key) < 0)
+                            if (Comparer<TKey>.Default.Compare(nextKey, key) < 0)
                             {
                                 key = nextKey;
                                 value = nextValue;
@@ -88,40 +102,20 @@ namespace System.Linq
                     }
                     else
                     {
-                        if (comparer == Comparer<TKey>.Default)
+                        while (await e.MoveNextAsync())
                         {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            TSource nextValue = e.Current;
+                            TKey nextKey = keySelector(nextValue);
+                            if (comparer.Compare(nextKey, key) < 0)
                             {
-                                TSource nextValue = e.Current;
-                                TKey nextKey = keySelector(nextValue);
-                                if (Comparer<TKey>.Default.Compare(nextKey, key) < 0)
-                                {
-                                    key = nextKey;
-                                    value = nextValue;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                TSource nextValue = e.Current;
-                                TKey nextKey = keySelector(nextValue);
-                                if (comparer.Compare(nextKey, key) < 0)
-                                {
-                                    key = nextKey;
-                                    value = nextValue;
-                                }
+                                key = nextKey;
+                                value = nextValue;
                             }
                         }
                     }
+                }
 
-                    return value;
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+                return value;
             }
         }
 
@@ -155,47 +149,61 @@ namespace System.Linq
                 IComparer<TKey> comparer,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        if (default(TSource) is not null)
-                        {
-                            ThrowHelper.ThrowNoElementsException();
-                        }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                        return default;
+                if (!await e.MoveNextAsync())
+                {
+                    if (default(TSource) is not null)
+                    {
+                        ThrowHelper.ThrowNoElementsException();
                     }
 
-                    TSource value = e.Current;
-                    TKey key = await keySelector(value, cancellationToken).ConfigureAwait(false);
+                    return default;
+                }
 
-                    if (default(TKey) is null)
+                TSource value = e.Current;
+                TKey key = await keySelector(value, cancellationToken);
+
+                if (default(TKey) is null)
+                {
+                    if (key is null)
                     {
-                        if (key is null)
+                        TSource firstValue = value;
+
+                        do
                         {
-                            TSource firstValue = value;
-
-                            do
+                            if (!await e.MoveNextAsync())
                             {
-                                if (!await e.MoveNextAsync().ConfigureAwait(false))
-                                {
-                                    // All keys are null, surface the first element.
-                                    return firstValue;
-                                }
-
-                                value = e.Current;
-                                key = await keySelector(value, cancellationToken).ConfigureAwait(false);
+                                // All keys are null, surface the first element.
+                                return firstValue;
                             }
-                            while (key is null);
-                        }
 
-                        while (await e.MoveNextAsync().ConfigureAwait(false))
+                            value = e.Current;
+                            key = await keySelector(value, cancellationToken);
+                        }
+                        while (key is null);
+                    }
+
+                    while (await e.MoveNextAsync())
+                    {
+                        TSource nextValue = e.Current;
+                        TKey nextKey = await keySelector(nextValue, cancellationToken);
+                        if (nextKey is not null && comparer.Compare(nextKey, key) < 0)
+                        {
+                            key = nextKey;
+                            value = nextValue;
+                        }
+                    }
+                }
+                else
+                {
+                    if (comparer == Comparer<TKey>.Default)
+                    {
+                        while (await e.MoveNextAsync())
                         {
                             TSource nextValue = e.Current;
-                            TKey nextKey = await keySelector(nextValue, cancellationToken).ConfigureAwait(false);
-                            if (nextKey is not null && comparer.Compare(nextKey, key) < 0)
+                            TKey nextKey = await keySelector(nextValue, cancellationToken);
+                            if (Comparer<TKey>.Default.Compare(nextKey, key) < 0)
                             {
                                 key = nextKey;
                                 value = nextValue;
@@ -204,40 +212,20 @@ namespace System.Linq
                     }
                     else
                     {
-                        if (comparer == Comparer<TKey>.Default)
+                        while (await e.MoveNextAsync())
                         {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
+                            TSource nextValue = e.Current;
+                            TKey nextKey = await keySelector(nextValue, cancellationToken);
+                            if (comparer.Compare(nextKey, key) < 0)
                             {
-                                TSource nextValue = e.Current;
-                                TKey nextKey = await keySelector(nextValue, cancellationToken).ConfigureAwait(false);
-                                if (Comparer<TKey>.Default.Compare(nextKey, key) < 0)
-                                {
-                                    key = nextKey;
-                                    value = nextValue;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                TSource nextValue = e.Current;
-                                TKey nextKey = await keySelector(nextValue, cancellationToken).ConfigureAwait(false);
-                                if (comparer.Compare(nextKey, key) < 0)
-                                {
-                                    key = nextKey;
-                                    value = nextValue;
-                                }
+                                key = nextKey;
+                                value = nextValue;
                             }
                         }
                     }
+                }
 
-                    return value;
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
-                }
+                return value;
             }
         }
     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OfType.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OfType.cs
@@ -34,7 +34,7 @@ namespace System.Linq
                 IAsyncEnumerable<object?> source,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (object? item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (object? item in source.WithCancellation(cancellationToken))
                 {
                     if (item is TResult target)
                     {

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OrderBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OrderBy.cs
@@ -256,10 +256,10 @@ namespace System.Linq
 
             public override async IAsyncEnumerator<TElement> GetAsyncEnumerator(CancellationToken cancellationToken)
             {
-                TElement[] buffer = await _source.ToArrayAsync(cancellationToken).ConfigureAwait(false);
+                TElement[] buffer = await _source.ToArrayAsync(cancellationToken);
                 if (buffer.Length > 0)
                 {
-                    int[] map = await CreateSortedMapAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    int[] map = await CreateSortedMapAsync(buffer, cancellationToken);
                     for (int i = 0; i < map.Length; i++)
                     {
                         yield return buffer[map[i]];
@@ -283,7 +283,7 @@ namespace System.Linq
 
             internal async ValueTask<int[]> SortAsync(TElement[] elements, int count, CancellationToken cancellationToken)
             {
-                await ComputeKeysAsync(elements, count, cancellationToken).ConfigureAwait(false);
+                await ComputeKeysAsync(elements, count, cancellationToken);
 
                 int[] map = new int[count];
                 for (int i = 0; i < map.Length; i++)
@@ -342,7 +342,7 @@ namespace System.Linq
                         var asyncSelector = (Func<TElement, CancellationToken, ValueTask<TKey>>)keySelector;
                         for (int i = 0; i < keys.Length; i++)
                         {
-                            keys[i] = await asyncSelector(elements[i], cancellationToken).ConfigureAwait(false);
+                            keys[i] = await asyncSelector(elements[i], cancellationToken);
                         }
                     }
                     _keys = keys;

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Prepend.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Prepend.cs
@@ -31,7 +31,7 @@ namespace System.Linq
             {
                 yield return element;
 
-                await foreach (TSource item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource item in source.WithCancellation(cancellationToken))
                 {
                     yield return item;
                 }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Reverse.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Reverse.cs
@@ -27,7 +27,7 @@ namespace System.Linq
                 IAsyncEnumerable<TSource> source,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                TSource[] array = await source.ToArrayAsync(cancellationToken).ConfigureAwait(false);
+                TSource[] array = await source.ToArrayAsync(cancellationToken);
                 for (int i = array.Length - 1; i >= 0; i--)
                 {
                     yield return array[i];

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/RightJoin.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/RightJoin.cs
@@ -54,36 +54,30 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TInner> e = inner.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TInner> e = inner.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    AsyncLookup<TKey, TOuter> outerLookup = await AsyncLookup<TKey, TOuter>.CreateForJoinAsync(outer, outerKeySelector, comparer, cancellationToken);
+                    do
                     {
-                        AsyncLookup<TKey, TOuter> outerLookup = await AsyncLookup<TKey, TOuter>.CreateForJoinAsync(outer, outerKeySelector, comparer, cancellationToken).ConfigureAwait(false);
-                        do
+                        TInner item = e.Current;
+                        Grouping<TKey, TOuter>? g = outerLookup.GetGrouping(innerKeySelector(item), create: false);
+                        if (g is null)
                         {
-                            TInner item = e.Current;
-                            Grouping<TKey, TOuter>? g = outerLookup.GetGrouping(innerKeySelector(item), create: false);
-                            if (g is null)
+                            yield return resultSelector(default, item);
+                        }
+                        else
+                        {
+                            int count = g._count;
+                            TOuter[] elements = g._elements;
+                            for (int i = 0; i != count; ++i)
                             {
-                                yield return resultSelector(default, item);
-                            }
-                            else
-                            {
-                                int count = g._count;
-                                TOuter[] elements = g._elements;
-                                for (int i = 0; i != count; ++i)
-                                {
-                                    yield return resultSelector(elements[i], item);
-                                }
+                                yield return resultSelector(elements[i], item);
                             }
                         }
-                        while (await e.MoveNextAsync().ConfigureAwait(false));
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
             }
         }
@@ -132,36 +126,30 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TInner> e = inner.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TInner> e = inner.GetAsyncEnumerator(cancellationToken);
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync().ConfigureAwait(false))
+                    AsyncLookup<TKey, TOuter> outerLookup = await AsyncLookup<TKey, TOuter>.CreateForJoinAsync(outer, outerKeySelector, comparer, cancellationToken);
+                    do
                     {
-                        AsyncLookup<TKey, TOuter> outerLookup = await AsyncLookup<TKey, TOuter>.CreateForJoinAsync(outer, outerKeySelector, comparer, cancellationToken).ConfigureAwait(false);
-                        do
+                        TInner item = e.Current;
+                        Grouping<TKey, TOuter>? g = outerLookup.GetGrouping(await innerKeySelector(item, cancellationToken), create: false);
+                        if (g is null)
                         {
-                            TInner item = e.Current;
-                            Grouping<TKey, TOuter>? g = outerLookup.GetGrouping(await innerKeySelector(item, cancellationToken).ConfigureAwait(false), create: false);
-                            if (g is null)
+                            yield return await resultSelector(default, item, cancellationToken);
+                        }
+                        else
+                        {
+                            int count = g._count;
+                            TOuter[] elements = g._elements;
+                            for (int i = 0; i != count; ++i)
                             {
-                                yield return await resultSelector(default, item, cancellationToken).ConfigureAwait(false);
-                            }
-                            else
-                            {
-                                int count = g._count;
-                                TOuter[] elements = g._elements;
-                                for (int i = 0; i != count; ++i)
-                                {
-                                    yield return await resultSelector(elements[i], item, cancellationToken).ConfigureAwait(false);
-                                }
+                                yield return await resultSelector(elements[i], item, cancellationToken);
                             }
                         }
-                        while (await e.MoveNextAsync().ConfigureAwait(false));
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    while (await e.MoveNextAsync());
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Select.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Select.cs
@@ -37,7 +37,7 @@ namespace System.Linq
                 Func<TSource, TResult> selector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     yield return selector(element);
                 }
@@ -71,9 +71,9 @@ namespace System.Linq
                 Func<TSource, CancellationToken, ValueTask<TResult>> selector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    yield return await selector(element, cancellationToken).ConfigureAwait(false);
+                    yield return await selector(element, cancellationToken);
                 }
             }
         }
@@ -109,7 +109,7 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     yield return selector(element, checked(++index));
                 }
@@ -147,9 +147,9 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    yield return await selector(element, checked(++index), cancellationToken).ConfigureAwait(false);
+                    yield return await selector(element, checked(++index), cancellationToken);
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SelectMany.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SelectMany.cs
@@ -40,7 +40,7 @@ namespace System.Linq
                 Func<TSource, IEnumerable<TResult>> selector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     foreach (TResult subElement in selector(element))
                     {
@@ -80,9 +80,9 @@ namespace System.Linq
                 Func<TSource, CancellationToken, ValueTask<IEnumerable<TResult>>> selector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    foreach (TResult subElement in await selector(element, cancellationToken).ConfigureAwait(false))
+                    foreach (TResult subElement in await selector(element, cancellationToken))
                     {
                         yield return subElement;
                     }
@@ -120,9 +120,9 @@ namespace System.Linq
                 Func<TSource, IAsyncEnumerable<TResult>> selector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    await foreach (TResult subElement in selector(element).WithCancellation(cancellationToken).ConfigureAwait(false))
+                    await foreach (TResult subElement in selector(element).WithCancellation(cancellationToken))
                     {
                         yield return subElement;
                     }
@@ -162,7 +162,7 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     foreach (TResult subElement in selector(element, checked(++index)))
                     {
@@ -204,9 +204,9 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    foreach (TResult subElement in await selector(element, checked(++index), cancellationToken).ConfigureAwait(false))
+                    foreach (TResult subElement in await selector(element, checked(++index), cancellationToken))
                     {
                         yield return subElement;
                     }
@@ -246,9 +246,9 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    await foreach (TResult subElement in selector(element, checked(++index)).WithCancellation(cancellationToken).ConfigureAwait(false))
+                    await foreach (TResult subElement in selector(element, checked(++index)).WithCancellation(cancellationToken))
                     {
                         yield return subElement;
                     }
@@ -296,7 +296,7 @@ namespace System.Linq
                 Func<TSource, TCollection, TResult> resultSelector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     foreach (TCollection subElement in collectionSelector(element))
                     {
@@ -346,11 +346,11 @@ namespace System.Linq
                 Func<TSource, TCollection, CancellationToken, ValueTask<TResult>> resultSelector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    foreach (TCollection subElement in await collectionSelector(element, cancellationToken).ConfigureAwait(false))
+                    foreach (TCollection subElement in await collectionSelector(element, cancellationToken))
                     {
-                        yield return await resultSelector(element, subElement, cancellationToken).ConfigureAwait(false);
+                        yield return await resultSelector(element, subElement, cancellationToken);
                     }
                 }
             }
@@ -396,9 +396,9 @@ namespace System.Linq
                 Func<TSource, TCollection, TResult> resultSelector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    await foreach (TCollection subElement in collectionSelector(element).WithCancellation(cancellationToken).ConfigureAwait(false))
+                    await foreach (TCollection subElement in collectionSelector(element).WithCancellation(cancellationToken))
                     {
                         yield return resultSelector(element, subElement);
                     }
@@ -446,11 +446,11 @@ namespace System.Linq
                 Func<TSource, TCollection, CancellationToken, ValueTask<TResult>> resultSelector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    await foreach (TCollection subElement in collectionSelector(element).WithCancellation(cancellationToken).ConfigureAwait(false))
+                    await foreach (TCollection subElement in collectionSelector(element).WithCancellation(cancellationToken))
                     {
-                        yield return await resultSelector(element, subElement, cancellationToken).ConfigureAwait(false);
+                        yield return await resultSelector(element, subElement, cancellationToken);
                     }
                 }
             }
@@ -496,7 +496,7 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     foreach (TCollection subElement in collectionSelector(element, checked(++index)))
                     {
@@ -546,11 +546,11 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    foreach (TCollection subElement in await collectionSelector(element, checked(++index), cancellationToken).ConfigureAwait(false))
+                    foreach (TCollection subElement in await collectionSelector(element, checked(++index), cancellationToken))
                     {
-                        yield return await resultSelector(element, subElement, cancellationToken).ConfigureAwait(false);
+                        yield return await resultSelector(element, subElement, cancellationToken);
                     }
                 }
             }
@@ -596,11 +596,11 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    await foreach (TCollection subElement in collectionSelector(element, checked(++index)).WithCancellation(cancellationToken).ConfigureAwait(false))
+                    await foreach (TCollection subElement in collectionSelector(element, checked(++index)).WithCancellation(cancellationToken))
                     {
-                        yield return await resultSelector(element, subElement, cancellationToken).ConfigureAwait(false);
+                        yield return await resultSelector(element, subElement, cancellationToken);
                     }
                 }
             }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SequenceEqualAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SequenceEqualAsync.cs
@@ -36,31 +36,18 @@ namespace System.Linq
                 IEqualityComparer<TSource> comparer,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e1 = first.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    IAsyncEnumerator<TSource> e2 = second.GetAsyncEnumerator(cancellationToken);
-                    try
-                    {
-                        while (await e1.MoveNextAsync().ConfigureAwait(false))
-                        {
-                            if (!await e2.MoveNextAsync().ConfigureAwait(false) || !comparer.Equals(e1.Current, e2.Current))
-                            {
-                                return false;
-                            }
-                        }
+                await using IAsyncEnumerator<TSource> e1 = first.GetAsyncEnumerator(cancellationToken);
+                await using IAsyncEnumerator<TSource> e2 = second.GetAsyncEnumerator(cancellationToken);
 
-                        return !await e2.MoveNextAsync().ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        await e2.DisposeAsync().ConfigureAwait(false);
-                    }
-                }
-                finally
+                while (await e1.MoveNextAsync())
                 {
-                    await e1.DisposeAsync().ConfigureAwait(false);
+                    if (!await e2.MoveNextAsync() || !comparer.Equals(e1.Current, e2.Current))
+                    {
+                        return false;
+                    }
                 }
+
+                return !await e2.MoveNextAsync();
             }
         }
     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Shuffle.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Shuffle.cs
@@ -32,7 +32,7 @@ namespace System.Linq
                 IAsyncEnumerable<TSource> source,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                TSource[] array = await source.ToArrayAsync(cancellationToken).ConfigureAwait(false);
+                TSource[] array = await source.ToArrayAsync(cancellationToken);
 
 #if NET
                 Random.Shared.Shuffle(array);

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Skip.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Skip.cs
@@ -31,25 +31,19 @@ namespace System.Linq
                 int count,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    while (count > 0 && await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        count--;
-                    }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                    if (count <= 0)
-                    {
-                        while (await e.MoveNextAsync().ConfigureAwait(false))
-                        {
-                            yield return e.Current;
-                        }
-                    }
-                }
-                finally
+                while (count > 0 && await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    count--;
+                }
+
+                if (count <= 0)
+                {
+                    while (await e.MoveNextAsync())
+                    {
+                        yield return e.Current;
+                    }
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipWhile.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SkipWhile.cs
@@ -40,27 +40,21 @@ namespace System.Linq
                 Func<TSource, bool> predicate,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        TSource element = e.Current;
-                        if (!predicate(element))
-                        {
-                            yield return element;
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                yield return e.Current;
-                            }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                            yield break;
-                        }
-                    }
-                }
-                finally
+                while (await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    TSource element = e.Current;
+                    if (!predicate(element))
+                    {
+                        yield return element;
+                        while (await e.MoveNextAsync())
+                        {
+                            yield return e.Current;
+                        }
+
+                        yield break;
+                    }
                 }
             }
         }
@@ -95,27 +89,21 @@ namespace System.Linq
                 Func<TSource, CancellationToken, ValueTask<bool>> predicate,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        TSource element = e.Current;
-                        if (!await predicate(element, cancellationToken).ConfigureAwait(false))
-                        {
-                            yield return element;
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                yield return e.Current;
-                            }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                            yield break;
-                        }
-                    }
-                }
-                finally
+                while (await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    TSource element = e.Current;
+                    if (!await predicate(element, cancellationToken))
+                    {
+                        yield return element;
+                        while (await e.MoveNextAsync())
+                        {
+                            yield return e.Current;
+                        }
+
+                        yield break;
+                    }
                 }
             }
         }
@@ -154,28 +142,22 @@ namespace System.Linq
                 Func<TSource, int, bool> predicate,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    int index = -1;
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        TSource element = e.Current;
-                        if (!predicate(element, checked(++index)))
-                        {
-                            yield return element;
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                yield return e.Current;
-                            }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                            yield break;
-                        }
-                    }
-                }
-                finally
+                int index = -1;
+                while (await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    TSource element = e.Current;
+                    if (!predicate(element, checked(++index)))
+                    {
+                        yield return element;
+                        while (await e.MoveNextAsync())
+                        {
+                            yield return e.Current;
+                        }
+
+                        yield break;
+                    }
                 }
             }
         }
@@ -214,28 +196,22 @@ namespace System.Linq
                 Func<TSource, int, CancellationToken, ValueTask<bool>> predicate,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    int index = -1;
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        TSource element = e.Current;
-                        if (!await predicate(element, checked(++index), cancellationToken).ConfigureAwait(false))
-                        {
-                            yield return element;
-                            while (await e.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                yield return e.Current;
-                            }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                            yield break;
-                        }
-                    }
-                }
-                finally
+                int index = -1;
+                while (await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    TSource element = e.Current;
+                    if (!await predicate(element, checked(++index), cancellationToken))
+                    {
+                        yield return element;
+                        while (await e.MoveNextAsync())
+                        {
+                            yield return e.Current;
+                        }
+
+                        yield break;
+                    }
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SumAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SumAsync.cs
@@ -22,7 +22,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<int> Impl(
                 ConfiguredCancelableAsyncEnumerable<int> source)
@@ -48,7 +48,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<long> Impl(
                 ConfiguredCancelableAsyncEnumerable<long> source)
@@ -73,7 +73,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<float> Impl(
                 ConfiguredCancelableAsyncEnumerable<float> source)
@@ -98,7 +98,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<double> Impl(
                 ConfiguredCancelableAsyncEnumerable<double> source)
@@ -123,7 +123,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<decimal> Impl(
                 ConfiguredCancelableAsyncEnumerable<decimal> source)
@@ -149,7 +149,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<int?> Impl(
                 ConfiguredCancelableAsyncEnumerable<int?> source)
@@ -178,7 +178,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<long?> Impl(
                 ConfiguredCancelableAsyncEnumerable<long?> source)
@@ -206,7 +206,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<float?> Impl(
                 ConfiguredCancelableAsyncEnumerable<float?> source)
@@ -234,7 +234,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<double?> Impl(
                 ConfiguredCancelableAsyncEnumerable<double?> source)
@@ -262,7 +262,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<decimal?> Impl(
                 ConfiguredCancelableAsyncEnumerable<decimal?> source)

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Take.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Take.cs
@@ -35,7 +35,7 @@ namespace System.Linq
                 int count,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     yield return element;
 
@@ -97,29 +97,23 @@ namespace System.Linq
                 Debug.Assert(source is not null);
                 Debug.Assert(startIndex >= 0 && startIndex < endIndex);
 
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                int index = 0;
+                while (index < startIndex && await e.MoveNextAsync())
                 {
-                    int index = 0;
-                    while (index < startIndex && await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        ++index;
-                    }
-
-                    if (index < startIndex)
-                    {
-                        yield break;
-                    }
-
-                    while (index < endIndex && await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        yield return e.Current;
-                        ++index;
-                    }
+                    ++index;
                 }
-                finally
+
+                if (index < startIndex)
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    yield break;
+                }
+
+                while (index < endIndex && await e.MoveNextAsync())
+                {
+                    yield return e.Current;
+                    ++index;
                 }
             }
         }
@@ -144,10 +138,9 @@ namespace System.Linq
             if (isStartIndexFromEnd)
             {
                 // TakeLast compat: enumerator should be disposed before yielding the first element.
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using (IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken))
                 {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
+                    if (!await e.MoveNextAsync())
                     {
                         yield break;
                     }
@@ -156,7 +149,7 @@ namespace System.Linq
                     queue.Enqueue(e.Current);
                     count = 1;
 
-                    while (await e.MoveNextAsync().ConfigureAwait(false))
+                    while (await e.MoveNextAsync())
                     {
                         if (count < startIndex)
                         {
@@ -171,17 +164,13 @@ namespace System.Linq
                                 queue.Enqueue(e.Current);
                                 checked { ++count; }
                             }
-                            while (await e.MoveNextAsync().ConfigureAwait(false));
+                            while (await e.MoveNextAsync());
 
                             break;
                         }
                     }
 
                     Debug.Assert(queue.Count == Math.Min(count, startIndex));
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
                 }
 
                 startIndex = CalculateStartIndexFromEnd(startIndex, count);
@@ -198,41 +187,35 @@ namespace System.Linq
                 Debug.Assert(!isStartIndexFromEnd && isEndIndexFromEnd);
 
                 // SkipLast compat: the enumerator should be disposed at the end of the enumeration.
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
+
+                count = 0;
+                while (count < startIndex && await e.MoveNextAsync())
                 {
-                    count = 0;
-                    while (count < startIndex && await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        ++count;
-                    }
+                    ++count;
+                }
 
-                    if (count == startIndex)
+                if (count == startIndex)
+                {
+                    queue = new Queue<TSource>();
+                    while (await e.MoveNextAsync())
                     {
-                        queue = new Queue<TSource>();
-                        while (await e.MoveNextAsync().ConfigureAwait(false))
+                        if (queue.Count == endIndex)
                         {
-                            if (queue.Count == endIndex)
-                            {
-                                do
-                                {
-                                    queue.Enqueue(e.Current);
-                                    yield return queue.Dequeue();
-                                }
-                                while (await e.MoveNextAsync().ConfigureAwait(false));
-
-                                break;
-                            }
-                            else
+                            do
                             {
                                 queue.Enqueue(e.Current);
+                                yield return queue.Dequeue();
                             }
+                            while (await e.MoveNextAsync());
+
+                            break;
+                        }
+                        else
+                        {
+                            queue.Enqueue(e.Current);
                         }
                     }
-                }
-                finally
-                {
-                    await e.DisposeAsync().ConfigureAwait(false);
                 }
             }
 

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeWhile.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/TakeWhile.cs
@@ -35,7 +35,7 @@ namespace System.Linq
                 IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     if (!predicate(element))
                     {
@@ -73,9 +73,9 @@ namespace System.Linq
                 Func<TSource, CancellationToken, ValueTask<bool>> predicate,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    if (!await predicate(element, cancellationToken).ConfigureAwait(false))
+                    if (!await predicate(element, cancellationToken))
                     {
                         break;
                     }
@@ -115,7 +115,7 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     if (!predicate(element, checked(++index)))
                     {
@@ -157,9 +157,9 @@ namespace System.Linq
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 int index = -1;
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    if (!await predicate(element, checked(++index), cancellationToken).ConfigureAwait(false))
+                    if (!await predicate(element, checked(++index), cancellationToken))
                     {
                         break;
                     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToArrayAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToArrayAsync.cs
@@ -22,32 +22,26 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<TSource[]> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source)
             {
-                ConfiguredCancelableAsyncEnumerable<TSource>.Enumerator e = source.GetAsyncEnumerator();
-                try
+                await using ConfiguredCancelableAsyncEnumerable<TSource>.Enumerator e = source.GetAsyncEnumerator();
+
+                if (await e.MoveNextAsync())
                 {
-                    if (await e.MoveNextAsync())
+                    List<TSource> list = [];
+                    do
                     {
-                        List<TSource> list = [];
-                        do
-                        {
-                            list.Add(e.Current);
-                        }
-                        while (await e.MoveNextAsync());
-
-                        return list.ToArray();
+                        list.Add(e.Current);
                     }
+                    while (await e.MoveNextAsync());
 
-                    return [];
+                    return list.ToArray();
                 }
-                finally
-                {
-                    await e.DisposeAsync();
-                }
+
+                return [];
             }
         }
     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToDictionaryAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToDictionaryAsync.cs
@@ -28,7 +28,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), comparer);
+            return Impl(source.WithCancellation(cancellationToken), comparer);
 
             static async ValueTask<Dictionary<TKey, TValue>> Impl(
                 ConfiguredCancelableAsyncEnumerable<KeyValuePair<TKey, TValue>> source,
@@ -82,7 +82,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), keySelector, comparer);
+            return Impl(source.WithCancellation(cancellationToken), keySelector, comparer);
 
             static async ValueTask<Dictionary<TKey, TSource>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -130,9 +130,9 @@ namespace System.Linq
                 CancellationToken cancellationToken)
             {
                 Dictionary<TKey, TSource> d = new(comparer);
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    d.Add(await keySelector(element, cancellationToken).ConfigureAwait(false), element);
+                    d.Add(await keySelector(element, cancellationToken), element);
                 }
                 return d;
             }
@@ -166,7 +166,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
             ThrowHelper.ThrowIfNull(elementSelector);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), keySelector, elementSelector, comparer);
+            return Impl(source.WithCancellation(cancellationToken), keySelector, elementSelector, comparer);
 
             static async ValueTask<Dictionary<TKey, TElement>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -222,11 +222,11 @@ namespace System.Linq
                 CancellationToken cancellationToken)
             {
                 Dictionary<TKey, TElement> d = new(comparer);
-                await foreach (TSource element in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
                     d.Add(
-                        await keySelector(element, cancellationToken).ConfigureAwait(false),
-                        await elementSelector(element, cancellationToken).ConfigureAwait(false));
+                        await keySelector(element, cancellationToken),
+                        await elementSelector(element, cancellationToken));
                 }
 
                 return d;

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToHashSetAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToHashSetAsync.cs
@@ -24,7 +24,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), comparer);
+            return Impl(source.WithCancellation(cancellationToken), comparer);
 
             static async ValueTask<HashSet<TSource>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToListAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToListAsync.cs
@@ -22,7 +22,7 @@ namespace System.Linq
         {
             ThrowHelper.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false));
+            return Impl(source.WithCancellation(cancellationToken));
 
             static async ValueTask<List<TSource>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source)

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToLookupAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToLookupAsync.cs
@@ -34,35 +34,29 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(source);
             ThrowHelper.ThrowIfNull(keySelector);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), keySelector, comparer);
+            return Impl(source.WithCancellation(cancellationToken), keySelector, comparer);
 
             static async ValueTask<ILookup<TKey, TSource>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
                 Func<TSource, TKey> keySelector,
                 IEqualityComparer<TKey>? comparer)
             {
-                ConfiguredCancelableAsyncEnumerable<TSource>.Enumerator e = source.GetAsyncEnumerator();
-                try
-                {
-                    if (!await e.MoveNextAsync())
-                    {
-                        return EmptyLookup<TKey, TSource>.Instance;
-                    }
+                await using ConfiguredCancelableAsyncEnumerable<TSource>.Enumerator e = source.GetAsyncEnumerator();
 
-                    AsyncLookup<TKey, TSource> lookup = new(comparer);
-                    do
-                    {
-                        TSource item = e.Current;
-                        lookup.GetGrouping(keySelector(item), create: true)!.Add(item);
-                    }
-                    while (await e.MoveNextAsync());
-
-                    return lookup;
-                }
-                finally
+                if (!await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync();
+                    return EmptyLookup<TKey, TSource>.Instance;
                 }
+
+                AsyncLookup<TKey, TSource> lookup = new(comparer);
+                do
+                {
+                    TSource item = e.Current;
+                    lookup.GetGrouping(keySelector(item), create: true)!.Add(item);
+                }
+                while (await e.MoveNextAsync());
+
+                return lookup;
             }
         }
 
@@ -96,28 +90,22 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        return EmptyLookup<TKey, TSource>.Instance;
-                    }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                    AsyncLookup<TKey, TSource> lookup = new(comparer);
-                    do
-                    {
-                        TSource item = e.Current;
-                        lookup.GetGrouping(await keySelector(item, cancellationToken).ConfigureAwait(false), create: true)!.Add(item);
-                    }
-                    while (await e.MoveNextAsync().ConfigureAwait(false));
-
-                    return lookup;
-                }
-                finally
+                if (!await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    return EmptyLookup<TKey, TSource>.Instance;
                 }
+
+                AsyncLookup<TKey, TSource> lookup = new(comparer);
+                do
+                {
+                    TSource item = e.Current;
+                    lookup.GetGrouping(await keySelector(item, cancellationToken), create: true)!.Add(item);
+                }
+                while (await e.MoveNextAsync());
+
+                return lookup;
             }
         }
 
@@ -147,7 +135,7 @@ namespace System.Linq
             ThrowHelper.ThrowIfNull(keySelector);
             ThrowHelper.ThrowIfNull(elementSelector);
 
-            return Impl(source.WithCancellation(cancellationToken).ConfigureAwait(false), keySelector, elementSelector, comparer);
+            return Impl(source.WithCancellation(cancellationToken), keySelector, elementSelector, comparer);
 
             static async ValueTask<ILookup<TKey, TElement>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -155,28 +143,22 @@ namespace System.Linq
                 Func<TSource, TElement> elementSelector,
                 IEqualityComparer<TKey>? comparer)
             {
-                ConfiguredCancelableAsyncEnumerable<TSource>.Enumerator e = source.GetAsyncEnumerator();
-                try
-                {
-                    if (!await e.MoveNextAsync())
-                    {
-                        return EmptyLookup<TKey, TElement>.Instance;
-                    }
+                await using ConfiguredCancelableAsyncEnumerable<TSource>.Enumerator e = source.GetAsyncEnumerator();
 
-                    AsyncLookup<TKey, TElement> lookup = new(comparer);
-                    do
-                    {
-                        TSource item = e.Current;
-                        lookup.GetGrouping(keySelector(item), create: true)!.Add(elementSelector(item));
-                    }
-                    while (await e.MoveNextAsync());
-
-                    return lookup;
-                }
-                finally
+                if (!await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync();
+                    return EmptyLookup<TKey, TElement>.Instance;
                 }
+
+                AsyncLookup<TKey, TElement> lookup = new(comparer);
+                do
+                {
+                    TSource item = e.Current;
+                    lookup.GetGrouping(keySelector(item), create: true)!.Add(elementSelector(item));
+                }
+                while (await e.MoveNextAsync());
+
+                return lookup;
             }
         }
 
@@ -215,28 +197,22 @@ namespace System.Linq
                 IEqualityComparer<TKey>? comparer,
                 CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
-                try
-                {
-                    if (!await e.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        return EmptyLookup<TKey, TElement>.Instance;
-                    }
+                await using IAsyncEnumerator<TSource> e = source.GetAsyncEnumerator(cancellationToken);
 
-                    AsyncLookup<TKey, TElement> lookup = new(comparer);
-                    do
-                    {
-                        TSource item = e.Current;
-                        lookup.GetGrouping(await keySelector(item, cancellationToken).ConfigureAwait(false), create: true)!.Add(await elementSelector(item, cancellationToken).ConfigureAwait(false));
-                    }
-                    while (await e.MoveNextAsync().ConfigureAwait(false));
-
-                    return lookup;
-                }
-                finally
+                if (!await e.MoveNextAsync())
                 {
-                    await e.DisposeAsync().ConfigureAwait(false);
+                    return EmptyLookup<TKey, TElement>.Instance;
                 }
+
+                AsyncLookup<TKey, TElement> lookup = new(comparer);
+                do
+                {
+                    TSource item = e.Current;
+                    lookup.GetGrouping(await keySelector(item, cancellationToken), create: true)!.Add(await elementSelector(item, cancellationToken));
+                }
+                while (await e.MoveNextAsync());
+
+                return lookup;
             }
         }
 
@@ -311,7 +287,7 @@ namespace System.Linq
                 Debug.Assert(keySelector is not null);
 
                 AsyncLookup<TKey, TElement> lookup = new(comparer);
-                await foreach (TElement item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TElement item in source.WithCancellation(cancellationToken))
                 {
                     TKey key = keySelector(item);
                     if (key is not null)
@@ -333,9 +309,9 @@ namespace System.Linq
                 Debug.Assert(keySelector is not null);
 
                 AsyncLookup<TKey, TElement> lookup = new(comparer);
-                await foreach (TElement item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TElement item in source.WithCancellation(cancellationToken))
                 {
-                    TKey key = await keySelector(item, cancellationToken).ConfigureAwait(false);
+                    TKey key = await keySelector(item, cancellationToken);
                     if (key is not null)
                     {
                         lookup.GetGrouping(key, create: true)!.Add(item);
@@ -459,7 +435,7 @@ namespace System.Linq
 
                         Debug.Assert(g is not null);
                         g.Trim();
-                        yield return await resultSelector(g._key, g._elements, cancellationToken).ConfigureAwait(false);
+                        yield return await resultSelector(g._key, g._elements, cancellationToken);
                     }
                     while (g != _lastGrouping);
                 }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Union.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Union.cs
@@ -38,7 +38,7 @@ namespace System.Linq
             {
                 HashSet<TSource> set = new(comparer);
 
-                await foreach (TSource element in first.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in first.WithCancellation(cancellationToken))
                 {
                     if (set.Add(element))
                     {
@@ -46,7 +46,7 @@ namespace System.Linq
                     }
                 }
 
-                await foreach (TSource element in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in second.WithCancellation(cancellationToken))
                 {
                     if (set.Add(element))
                     {

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/UnionBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/UnionBy.cs
@@ -43,7 +43,7 @@ namespace System.Linq
             {
                 HashSet<TKey> set = new(comparer);
 
-                await foreach (TSource element in first.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in first.WithCancellation(cancellationToken))
                 {
                     if (set.Add(keySelector(element)))
                     {
@@ -51,7 +51,7 @@ namespace System.Linq
                     }
                 }
 
-                await foreach (TSource element in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in second.WithCancellation(cancellationToken))
                 {
                     if (set.Add(keySelector(element)))
                     {
@@ -94,17 +94,17 @@ namespace System.Linq
             {
                 HashSet<TKey> set = new(comparer);
 
-                await foreach (TSource element in first.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in first.WithCancellation(cancellationToken))
                 {
-                    if (set.Add(await keySelector(element, cancellationToken).ConfigureAwait(false)))
+                    if (set.Add(await keySelector(element, cancellationToken)))
                     {
                         yield return element;
                     }
                 }
 
-                await foreach (TSource element in second.WithCancellation(cancellationToken).ConfigureAwait(false))
+                await foreach (TSource element in second.WithCancellation(cancellationToken))
                 {
-                    if (set.Add(await keySelector(element, cancellationToken).ConfigureAwait(false)))
+                    if (set.Add(await keySelector(element, cancellationToken)))
                     {
                         yield return element;
                     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Where.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Where.cs
@@ -68,7 +68,7 @@ namespace System.Linq
             {
                 await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    if (await predicate(element, cancellationToken).ConfigureAwait(false))
+                    if (await predicate(element, cancellationToken))
                     {
                         yield return element;
                     }
@@ -148,7 +148,7 @@ namespace System.Linq
                 int index = -1;
                 await foreach (TSource element in source.WithCancellation(cancellationToken))
                 {
-                    if (await predicate(element, checked(++index), cancellationToken).ConfigureAwait(false))
+                    if (await predicate(element, checked(++index), cancellationToken))
                     {
                         yield return element;
                     }

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Zip.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/Zip.cs
@@ -43,26 +43,13 @@ namespace System.Linq
                 Func<TFirst, TSecond, TResult> resultSelector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TFirst> e1 = first.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TFirst> e1 = first.GetAsyncEnumerator(cancellationToken);
+                await using IAsyncEnumerator<TSecond> e2 = second.GetAsyncEnumerator(cancellationToken);
+
+                while (await e1.MoveNextAsync() &&
+                       await e2.MoveNextAsync())
                 {
-                    IAsyncEnumerator<TSecond> e2 = second.GetAsyncEnumerator(cancellationToken);
-                    try
-                    {
-                        while (await e1.MoveNextAsync().ConfigureAwait(false) &&
-                               await e2.MoveNextAsync().ConfigureAwait(false))
-                        {
-                            yield return resultSelector(e1.Current, e2.Current);
-                        }
-                    }
-                    finally
-                    {
-                        await e2.DisposeAsync().ConfigureAwait(false);
-                    }
-                }
-                finally
-                {
-                    await e1.DisposeAsync().ConfigureAwait(false);
+                    yield return resultSelector(e1.Current, e2.Current);
                 }
             }
         }
@@ -100,26 +87,13 @@ namespace System.Linq
                 Func<TFirst, TSecond, CancellationToken, ValueTask<TResult>> resultSelector,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TFirst> e1 = first.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TFirst> e1 = first.GetAsyncEnumerator(cancellationToken);
+                await using IAsyncEnumerator<TSecond> e2 = second.GetAsyncEnumerator(cancellationToken);
+
+                while (await e1.MoveNextAsync() &&
+                       await e2.MoveNextAsync())
                 {
-                    IAsyncEnumerator<TSecond> e2 = second.GetAsyncEnumerator(cancellationToken);
-                    try
-                    {
-                        while (await e1.MoveNextAsync().ConfigureAwait(false) &&
-                               await e2.MoveNextAsync().ConfigureAwait(false))
-                        {
-                            yield return await resultSelector(e1.Current, e2.Current, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-                    finally
-                    {
-                        await e2.DisposeAsync().ConfigureAwait(false);
-                    }
-                }
-                finally
-                {
-                    await e1.DisposeAsync().ConfigureAwait(false);
+                    yield return await resultSelector(e1.Current, e2.Current, cancellationToken);
                 }
             }
         }
@@ -148,26 +122,13 @@ namespace System.Linq
                 IAsyncEnumerable<TSecond> second,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TFirst> e1 = first.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TFirst> e1 = first.GetAsyncEnumerator(cancellationToken);
+                await using IAsyncEnumerator<TSecond> e2 = second.GetAsyncEnumerator(cancellationToken);
+
+                while (await e1.MoveNextAsync() &&
+                       await e2.MoveNextAsync())
                 {
-                    IAsyncEnumerator<TSecond> e2 = second.GetAsyncEnumerator(cancellationToken);
-                    try
-                    {
-                        while (await e1.MoveNextAsync().ConfigureAwait(false) &&
-                               await e2.MoveNextAsync().ConfigureAwait(false))
-                        {
-                            yield return (e1.Current, e2.Current);
-                        }
-                    }
-                    finally
-                    {
-                        await e2.DisposeAsync().ConfigureAwait(false);
-                    }
-                }
-                finally
-                {
-                    await e1.DisposeAsync().ConfigureAwait(false);
+                    yield return (e1.Current, e2.Current);
                 }
             }
         }
@@ -199,35 +160,15 @@ namespace System.Linq
             static async IAsyncEnumerable<(TFirst First, TSecond Second, TThird)> Impl(
                 IAsyncEnumerable<TFirst> first, IAsyncEnumerable<TSecond> second, IAsyncEnumerable<TThird> third, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                IAsyncEnumerator<TFirst> e1 = first.GetAsyncEnumerator(cancellationToken);
-                try
+                await using IAsyncEnumerator<TFirst> e1 = first.GetAsyncEnumerator(cancellationToken);
+                await using IAsyncEnumerator<TSecond> e2 = second.GetAsyncEnumerator(cancellationToken);
+                await using IAsyncEnumerator<TThird> e3 = third.GetAsyncEnumerator(cancellationToken);
+
+                while (await e1.MoveNextAsync() &&
+                       await e2.MoveNextAsync() &&
+                       await e3.MoveNextAsync())
                 {
-                    IAsyncEnumerator<TSecond> e2 = second.GetAsyncEnumerator(cancellationToken);
-                    try
-                    {
-                        IAsyncEnumerator<TThird> e3 = third.GetAsyncEnumerator(cancellationToken);
-                        try
-                        {
-                            while (await e1.MoveNextAsync().ConfigureAwait(false) &&
-                                   await e2.MoveNextAsync().ConfigureAwait(false) &&
-                                   await e3.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                yield return (e1.Current, e2.Current, e3.Current);
-                            }
-                        }
-                        finally
-                        {
-                            await e3.DisposeAsync().ConfigureAwait(false);
-                        }
-                    }
-                    finally
-                    {
-                        await e2.DisposeAsync().ConfigureAwait(false);
-                    }
-                }
-                finally
-                {
-                    await e1.DisposeAsync().ConfigureAwait(false);
+                    yield return (e1.Current, e2.Current, e3.Current);
                 }
             }
         }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/AggregateAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/AggregateAsyncTests.cs
@@ -304,5 +304,21 @@ namespace System.Linq.Tests
                 Assert.Equal(1, resultCount);
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await CreateSource(2, 4, 8, 16).Yield().AggregateAsync((x, y) =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return x + y;
+                });
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/AggregateByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/AggregateByTests.cs
@@ -186,5 +186,32 @@ namespace System.Linq.Tests
                 Assert.Equal(4, funcCount);
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await ConsumeAsync(CreateSource(2, 4, 8, 16).Yield().AggregateBy(
+                    i =>
+                    {
+                        Assert.Same(ctx, SynchronizationContext.Current);
+                        return i;
+                    },
+                    i =>
+                    {
+                        Assert.Same(ctx, SynchronizationContext.Current);
+                        return i;
+                    },
+                    (x, y) =>
+                    {
+                        Assert.Same(ctx, SynchronizationContext.Current);
+                        return x + y;
+                    }));
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/AllAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/AllAsyncTests.cs
@@ -97,5 +97,21 @@ namespace System.Linq.Tests
                 Assert.Equal(1, source.DisposeAsyncCount);
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await CreateSource(2, 4, 8, 16).Yield().AllAsync(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return true;
+                });
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/AnyAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/AnyAsyncTests.cs
@@ -109,5 +109,21 @@ namespace System.Linq.Tests
                 Assert.Equal(1, source.DisposeAsyncCount);
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await CreateSource(2, 4, 8, 16).Yield().AnyAsync(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return false;
+                });
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/AsyncEnumerableTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/AsyncEnumerableTests.cs
@@ -98,9 +98,17 @@ namespace System.Linq.Tests
             await foreach (T item in source.WithCancellation(cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await Task.Yield();
+                await default(ForceYieldingAwaiter);
                 yield return item;
             }
+        }
+
+        private readonly struct ForceYieldingAwaiter : INotifyCompletion
+        {
+            public ForceYieldingAwaiter GetAwaiter() => this;
+            public bool IsCompleted => false;
+            public void OnCompleted(Action continuation) => ThreadPool.QueueUserWorkItem(s => ((Action)s)(), continuation);
+            public void GetResult() { }
         }
 
         public static TrackingAsyncEnumerable<T> Track<T>(this IAsyncEnumerable<T> source) =>
@@ -152,6 +160,18 @@ namespace System.Linq.Tests
                 parent.DisposeAsyncCount++;
                 return source.DisposeAsync();
             }
+        }
+    }
+
+    public sealed class TrackingSynchronizationContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            ThreadPool.QueueUserWorkItem(_ =>
+            {
+                SetSynchronizationContext(this);
+                d(state);
+            });
         }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/AverageAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/AverageAsyncTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/CountAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/CountAsyncTests.cs
@@ -161,5 +161,21 @@ namespace System.Linq.Tests
                 }
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await CreateSource(2, 4, 8, 16).Yield().CountAsync(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return true;
+                });
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/CountByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/CountByTests.cs
@@ -97,5 +97,21 @@ namespace System.Linq.Tests
             Assert.Equal(7, source.CurrentCount);
             Assert.Equal(1, source.DisposeAsyncCount);
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await ConsumeAsync(CreateSource(2, 4, 8, 16).Yield().CountBy(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return i;
+                }));
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/DistinctByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/DistinctByTests.cs
@@ -119,5 +119,21 @@ namespace System.Linq.Tests
             Assert.Equal(1, source.DisposeAsyncCount);
             Assert.Equal(4, funcCount);
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await ConsumeAsync(CreateSource(2, 4, 8, 16).Yield().DistinctBy(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return i;
+                }));
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/FirstAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/FirstAsyncTests.cs
@@ -115,5 +115,21 @@ namespace System.Linq.Tests
             Assert.Equal(4, source.CurrentCount);
             Assert.Equal(1, source.DisposeAsyncCount);
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await CreateSource(2, 4, 8, 16).Yield().FirstAsync(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return i == 16;
+                });
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/FirstOrDefaultAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/FirstOrDefaultAsyncTests.cs
@@ -112,5 +112,21 @@ namespace System.Linq.Tests
                 Assert.Equal(1, source.DisposeAsyncCount);
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await CreateSource(2, 4, 8, 16).Yield().FirstOrDefaultAsync(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return false;
+                });
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/LastAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/LastAsyncTests.cs
@@ -125,5 +125,21 @@ namespace System.Linq.Tests
             Assert.Equal(4, source.CurrentCount);
             Assert.Equal(1, source.DisposeAsyncCount);
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await CreateSource(2, 4, 8, 16).Yield().LastAsync(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return i == 2;
+                });
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/LastOrDefaultAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/LastOrDefaultAsyncTests.cs
@@ -126,5 +126,21 @@ namespace System.Linq.Tests
             Assert.Equal(4, source.CurrentCount);
             Assert.Equal(1, source.DisposeAsyncCount);
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await CreateSource(2, 4, 8, 16).Yield().LastOrDefaultAsync(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return false;
+                });
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/OrderByTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/OrderByTests.cs
@@ -198,5 +198,21 @@ namespace System.Linq.Tests
                 Assert.Equal(1, source.DisposeAsyncCount);
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await ConsumeAsync(CreateSource(2, 4, 8, 16).Yield().OrderBy(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return i;
+                }));
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/SelectManyTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/SelectManyTests.cs
@@ -218,5 +218,21 @@ namespace System.Linq.Tests
                 Assert.Equal(1, source.DisposeAsyncCount);
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await ConsumeAsync(CreateSource(2, 4, 8, 16).Yield().SelectMany(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return new int[] { i };
+                }));
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/SelectTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/SelectTests.cs
@@ -101,5 +101,21 @@ namespace System.Linq.Tests
                 Assert.Equal(1, source.DisposeAsyncCount);
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await ConsumeAsync(CreateSource(2, 4, 8, 16).Yield().Select(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return i;
+                }));
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/SkipWhileTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/SkipWhileTests.cs
@@ -139,5 +139,21 @@ namespace System.Linq.Tests
                 }
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await ConsumeAsync(CreateSource(2, 4, 8, 16).Yield().SkipWhile(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return true;
+                }));
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/SumAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/SumAsyncTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/TakeWhileTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/TakeWhileTests.cs
@@ -139,5 +139,21 @@ namespace System.Linq.Tests
                 }
             }
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await ConsumeAsync(CreateSource(2, 4, 8, 16).Yield().TakeWhile(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return true;
+                }));
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ToDictionaryAsyncTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ToDictionaryAsyncTests.cs
@@ -232,5 +232,21 @@ namespace System.Linq.Tests
             Assert.Equal(4, keySelectorCount);
             Assert.Equal(4, elementSelectorCount);
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await CreateSource(2, 4, 8, 16).Yield().ToDictionaryAsync(i =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return i;
+                });
+            });
+        }
     }
 }

--- a/src/libraries/System.Linq.AsyncEnumerable/tests/ZipTests.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/tests/ZipTests.cs
@@ -173,5 +173,21 @@ namespace System.Linq.Tests
             Assert.Equal(2, third.CurrentCount);
             Assert.Equal(1, third.DisposeAsyncCount);
         }
+
+        [Fact]
+        public async Task Callbacks_InvokedOnOriginalContext()
+        {
+            await Task.Run(async () =>
+            {
+                TrackingSynchronizationContext ctx = new();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+
+                await ConsumeAsync(CreateSource(2, 4, 8, 16).Yield().Zip(CreateSource(2, 4, 8, 16).Yield(), (x, y) =>
+                {
+                    Assert.Same(ctx, SynchronizationContext.Current);
+                    return x + y;
+                }));
+            });
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/113567

To quote from whoever wrote https://devblogs.microsoft.com/dotnet/configureawait-faq/:

> As with all guidance, of course, there can be exceptions, places where it doesn’t make sense. For example, one of the larger exemptions (or at least categories that requires thought) in general-purpose libraries is when those libraries have APIs that take delegates to be invoked. In such cases, the caller of the library is passing potentially app-level code to be invoked by the library, which then effectively renders those “general purpose” assumptions of the library moot. Consider, for example, an asynchronous version of LINQ’s Where method, e.g. public static async IAsyncEnumerable<T> WhereAsync(this IAsyncEnumerable<T> source, Func<T, bool> predicate). Does predicate here need to be invoked back on the original SynchronizationContext of the caller? That’s up to the implementation of WhereAsync to decide, and it’s a reason it may choose not to use ConfigureAwait(false).