### PR TITLE
Do not generate unconstructed EEType for arrays that have a template

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -253,7 +253,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                if (!_type.HasInstantiation)
+                if (_type.IsArrayTypeWithoutGenericInterfaces())
                     return false;
 
                 if (!_type.Context.SupportsCanon)

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -45,6 +45,7 @@ internal static class ReflectionTest
         TestTypesInMethodSignatures.Run();
 
         TestAttributeInheritance.Run();
+        Test113750Regression.Run();
         TestStringConstructor.Run();
         TestAssemblyAndModuleAttributes.Run();
         TestAttributeExpressions.Run();
@@ -1199,6 +1200,22 @@ internal static class ReflectionTest
             {
                 _i = i;
             }
+        }
+    }
+
+    class Test113750Regression
+    {
+        class Atom;
+
+        public static void Run()
+        {
+            var arr = Array.CreateInstance(GetAtom(), 0);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static Type GetAtom() => typeof(Atom);
+
+            if (!(arr is Atom[]))
+                throw new Exception();
         }
     }
 


### PR DESCRIPTION
Fixes #113750

When `CanonFormTypeMayExist` was written, it was okay for arrays to return false since arrays were always compared structurally (it was allowed to have multiple `MethodTable`s for a single array type).

We stopped allowing this some time ago and we now have to maintain the same invariant as for any other `MethodTable` - the address of the `MethodTable` is the unique identity. We cannot allow the compiler to generate unconstructed `MethodTable` for something that can be template-constructed at runtime.

Cc @dotnet/ilc-contrib 