### PR TITLE
Generating Debug Info for interpreted bytecode

### DIFF
--- a/src/coreclr/inc/cordebuginfo.h
+++ b/src/coreclr/inc/cordebuginfo.h
@@ -226,6 +226,7 @@ public:
         REGNUM_FP = REGNUM_EBP,
         REGNUM_SP = REGNUM_ESP,
 #elif TARGET_AMD64
+        REGNUM_FP = REGNUM_RBP,
         REGNUM_SP = REGNUM_RSP,
 #elif TARGET_ARM
         REGNUM_FP = REGNUM_R11,

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -761,7 +761,11 @@ void InterpCompiler::EmitCode()
 
     // These will eventually be freed by the VM, and they use the delete [] operator for the deletion.
     m_pILToNativeMap = new ICorDebugInfo::OffsetMapping[m_ILCodeSize];
-    ICorDebugInfo::NativeVarInfo* eeVars = new ICorDebugInfo::NativeVarInfo[m_numILVars];
+    ICorDebugInfo::NativeVarInfo* eeVars = NULL;
+    if (m_numILVars > 0)
+    {
+        eeVars = new ICorDebugInfo::NativeVarInfo[m_numILVars];
+    }
 
     int32_t *ip = m_pMethodCode;
     for (InterpBasicBlock *bb = m_pEntryBB; bb != NULL; bb = bb->pNextBB)
@@ -794,7 +798,10 @@ void InterpCompiler::EmitCode()
         j++;
     }
 
-    m_compHnd->setVars(m_methodInfo->ftn, m_numILVars, eeVars);
+    if (m_numILVars > 0)
+    {
+        m_compHnd->setVars(m_methodInfo->ftn, m_numILVars, eeVars);
+    }
     m_compHnd->setBoundaries(m_methodInfo->ftn, m_ILToNativeMapSize, m_pILToNativeMap);
 }
 
@@ -1787,6 +1794,7 @@ int InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
 
     if ((methodInfo->options & CORINFO_OPT_INIT_LOCALS) && m_ILLocalsSize > 0)
     {
+        m_currentILOffset = 0;
         AddIns(INTOP_INITLOCALS);
         m_pLastNewIns->data[0] = m_ILLocalsOffset;
         m_pLastNewIns->data[1] = m_ILLocalsSize;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -110,7 +110,7 @@ InterpInst* InterpCompiler::NewIns(int opcode, int dataLen)
     memset(ins, 0, insSize);
     ins->opcode = opcode;
     ins->ilOffset = m_currentILOffset;
-    m_pLastIns = ins;
+    m_pLastNewIns = ins;
     return ins;
 }
 
@@ -408,13 +408,13 @@ void InterpCompiler::EmitBBEndVarMoves(InterpBasicBlock *pTargetBB)
             int32_t movOp = InterpGetMovForType(interpType, false);
 
             AddIns(movOp);
-            m_pLastIns->SetSVar(m_pStackPointer[i].var);
-            m_pLastIns->SetDVar(pTargetBB->pStackState[i].var);
+            m_pLastNewIns->SetSVar(m_pStackPointer[i].var);
+            m_pLastNewIns->SetDVar(pTargetBB->pStackState[i].var);
 
             if (interpType == InterpTypeVT)
             {
                 assert(m_pVars[sVar].size == m_pVars[dVar].size);
-                m_pLastIns->data[0] = m_pVars[sVar].size;
+                m_pLastNewIns->data[0] = m_pVars[sVar].size;
             }
         }
     }
@@ -1162,7 +1162,7 @@ void InterpCompiler::EmitBranch(InterpOpcode opcode, int32_t ilOffset)
     InitBBStackState(pTargetBB);
 
     AddIns(opcode);
-    m_pLastIns->info.pTargetBB = pTargetBB;
+    m_pLastNewIns->info.pTargetBB = pTargetBB;
 }
 
 void InterpCompiler::EmitOneArgBranch(InterpOpcode opcode, int32_t ilOffset, int insSize)
