### PR TITLE
JIT: Propagate flow into finally regions correctly in synthesis

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -368,6 +368,16 @@ void Compiler::fgRemoveEhfSuccessor(BasicBlock* block, const unsigned succIndex)
                   (succCount - succIndex - 1) * sizeof(FlowEdge*));
     }
 
+    // If the block has other successors, distribute the removed edge's likelihood among the remaining successor edges.
+    if (succCount > 1)
+    {
+        const weight_t likelihoodIncrease = succEdge->getLikelihood() / (succCount - 1);
+        for (unsigned i = 0; i < (succCount - 1); i++)
+        {
+            succTab[i]->addLikelihood(likelihoodIncrease);
+        }
+    }
+
 #ifdef DEBUG
     // We only expect to see a successor once in the table.
     for (unsigned i = succIndex; i < (succCount - 1); i++)
@@ -424,6 +434,16 @@ void Compiler::fgRemoveEhfSuccessor(FlowEdge* succEdge)
                 assert(succTab[i]->getDestinationBlock() != succEdge->getDestinationBlock());
             }
 #endif // DEBUG
+        }
+    }
+
+    // If the block has other successors, distribute the removed edge's likelihood among the remaining successor edges.
+    if (succCount > 1)
+    {
+        const weight_t likelihoodIncrease = succEdge->getLikelihood() / (succCount - 1);
+        for (unsigned i = 0; i < (succCount - 1); i++)
+        {
+            succTab[i]->addLikelihood(likelihoodIncrease);
         }
     }
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -370,10 +370,14 @@ void Compiler::fgRemoveEhfSuccessor(BasicBlock* block, const unsigned succIndex)
 
     // Recompute the likelihoods of the block's other successor edges.
     const weight_t removedLikelihood = succEdge->getLikelihood();
-    for (unsigned i = 0; (removedLikelihood != 1.0) && (i < (succCount - 1)); i++)
+    const unsigned newSuccCount      = succCount - 1;
+
+    for (unsigned i = 0; i < newSuccCount; i++)
     {
+        // If we removed all of the flow out of 'block', distribute flow among the remaining edges evenly.
         const weight_t currLikelihood = succTab[i]->getLikelihood();
-        const weight_t newLikelihood  = currLikelihood / (1.0 - removedLikelihood);
+        const weight_t newLikelihood =
+            currLikelihood / ((removedLikelihood == 1.0) ? newSuccCount : (1.0 - removedLikelihood));
         succTab[i]->setLikelihood(min(1.0, newLikelihood));
     }
 
@@ -438,10 +442,14 @@ void Compiler::fgRemoveEhfSuccessor(FlowEdge* succEdge)
 
     // Recompute the likelihoods of the block's other successor edges.
     const weight_t removedLikelihood = succEdge->getLikelihood();
-    for (unsigned i = 0; (removedLikelihood != 1.0) && (i < (succCount - 1)); i++)
+    const unsigned newSuccCount      = succCount - 1;
+
+    for (unsigned i = 0; i < newSuccCount; i++)
     {
+        // If we removed all of the flow out of 'block', distribute flow among the remaining edges evenly.
         const weight_t currLikelihood = succTab[i]->getLikelihood();
-        const weight_t newLikelihood  = currLikelihood / (1.0 - removedLikelihood);
+        const weight_t newLikelihood =
+            currLikelihood / ((removedLikelihood == 1.0) ? newSuccCount : (1.0 - removedLikelihood));
         succTab[i]->setLikelihood(min(1.0, newLikelihood));
     }
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -368,14 +368,13 @@ void Compiler::fgRemoveEhfSuccessor(BasicBlock* block, const unsigned succIndex)
                   (succCount - succIndex - 1) * sizeof(FlowEdge*));
     }
 
-    // If the block has other successors, distribute the removed edge's likelihood among the remaining successor edges.
-    if (succCount > 1)
+    // Recompute the likelihoods of the block's other successor edges.
+    const weight_t removedLikelihood = succEdge->getLikelihood();
+    for (unsigned i = 0; (removedLikelihood != 1.0) && (i < (succCount - 1)); i++)
     {
-        const weight_t likelihoodIncrease = succEdge->getLikelihood() / (succCount - 1);
-        for (unsigned i = 0; i < (succCount - 1); i++)
-        {
-            succTab[i]->addLikelihood(likelihoodIncrease);
-        }
+        const weight_t currLikelihood = succTab[i]->getLikelihood();
+        const weight_t newLikelihood  = currLikelihood / (1.0 - removedLikelihood);
+        succTab[i]->setLikelihood(min(1.0, newLikelihood));
     }
 
 #ifdef DEBUG
