### PR TITLE
JIT: Always set block weight during method entry canonicalization

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -89,6 +89,10 @@ void Compiler::fgCreateNewInitBB()
             block->setBBProfileWeight(entryWeight);
         }
     }
+    else
+    {
+        block->inheritWeight(fgFirstBB);
+    }
 
     // The new scratch bb will fall through to the old first bb
     FlowEdge* const edge = fgAddRefPred(fgFirstBB, block);


### PR DESCRIPTION
When the current method entry block doesn't have a profile-derived weight, just inherit whatever weight it has for the canonical entry block. This way, cold inlinees will always have zero-weight entries. Fixes #114073.