### PR TITLE
JIT: expose inline budget as a jit config option

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -11410,9 +11410,11 @@ public:
 
 #define DEFAULT_MAX_INLINE_SIZE                                                                                        \
     100 // Methods with >  DEFAULT_MAX_INLINE_SIZE IL bytes will never be inlined.
-        // This can be overwritten by setting DOTNET_JITInlineSize env variable.
+        // This can be overwritten by setting DOTNET_JitInlineSize env variable.
 
 #define DEFAULT_MAX_INLINE_DEPTH 20 // Methods at more than this level deep will not be inlined
+
+#define DEFAULT_INLINE_BUDGET 10 // Maximum estimated compile time increase via inlining
 
 #define DEFAULT_MAX_FORCE_INLINE_DEPTH 1 // Methods at more than this level deep will not be force inlined
 

--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -927,7 +927,14 @@ InlineContext* InlineStrategy::GetRootContext()
         // Set the initial budget for inlining. Note this is
         // deliberately set very high and is intended to catch
         // only pathological runaway inline cases.
-        m_InitialTimeBudget = BUDGET * m_InitialTimeEstimate;
+        const unsigned budget = JitConfig.JitInlineBudget();
+
+        if (budget != DEFAULT_INLINE_BUDGET)
+        {
+            JITDUMP("Using non-default inline budget %u\n", budget);
+        }
+
+        m_InitialTimeBudget = budget * m_InitialTimeEstimate;
         m_CurrentTimeBudget = m_InitialTimeBudget;
 
         // Estimate the code size  if there's no inlining

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -1073,14 +1073,6 @@ private:
     // Accounting updates for a successful or failed inline.
     void NoteOutcome(InlineContext* context);
 
-    // Cap on allowable increase in jit time due to inlining.
-    // Multiplicative, so BUDGET = 10 means up to 10x increase
-    // in jit time.
-    enum
-    {
-        BUDGET = 10
-    };
-
     // Estimate the jit time change because of this inline.
     int EstimateTime(InlineContext* context);
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -116,9 +116,10 @@ CONFIG_INTEGER(JitHashBreak, "JitHashBreak", -1)        // Same as JitBreak, but
 CONFIG_INTEGER(JitHashHalt, "JitHashHalt", -1)          // Same as JitHalt, but for a method hash
 CONFIG_INTEGER(JitInlineAdditionalMultiplier, "JitInlineAdditionalMultiplier", 0)
 CONFIG_INTEGER(JitInlinePrintStats, "JitInlinePrintStats", 0)
-CONFIG_INTEGER(JitInlineSize, "JITInlineSize", DEFAULT_MAX_INLINE_SIZE)
-CONFIG_INTEGER(JitInlineDepth, "JITInlineDepth", DEFAULT_MAX_INLINE_DEPTH)
-CONFIG_INTEGER(JitForceInlineDepth, "JITForceInlineDepth", DEFAULT_MAX_FORCE_INLINE_DEPTH)
+CONFIG_INTEGER(JitInlineSize, "JitInlineSize", DEFAULT_MAX_INLINE_SIZE)
+CONFIG_INTEGER(JitInlineDepth, "JitInlineDepth", DEFAULT_MAX_INLINE_DEPTH)
+RELEASE_CONFIG_INTEGER(JitInlineBudget, "JitInlineBudget", DEFAULT_INLINE_BUDGET)
+CONFIG_INTEGER(JitForceInlineDepth, "JitForceInlineDepth", DEFAULT_MAX_FORCE_INLINE_DEPTH)
 RELEASE_CONFIG_INTEGER(JitInlineMethodsWithEH, "JitInlineMethodsWithEH", 1)
 CONFIG_STRING(JitInlineMethodsWithEHRange, "JitInlineMethodsWithEHRange")
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_63942/Runtime_63942.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_63942/Runtime_63942.csproj
@@ -8,7 +8,7 @@
     <Compile Include="$(MSBuildProjectName).cs" />
 
     <CLRTestEnvironmentVariable Include="DOTNET_EnableHWIntrinsic" Value="0" />
-    <CLRTestEnvironmentVariable Include="DOTNET_JITInlineDepth" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitInlineDepth" Value="0" />
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Also, rename some related configs to use "Jit" and not "JIT".