### PR TITLE
Dev/rokonec/101022 httplistner mem leak

### DIFF
--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
@@ -151,7 +151,9 @@ namespace System.Net.WebSockets
                     }
                     catch
                     {
-                        // explain why we ignore exceptions here
+                        // We are doing best effort here to handle the case where the user does not properly Dispose the WebSocket.
+                        // If we fail to close the reponse, we are not going to throw an exception and possibly crash.
+                        // We are just going to ignore it and let the GC do its best.
                     }
                 }
             }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
@@ -61,7 +61,7 @@ namespace System.Net.WebSockets
 
             // Wrap the raw websocket so its Dispose() automatically closes the connection.
             // This is important as common and recommended usage is to just Dispose the HttpListenerWebSocketContext.WebSocket
-            // and without it connection would not be cleaned up causing memory leaks and possible other issues.
+            // and without it connection would not be cleaned up causing memory leaks and other issues.
             HttpListenerWrappedWebSocket webSocket = new(rawWebSocket, context);
 
             HttpListenerWebSocketContext webSocketContext = new HttpListenerWebSocketContext(
@@ -127,8 +127,9 @@ namespace System.Net.WebSockets
                 // Dispose the underlying raw WebSocket
                 _inner.Dispose();
 
-                // Close the response stream, which will close and clean connection
-                // unregistering the context and freeing it from memory.
+                // Ensure we remove the context from the HttpListener's tracking dictionary
+                // by forcibly calling Response.Close(). This closes the underlying connection
+                // and also calls UnregisterContext(context), preventing stale HttpListenerContext objects causing memory leak.
                 _context.Response.Close();
             }
 


### PR DESCRIPTION
Fixes #101022 

### Context
Unix only.
`HttpListenerContext` is not released from `Dictionary<HttpListenerContext, HttpListenerContext> _listenerContexts` when code is written by best and documented practices. Cleaning is done by disposing websocket instance but websocket does not close connection, which is needed to properly cleanup.
This is causing HttpListenerContext piling in `_listenerContexts` resulting in memory leak.

See #101022 for more details.

### Code changes
I have not found other solution than wrapping websocket into private class `HttpListenerWrappedWebSocket` along with needed objects to cleanup connection at websocket Dispose.

### Testing
I have verified that my mini repro (client and sever consoles) no longer reproes after give changes been compiled into experimental dotnet Runtime.