@@ -1175,7 +1175,7 @@ void InterpCompiler::EmitOneArgBranch(InterpOpcode opcode, int32_t ilOffset, int
     if (ilOffset)
     {
         EmitBranch(opcodeArgType, ilOffset + insSize);
-        m_pLastIns->SetSVar(m_pStackPointer[0].var);
+        m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
     }
     else
     {
@@ -1193,21 +1193,21 @@ void InterpCompiler::EmitTwoArgBranch(InterpOpcode opcode, int32_t ilOffset, int
     // emitting the conditional branch
     if (argType1 == StackTypeI4 && argType2 == StackTypeI8)
     {
-        EmitConv(m_pStackPointer - 1, m_pLastIns, StackTypeI8, INTOP_CONV_I8_I4);
+        EmitConv(m_pStackPointer - 1, m_pLastNewIns, StackTypeI8, INTOP_CONV_I8_I4);
         argType1 = StackTypeI8;
     }
     else if (argType1 == StackTypeI8 && argType2 == StackTypeI4)
     {
-        EmitConv(m_pStackPointer - 2, m_pLastIns, StackTypeI8, INTOP_CONV_I8_I4);
+        EmitConv(m_pStackPointer - 2, m_pLastNewIns, StackTypeI8, INTOP_CONV_I8_I4);
     }
     else if (argType1 == StackTypeR4 && argType2 == StackTypeR8)
     {
-        EmitConv(m_pStackPointer - 1, m_pLastIns, StackTypeR8, INTOP_CONV_R8_R4);
+        EmitConv(m_pStackPointer - 1, m_pLastNewIns, StackTypeR8, INTOP_CONV_R8_R4);
         argType1 = StackTypeR8;
     }
     else if (argType1 == StackTypeR8 && argType2 == StackTypeR4)
     {
-        EmitConv(m_pStackPointer - 2, m_pLastIns, StackTypeR8, INTOP_CONV_R8_R4);
+        EmitConv(m_pStackPointer - 2, m_pLastNewIns, StackTypeR8, INTOP_CONV_R8_R4);
     }
     else if (argType1 != argType2)
     {
@@ -1222,7 +1222,7 @@ void InterpCompiler::EmitTwoArgBranch(InterpOpcode opcode, int32_t ilOffset, int
     if (ilOffset)
     {
         EmitBranch(opcodeArgType, ilOffset + insSize);
-        m_pLastIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
+        m_pLastNewIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
     }
     else
     {
@@ -1243,10 +1243,10 @@ void InterpCompiler::EmitLoadVar(int32_t var)
         PushInterpType(interpType, clsHnd);
 
     AddIns(InterpGetMovForType(interpType, true));
-    m_pLastIns->SetSVar(var);
-    m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+    m_pLastNewIns->SetSVar(var);
+    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
     if (interpType == InterpTypeVT)
-        m_pLastIns->data[0] = size;
+        m_pLastNewIns->data[0] = size;
 }
 
 void InterpCompiler::EmitStoreVar(int32_t var)
@@ -1266,10 +1266,10 @@ void InterpCompiler::EmitStoreVar(int32_t var)
 
     m_pStackPointer--;
     AddIns(InterpGetMovForType(interpType, false));
-    m_pLastIns->SetSVar(m_pStackPointer[0].var);
-    m_pLastIns->SetDVar(var);
+    m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
+    m_pLastNewIns->SetDVar(var);
     if (interpType == InterpTypeVT)
-        m_pLastIns->data[0] = m_pVars[var].size;
+        m_pLastNewIns->data[0] = m_pVars[var].size;
 }
 
 void InterpCompiler::EmitBinaryArithmeticOp(int32_t opBase)
@@ -1384,9 +1384,9 @@ void InterpCompiler::EmitBinaryArithmeticOp(int32_t opBase)
 
     m_pStackPointer -= 2;
     AddIns(finalOpcode);
-    m_pLastIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
+    m_pLastNewIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
     PushStackType(typeRes, NULL);
-    m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
 }
 
 void InterpCompiler::EmitUnaryArithmeticOp(int32_t opBase)
@@ -1402,9 +1402,9 @@ void InterpCompiler::EmitUnaryArithmeticOp(int32_t opBase)
 
     m_pStackPointer--;
     AddIns(finalOpcode);
-    m_pLastIns->SetSVar(m_pStackPointer[0].var);
+    m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
     PushStackType(stackType, NULL);
-    m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
 }
 
 void InterpCompiler::EmitShiftOp(int32_t opBase)
@@ -1421,9 +1421,9 @@ void InterpCompiler::EmitShiftOp(int32_t opBase)
 
     m_pStackPointer -= 2;
     AddIns(finalOpcode);
-    m_pLastIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
+    m_pLastNewIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
     PushStackType(stackType, NULL);
-    m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
 }
 
 void InterpCompiler::EmitCompareOp(int32_t opBase)
@@ -1442,9 +1442,9 @@ void InterpCompiler::EmitCompareOp(int32_t opBase)
         AddIns(opBase + m_pStackPointer[-1].type - StackTypeI4);
     }
     m_pStackPointer -= 2;
