### PR TITLE
Implement breakpoint disassembly support for Intel APX

### DIFF
--- a/src/coreclr/debug/ee/amd64/amd64InstrDecode.h
+++ b/src/coreclr/debug/ee/amd64/amd64InstrDecode.h
@@ -30,12 +30,21 @@ namespace Amd64InstrDecode
     //      I4B      // Instruction includes 4  bytes of immediates
     //      I8B      // Instruction includes 8  bytes of immediates
     //      Unknown  // Instruction samples did not include a modrm configured to produce RIP addressing
-    //      L        // Flags depend on L bit in encoding.  L_<flagsLTrue>_or_<flagsLFalse>
-    //      LL       // Flags depend on L'L bits in EVEX encoding.  LL_<flagsLL00>_<flagsLL01>_<flagsLL10>
-    //                  LL00 = 128-bit vector; LL01 = 256-bit vector; LL10 = 512-bit vector
-    //      W        // Flags depend on W bit in encoding.  W_<flagsWTrue>_or_<flagsWFalse>
-    //      P        // Flags depend on OpSize prefix for encoding.  P_<flagsNoOpSizePrefix>_or_<flagsOpSizePrefix>
-    //      WP       // Flags depend on W bit in encoding and OpSize prefix.  WP_<flagsWTrue>_or_<flagsNoOpSizePrefix>_or_<flagsOpSizePrefix>
+    //      L        // Flags depend on L bit in encoding.
+    //               //     L_<flagsLTrue>_or_<flagsLFalse>
+    //               //     L_<L=1>_or_<L=0>
+    //      LL       // Flags depend on L'L bits in EVEX encoding.
+    //               //     LL_<flagsLL00>_<flagsLL01>_<flagsLL10>
+    //               //     LL00 = 128-bit vector; LL01 = 256-bit vector; LL10 = 512-bit vector
+    //      W        // Flags depend on W bit in encoding.
+    //               //     W_<flagsWTrue>_or_<flagsWFalse>
+    //               //     W_<W=1>_or_<W=0>
+    //      P        // Flags depend on OpSize prefix for encoding.
+    //               //     P_<flagsNoOpSizePrefix>_or_<flagsOpSizePrefix>
+    //               //     P_<P=0>_or_<P=1>
+    //      WP       // Flags depend on W bit in encoding and OpSize prefix.
+    //               //     WP_<flagsWTrue>_or_<flagsNoOpSizePrefix>_or_<flagsOpSizePrefix>
+    //               //     WP_<W=1>_or_<W=0 P=0>_or_<W=0 P=1>
     //      WLL      // Flags depend on W and L'L bits.
     //               //     WLL_<W=1 LL=00>_<W=1 LL=01>_<W=1 LL=10>_or_<W=0 LL=00>_<W=0 LL=01>_<W=0 LL=10>
     //      bLL      // Flags depend on EVEX.b and L'L bits.
@@ -53,12 +62,12 @@ namespace Amd64InstrDecode
        I3B,
        I4B,
        I8B,
-       M1st_bLL_M4B_M16B_M32B_M64B,
-       M1st_bLL_M8B_M16B_M32B_M64B,
        M1st_I1B_L_M16B_or_M8B,
        M1st_I1B_LL_M8B_M16B_M32B,
+       M1st_I1B_W_M8B_or_M2B,
        M1st_I1B_W_M8B_or_M4B,
        M1st_I1B_WP_M8B_or_M4B_or_M2B,
+       M1st_I4B_W_M8B_or_M4B,
        M1st_L_M32B_or_M16B,
        M1st_LL_M16B_M32B_M64B,
        M1st_LL_M2B_M4B_M8B,
@@ -76,6 +85,7 @@ namespace Amd64InstrDecode
        M1st_M8B,
        M1st_MUnknown,
        M1st_W_M4B_or_M1B,
+       M1st_W_M8B_I4B_or_M2B_I2B,
        M1st_W_M8B_or_M2B,
        M1st_W_M8B_or_M4B,
        M1st_WP_M8B_I4B_or_M4B_I4B_or_M2B_I2B,
@@ -88,6 +98,7 @@ namespace Amd64InstrDecode
        MOnly_MUnknown,
        MOnly_P_M6B_or_M4B,
        MOnly_W_M16B_or_M8B,
+       MOnly_W_M8B_or_M2B,
        MOnly_W_M8B_or_M4B,
        MOnly_WP_M8B_or_M4B_or_M2B,
        MOnly_WP_M8B_or_M8B_or_M2B,
@@ -138,14 +149,14 @@ namespace Amd64InstrDecode
        MOp_WP_M8B_or_M4B_or_M2B,
        WP_I4B_or_I4B_or_I2B,
        WP_I8B_or_I4B_or_I2B,
-       Extension = 0x80, // The instruction encoding form depends on the modrm.reg field. Extension table location in encoded in lower bits
+       Extension = 0x80, // The instruction encoding form depends on the modrm.reg field. Extension table location is encoded in lower bits.
     };
 
-    // The following instrForm maps correspond to the amd64 instr maps
-    // The comments are for debugging convenience.  The comments use a packed opcode followed by a list of observed mnemonics
-    // The opcode is packed to be human readable.  PackedOpcode = opcode << 4 + pp
-    //   - For Vex* the pp is directly included in the encoding
-    //   - For the Secondary, F38, and F3A pages the pp is not defined in the encoding, but affects instr form.
+    // The following instrForm maps correspond to the amd64 instruction maps.
+    // The comments are for debugging convenience. The comments use a packed opcode followed by a list of observed mnemonics.
+    // The opcode is packed to be human readable. PackedOpcode = opcode << 4 + pp. For example, 0x123 is opcode 0x12, pp=0x3.
+    //   - For Vex* and EVEX the pp is directly included in the encoding
+    //   - For the Secondary (0F), 0F 38, and 0F 3A pages the pp is not defined in the encoding, but affects instruction form.
     //          - pp = 0 implies no prefix.
     //          - pp = 1 implies 0x66 OpSize prefix only.
     //          - pp = 2 implies 0xF3 prefix.
@@ -153,9 +164,9 @@ namespace Amd64InstrDecode
     //   - For the primary map, pp is not used and is always 0 in the comments.
 
 
-    // Instruction which change forms based on modrm.reg are encoded in this extension table.
-    // Since there are 8 modrm.reg values, they occur is groups of 8.
-    // Each group is referenced from the other tables below using Extension|(index >> 3).
+    // Instructions which change forms based on modrm.reg are encoded in this extension table.
+    // Since there are 8 modrm.reg values, they occur in groups of 8.
+    // Each group is referenced from the other tables below using (Extension|(index >> 3)).
     static const InstrForm instrFormExtension[217]
     {
         MOnly_M4B,                               // Primary:0xd90/0 fld
@@ -252,32 +263,32 @@ namespace Amd64InstrDecode
         MOnly_M1B,                               // Secondary:0x180/3 prefetcht2
         MOnly_W_M8B_or_M4B,                      // Secondary:0x180/4 nop
         MOnly_W_M8B_or_M4B,                      // Secondary:0x180/5 nop
-        MOnly_W_M8B_or_M4B,                      // Secondary:0x180/6 nop
-        MOnly_W_M8B_or_M4B,                      // Secondary:0x180/7 nop
+        MOnly_M1B,                               // Secondary:0x180/6 prefetchit1
+        MOnly_M1B,                               // Secondary:0x180/7 prefetchit0
         MOnly_M1B,                               // Secondary:0x181/0 prefetchnta
         MOnly_M1B,                               // Secondary:0x181/1 prefetcht0
         MOnly_M1B,                               // Secondary:0x181/2 prefetcht1
         MOnly_M1B,                               // Secondary:0x181/3 prefetcht2
-        MOnly_M2B,                               // Secondary:0x181/4 nop
-        MOnly_M2B,                               // Secondary:0x181/5 nop
-        MOnly_M2B,                               // Secondary:0x181/6 nop
-        MOnly_M2B,                               // Secondary:0x181/7 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x181/4 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x181/5 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x181/6 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x181/7 nop
         MOnly_M1B,                               // Secondary:0x182/0 prefetchnta
         MOnly_M1B,                               // Secondary:0x182/1 prefetcht0
         MOnly_M1B,                               // Secondary:0x182/2 prefetcht1
         MOnly_M1B,                               // Secondary:0x182/3 prefetcht2
-        MOnly_M4B,                               // Secondary:0x182/4 nop
-        MOnly_M4B,                               // Secondary:0x182/5 nop
-        MOnly_M4B,                               // Secondary:0x182/6 nop
-        MOnly_M4B,                               // Secondary:0x182/7 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x182/4 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x182/5 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x182/6 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x182/7 nop
         MOnly_M1B,                               // Secondary:0x183/0 prefetchnta
         MOnly_M1B,                               // Secondary:0x183/1 prefetcht0
         MOnly_M1B,                               // Secondary:0x183/2 prefetcht1
         MOnly_M1B,                               // Secondary:0x183/3 prefetcht2
-        MOnly_M4B,                               // Secondary:0x183/4 nop
-        MOnly_M4B,                               // Secondary:0x183/5 nop
-        MOnly_M4B,                               // Secondary:0x183/6 nop
-        MOnly_M4B,                               // Secondary:0x183/7 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x183/4 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x183/5 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x183/6 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x183/7 nop
         MOnly_M1B,                               // Secondary:0x1c0/0 cldemote
         MOnly_W_M8B_or_M4B,                      // Secondary:0x1c0/1 nop
         MOnly_W_M8B_or_M4B,                      // Secondary:0x1c0/2 nop
@@ -286,30 +297,30 @@ namespace Amd64InstrDecode
         MOnly_W_M8B_or_M4B,                      // Secondary:0x1c0/5 nop
         MOnly_W_M8B_or_M4B,                      // Secondary:0x1c0/6 nop
         MOnly_W_M8B_or_M4B,                      // Secondary:0x1c0/7 nop
-        MOnly_M2B,                               // Secondary:0x1c1/0 nop
-        MOnly_M2B,                               // Secondary:0x1c1/1 nop
-        MOnly_M2B,                               // Secondary:0x1c1/2 nop
-        MOnly_M2B,                               // Secondary:0x1c1/3 nop
-        MOnly_M2B,                               // Secondary:0x1c1/4 nop
-        MOnly_M2B,                               // Secondary:0x1c1/5 nop
-        MOnly_M2B,                               // Secondary:0x1c1/6 nop
-        MOnly_M2B,                               // Secondary:0x1c1/7 nop
-        MOnly_M4B,                               // Secondary:0x1c2/0 nop
-        MOnly_M4B,                               // Secondary:0x1c2/1 nop
-        MOnly_M4B,                               // Secondary:0x1c2/2 nop
-        MOnly_M4B,                               // Secondary:0x1c2/3 nop
-        MOnly_M4B,                               // Secondary:0x1c2/4 nop
-        MOnly_M4B,                               // Secondary:0x1c2/5 nop
-        MOnly_M4B,                               // Secondary:0x1c2/6 nop
-        MOnly_M4B,                               // Secondary:0x1c2/7 nop
-        MOnly_M4B,                               // Secondary:0x1c3/0 nop
-        MOnly_M4B,                               // Secondary:0x1c3/1 nop
-        MOnly_M4B,                               // Secondary:0x1c3/2 nop
-        MOnly_M4B,                               // Secondary:0x1c3/3 nop
-        MOnly_M4B,                               // Secondary:0x1c3/4 nop
-        MOnly_M4B,                               // Secondary:0x1c3/5 nop
-        MOnly_M4B,                               // Secondary:0x1c3/6 nop
-        MOnly_M4B,                               // Secondary:0x1c3/7 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x1c1/0 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x1c1/1 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x1c1/2 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x1c1/3 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x1c1/4 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x1c1/5 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x1c1/6 nop
+        MOnly_W_M8B_or_M2B,                      // Secondary:0x1c1/7 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c2/0 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c2/1 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c2/2 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c2/3 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c2/4 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c2/5 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c2/6 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c2/7 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c3/0 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c3/1 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c3/2 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c3/3 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c3/4 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c3/5 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c3/6 nop
+        MOnly_W_M8B_or_M4B,                      // Secondary:0x1c3/7 nop
         MOnly_MUnknown,                          // Secondary:0xae0/0 fxsave,fxsave64
         MOnly_MUnknown,                          // Secondary:0xae0/1 fxrstor,fxrstor64
         MOnly_M4B,                               // Secondary:0xae0/2 ldmxcsr
@@ -318,24 +329,24 @@ namespace Amd64InstrDecode
         MOnly_MUnknown,                          // Secondary:0xae0/5 xrstor,xrstor64
         MOnly_MUnknown,                          // Secondary:0xae0/6 xsaveopt,xsaveopt64
         MOnly_M1B,                               // Secondary:0xae0/7 clflush
-        MOnly_MUnknown,                          // Secondary:0xae1/0 fxsave
-        MOnly_MUnknown,                          // Secondary:0xae1/1 fxrstor
+        MOnly_MUnknown,                          // Secondary:0xae1/0 fxsave,fxsave64
+        MOnly_MUnknown,                          // Secondary:0xae1/1 fxrstor,fxrstor64
         MOnly_M4B,                               // Secondary:0xae1/2 ldmxcsr
         MOnly_M4B,                               // Secondary:0xae1/3 stmxcsr
         None,
         None,
         MOnly_M1B,                               // Secondary:0xae1/6 clwb
         MOnly_M1B,                               // Secondary:0xae1/7 clflushopt
-        MOnly_MUnknown,                          // Secondary:0xae2/0 fxsave
-        MOnly_MUnknown,                          // Secondary:0xae2/1 fxrstor
+        MOnly_MUnknown,                          // Secondary:0xae2/0 fxsave,fxsave64
+        MOnly_MUnknown,                          // Secondary:0xae2/1 fxrstor,fxrstor64
         MOnly_M4B,                               // Secondary:0xae2/2 ldmxcsr
         MOnly_M4B,                               // Secondary:0xae2/3 stmxcsr
-        MOnly_M4B,                               // Secondary:0xae2/4 ptwrite
+        MOnly_W_M8B_or_M4B,                      // Secondary:0xae2/4 ptwrite
         None,
         MOnly_M8B,                               // Secondary:0xae2/6 clrssbsy
         None,
-        MOnly_MUnknown,                          // Secondary:0xae3/0 fxsave
-        MOnly_MUnknown,                          // Secondary:0xae3/1 fxrstor
+        MOnly_MUnknown,                          // Secondary:0xae3/0 fxsave,fxsave64
+        MOnly_MUnknown,                          // Secondary:0xae3/1 fxrstor,fxrstor64
         MOnly_M4B,                               // Secondary:0xae3/2 ldmxcsr
         MOnly_M4B,                               // Secondary:0xae3/3 stmxcsr
         None,
@@ -351,27 +362,27 @@ namespace Amd64InstrDecode
         MOnly_M8B,                               // Secondary:0xc70/6 vmptrld
         MOnly_M8B,                               // Secondary:0xc70/7 vmptrst
         None,
-        MOnly_M8B,                               // Secondary:0xc71/1 cmpxchg8b
+        MOnly_W_M16B_or_M8B,                     // Secondary:0xc71/1 cmpxchg16b,cmpxchg8b
         None,
-        MOnly_MUnknown,                          // Secondary:0xc71/3 xrstors
-        MOnly_MUnknown,                          // Secondary:0xc71/4 xsavec
-        MOnly_MUnknown,                          // Secondary:0xc71/5 xsaves
+        MOnly_MUnknown,                          // Secondary:0xc71/3 xrstors,xrstors64
+        MOnly_MUnknown,                          // Secondary:0xc71/4 xsavec,xsavec64
+        MOnly_MUnknown,                          // Secondary:0xc71/5 xsaves,xsaves64
         MOnly_M8B,                               // Secondary:0xc71/6 vmclear
         MOnly_M8B,                               // Secondary:0xc71/7 vmptrst
         None,
-        MOnly_M8B,                               // Secondary:0xc72/1 cmpxchg8b
+        MOnly_W_M16B_or_M8B,                     // Secondary:0xc72/1 cmpxchg16b,cmpxchg8b
         None,
-        MOnly_MUnknown,                          // Secondary:0xc72/3 xrstors
-        MOnly_MUnknown,                          // Secondary:0xc72/4 xsavec
-        MOnly_MUnknown,                          // Secondary:0xc72/5 xsaves
+        MOnly_MUnknown,                          // Secondary:0xc72/3 xrstors,xrstors64
+        MOnly_MUnknown,                          // Secondary:0xc72/4 xsavec,xsavec64
+        MOnly_MUnknown,                          // Secondary:0xc72/5 xsaves,xsaves64
         MOnly_M8B,                               // Secondary:0xc72/6 vmxon
         MOnly_M8B,                               // Secondary:0xc72/7 vmptrst
         None,
-        MOnly_M8B,                               // Secondary:0xc73/1 cmpxchg8b
+        MOnly_W_M16B_or_M8B,                     // Secondary:0xc73/1 cmpxchg16b,cmpxchg8b
         None,
-        MOnly_MUnknown,                          // Secondary:0xc73/3 xrstors
-        MOnly_MUnknown,                          // Secondary:0xc73/4 xsavec
-        MOnly_MUnknown,                          // Secondary:0xc73/5 xsaves
+        MOnly_MUnknown,                          // Secondary:0xc73/3 xrstors,xrstors64
+        MOnly_MUnknown,                          // Secondary:0xc73/4 xsavec,xsavec64
+        MOnly_MUnknown,                          // Secondary:0xc73/5 xsaves,xsaves64
         None,
         MOnly_M8B,                               // Secondary:0xc73/7 vmptrst
     };
