### PR TITLE
Bring back yml necessary change types in label checkers

### DIFF
--- a/.github/workflows/check-no-merge-label.yml
+++ b/.github/workflows/check-no-merge-label.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request_target:
-    types: [labeled, unlabeled]
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
     branches:
       - 'main'
       - 'release/**'

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request_target:
-    types: [labeled, unlabeled]
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
     branches:
       - 'release/**'
 


### PR DESCRIPTION
There are some `on pull_request_target types` in the label checking yml files that I removed but they are actually necessary, so the labeler keeps working after for example: pushing new commits, pressing the update the branch, closing and opening the PR.

Will backport too.