### PR TITLE
Notify profiler about unloads of all class instances when module is unloaded

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -1407,7 +1407,7 @@ void Module::FreeClassTables()
             {
                 TypeHandle th = pEntry->GetTypeHandle();
 
-                // Type desc is handled differently
+                // Array EEClass doesn't need notification and there is no work for Destruct()
                 if (th.IsTypeDesc())
                     continue;
 
@@ -1415,7 +1415,6 @@ void Module::FreeClassTables()
                 EEClass::NotifyUnload(pMT, true);
 
                 // We need to call destruct on instances of EEClass whose "canonical" dependent lives in this table
-                // There is nothing interesting to destruct on array EEClass
                 if (pMT->IsCanonicalMethodTable())
                 {
                     pMT->GetClass()->Destruct(pMT);

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -1389,7 +1389,9 @@ void Module::FreeClassTables()
         MethodTable * pMT = typeDefIter.GetElement();
         if (pMT != NULL)
         {
+            EEClass::NotifyUnload(pMT, true);
             pMT->GetClass()->Destruct(pMT);
+            EEClass::NotifyUnload(pMT, false);
         }
     }
 
@@ -1405,14 +1407,21 @@ void Module::FreeClassTables()
             {
                 TypeHandle th = pEntry->GetTypeHandle();
 
+                // Type desc is handled differently
+                if (th.IsTypeDesc())
+                    continue;
+
+                MethodTable * pMT = th.AsMethodTable();
+                EEClass::NotifyUnload(pMT, true);
+
                 // We need to call destruct on instances of EEClass whose "canonical" dependent lives in this table
                 // There is nothing interesting to destruct on array EEClass
-                if (!th.IsTypeDesc())
+                if (pMT->IsCanonicalMethodTable())
                 {
-                    MethodTable * pMT = th.AsMethodTable();
-                    if (pMT->IsCanonicalMethodTable())
-                        pMT->GetClass()->Destruct(pMT);
+                    pMT->GetClass()->Destruct(pMT);
                 }
+
+                EEClass::NotifyUnload(pMT, false);
             }
         }
     }

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -1389,9 +1389,9 @@ void Module::FreeClassTables()
         MethodTable * pMT = typeDefIter.GetElement();
         if (pMT != NULL)
         {
-            EEClass::NotifyUnload(pMT, true);
-            pMT->GetClass()->Destruct(pMT);
-            EEClass::NotifyUnload(pMT, false);
+            ClassLoader::NotifyUnload(pMT, true);
+            pMT->GetClass()->Destruct();
+            ClassLoader::NotifyUnload(pMT, false);
         }
     }
 
@@ -1412,15 +1412,15 @@ void Module::FreeClassTables()
                     continue;
 
                 MethodTable * pMT = th.AsMethodTable();
-                EEClass::NotifyUnload(pMT, true);
+                ClassLoader::NotifyUnload(pMT, true);
 
                 // We need to call destruct on instances of EEClass whose "canonical" dependent lives in this table
                 if (pMT->IsCanonicalMethodTable())
                 {
-                    pMT->GetClass()->Destruct(pMT);
+                    pMT->GetClass()->Destruct();
                 }
 
-                EEClass::NotifyUnload(pMT, false);
+                ClassLoader::NotifyUnload(pMT, false);
             }
         }
     }

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -54,14 +54,13 @@ void *EEClass::operator new(
 }
 
 //*******************************************************************************
