### PR TITLE
Add support for `.vtfixup` in ILC

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -4480,9 +4480,10 @@ namespace Internal.JitInterface
             Debug.Assert(field.IsStatic);
             Debug.Assert(field.HasRva);
 
-            if (!field.IsThreadStatic && field.IsInitOnly && field is EcmaField ecmaField)
+            if (!field.IsThreadStatic && field.IsInitOnly && field is EcmaField ecmaField
+                && ecmaField.TryGetFieldRvaData(out byte[] rvaDataBytes))
             {
-                ReadOnlySpan<byte> rvaData = ecmaField.GetFieldRvaData();
+                ReadOnlySpan<byte> rvaData = rvaDataBytes;
                 if (rvaData.Length >= bufferSize && valueOffset <= rvaData.Length - bufferSize)
                 {
                     rvaData.Slice(valueOffset, bufferSize).CopyTo(new Span<byte>(buffer, bufferSize));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldRvaDataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldRvaDataNode.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 
 using Internal.Text;
 using Internal.TypeSystem;
@@ -35,11 +39,78 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
+            Relocation[] relocs;
+
+            CorHeader corHeader = _field.Module.PEReader.PEHeaders.CorHeader;
+            DirectoryEntry vtableFixups = corHeader.VtableFixupsDirectory;
+            byte[] data = null;
+            if (vtableFixups.Size != 0)
+            {
+                ArrayBuilder<Relocation> relocBuilder = default;
+
+                int fieldAddr = _field.MetadataReader.GetFieldDefinition(_field.Handle).GetRelativeVirtualAddress();
+                int fieldSize = _field.FieldType.GetElementSize().AsInt;
+
+                BlobReader reader = _field.Module.PEReader.GetSectionData(vtableFixups.RelativeVirtualAddress).GetReader(0, vtableFixups.Size);
+                while (reader.Offset < reader.Length)
+                {
+                    int fixupAddr = reader.ReadInt32();
+                    int numFixups = reader.ReadInt16();
+                    int fixupType = reader.ReadInt16();
+
+                    if ((fixupType != 1 && factory.Target.PointerSize == 4) || (fixupType != 2 && factory.Target.PointerSize == 8))
+                        ThrowHelper.ThrowBadImageFormatException();
+
+                    int fixupSize = numFixups * factory.Target.PointerSize;
+                    if (fieldAddr >= fixupAddr + fixupSize || fieldAddr + fieldSize <= fixupAddr)
+                        continue;
+
+                    // Simplifying assumptions (the data blob is a vtable), we could relax this
+                    if (fixupAddr != fieldAddr || fixupSize != fieldSize)
+                        ThrowHelper.ThrowBadImageFormatException();
+
+                    BlobReader fixupReader = _field.Module.PEReader.GetSectionData(fieldAddr).GetReader(0, fieldSize);
+                    int relocOffset = 0;
+                    while (fixupReader.Offset < fixupReader.Length)
+                    {
+                        var token = (int)(factory.Target.PointerSize == 4 ? (long)fixupReader.ReadInt32() : fixupReader.ReadInt64());
+                        MethodDesc method = _field.Module.GetMethod(MetadataTokens.EntityHandle(token));
+                        relocBuilder.Add(new Relocation(
+                            (factory.Target.PointerSize == 8) ? RelocType.IMAGE_REL_BASED_DIR64 : RelocType.IMAGE_REL_BASED_HIGHLOW,
+                            relocOffset,
+                            factory.AddressTakenMethodEntrypoint(method, unboxingStub: false)));
+                        relocOffset = fixupReader.Offset;
+                    }
+
+                    if (!relocsOnly)
+                        data = new byte[fieldSize];
+                    break;
+                }
+
+                relocs = relocBuilder.ToArray();
+            }
+            else
+            {
+                relocs = Array.Empty<Relocation>();
+            }
+
+            if (data == null)
+            {
+                if (relocsOnly)
+                {
+                    data = Array.Empty<byte>();
+                }
+                else
+                {
+                    bool success = _field.TryGetFieldRvaData(out data);
+                    Debug.Assert(success);
+                }
+            }
+
             int fieldTypePack = (_field.FieldType as MetadataType)?.GetClassLayout().PackingSize ?? 1;
-            byte[] data = relocsOnly ? Array.Empty<byte>() : _field.GetFieldRvaData();
             return new ObjectData(
                 data,
-                Array.Empty<Relocation>(),
+                relocs,
                 Math.Max(factory.Target.PointerSize, fieldTypePack),
                 new ISymbolDefinitionNode[] { this });
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
@@ -78,7 +78,7 @@ namespace ILCompiler
                 case FieldRvaDataNode rvaDataNode:
                     _fieldRvas.OpCode(ILOpCode.Ldtoken);
                     _fieldRvas.Token(_emitter.EmitMetadataHandleForTypeSystemEntity(rvaDataNode.Field));
-                    _fieldRvas.LoadConstantI4(rvaDataNode.Field.GetFieldRvaData().Length);
+                    _fieldRvas.LoadConstantI4(rvaDataNode.Field.FieldType.GetElementSize().AsInt);
                     _fieldRvas.LoadConstantI4(AppendMangledName(DependencyNodeCore<NodeFactory>.GetNodeName(node, factory)));
                     // Breakdown of RVA data was introduced in MSTAT 2.1. Readers of 2.0 should still see it in the
                     // global blobs section. We can remove it from there in 3.0.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1941,10 +1941,10 @@ namespace ILCompiler
                         && parameters[0] is ArrayInstance array
                         && parameters[1] is RuntimeFieldHandleValue fieldHandle
                         && fieldHandle.Field.IsStatic && fieldHandle.Field.HasRva
-                        && fieldHandle.Field is Internal.TypeSystem.Ecma.EcmaField ecmaField)
+                        && fieldHandle.Field is Internal.TypeSystem.Ecma.EcmaField ecmaField
+                        && Internal.TypeSystem.Ecma.EcmaFieldExtensions.TryGetFieldRvaData(ecmaField, out byte[] arrayRvaData))
                     {
-                        byte[] rvaData = Internal.TypeSystem.Ecma.EcmaFieldExtensions.GetFieldRvaData(ecmaField);
-                        return array.TryInitialize(rvaData);
+                        return array.TryInitialize(arrayRvaData);
                     }
                     return false;
                 case "CreateSpan":