-    m_pLastIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
+    m_pLastNewIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
     PushStackType(StackTypeI4, NULL);
-    m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
 }
 
 int32_t InterpCompiler::GetDataItemIndex(void *data)
@@ -1571,13 +1571,13 @@ void InterpCompiler::EmitCall(CORINFO_CLASS_HANDLE constrainedClass, bool readon
 
     // Emit call instruction
     AddIns(INTOP_CALL);
-    m_pLastIns->SetDVar(dVar);
-    m_pLastIns->SetSVar(CALL_ARGS_SVAR);
-    m_pLastIns->data[0] = GetMethodDataItemIndex(targetMethod);
+    m_pLastNewIns->SetDVar(dVar);
+    m_pLastNewIns->SetSVar(CALL_ARGS_SVAR);
+    m_pLastNewIns->data[0] = GetMethodDataItemIndex(targetMethod);
 
-    m_pLastIns->flags |= INTERP_INST_FLAG_CALL;
-    m_pLastIns->info.pCallInfo = (InterpCallInfo*)AllocMemPool0(sizeof (InterpCallInfo));
-    m_pLastIns->info.pCallInfo->pCallArgs = callArgs;
+    m_pLastNewIns->flags |= INTERP_INST_FLAG_CALL;
+    m_pLastNewIns->info.pCallInfo = (InterpCallInfo*)AllocMemPool0(sizeof (InterpCallInfo));
+    m_pLastNewIns->info.pCallInfo->pCallArgs = callArgs;
 
     m_ip += 5;
 }
@@ -1628,19 +1628,19 @@ void InterpCompiler::EmitLdind(InterpType interpType, CORINFO_CLASS_HANDLE clsHn
     m_pStackPointer--;
     int32_t opcode = GetLdindForType(interpType);
     AddIns(opcode);
-    m_pLastIns->SetSVar(m_pStackPointer[0].var);
-    m_pLastIns->data[0] = offset;
+    m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
+    m_pLastNewIns->data[0] = offset;
     if (interpType == InterpTypeVT)
     {
         int size = m_compHnd->getClassSize(clsHnd);
-        m_pLastIns->data[1] = size;
+        m_pLastNewIns->data[1] = size;
         PushTypeVT(clsHnd, size);
     }
     else
     {
         PushInterpType(interpType, NULL);
     }
-    m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
 }
 
 void InterpCompiler::EmitStind(InterpType interpType, CORINFO_CLASS_HANDLE clsHnd, int32_t offset, bool reverseSVarOrder)
@@ -1652,12 +1652,12 @@ void InterpCompiler::EmitStind(InterpType interpType, CORINFO_CLASS_HANDLE clsHn
         if (m_compHnd->getClassAttribs(clsHnd) & CORINFO_FLG_CONTAINS_GC_PTR)
         {
             AddIns(INTOP_STIND_VT);
-            m_pLastIns->data[1] = GetDataItemIndex(clsHnd);
+            m_pLastNewIns->data[1] = GetDataItemIndex(clsHnd);
         }
         else
         {
             AddIns(INTOP_STIND_VT_NOREF);
-            m_pLastIns->data[1] = m_compHnd->getClassSize(clsHnd);
+            m_pLastNewIns->data[1] = m_compHnd->getClassSize(clsHnd);
         }
     }
     else
@@ -1665,13 +1665,13 @@ void InterpCompiler::EmitStind(InterpType interpType, CORINFO_CLASS_HANDLE clsHn
         AddIns(GetStindForType(interpType));
     }
 