-void EEClass::Destruct(MethodTable * pOwningMT)
+void EEClass::Destruct()
 {
     CONTRACTL
     {
         NOTHROW;
         GC_TRIGGERS;
         FORBID_FAULT;
-        PRECONDITION(pOwningMT != NULL);
     }
     CONTRACTL_END
 
@@ -109,68 +108,6 @@ void EEClass::Destruct(MethodTable * pOwningMT)
     if (GetSparseCOMInteropVTableMap() != NULL)
         delete GetSparseCOMInteropVTableMap();
 #endif // FEATURE_COMINTEROP
-}
-
-//*******************************************************************************
-void EEClass::NotifyUnload(MethodTable* pMT, bool unloadStarted)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_ANY;
-        FORBID_FAULT;
-        PRECONDITION(pMT != NULL);
-    }
-    CONTRACTL_END
-
-#ifdef PROFILING_SUPPORTED
-    // If profiling, then notify the class is getting unloaded.
-    {
-        BEGIN_PROFILER_CALLBACK(CORProfilerTrackClasses());
-        {
-            if (pMT->ContainsGenericVariables() || pMT->IsArray())
-            {
-                // Don't notify the profiler about types with unbound variables or arrays.
-                // See ClassLoadStarted callback for more details.
-                return;
-            }
-        
-            // Calls to the profiler callback may throw, or otherwise fail, if
-            // the profiler AVs/throws an unhandled exception/etc. We don't want
-            // those failures to affect the runtime, so we'll ignore them.
-            //
-            // Note that the profiler callback may turn around and make calls into
-            // the profiling runtime that may throw. This try/catch block doesn't
-            // protect the profiler against such failures. To protect the profiler
-            // against that, we will need try/catch blocks around all calls into the
-            // profiling API.
-            //
-            // (Bug #26467)
-            //
-
-            FAULT_NOT_FATAL();
-
-            EX_TRY
-            {
-                GCX_PREEMP();
-
-                if (unloadStarted)
-                    (&g_profControlBlock)->ClassUnloadStarted((ClassID) pMT);
-                else
-                    (&g_profControlBlock)->ClassUnloadFinished((ClassID) pMT, S_OK);
-            }
-            EX_CATCH
-            {
-                // The exception here came from the profiler itself. We'll just
-                // swallow the exception, since we don't want the profiler to bring
-                // down the runtime.
-            }
-            EX_END_CATCH(RethrowTerminalExceptions);
-        }
-        END_PROFILER_CALLBACK();
-    }
-#endif // PROFILING_SUPPORTED
 }
 
 //*******************************************************************************

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -726,10 +726,7 @@ public:
 
 #ifndef DACCESS_COMPILE
     void *operator new(size_t size, LoaderHeap* pHeap, AllocMemTracker *pamTracker);
-    void Destruct(MethodTable * pMT);
-
-    // Notify profiler about class unload
-    static void NotifyUnload(MethodTable* pMT, bool unloadStarted);
+    void Destruct();
 
     static EEClass * CreateMinimalClass(LoaderHeap *pHeap, AllocMemTracker *pamTracker);
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -728,6 +728,9 @@ public:
     void *operator new(size_t size, LoaderHeap* pHeap, AllocMemTracker *pamTracker);
     void Destruct(MethodTable * pMT);
 
