### PR TITLE
Remove List<T> allocation in Task.WhenAll for empty sequences

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -6293,9 +6293,7 @@ namespace System.Threading.Tasks
             while (enumerator.MoveNext());
 
 
-            return taskList.Count == 0 ?
-                new Task<TResult[]>(false, [], TaskCreationOptions.None, default) :
-                new WhenAllPromise<TResult>([.. taskList]);
+            return new WhenAllPromise<TResult>([.. taskList]);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently `Task.WhenAll<TResult>(IEnumerable)` always allocates a `List<T>` for empty source sequences.