-    m_pLastIns->data[0] = offset;
+    m_pLastNewIns->data[0] = offset;
 
     m_pStackPointer -= 2;
     if (reverseSVarOrder)
-        m_pLastIns->SetSVars2(m_pStackPointer[1].var, m_pStackPointer[0].var);
+        m_pLastNewIns->SetSVars2(m_pStackPointer[1].var, m_pStackPointer[0].var);
     else
-        m_pLastIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
+        m_pLastNewIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
 
 }
 
@@ -1686,8 +1686,8 @@ void InterpCompiler::EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORI
             assert(pFieldInfo->fieldLookup.accessType == IAT_VALUE);
             AddIns(INTOP_LDPTR);
             PushInterpType(InterpTypeByRef, NULL);
-            m_pLastIns->SetDVar(m_pStackPointer[-1].var);
-            m_pLastIns->data[0] = GetDataItemIndex(pFieldInfo->fieldLookup.addr);
+            m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+            m_pLastNewIns->data[0] = GetDataItemIndex(pFieldInfo->fieldLookup.addr);
             break;
         }
         case CORINFO_FIELD_STATIC_TLS_MANAGED:
@@ -1719,19 +1719,19 @@ void InterpCompiler::EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORI
             void *helperFtn = m_compHnd->getHelperFtn(pFieldInfo->helper, &helperFtnSlot);
             // Call helper to obtain thread static base address
             AddIns(INTOP_CALL_HELPER_PP);
-            m_pLastIns->data[0] = GetDataItemIndex(helperFtn);
-            m_pLastIns->data[1] = GetDataItemIndex(helperFtnSlot);
-            m_pLastIns->data[2] = GetDataItemIndex(helperArg);
+            m_pLastNewIns->data[0] = GetDataItemIndex(helperFtn);
+            m_pLastNewIns->data[1] = GetDataItemIndex(helperFtnSlot);
+            m_pLastNewIns->data[2] = GetDataItemIndex(helperArg);
             PushInterpType(InterpTypeByRef, NULL);
-            m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+            m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
 
             // Add field offset
             m_pStackPointer--;
             AddIns(INTOP_ADD_P_IMM);
-            m_pLastIns->data[0] = (int32_t)pFieldInfo->offset;
-            m_pLastIns->SetSVar(m_pStackPointer[0].var);
+            m_pLastNewIns->data[0] = (int32_t)pFieldInfo->offset;
+            m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
             PushInterpType(InterpTypeByRef, NULL);
-            m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+            m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
             break;
         }
         default:
@@ -1753,10 +1753,10 @@ void InterpCompiler::EmitStaticFieldAccess(InterpType interpFieldType, CORINFO_F
 void InterpCompiler::EmitLdLocA(int32_t var)
 {
     AddIns(INTOP_LDLOCA);
-    m_pLastIns->SetSVar(var);
+    m_pLastNewIns->SetSVar(var);
     m_pVars[var].indirects++;
     PushInterpType(InterpTypeByRef, NULL);
-    m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
 }
 
 int InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
@@ -1788,8 +1788,8 @@ int InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
     if ((methodInfo->options & CORINFO_OPT_INIT_LOCALS) && m_ILLocalsSize > 0)
     {
         AddIns(INTOP_INITLOCALS);
-        m_pLastIns->data[0] = m_ILLocalsOffset;
-        m_pLastIns->data[1] = m_ILLocalsSize;
+        m_pLastNewIns->data[0] = m_ILLocalsOffset;
+        m_pLastNewIns->data[1] = m_ILLocalsSize;
     }
 
     codeEnd = m_ip + m_ILCodeSize;
@@ -1935,29 +1935,29 @@ retry_emit:
             case CEE_LDC_I4_7:
             case CEE_LDC_I4_8:
                 AddIns(INTOP_LDC_I4);
-                m_pLastIns->data[0] = opcode - CEE_LDC_I4_0;
+                m_pLastNewIns->data[0] = opcode - CEE_LDC_I4_0;
                 PushStackType(StackTypeI4, NULL);
-                m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_ip++;
                 break;
             case CEE_LDC_I4_S:
                 AddIns(INTOP_LDC_I4);
-                m_pLastIns->data[0] = (int8_t)m_ip[1];
+                m_pLastNewIns->data[0] = (int8_t)m_ip[1];
                 PushStackType(StackTypeI4, NULL);
-                m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_ip += 2;
                 break;
             case CEE_LDC_I4:
                 AddIns(INTOP_LDC_I4);
-                m_pLastIns->data[0] = getI4LittleEndian(m_ip + 1);
+                m_pLastNewIns->data[0] = getI4LittleEndian(m_ip + 1);
                 PushStackType(StackTypeI4, NULL);
-                m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_ip += 5;
                 break;
             case CEE_LDNULL:
                 AddIns(INTOP_LDNULL);
                 PushStackType(StackTypeO, NULL);
-                m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_ip++;
                 break;
 
@@ -2022,15 +2022,15 @@ retry_emit:
                     AddIns(INTOP_RET_VT);
                     m_pStackPointer--;
                     int32_t retVar = m_pStackPointer[0].var;
-                    m_pLastIns->SetSVar(retVar);
-                    m_pLastIns->data[0] = m_pVars[retVar].size;
+                    m_pLastNewIns->SetSVar(retVar);
+                    m_pLastNewIns->data[0] = m_pVars[retVar].size;
                 }
                 else
                 {
                     CHECK_STACK(1);
                     AddIns(INTOP_RET);
                     m_pStackPointer--;
-                    m_pLastIns->SetSVar(m_pStackPointer[0].var);
+                    m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
                 }
                 m_ip++;
                 break;