+    // Notify profiler about class unload
+    static void NotifyUnload(MethodTable* pMT, bool unloadStarted);
+
     static EEClass * CreateMinimalClass(LoaderHeap *pHeap, AllocMemTracker *pamTracker);
 #endif // !DACCESS_COMPILE
 

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -2614,7 +2614,7 @@ TypeHandle ClassLoader::DoIncrementalLoad(const TypeKey *pTypeKey, TypeHandle ty
 
     if (typeHnd.GetLoadLevel() >= CLASS_LOAD_EXACTPARENTS)
     {
-        Notify(typeHnd);
+        NotifyLoad(typeHnd);
     }
 
     return typeHnd;
@@ -2828,7 +2828,7 @@ TypeHandle ClassLoader::PublishType(const TypeKey *pTypeKey, TypeHandle typeHnd)
 // Notify profiler and debugger that a type load has completed
 // Also adjust perf counters
 /*static*/
-void ClassLoader::Notify(TypeHandle typeHnd)
+void ClassLoader::NotifyLoad(TypeHandle typeHnd)
 {
     CONTRACTL
     {
@@ -2896,6 +2896,68 @@ void ClassLoader::Notify(TypeHandle typeHnd)
     }
 }
 
+// Notify profiler that a MethodTable is being unloaded
+/*static*/
+void ClassLoader::NotifyUnload(MethodTable* pMT, bool unloadStarted)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_TRIGGERS;
+        MODE_ANY;
+        FORBID_FAULT;
+        PRECONDITION(pMT != NULL);
+    }
+    CONTRACTL_END
+
+#ifdef PROFILING_SUPPORTED
+    // If profiling, then notify the class is getting unloaded.
+    {
+        BEGIN_PROFILER_CALLBACK(CORProfilerTrackClasses());
+        {
+            if (pMT->ContainsGenericVariables() || pMT->IsArray())
+            {
+                // Don't notify the profiler about types with unbound variables or arrays.
+                // See ClassLoadStarted callback for more details.
+                return;
+            }
+        
+            // Calls to the profiler callback may throw, or otherwise fail, if
+            // the profiler AVs/throws an unhandled exception/etc. We don't want
+            // those failures to affect the runtime, so we'll ignore them.
+            //
+            // Note that the profiler callback may turn around and make calls into
+            // the profiling runtime that may throw. This try/catch block doesn't
+            // protect the profiler against such failures. To protect the profiler
+            // against that, we will need try/catch blocks around all calls into the
+            // profiling API.
+            //
+            // (Bug #26467)
+            //
+
+            FAULT_NOT_FATAL();
+
+            EX_TRY
+            {
+                GCX_PREEMP();
+
+                if (unloadStarted)
+                    (&g_profControlBlock)->ClassUnloadStarted((ClassID) pMT);
+                else
+                    (&g_profControlBlock)->ClassUnloadFinished((ClassID) pMT, S_OK);
+            }
+            EX_CATCH
+            {
+                // The exception here came from the profiler itself. We'll just
+                // swallow the exception, since we don't want the profiler to bring
+                // down the runtime.
+            }
+            EX_END_CATCH(RethrowTerminalExceptions);
+        }
+        END_PROFILER_CALLBACK();
+    }
+#endif // PROFILING_SUPPORTED
+}
 
 //-----------------------------------------------------------------------------
 // Common helper for LoadTypeHandleForTypeKey and LoadTypeHandleForTypeKeyNoLock.

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -2932,8 +2932,6 @@ void ClassLoader::NotifyUnload(MethodTable* pMT, bool unloadStarted)
             // against that, we will need try/catch blocks around all calls into the
             // profiling API.
             //
-            // (Bug #26467)
-            //
 
             FAULT_NOT_FATAL();
 

--- a/src/coreclr/vm/clsload.hpp
+++ b/src/coreclr/vm/clsload.hpp
@@ -910,7 +910,9 @@ private:
 
     // Notify profiler and debugger that a type load has completed
     // Also update perf counters
-    static void Notify(TypeHandle typeHnd);
+    static void NotifyLoad(TypeHandle typeHnd);
+    // Notify profiler that a MethodTable is being unloaded
+    static void NotifyUnload(MethodTable* pMT, bool unloadStarted);
 
     // Phase CLASS_LOAD_EXACTPARENTS of class loading
     // Load exact parents and interfaces and dependent structures (generics dictionary, vtable fixes)