@@ -458,22 +469,22 @@ namespace Amd64InstrDecode
         None,                                    // 0x4d0
         None,                                    // 0x4e0
         None,                                    // 0x4f0
-        None,                                    // 0x500 push
-        None,                                    // 0x510 push
-        None,                                    // 0x520 push
-        None,                                    // 0x530 push
-        None,                                    // 0x540 push
-        None,                                    // 0x550 push
-        None,                                    // 0x560 push
-        None,                                    // 0x570 push
-        None,                                    // 0x580 pop
-        None,                                    // 0x590 pop
-        None,                                    // 0x5a0 pop
-        None,                                    // 0x5b0 pop
-        None,                                    // 0x5c0 pop
-        None,                                    // 0x5d0 pop
-        None,                                    // 0x5e0 pop
-        None,                                    // 0x5f0 pop
+        None,                                    // 0x500 push,pushp
+        None,                                    // 0x510 push,pushp
+        None,                                    // 0x520 push,pushp
+        None,                                    // 0x530 push,pushp
+        None,                                    // 0x540 push,pushp
+        None,                                    // 0x550 push,pushp
+        None,                                    // 0x560 push,pushp
+        None,                                    // 0x570 push,pushp
+        None,                                    // 0x580 pop,popp
+        None,                                    // 0x590 pop,popp
+        None,                                    // 0x5a0 pop,popp
+        None,                                    // 0x5b0 pop,popp
+        None,                                    // 0x5c0 pop,popp
+        None,                                    // 0x5d0 pop,popp
+        None,                                    // 0x5e0 pop,popp
+        None,                                    // 0x5f0 pop,popp
         None,                                    // 0x600
         None,                                    // 0x610
         None,                                    // 0x620
@@ -539,7 +550,7 @@ namespace Amd64InstrDecode
         None,                                    // 0x9e0 sahf
         None,                                    // 0x9f0 lahf
         I8B,                                     // 0xa00 movabs
-        I8B,                                     // 0xa10 movabs
+        I8B,                                     // 0xa10 jmpabs,movabs
         I8B,                                     // 0xa20 movabs
         I8B,                                     // 0xa30 movabs
         None,                                    // 0xa40 movs
@@ -641,7 +652,7 @@ namespace Amd64InstrDecode
         MOnly_M2B,                               // 0x000 lldt,ltr,sldt,str,verr,verw
         MOnly_M2B,                               // 0x001 lldt,ltr,sldt,str,verr,verw
         MOnly_M2B,                               // 0x002 lldt,ltr,sldt,str,verr,verw
-        MOnly_M2B,                               // 0x003 lldt,ltr,sldt,str,verr,verw
+        MOnly_M2B,                               // 0x003 lkgs,lldt,ltr,sldt,str,verr,verw
         InstrForm(int(Extension)|0x07),          // 0x010
         InstrForm(int(Extension)|0x08),          // 0x011
         InstrForm(int(Extension)|0x09),          // 0x012
@@ -667,9 +678,9 @@ namespace Amd64InstrDecode
         None,                                    // 0x062 clts
         None,                                    // 0x063 clts
         None,                                    // 0x070 sysretd,sysretq
-        None,                                    // 0x071 sysretd
-        None,                                    // 0x072 sysretd
-        None,                                    // 0x073 sysretd
+        None,                                    // 0x071 sysretd,sysretq
+        None,                                    // 0x072 sysretd,sysretq
+        None,                                    // 0x073 sysretd,sysretq
         None,                                    // 0x080 invd
         None,                                    // 0x081 invd
         None,                                    // 0x082 invd
@@ -739,9 +750,9 @@ namespace Amd64InstrDecode
         InstrForm(int(Extension)|0x0d),          // 0x182
         InstrForm(int(Extension)|0x0e),          // 0x183
         MOnly_W_M8B_or_M4B,                      // 0x190 nop
-        MOnly_M2B,                               // 0x191 nop
-        MOnly_M4B,                               // 0x192 nop
-        MOnly_M4B,                               // 0x193 nop
+        MOnly_W_M8B_or_M2B,                      // 0x191 nop
+        MOnly_W_M8B_or_M4B,                      // 0x192 nop
+        MOnly_W_M8B_or_M4B,                      // 0x193 nop
         None,                                    // 0x1a0
         MOp_MUnknown,                            // 0x1a1 bndmov
         MOp_MUnknown,                            // 0x1a2 bndcl
@@ -755,17 +766,17 @@ namespace Amd64InstrDecode
         InstrForm(int(Extension)|0x11),          // 0x1c2
         InstrForm(int(Extension)|0x12),          // 0x1c3
         MOnly_W_M8B_or_M4B,                      // 0x1d0 nop
-        MOnly_M2B,                               // 0x1d1 nop
-        MOnly_M4B,                               // 0x1d2 nop
-        MOnly_M4B,                               // 0x1d3 nop
+        MOnly_W_M8B_or_M2B,                      // 0x1d1 nop
+        MOnly_W_M8B_or_M4B,                      // 0x1d2 nop
+        MOnly_W_M8B_or_M4B,                      // 0x1d3 nop
         MOnly_W_M8B_or_M4B,                      // 0x1e0 nop
-        MOnly_M2B,                               // 0x1e1 nop
-        MOnly_M4B,                               // 0x1e2 nop
-        MOnly_M4B,                               // 0x1e3 nop
+        MOnly_W_M8B_or_M2B,                      // 0x1e1 nop
+        MOnly_W_M8B_or_M4B,                      // 0x1e2 nop
+        MOnly_W_M8B_or_M4B,                      // 0x1e3 nop
         MOnly_W_M8B_or_M4B,                      // 0x1f0 nop
-        MOnly_M2B,                               // 0x1f1 nop
-        MOnly_M4B,                               // 0x1f2 nop
-        MOnly_M4B,                               // 0x1f3 nop
+        MOnly_W_M8B_or_M2B,                      // 0x1f1 nop
+        MOnly_W_M8B_or_M4B,                      // 0x1f2 nop
+        MOnly_W_M8B_or_M4B,                      // 0x1f3 nop
         I1B,                                     // 0x200 mov
         I1B,                                     // 0x201 mov
         I1B,                                     // 0x202 mov
@@ -808,8 +819,8 @@ namespace Amd64InstrDecode
         None,                                    // 0x293
         MOp_M8B,                                 // 0x2a0 cvtpi2ps
         MOp_M8B,                                 // 0x2a1 cvtpi2pd
-        MOp_M4B,                                 // 0x2a2 cvtsi2ss
-        MOp_M4B,                                 // 0x2a3 cvtsi2sd
+        MOp_W_M8B_or_M4B,                        // 0x2a2 cvtsi2ss
+        MOp_W_M8B_or_M4B,                        // 0x2a3 cvtsi2sd
         M1st_M16B,                               // 0x2b0 movntps
         M1st_M16B,                               // 0x2b1 movntpd
         M1st_M4B,                                // 0x2b2 movntss
@@ -851,9 +862,9 @@ namespace Amd64InstrDecode
         None,                                    // 0x342 sysenter
         None,                                    // 0x343 sysenter
         None,                                    // 0x350 sysexitd,sysexitq
-        None,                                    // 0x351 sysexitd
-        None,                                    // 0x352 sysexitd
-        None,                                    // 0x353 sysexitd
+        None,                                    // 0x351 sysexitd,sysexitq
+        None,                                    // 0x352 sysexitd,sysexitq
+        None,                                    // 0x353 sysexitd,sysexitq
         None,                                    // 0x360
         None,                                    // 0x361
         None,                                    // 0x362
@@ -895,69 +906,69 @@ namespace Amd64InstrDecode
         None,                                    // 0x3f2
         None,                                    // 0x3f3
         MOp_W_M8B_or_M4B,                        // 0x400 cmovo
-        MOp_M2B,                                 // 0x401 cmovo
-        MOp_M4B,                                 // 0x402 cmovo
-        MOp_M4B,                                 // 0x403 cmovo
+        MOp_W_M8B_or_M2B,                        // 0x401 cmovo
+        MOp_W_M8B_or_M4B,                        // 0x402 cmovo
+        MOp_W_M8B_or_M4B,                        // 0x403 cmovo
         MOp_W_M8B_or_M4B,                        // 0x410 cmovno
-        MOp_M2B,                                 // 0x411 cmovno
-        MOp_M4B,                                 // 0x412 cmovno
-        MOp_M4B,                                 // 0x413 cmovno
+        MOp_W_M8B_or_M2B,                        // 0x411 cmovno
+        MOp_W_M8B_or_M4B,                        // 0x412 cmovno
+        MOp_W_M8B_or_M4B,                        // 0x413 cmovno
         MOp_W_M8B_or_M4B,                        // 0x420 cmovb
-        MOp_M2B,                                 // 0x421 cmovb
-        MOp_M4B,                                 // 0x422 cmovb
-        MOp_M4B,                                 // 0x423 cmovb
+        MOp_W_M8B_or_M2B,                        // 0x421 cmovb
+        MOp_W_M8B_or_M4B,                        // 0x422 cmovb
+        MOp_W_M8B_or_M4B,                        // 0x423 cmovb
         MOp_W_M8B_or_M4B,                        // 0x430 cmovae
-        MOp_M2B,                                 // 0x431 cmovae
-        MOp_M4B,                                 // 0x432 cmovae
-        MOp_M4B,                                 // 0x433 cmovae
+        MOp_W_M8B_or_M2B,                        // 0x431 cmovae
+        MOp_W_M8B_or_M4B,                        // 0x432 cmovae
+        MOp_W_M8B_or_M4B,                        // 0x433 cmovae
         MOp_W_M8B_or_M4B,                        // 0x440 cmove
-        MOp_M2B,                                 // 0x441 cmove
-        MOp_M4B,                                 // 0x442 cmove
-        MOp_M4B,                                 // 0x443 cmove
+        MOp_W_M8B_or_M2B,                        // 0x441 cmove
+        MOp_W_M8B_or_M4B,                        // 0x442 cmove
+        MOp_W_M8B_or_M4B,                        // 0x443 cmove
         MOp_W_M8B_or_M4B,                        // 0x450 cmovne
-        MOp_M2B,                                 // 0x451 cmovne
-        MOp_M4B,                                 // 0x452 cmovne
-        MOp_M4B,                                 // 0x453 cmovne
+        MOp_W_M8B_or_M2B,                        // 0x451 cmovne
+        MOp_W_M8B_or_M4B,                        // 0x452 cmovne
+        MOp_W_M8B_or_M4B,                        // 0x453 cmovne
         MOp_W_M8B_or_M4B,                        // 0x460 cmovbe
-        MOp_M2B,                                 // 0x461 cmovbe
-        MOp_M4B,                                 // 0x462 cmovbe
-        MOp_M4B,                                 // 0x463 cmovbe
+        MOp_W_M8B_or_M2B,                        // 0x461 cmovbe
+        MOp_W_M8B_or_M4B,                        // 0x462 cmovbe
+        MOp_W_M8B_or_M4B,                        // 0x463 cmovbe
         MOp_W_M8B_or_M4B,                        // 0x470 cmova
-        MOp_M2B,                                 // 0x471 cmova
-        MOp_M4B,                                 // 0x472 cmova
-        MOp_M4B,                                 // 0x473 cmova
+        MOp_W_M8B_or_M2B,                        // 0x471 cmova
+        MOp_W_M8B_or_M4B,                        // 0x472 cmova
+        MOp_W_M8B_or_M4B,                        // 0x473 cmova
         MOp_W_M8B_or_M4B,                        // 0x480 cmovs
