### PR TITLE
Fill out more SuperPMI cases for LoongArch64 and RISCV64

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10793,7 +10793,15 @@ public:
     {
         return info.compMethodSuperPMIIndex != -1;
     }
-#endif // DEBUG
+#else  // !DEBUG
+    // Are we running a replay under SuperPMI?
+    // Note: you can certainly run a SuperPMI replay with a non-DEBUG JIT, and if necessary and useful we could
+    // make compMethodSuperPMIIndex always available.
+    bool RunningSuperPmiReplay() const
+    {
+        return false;
+    }
+#endif // !DEBUG
 
     ReturnTypeDesc compRetTypeDesc; // ABI return type descriptor for the method
 

--- a/src/coreclr/jit/disasm.cpp
+++ b/src/coreclr/jit/disasm.cpp
@@ -1704,6 +1704,10 @@ bool DisAssembler::InitCoredistoolsDisasm()
     coreDisTargetArchitecture = Target_X86;
 #elif defined(TARGET_AMD64)
     coreDisTargetArchitecture = Target_X64;
+#elif defined(TARGET_LOONGARCH64)
+    coreDisTargetArchitecture = Target_LoongArch64;
+#elif 0 && defined(TARGET_RISCV64) // TODO-RISCV64: enable this when coredistools is updated
+    coreDisTargetArchitecture = Target_RiscV64;
 #else
 #error Unsupported target for LATE_DISASM with USE_COREDISTOOLS
 #endif

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -219,10 +219,12 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         // <NICE> Factor this into getCallInfo </NICE>
         bool isSpecialIntrinsic = false;
 
-        if (isIntrinsic || !info.compMatchedVM)
+        if (isIntrinsic || (!info.compMatchedVM && !RunningSuperPmiReplay()))
         {
             // For mismatched VM (AltJit) we want to check all methods as intrinsic to ensure
-            // we get more accurate codegen. This particularly applies to HWIntrinsic usage
+            // we get more accurate codegen. This particularly applies to HWIntrinsic usage.
+            // But don't do this under SuperPMI replay, because it's unlikely we'll have
+            // the right data in the MethodContext in that case.
 
             const bool isTailCall = canTailCall && (tailCallFlags != 0);
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -145,13 +145,13 @@ to get that version. Otherwise, use "unknown-jit-ee-version".
 
 host_os_help = "OS (windows, osx, linux). Default: current OS."
 
-arch_help = "Architecture (x64, x86, arm, arm64). Default: current architecture."
+arch_help = "Architecture (x64, x86, arm, arm64, loongarch64, riscv64). Default: current architecture."
 
 target_os_help = "Target OS, for use with cross-compilation JIT (windows, osx, linux). Default: current OS."
 
-target_arch_help = "Target architecture, for use with cross-compilation JIT (x64, x86, arm, arm64). Passed as asm diffs target to SuperPMI. Default: current architecture."
+target_arch_help = "Target architecture, for use with cross-compilation JIT (x64, x86, arm, arm64, loongarch64, riscv64). Passed as asm diffs target to SuperPMI. Default: current architecture."
 
-mch_arch_help = "Architecture of MCH files to download, used for cross-compilation altjit (x64, x86, arm, arm64). Default: target architecture."
+mch_arch_help = "Architecture of MCH files to download, used for cross-compilation altjit (x64, x86, arm, arm64, loongarch64, riscv64). Default: target architecture."
 
 build_type_help = "Build type (Debug, Checked, Release). Default: Checked."
 
@@ -4628,6 +4628,15 @@ def setup_args(args):
                             lambda mch_arch: check_mch_arch(coreclr_args, mch_arch),
                             lambda mch_arch: "Unknown mch_arch {}\nSupported architectures: {}".format(mch_arch, (", ".join(coreclr_args.valid_arches))),
                             modify_arg=lambda mch_arch: mch_arch if mch_arch is not None else coreclr_args.target_arch) # Default to `target_arch`
+
+        # For LoongArch64, RiscV64, assume we are doing altjit cross-compilation and set mch_arch to 'arch', and target_os to Linux.
+        if coreclr_args.target_arch == "loongarch64" or coreclr_args.target_arch == "riscv64":
+            if coreclr_args.target_os == coreclr_args.host_os and coreclr_args.target_os != "linux":
+                logging.warning("Overriding 'target_os' to 'linux'")
+                coreclr_args.target_os = "linux"
+            if coreclr_args.mch_arch == coreclr_args.target_arch and coreclr_args.mch_arch != coreclr_args.arch:
+                logging.warning("Overriding 'mch_arch' to '%s'", coreclr_args.arch)
+                coreclr_args.mch_arch = coreclr_args.arch
 
     def verify_superpmi_common_args():
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
@@ -911,11 +911,6 @@ void CompileResult::applyRelocs(RelocContext* rc, unsigned char* block1, ULONG b
             }
         }
 
-        if (targetArch == SPMI_TARGET_ARCHITECTURE_LOONGARCH64)
-        {
-            Assert(!"FIXME: Not Implements on loongarch64");
-        }
-
         if (IsSpmiTarget64Bit())
         {
             if (!wasRelocHandled && (relocType == IMAGE_REL_BASED_DIR64))

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.h
@@ -63,12 +63,16 @@ void SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE spmiTargetArchitecture);
 
 inline bool IsSpmiTarget32Bit()
 {
-    return (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_X86) || (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM);
+    return (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_X86) ||
+           (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM);
 }
 
 inline bool IsSpmiTarget64Bit()
 {
-    return (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_AMD64) || (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM64) || (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_LOONGARCH64) || (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_RISCV64);
+    return (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_AMD64) ||
+           (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_ARM64) ||
+           (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_LOONGARCH64) ||
+           (GetSpmiTargetArchitecture() == SPMI_TARGET_ARCHITECTURE_RISCV64);
 }
 
 inline size_t SpmiTargetPointerSize()

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -127,8 +127,10 @@ void CommandLine::DumpHelp(const char* program)
     printf("     trying to measure JIT throughput for a specific set of methods. Default=1.\n");
     printf("\n");
     printf(" -target <target>\n");