@@ -2359,11 +2359,11 @@ retry_emit:
                 uint32_t n = getU4LittleEndian(m_ip);
                 // Format of switch instruction is opcode + srcVal + n + T1 + T2 + ... + Tn
                 AddInsExplicit(INTOP_SWITCH, n + 3);
-                m_pLastIns->data[0] = n;
+                m_pLastNewIns->data[0] = n;
                 m_ip += 4;
                 const uint8_t *nextIp = m_ip + n * 4;
                 m_pStackPointer--;
-                m_pLastIns->SetSVar(m_pStackPointer->var);
+                m_pLastNewIns->SetSVar(m_pStackPointer->var);
                 InterpBasicBlock **targetBBTable = (InterpBasicBlock**)AllocMemPool(sizeof (InterpBasicBlock*) * n);
 
                 for (uint32_t i = 0; i < n; i++)
@@ -2378,7 +2378,7 @@ retry_emit:
                     LinkBBs(m_pCBB, targetBB);
                     m_ip += 4;
                 }
-                m_pLastIns->info.ppTargetBBTable = targetBBTable;
+                m_pLastNewIns->info.ppTargetBBTable = targetBBTable;
                 break;
             }
             case CEE_BR:
@@ -2590,26 +2590,26 @@ retry_emit:
                 int32_t thisVar = m_pStackPointer[-1].var;
                 // Consider this arg as being defined, although newobj defines it
                 AddIns(INTOP_DEF);
-                m_pLastIns->SetDVar(thisVar);
+                m_pLastNewIns->SetDVar(thisVar);
                 callArgs[0] = thisVar;
 
                 if (retType == InterpTypeVT)
                 {
                     AddIns(INTOP_NEWOBJ_VT);
-                    m_pLastIns->data[1] = (int32_t)ALIGN_UP_TO(vtsize, INTERP_STACK_SLOT_SIZE);
+                    m_pLastNewIns->data[1] = (int32_t)ALIGN_UP_TO(vtsize, INTERP_STACK_SLOT_SIZE);
                 }
                 else
                 {
                     AddIns(INTOP_NEWOBJ);
-                    m_pLastIns->data[1] = GetDataItemIndex(ctorClass);
+                    m_pLastNewIns->data[1] = GetDataItemIndex(ctorClass);
                 }
-                m_pLastIns->data[0] = GetMethodDataItemIndex(ctorMethod);
-                m_pLastIns->SetSVar(CALL_ARGS_SVAR);
-                m_pLastIns->SetDVar(dVar);
+                m_pLastNewIns->data[0] = GetMethodDataItemIndex(ctorMethod);
+                m_pLastNewIns->SetSVar(CALL_ARGS_SVAR);
+                m_pLastNewIns->SetDVar(dVar);
 
