### PR TITLE
JIT: layout compatibility vs assignability

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8672,8 +8672,7 @@ GenTree* Compiler::gtNewLoadValueNode(var_types type, ClassLayout* layout, GenTr
     {
         unsigned   lclNum = addr->AsLclFld()->GetLclNum();
         LclVarDsc* varDsc = lvaGetDesc(lclNum);
-        if ((varDsc->TypeGet() == type) &&
-            ((type != TYP_STRUCT) || ClassLayout::AreCompatible(layout, varDsc->GetLayout())))
+        if ((varDsc->TypeGet() == type) && ((type != TYP_STRUCT) || layout->CanAssignFrom(varDsc->GetLayout())))
         {
             return gtNewLclvNode(lclNum, type);
         }
@@ -8697,7 +8696,7 @@ GenTree* Compiler::gtNewLoadValueNode(var_types type, ClassLayout* layout, GenTr
 GenTreeBlk* Compiler::gtNewStoreBlkNode(ClassLayout* layout, GenTree* addr, GenTree* value, GenTreeFlags indirFlags)
 {
     assert((indirFlags & GTF_IND_INVARIANT) == 0);
-    assert(value->IsInitVal() || ClassLayout::AreCompatible(layout, value->GetLayout(this)));
+    assert(value->IsInitVal() || layout->CanAssignFrom(value->GetLayout(this)));
 
     GenTreeBlk* store = new (this, GT_STORE_BLK) GenTreeBlk(GT_STORE_BLK, TYP_STRUCT, addr, value, layout);
     store->gtFlags |= GTF_ASG;
@@ -8754,8 +8753,7 @@ GenTree* Compiler::gtNewStoreValueNode(
     {
         unsigned   lclNum = addr->AsLclFld()->GetLclNum();
         LclVarDsc* varDsc = lvaGetDesc(lclNum);
-        if ((varDsc->TypeGet() == type) &&
-            ((type != TYP_STRUCT) || ClassLayout::AreCompatible(layout, varDsc->GetLayout())))
+        if ((varDsc->TypeGet() == type) && ((type != TYP_STRUCT) || varDsc->GetLayout()->CanAssignFrom(layout)))
         {
             return gtNewStoreLclVarNode(lclNum, value);
         }

--- a/src/coreclr/jit/layout.cpp
+++ b/src/coreclr/jit/layout.cpp
@@ -656,6 +656,9 @@ const SegmentList& ClassLayout::GetNonPadding(Compiler* comp)
 //    Layouts are called compatible if they are equal or if
 //    they have the same size and the same GC slots.
 //
+//    This is an equivalence relation:
+//      AreCompatible(a, b) == AreCompatible(b, a)
+//
 // static
 bool ClassLayout::AreCompatible(const ClassLayout* layout1, const ClassLayout* layout2)
 {
@@ -726,6 +729,26 @@ bool ClassLayout::AreCompatible(const ClassLayout* layout1, const ClassLayout* l
         }
     }
     return true;
+}
+
+//------------------------------------------------------------------------
+// CanAssignFrom: true if assignment to this layout from the indicated layout is sensible
+//
+// Arguments:
+//    layout - the source of a possible assigment
+//
+// Return value:
+//    true if assignable, false otherwise.
+//
+// Notes:
+//    This may not be an equivalence relation:
+//    a->CanAssignFrom(b) and b->CanAssignFrom(a) may differ.
+//
+bool ClassLayout::CanAssignFrom(const ClassLayout* layout)
+{
+    // Currently this is the same as compatability
+    //
+    return AreCompatible(this, layout);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/layout.h
+++ b/src/coreclr/jit/layout.h
@@ -260,6 +260,8 @@ public:
 
     static bool AreCompatible(const ClassLayout* layout1, const ClassLayout* layout2);
 
+    bool CanAssignFrom(const ClassLayout* sourceLayout);
+
 private:
     const BYTE* GetGCPtrs() const
     {

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -2000,7 +2000,7 @@ private:
             return IndirTransform::LclFld;
         }
 
-        if ((offset == 0) && ClassLayout::AreCompatible(indir->AsBlk()->GetLayout(), varDsc->GetLayout()))
+        if ((offset == 0) && indir->AsBlk()->GetLayout()->CanAssignFrom(varDsc->GetLayout()))
         {
             return IndirTransform::LclVar;
         }

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -666,7 +666,7 @@ void MorphCopyBlockHelper::PrepareSrc()
     assert(m_store->TypeGet() == m_src->TypeGet());
     if (m_store->TypeIs(TYP_STRUCT))
     {
-        assert(ClassLayout::AreCompatible(m_blockLayout, m_src->GetLayout(m_comp)));
+        assert(m_blockLayout->CanAssignFrom(m_src->GetLayout(m_comp)));
     }
 }
 


### PR DESCRIPTION
Introduce a new `CanAssignFrom` method on `ClassLayout` that will ultimately do more relaxed (and asymmetric) checking for cases that can arise from escape analysis. For now it just defers to `AreCompatible`, which is and will remain an equivalence relation (hence symmetric).

Split off some callers of `AreCompatible` to call `CanAssignFrom` instead. Generally methods invoked after we run escape analysis will need to start using `CanAssignFrom` as it will introduce new layouts.