### PR TITLE
Use the shipping version in PackageOverrides.txt

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.targets
@@ -22,7 +22,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <CreatePackageOverridesTemplateProperty Include="ProductVersion=$(ProductVersion)" />
+      <CreatePackageOverridesTemplateProperty Include="ProductVersion=$(Version)" />
     </ItemGroup>
 
     <GenerateFileFromTemplate


### PR DESCRIPTION
This allows the consumption of newer packages in the same release band when an SDK with package pruning enabled is used.

This means that i.e. a `System.Text.Json/10.0.0-preview.4` package can be used with a .NET 10 Preview 3 SDK.