### PR TITLE
Don't use `Delegate.Method` in ServiceDescriptor

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -262,7 +263,17 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 if (KeyedImplementationFactory != null)
                 {
-                    return lifetime + $"{nameof(KeyedImplementationFactory)}: {KeyedImplementationFactory.Method}";
+#if NET9_0_OR_GREATER
+                    DiagnosticMethodInfo? dmi = DiagnosticMethodInfo.Create(KeyedImplementationFactory);
+                    string declaringTypeName = dmi?.DeclaringTypeName ?? "?";
+                    string methodName = dmi?.Name ?? "?";
+#else
+                    MethodInfo mi = KeyedImplementationFactory.Method;
+                    string? declaringTypeName = mi.DeclaringType?.FullName;
+                    string methodName = mi.Name;
+#endif
+
+                    return lifetime + $"{nameof(KeyedImplementationFactory)}: {declaringTypeName}.{methodName}";
                 }
 
                 return lifetime + $"{nameof(KeyedImplementationInstance)}: {KeyedImplementationInstance}";
@@ -276,7 +287,17 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 if (ImplementationFactory != null)
                 {
-                    return lifetime + $"{nameof(ImplementationFactory)}: {ImplementationFactory.Method}";
+#if NET9_0_OR_GREATER
+                    DiagnosticMethodInfo? dmi = DiagnosticMethodInfo.Create(ImplementationFactory);
+                    string declaringTypeName = dmi?.DeclaringTypeName ?? "?";
+                    string methodName = dmi?.Name ?? "?";
+#else
+                    MethodInfo mi = ImplementationFactory.Method;
+                    string? declaringTypeName = mi.DeclaringType?.FullName;
+                    string methodName = mi.Name;
+#endif
+
+                    return lifetime + $"{nameof(ImplementationFactory)}: {declaringTypeName}.{methodName}";
                 }
 
                 return lifetime + $"{nameof(ImplementationInstance)}: {ImplementationInstance}";

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionDescriptorExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionDescriptorExtensionsTests.cs
@@ -81,15 +81,15 @@ namespace Microsoft.Extensions.DependencyInjection
             },
             {
                 new ServiceDescriptor(typeof(IFakeService), CreateFakeService, ServiceLifetime.Scoped),
-                "ServiceType: Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService Lifetime: Scoped ImplementationFactory: Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeService CreateFakeService(System.IServiceProvider)"
+                "ServiceType: Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService Lifetime: Scoped ImplementationFactory: Microsoft.Extensions.DependencyInjection.ServiceCollectionDescriptorExtensionsTest.CreateFakeService"
             },
             {
                 new ServiceDescriptor(typeof(IFakeService), CreateFakeService, ServiceLifetime.Singleton),
-                "ServiceType: Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService Lifetime: Singleton ImplementationFactory: Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeService CreateFakeService(System.IServiceProvider)"
+                "ServiceType: Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService Lifetime: Singleton ImplementationFactory: Microsoft.Extensions.DependencyInjection.ServiceCollectionDescriptorExtensionsTest.CreateFakeService"
             },
             {
                 new ServiceDescriptor(typeof(IFakeService), CreateFakeService, ServiceLifetime.Transient),
-                "ServiceType: Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService Lifetime: Transient ImplementationFactory: Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeService CreateFakeService(System.IServiceProvider)"
+                "ServiceType: Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService Lifetime: Transient ImplementationFactory: Microsoft.Extensions.DependencyInjection.ServiceCollectionDescriptorExtensionsTest.CreateFakeService"
             },
         };
 


### PR DESCRIPTION
The problem with this API is that in a trimmed app, accessing `Method` on a delegate type forces trimming to consider all delegate targets also targets of reflection (since we're grabbing a `MethodInfo` for whatever is the target). We do try to optimize this and only consider targets of the same delegate type, but in this case it means `Func<T, U>` and `Func<T,U,V>` which are very popular delegate types. Avoiding `Delegate.Method` is a 0.8% size saving for the Microsoft Store app.

The differences are:
* Originally this was calling `ToString` on the `MethodInfo`, which returns the name and signature of the method. I'm replacing this with `FullName` of the owning type and the name of the method. This is both more information and less information - we get owning type, we lose signature. It feels more useful nevertheless.
* When the app is trimmed and `StackTraceSupport` feature switch is set to false, this will return question marks.

The 0.8% size savings is present no matter the value of the `StackTraceSupport` switch.