-        MOp_M2B,                                 // 0x481 cmovs
-        MOp_M4B,                                 // 0x482 cmovs
-        MOp_M4B,                                 // 0x483 cmovs
+        MOp_W_M8B_or_M2B,                        // 0x481 cmovs
+        MOp_W_M8B_or_M4B,                        // 0x482 cmovs
+        MOp_W_M8B_or_M4B,                        // 0x483 cmovs
         MOp_W_M8B_or_M4B,                        // 0x490 cmovns
-        MOp_M2B,                                 // 0x491 cmovns
-        MOp_M4B,                                 // 0x492 cmovns
-        MOp_M4B,                                 // 0x493 cmovns
+        MOp_W_M8B_or_M2B,                        // 0x491 cmovns
+        MOp_W_M8B_or_M4B,                        // 0x492 cmovns
+        MOp_W_M8B_or_M4B,                        // 0x493 cmovns
         MOp_W_M8B_or_M4B,                        // 0x4a0 cmovp
-        MOp_M2B,                                 // 0x4a1 cmovp
-        MOp_M4B,                                 // 0x4a2 cmovp
-        MOp_M4B,                                 // 0x4a3 cmovp
+        MOp_W_M8B_or_M2B,                        // 0x4a1 cmovp
+        MOp_W_M8B_or_M4B,                        // 0x4a2 cmovp
+        MOp_W_M8B_or_M4B,                        // 0x4a3 cmovp
         MOp_W_M8B_or_M4B,                        // 0x4b0 cmovnp
-        MOp_M2B,                                 // 0x4b1 cmovnp
-        MOp_M4B,                                 // 0x4b2 cmovnp
-        MOp_M4B,                                 // 0x4b3 cmovnp
+        MOp_W_M8B_or_M2B,                        // 0x4b1 cmovnp
+        MOp_W_M8B_or_M4B,                        // 0x4b2 cmovnp
+        MOp_W_M8B_or_M4B,                        // 0x4b3 cmovnp
         MOp_W_M8B_or_M4B,                        // 0x4c0 cmovl
-        MOp_M2B,                                 // 0x4c1 cmovl
-        MOp_M4B,                                 // 0x4c2 cmovl
-        MOp_M4B,                                 // 0x4c3 cmovl
+        MOp_W_M8B_or_M2B,                        // 0x4c1 cmovl
+        MOp_W_M8B_or_M4B,                        // 0x4c2 cmovl
+        MOp_W_M8B_or_M4B,                        // 0x4c3 cmovl
         MOp_W_M8B_or_M4B,                        // 0x4d0 cmovge
-        MOp_M2B,                                 // 0x4d1 cmovge
-        MOp_M4B,                                 // 0x4d2 cmovge
-        MOp_M4B,                                 // 0x4d3 cmovge
+        MOp_W_M8B_or_M2B,                        // 0x4d1 cmovge
+        MOp_W_M8B_or_M4B,                        // 0x4d2 cmovge
+        MOp_W_M8B_or_M4B,                        // 0x4d3 cmovge
         MOp_W_M8B_or_M4B,                        // 0x4e0 cmovle
-        MOp_M2B,                                 // 0x4e1 cmovle
-        MOp_M4B,                                 // 0x4e2 cmovle
-        MOp_M4B,                                 // 0x4e3 cmovle
+        MOp_W_M8B_or_M2B,                        // 0x4e1 cmovle
+        MOp_W_M8B_or_M4B,                        // 0x4e2 cmovle
+        MOp_W_M8B_or_M4B,                        // 0x4e3 cmovle
         MOp_W_M8B_or_M4B,                        // 0x4f0 cmovg
-        MOp_M2B,                                 // 0x4f1 cmovg
-        MOp_M4B,                                 // 0x4f2 cmovg
-        MOp_M4B,                                 // 0x4f3 cmovg
+        MOp_W_M8B_or_M2B,                        // 0x4f1 cmovg
+        MOp_W_M8B_or_M4B,                        // 0x4f2 cmovg
+        MOp_W_M8B_or_M4B,                        // 0x4f3 cmovg
         None,                                    // 0x500
         None,                                    // 0x501
         None,                                    // 0x502
@@ -1079,7 +1090,7 @@ namespace Amd64InstrDecode
         None,                                    // 0x6d2
         None,                                    // 0x6d3
         MOp_W_M8B_or_M4B,                        // 0x6e0 movd,movq
-        MOp_M4B,                                 // 0x6e1 movd
+        MOp_W_M8B_or_M4B,                        // 0x6e1 movd,movq
         None,                                    // 0x6e2
         None,                                    // 0x6e3
         MOp_M8B,                                 // 0x6f0 movq
@@ -1143,7 +1154,7 @@ namespace Amd64InstrDecode
         None,                                    // 0x7d2
         MOp_M16B,                                // 0x7d3 hsubps
         M1st_W_M8B_or_M4B,                       // 0x7e0 movd,movq
-        M1st_M4B,                                // 0x7e1 movd
+        M1st_W_M8B_or_M4B,                       // 0x7e1 movd,movq
         MOp_M8B,                                 // 0x7e2 movq
         None,                                    // 0x7e3
         M1st_M8B,                                // 0x7f0 movq
@@ -1151,67 +1162,67 @@ namespace Amd64InstrDecode
         M1st_M16B,                               // 0x7f2 movdqu
         None,                                    // 0x7f3
         I4B,                                     // 0x800 jo
-        I2B,                                     // 0x801 jo
+        WP_I4B_or_I4B_or_I2B,                    // 0x801 jo
         I4B,                                     // 0x802 jo
         I4B,                                     // 0x803 jo
         I4B,                                     // 0x810 jno
-        I2B,                                     // 0x811 jno
+        WP_I4B_or_I4B_or_I2B,                    // 0x811 jno
         I4B,                                     // 0x812 jno
         I4B,                                     // 0x813 jno
         I4B,                                     // 0x820 jb
-        I2B,                                     // 0x821 jb
+        WP_I4B_or_I4B_or_I2B,                    // 0x821 jb
         I4B,                                     // 0x822 jb
         I4B,                                     // 0x823 jb
         I4B,                                     // 0x830 jae
-        I2B,                                     // 0x831 jae
+        WP_I4B_or_I4B_or_I2B,                    // 0x831 jae
         I4B,                                     // 0x832 jae
         I4B,                                     // 0x833 jae
         I4B,                                     // 0x840 je
-        I2B,                                     // 0x841 je
+        WP_I4B_or_I4B_or_I2B,                    // 0x841 je
         I4B,                                     // 0x842 je
         I4B,                                     // 0x843 je
         I4B,                                     // 0x850 jne
-        I2B,                                     // 0x851 jne
+        WP_I4B_or_I4B_or_I2B,                    // 0x851 jne
         I4B,                                     // 0x852 jne
         I4B,                                     // 0x853 jne
         I4B,                                     // 0x860 jbe
-        I2B,                                     // 0x861 jbe
+        WP_I4B_or_I4B_or_I2B,                    // 0x861 jbe
         I4B,                                     // 0x862 jbe
         I4B,                                     // 0x863 jbe
         I4B,                                     // 0x870 ja
-        I2B,                                     // 0x871 ja
+        WP_I4B_or_I4B_or_I2B,                    // 0x871 ja
         I4B,                                     // 0x872 ja
         I4B,                                     // 0x873 ja
         I4B,                                     // 0x880 js
-        I2B,                                     // 0x881 js
+        WP_I4B_or_I4B_or_I2B,                    // 0x881 js
         I4B,                                     // 0x882 js
         I4B,                                     // 0x883 js
         I4B,                                     // 0x890 jns
-        I2B,                                     // 0x891 jns
+        WP_I4B_or_I4B_or_I2B,                    // 0x891 jns
         I4B,                                     // 0x892 jns
         I4B,                                     // 0x893 jns
         I4B,                                     // 0x8a0 jp
-        I2B,                                     // 0x8a1 jp
+        WP_I4B_or_I4B_or_I2B,                    // 0x8a1 jp
         I4B,                                     // 0x8a2 jp
         I4B,                                     // 0x8a3 jp
         I4B,                                     // 0x8b0 jnp
-        I2B,                                     // 0x8b1 jnp
+        WP_I4B_or_I4B_or_I2B,                    // 0x8b1 jnp
         I4B,                                     // 0x8b2 jnp
         I4B,                                     // 0x8b3 jnp
         I4B,                                     // 0x8c0 jl
-        I2B,                                     // 0x8c1 jl
+        WP_I4B_or_I4B_or_I2B,                    // 0x8c1 jl
         I4B,                                     // 0x8c2 jl
         I4B,                                     // 0x8c3 jl
         I4B,                                     // 0x8d0 jge
-        I2B,                                     // 0x8d1 jge
+        WP_I4B_or_I4B_or_I2B,                    // 0x8d1 jge
         I4B,                                     // 0x8d2 jge
         I4B,                                     // 0x8d3 jge
         I4B,                                     // 0x8e0 jle
-        I2B,                                     // 0x8e1 jle
+        WP_I4B_or_I4B_or_I2B,                    // 0x8e1 jle
         I4B,                                     // 0x8e2 jle
         I4B,                                     // 0x8e3 jle
         I4B,                                     // 0x8f0 jg
-        I2B,                                     // 0x8f1 jg
+        WP_I4B_or_I4B_or_I2B,                    // 0x8f1 jg
         I4B,                                     // 0x8f2 jg
         I4B,                                     // 0x8f3 jg
         MOnly_M1B,                               // 0x900 seto
@@ -1279,11 +1290,11 @@ namespace Amd64InstrDecode
         MOnly_M1B,                               // 0x9f2 setg
         MOnly_M1B,                               // 0x9f3 setg
         None,                                    // 0xa00 push
-        None,                                    // 0xa01 pushw
+        None,                                    // 0xa01 push,pushw
         None,                                    // 0xa02 push
         None,                                    // 0xa03 push
         None,                                    // 0xa10 pop
-        None,                                    // 0xa11 popw
+        None,                                    // 0xa11 pop,popw
         None,                                    // 0xa12 pop
         None,                                    // 0xa13 pop
         None,                                    // 0xa20 cpuid
@@ -1291,17 +1302,17 @@ namespace Amd64InstrDecode
         None,                                    // 0xa22 cpuid
         None,                                    // 0xa23 cpuid
         M1st_W_M8B_or_M4B,                       // 0xa30 bt
-        M1st_M2B,                                // 0xa31 bt
-        M1st_M4B,                                // 0xa32 bt
-        M1st_M4B,                                // 0xa33 bt
+        M1st_W_M8B_or_M2B,                       // 0xa31 bt
+        M1st_W_M8B_or_M4B,                       // 0xa32 bt
+        M1st_W_M8B_or_M4B,                       // 0xa33 bt
         M1st_I1B_W_M8B_or_M4B,                   // 0xa40 shld
-        M1st_M2B_I1B,                            // 0xa41 shld
-        M1st_M4B_I1B,                            // 0xa42 shld
-        M1st_M4B_I1B,                            // 0xa43 shld
+        M1st_I1B_W_M8B_or_M2B,                   // 0xa41 shld
+        M1st_I1B_W_M8B_or_M4B,                   // 0xa42 shld
+        M1st_I1B_W_M8B_or_M4B,                   // 0xa43 shld
         M1st_W_M8B_or_M4B,                       // 0xa50 shld
-        M1st_M2B,                                // 0xa51 shld
-        M1st_M4B,                                // 0xa52 shld
-        M1st_M4B,                                // 0xa53 shld
+        M1st_W_M8B_or_M2B,                       // 0xa51 shld
+        M1st_W_M8B_or_M4B,                       // 0xa52 shld
+        M1st_W_M8B_or_M4B,                       // 0xa53 shld
         None,                                    // 0xa60
         None,                                    // 0xa61
         None,                                    // 0xa62
@@ -1311,11 +1322,11 @@ namespace Amd64InstrDecode
         None,                                    // 0xa72
         None,                                    // 0xa73
         None,                                    // 0xa80 push
-        None,                                    // 0xa81 pushw
+        None,                                    // 0xa81 push,pushw
         None,                                    // 0xa82 push
         None,                                    // 0xa83 push
         None,                                    // 0xa90 pop
-        None,                                    // 0xa91 popw
+        None,                                    // 0xa91 pop,popw
         None,                                    // 0xa92 pop
         None,                                    // 0xa93 pop
         None,                                    // 0xaa0 rsm
@@ -1323,41 +1334,41 @@ namespace Amd64InstrDecode
         None,                                    // 0xaa2 rsm
         None,                                    // 0xaa3 rsm
         M1st_W_M8B_or_M4B,                       // 0xab0 bts
-        M1st_M2B,                                // 0xab1 bts
-        M1st_M4B,                                // 0xab2 bts
-        M1st_M4B,                                // 0xab3 bts
+        M1st_W_M8B_or_M2B,                       // 0xab1 bts
+        M1st_W_M8B_or_M4B,                       // 0xab2 bts
+        M1st_W_M8B_or_M4B,                       // 0xab3 bts
         M1st_I1B_W_M8B_or_M4B,                   // 0xac0 shrd
-        M1st_M2B_I1B,                            // 0xac1 shrd
-        M1st_M4B_I1B,                            // 0xac2 shrd
-        M1st_M4B_I1B,                            // 0xac3 shrd
+        M1st_I1B_W_M8B_or_M2B,                   // 0xac1 shrd
+        M1st_I1B_W_M8B_or_M4B,                   // 0xac2 shrd
+        M1st_I1B_W_M8B_or_M4B,                   // 0xac3 shrd
         M1st_W_M8B_or_M4B,                       // 0xad0 shrd
-        M1st_M2B,                                // 0xad1 shrd
-        M1st_M4B,                                // 0xad2 shrd
-        M1st_M4B,                                // 0xad3 shrd
+        M1st_W_M8B_or_M2B,                       // 0xad1 shrd
+        M1st_W_M8B_or_M4B,                       // 0xad2 shrd
+        M1st_W_M8B_or_M4B,                       // 0xad3 shrd
         InstrForm(int(Extension)|0x13),          // 0xae0
         InstrForm(int(Extension)|0x14),          // 0xae1
         InstrForm(int(Extension)|0x15),          // 0xae2
         InstrForm(int(Extension)|0x16),          // 0xae3
         MOp_W_M8B_or_M4B,                        // 0xaf0 imul