@@ -437,14 +436,13 @@ void Compiler::fgRemoveEhfSuccessor(FlowEdge* succEdge)
         }
     }
 
-    // If the block has other successors, distribute the removed edge's likelihood among the remaining successor edges.
-    if (succCount > 1)
+    // Recompute the likelihoods of the block's other successor edges.
+    const weight_t removedLikelihood = succEdge->getLikelihood();
+    for (unsigned i = 0; (removedLikelihood != 1.0) && (i < (succCount - 1)); i++)
     {
-        const weight_t likelihoodIncrease = succEdge->getLikelihood() / (succCount - 1);
-        for (unsigned i = 0; i < (succCount - 1); i++)
-        {
-            succTab[i]->addLikelihood(likelihoodIncrease);
-        }
+        const weight_t currLikelihood = succTab[i]->getLikelihood();
+        const weight_t newLikelihood  = currLikelihood / (1.0 - removedLikelihood);
+        succTab[i]->setLikelihood(min(1.0, newLikelihood));
     }
 
     assert(found);

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -377,7 +377,7 @@ void Compiler::fgRemoveEhfSuccessor(BasicBlock* block, const unsigned succIndex)
         // If we removed all of the flow out of 'block', distribute flow among the remaining edges evenly.
         const weight_t currLikelihood = succTab[i]->getLikelihood();
         const weight_t newLikelihood =
-            currLikelihood / ((removedLikelihood == 1.0) ? newSuccCount : (1.0 - removedLikelihood));
+            (removedLikelihood == 1.0) ? (1.0 / newSuccCount) : (currLikelihood / (1.0 - removedLikelihood));
         succTab[i]->setLikelihood(min(1.0, newLikelihood));
     }
 
@@ -449,7 +449,7 @@ void Compiler::fgRemoveEhfSuccessor(FlowEdge* succEdge)
         // If we removed all of the flow out of 'block', distribute flow among the remaining edges evenly.
         const weight_t currLikelihood = succTab[i]->getLikelihood();
         const weight_t newLikelihood =