-                m_pLastIns->flags |= INTERP_INST_FLAG_CALL;
-                m_pLastIns->info.pCallInfo = (InterpCallInfo*)AllocMemPool0(sizeof(InterpCallInfo));
-                m_pLastIns->info.pCallInfo->pCallArgs = callArgs;
+                m_pLastNewIns->flags |= INTERP_INST_FLAG_CALL;
+                m_pLastNewIns->info.pCallInfo = (InterpCallInfo*)AllocMemPool0(sizeof(InterpCallInfo));
+                m_pLastNewIns->info.pCallInfo->pCallArgs = callArgs;
 
                 // Pop this, the result of the newobj still remains on the stack
                 m_pStackPointer--;
@@ -2642,10 +2642,10 @@ retry_emit:
                     assert(fieldInfo.fieldAccessor == CORINFO_FIELD_INSTANCE);
                     m_pStackPointer--;
                     AddIns(INTOP_LDFLDA);
-                    m_pLastIns->data[0] = (int32_t)fieldInfo.offset;
-                    m_pLastIns->SetSVar(m_pStackPointer[0].var);
+                    m_pLastNewIns->data[0] = (int32_t)fieldInfo.offset;
+                    m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
                     PushInterpType(InterpTypeByRef, NULL);
-                    m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+                    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 }
 
                 m_ip += 5;
@@ -2679,27 +2679,27 @@ retry_emit:
                     {
                         sizeDataIndexOffset = 1;
                         AddIns(INTOP_MOV_SRC_OFF);
-                        m_pLastIns->data[1] = interpFieldType;
+                        m_pLastNewIns->data[1] = interpFieldType;
                     }
                     else
                     {
                         int32_t opcode = GetLdindForType(interpFieldType);
                         AddIns(opcode);
                     }
-                    m_pLastIns->SetSVar(m_pStackPointer[0].var);
-                    m_pLastIns->data[0] = (int32_t)fieldInfo.offset;
+                    m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
+                    m_pLastNewIns->data[0] = (int32_t)fieldInfo.offset;
                     if (interpFieldType == InterpTypeVT)
                     {
                         CORINFO_CLASS_HANDLE fieldClass = fieldInfo.structType;
                         int size = m_compHnd->getClassSize(fieldClass);
-                        m_pLastIns->data[1 + sizeDataIndexOffset] = size;
+                        m_pLastNewIns->data[1 + sizeDataIndexOffset] = size;
                         PushTypeVT(fieldClass, size);
                     }
                     else
                     {
                         PushInterpType(interpFieldType, NULL);
                     }
-                    m_pLastIns->SetDVar(m_pStackPointer[-1].var);
+                    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 }
 
                 m_ip += 5;

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -94,6 +94,7 @@ struct InterpInst
 
     int32_t opcode;
     int32_t ilOffset;
+    int32_t nativeOffset;
     uint32_t flags;
     int32_t dVar;
     int32_t sVars[3]; // Currently all instructions have at most 3 sregs
@@ -179,8 +180,8 @@ struct InterpVar
     int offset;
     int size;
     // live_start and live_end are used by the offset allocator
-    int liveStart;
-    int liveEnd;
+    InterpInst* liveStart;
+    InterpInst* liveEnd;
     // index of first basic block where this var is used
     int bbIndex;
     // If var is callArgs, this is the call instruction using it.
@@ -199,7 +200,7 @@ struct InterpVar
         this->clsHnd = clsHnd;
         this->size = size;
         offset = -1;
-        liveStart = -1;
+        liveStart = NULL;
         bbIndex = -1;
         indirects = 0;
 
@@ -321,6 +322,9 @@ private:
     int m_BBCount = 0;
     InterpBasicBlock**  m_ppOffsetToBB;
 
+    ICorDebugInfo::OffsetMapping* m_pILToNativeMap = NULL;
+    int32_t m_ILToNativeMapSize = 0;
+
     InterpBasicBlock*   AllocBB(int32_t ilOffset);
     InterpBasicBlock*   GetBB(int32_t ilOffset);
     void                LinkBBs(InterpBasicBlock *from, InterpBasicBlock *to);
@@ -338,6 +342,7 @@ private:
     InterpVar *m_pVars = NULL;
     int32_t m_varsSize = 0;
     int32_t m_varsCapacity = 0;