-        MOp_M2B,                                 // 0xaf1 imul
-        MOp_M4B,                                 // 0xaf2 imul
-        MOp_M4B,                                 // 0xaf3 imul
+        MOp_W_M8B_or_M2B,                        // 0xaf1 imul
+        MOp_W_M8B_or_M4B,                        // 0xaf2 imul
+        MOp_W_M8B_or_M4B,                        // 0xaf3 imul
         M1st_M1B,                                // 0xb00 cmpxchg
         M1st_M1B,                                // 0xb01 cmpxchg
         M1st_M1B,                                // 0xb02 cmpxchg
         M1st_M1B,                                // 0xb03 cmpxchg
         M1st_W_M8B_or_M4B,                       // 0xb10 cmpxchg
-        M1st_M2B,                                // 0xb11 cmpxchg
-        M1st_M4B,                                // 0xb12 cmpxchg
-        M1st_M4B,                                // 0xb13 cmpxchg
+        M1st_W_M8B_or_M2B,                       // 0xb11 cmpxchg
+        M1st_W_M8B_or_M4B,                       // 0xb12 cmpxchg
+        M1st_W_M8B_or_M4B,                       // 0xb13 cmpxchg
         MOp_M6B,                                 // 0xb20 lss
         MOp_M4B,                                 // 0xb21 lss
         MOp_M6B,                                 // 0xb22 lss
         MOp_M6B,                                 // 0xb23 lss
         M1st_W_M8B_or_M4B,                       // 0xb30 btr
-        M1st_M2B,                                // 0xb31 btr
-        M1st_M4B,                                // 0xb32 btr
-        M1st_M4B,                                // 0xb33 btr
+        M1st_W_M8B_or_M2B,                       // 0xb31 btr
+        M1st_W_M8B_or_M4B,                       // 0xb32 btr
+        M1st_W_M8B_or_M4B,                       // 0xb33 btr
         MOp_M6B,                                 // 0xb40 lfs
         MOp_M4B,                                 // 0xb41 lfs
         MOp_M6B,                                 // 0xb42 lfs
@@ -1376,27 +1387,27 @@ namespace Amd64InstrDecode
         MOp_M2B,                                 // 0xb73 movzx
         None,                                    // 0xb80
         None,                                    // 0xb81
-        MOp_M4B,                                 // 0xb82 popcnt
+        MOp_W_M8B_or_M4B,                        // 0xb82 popcnt
         None,                                    // 0xb83
         MOp_W_M8B_or_M4B,                        // 0xb90 ud1
-        MOp_M2B,                                 // 0xb91 ud1
-        MOp_M4B,                                 // 0xb92 ud1
-        MOp_M4B,                                 // 0xb93 ud1
+        MOp_W_M8B_or_M2B,                        // 0xb91 ud1
+        MOp_W_M8B_or_M4B,                        // 0xb92 ud1
+        MOp_W_M8B_or_M4B,                        // 0xb93 ud1
         M1st_I1B_W_M8B_or_M4B,                   // 0xba0 bt,btc,btr,bts
-        M1st_M2B_I1B,                            // 0xba1 bt,btc,btr,bts
-        M1st_M4B_I1B,                            // 0xba2 bt,btc,btr,bts
-        M1st_M4B_I1B,                            // 0xba3 bt,btc,btr,bts
+        M1st_I1B_W_M8B_or_M2B,                   // 0xba1 bt,btc,btr,bts
+        M1st_I1B_W_M8B_or_M4B,                   // 0xba2 bt,btc,btr,bts
+        M1st_I1B_W_M8B_or_M4B,                   // 0xba3 bt,btc,btr,bts
         M1st_W_M8B_or_M4B,                       // 0xbb0 btc
-        M1st_M2B,                                // 0xbb1 btc
-        M1st_M4B,                                // 0xbb2 btc
-        M1st_M4B,                                // 0xbb3 btc
+        M1st_W_M8B_or_M2B,                       // 0xbb1 btc
+        M1st_W_M8B_or_M4B,                       // 0xbb2 btc
+        M1st_W_M8B_or_M4B,                       // 0xbb3 btc
         MOp_W_M8B_or_M4B,                        // 0xbc0 bsf
-        MOp_M2B,                                 // 0xbc1 bsf
-        MOp_M4B,                                 // 0xbc2 tzcnt
+        MOp_W_M8B_or_M2B,                        // 0xbc1 bsf
+        MOp_W_M8B_or_M4B,                        // 0xbc2 tzcnt
         None,                                    // 0xbc3
         MOp_W_M8B_or_M4B,                        // 0xbd0 bsr
-        MOp_M2B,                                 // 0xbd1 bsr
-        MOp_M4B,                                 // 0xbd2 lzcnt
+        MOp_W_M8B_or_M2B,                        // 0xbd1 bsr
+        MOp_W_M8B_or_M4B,                        // 0xbd2 lzcnt
         None,                                    // 0xbd3
         MOp_M1B,                                 // 0xbe0 movsx
         MOp_M1B,                                 // 0xbe1 movsx
@@ -1411,9 +1422,9 @@ namespace Amd64InstrDecode
         M1st_M1B,                                // 0xc02 xadd
         M1st_M1B,                                // 0xc03 xadd
         M1st_W_M8B_or_M4B,                       // 0xc10 xadd
-        M1st_M2B,                                // 0xc11 xadd
-        M1st_M4B,                                // 0xc12 xadd
-        M1st_M4B,                                // 0xc13 xadd
+        M1st_W_M8B_or_M2B,                       // 0xc11 xadd
+        M1st_W_M8B_or_M4B,                       // 0xc12 xadd
+        M1st_W_M8B_or_M4B,                       // 0xc13 xadd
         MOp_M16B_I1B,                            // 0xc20 cmpps
         MOp_M16B_I1B,                            // 0xc21 cmppd
         MOp_M4B_I1B,                             // 0xc22 cmpss
@@ -1659,9 +1670,9 @@ namespace Amd64InstrDecode
         None,                                    // 0xfe2
         None,                                    // 0xfe3
         MOp_W_M8B_or_M4B,                        // 0xff0 ud0
-        MOp_M2B,                                 // 0xff1 ud0
-        MOp_M4B,                                 // 0xff2 ud0
-        MOp_M4B,                                 // 0xff3 ud0
+        MOp_W_M8B_or_M2B,                        // 0xff1 ud0
+        MOp_W_M8B_or_M4B,                        // 0xff2 ud0
+        MOp_W_M8B_or_M4B,                        // 0xff3 ud0
     };
 
     static const InstrForm instrFormF38[1024]
@@ -2674,10 +2685,10 @@ namespace Amd64InstrDecode
         None,                                    // 0xfb1
         None,                                    // 0xfb2
         None,                                    // 0xfb3
-        None,                                    // 0xfc0
-        None,                                    // 0xfc1
-        None,                                    // 0xfc2
-        None,                                    // 0xfc3
+        M1st_W_M8B_or_M4B,                       // 0xfc0 aadd
+        M1st_W_M8B_or_M4B,                       // 0xfc1 aand
+        M1st_W_M8B_or_M4B,                       // 0xfc2 axor
+        M1st_W_M8B_or_M4B,                       // 0xfc3 aor
         None,                                    // 0xfd0
         None,                                    // 0xfd1
         None,                                    // 0xfd2
@@ -5070,14 +5081,14 @@ namespace Amd64InstrDecode
         None,                                    // 0x4f1
         None,                                    // 0x4f2
         None,                                    // 0x4f3
-        None,                                    // 0x500
+        MOp_L_M32B_or_M16B,                      // 0x500 vpdpbuud
         None,                                    // 0x501
-        None,                                    // 0x502
-        None,                                    // 0x503
-        None,                                    // 0x510
+        MOp_L_M32B_or_M16B,                      // 0x502 vpdpbsud
+        MOp_L_M32B_or_M16B,                      // 0x503 vpdpbssd
+        MOp_L_M32B_or_M16B,                      // 0x510 vpdpbuuds
         None,                                    // 0x511
-        None,                                    // 0x512
-        None,                                    // 0x513
+        MOp_L_M32B_or_M16B,                      // 0x512 vpdpbsuds
+        MOp_L_M32B_or_M16B,                      // 0x513 vpdpbssds
         None,                                    // 0x520
         None,                                    // 0x521
         None,                                    // 0x522
@@ -5454,13 +5465,13 @@ namespace Amd64InstrDecode
         MOp_W_M8B_or_M4B,                        // 0xaf1 vfnmsub213sd,vfnmsub213ss
         None,                                    // 0xaf2
         None,                                    // 0xaf3
-        None,                                    // 0xb00
-        None,                                    // 0xb01
-        None,                                    // 0xb02
-        None,                                    // 0xb03
+        MOp_L_M32B_or_M16B,                      // 0xb00 vcvtneoph2ps
+        MOp_L_M32B_or_M16B,                      // 0xb01 vcvtneeph2ps
+        MOp_L_M32B_or_M16B,                      // 0xb02 vcvtneebf162ps
+        MOp_L_M32B_or_M16B,                      // 0xb03 vcvtneobf162ps
         None,                                    // 0xb10
-        None,                                    // 0xb11
-        None,                                    // 0xb12
+        MOp_M2B,                                 // 0xb11 vbcstnesh2ps
+        MOp_M2B,                                 // 0xb12 vbcstnebf162ps
         None,                                    // 0xb13
         None,                                    // 0xb20
         None,                                    // 0xb21
@@ -5590,13 +5601,13 @@ namespace Amd64InstrDecode
         None,                                    // 0xd11
         None,                                    // 0xd12
         None,                                    // 0xd13
-        None,                                    // 0xd20
-        None,                                    // 0xd21
-        None,                                    // 0xd22
+        MOp_L_M32B_or_M16B,                      // 0xd20 vpdpwuud
+        MOp_L_M32B_or_M16B,                      // 0xd21 vpdpwusd
+        MOp_L_M32B_or_M16B,                      // 0xd22 vpdpwsud
         None,                                    // 0xd23
-        None,                                    // 0xd30
-        None,                                    // 0xd31
-        None,                                    // 0xd32
+        MOp_L_M32B_or_M16B,                      // 0xd30 vpdpwuuds
+        MOp_L_M32B_or_M16B,                      // 0xd31 vpdpwusds
+        MOp_L_M32B_or_M16B,                      // 0xd32 vpdpwsuds
         None,                                    // 0xd33
         None,                                    // 0xd40
         None,                                    // 0xd41
@@ -5622,10 +5633,10 @@ namespace Amd64InstrDecode
         None,                                    // 0xd91
         None,                                    // 0xd92
         None,                                    // 0xd93
-        None,                                    // 0xda0
-        None,                                    // 0xda1
-        None,                                    // 0xda2
-        None,                                    // 0xda3
+        MOp_M16B,                                // 0xda0 vsm3msg1
+        MOp_M16B,                                // 0xda1 vsm3msg2
+        MOp_L_M32B_or_M16B,                      // 0xda2 vsm4key4
+        MOp_L_M32B_or_M16B,                      // 0xda3 vsm4rnds4
         None,                                    // 0xdb0
         MOp_M16B,                                // 0xdb1 vaesimc
         None,                                    // 0xdb2
@@ -5647,67 +5658,67 @@ namespace Amd64InstrDecode
         None,                                    // 0xdf2
         None,                                    // 0xdf3
         None,                                    // 0xe00
-        None,                                    // 0xe01
+        M1st_W_M8B_or_M4B,                       // 0xe01 cmpoxadd
         None,                                    // 0xe02
         None,                                    // 0xe03
         None,                                    // 0xe10
-        None,                                    // 0xe11
+        M1st_W_M8B_or_M4B,                       // 0xe11 cmpnoxadd
         None,                                    // 0xe12
         None,                                    // 0xe13
         None,                                    // 0xe20
-        None,                                    // 0xe21
+        M1st_W_M8B_or_M4B,                       // 0xe21 cmpbxadd
         None,                                    // 0xe22
         None,                                    // 0xe23
         None,                                    // 0xe30
-        None,                                    // 0xe31
+        M1st_W_M8B_or_M4B,                       // 0xe31 cmpnbxadd
         None,                                    // 0xe32
         None,                                    // 0xe33
         None,                                    // 0xe40
-        None,                                    // 0xe41
+        M1st_W_M8B_or_M4B,                       // 0xe41 cmpzxadd
         None,                                    // 0xe42
         None,                                    // 0xe43
         None,                                    // 0xe50
-        None,                                    // 0xe51
+        M1st_W_M8B_or_M4B,                       // 0xe51 cmpnzxadd
         None,                                    // 0xe52
         None,                                    // 0xe53
         None,                                    // 0xe60
-        None,                                    // 0xe61
+        M1st_W_M8B_or_M4B,                       // 0xe61 cmpbexadd
         None,                                    // 0xe62
         None,                                    // 0xe63
         None,                                    // 0xe70
-        None,                                    // 0xe71
+        M1st_W_M8B_or_M4B,                       // 0xe71 cmpnbexadd
         None,                                    // 0xe72
         None,                                    // 0xe73
         None,                                    // 0xe80
-        None,                                    // 0xe81
+        M1st_W_M8B_or_M4B,                       // 0xe81 cmpsxadd
         None,                                    // 0xe82
         None,                                    // 0xe83
         None,                                    // 0xe90
-        None,                                    // 0xe91
+        M1st_W_M8B_or_M4B,                       // 0xe91 cmpnsxadd
         None,                                    // 0xe92
         None,                                    // 0xe93
         None,                                    // 0xea0
-        None,                                    // 0xea1
+        M1st_W_M8B_or_M4B,                       // 0xea1 cmppxadd
         None,                                    // 0xea2
         None,                                    // 0xea3
         None,                                    // 0xeb0
-        None,                                    // 0xeb1
+        M1st_W_M8B_or_M4B,                       // 0xeb1 cmpnpxadd
         None,                                    // 0xeb2
         None,                                    // 0xeb3
         None,                                    // 0xec0
-        None,                                    // 0xec1
+        M1st_W_M8B_or_M4B,                       // 0xec1 cmplxadd
         None,                                    // 0xec2
         None,                                    // 0xec3
         None,                                    // 0xed0
-        None,                                    // 0xed1
+        M1st_W_M8B_or_M4B,                       // 0xed1 cmpnlxadd
         None,                                    // 0xed2
         None,                                    // 0xed3
         None,                                    // 0xee0
-        None,                                    // 0xee1
+        M1st_W_M8B_or_M4B,                       // 0xee1 cmplexadd
         None,                                    // 0xee2
         None,                                    // 0xee3
         None,                                    // 0xef0
-        None,                                    // 0xef1
+        M1st_W_M8B_or_M4B,                       // 0xef1 cmpnlexadd
         None,                                    // 0xef2
         None,                                    // 0xef3
         None,                                    // 0xf00
