### PR TITLE
Fix SslStreamDisposeTest for parallel handshake on Unix

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
@@ -60,7 +60,7 @@ namespace System.Net.Security.Tests
             using CancellationTokenSource cts = new CancellationTokenSource();
             cts.CancelAfter(TestConfiguration.PassingTestTimeout);
 
-            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams(leaveInnerStreamOpen: true);
+            (SslStream client, SslStream server) = TestHelper.GetConnectedStreams();
             using (client)
             using (server)
             using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
@@ -150,7 +150,8 @@ namespace System.Net.Security.Tests
                     await task;
                 }
                 catch (Exception ex) when (ex
-                    is ObjectDisposedException // disposed locally
+                    is ObjectDisposedException // disposed locall
+                    or InvalidOperationException // Writing to a disposed ConnectedStream (test only, does not happen with NetworkStream)
                     or IOException // disposed remotely (received unexpected EOF)
                     or AuthenticationException) // disposed wrapped in AuthenticationException or error from platform library
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
@@ -60,7 +60,8 @@ namespace System.Net.Security.Tests
             using CancellationTokenSource cts = new CancellationTokenSource();
             cts.CancelAfter(TestConfiguration.PassingTestTimeout);
 
-            (SslStream client, SslStream server) = TestHelper.GetConnectedStreams();
+
+            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams(leaveInnerStreamOpen: true);
             using (client)
             using (server)
             using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
@@ -148,7 +149,7 @@ namespace System.Net.Security.Tests
                 {
                     await task;
                 }
-                catch (InvalidOperationException ex) when (ex.StackTrace?.Contains("System.IO.StreamBuffer.WriteAsync"))
+                catch (InvalidOperationException ex) when (ex.StackTrace?.Contains("System.IO.StreamBuffer.WriteAsync") ?? true)
                 {
                     // Writing to a disposed ConnectedStream (test only, does not happen with NetworkStream)
                     return;

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
@@ -113,8 +113,7 @@ namespace System.Net.Security.Tests
 
             await Parallel.ForEachAsync(System.Linq.Enumerable.Range(0, 10000), cts.Token, async (i, token) =>
             {
-                // use real Tcp streams to avoid specific behavior of ConnectedStreams when concurrently disposed
-                (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedTcpStreams();
+                (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
 
                 using SslStream client = new SslStream(clientStream);
                 using SslStream server = new SslStream(serverStream);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
@@ -154,7 +154,7 @@ namespace System.Net.Security.Tests
                     return;
                 }
                 catch (Exception ex) when (ex
-                    is ObjectDisposedException // disposed locall
+                    is ObjectDisposedException // disposed locally
                     or IOException // disposed remotely (received unexpected EOF)
                     or AuthenticationException) // disposed wrapped in AuthenticationException or error from platform library
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
@@ -148,9 +148,13 @@ namespace System.Net.Security.Tests
                 {
                     await task;
                 }
+                catch (InvalidOperationException ex) when (ex.StackTrace?.Contains("System.IO.StreamBuffer.WriteAsync"))
+                {
+                    // Writing to a disposed ConnectedStream (test only, does not happen with NetworkStream)
+                    return;
+                }
                 catch (Exception ex) when (ex
                     is ObjectDisposedException // disposed locall
-                    or InvalidOperationException // Writing to a disposed ConnectedStream (test only, does not happen with NetworkStream)
                     or IOException // disposed remotely (received unexpected EOF)
                     or AuthenticationException) // disposed wrapped in AuthenticationException or error from platform library
                 {


### PR DESCRIPTION
Fixes #113833.

Previous fix was not enough, lots of opened sockets caused additional failures. This PR changes back to in-memory streams and filters out the InvalidOperationException which happens only in those cases.