+    int32_t m_numILVars = 0;
 
     int32_t CreateVarExplicit(InterpType interpType, CORINFO_CLASS_HANDLE clsHnd, int size);
 
@@ -346,6 +351,8 @@ private:
     int32_t m_ILLocalsOffset, m_ILLocalsSize;
     void    AllocVarOffsetCB(int *pVar, void *pData);
     int32_t AllocVarOffset(int var, int32_t *pPos);
+    int32_t GetLiveStartOffset(int var);
+    int32_t GetLiveEndOffset(int var);
 
     int32_t GetInterpTypeStackSize(CORINFO_CLASS_HANDLE clsHnd, InterpType interpType, int32_t *pAlign);
     void    CreateILVars();
@@ -384,7 +391,7 @@ private:
     TSList<InterpInst*> *m_pDeferredCalls;
 
     int32_t AllocGlobalVarOffset(int var);
-    void    SetVarLiveRange(int32_t var, int insIndex);
+    void    SetVarLiveRange(int32_t var, InterpInst* ins);
     void    SetVarLiveRangeCB(int32_t *pVar, void *pData);
     void    InitializeGlobalVar(int32_t var, int bbIndex);
     void    InitializeGlobalVarCB(int32_t *pVar, void *pData);
@@ -398,6 +405,7 @@ private:
 
     void AllocOffsets();
     int32_t ComputeCodeSize();
+    uint32_t ConvertOffset(int32_t offset);
     void EmitCode();
     int32_t* EmitCodeIns(int32_t *ip, InterpInst *pIns, TArray<Reloc*> *relocs);
     void PatchRelocations(TArray<Reloc*> *relocs);

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -301,7 +301,7 @@ private:
 
     // Instructions
     InterpBasicBlock *m_pCBB, *m_pEntryBB;
-    InterpInst* m_pLastIns;
+    InterpInst* m_pLastNewIns;
 
     int32_t     GetInsLength(InterpInst *pIns);
     bool        InsIsNop(InterpInst *pIns);

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -2289,6 +2289,7 @@ static void VirtualUnwindInterpreterCallFrame(TADDR sp, T_CONTEXT *pContext)
     {
         SetIP(pContext, (TADDR)pFrame->ip);
         SetSP(pContext, dac_cast<TADDR>(pFrame));
+        SetFP(pContext, (TADDR)pFrame->pStack);
     }
     else
     {

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2876,6 +2876,7 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                     PREGDISPLAY pRD = m_crawl.GetRegisterSet();
                     SetIP(pRD->pCurrentContext, (TADDR)pTOSInterpMethodContextFrame->ip);
                     SetSP(pRD->pCurrentContext, dac_cast<TADDR>(pTOSInterpMethodContextFrame));
+                    SetFP(pRD->pCurrentContext, (TADDR)pTOSInterpMethodContextFrame->pStack);
                     pRD->pCurrentContext->ContextFlags = CONTEXT_CONTROL;
                     SyncRegDisplayToCurrentContext(pRD);
                     ProcessIp(GetControlPC(pRD));


### PR DESCRIPTION
This change produces the debug info for interpreted byte code.

**Changes:**

**_On the compiler:_**
1. Changes the offset allocator so that variable are all associated with the first and last instruction when it is alive, and all instructions associated with the `nativeOffset`, so we have the liveness of all variables and the nativeOffset for all instruction.
2. Report, for all 1st instruction that has an IL offset, to the debugger a mapping between its ILOffset and IROffset
3. Report, for all IL variables, their liveness and their offset from the virtualized stack pointer.

 **_On the stack walker:_**
1. Whenever we set `SP` to `pFrame`, we also set `FP` to `pFrame->pStack`, that is because the offset of the variables are relative to `pFrame->pStack`, and so the debugger needs to know about it, and we chose to report that value through the `FP`.

**_On the debugger:_**
1. It turns out `REGNUM_FP` is not defined for AMD64 and is causing problem, just define it there.

The change is tested under SOS so that if we set a breakpoint inside the interpreter routine and do a `!clrstack -i -a`, we will be able to see the argument and local variables values. 

@janvorli 
@BrzVlad 
@kg 
@dotnet/dotnet-diag