### PR TITLE
Fix issue where wrong message was added to EventReporter.

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4808,9 +4808,9 @@ DefaultCatchHandlerExceptionMessageWorker(Thread* pThread,
 
                 if (IsException(throwable->GetMethodTable()))
                 {
-                    if (!message.IsEmpty())
+                    if (!exceptionMessage.IsEmpty())
                     {
-                        reporter.AddDescription(message);
+                        reporter.AddDescription(exceptionMessage);
                     }
                     reporter.Report();
                 }


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/113416 used a shared SString buffer when building the log message written to console when hitting an unhandled managed exception. It appears that the same buffer was used when passing data over to EventReporter, but it would then include more information than expected. This will fix so we only pass over the exception message, inline with previous beharior.

Fixes issue found in https://github.com/dotnet/aspnetcore/pull/61011.