### PR TITLE
[RFC] Add support for Fastcall function pointers

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -6526,9 +6526,7 @@ void Compiler::impCheckForPInvokeCall(
 
     // If we can't get the unmanaged calling convention or the calling convention is unsupported in the JIT,
     // return here without inlining the native call.
-    if (unmanagedCallConv == CorInfoCallConvExtension::Managed ||
-        unmanagedCallConv == CorInfoCallConvExtension::Fastcall ||
-        unmanagedCallConv == CorInfoCallConvExtension::FastcallMemberFunction)
+    if (unmanagedCallConv == CorInfoCallConvExtension::Managed)
     {
         return;
     }

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -4231,9 +4231,7 @@ static void CreateNDirectStubAccessMetadata(
     }
     else
     {
-        if (unmgdCallConv == CorInfoCallConvExtension::Managed ||
-            unmgdCallConv == CorInfoCallConvExtension::Fastcall ||
-            unmgdCallConv == CorInfoCallConvExtension::FastcallMemberFunction)
+        if (unmgdCallConv == CorInfoCallConvExtension::Managed)
         {
             COMPlusThrow(kTypeLoadException, IDS_INVALID_PINVOKE_CALLCONV);
         }


### PR DESCRIPTION
Fixes #113851 

I was trying to figure out how to add support to calling Fastcall function pointers, and it appears to me that nothing is actually missing...?

Please do comment on all the obvious issues I missed, I am not familiar with the codebase at all.
If there is a chance of this actually becoming a viable PR, I am open to cleaning up and adding tests.