@@ -6667,7 +6678,7 @@ namespace Amd64InstrDecode
         None,                                    // 0xdd2
         None,                                    // 0xdd3
         None,                                    // 0xde0
-        None,                                    // 0xde1
+        MOp_M16B_I1B,                            // 0xde1 vsm3rnds2
         None,                                    // 0xde2
         None,                                    // 0xde3
         None,                                    // 0xdf0
@@ -6978,8 +6989,8 @@ namespace Amd64InstrDecode
         None,                                    // 0x2a1
         MOp_W_M8B_or_M4B,                        // 0x2a2 vcvtsi2ss
         MOp_W_M8B_or_M4B,                        // 0x2a3 vcvtsi2sd
-        M1st_bLL_M4B_M16B_M32B_M64B,             // 0x2b0 vmovntps
-        M1st_bLL_M8B_M16B_M32B_M64B,             // 0x2b1 vmovntpd
+        M1st_LL_M16B_M32B_M64B,                  // 0x2b0 vmovntps
+        M1st_LL_M16B_M32B_M64B,                  // 0x2b1 vmovntpd
         None,                                    // 0x2b2
         None,                                    // 0x2b3
         None,                                    // 0x2c0
@@ -7130,8 +7141,8 @@ namespace Amd64InstrDecode
         None,                                    // 0x501
         None,                                    // 0x502
         None,                                    // 0x503
-        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x510 vsqrtps
-        MOp_bLL_M8B_M16B_M32B_M64B,              // 0x511 vsqrtpd
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x510 vsqrtps
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x511 vsqrtpd
         MOp_M4B,                                 // 0x512 vsqrtss
         MOp_M8B,                                 // 0x513 vsqrtsd
         None,                                    // 0x520
@@ -7158,12 +7169,12 @@ namespace Amd64InstrDecode
         MOp_bLL_M8B_M16B_M32B_M64B,              // 0x571 vxorpd
         None,                                    // 0x572
         None,                                    // 0x573
-        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x580 vaddps
-        MOp_bLL_M8B_M16B_M32B_M64B,              // 0x581 vaddpd
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x580 vaddps
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x581 vaddpd
         MOp_M4B,                                 // 0x582 vaddss
         MOp_M8B,                                 // 0x583 vaddsd
-        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x590 vmulps
-        MOp_bLL_M8B_M16B_M32B_M64B,              // 0x591 vmulpd
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x590 vmulps
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x591 vmulpd
         MOp_M4B,                                 // 0x592 vmulss
         MOp_M8B,                                 // 0x593 vmulsd
         MOp_bLL_M4B_M8B_M16B_M32B,               // 0x5a0 vcvtps2pd
@@ -7174,20 +7185,20 @@ namespace Amd64InstrDecode
         MOp_bLL_M4B_M16B_M32B_M64B,              // 0x5b1 vcvtps2dq
         MOp_bLL_M4B_M16B_M32B_M64B,              // 0x5b2 vcvttps2dq
         None,                                    // 0x5b3
-        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x5c0 vsubps
-        MOp_bLL_M8B_M16B_M32B_M64B,              // 0x5c1 vsubpd
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x5c0 vsubps
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x5c1 vsubpd
         MOp_M4B,                                 // 0x5c2 vsubss
         MOp_M8B,                                 // 0x5c3 vsubsd
-        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x5d0 vminps
-        MOp_bLL_M8B_M16B_M32B_M64B,              // 0x5d1 vminpd
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x5d0 vminps
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x5d1 vminpd
         MOp_M4B,                                 // 0x5d2 vminss
         MOp_M8B,                                 // 0x5d3 vminsd
-        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x5e0 vdivps
-        MOp_bLL_M8B_M16B_M32B_M64B,              // 0x5e1 vdivpd
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x5e0 vdivps
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x5e1 vdivpd
         MOp_M4B,                                 // 0x5e2 vdivss
         MOp_M8B,                                 // 0x5e3 vdivsd
-        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x5f0 vmaxps
-        MOp_bLL_M8B_M16B_M32B_M64B,              // 0x5f1 vmaxpd
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x5f0 vmaxps
+        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x5f1 vmaxpd
         MOp_M4B,                                 // 0x5f2 vmaxss
         MOp_M8B,                                 // 0x5f3 vmaxsd
         None,                                    // 0x600
@@ -7382,12 +7393,12 @@ namespace Amd64InstrDecode
         None,                                    // 0x8f1
         None,                                    // 0x8f2
         None,                                    // 0x8f3
-        None,                                    // 0x900
-        None,                                    // 0x901
+        MOp_W_M8B_or_M2B,                        // 0x900 kmovq,kmovw
+        MOp_W_M4B_or_M1B,                        // 0x901 kmovb,kmovd
         None,                                    // 0x902
         None,                                    // 0x903
-        None,                                    // 0x910
-        None,                                    // 0x911
+        M1st_W_M8B_or_M2B,                       // 0x910 kmovq,kmovw
+        M1st_W_M4B_or_M1B,                       // 0x911 kmovb,kmovd
         None,                                    // 0x912
         None,                                    // 0x913
         None,                                    // 0x920
@@ -8000,7 +8011,7 @@ namespace Amd64InstrDecode
         None,                                    // 0x283
         None,                                    // 0x290
         MOp_bLL_M8B_M16B_M32B_M64B,              // 0x291 vpcmpeqq
-        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x292 vpmovb2m,vpmovw2m
+        None,                                    // 0x292
         None,                                    // 0x293
         None,                                    // 0x2a0
         MOp_LL_M16B_M32B_M64B,                   // 0x2a1 vmovntdqa
@@ -8064,7 +8075,7 @@ namespace Amd64InstrDecode
         None,                                    // 0x383
         None,                                    // 0x390
         MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x391 vpminsd,vpminsq
-        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x392 vpmovd2m,vpmovq2m
+        None,                                    // 0x392
         None,                                    // 0x393
         None,                                    // 0x3a0
         MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x3a1 vpminuw
@@ -8126,8 +8137,8 @@ namespace Amd64InstrDecode
         None,                                    // 0x481
         None,                                    // 0x482
         None,                                    // 0x483
-        None,                                    // 0x490
-        None,                                    // 0x491
+        MOnly_MUnknown,                          // 0x490 ldtilecfg
+        MOnly_MUnknown,                          // 0x491 sttilecfg
         None,                                    // 0x492
         None,                                    // 0x493
         None,                                    // 0x4a0
@@ -8154,20 +8165,20 @@ namespace Amd64InstrDecode
         MOp_W_M8B_or_M4B,                        // 0x4f1 vrsqrt14sd,vrsqrt14ss
         None,                                    // 0x4f2
         None,                                    // 0x4f3
-        None,                                    // 0x500
-        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x501 vpdpbusd
-        None,                                    // 0x502
-        None,                                    // 0x503
-        None,                                    // 0x510
-        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x511 vpdpbusds
-        None,                                    // 0x512
-        None,                                    // 0x513
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x500 vpdpbuud
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x501 vpdpbusd
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x502 vpdpbsud
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x503 vpdpbssd
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x510 vpdpbuuds
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x511 vpdpbusds
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x512 vpdpbsuds
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x513 vpdpbssds
         None,                                    // 0x520
-        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x521 vpdpwssd
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x521 vpdpwssd
         MOp_bLL_M4B_M16B_M32B_M64B,              // 0x522 vdpbf16ps
         MOp_M16B,                                // 0x523 vp4dpwssd
         None,                                    // 0x530
-        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0x531 vpdpwssds
+        MOp_bLL_M4B_M16B_M32B_M64B,              // 0x531 vpdpwssds
         None,                                    // 0x532
         MOp_M16B,                                // 0x533 vp4dpwssds
         None,                                    // 0x540
@@ -8555,11 +8566,11 @@ namespace Amd64InstrDecode
         None,                                    // 0xb32
         None,                                    // 0xb33
         None,                                    // 0xb40
-        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0xb41 vpmadd52luq
+        MOp_bLL_M8B_M16B_M32B_M64B,              // 0xb41 vpmadd52luq
         None,                                    // 0xb42
         None,                                    // 0xb43
         None,                                    // 0xb50
-        MOp_bWLL_M4B_M8B_M16B_M32B_M64B,         // 0xb51 vpmadd52huq
+        MOp_bLL_M8B_M16B_M32B_M64B,              // 0xb51 vpmadd52huq
         None,                                    // 0xb52
         None,                                    // 0xb53
         None,                                    // 0xb60
@@ -8731,67 +8742,67 @@ namespace Amd64InstrDecode
         None,                                    // 0xdf2
         None,                                    // 0xdf3
         None,                                    // 0xe00
-        None,                                    // 0xe01
+        M1st_W_M8B_or_M4B,                       // 0xe01 cmpoxadd
         None,                                    // 0xe02
         None,                                    // 0xe03
         None,                                    // 0xe10
-        None,                                    // 0xe11
+        M1st_W_M8B_or_M4B,                       // 0xe11 cmpnoxadd
         None,                                    // 0xe12
         None,                                    // 0xe13
         None,                                    // 0xe20
-        None,                                    // 0xe21
+        M1st_W_M8B_or_M4B,                       // 0xe21 cmpbxadd
         None,                                    // 0xe22
         None,                                    // 0xe23
         None,                                    // 0xe30
-        None,                                    // 0xe31
+        M1st_W_M8B_or_M4B,                       // 0xe31 cmpnbxadd
         None,                                    // 0xe32
         None,                                    // 0xe33
         None,                                    // 0xe40
-        None,                                    // 0xe41
+        M1st_W_M8B_or_M4B,                       // 0xe41 cmpzxadd
         None,                                    // 0xe42
         None,                                    // 0xe43
         None,                                    // 0xe50
-        None,                                    // 0xe51
+        M1st_W_M8B_or_M4B,                       // 0xe51 cmpnzxadd
         None,                                    // 0xe52
         None,                                    // 0xe53
         None,                                    // 0xe60
-        None,                                    // 0xe61
+        M1st_W_M8B_or_M4B,                       // 0xe61 cmpbexadd
         None,                                    // 0xe62
         None,                                    // 0xe63
         None,                                    // 0xe70
-        None,                                    // 0xe71
+        M1st_W_M8B_or_M4B,                       // 0xe71 cmpnbexadd
         None,                                    // 0xe72
         None,                                    // 0xe73
         None,                                    // 0xe80
-        None,                                    // 0xe81
+        M1st_W_M8B_or_M4B,                       // 0xe81 cmpsxadd
         None,                                    // 0xe82
         None,                                    // 0xe83
         None,                                    // 0xe90
-        None,                                    // 0xe91
+        M1st_W_M8B_or_M4B,                       // 0xe91 cmpnsxadd
         None,                                    // 0xe92
         None,                                    // 0xe93
         None,                                    // 0xea0
-        None,                                    // 0xea1
+        M1st_W_M8B_or_M4B,                       // 0xea1 cmppxadd
         None,                                    // 0xea2
         None,                                    // 0xea3
         None,                                    // 0xeb0
-        None,                                    // 0xeb1
+        M1st_W_M8B_or_M4B,                       // 0xeb1 cmpnpxadd
         None,                                    // 0xeb2
         None,                                    // 0xeb3
         None,                                    // 0xec0
-        None,                                    // 0xec1
+        M1st_W_M8B_or_M4B,                       // 0xec1 cmplxadd
         None,                                    // 0xec2
         None,                                    // 0xec3
         None,                                    // 0xed0
-        None,                                    // 0xed1
+        M1st_W_M8B_or_M4B,                       // 0xed1 cmpnlxadd
         None,                                    // 0xed2
         None,                                    // 0xed3
         None,                                    // 0xee0
-        None,                                    // 0xee1
+        M1st_W_M8B_or_M4B,                       // 0xee1 cmplexadd
         None,                                    // 0xee2
         None,                                    // 0xee3
         None,                                    // 0xef0
-        None,                                    // 0xef1
+        M1st_W_M8B_or_M4B,                       // 0xef1 cmpnlexadd
         None,                                    // 0xef2
         None,                                    // 0xef3
         None,                                    // 0xf00
@@ -8802,11 +8813,11 @@ namespace Amd64InstrDecode
         None,                                    // 0xf11
         None,                                    // 0xf12
         None,                                    // 0xf13
-        None,                                    // 0xf20
+        MOp_W_M8B_or_M4B,                        // 0xf20 andn
         None,                                    // 0xf21
         None,                                    // 0xf22
         None,                                    // 0xf23
-        None,                                    // 0xf30
+        MOp_W_M8B_or_M4B,                        // 0xf30 blsi,blsmsk,blsr
         None,                                    // 0xf31
         None,                                    // 0xf32
         None,                                    // 0xf33
@@ -8814,18 +8825,18 @@ namespace Amd64InstrDecode
         None,                                    // 0xf41
         None,                                    // 0xf42
         None,                                    // 0xf43
-        None,                                    // 0xf50
+        MOp_W_M8B_or_M4B,                        // 0xf50 bzhi
         None,                                    // 0xf51
-        None,                                    // 0xf52
-        None,                                    // 0xf53
+        MOp_W_M8B_or_M4B,                        // 0xf52 pext
+        MOp_W_M8B_or_M4B,                        // 0xf53 pdep
         None,                                    // 0xf60
         None,                                    // 0xf61
         None,                                    // 0xf62
-        None,                                    // 0xf63
-        None,                                    // 0xf70
-        None,                                    // 0xf71
-        None,                                    // 0xf72
-        None,                                    // 0xf73
+        MOp_W_M8B_or_M4B,                        // 0xf63 mulx
+        MOp_W_M8B_or_M4B,                        // 0xf70 bextr
+        MOp_W_M8B_or_M4B,                        // 0xf71 shlx
+        MOp_W_M8B_or_M4B,                        // 0xf72 sarx
+        MOp_W_M8B_or_M4B,                        // 0xf73 shrx
         None,                                    // 0xf80
         None,                                    // 0xf81
         None,                                    // 0xf82
@@ -9691,7 +9702,7 @@ namespace Amd64InstrDecode
         None,                                    // 0xce2
         None,                                    // 0xce3
         None,                                    // 0xcf0
-        None,                                    // 0xcf1
+        MOp_I1B_bLL_M8B_M16B_M32B_M64B,          // 0xcf1 vgf2p8affineinvqb
         None,                                    // 0xcf2
         None,                                    // 0xcf3
         None,                                    // 0xd00
@@ -9825,7 +9836,7 @@ namespace Amd64InstrDecode
         None,                                    // 0xf00
         None,                                    // 0xf01
         None,                                    // 0xf02
