### PR TITLE
Remove unused OutputPgoPathForCI target from nativepgo.targets

### DIFF
--- a/eng/nativepgo.targets
+++ b/eng/nativepgo.targets
@@ -60,8 +60,4 @@
 
     <Error Condition="!Exists('$(PgoPackagePath)') And '$(NativeOptimizationDataSupported)' == 'true'" Text="Unable to locate restored PGO package at $(PgoPackagePath). Maybe the platform-specific package naming changed?" />
   </Target>
-
-  <Target Name="OutputPgoPathForCI" Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(NativeOptimizationDataSupported)' == 'true'" DependsOnTargets="GetPgoDataPackagePath">
-    <Message Text="##vso[task.setvariable variable=CoreClrPgoDataArg]-pgodatapath &quot;$(PgoPackagePath)&quot;" Importance="High" />
-  </Target>
 </Project>

--- a/eng/nativepgo.targets
+++ b/eng/nativepgo.targets
@@ -33,7 +33,7 @@
   <!--                                                                       -->
   <!-- Notes:                                                                -->
   <!--                                                                       -->
-  <!-- DumpPgoDataPackagePath is used to get the path of the native PGO data -->
+  <!-- GetPgoDataPackagePath is used to get the path of the native PGO data -->
   <!-- for other MSBuild projects, generally to pass to another project or   -->
   <!-- native script like build-runtime.cmd/sh.                              -->
   <!--                                                                       -->

--- a/src/coreclr/runtime-prereqs.proj
+++ b/src/coreclr/runtime-prereqs.proj
@@ -13,7 +13,7 @@
   <Import Project="$(RepositoryEngineeringDir)versioning.targets" />
   <Import Project="$(RepositoryEngineeringDir)nativepgo.targets" />
 
-  <Target Name="BuildPrereqs" BeforeTargets="Build" DependsOnTargets="GenerateRuntimeVersionFile;GenerateNativeSourcelinkFile;OutputPgoPathForCI" />
+  <Target Name="BuildPrereqs" BeforeTargets="Build" DependsOnTargets="GenerateRuntimeVersionFile;GenerateNativeSourcelinkFile" />
   
   <!-- 
     This is a workaround when cross-compiling on Windows for Android. 


### PR DESCRIPTION
This was refactored in https://github.com/dotnet/runtime/pull/99179 and we no longer use the AzDO variable to pass around the path to the PGO data file.