-            currLikelihood / ((removedLikelihood == 1.0) ? newSuccCount : (1.0 - removedLikelihood));
+            (removedLikelihood == 1.0) ? (1.0 / newSuccCount) : (currLikelihood / (1.0 - removedLikelihood));
         succTab[i]->setLikelihood(min(1.0, newLikelihood));
     }
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -4787,20 +4787,12 @@ bool Compiler::fgDebugCheckIncomingProfileData(BasicBlock* block, ProfileChecks 
     weight_t       incomingLikelyWeight = 0;
     unsigned       missingLikelyWeight  = 0;
     bool           foundPreds           = false;
-    bool           foundEHPreds         = false;
 
     for (FlowEdge* const predEdge : block->PredEdges())
     {
         if (predEdge->hasLikelihood())
         {
-            if (BasicBlock::sameHndRegion(block, predEdge->getSourceBlock()))
-            {
-                incomingLikelyWeight += predEdge->getLikelyWeight();
-            }
-            else
-            {
-                foundEHPreds = true;
-            }
+            incomingLikelyWeight += predEdge->getLikelyWeight();
         }
         else
         {
@@ -4812,29 +4804,11 @@ bool Compiler::fgDebugCheckIncomingProfileData(BasicBlock* block, ProfileChecks 
         foundPreds = true;
     }
 
-    // We almost certainly won't get the likelihoods on a BBJ_EHFINALLYRET right,
-    // so special-case BBJ_CALLFINALLYRET incoming flow.
-    //
-    if (block->isBBCallFinallyPairTail())
-    {
-        incomingLikelyWeight = block->Prev()->bbWeight;
-        foundEHPreds         = false;
-    }
-
-    // We almost certainly won't get the likelihoods on a BBJ_EHFINALLYRET right,
-    // so special-case BBJ_CALLFINALLYRET incoming flow.
-    //
-    if (block->isBBCallFinallyPairTail())
-    {
-        incomingLikelyWeight = block->Prev()->bbWeight;
-        foundEHPreds         = false;
-    }
-
     bool likelyWeightsValid = true;
 
     // If we have EH preds we may not have consistent incoming flow.
     //
-    if (foundPreds && !foundEHPreds)
+    if (foundPreds)
     {
         if (verifyLikelyWeights)
         {

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -4864,7 +4864,7 @@ bool Compiler::fgDebugCheckOutgoingProfileData(BasicBlock* block, ProfileChecks 
     //
     const unsigned numSuccs = block->NumSucc(this);
 
-    if ((numSuccs > 0) && !block->KindIs(BBJ_EHFINALLYRET, BBJ_EHFAULTRET, BBJ_EHFILTERRET))
+    if ((numSuccs > 0) && !block->KindIs(BBJ_EHFAULTRET, BBJ_EHFILTERRET))
     {
         weight_t const blockWeight        = block->bbWeight;
         weight_t       outgoingLikelihood = 0;

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -216,7 +216,7 @@ void ProfileSynthesis::Run(ProfileSynthesisOption option)
         // Leave a note so we can bypass the post-phase check, and
         // instead assert at the end of fgImport, if we make it that far.
         //
-        if (!isConsistent)
+        if (!isConsistent && !m_comp->fgImportDone)
         {
             m_comp->fgPgoDeferredInconsistency = true;
             JITDUMP("Will defer asserting until after importation\n");
@@ -1437,10 +1437,12 @@ void ProfileSynthesis::GaussSeidelSolver()
             }
         }
 
-        // If there were no improper headers, we will have converged in one pass.
+        // If there were no improper headers, we will have converged in one pass
         // (profile may still be inconsistent, if there were capped cyclic probabilities).
+        // After the importer runs, we require that synthesis achieves profile consistency
+        // unless the resultant profile is approximate, so don't skip the below checks.
         //
-        if (m_improperLoopHeaders == 0)
+        if ((m_improperLoopHeaders == 0) && !m_comp->fgImportDone)
         {
             converged = true;
             break;

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -41,6 +41,11 @@ void ProfileSynthesis::Run(ProfileSynthesisOption option)
         assert(m_loops != nullptr);
     }
 
+    if (m_loops->NumLoops() > 0)
+    {
+        m_cyclicProbabilities = new (m_comp, CMK_Pgo) weight_t[m_loops->NumLoops()];
+    }
+
     // Profile synthesis can be run before or after morph, so tolerate (non-)canonical method entries
     //
     m_entryBlock = (m_comp->opts.IsOSR() && (m_comp->fgEntryBB != nullptr)) ? m_comp->fgEntryBB : m_comp->fgFirstBB;
@@ -748,13 +753,6 @@ void ProfileSynthesis::RandomizeLikelihoods()
 //
 void ProfileSynthesis::ComputeCyclicProbabilities()
 {
-    m_cyclicProbabilities = nullptr;
-    if (m_loops->NumLoops() == 0)
-    {
-        return;
-    }
-
-    m_cyclicProbabilities = new (m_comp, CMK_Pgo) weight_t[m_loops->NumLoops()];
     // Walk loops in post order to visit inner loops before outer loops.
     for (FlowGraphNaturalLoop* loop : m_loops->InPostOrder())
     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12670,7 +12670,9 @@ void Compiler::impFixPredLists()
 
                     if (!profileConsistent)
                     {
-                        JITDUMP("Flow propagation out of " FMT_BB " might have introduced inconsistency. Data %s inconsistent.\n", finallyBlock->bbNum, fgPgoConsistent ? "is now" : "was already");
+                        JITDUMP("Flow propagation out of " FMT_BB
+                                " might have introduced inconsistency. Data %s inconsistent.\n",
+                                finallyBlock->bbNum, fgPgoConsistent ? "is now" : "was already");
                         fgPgoConsistent = false;
                     }
                 }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12576,8 +12576,9 @@ void Compiler::impImport()
 //
 void Compiler::impFixPredLists()
 {
-    unsigned XTnum = 0;
-    bool     added = false;
+    unsigned   XTnum               = 0;
+    bool       added               = false;
+    const bool usingProfileWeights = fgIsUsingProfileWeights();
 
     for (EHblkDsc* HBtab = compHndBBtab; XTnum < compHndBBtabCount; XTnum++, HBtab++)
     {
@@ -12586,6 +12587,7 @@ void Compiler::impFixPredLists()
             BasicBlock* const finallyBegBlock  = HBtab->ebdHndBeg;
             BasicBlock* const finallyLastBlock = HBtab->ebdHndLast;
             unsigned          predCount        = (unsigned)-1;
+            const weight_t    finallyWeight    = finallyBegBlock->bbWeight;
 
             for (BasicBlock* const finallyBlock : BasicBlockRangeList(finallyBegBlock, finallyLastBlock))
             {
@@ -12629,7 +12631,8 @@ void Compiler::impFixPredLists()
                     jumpEhf->bbeCount = predCount;
                     jumpEhf->bbeSuccs = new (this, CMK_FlowEdge) FlowEdge*[predCount];
 
-                    unsigned predNum = 0;
+                    unsigned predNum             = 0;
+                    weight_t remainingLikelihood = 1.0;
                     for (BasicBlock* const predBlock : finallyBegBlock->PredBlocks())
                     {
                         // We only care about preds that are callfinallies.
@@ -12642,6 +12645,22 @@ void Compiler::impFixPredLists()
                         BasicBlock* const continuation = predBlock->Next();
                         FlowEdge* const   newEdge      = fgAddRefPred(continuation, finallyBlock);
                         newEdge->setLikelihood(1.0 / predCount);
+
+                        if (usingProfileWeights && (finallyWeight != BB_ZERO_WEIGHT))
+                        {
+                            // Derive edge likelihood from the entry block's weight relative to other entries.
+                            //
+                            const weight_t callFinallyWeight = predBlock->bbWeight;
+                            const weight_t likelihood        = min(callFinallyWeight / finallyWeight, 1.0);
+                            newEdge->setLikelihood(min(likelihood, remainingLikelihood));
+                            remainingLikelihood = max(BB_ZERO_WEIGHT, remainingLikelihood - likelihood);
+                        }
+                        else
+                        {
+                            // If we don't have profile data, evenly distribute the likelihoods.
+                            //
+                            newEdge->setLikelihood(1.0 / predCount);
+                        }
 
                         jumpEhf->bbeSuccs[predNum] = newEdge;
                         ++predNum;
@@ -12656,25 +12675,25 @@ void Compiler::impFixPredLists()
                 }
 
                 finallyBlock->SetEhfTargets(jumpEhf);
+            }
 
-                if (finallyBlock->hasProfileWeight())
+            if (usingProfileWeights)
+            {
+                // Compute new flow into the finally region's continuation successors.
+                //
+                bool profileConsistent = true;
+                for (BasicBlock* const callFinally : finallyBegBlock->PredBlocks())
                 {
-                    bool profileConsistent = false;
-                    for (BasicBlock* const succBlock : finallyBlock->Succs())
-                    {
-                        const weight_t oldWeight = succBlock->bbWeight;
-                        const weight_t newWeight = succBlock->computeIncomingWeight();
-                        succBlock->setBBProfileWeight(newWeight);
-                        profileConsistent &= fgProfileWeightsEqual(oldWeight, newWeight);
-                    }
+                    BasicBlock* const callFinallyRet = callFinally->Next();
+                    callFinallyRet->setBBProfileWeight(callFinallyRet->computeIncomingWeight());
+                    profileConsistent &= fgProfileWeightsEqual(callFinally->bbWeight, callFinallyRet->bbWeight);
+                }
 
-                    if (!profileConsistent)
-                    {
-                        JITDUMP("Flow propagation out of " FMT_BB
-                                " might have introduced inconsistency. Data %s inconsistent.\n",
-                                finallyBlock->bbNum, fgPgoConsistent ? "is now" : "was already");
-                        fgPgoConsistent = false;
-                    }
+                if (!profileConsistent)
+                {
+                    JITDUMP("Flow into finally handler EH%u does not match outgoing flow. Data %s inconsistent.\n",
+                            XTnum, fgPgoConsistent ? "is now" : "was already");
+                    fgPgoConsistent = false;
                 }
             }
         }


### PR DESCRIPTION
Part of #107749. The first profile synthesis run happens before importation, so we don't model flow in and out of finally regions with flow edges yet. As a workaround, synthesis gives each finally region the same weight as its corresponding try region. When call-finally pairs are created, the tail inherits the weight of its head under the (faulty) assumption that all flow into a call-finally will return to the same pair. Once we have flow edges, we can compute the flow out of finally regions the same way as we compute flow elsewhere. It's important that synthesis models flow through finally regions via flow edges once we have them, or else flow through a loop that executes a finally might be lost, messing up the cyclic probability computation and flattening the loop's weight.

I noticed this issue after discovering that profile synthesis can disable profile consistency checking if it messed up the profile under the assumption that incorrect IL can have nonsensical flow. In such cases, synthesis will disable profile checks until the importer has run, after which the checks will be re-enabled. This quirk is specific to the pre-importation run of synthesis, so later runs can quietly disable consistency checks indefinitely, hiding bugs in synthesis (such as its inability to handle finally regions).

I want to disable this quirk for post-importation runs of synthesis, but there's one more issue with synthesis I have to resolve first: I'm seeing instances where synthesis computes cyclic probabilities close to the cap, but not quite exceeding it. Thus, synthesis doesn't flag the profile as approximate, but consistency checks find that the flow exiting a loop exceeds the flow entering it. I'm not sure if lowering the likelihood cap is a sustainable or desirable fix for this -- perhaps some more sophisticated detection of approximate consistency would be better.