### PR TITLE
[release/10.0-preview3] Publish cross-apphost VS insertion packs

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -106,6 +106,11 @@
               SubBlobFolder="workloads/" />
   </ItemGroup>
 
+  <!-- Include cross-arch apphost MSI packages. A bug in arcade means these aren't included by default. -->
+  <ItemGroup Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">
+    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.*_$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
+  </ItemGroup>
+
   <!--
     Filter out the RID-specific (Runtime) nupkgs for this RID.
     Every job will publish their RID-specific packages.


### PR DESCRIPTION
main PR https://github.com/dotnet/arcade/pull/15678

# Description

The cross-apphost packs weren't being published. This ensures they are published correctly.

# Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
This affects VS integration.

# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
Yes

# Testing

<!-- What kind of testing has been done with the fix. -->
Manual validation of the final asset manifest

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low. This only adds publishing steps for assets that we were mistakenly not publishing. It does not remove any publishing steps nor does it change how we build anything


# Package authoring no longer needed in .NET 9

IMPORTANT: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.