### PR TITLE
Fix EH and stack walking on linux-x86

### DIFF
--- a/src/coreclr/inc/regdisp.h
+++ b/src/coreclr/inc/regdisp.h
@@ -146,21 +146,12 @@ inline void SetRegdisplayPCTAddr(REGDISPLAY *display, TADDR addr)
 inline BOOL IsInCalleesFrames(REGDISPLAY *display, LPVOID stackPointer) {
     LIMITED_METHOD_CONTRACT;
 
-#ifdef FEATURE_EH_FUNCLETS
-    return stackPointer < ((LPVOID)(display->SP));
-#else
     return (TADDR)stackPointer < display->PCTAddr;
-#endif
 }
 inline TADDR GetRegdisplayStackMark(REGDISPLAY *display) {
     LIMITED_METHOD_DAC_CONTRACT;
 
-#ifdef FEATURE_EH_FUNCLETS
-    _ASSERTE(GetRegdisplaySP(display) == GetSP(display->pCurrentContext));
-    return GetRegdisplaySP(display);
-#else
     return display->PCTAddr;
-#endif
 }
 
 #elif defined(TARGET_64BIT)

--- a/src/coreclr/unwinder/i386/unwinder.cpp
+++ b/src/coreclr/unwinder/i386/unwinder.cpp
@@ -52,7 +52,7 @@ BOOL OOPStackUnwinderX86::Unwind(T_CONTEXT* pContextRecord, T_KNONVOLATILE_CONTE
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 
-    pContextRecord->Esp = rd.SP - codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo);
+    pContextRecord->Esp = rd.SP;
     pContextRecord->Eip = rd.ControlPC;
 
     return TRUE;

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -2267,8 +2267,6 @@ ULONG32 EECodeManager::GetStackParameterSize(EECodeInfo * pCodeInfo)
     hdrInfo * pHdrInfo = &(pStateBuf->hdrInfoBody);
     pStateBuf->hdrInfoSize = (DWORD)DecodeGCHdrInfo(gcInfoToken, dwOffset, pHdrInfo);
 
-    // We need to subtract 4 here because ESPIncrOnReturn() includes the stack slot containing the return
-    // address.
     return (ULONG32)::GetStackParameterSize(pHdrInfo);
 
 #else

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -11549,8 +11549,7 @@ void SoftwareExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 #ifndef DACCESS_COMPILE
 #ifdef TARGET_X86
 
-SoftwareExceptionFrame::SoftwareExceptionFrame(TransitionBlock *pTransitionBlock)
-    : Frame(FrameIdentifier::SoftwareExceptionFrame)
+void SoftwareExceptionFrame::UpdateContextFromTransitionBlock(TransitionBlock *pTransitionBlock)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -11579,8 +11578,8 @@ void SoftwareExceptionFrame::Init()
 {
     WRAPPER_NO_CONTRACT;
 
-    // On x86 we initialize the context state from transition block in a special
-    // constructor.
+    // On x86 we initialize the context state from transition block in
+    // UpdateContextFromTransitionBlock method.
 #ifndef TARGET_X86
 #define CALLEE_SAVED_REGISTER(regname) m_ContextPointers.regname = NULL;
     ENUM_CALLEE_SAVED_REGISTERS();

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -2494,7 +2494,7 @@ VOID DECLSPEC_NORETURN RealCOMPlusThrow(OBJECTREF throwable)
     RealCOMPlusThrow(throwable, FALSE);
 }
 