@@ -1954,14 +1954,14 @@ namespace ILCompiler
                         && parameters[0] is RuntimeFieldHandleValue createSpanFieldHandle
                         && createSpanFieldHandle.Field.IsStatic && createSpanFieldHandle.Field.HasRva
                         && createSpanFieldHandle.Field is Internal.TypeSystem.Ecma.EcmaField createSpanEcmaField
-                        && method.Instantiation[0].IsValueType)
+                        && method.Instantiation[0].IsValueType
+                        && Internal.TypeSystem.Ecma.EcmaFieldExtensions.TryGetFieldRvaData(createSpanEcmaField, out byte[] spanRvaData))
                     {
                         var elementType = (MetadataType)method.Instantiation[0];
                         int elementSize = elementType.InstanceFieldSize.AsInt;
-                        byte[] rvaData = Internal.TypeSystem.Ecma.EcmaFieldExtensions.GetFieldRvaData(createSpanEcmaField);
-                        if (rvaData.Length % elementSize != 0)
+                        if (spanRvaData.Length % elementSize != 0)
                             return false;
-                        retVal = new ReadOnlySpanValue(elementType, rvaData, 0, rvaData.Length);
+                        retVal = new ReadOnlySpanValue(elementType, spanRvaData, 0, spanRvaData.Length);
                         return true;
                     }
                     return false;


### PR DESCRIPTION
Needs a test, there's no testing for `.vtfixup` in the entire CLR tree.

There's also a problem that CoreCLR will reject `.vtfixup` if the assembly is marked ILOnly and ILC on the other hand will reject assemblies that are not ILOnly.