### PR TITLE
[PERF][Android] Setup Android sample app for AOT/R2R perf testing

### DIFF
--- a/eng/pipelines/performance/templates/build-perf-sample-apps.yml
+++ b/eng/pipelines/performance/templates/build-perf-sample-apps.yml
@@ -8,6 +8,7 @@ steps:
 # Build Android sample app
   - ${{ if eq(parameters.osGroup, 'android') }}:
     - ${{ if eq(parameters.runtimeType, 'mono') }}:
+      # Mono JIT Build
       - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=Mono
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=Mono
@@ -30,7 +31,31 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
         displayName: clean bindir
 
+      # Mono AOT Build
+      - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=Mono AOT=true
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
+        displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=Mono AOT=true
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish binlog'
+        inputs:
+          pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
+          artifactName:  AndroidMonoAOTArm64BuildLog
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/Bundle/bin/HelloAndroid.apk
+          includeRootFolder: true
+          displayName: Android Sample App AOT Mono
+          artifactName: AndroidHelloWorldArm64MonoAOT
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
+      - script: rm -r -f $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp
+        workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
+        displayName: clean bindir
+
     - ${{ if eq(parameters.runtimeType, 'coreclr') }}:
+      # CoreCLR JIT Build
       - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=CoreCLR
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=CoreCLR
@@ -46,6 +71,29 @@ steps:
           includeRootFolder: true
           displayName: Android Sample App JIT CoreCLR
           artifactName: AndroidHelloWorldArm64CoreCLR
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
+      - script: rm -r -f $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp
+        workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
+        displayName: clean bindir
+
+      # CoreCLR R2R build
+      - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=CoreCLR R2R=true
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
+        displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=CoreCLR R2R=true
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish binlog'
+        inputs:
+          pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
+          artifactName:  AndroidCoreCLRR2RArm64BuildLog
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/Bundle/bin/HelloAndroid.apk
+          includeRootFolder: true
+          displayName: Android Sample App R2R CoreCLR
+          artifactName: AndroidHelloWorldArm64CoreCLRR2R
           archiveExtension: '.tar.gz'
           archiveType: tar
           tarCompression: gz

--- a/eng/testing/performance/android_scenarios.proj
+++ b/eng/testing/performance/android_scenarios.proj
@@ -13,10 +13,6 @@
     </HelixCorrelationPayload>
   </ItemGroup>
 
-  <PropertyGroup>
-    <RunConfigsString>$(RuntimeFlavor)_$(CodegenType)</RunConfigsString>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
     <ScenarioDirectory>%HELIX_WORKITEM_ROOT%\performance\src\scenarios\</ScenarioDirectory>
   </PropertyGroup>
@@ -25,19 +21,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <HelixWorkItem Include="SOD - Android HelloWorld APK Size $(RunConfigsString)">
+    <HelixWorkItem Include="SOD - Android HelloWorld APK Size">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
         <PreCommands>cd $(ScenarioDirectory)helloandroid;copy %HELIX_WORKITEM_ROOT%\HelloAndroid.apk .;$(Python) pre.py --apk-name HelloAndroid.apk</PreCommands>
         <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - Android HelloWorld Extracted Size $(RunConfigsString)">
+    <HelixWorkItem Include="SOD - Android HelloWorld Extracted Size">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
         <PreCommands>cd $(ScenarioDirectory)helloandroid;copy %HELIX_WORKITEM_ROOT%\HelloAndroid.apk .;$(Python) pre.py --unzip --apk-name HelloAndroid.apk</PreCommands>
         <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="Device Startup - Android HelloWorld $(RunConfigsString)">
+    <HelixWorkItem Include="Device Startup - Android HelloWorld">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands>cd $(ScenarioDirectory)helloandroid;copy %HELIX_WORKITEM_ROOT%\HelloAndroid.apk .;$(Python) pre.py --apk-name HelloAndroid.apk</PreCommands>
       <Command>$(Python) test.py devicestartup --device-type android --package-path pub\HelloAndroid.apk --package-name net.dot.HelloAndroid --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>

--- a/eng/testing/performance/android_scenarios.proj
+++ b/eng/testing/performance/android_scenarios.proj
@@ -13,6 +13,10 @@
     </HelixCorrelationPayload>
   </ItemGroup>
 
+  <PropertyGroup>
+    <RunConfigsString>$(RuntimeFlavor)_$(CodegenType)</RunConfigsString>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
     <ScenarioDirectory>%HELIX_WORKITEM_ROOT%\performance\src\scenarios\</ScenarioDirectory>
   </PropertyGroup>
@@ -21,19 +25,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <HelixWorkItem Include="SOD - Android HelloWorld APK Size">
+    <HelixWorkItem Include="SOD - Android HelloWorld APK Size $(RunConfigsString)">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
         <PreCommands>cd $(ScenarioDirectory)helloandroid;copy %HELIX_WORKITEM_ROOT%\HelloAndroid.apk .;$(Python) pre.py --apk-name HelloAndroid.apk</PreCommands>
         <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - Android HelloWorld Extracted Size">
+    <HelixWorkItem Include="SOD - Android HelloWorld Extracted Size $(RunConfigsString)">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
         <PreCommands>cd $(ScenarioDirectory)helloandroid;copy %HELIX_WORKITEM_ROOT%\HelloAndroid.apk .;$(Python) pre.py --unzip --apk-name HelloAndroid.apk</PreCommands>
         <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="Device Startup - Android HelloWorld">
+    <HelixWorkItem Include="Device Startup - Android HelloWorld $(RunConfigsString)">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands>cd $(ScenarioDirectory)helloandroid;copy %HELIX_WORKITEM_ROOT%\HelloAndroid.apk .;$(Python) pre.py --apk-name HelloAndroid.apk</PreCommands>
       <Command>$(Python) test.py devicestartup --device-type android --package-path pub\HelloAndroid.apk --package-name net.dot.HelloAndroid --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>


### PR DESCRIPTION
- Added Mono AOT and CoreCLR R2R to the list of build Android sample apps.
- Extended Android scenario names to include runtime and codegen information.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2676838
Associated dotnet/performance PR: https://github.com/dotnet/performance/pull/4808

Test run results:
|             | Startup (ms) | Size - apk (B) |
|-------------|--------------|----------------|
| Mono JIT    | 188.000      | 2679958        |
| CoreCLR JIT | 238.900      | 5543035        |
| Mono AOT    | 191.800      | 6845590        |
| CoreCLR R2R | 252.600      | 7193723        |