-    printf("     Used by the assembly differences calculator. This specifies the target\n");
-    printf("     architecture for cross-compilation. Currently allowed <target> values: x64, x86, arm, arm64\n");
+    printf("     Specifies the target architecture if doing cross-compilation.\n");
+    printf("     Allowed <target> values: x64, x86, arm, arm64, loongarch64, riscv64\n");
+    printf("     Used by the assembly differences calculator; to determine a default JIT dll name;\n");
+    printf("     and to avoid treating mismatched cross-compilation replay as failure.\n");
     printf("\n");
     printf(" -coredistools\n");
     printf("     Use disassembly tools from the CoreDisTools library\n");
@@ -685,9 +687,11 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
             (0 != _stricmp(o->targetArchitecture, "x86")) &&
             (0 != _stricmp(o->targetArchitecture, "arm64")) &&
             (0 != _stricmp(o->targetArchitecture, "arm")) &&
-            (0 != _stricmp(o->targetArchitecture, "arm32")))
+            (0 != _stricmp(o->targetArchitecture, "arm32")) &&
+            (0 != _stricmp(o->targetArchitecture, "loongarch64")) &&
+            (0 != _stricmp(o->targetArchitecture, "riscv64")))
         {
-            LogError("Illegal target architecture specified with -target (use 'x64', 'x86', 'arm64', or 'arm').");
+            LogError("Illegal target architecture specified with -target.");
             DumpHelp(argv[0]);
             return false;
         }
@@ -753,6 +757,10 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
         hostArch = "arm";
 #elif defined(HOST_ARM64)
         hostArch = "arm64";
+#elif defined(HOST_LOONGARCH64)
+        hostArch = "loongarch64";
+#elif defined(HOST_RISCV64)
+        hostArch = "riscv64";
 #else
         allowDefaultJIT = false;
 #endif
@@ -772,6 +780,12 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                 break;
             case SPMI_TARGET_ARCHITECTURE_ARM64:
                 targetArch = "arm64";
+                break;
+            case SPMI_TARGET_ARCHITECTURE_LOONGARCH64:
+                targetArch = "loongarch64";
+                break;
+            case SPMI_TARGET_ARCHITECTURE_RISCV64:
+                targetArch = "riscv64";
                 break;
             default:
                 allowDefaultJIT = false;
@@ -809,6 +823,10 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                     case SPMI_TARGET_ARCHITECTURE_ARM:
                     case SPMI_TARGET_ARCHITECTURE_ARM64:
                         jitOSName = "universal";
+                        break;
+                    case SPMI_TARGET_ARCHITECTURE_LOONGARCH64:
+                    case SPMI_TARGET_ARCHITECTURE_RISCV64:
+                        jitOSName = "unix";
                         break;
                     default:
                         // Can't get here if `allowDefaultJIT` was properly set above.

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -297,6 +297,14 @@ ReplayResults JitInstance::CompileMethod(MethodContext* MethodToCompile, int mcI
                     matchesTargetArch = (targetArch == SPMI_TARGET_ARCHITECTURE_ARM64);
                     break;
 
+                case IMAGE_FILE_MACHINE_LOONGARCH64:
+                    matchesTargetArch = (targetArch == SPMI_TARGET_ARCHITECTURE_LOONGARCH64);
+                    break;
+
+                case IMAGE_FILE_MACHINE_RISCV64:
+                    matchesTargetArch = (targetArch == SPMI_TARGET_ARCHITECTURE_RISCV64);
+                    break;
+
                 default:
                     LogError("Unknown target architecture");
                     break;

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -149,6 +149,16 @@ bool NearDiffer::InitAsmDiff()
             {
                 coreDisTargetArchitecture = Target_Arm64;
             }
+            else if (0 == _stricmp(TargetArchitecture, "loongarch64"))
+            {
+                coreDisTargetArchitecture = Target_LoongArch64;
+            }
+#if 0 // TODO-RISCV64: enable this when coredistools is updated with one that supports RISC-V
+            else if (0 == _stricmp(TargetArchitecture, "riscv64"))
+            {
+                coreDisTargetArchitecture = Target_RiscV64;
+            }
+#endif // 0
             else
             {
                 LogError("Illegal target architecture '%s'", TargetArchitecture);

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -58,6 +58,10 @@ void SetSuperPmiTargetArchitecture(const char* targetArchitecture)
         {
             SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE_LOONGARCH64);
         }
+        else if (0 == _stricmp(targetArchitecture, "riscv64"))
+        {
+            SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE_RISCV64);
+        }
         else
         {
             LogError("Illegal target architecture '%s'", targetArchitecture);


### PR DESCRIPTION
With these changes, SuperPMI can be used with a LoongArch64 or RISCV64 cross-targeting altjit and x64 MCH files to generate and view some code. There are lots of "missing data" cases; for RISCV64 about half of x64 contexts replay successfully.

More work is required for asmdiffs to work, such as updating coredistools and implementing Loongarch64/RISCV64 relocation handling.