-VOID DECLSPEC_NORETURN PropagateExceptionThroughNativeFrames(Object *exceptionObj)
+VOID DECLSPEC_NORETURN __fastcall PropagateExceptionThroughNativeFrames(Object *exceptionObj)
 {
     CONTRACTL
     {
@@ -11547,6 +11547,31 @@ void SoftwareExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 }
 
 #ifndef DACCESS_COMPILE
+#ifdef TARGET_X86
+
+SoftwareExceptionFrame::SoftwareExceptionFrame(TransitionBlock *pTransitionBlock)
+    : Frame(FrameIdentifier::SoftwareExceptionFrame)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    m_Context.Ecx = pTransitionBlock->m_argumentRegisters.ECX;
+    m_Context.Edx = pTransitionBlock->m_argumentRegisters.EDX;
+    m_ContextPointers.Ecx = &m_Context.Ecx;
+    m_ContextPointers.Edx = &m_Context.Edx;
+
+#define CALLEE_SAVED_REGISTER(reg) \
+    m_Context.reg = pTransitionBlock->m_calleeSavedRegisters.reg; \
+    m_ContextPointers.reg = &m_Context.reg;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+
+    m_Context.Esp = (UINT_PTR)(pTransitionBlock + 1);
+    m_Context.Eip = pTransitionBlock->m_ReturnAddress;
+    m_ReturnAddress = pTransitionBlock->m_ReturnAddress;
+}
+
+#endif // TARGET_X86
+
 //
 // Init a new frame
 //
