### PR TITLE
Make the eager-enumerator a sealed class

### DIFF
--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SearchResultCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SearchResultCollection.cs
@@ -215,7 +215,7 @@ namespace System.DirectoryServices
         }
 
         /// <summary>Provides an enumerator implementation for the array of <see cref="SearchResult"/>.</summary>
-        private struct AlreadyReadResultsEnumerator : IEnumerator
+        private sealed class AlreadyReadResultsEnumerator : IEnumerator
         {
             private readonly IEnumerator _innerEnumerator;
 


### PR DESCRIPTION
Per [review feedback from @stephentoub](https://github.com/dotnet/runtime/pull/113775#discussion_r2014543804) post-merge, change the AlreadyReadResultsEnumerator back to a `private sealed class` (instead of a `private struct`)