### PR TITLE
Fix handling of empty RUNTIME_FUNCTIONs sections in R2R

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -507,9 +507,12 @@ namespace ILCompiler.PEWriter
             if (_getRuntimeFunctionsTable != null)
             {
                 RuntimeFunctionsTableNode runtimeFunctionsTable = _getRuntimeFunctionsTable();
-                builder.ExceptionTable = new DirectoryEntry(
-                    relativeVirtualAddress: _sectionBuilder.GetSymbolRVA(runtimeFunctionsTable),
-                    size: runtimeFunctionsTable.TableSizeExcludingSentinel);
+                if (runtimeFunctionsTable.TableSizeExcludingSentinel != 0)
+                {
+                    builder.ExceptionTable = new DirectoryEntry(
+                        relativeVirtualAddress: _sectionBuilder.GetSymbolRVA(runtimeFunctionsTable),
+                        size: runtimeFunctionsTable.TableSizeExcludingSentinel);
+                }
             }
     
             return builder;

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -492,7 +492,7 @@ ConvertedImageLayout::ConvertedImageLayout(FlatImageLayout* source, bool disable
         PT_RUNTIME_FUNCTION   pExceptionDir = (PT_RUNTIME_FUNCTION)GetDirectoryEntryData(IMAGE_DIRECTORY_ENTRY_EXCEPTION, &cbSize);
         DWORD tableSize = cbSize / sizeof(T_RUNTIME_FUNCTION);
 
-        if (pExceptionDir != NULL)
+        if (tableSize != 0)
         {
             // the only native code that we expect here is from R2R images
             _ASSERTE(HasReadyToRunHeader());


### PR DESCRIPTION
- Do not set RVA for empty RUNTIME_FUNCTION section in crossgen2
- Do not register empty RUNTIME_FUNCTIONs section at runtime

Fixes #113117