@@ -11554,6 +11579,9 @@ void SoftwareExceptionFrame::Init()
 {
     WRAPPER_NO_CONTRACT;
 
+    // On x86 we initialize the context state from transition block in a special
+    // constructor.
+#ifndef TARGET_X86
 #define CALLEE_SAVED_REGISTER(regname) m_ContextPointers.regname = NULL;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
@@ -11576,6 +11604,7 @@ void SoftwareExceptionFrame::Init()
     _ASSERTE(ExecutionManager::IsManagedCode(::GetIP(&m_Context)));
 
     m_ReturnAddress = ::GetIP(&m_Context);
+#endif // !TARGET_X86
 }
 
 //

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -252,7 +252,7 @@ VOID DECLSPEC_NORETURN RealCOMPlusThrowNonLocalized(RuntimeExceptionKind reKind,
 //==========================================================================
 
 VOID DECLSPEC_NORETURN RealCOMPlusThrow(OBJECTREF throwable);
-VOID DECLSPEC_NORETURN PropagateExceptionThroughNativeFrames(Object *exceptionObj);
+VOID DECLSPEC_NORETURN __fastcall PropagateExceptionThroughNativeFrames(Object *exceptionObj);
 
 //==========================================================================
 // Throw an undecorated runtime exception.

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -7800,6 +7800,8 @@ extern "C" void * QCALLTYPE CallCatchFunclet(QCall::ObjectHandleOnStack exceptio
                                    CastHandlerFn(pfnHandler),
                                    GetFirstNonVolatileRegisterAddress(pvRegDisplay->pCurrentContext),
                                    pFuncletCallerSP);
+
+        FixContext(pvRegDisplay->pCurrentContext);
 #else
         dwResumePC = pfnHandler(establisherFrame, OBJECTREFToObject(throwable));
 #endif
@@ -8128,7 +8130,11 @@ extern "C" CLR_BOOL QCALLTYPE CallFilterFunclet(QCall::ObjectHandleOnStack excep
         // it will retrieve the framepointer for accessing the locals in the parent
         // method.
         dwResult = CallEHFilterFunclet(OBJECTREFToObject(throwable),
+#ifdef TARGET_X86
+                                       GetRegdisplayFP(pvRegDisplay),
+#else
                                        GetFrameRestoreBase(pvRegDisplay->pCallerContext),
+#endif
                                        CastHandlerFn(pfnHandler),
                                        pFuncletCallerSP);
 #else

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -8130,8 +8130,8 @@ extern "C" CLR_BOOL QCALLTYPE CallFilterFunclet(QCall::ObjectHandleOnStack excep
         // it will retrieve the framepointer for accessing the locals in the parent
         // method.
         dwResult = CallEHFilterFunclet(OBJECTREFToObject(throwable),
-#ifdef TARGET_X86
-                                       GetRegdisplayFP(pvRegDisplay),
+#ifdef USE_CURRENT_CONTEXT_IN_FILTER
+                                       GetFrameRestoreBase(pvRegDisplay->pCurrentContext),
 #else
                                        GetFrameRestoreBase(pvRegDisplay->pCallerContext),
 #endif

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -1051,7 +1051,7 @@ public:
     }
 
 #ifdef TARGET_X86
-    SoftwareExceptionFrame(TransitionBlock *pTransitionBlock);
+    void UpdateContextFromTransitionBlock(TransitionBlock *pTransitionBlock);
 #endif
 #endif
 

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -1049,6 +1049,10 @@ public:
     SoftwareExceptionFrame() : Frame(FrameIdentifier::SoftwareExceptionFrame) {
         LIMITED_METHOD_CONTRACT;
     }
+
+#ifdef TARGET_X86
+    SoftwareExceptionFrame(TransitionBlock *pTransitionBlock);
+#endif
 #endif
 
     TADDR GetReturnAddressPtr_Impl()
@@ -1057,8 +1061,10 @@ public:
         return PTR_HOST_MEMBER_TADDR(SoftwareExceptionFrame, this, m_ReturnAddress);
     }
 
+#ifndef DACCESS_COMPILE
     void Init();
     void InitAndLink(Thread *pThread);
+#endif
 
     Interception GetInterception_Impl()
     {

--- a/src/coreclr/vm/i386/asmhelpers.S
+++ b/src/coreclr/vm/i386/asmhelpers.S
@@ -1091,3 +1091,52 @@ LEAF_ENTRY ThisPtrRetBufPrecodeWorker, _TEXT
     xor edi, esi
     jmp eax
 LEAF_END ThisPtrRetBufPrecodeWorker, _TEXT
+
+//==========================================================================
+// Capture a transition block with register values and call the IL_Throw
+// implementation written in C.
+//
+// Input state:
+//   ECX = Pointer to exception object
+//==========================================================================
+LEAF_ENTRY IL_Throw, _TEXT
+    STUB_PROLOG
+
+    mov     edx, esp
+
+    #define STACK_ALIGN_PADDING 4
+    sub     esp, STACK_ALIGN_PADDING
+
+    CHECK_STACK_ALIGNMENT
+
+    call    C_FUNC(IL_Throw_x86)
+
+    add     esp, STACK_ALIGN_PADDING
+    #undef STACK_ALIGN_PADDING
+
+    STUB_EPILOG
+    ret     4
+LEAF_END IL_Throw, _TEXT
+
+//==========================================================================
+// Capture a transition block with register values and call the IL_Rethrow
+// implementation written in C.
+//==========================================================================
+LEAF_ENTRY IL_Rethrow, _TEXT
+    STUB_PROLOG
+
+    mov     ecx, esp
+
+    #define STACK_ALIGN_PADDING 4
+    sub     esp, STACK_ALIGN_PADDING
+
+    CHECK_STACK_ALIGNMENT
+
+    call    C_FUNC(IL_Rethrow_x86)
+
+    add     esp, STACK_ALIGN_PADDING
+    #undef STACK_ALIGN_PADDING
+
+    STUB_EPILOG
+    ret     4
+LEAF_END IL_Rethrow

--- a/src/coreclr/vm/i386/asmhelpers.asm
+++ b/src/coreclr/vm/i386/asmhelpers.asm
@@ -1599,4 +1599,37 @@ _BackPatchWorkerAsmStub@0 proc public
     ret
 _BackPatchWorkerAsmStub@0 endp
 
+ifdef FEATURE_EH_FUNCLETS
+;==========================================================================
+; Capture a transition block with register values and call the IL_Throw
+; implementation written in C.
+;
+; Input state:
+;   ECX = Pointer to exception object
+;==========================================================================
+FASTCALL_FUNC IL_Throw, 4
+    STUB_PROLOG
+
+    mov     edx, esp
+    call    @IL_Throw_x86@8
+
+    STUB_EPILOG
+    ret     4
+FASTCALL_ENDFUNC IL_Throw
+
+;==========================================================================
+; Capture a transition block with register values and call the IL_Rethrow
+; implementation written in C.
+;==========================================================================
+FASTCALL_FUNC IL_Rethrow, 0
+    STUB_PROLOG
+
+    mov     ecx, esp
+    call    @IL_Rethrow_x86@4
+
+    STUB_EPILOG
+    ret     4
+FASTCALL_ENDFUNC IL_Rethrow
+endif ; FEATURE_EH_FUNCLETS
+
     end

--- a/src/coreclr/vm/i386/cgenx86.cpp
+++ b/src/coreclr/vm/i386/cgenx86.cpp
@@ -437,7 +437,9 @@ void StubDispatchFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool update
         // code:VSD_ResolveWorker or code:StubDispatchFixupWorker
         pRD->ControlPC = GetAdjustedCallAddress(pRD->ControlPC);
 #ifdef FEATURE_EH_FUNCLETS
-        // We need to set EIP to match to ensude Thread::VirtualUnwindCallFrame
+        // We need to set EIP to match ControlPC to ensure Thread::VirtualUnwindCallFrame
+        // doesn't fail assertion on GetControlPC(pRD) == GetIP(pRD->pCurrentContext)
+        // precondition.
         pRD->pCurrentContext->Eip = pRD->ControlPC;
 #endif
     }

--- a/src/coreclr/vm/i386/cgenx86.cpp
+++ b/src/coreclr/vm/i386/cgenx86.cpp
@@ -175,14 +175,14 @@ void TransitionFrame::UpdateRegDisplayHelper(const PREGDISPLAY pRD, UINT cbStack
 
     pRD->PCTAddr = GetReturnAddressPtr();
 
-#ifdef FEATURE_EH_FUNCLETS
+    DWORD CallerSP = (DWORD)(pRD->PCTAddr + sizeof(TADDR) + cbStackPop);
 
-    DWORD CallerSP = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
+#ifdef FEATURE_EH_FUNCLETS
 
     pRD->IsCallerContextValid = FALSE;
     pRD->IsCallerSPValid      = FALSE;
 
-    pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);;
+    pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);
     pRD->pCurrentContext->Esp = CallerSP;
 
     UpdateRegDisplayFromCalleeSavedRegisters(pRD, regs);
@@ -200,7 +200,7 @@ void TransitionFrame::UpdateRegDisplayHelper(const PREGDISPLAY pRD, UINT cbStack
 #undef CALLEE_SAVED_REGISTER
 
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
-    pRD->SP  = (DWORD)(pRD->PCTAddr + sizeof(TADDR) + cbStackPop);
+    pRD->SP  = CallerSP;
 
 #endif // FEATURE_EH_FUNCLETS
 
@@ -436,6 +436,10 @@ void StubDispatchFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool update
         // This path is hit when we are throwing null reference exception from
         // code:VSD_ResolveWorker or code:StubDispatchFixupWorker
         pRD->ControlPC = GetAdjustedCallAddress(pRD->ControlPC);
+#ifdef FEATURE_EH_FUNCLETS
+        // We need to set EIP to match to ensude Thread::VirtualUnwindCallFrame
+        pRD->pCurrentContext->Eip = pRD->ControlPC;
+#endif
     }
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    StubDispatchFrame::UpdateRegDisplay_Impl(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -1510,7 +1510,12 @@ HCIMPLEND
 
 /*************************************************************/
 
+#if defined(TARGET_X86) && defined(FEATURE_EH_FUNCLETS)
+EXTERN_C FCDECL1(void, IL_Throw,  Object* obj);
+EXTERN_C HCIMPL2(void, IL_Throw_x86,  Object* obj, TransitionBlock* transitionBlock)
+#else
 HCIMPL1(void, IL_Throw,  Object* obj)
+#endif
 {
     FCALL_CONTRACT;
 
@@ -1526,8 +1531,12 @@ HCIMPL1(void, IL_Throw,  Object* obj)
     {
         Thread *pThread = GetThread();
 
+#ifdef TARGET_X86
+        SoftwareExceptionFrame exceptionFrame(transitionBlock);
+#else
         SoftwareExceptionFrame exceptionFrame;
         RtlCaptureContext(exceptionFrame.GetContext());
+#endif
         exceptionFrame.InitAndLink(pThread);
 
         FC_CAN_TRIGGER_GC();
@@ -1605,7 +1614,12 @@ HCIMPLEND
 
 /*************************************************************/
 
+#if defined(TARGET_X86) && defined(FEATURE_EH_FUNCLETS)
+EXTERN_C FCDECL0(void, IL_Rethrow);
+EXTERN_C HCIMPL1(void, IL_Rethrow_x86, TransitionBlock* transitionBlock)
+#else
 HCIMPL0(void, IL_Rethrow)
+#endif
 {
     FCALL_CONTRACT;
 
@@ -1616,8 +1630,12 @@ HCIMPL0(void, IL_Rethrow)
     {
         Thread *pThread = GetThread();
 
+#ifdef TARGET_X86
+        SoftwareExceptionFrame exceptionFrame(transitionBlock);
+#else
         SoftwareExceptionFrame exceptionFrame;
         RtlCaptureContext(exceptionFrame.GetContext());
+#endif
         exceptionFrame.InitAndLink(pThread);
 
         ExInfo *pActiveExInfo = (ExInfo*)pThread->GetExceptionState()->GetCurrentExceptionTracker();

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -1531,10 +1531,10 @@ HCIMPL1(void, IL_Throw,  Object* obj)
     {
         Thread *pThread = GetThread();
 
-#ifdef TARGET_X86
-        SoftwareExceptionFrame exceptionFrame(transitionBlock);
-#else
         SoftwareExceptionFrame exceptionFrame;
+#ifdef TARGET_X86
+        exceptionFrame.UpdateContextFromTransitionBlock(transitionBlock);
+#else
         RtlCaptureContext(exceptionFrame.GetContext());
 #endif
         exceptionFrame.InitAndLink(pThread);
@@ -1630,10 +1630,10 @@ HCIMPL0(void, IL_Rethrow)
     {
         Thread *pThread = GetThread();
 
-#ifdef TARGET_X86
-        SoftwareExceptionFrame exceptionFrame(transitionBlock);
-#else
         SoftwareExceptionFrame exceptionFrame;
+#ifdef TARGET_X86
+        exceptionFrame.UpdateContextFromTransitionBlock(transitionBlock);
+#else
         RtlCaptureContext(exceptionFrame.GetContext());
 #endif
         exceptionFrame.InitAndLink(pThread);

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -4781,7 +4781,11 @@ StackWalkAction SWCB_GetExecutionState(CrawlFrame *pCF, VOID *pData)
                             pES->m_ppvRetAddrPtr = (void **) pRDT->pCallerContextPointers->Lr;
 #endif
                         }
-#elif defined(TARGET_X86) || defined(TARGET_AMD64)
+#elif defined(TARGET_X86)
+                        // peel off the next frame to expose the return address on the stack
+                        pES->m_FirstPass = FALSE;
+                        action = SWA_CONTINUE;
+#elif defined(TARGET_AMD64)
                         pES->m_ppvRetAddrPtr = (void **) (EECodeManager::GetCallerSp(pRDT) - sizeof(void*));
 #else // TARGET_X86 || TARGET_AMD64
                         PORTABILITY_ASSERT("Platform NYI");
@@ -4820,7 +4824,7 @@ StackWalkAction SWCB_GetExecutionState(CrawlFrame *pCF, VOID *pData)
     }
     else
     {
-#if defined(TARGET_X86) && !defined(FEATURE_EH_FUNCLETS)
+#ifdef TARGET_X86
         // Second pass, looking for the address of the return address so we can
         // hijack:
 


### PR DESCRIPTION
On x86 we don't have mechanism for unwinding of native code, so we have to handle IL_Throw/IL_Rethrow initial context for new exception handling differently.

Stack walking on x86 is also significantly different because we don't produce unwind codes and rely solely on GC info produced by JIT. In order to unwind this efficiently we always need EECodeInfo. The previous implementation used a custom reimplementation of RtlVirtualUnwind method which meant that we did the lookup multiple times. Another problem was that it inconsistently treated the the "caller SP" and "return address location". On x86 we have calling conventions that use "ret N" opcode which pops the return adress from stack and then pops an additional number of bytes from the stack pointer to skip over pushed arguments. This distinction is important and most of the runtime code expects unwound SP to point to the caller SP (ie. as if the RET N instruction was executed). An exception is the return address hijacking which needs the return address location instead. We now treat the SP and PCTAddr fields of REGDISPLAY the same as on non-funclet runtime to make this distinction respected in a consistent way.