### PR TITLE
Include in WaitingWriteCount the thread that may be waiting in upgradable mode

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ReaderWriterLockSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ReaderWriterLockSlim.cs
@@ -1412,7 +1412,8 @@ namespace System.Threading
 
         public int WaitingUpgradeCount => (int)_numUpgradeWaiters;
 
-        public int WaitingWriteCount => (int)_numWriteWaiters;
+        // Include the thread that may be waiting in upgradable mode.
+        public int WaitingWriteCount => (int)_numWriteWaiters + (int)_numWriteUpgradeWaiters;
 
         private struct SpinLock
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/107077.