### PR TITLE
Fix ZipArchive loop condition for reading central directory headers

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -526,8 +526,7 @@ namespace System.IO.Compression
                     // the buffer read must always be large enough to fit the constant section size of at least one header
                     continueReadingCentralDirectory = sizedFileBuffer.Length >= ZipCentralDirectoryFileHeader.BlockConstantSectionSize;
 
-                    while (continueReadingCentralDirectory
-                        && currPosition + ZipCentralDirectoryFileHeader.BlockConstantSectionSize < sizedFileBuffer.Length)
+                    while (currPosition + ZipCentralDirectoryFileHeader.BlockConstantSectionSize <= sizedFileBuffer.Length)
                     {
                         if (!ZipCentralDirectoryFileHeader.TryReadBlock(sizedFileBuffer.Slice(currPosition), _archiveStream,
                             saveExtraFieldsAndComments, out bytesConsumed, out ZipCentralDirectoryFileHeader? currentHeader))

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -366,6 +367,45 @@ namespace System.IO.Compression.Tests
 
                 source.Dispose();
             }
+        }
+
+        [Fact]
+        public static void EntriesMalformed_InvalidDataException()
+        {
+            string entryName = "entry.txt";
+
+            var stream = new MemoryStream();
+            using (var archiveWrite = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                archiveWrite.CreateEntry(entryName);
+            }
+
+            stream.Position = 0;
+
+            // Malform the archive
+            using (var archiveRead = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
+            {
+                var unused = archiveRead.Entries;
+
+                // Read the last 22 bytes of stream to get the EOCD.
+                byte[] buffer = new byte[22];
+                stream.Seek(-22, SeekOrigin.End);
+                stream.ReadExactly(buffer);
+
+                var startCentralDir = (long)typeof(ZipArchive).GetField("_centralDirectoryStart", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(archiveRead);
+                // Truncate to exactly 46 bytes after start.
+                stream.SetLength(startCentralDir + 46);
+
+                // Write the EOCD back.
+                stream.Seek(-22, SeekOrigin.End);
+                stream.Write(buffer);
+            }
+
+            stream.Position = 0;
+
+            ZipArchive archive = new ZipArchive(stream);
+
+            Assert.Throws<InvalidDataException>(() => _ = archive.Entries);
         }
 
         private static byte[] ReverseCentralDirectoryEntries(byte[] zipFile)


### PR DESCRIPTION
Updated the `while` loop condition in `ReadCentralDirectory` to use `<=` instead of `<` for the buffer length. This change allows the loop to quickly throw if the expected number of entries is found to be incorrect due to the central directory data being malformed.

Added a test to verify this case by malforming the archive in a way that the while loop condition that checks for the buffer length being smaller or equal than current position + block constant section size becomes false and exits immediately.

No backport needed, this fix is just for the new code in main.

cc @edwardneal 