### PR TITLE
Fix propagating of unhandled exception to native caller

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -946,7 +946,7 @@ ProcessCLRExceptionNew(IN     PEXCEPTION_RECORD   pExceptionRecord,
     {
         // We are in the 1st pass of exception handling, but the thread mark says that it has already executed 2nd pass
         // of unhandled exception handling. That means that some external native code on top of the stack has caught the
-        // exception that runtime considered to be unhandledand a new native exception was thrown on the current thread.
+        // exception that runtime considered to be unhandled, and a new native exception was thrown on the current thread.
         // We need to reset the flags below so that we no longer block exception handling for the managed frames.
         pThread->ResetThreadStateNC(Thread::TSNC_UnhandledException2ndPass);
         pThread->ResetThreadStateNC(Thread::TSNC_ProcessedUnhandledException);

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -655,7 +655,7 @@ public:
                                                       // effort.
                                                       //
                                                       // Once we are completely independent of the OS UEF, we could remove this.
-        // unused                       = 0x02000000,
+        TSNC_UnhandledException2ndPass  = 0x02000000, // The unhandled exception propagation is in the 2nd pass
         TSNC_DebuggerSleepWaitJoin      = 0x04000000, // Indicates to the debugger that this thread is in a sleep wait or join state
                                                       // This almost mirrors the TS_Interruptible state however that flag can change
                                                       // during GC-preemptive mode whereas this one cannot.

--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
@@ -63,7 +63,7 @@ public class ForeignThreadExceptionsTest
             }
         });
 
-        if (OperatingSystem.IsWindows() && !TestLibrary.Utilities.IsNativeAot)
+        if (OperatingSystem.IsWindows() && !TestLibrary.Utilities.IsNativeAot && !TestLibrary.Utilities.IsMonoRuntime)
         {
             InvokeCallbackAndCatchTwiceOnNewThread(() => {
                 throw new Exception("Exception unhandled in any managed code");

--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
@@ -15,6 +15,12 @@ public class ForeignThreadExceptionsTest
     [DllImport("ForeignThreadExceptionsNative")]
     public static extern void InvokeCallbackOnNewThread(MyCallback callback);
 
+    [DllImport("ForeignThreadExceptionsNative")]
+    public static extern void InvokeCallbackAndCatchTwiceOnNewThread(MyCallback callback);
+
+    [DllImport("ForeignThreadExceptionsNative")]
+    public static extern void ThrowException();
+
     public static void MethodThatThrows()
     {
         throw new Exception("This is MethodThatThrows.");
@@ -56,6 +62,25 @@ public class ForeignThreadExceptionsTest
                 Console.WriteLine("Caught hardware exception in a delegate called through Reverse PInvoke on a foreign thread.");
             }
         });
+
+        InvokeCallbackAndCatchTwiceOnNewThread(() => {
+            throw new Exception("Exception unhandled in any managed code");
+        });
+
+        int finallyCallsCount = 0;
+        InvokeCallbackAndCatchTwiceOnNewThread(() => {
+            try
+            {
+                // Throw native exception that is not handled in any managed code
+                ThrowException();
+            }
+            finally
+            {
+                finallyCallsCount++;
+            }
+        });
+
+        Assert.Equal(2, finallyCallsCount);
     }
 
     [Fact]

--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
@@ -63,24 +63,27 @@ public class ForeignThreadExceptionsTest
             }
         });
 
-        InvokeCallbackAndCatchTwiceOnNewThread(() => {
-            throw new Exception("Exception unhandled in any managed code");
-        });
+        if (OperatingSystem.IsWindows() && !TestLibrary.Utilities.IsNativeAot)
+        {
+            InvokeCallbackAndCatchTwiceOnNewThread(() => {
+                throw new Exception("Exception unhandled in any managed code");
+            });
 
-        int finallyCallsCount = 0;
-        InvokeCallbackAndCatchTwiceOnNewThread(() => {
-            try
-            {
-                // Throw native exception that is not handled in any managed code
-                ThrowException();
-            }
-            finally
-            {
-                finallyCallsCount++;
-            }
-        });
+            int finallyCallsCount = 0;
+            InvokeCallbackAndCatchTwiceOnNewThread(() => {
+                try
+                {
+                    // Throw native exception that is not handled in any managed code
+                    ThrowException();
+                }
+                finally
+                {
+                    finallyCallsCount++;
+                }
+            });
 
-        Assert.Equal(2, finallyCallsCount);
+            Assert.Equal(2, finallyCallsCount);
+        }
     }
 
     [Fact]

--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ForeignThreadExceptions.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="CMakeLists.txt" />

