### PR TITLE
Enable more constant foldings for switch ops using assertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -6557,11 +6557,6 @@ PhaseStatus Compiler::optAssertionPropMain()
         compCurBB           = block;
         fgRemoveRestOfBlock = false;
 
-        if (block->KindIs(BBJ_SWITCH))
-        {
-            switchBlocks.Push(block);
-        }
-
         Statement* stmt = block->firstStmt();
         while (stmt != nullptr)
         {
@@ -6603,6 +6598,11 @@ PhaseStatus Compiler::optAssertionPropMain()
 
             // Advance the iterator
             stmt = stmt->GetNextStmt();
+        }
+
+        if (block->KindIs(BBJ_SWITCH))
+        {
+            switchBlocks.Push(block);
         }
     }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8112,6 +8112,7 @@ public:
     // Implied assertion functions.
     void optImpliedAssertions(AssertionIndex assertionIndex, ASSERT_TP& activeAssertions);
     void optImpliedByTypeOfAssertions(ASSERT_TP& activeAssertions);
+    bool optCreateJumpTableImpliedAssertions(BasicBlock* switchBb);
     void optImpliedByConstAssertion(AssertionDsc* curAssertion, ASSERT_TP& result);
 
 #ifdef DEBUG


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/113992

This PR creates global assertions for switch targets.

An example from System.Text.Json:
```cs
public static ulong GetKey(ReadOnlySpan<byte> name)
{
    int length = name.Length;
    ulong key = (ulong)(byte)length << 56;

    switch (length)
    {
        case 0: goto ComputedKey;
        case 1: goto OddLength;
        case 2: key |= MemoryMarshal.Read<ushort>(name); goto ComputedKey;
        case 3: key |= MemoryMarshal.Read<ushort>(name); goto OddLength;
        case 4: key |= MemoryMarshal.Read<uint>(name); goto ComputedKey;
        case 5: key |= MemoryMarshal.Read<uint>(name); goto OddLength;
        case 6:
            key |= MemoryMarshal.Read<uint>(name) |
                   (ulong)MemoryMarshal.Read<ushort>(name.Slice(4, 2)) << 32; goto ComputedKey;
        case 7:
            key |= MemoryMarshal.Read<uint>(name) |
                   (ulong)MemoryMarshal.Read<ushort>(name.Slice(4, 2)) << 32; goto OddLength;
        default: key |= MemoryMarshal.Read<ulong>(name) & 0x00ffffffffffffffL; goto ComputedKey;
    }

    OddLength:
    int offset = length - 1;
    key |= (ulong)name[offset] << (offset * 8);

    ComputedKey:
    return key;
}
```
Codegen diff (Main vs PR): https://www.diffchecker.com/cxZY6tn3/ (still not perfect, though).

Another use-case is `switch` over string literals. Roslyn emits a trie-like algorithm for them where we do switch over string's length and end up comparing length inside all cases:
```cs
int Trie(string x) =>
    x switch
    {
        "1" => 1,
        "11" => 11,
        "111" => 111,
        "1111" => 1111,
        "11111" => 11111,
        "111111" => 111111,
        "1111111" => 1111111,
        "11111111" => 11111111,
        _ => 0
    };
```
Codegen diff (Main vs PR): https://www.diffchecker.com/CeHgRf8I/
