### PR TITLE
Don't expose TrustedCertificatesDirectory() and StartNewTlsSessionContext() to NetFx

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/ref/System.DirectoryServices.Protocols.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/ref/System.DirectoryServices.Protocols.cs
@@ -382,8 +382,10 @@ namespace System.DirectoryServices.Protocols
         internal LdapSessionOptions() { }
         public bool AutoReconnect { get { throw null; } set { } }
         public string DomainName { get { throw null; } set { } }
+#if NET
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
         public string TrustedCertificatesDirectory { get { throw null; } set { } }
+#endif
         public string HostName { get { throw null; } set { } }
         public bool HostReachable { get { throw null; } }
         public System.DirectoryServices.Protocols.LocatorFlags LocatorFlag { get { throw null; } set { } }
@@ -404,8 +406,10 @@ namespace System.DirectoryServices.Protocols
         public bool Signing { get { throw null; } set { } }
         public System.DirectoryServices.Protocols.SecurityPackageContextConnectionInformation SslInformation { get { throw null; } }
         public int SspiFlag { get { throw null; } set { } }
+#if NET
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
         public void StartNewTlsSessionContext() { }
+#endif
         public bool TcpKeepAlive { get { throw null; } set { } }
         public System.DirectoryServices.Protocols.VerifyServerCertificateCallback VerifyServerCertificate { get { throw null; } set { } }
         public void FastConcurrentBind() { }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/113947

Will need to backport to v9 and v8.