--- a/src/tests/profiler/native/CMakeLists.txt
+++ b/src/tests/profiler/native/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Profiler)
 
 set(SOURCES
     assemblyprofiler/assemblyprofiler.cpp
+    classload/classload.cpp
     eltprofiler/slowpatheltprofiler.cpp
     enumthreadsprofiler/enumthreadsprofiler.cpp
     eventpipeprofiler/eventpipereadingprofiler.cpp

--- a/src/tests/profiler/native/classfactory.cpp
+++ b/src/tests/profiler/native/classfactory.cpp
@@ -22,6 +22,7 @@
 #include "inlining/inlining.h"
 #include "moduleload/moduleload.h"
 #include "assemblyprofiler/assemblyprofiler.h"
+#include "classload/classload.h"
 
 ClassFactory::ClassFactory(REFCLSID clsid) : refCount(0), clsid(clsid)
 {
@@ -148,6 +149,10 @@ HRESULT STDMETHODCALLTYPE ClassFactory::CreateInstance(IUnknown *pUnkOuter, REFI
     else if (clsid == EnumThreadsProfiler::GetClsid())
     {
         profiler = new EnumThreadsProfiler();
+    }
+    else if (clsid == ClassLoad::GetClsid())
+    {
+        profiler = new ClassLoad();
     }
     else
     {

--- a/src/tests/profiler/native/classload/classload.cpp
+++ b/src/tests/profiler/native/classload/classload.cpp
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "classload.h"
+
+GUID ClassLoad::GetClsid()
+{
+    // {A1B2C3D4-E5F6-7890-1234-56789ABCDEF0}
+    GUID clsid = {0xa1b2c3d4, 0xe5f6, 0x7890, {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0}};
+    return clsid;
+}
+
+HRESULT ClassLoad::InitializeCommon(IUnknown* pICorProfilerInfoUnk)
+{
+    Profiler::Initialize(pICorProfilerInfoUnk);
+
+    HRESULT hr = S_OK;
+    printf("Setting COR_PRF_MONITOR_CLASS_LOADS mask\n");
+    if (FAILED(hr = pCorProfilerInfo->SetEventMask2(COR_PRF_MONITOR_CLASS_LOADS, 0)))
+    {
+        _failures++;
+        printf("FAIL: ICorProfilerInfo::SetEventMask2() failed hr=0x%x", hr);
+        return hr;
+    }
+
+    return S_OK;
+}
+
+HRESULT ClassLoad::Initialize(IUnknown* pICorProfilerInfoUnk)
+{
+    return InitializeCommon(pICorProfilerInfoUnk);
+}
+
+HRESULT ClassLoad::InitializeForAttach(IUnknown* pICorProfilerInfoUnk, void* pvClientData, UINT cbClientData)
+{
+    return InitializeCommon(pICorProfilerInfoUnk);
+}
+
+HRESULT ClassLoad::LoadAsNotificationOnly(BOOL *pbNotificationOnly)
+{
+    *pbNotificationOnly = TRUE;
+    return S_OK;
+}
+
+HRESULT ClassLoad::ClassLoadStarted(ClassID classId)
+{
+    _classLoadStartedCount++;
+    return S_OK;
+}
+
+HRESULT ClassLoad::ClassLoadFinished(ClassID classId, HRESULT hrStatus)
+{
+    _classLoadFinishedCount++;
+    return S_OK;
+}
+
+HRESULT ClassLoad::ClassUnloadStarted(ClassID classId)
+{
+    _classUnloadStartedCount++;
+    wprintf(L"ClassUnloadStarted: %s\n", GetClassIDName(classId).ToCStr());
+
+    return S_OK;
+}
+
+HRESULT ClassLoad::ClassUnloadFinished(ClassID classID, HRESULT hrStatus)
+{
+    _classUnloadFinishedCount++;
+    return S_OK;
+}
+
+
+HRESULT ClassLoad::Shutdown()
+{
+    Profiler::Shutdown();
+
+    if(_failures == 0 
+        && (_classLoadStartedCount != 0)
+        // Expect unloading of UnloadLibrary.TestClass and
+        // List<UnloadLibrary.TestClass> with all its base classes with everything used in List constructor.
+        && (_classUnloadStartedCount == 7)
+        && (_classLoadStartedCount == _classLoadFinishedCount)
+        && (_classUnloadStartedCount == _classUnloadFinishedCount))
+    {
+        printf("PROFILER TEST PASSES\n");
+    }
+    else
+    {
+        printf("PROFILER TEST FAILED, failures=%d classLoadStartedCount=%d classLoadFinishedCount=%d classUnloadStartedCount=%d classUnloadFinishedCount=%d\n",
+               _failures.load(),
+               _classLoadStartedCount.load(),
+               _classLoadFinishedCount.load(),
+               _classUnloadStartedCount.load(),
+               _classUnloadFinishedCount.load());
+    }
+
+    fflush(stdout);
+
+    return S_OK;
+}

--- a/src/tests/profiler/native/classload/classload.cpp
+++ b/src/tests/profiler/native/classload/classload.cpp
@@ -10,7 +10,7 @@ GUID ClassLoad::GetClsid()
     return clsid;
 }
 
-HRESULT ClassLoad::InitializeCommon(IUnknown* pICorProfilerInfoUnk)
+HRESULT ClassLoad::Initialize(IUnknown* pICorProfilerInfoUnk)
 {
     Profiler::Initialize(pICorProfilerInfoUnk);
 
@@ -23,22 +23,6 @@ HRESULT ClassLoad::InitializeCommon(IUnknown* pICorProfilerInfoUnk)
         return hr;
     }
 
-    return S_OK;
-}
-
-HRESULT ClassLoad::Initialize(IUnknown* pICorProfilerInfoUnk)
-{
-    return InitializeCommon(pICorProfilerInfoUnk);
-}
-
-HRESULT ClassLoad::InitializeForAttach(IUnknown* pICorProfilerInfoUnk, void* pvClientData, UINT cbClientData)
-{
-    return InitializeCommon(pICorProfilerInfoUnk);
-}
-
-HRESULT ClassLoad::LoadAsNotificationOnly(BOOL *pbNotificationOnly)
-{
-    *pbNotificationOnly = TRUE;
     return S_OK;
 }
 
@@ -76,7 +60,14 @@ HRESULT ClassLoad::Shutdown()
     if(_failures == 0 
         && (_classLoadStartedCount != 0)
         // Expect unloading of UnloadLibrary.TestClass and
-        // List<UnloadLibrary.TestClass> with all its base classes with everything used in List constructor.
+        // List<UnloadLibrary.TestClass> with all its base classes with everything used in List constructor:
+        // - UnloadLibrary.TestClass
+        // - System.Collections.Generic.IEnumerable`1<UnloadLibrary.TestClass>
+        // - System.Collections.Generic.IList`1<UnloadLibrary.TestClass>
+        // - System.Collections.Generic.IReadOnlyCollection`1<UnloadLibrary.TestClass>
+        // - System.Collections.Generic.IReadOnlyList`1<UnloadLibrary.TestClass>
+        // - System.Collections.Generic.List`1<UnloadLibrary.TestClass>
+        // - System.Collections.Generic.ICollection`1<UnloadLibrary.TestClass>        
         && (_classUnloadStartedCount == 7)
         && (_classLoadStartedCount == _classLoadFinishedCount)
         && (_classUnloadStartedCount == _classUnloadFinishedCount))

--- a/src/tests/profiler/native/classload/classload.h
+++ b/src/tests/profiler/native/classload/classload.h
@@ -21,9 +21,7 @@ public:
 
     static GUID GetClsid();
     virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk);
-    virtual HRESULT STDMETHODCALLTYPE InitializeForAttach(IUnknown* pICorProfilerInfoUnk, void* pvClientData, UINT cbClientData);
     virtual HRESULT STDMETHODCALLTYPE Shutdown();
-    virtual HRESULT STDMETHODCALLTYPE LoadAsNotificationOnly(BOOL *pbNotificationOnly);
 
     virtual HRESULT STDMETHODCALLTYPE ClassLoadStarted(ClassID classId);
     virtual HRESULT STDMETHODCALLTYPE ClassLoadFinished(ClassID classId, HRESULT hrStatus);
@@ -36,6 +34,4 @@ private:
     std::atomic<int> _classUnloadStartedCount;
     std::atomic<int> _classUnloadFinishedCount;
     std::atomic<int> _failures;
-
-    HRESULT InitializeCommon(IUnknown* pCorProfilerInfoUnk);
 };