-        None,                                    // 0xf03
+        MOp_I1B_W_M8B_or_M4B,                    // 0xf03 rorx
         None,                                    // 0xf10
         None,                                    // 0xf11
         None,                                    // 0xf12
@@ -9883,6 +9894,1034 @@ namespace Amd64InstrDecode
         None,                                    // 0xfe2
         None,                                    // 0xfe3
         None,                                    // 0xff0
+        None,                                    // 0xff1
+        None,                                    // 0xff2
+        None,                                    // 0xff3
+    };
+
+    static const InstrForm instrFormEvex_4[1024]
+    {
+        M1st_M1B,                                // 0x000 add
+        None,                                    // 0x001
+        None,                                    // 0x002
+        None,                                    // 0x003
+        M1st_W_M8B_or_M4B,                       // 0x010 add
+        M1st_W_M8B_or_M2B,                       // 0x011 add
+        None,                                    // 0x012
+        None,                                    // 0x013
+        MOp_M1B,                                 // 0x020 add
+        None,                                    // 0x021
+        None,                                    // 0x022
+        None,                                    // 0x023
+        MOp_W_M8B_or_M4B,                        // 0x030 add
+        MOp_W_M8B_or_M2B,                        // 0x031 add
+        None,                                    // 0x032
+        None,                                    // 0x033
+        None,                                    // 0x040
+        None,                                    // 0x041
+        None,                                    // 0x042
+        None,                                    // 0x043
+        None,                                    // 0x050
+        None,                                    // 0x051
+        None,                                    // 0x052
+        None,                                    // 0x053
+        None,                                    // 0x060
+        None,                                    // 0x061
+        None,                                    // 0x062
+        None,                                    // 0x063
+        None,                                    // 0x070
+        None,                                    // 0x071
+        None,                                    // 0x072
+        None,                                    // 0x073
+        M1st_M1B,                                // 0x080 or
+        None,                                    // 0x081
+        None,                                    // 0x082
+        None,                                    // 0x083
+        M1st_W_M8B_or_M4B,                       // 0x090 or
+        M1st_W_M8B_or_M2B,                       // 0x091 or
+        None,                                    // 0x092
+        None,                                    // 0x093
+        MOp_M1B,                                 // 0x0a0 or
+        None,                                    // 0x0a1
+        None,                                    // 0x0a2
+        None,                                    // 0x0a3
+        MOp_W_M8B_or_M4B,                        // 0x0b0 or
+        MOp_W_M8B_or_M2B,                        // 0x0b1 or
+        None,                                    // 0x0b2
+        None,                                    // 0x0b3
+        None,                                    // 0x0c0
+        None,                                    // 0x0c1
+        None,                                    // 0x0c2
+        None,                                    // 0x0c3
+        None,                                    // 0x0d0
+        None,                                    // 0x0d1
+        None,                                    // 0x0d2
+        None,                                    // 0x0d3
+        None,                                    // 0x0e0
+        None,                                    // 0x0e1
+        None,                                    // 0x0e2
+        None,                                    // 0x0e3
+        None,                                    // 0x0f0
+        None,                                    // 0x0f1
+        None,                                    // 0x0f2
+        None,                                    // 0x0f3
+        M1st_M1B,                                // 0x100 adc
+        None,                                    // 0x101
+        None,                                    // 0x102
+        None,                                    // 0x103
+        M1st_W_M8B_or_M4B,                       // 0x110 adc
+        M1st_W_M8B_or_M2B,                       // 0x111 adc
+        None,                                    // 0x112
+        None,                                    // 0x113
+        MOp_M1B,                                 // 0x120 adc
+        None,                                    // 0x121
+        None,                                    // 0x122
+        None,                                    // 0x123
+        MOp_W_M8B_or_M4B,                        // 0x130 adc
+        MOp_W_M8B_or_M2B,                        // 0x131 adc
+        None,                                    // 0x132
+        None,                                    // 0x133
+        None,                                    // 0x140
+        None,                                    // 0x141
+        None,                                    // 0x142
+        None,                                    // 0x143
+        None,                                    // 0x150
+        None,                                    // 0x151
+        None,                                    // 0x152
+        None,                                    // 0x153
+        None,                                    // 0x160
+        None,                                    // 0x161
+        None,                                    // 0x162
+        None,                                    // 0x163
+        None,                                    // 0x170
+        None,                                    // 0x171
+        None,                                    // 0x172
+        None,                                    // 0x173
+        M1st_M1B,                                // 0x180 sbb
+        None,                                    // 0x181
+        None,                                    // 0x182
+        None,                                    // 0x183
+        M1st_W_M8B_or_M4B,                       // 0x190 sbb
+        M1st_W_M8B_or_M2B,                       // 0x191 sbb
+        None,                                    // 0x192
+        None,                                    // 0x193
+        MOp_M1B,                                 // 0x1a0 sbb
+        None,                                    // 0x1a1
+        None,                                    // 0x1a2
+        None,                                    // 0x1a3
+        MOp_W_M8B_or_M4B,                        // 0x1b0 sbb
+        MOp_W_M8B_or_M2B,                        // 0x1b1 sbb
+        None,                                    // 0x1b2
+        None,                                    // 0x1b3
+        None,                                    // 0x1c0
+        None,                                    // 0x1c1
+        None,                                    // 0x1c2
+        None,                                    // 0x1c3
+        None,                                    // 0x1d0
+        None,                                    // 0x1d1
+        None,                                    // 0x1d2
+        None,                                    // 0x1d3
+        None,                                    // 0x1e0
+        None,                                    // 0x1e1
+        None,                                    // 0x1e2
+        None,                                    // 0x1e3
+        None,                                    // 0x1f0
+        None,                                    // 0x1f1
+        None,                                    // 0x1f2
+        None,                                    // 0x1f3
+        M1st_M1B,                                // 0x200 and
+        None,                                    // 0x201
+        None,                                    // 0x202
+        None,                                    // 0x203
+        M1st_W_M8B_or_M4B,                       // 0x210 and
+        M1st_W_M8B_or_M2B,                       // 0x211 and
+        None,                                    // 0x212
+        None,                                    // 0x213
+        MOp_M1B,                                 // 0x220 and
+        None,                                    // 0x221
+        None,                                    // 0x222
+        None,                                    // 0x223
+        MOp_W_M8B_or_M4B,                        // 0x230 and
+        MOp_W_M8B_or_M2B,                        // 0x231 and
+        None,                                    // 0x232
+        None,                                    // 0x233
+        M1st_I1B_W_M8B_or_M4B,                   // 0x240 shld
+        M1st_I1B_W_M8B_or_M2B,                   // 0x241 shld
+        None,                                    // 0x242
+        None,                                    // 0x243
+        None,                                    // 0x250
+        None,                                    // 0x251
+        None,                                    // 0x252
+        None,                                    // 0x253
+        None,                                    // 0x260
+        None,                                    // 0x261
+        None,                                    // 0x262
+        None,                                    // 0x263
+        None,                                    // 0x270
+        None,                                    // 0x271
+        None,                                    // 0x272
+        None,                                    // 0x273
+        M1st_M1B,                                // 0x280 sub
+        None,                                    // 0x281
+        None,                                    // 0x282
+        None,                                    // 0x283
+        M1st_W_M8B_or_M4B,                       // 0x290 sub
+        M1st_W_M8B_or_M2B,                       // 0x291 sub
+        None,                                    // 0x292
+        None,                                    // 0x293
+        MOp_M1B,                                 // 0x2a0 sub
+        None,                                    // 0x2a1
+        None,                                    // 0x2a2
+        None,                                    // 0x2a3
+        MOp_W_M8B_or_M4B,                        // 0x2b0 sub
+        MOp_W_M8B_or_M2B,                        // 0x2b1 sub
+        None,                                    // 0x2b2
+        None,                                    // 0x2b3
+        M1st_I1B_W_M8B_or_M4B,                   // 0x2c0 shrd
+        M1st_I1B_W_M8B_or_M2B,                   // 0x2c1 shrd
+        None,                                    // 0x2c2
+        None,                                    // 0x2c3
+        None,                                    // 0x2d0
+        None,                                    // 0x2d1
+        None,                                    // 0x2d2
+        None,                                    // 0x2d3
+        None,                                    // 0x2e0
+        None,                                    // 0x2e1
+        None,                                    // 0x2e2
+        None,                                    // 0x2e3
+        None,                                    // 0x2f0
+        None,                                    // 0x2f1
+        None,                                    // 0x2f2
+        None,                                    // 0x2f3
+        M1st_M1B,                                // 0x300 xor
+        None,                                    // 0x301
+        None,                                    // 0x302
+        None,                                    // 0x303
+        M1st_W_M8B_or_M4B,                       // 0x310 xor
+        M1st_W_M8B_or_M2B,                       // 0x311 xor
+        None,                                    // 0x312
+        None,                                    // 0x313
+        MOp_M1B,                                 // 0x320 xor
+        None,                                    // 0x321
+        None,                                    // 0x322
+        None,                                    // 0x323
+        MOp_W_M8B_or_M4B,                        // 0x330 xor
+        MOp_W_M8B_or_M2B,                        // 0x331 xor
+        None,                                    // 0x332
+        None,                                    // 0x333
+        None,                                    // 0x340
+        None,                                    // 0x341
+        None,                                    // 0x342
+        None,                                    // 0x343
+        None,                                    // 0x350
+        None,                                    // 0x351
+        None,                                    // 0x352
+        None,                                    // 0x353
+        None,                                    // 0x360
+        None,                                    // 0x361
+        None,                                    // 0x362
+        None,                                    // 0x363
+        None,                                    // 0x370
+        None,                                    // 0x371
+        None,                                    // 0x372
+        None,                                    // 0x373
+        None,                                    // 0x380
+        None,                                    // 0x381
+        None,                                    // 0x382
+        None,                                    // 0x383
+        None,                                    // 0x390
+        None,                                    // 0x391
+        None,                                    // 0x392
+        None,                                    // 0x393
+        None,                                    // 0x3a0
+        None,                                    // 0x3a1
+        None,                                    // 0x3a2
+        None,                                    // 0x3a3
+        None,                                    // 0x3b0
+        None,                                    // 0x3b1
+        None,                                    // 0x3b2
+        None,                                    // 0x3b3
+        None,                                    // 0x3c0
+        None,                                    // 0x3c1
+        None,                                    // 0x3c2
+        None,                                    // 0x3c3
+        None,                                    // 0x3d0
+        None,                                    // 0x3d1
+        None,                                    // 0x3d2
+        None,                                    // 0x3d3
+        None,                                    // 0x3e0
+        None,                                    // 0x3e1
+        None,                                    // 0x3e2
+        None,                                    // 0x3e3
+        None,                                    // 0x3f0
+        None,                                    // 0x3f1
+        None,                                    // 0x3f2
+        None,                                    // 0x3f3
+        MOp_W_M8B_or_M4B,                        // 0x400 cmovo
+        MOp_W_M8B_or_M2B,                        // 0x401 cmovo
+        None,                                    // 0x402
+        None,                                    // 0x403
+        MOp_W_M8B_or_M4B,                        // 0x410 cmovno
+        MOp_W_M8B_or_M2B,                        // 0x411 cmovno
+        None,                                    // 0x412
+        None,                                    // 0x413
+        MOp_W_M8B_or_M4B,                        // 0x420 cmovb
+        MOp_W_M8B_or_M2B,                        // 0x421 cmovb
+        None,                                    // 0x422
+        None,                                    // 0x423
+        MOp_W_M8B_or_M4B,                        // 0x430 cmovae
+        MOp_W_M8B_or_M2B,                        // 0x431 cmovae
+        None,                                    // 0x432
+        None,                                    // 0x433
+        MOp_W_M8B_or_M4B,                        // 0x440 cmove
+        MOp_W_M8B_or_M2B,                        // 0x441 cmove
+        None,                                    // 0x442
+        None,                                    // 0x443
+        MOp_W_M8B_or_M4B,                        // 0x450 cmovne
+        MOp_W_M8B_or_M2B,                        // 0x451 cmovne
+        None,                                    // 0x452
+        None,                                    // 0x453
+        MOp_W_M8B_or_M4B,                        // 0x460 cmovbe
+        MOp_W_M8B_or_M2B,                        // 0x461 cmovbe
+        None,                                    // 0x462
+        None,                                    // 0x463
+        MOp_W_M8B_or_M4B,                        // 0x470 cmova
+        MOp_W_M8B_or_M2B,                        // 0x471 cmova
+        None,                                    // 0x472
+        None,                                    // 0x473
+        MOp_W_M8B_or_M4B,                        // 0x480 cmovs
+        MOp_W_M8B_or_M2B,                        // 0x481 cmovs
+        None,                                    // 0x482
+        None,                                    // 0x483
+        MOp_W_M8B_or_M4B,                        // 0x490 cmovns
+        MOp_W_M8B_or_M2B,                        // 0x491 cmovns
+        None,                                    // 0x492
+        None,                                    // 0x493
+        MOp_W_M8B_or_M4B,                        // 0x4a0 cmovp
+        MOp_W_M8B_or_M2B,                        // 0x4a1 cmovp
+        None,                                    // 0x4a2
+        None,                                    // 0x4a3
+        MOp_W_M8B_or_M4B,                        // 0x4b0 cmovnp
+        MOp_W_M8B_or_M2B,                        // 0x4b1 cmovnp
+        None,                                    // 0x4b2
+        None,                                    // 0x4b3
+        MOp_W_M8B_or_M4B,                        // 0x4c0 cmovl
+        MOp_W_M8B_or_M2B,                        // 0x4c1 cmovl
+        None,                                    // 0x4c2
+        None,                                    // 0x4c3
+        MOp_W_M8B_or_M4B,                        // 0x4d0 cmovge
+        MOp_W_M8B_or_M2B,                        // 0x4d1 cmovge
+        None,                                    // 0x4d2
+        None,                                    // 0x4d3
+        MOp_W_M8B_or_M4B,                        // 0x4e0 cmovle
+        MOp_W_M8B_or_M2B,                        // 0x4e1 cmovle
+        None,                                    // 0x4e2
+        None,                                    // 0x4e3
+        MOp_W_M8B_or_M4B,                        // 0x4f0 cmovg
+        MOp_W_M8B_or_M2B,                        // 0x4f1 cmovg
+        None,                                    // 0x4f2
+        None,                                    // 0x4f3
+        None,                                    // 0x500
+        None,                                    // 0x501
+        None,                                    // 0x502
+        None,                                    // 0x503
+        None,                                    // 0x510
+        None,                                    // 0x511
+        None,                                    // 0x512
+        None,                                    // 0x513
+        None,                                    // 0x520
+        None,                                    // 0x521
+        None,                                    // 0x522
+        None,                                    // 0x523
+        None,                                    // 0x530
+        None,                                    // 0x531
+        None,                                    // 0x532
+        None,                                    // 0x533
+        None,                                    // 0x540
+        None,                                    // 0x541
+        None,                                    // 0x542
+        None,                                    // 0x543
+        None,                                    // 0x550
+        None,                                    // 0x551
+        None,                                    // 0x552
+        None,                                    // 0x553
+        None,                                    // 0x560
+        None,                                    // 0x561
+        None,                                    // 0x562
+        None,                                    // 0x563
+        None,                                    // 0x570
+        None,                                    // 0x571
+        None,                                    // 0x572
+        None,                                    // 0x573
+        None,                                    // 0x580
+        None,                                    // 0x581
+        None,                                    // 0x582
+        None,                                    // 0x583
+        None,                                    // 0x590
+        None,                                    // 0x591
+        None,                                    // 0x592
+        None,                                    // 0x593
+        None,                                    // 0x5a0
+        None,                                    // 0x5a1
+        None,                                    // 0x5a2
+        None,                                    // 0x5a3
+        None,                                    // 0x5b0
+        None,                                    // 0x5b1
+        None,                                    // 0x5b2
+        None,                                    // 0x5b3
+        None,                                    // 0x5c0
+        None,                                    // 0x5c1
+        None,                                    // 0x5c2
+        None,                                    // 0x5c3
+        None,                                    // 0x5d0
+        None,                                    // 0x5d1
+        None,                                    // 0x5d2
+        None,                                    // 0x5d3
+        None,                                    // 0x5e0
+        None,                                    // 0x5e1
+        None,                                    // 0x5e2
+        None,                                    // 0x5e3
+        None,                                    // 0x5f0
+        None,                                    // 0x5f1
+        None,                                    // 0x5f2
+        None,                                    // 0x5f3
+        MOp_W_M8B_or_M4B,                        // 0x600 movbe
+        MOp_W_M8B_or_M2B,                        // 0x601 movbe
+        None,                                    // 0x602
+        None,                                    // 0x603
+        M1st_W_M8B_or_M4B,                       // 0x610 movbe
+        M1st_W_M8B_or_M2B,                       // 0x611 movbe
+        None,                                    // 0x612
+        None,                                    // 0x613
+        None,                                    // 0x620
+        None,                                    // 0x621
+        None,                                    // 0x622
+        None,                                    // 0x623
+        None,                                    // 0x630
+        None,                                    // 0x631
+        None,                                    // 0x632
+        None,                                    // 0x633
+        None,                                    // 0x640
+        None,                                    // 0x641
+        None,                                    // 0x642
+        None,                                    // 0x643
+        None,                                    // 0x650
+        M1st_MUnknown,                           // 0x651 wrussd,wrussq
+        None,                                    // 0x652
+        None,                                    // 0x653
+        M1st_MUnknown,                           // 0x660 wrssd,wrssq
+        MOp_W_M8B_or_M4B,                        // 0x661 adcx
+        MOp_W_M8B_or_M4B,                        // 0x662 adox
+        None,                                    // 0x663
+        None,                                    // 0x670
+        None,                                    // 0x671
+        None,                                    // 0x672
+        None,                                    // 0x673
+        None,                                    // 0x680
+        None,                                    // 0x681
+        None,                                    // 0x682
+        None,                                    // 0x683
+        None,                                    // 0x690
+        None,                                    // 0x691
+        None,                                    // 0x692
+        None,                                    // 0x693
+        None,                                    // 0x6a0
+        None,                                    // 0x6a1
+        None,                                    // 0x6a2
+        None,                                    // 0x6a3
+        None,                                    // 0x6b0
+        None,                                    // 0x6b1
+        None,                                    // 0x6b2
+        None,                                    // 0x6b3
+        None,                                    // 0x6c0
+        None,                                    // 0x6c1
+        None,                                    // 0x6c2
+        None,                                    // 0x6c3
+        None,                                    // 0x6d0
+        None,                                    // 0x6d1
+        None,                                    // 0x6d2
+        None,                                    // 0x6d3
+        None,                                    // 0x6e0
+        None,                                    // 0x6e1
+        None,                                    // 0x6e2
+        None,                                    // 0x6e3
+        None,                                    // 0x6f0
+        None,                                    // 0x6f1
+        None,                                    // 0x6f2
+        None,                                    // 0x6f3
+        None,                                    // 0x700
+        None,                                    // 0x701
+        None,                                    // 0x702
+        None,                                    // 0x703
+        None,                                    // 0x710
+        None,                                    // 0x711
+        None,                                    // 0x712
+        None,                                    // 0x713
+        None,                                    // 0x720
+        None,                                    // 0x721
+        None,                                    // 0x722
+        None,                                    // 0x723
+        None,                                    // 0x730
+        None,                                    // 0x731
+        None,                                    // 0x732
+        None,                                    // 0x733
+        None,                                    // 0x740
+        None,                                    // 0x741
+        None,                                    // 0x742
+        None,                                    // 0x743
+        None,                                    // 0x750
+        None,                                    // 0x751
+        None,                                    // 0x752
+        None,                                    // 0x753
+        None,                                    // 0x760
+        None,                                    // 0x761
+        None,                                    // 0x762
+        None,                                    // 0x763
+        None,                                    // 0x770
+        None,                                    // 0x771
+        None,                                    // 0x772
+        None,                                    // 0x773
+        None,                                    // 0x780
+        None,                                    // 0x781
+        None,                                    // 0x782
+        None,                                    // 0x783
+        None,                                    // 0x790
+        None,                                    // 0x791
+        None,                                    // 0x792
+        None,                                    // 0x793
+        None,                                    // 0x7a0
+        None,                                    // 0x7a1
+        None,                                    // 0x7a2
+        None,                                    // 0x7a3
+        None,                                    // 0x7b0
+        None,                                    // 0x7b1
+        None,                                    // 0x7b2
+        None,                                    // 0x7b3
+        None,                                    // 0x7c0
+        None,                                    // 0x7c1
+        None,                                    // 0x7c2
+        None,                                    // 0x7c3
+        None,                                    // 0x7d0
+        None,                                    // 0x7d1
+        None,                                    // 0x7d2
+        None,                                    // 0x7d3
+        None,                                    // 0x7e0
+        None,                                    // 0x7e1
+        None,                                    // 0x7e2
+        None,                                    // 0x7e3
+        None,                                    // 0x7f0
+        None,                                    // 0x7f1
+        None,                                    // 0x7f2
+        None,                                    // 0x7f3
+        M1st_M1B_I1B,                            // 0x800 adc,add,and,or,sbb,sub,xor
+        None,                                    // 0x801
+        None,                                    // 0x802
+        None,                                    // 0x803
+        M1st_I4B_W_M8B_or_M4B,                   // 0x810 adc,add,and,or,sbb,sub,xor
+        M1st_W_M8B_I4B_or_M2B_I2B,               // 0x811 adc,add,and,or,sbb,sub,xor
+        None,                                    // 0x812
+        None,                                    // 0x813
+        None,                                    // 0x820
+        None,                                    // 0x821
+        None,                                    // 0x822
+        None,                                    // 0x823
+        M1st_I1B_W_M8B_or_M4B,                   // 0x830 adc,add,and,or,sbb,sub,xor
+        M1st_I1B_W_M8B_or_M2B,                   // 0x831 adc,add,and,or,sbb,sub,xor
+        None,                                    // 0x832
+        None,                                    // 0x833
+        None,                                    // 0x840
+        None,                                    // 0x841
+        None,                                    // 0x842
+        None,                                    // 0x843
+        None,                                    // 0x850
+        None,                                    // 0x851
+        None,                                    // 0x852
+        None,                                    // 0x853
+        None,                                    // 0x860
+        None,                                    // 0x861
+        None,                                    // 0x862
+        None,                                    // 0x863
+        None,                                    // 0x870
+        None,                                    // 0x871
+        None,                                    // 0x872
+        None,                                    // 0x873
+        None,                                    // 0x880
+        None,                                    // 0x881
+        None,                                    // 0x882
+        None,                                    // 0x883
+        None,                                    // 0x890
+        None,                                    // 0x891
+        None,                                    // 0x892
+        None,                                    // 0x893
+        None,                                    // 0x8a0
+        None,                                    // 0x8a1
+        None,                                    // 0x8a2
+        None,                                    // 0x8a3
+        None,                                    // 0x8b0
+        None,                                    // 0x8b1
+        None,                                    // 0x8b2
+        None,                                    // 0x8b3
+        None,                                    // 0x8c0
+        None,                                    // 0x8c1
+        None,                                    // 0x8c2
+        None,                                    // 0x8c3
+        None,                                    // 0x8d0
+        None,                                    // 0x8d1
+        None,                                    // 0x8d2
+        None,                                    // 0x8d3
+        None,                                    // 0x8e0
+        None,                                    // 0x8e1
+        None,                                    // 0x8e2
+        None,                                    // 0x8e3
+        None,                                    // 0x8f0
+        None,                                    // 0x8f1
+        None,                                    // 0x8f2
+        None,                                    // 0x8f3
+        None,                                    // 0x900
+        None,                                    // 0x901
+        None,                                    // 0x902
+        None,                                    // 0x903
+        None,                                    // 0x910
+        None,                                    // 0x911
+        None,                                    // 0x912
+        None,                                    // 0x913
+        None,                                    // 0x920
+        None,                                    // 0x921
+        None,                                    // 0x922
+        None,                                    // 0x923
+        None,                                    // 0x930
+        None,                                    // 0x931
+        None,                                    // 0x932
+        None,                                    // 0x933
+        None,                                    // 0x940
+        None,                                    // 0x941
+        None,                                    // 0x942
+        None,                                    // 0x943
+        None,                                    // 0x950
+        None,                                    // 0x951
+        None,                                    // 0x952
+        None,                                    // 0x953
+        None,                                    // 0x960
+        None,                                    // 0x961
+        None,                                    // 0x962
+        None,                                    // 0x963
+        None,                                    // 0x970
+        None,                                    // 0x971
+        None,                                    // 0x972
+        None,                                    // 0x973
+        None,                                    // 0x980
+        None,                                    // 0x981
+        None,                                    // 0x982
+        None,                                    // 0x983
+        None,                                    // 0x990
+        None,                                    // 0x991
+        None,                                    // 0x992
+        None,                                    // 0x993
+        None,                                    // 0x9a0
+        None,                                    // 0x9a1
+        None,                                    // 0x9a2
+        None,                                    // 0x9a3
+        None,                                    // 0x9b0
+        None,                                    // 0x9b1
+        None,                                    // 0x9b2
+        None,                                    // 0x9b3
+        None,                                    // 0x9c0
+        None,                                    // 0x9c1
+        None,                                    // 0x9c2
+        None,                                    // 0x9c3
+        None,                                    // 0x9d0
+        None,                                    // 0x9d1
+        None,                                    // 0x9d2
+        None,                                    // 0x9d3
+        None,                                    // 0x9e0
+        None,                                    // 0x9e1
+        None,                                    // 0x9e2
+        None,                                    // 0x9e3
+        None,                                    // 0x9f0
+        None,                                    // 0x9f1
+        None,                                    // 0x9f2
+        None,                                    // 0x9f3
+        None,                                    // 0xa00
+        None,                                    // 0xa01
+        None,                                    // 0xa02
+        None,                                    // 0xa03
+        None,                                    // 0xa10
+        None,                                    // 0xa11
+        None,                                    // 0xa12
+        None,                                    // 0xa13
+        None,                                    // 0xa20
+        None,                                    // 0xa21
+        None,                                    // 0xa22
+        None,                                    // 0xa23
+        None,                                    // 0xa30
+        None,                                    // 0xa31
+        None,                                    // 0xa32
+        None,                                    // 0xa33
+        None,                                    // 0xa40
+        None,                                    // 0xa41
+        None,                                    // 0xa42
+        None,                                    // 0xa43
+        M1st_W_M8B_or_M4B,                       // 0xa50 shld
+        M1st_W_M8B_or_M2B,                       // 0xa51 shld
+        None,                                    // 0xa52
+        None,                                    // 0xa53
+        None,                                    // 0xa60
+        None,                                    // 0xa61
+        None,                                    // 0xa62
+        None,                                    // 0xa63
+        None,                                    // 0xa70
+        None,                                    // 0xa71
+        None,                                    // 0xa72
+        None,                                    // 0xa73
+        None,                                    // 0xa80
+        None,                                    // 0xa81
+        None,                                    // 0xa82
+        None,                                    // 0xa83
+        None,                                    // 0xa90
+        None,                                    // 0xa91
+        None,                                    // 0xa92
+        None,                                    // 0xa93
+        None,                                    // 0xaa0
+        None,                                    // 0xaa1
+        None,                                    // 0xaa2
+        None,                                    // 0xaa3
+        None,                                    // 0xab0
+        None,                                    // 0xab1
+        None,                                    // 0xab2
+        None,                                    // 0xab3
+        None,                                    // 0xac0
+        None,                                    // 0xac1
+        None,                                    // 0xac2
+        None,                                    // 0xac3
+        M1st_W_M8B_or_M4B,                       // 0xad0 shrd
+        M1st_W_M8B_or_M2B,                       // 0xad1 shrd
+        None,                                    // 0xad2
+        None,                                    // 0xad3
+        None,                                    // 0xae0
+        None,                                    // 0xae1
+        None,                                    // 0xae2
+        None,                                    // 0xae3
+        MOp_W_M8B_or_M4B,                        // 0xaf0 imul
+        MOp_W_M8B_or_M2B,                        // 0xaf1 imul
+        None,                                    // 0xaf2
+        None,                                    // 0xaf3
+        None,                                    // 0xb00
+        None,                                    // 0xb01
+        None,                                    // 0xb02
+        None,                                    // 0xb03
+        None,                                    // 0xb10
+        None,                                    // 0xb11
+        None,                                    // 0xb12
+        None,                                    // 0xb13
+        None,                                    // 0xb20
+        None,                                    // 0xb21
+        None,                                    // 0xb22
+        None,                                    // 0xb23
+        None,                                    // 0xb30
+        None,                                    // 0xb31
+        None,                                    // 0xb32
+        None,                                    // 0xb33
+        None,                                    // 0xb40
+        None,                                    // 0xb41
+        None,                                    // 0xb42
+        None,                                    // 0xb43
+        None,                                    // 0xb50
+        None,                                    // 0xb51
+        None,                                    // 0xb52
+        None,                                    // 0xb53
+        None,                                    // 0xb60
+        None,                                    // 0xb61
+        None,                                    // 0xb62
+        None,                                    // 0xb63
+        None,                                    // 0xb70
+        None,                                    // 0xb71
+        None,                                    // 0xb72
+        None,                                    // 0xb73
+        None,                                    // 0xb80
+        None,                                    // 0xb81
+        None,                                    // 0xb82
+        None,                                    // 0xb83
+        None,                                    // 0xb90
+        None,                                    // 0xb91
+        None,                                    // 0xb92
+        None,                                    // 0xb93
+        None,                                    // 0xba0
+        None,                                    // 0xba1
+        None,                                    // 0xba2
+        None,                                    // 0xba3
+        None,                                    // 0xbb0
+        None,                                    // 0xbb1
+        None,                                    // 0xbb2
+        None,                                    // 0xbb3
+        None,                                    // 0xbc0
+        None,                                    // 0xbc1
+        None,                                    // 0xbc2
+        None,                                    // 0xbc3
+        None,                                    // 0xbd0
+        None,                                    // 0xbd1
+        None,                                    // 0xbd2
+        None,                                    // 0xbd3
+        None,                                    // 0xbe0
+        None,                                    // 0xbe1
+        None,                                    // 0xbe2
+        None,                                    // 0xbe3
+        None,                                    // 0xbf0
+        None,                                    // 0xbf1
+        None,                                    // 0xbf2
+        None,                                    // 0xbf3
+        M1st_M1B_I1B,                            // 0xc00 rcl,rcr,rol,ror,sar,shl,shr
+        None,                                    // 0xc01
+        None,                                    // 0xc02
+        None,                                    // 0xc03
+        M1st_I1B_W_M8B_or_M4B,                   // 0xc10 rcl,rcr,rol,ror,sar,shl,shr
+        M1st_I1B_W_M8B_or_M2B,                   // 0xc11 rcl,rcr,rol,ror,sar,shl,shr
+        None,                                    // 0xc12
+        None,                                    // 0xc13
+        None,                                    // 0xc20
+        None,                                    // 0xc21
+        None,                                    // 0xc22
+        None,                                    // 0xc23
+        None,                                    // 0xc30
+        None,                                    // 0xc31
+        None,                                    // 0xc32
+        None,                                    // 0xc33
+        None,                                    // 0xc40
+        None,                                    // 0xc41
+        None,                                    // 0xc42
+        None,                                    // 0xc43
+        None,                                    // 0xc50
+        None,                                    // 0xc51
+        None,                                    // 0xc52
+        None,                                    // 0xc53
+        None,                                    // 0xc60
+        None,                                    // 0xc61
+        None,                                    // 0xc62
+        None,                                    // 0xc63
+        None,                                    // 0xc70
+        None,                                    // 0xc71
+        None,                                    // 0xc72
+        None,                                    // 0xc73
+        None,                                    // 0xc80
+        None,                                    // 0xc81
+        None,                                    // 0xc82
+        None,                                    // 0xc83
+        None,                                    // 0xc90
+        None,                                    // 0xc91
+        None,                                    // 0xc92
+        None,                                    // 0xc93
+        None,                                    // 0xca0
+        None,                                    // 0xca1
+        None,                                    // 0xca2
+        None,                                    // 0xca3
+        None,                                    // 0xcb0
+        None,                                    // 0xcb1
+        None,                                    // 0xcb2
+        None,                                    // 0xcb3
+        None,                                    // 0xcc0
+        None,                                    // 0xcc1
+        None,                                    // 0xcc2
+        None,                                    // 0xcc3
+        None,                                    // 0xcd0
+        None,                                    // 0xcd1
+        None,                                    // 0xcd2
+        None,                                    // 0xcd3
+        None,                                    // 0xce0
+        None,                                    // 0xce1
+        None,                                    // 0xce2
+        None,                                    // 0xce3
+        None,                                    // 0xcf0
+        None,                                    // 0xcf1
+        None,                                    // 0xcf2
+        None,                                    // 0xcf3
+        M1st_M1B,                                // 0xd00 rcl,rcr,rol,ror,sar,shl,shr
+        None,                                    // 0xd01
+        None,                                    // 0xd02
+        None,                                    // 0xd03
+        M1st_W_M8B_or_M4B,                       // 0xd10 rcl,rcr,rol,ror,sar,shl,shr
+        M1st_W_M8B_or_M2B,                       // 0xd11 rcl,rcr,rol,ror,sar,shl,shr
+        None,                                    // 0xd12
+        None,                                    // 0xd13
+        M1st_M1B,                                // 0xd20 rcl,rcr,rol,ror,sar,shl,shr
+        None,                                    // 0xd21
+        None,                                    // 0xd22
+        None,                                    // 0xd23
+        M1st_W_M8B_or_M4B,                       // 0xd30 rcl,rcr,rol,ror,sar,shl,shr
+        M1st_W_M8B_or_M2B,                       // 0xd31 rcl,rcr,rol,ror,sar,shl,shr
+        None,                                    // 0xd32
+        None,                                    // 0xd33
+        MOp_M16B_I1B,                            // 0xd40 sha1rnds4
+        None,                                    // 0xd41
+        None,                                    // 0xd42
+        None,                                    // 0xd43
+        None,                                    // 0xd50
+        None,                                    // 0xd51
+        None,                                    // 0xd52
+        None,                                    // 0xd53
+        None,                                    // 0xd60
+        None,                                    // 0xd61
+        None,                                    // 0xd62
+        None,                                    // 0xd63
+        None,                                    // 0xd70
+        None,                                    // 0xd71
+        None,                                    // 0xd72
+        None,                                    // 0xd73
+        MOp_M16B,                                // 0xd80 sha1nexte
+        None,                                    // 0xd81
+        MOnly_MUnknown,                          // 0xd82 aesdecwide128kl,aesdecwide256kl,aesencwide128kl,aesencwide256kl
+        None,                                    // 0xd83
+        MOp_M16B,                                // 0xd90 sha1msg1
+        None,                                    // 0xd91
+        None,                                    // 0xd92
+        None,                                    // 0xd93
+        MOp_M16B,                                // 0xda0 sha1msg2
+        None,                                    // 0xda1
+        None,                                    // 0xda2
+        None,                                    // 0xda3
+        MOp_M16B,                                // 0xdb0 sha256rnds2
+        None,                                    // 0xdb1
+        None,                                    // 0xdb2
+        None,                                    // 0xdb3
+        MOp_M16B,                                // 0xdc0 sha256msg1
+        None,                                    // 0xdc1
+        MOp_MUnknown,                            // 0xdc2 aesenc128kl
+        None,                                    // 0xdc3
+        MOp_M16B,                                // 0xdd0 sha256msg2
+        None,                                    // 0xdd1
+        MOp_MUnknown,                            // 0xdd2 aesdec128kl
+        None,                                    // 0xdd3
+        None,                                    // 0xde0
+        None,                                    // 0xde1
+        MOp_MUnknown,                            // 0xde2 aesenc256kl
+        None,                                    // 0xde3
+        None,                                    // 0xdf0
+        None,                                    // 0xdf1
+        MOp_MUnknown,                            // 0xdf2 aesdec256kl
+        None,                                    // 0xdf3
+        None,                                    // 0xe00
+        None,                                    // 0xe01
+        None,                                    // 0xe02
+        None,                                    // 0xe03
+        None,                                    // 0xe10
+        None,                                    // 0xe11
+        None,                                    // 0xe12
+        None,                                    // 0xe13
+        None,                                    // 0xe20
+        None,                                    // 0xe21
+        None,                                    // 0xe22
+        None,                                    // 0xe23
+        None,                                    // 0xe30
+        None,                                    // 0xe31
+        None,                                    // 0xe32
+        None,                                    // 0xe33
+        None,                                    // 0xe40
+        None,                                    // 0xe41
+        None,                                    // 0xe42
+        None,                                    // 0xe43
+        None,                                    // 0xe50
+        None,                                    // 0xe51
+        None,                                    // 0xe52
+        None,                                    // 0xe53
+        None,                                    // 0xe60
+        None,                                    // 0xe61
+        None,                                    // 0xe62
+        None,                                    // 0xe63
+        None,                                    // 0xe70
+        None,                                    // 0xe71
+        None,                                    // 0xe72
+        None,                                    // 0xe73
+        None,                                    // 0xe80
+        None,                                    // 0xe81
+        None,                                    // 0xe82
+        None,                                    // 0xe83
+        None,                                    // 0xe90
+        None,                                    // 0xe91
+        None,                                    // 0xe92
+        None,                                    // 0xe93
+        None,                                    // 0xea0
+        None,                                    // 0xea1
+        None,                                    // 0xea2
+        None,                                    // 0xea3
+        None,                                    // 0xeb0
+        None,                                    // 0xeb1
+        None,                                    // 0xeb2
+        None,                                    // 0xeb3
+        None,                                    // 0xec0
+        None,                                    // 0xec1
+        None,                                    // 0xec2
+        None,                                    // 0xec3
+        None,                                    // 0xed0
+        None,                                    // 0xed1
+        None,                                    // 0xed2
+        None,                                    // 0xed3
+        None,                                    // 0xee0
+        None,                                    // 0xee1
+        None,                                    // 0xee2
+        None,                                    // 0xee3
+        None,                                    // 0xef0
+        None,                                    // 0xef1
+        None,                                    // 0xef2
+        None,                                    // 0xef3
+        MOp_M1B,                                 // 0xf00 crc32
+        None,                                    // 0xf01
+        MOp_M16B,                                // 0xf02 invept
+        None,                                    // 0xf03
+        MOp_W_M8B_or_M4B,                        // 0xf10 crc32
+        MOp_W_M8B_or_M2B,                        // 0xf11 crc32
+        MOp_M16B,                                // 0xf12 invvpid
+        None,                                    // 0xf13
+        None,                                    // 0xf20
+        None,                                    // 0xf21
+        MOp_MUnknown,                            // 0xf22 invpcid
+        None,                                    // 0xf23
+        None,                                    // 0xf30
+        None,                                    // 0xf31
+        None,                                    // 0xf32
+        None,                                    // 0xf33
+        None,                                    // 0xf40
+        None,                                    // 0xf41
+        None,                                    // 0xf42
+        None,                                    // 0xf43
+        None,                                    // 0xf50
+        None,                                    // 0xf51
+        None,                                    // 0xf52
+        None,                                    // 0xf53
+        MOnly_M1B,                               // 0xf60 neg,not
+        None,                                    // 0xf61
+        None,                                    // 0xf62
+        None,                                    // 0xf63
+        MOnly_W_M8B_or_M4B,                      // 0xf70 neg,not
+        MOnly_W_M8B_or_M2B,                      // 0xf71 neg,not
+        None,                                    // 0xf72
+        None,                                    // 0xf73
+        None,                                    // 0xf80
+        MOp_MUnknown,                            // 0xf81 movdir64b
+        MOp_MUnknown,                            // 0xf82 enqcmds
+        MOp_MUnknown,                            // 0xf83 enqcmd
+        M1st_W_M8B_or_M4B,                       // 0xf90 movdiri
+        None,                                    // 0xf91
+        None,                                    // 0xf92
+        None,                                    // 0xf93
+        None,                                    // 0xfa0
+        None,                                    // 0xfa1
+        None,                                    // 0xfa2
+        None,                                    // 0xfa3
+        None,                                    // 0xfb0
+        None,                                    // 0xfb1
+        None,                                    // 0xfb2
+        None,                                    // 0xfb3
+        M1st_W_M8B_or_M4B,                       // 0xfc0 aadd
+        M1st_W_M8B_or_M4B,                       // 0xfc1 aand
+        M1st_W_M8B_or_M4B,                       // 0xfc2 axor
+        M1st_W_M8B_or_M4B,                       // 0xfc3 aor
+        None,                                    // 0xfd0
+        None,                                    // 0xfd1
+        None,                                    // 0xfd2
+        None,                                    // 0xfd3
+        MOnly_M1B,                               // 0xfe0 dec,inc
+        None,                                    // 0xfe1
+        None,                                    // 0xfe2
+        None,                                    // 0xfe3
+        MOnly_W_M8B_or_M4B,                      // 0xff0 dec,inc
         None,                                    // 0xff1
         None,                                    // 0xff2
         None,                                    // 0xff3


### PR DESCRIPTION
Teach the amd64 breakpoint disassembler about APX, specifically the REX2 and extended EVEX encodings.

Update the tools to work with newer versions of gcc/gdb, such as handling new gdb output format in the parsing regular expressions.

Due to these newer versions, there are differences in the non-APX tables, apparently due to gcc/gdb bug fixes and improvements (e.g., supporting instructions previously unsupported).

Note that the APX code is untested due to lack of APX hardware. Also, the Windows SDK CONTEXT record does not define APX extended GPR (eGPR) registers yet, so accessing those registers is disabled.

The tables were generated using the following versions of gcc/gdb on Ubuntu 24.04.2 LTS, in WSL2:
```
gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
GNU gdb (Ubuntu 15.0.50.20240403-0ubuntu1) 15.0.50.20240403-git
```

Details:
1. Change the "createOpcodes.cpp" tool to generate more varieties of possible instructions, to include encoding forms for REX2 and extended EVEX.
2. Change createOpcodes to always generate 16 bytes of codes. Previously, the parser looked for a "58" followed by "59 pop" to indicate the end of an instruction sequence. This failed in various cases. Note that the longest legal x86 instruction sequence is 15 bytes, as defined by the architecture.
3. Update the parser and table generation tool (Amd64InstructionTableGenerator.cs) to be able to parse REX2 and extended EVEX instructions, and generate a new EVEX table for EVEX map 4.
4. The parser was updated to handle new gdb disassembly formats, such as different whitespace usage (spaces versus tabs), and using the "BCST" tag to indicate EVEX embedded broadcast.
5. The native walker was updated to understand the new tables, including when to use them (thus, it needs to recognize REX2 and extended EVEX formats).
6. Fixed bugs in existing AVX-512 (EVEX) handling of `b`, `L'L`, and `pp` bits: they were being read from the wrong prefix byte.
7. There seem to be a couple existing bugs in `NativeWalker::Decode` which I annotated but did not feel confident fixing: a. the loop to read and process instruction prefixes only reads a single prefix. Thus, a case like 0x66 (operand size) followed by 0x40 (REX) improperly assumes the REX byte is the instruction opcode. b. if the instruction opcode (after the prefix) is 0xcc, `DebuggerController::GetPatchedOpcode()` is called to read the actual opcode, but it uses the wrong address to do so.

Contributes to #112588