### PR TITLE
Fix non-portable build for < OpenSSL 3.4

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/openssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/openssl.c
@@ -1292,7 +1292,7 @@ int32_t CryptoNative_IsSignatureAlgorithmAvailable(const char* algorithm)
 {
     int32_t ret = 0;
 
-#if defined(NEED_OPENSSL_3_0) && defined(HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT)
+#if defined(NEED_OPENSSL_3_0) && HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT
     if (!API_EXISTS(EVP_PKEY_sign_message_init) ||
         !API_EXISTS(EVP_PKEY_verify_message_init))
     {
@@ -1306,7 +1306,7 @@ int32_t CryptoNative_IsSignatureAlgorithmAvailable(const char* algorithm)
     {
         ret = 1;
         EVP_SIGNATURE_free(sigAlg);
-    } 
+    }
 #endif
 
     (void)algorithm;

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_ml_dsa.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_ml_dsa.c
@@ -9,7 +9,7 @@
 
 EVP_PKEY* CryptoNative_MLDsaGenerateKey(const char* keyType, uint8_t* seed, int32_t seedLen)
 {
-#if defined(NEED_OPENSSL_3_0) && defined(HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT)
+#if defined(NEED_OPENSSL_3_0) && HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT
     if (!API_EXISTS(EVP_PKEY_sign_message_init) ||
         !API_EXISTS(EVP_PKEY_verify_message_init))
     {
@@ -84,7 +84,7 @@ int32_t CryptoNative_MLDsaSignPure(EVP_PKEY *pkey,
     assert(destination);
     assert(destinationLen >= 2420 /* ML-DSA-44 signature size */);
 
-#if defined(NEED_OPENSSL_3_0) && defined(HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT)
+#if defined(NEED_OPENSSL_3_0) && HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT
     if (!API_EXISTS(EVP_PKEY_sign_message_init) ||
         !API_EXISTS(EVP_PKEY_verify_message_init))
     {
@@ -164,7 +164,7 @@ int32_t CryptoNative_MLDsaVerifyPure(EVP_PKEY *pkey,
     assert(sigLen >= 2420 /* ML-DSA-44 signature size */);
     assert(contextLen >= 0);
 
-#if defined(NEED_OPENSSL_3_0) && defined(HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT)
+#if defined(NEED_OPENSSL_3_0) && HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT
     if (!API_EXISTS(EVP_PKEY_sign_message_init) ||
         !API_EXISTS(EVP_PKEY_verify_message_init))
     {


### PR DESCRIPTION
The build was checking to see if HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT was defined, however because we use cmakedefine01 in the build, it is always defined. We care about the value of the define, not if it is defined or not. This is different from `NEED_OPENSSL_3_0`, which uses the presence of the define or not.

/cc @tmds @omajid since y'all reported the initial build break.