### PR TITLE
Fix crossgen2 sometimes emitting tokens from the wrong module into R2R output

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -305,6 +305,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public int GetModuleIndex(IEcmaModule module)
         {
+            int moduleIndex = _moduleIndexLookup(module);
+            if (moduleIndex != 0 && !(module is Internal.TypeSystem.Ecma.MutableModule))
+            {
+                if (!_compilationModuleGroup.VersionsWithModule(module))
+                {
+                    throw new InternalCompilerErrorException("Attempt to use token from a module not within the version bubble");
+                }
+            }
             return _moduleIndexLookup(module);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -308,7 +308,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             int moduleIndex = _moduleIndexLookup(module);
             if (moduleIndex != 0 && !(module is Internal.TypeSystem.Ecma.MutableModule))
             {
-                if (!_compilationModuleGroup.VersionsWithModule(module))
+                if (!_compilationModuleGroup.VersionsWithModule((ModuleDesc)module))
                 {
                     throw new InternalCompilerErrorException("Attempt to use token from a module not within the version bubble");
                 }
@@ -324,7 +324,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         /// </summary>
         private class DummyTypeInfo
         {
-            public static DummyTypeInfo Instance = new DummyTypeInfo(); 
+            public static DummyTypeInfo Instance = new DummyTypeInfo();
         }
 
         private class TokenResolverProvider : ISignatureTypeProvider<DummyTypeInfo, ModuleTokenResolver>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -602,6 +602,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             else
             {
                 EmitByte((byte)(fixupKind | ReadyToRunFixupKind.ModuleOverride));
+                if (!(targetModule is Internal.TypeSystem.Ecma.MutableModule) && !factory.CompilationModuleGroup.VersionsWithModule((ModuleDesc)targetModule))
+                {
+                    throw new InternalCompilerErrorException("Attempt to use token from a module not within the version bubble");
+                }
+                
                 EmitUInt((uint)factory.ManifestMetadataTable.ModuleToIndex(targetModule));
                 return new SignatureContext(targetModule, outerContext.Resolver);
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/RuntimeDeterminedTypeHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/RuntimeDeterminedTypeHelper.cs
@@ -132,6 +132,7 @@ namespace ILCompiler
             return Equals(methodWithToken1.Method, methodWithToken2.Method)
                 && Equals(methodWithToken1.OwningType, methodWithToken2.OwningType)
                 && Equals(methodWithToken1.ConstrainedType, methodWithToken2.ConstrainedType)
+                && Equals(methodWithToken1.Token.Module, methodWithToken2.Token.Module)
                 && methodWithToken1.Unboxing == methodWithToken2.Unboxing;
         }
 
@@ -152,7 +153,8 @@ namespace ILCompiler
             {
                 return field1 == null && field2 == null;
             }
-            return RuntimeDeterminedTypeHelper.Equals(field1.Field, field2.Field);
+            return RuntimeDeterminedTypeHelper.Equals(field1.Field, field2.Field) &&
+                Equals(field1.Token.Module, field2.Token.Module);
         }
 
         public static int GetHashCode(Instantiation instantiation)


### PR DESCRIPTION
# Description

Under very specific circumstances, R2R can accidentally allow tokens from other modules into its output. These tokens are valid as long as none of the assemblies in use change, but if an assembly changes (i.e. due to a runtime update) tokens pointing into that assembly are no longer valid, and you'll get crashes at runtime from the tokens no longer being what the R2R module expects them to be.

This PR adds a safety check to detect this happening during R2R generation so that we won't quietly produce broken R2R modules, and it also fixes a couple comparers to detect the case where tokens are from different modules (previously, tokens from different modules would compare as equal if they were otherwise equivalent.)

# Customer Impact

Customers rely on R2R and without this fix, users who install updated versions of the .NET runtime will experience breakage due to BCL assemblies no longer matching the ones that the application's R2R modules were compiled against

# Regression

No

# Testing

Manual testing by building+packaging an affected assembly (from roslyn) from source using 9.0.3 and this PR. File size did not meaningfully change and the bad tokens are no longer emitted.

# Risk

If I missed a scenario where bad tokens can be emitted, R2R compilation will now fail with an error instead of silently producing a corrupted assembly. This would stop the customer from using R2R until the issue is fixed.