--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptionsNative.cpp
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptionsNative.cpp
@@ -15,10 +15,44 @@
 
 #include <platformdefines.h>
 
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE ThrowException()
+{
+    throw std::exception{};
+}
+
 typedef void (*PFNACTION1)();
 extern "C" DLL_EXPORT void InvokeCallback(PFNACTION1 callback)
 {
     callback();
+}
+
+extern "C" DLL_EXPORT void InvokeCallbackAndCatchTwice(PFNACTION1 callback)
+{
+    try
+    {
+        callback();
+    }
+    catch (...)
+    {
+        printf("Caught exception once\n");
+    }
+
+    try
+    {
+        // Put garbage on the stack that was possibly used by the previous callback to catch
+        // cases when the explicit frames or ExInfos were not cleaned up properly when the
+        // exception is not handled in the managed code and reaches this native caller.
+        unsigned int *p = (unsigned int *)alloca(16384);
+        for (int i = 0; i < 16384 / sizeof(unsigned int); i++)
+        {
+            *p++ = 0xbaadf00d;
+        }
+        callback();
+    }
+    catch (...)
+    {
+        printf("Caught exception again\n");
+    }
 }
 
 #ifndef _WIN32
@@ -28,16 +62,25 @@ void* InvokeCallbackUnix(void* callback)
     return NULL;
 }
 
+void* InvokeCallbackAndCatchTwiceUnix(void* callback)
+{
+    InvokeCallbackAndCatchTwice((PFNACTION1)callback);
+    return NULL;
+}
+
 #define AbortIfFail(st) if (st != 0) abort()
 
 #endif // !_WIN32
 
-extern "C" DLL_EXPORT void InvokeCallbackOnNewThread(PFNACTION1 callback)
-{
 #ifdef _WIN32
-    std::thread t1(InvokeCallback, callback);
+void InvokeCallbackOnNewThreadCommon(PFNACTION1 callback, void (*startRoutine)(PFNACTION1))
+{
+    std::thread t1(startRoutine, callback);
     t1.join();
+}
 #else // _WIN32
+void InvokeCallbackOnNewThreadCommon(PFNACTION1 callback, void *(*startRoutine)(void*))
+{
     // For Unix, we need to use pthreads to create the thread so that we can set its stack size.
     // We need to set the stack size due to the very small (80kB) default stack size on MUSL
     // based Linux distros.
@@ -50,10 +93,28 @@ extern "C" DLL_EXPORT void InvokeCallbackOnNewThread(PFNACTION1 callback)
     AbortIfFail(st);
 
     pthread_t t;
-    st = pthread_create(&t, &attr, InvokeCallbackUnix, (void*)callback);
+    st = pthread_create(&t, &attr, startRoutine, (void*)callback);
     AbortIfFail(st);
 
     st = pthread_join(t, NULL);
     AbortIfFail(st);
+}
 #endif // _WIN32
+
+extern "C" DLL_EXPORT void InvokeCallbackAndCatchTwiceOnNewThread(PFNACTION1 callback)
+{
+#ifdef _WIN32
+    InvokeCallbackOnNewThreadCommon(callback, InvokeCallbackAndCatchTwice);
+#else // _WIN32
+    InvokeCallbackOnNewThreadCommon(callback, InvokeCallbackAndCatchTwiceUnix);
+#endif
+}
+
+extern "C" DLL_EXPORT void InvokeCallbackOnNewThread(PFNACTION1 callback)
+{
+#ifdef _WIN32
+    InvokeCallbackOnNewThreadCommon(callback, InvokeCallback);
+#else // _WIN32
+    InvokeCallbackOnNewThreadCommon(callback, InvokeCallbackUnix);
+#endif
 }

--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptionsNative.cpp
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptionsNative.cpp
@@ -15,6 +15,8 @@
 
 #include <platformdefines.h>
 
+typedef void (*PFNACTION1)();
+
 #ifdef _WIN32
 extern "C" DLL_EXPORT void STDMETHODCALLTYPE ThrowException()
 {
@@ -52,7 +54,6 @@ extern "C" DLL_EXPORT void InvokeCallbackAndCatchTwice(PFNACTION1 callback)
 
 #endif // _WIN32
 
-typedef void (*PFNACTION1)();
 extern "C" DLL_EXPORT void InvokeCallback(PFNACTION1 callback)
 {
     callback();


### PR DESCRIPTION
The final propagation of unhandled exception into topmost native frames on foreign threads has a bug that hits when the native caller catches the exception and then calls into managed code again. The problem is that we weren't popping out the explicit frames and ExInfos. So when the managed code is entered again, the `Thread::m_pFrame` points to a garbage. The same is true for the `ExInfo` chain.

This is causing crashes in a 3rd party application where a foreign thread runs some MFC code that calls to some managed functions regularly and swallows exceptions stemming from it.

While investigating the issue, I have found that there is a secondary related problem. When we mark the thread by setting the TSNC_ProcessedUnhandledException flag, the ProcessCLRException intentionally starts ignoring managed frames, because we try to let the exception bubble out to the 3rd party code. But if it catches the exception and calls back to managed code, the
TSNC_ProcessedUnhandledException flag stays set and thus when the exception would need to propagate through native frames, all the managed frames would be ignored.

This change fixes both of the problems and adds a test that crashes without the fix in both of the cases.

Close #113751