--- a/src/tests/profiler/native/classload/classload.h
+++ b/src/tests/profiler/native/classload/classload.h
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "../profiler.h"
+
+class ClassLoad : public Profiler
+{
+public:
+
+    ClassLoad() : 
+        Profiler(),
+        _classLoadStartedCount(0),
+        _classLoadFinishedCount(0),
+        _classUnloadStartedCount(0),
+        _classUnloadFinishedCount(0),
+        _failures(0)
+    {
+    }
+
+    static GUID GetClsid();
+    virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk);
+    virtual HRESULT STDMETHODCALLTYPE InitializeForAttach(IUnknown* pICorProfilerInfoUnk, void* pvClientData, UINT cbClientData);
+    virtual HRESULT STDMETHODCALLTYPE Shutdown();
+    virtual HRESULT STDMETHODCALLTYPE LoadAsNotificationOnly(BOOL *pbNotificationOnly);
+
+    virtual HRESULT STDMETHODCALLTYPE ClassLoadStarted(ClassID classId);
+    virtual HRESULT STDMETHODCALLTYPE ClassLoadFinished(ClassID classId, HRESULT hrStatus);
+    virtual HRESULT STDMETHODCALLTYPE ClassUnloadStarted(ClassID classId);
+    virtual HRESULT STDMETHODCALLTYPE ClassUnloadFinished(ClassID classId, HRESULT hrStatus);
+
+private:
+    std::atomic<int> _classLoadStartedCount;
+    std::atomic<int> _classLoadFinishedCount;
+    std::atomic<int> _classUnloadStartedCount;
+    std::atomic<int> _classUnloadFinishedCount;
+    std::atomic<int> _failures;
+
+    HRESULT InitializeCommon(IUnknown* pCorProfilerInfoUnk);
+};

