### PR TITLE
[8.0] Bring back yml necessary change types in label checkers

### DIFF
--- a/.github/workflows/check-no-merge-label.yml
+++ b/.github/workflows/check-no-merge-label.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request_target:
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
     branches:
       - 'main'
       - 'release/**'

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request_target:
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
     branches:
       - 'release/**'
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/114165

Tell mode.

There are some `on pull_request_target types` in the label checking yml files that I removed but they are actually necessary, so the labeler keeps working after for example: pushing new commits, pressing the update the branch, closing and opening the PR.