### PR TITLE
[cDAC] Change FrameIdentifiers to be contract literals

### DIFF
--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -764,7 +764,7 @@ CDAC_GLOBAL_POINTER(GCThread, &::g_pSuspensionThread)
 
 // Add FrameIdentifier for all defined Frame types. Used to differentiate Frame objects.
 #define FRAME_TYPE_NAME(frameType) \
-    CDAC_GLOBAL_POINTER(frameType##Identifier, FrameIdentifier::frameType)
+    CDAC_GLOBAL(frameType##Identifier, nuint, (uint64_t)FrameIdentifier::frameType)
 
     #include "frames.h"
 #undef FRAME_TYPE_NAME

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
@@ -120,6 +120,15 @@ public abstract class Target
     public abstract T ReadGlobal<T>(string name) where T : struct, INumber<T>;
 
     /// <summary>
+    /// Read a well known global from the target process as a number in the target endianness
+    /// </summary>
+    /// <typeparam name="T">The numeric type to be read</typeparam>
+    /// <param name="name">The name of the global</param>
+    /// <param name="value">The numeric value read.</param>
+    /// <returns>True if a global is found, false otherwise.</returns>
+    public abstract bool TryReadGlobal<T>(string name, [NotNullWhen(true)] out T? value) where T : struct, INumber<T>;
+
+    /// <summary>
     /// Read a value from the target in target endianness
     /// </summary>
     /// <typeparam name="T">Type of value to read</typeparam>

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
@@ -70,6 +70,14 @@ public abstract class Target
     public abstract TargetPointer ReadGlobalPointer(string global);
 
     /// <summary>
+    /// Reads a well-known global pointer value from the target process
+    /// </summary>
+    /// <param name="global">The name of the global</param>
+    /// <param name="value">The value of the global, if found.</param>
+    /// <returns>True if the global is found, false otherwise.</returns>
+    public abstract bool TryReadGlobalPointer(string name, [NotNullWhen(true)] out TargetPointer? value);
+
+    /// <summary>
     /// Read a pointer from the target in target endianness
     /// </summary>
     /// <param name="address">Address to start reading from</param>

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
@@ -144,12 +144,9 @@ internal sealed class FrameIterator
     {
         foreach (FrameType frameType in Enum.GetValues<FrameType>())
         {
-            TargetPointer foundFrameIdentifier;
-            try
+            if (target.TryReadGlobal(frameType.ToString() + "Identifier", out ulong? id))
             {
-                // not all Frames are in all builds, so we need to catch the exception
-                foundFrameIdentifier = target.ReadGlobalPointer(frameType.ToString() + "Identifier");
-                if (frameIdentifier == foundFrameIdentifier)
+                if (frame.Identifier == new TargetPointer(id.Value))
                 {
                     return frameType;
                 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
@@ -146,7 +146,7 @@ internal sealed class FrameIterator
         {
             if (target.TryReadGlobal(frameType.ToString() + "Identifier", out ulong? id))
             {
-                if (frame.Identifier == new TargetPointer(id.Value))
+                if (frameIdentifier == new TargetPointer(id.Value))
                 {
                     return frameType;
                 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
@@ -144,9 +144,9 @@ internal sealed class FrameIterator
     {
         foreach (FrameType frameType in Enum.GetValues<FrameType>())
         {
-            if (target.TryReadGlobal(frameType.ToString() + "Identifier", out ulong? id))
+            if (target.TryReadGlobalPointer(frameType.ToString() + "Identifier", out TargetPointer? id))
             {
-                if (frameIdentifier == new TargetPointer(id.Value))
+                if (frameIdentifier == id)
                 {
                     return frameType;
                 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
@@ -154,9 +154,6 @@ internal sealed class FrameIterator
                     return frameType;
                 }
             }
-            catch (InvalidOperationException)
-            {
-            }
         }
 
         return FrameType.Unknown;

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
@@ -496,6 +496,22 @@ public sealed unsafe class ContractDescriptorTarget : Target
     public override bool IsAlignedToPointerSize(TargetPointer pointer)
         => IsAligned(pointer.Value, _config.PointerSize);
 
+    public override bool TryReadGlobal<T>(string name, [NotNullWhen(true)] out T? value)
+        => TryReadGlobal<T>(name, out value, out _);
+
+    public bool TryReadGlobal<T>(string name, [NotNullWhen(true)] out T? value, out string? type) where T : struct, INumber<T>
+    {
+        value = null;
+        type = null;
+        if (!_globals.TryGetValue(name, out (ulong Value, string? Type) global))
+        {
+            return false;
+        }
+        type = global.Type;
+        value = T.CreateChecked(global.Value);
+        return true;
+    }
+
     public override T ReadGlobal<T>(string name)
         => ReadGlobal<T>(name, out _);
 

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
@@ -524,6 +524,21 @@ public sealed unsafe class ContractDescriptorTarget : Target
         return T.CreateChecked(global.Value);
     }
 
+    public override bool TryReadGlobalPointer(string name, [NotNullWhen(true)] out TargetPointer? value)
+        => TryReadGlobalPointer(name, out value, out _);
+
+    public bool TryReadGlobalPointer(string name, [NotNullWhen(true)] out TargetPointer? value, out string? type)
+    {
+        value = null;
+        type = null;
+        if (!_globals.TryGetValue(name, out (ulong Value, string? Type) global))
+            return false;
+
+        type = global.Type;
+        value = new TargetPointer(global.Value);
+        return true;
+    }
+
     public override TargetPointer ReadGlobalPointer(string name)
         => ReadGlobalPointer(name, out _);
 

--- a/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
@@ -93,6 +93,20 @@ internal class TestPlaceholderTarget : Target
     }
 
     public override TargetNUInt ReadNUInt(ulong address) => DefaultReadNUInt(address);
+
+    public override bool TryReadGlobal<T>(string name, [NotNullWhen(true)] out T? value)
+    {
+        value = default;
+        foreach (var global in _globals)
+        {
+            if (global.Name == name)
+            {
+                value = T.CreateChecked(global.Value);
+                return true;
+            }
+        }
+        return false;
+    }
     public override T ReadGlobal<T>(string name)
     {
         foreach (var global in _globals)

--- a/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdacreader/tests/TestPlaceholderTarget.cs
@@ -51,6 +51,20 @@ internal class TestPlaceholderTarget : Target
         return (pointer.Value & (ulong)(PointerSize - 1)) == 0;
     }
 
+    public override bool TryReadGlobalPointer(string name, [NotNullWhen(true)] out TargetPointer? value)
+    {
+        value = null;
+        foreach (var global in _globals)
+        {
+            if (global.Name == name)
+            {
+                value = new TargetPointer(global.Value);
+                return true;
+            }
+        }
+        return false;
+    }
+
     public override TargetPointer ReadGlobalPointer(string name)
     {
         foreach (var global in _globals)


### PR DESCRIPTION
Previously these were indirect pointers, this places them in the contract directly.

Indirect pointers are used so the dynamic linker can resolve the addresses. These values are known at compile time and therefore don't need the extra layer of indirection.

Additionally adds to the `Target` interface to allow `TryReadGlobal` and `TryReadGlobalPointer` instead of using exceptions for control-flow