--- a/src/tests/profiler/unittest/classload.cs
+++ b/src/tests/profiler/unittest/classload.cs
@@ -31,6 +31,8 @@ namespace Profiler.Tests
         static int RunTest()
         {
             LoadCollectibleAssembly();
+
+            // Force a garbage collection to ensure the assembly is unloaded
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
@@ -49,7 +51,6 @@ namespace Profiler.Tests
             object instance = Activator.CreateInstance(testType);
 
             Console.WriteLine(instance.GetHashCode());
-            GC.Collect();
             collectibleContext.Unload();
         }
     }

--- a/src/tests/profiler/unittest/classload.cs
+++ b/src/tests/profiler/unittest/classload.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Profiler.Tests
+{
+    class ClassLoadTest
+    {
+        private static readonly Guid ClassLoadGuid = new Guid("A1B2C3D4-E5F6-7890-1234-56789ABCDEF0");
+
+        static int Main(string[] args)
+        {
+            if (args.Length == 1 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
+            {
+                return RunTest();
+            }
+
+            return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
+                                          testName: "UnitTestClassLoad",
+                                          profilerClsid: ClassLoadGuid);
+        }
+
+        static int RunTest()
+        {
+            LoadCollectibleAssembly();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            return 100;
+        }
+
+        private static void LoadCollectibleAssembly()
+        {
+            var collectibleContext = new AssemblyLoadContext("Collectible", true);
+
+            var asmDir = Path.GetDirectoryName(typeof(ClassLoadTest).Assembly.Location);
+            var dynamicLibrary = collectibleContext.LoadFromAssemblyPath(Path.Combine(asmDir, "unloadlibrary.dll"));
+            var testType = dynamicLibrary.GetType("UnloadLibrary.TestClass");
+
+            object instance = Activator.CreateInstance(testType);
+
+            Console.WriteLine(instance.GetHashCode());
+            GC.Collect();
+            collectibleContext.Unload();
+        }
+    }
+}

--- a/src/tests/profiler/unittest/classload.csproj
+++ b/src/tests/profiler/unittest/classload.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- This test provides no interesting scenarios for GCStress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../common/profiler_common.csproj" />
+    <ProjectReference Include="unloadlibrary.csproj" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/profiler/unittest/unloadlibrary.cs
+++ b/src/tests/profiler/unittest/unloadlibrary.cs
@@ -21,7 +21,7 @@ namespace UnloadLibrary
             {
                 instanceStrings[i] = staticString + (++s_count);
             }
-            Console.WriteLine("Class1 constructed");
+            Console.WriteLine("TestClass constructed");
 
             instances.Add(this);
         }


### PR DESCRIPTION
Fix `ClassLoadStarted` and `ClassUnloadStarted` profiler callbacks symmetry when unloading modules with generic class instances.
The PR solves issue https://github.com/dotnet/runtime/issues/114068

`ClassUnloadStarted` and `ClassUnloadFinished` profiler api callbacks are not called for generic instances which are allocated under a different loader allocator. That:

- Doesn't match `Notify` logic which is done at class loading time - https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/clsload.cpp#L2617
- Creates issues with tracking live classes.

The suggested change adds a separate `EEClass:NotifyUnload` method that is called for all classes symmetrically to `ClassLoadStarted` notification.

Added a profiler test to validate the callbacks correctness for unloading modules and validated it locally.