### PR TITLE
Pin the System.Memory package reference version in Microsoft.Extensions.DependencyModel

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -138,6 +138,8 @@
     <SystemThreadingAccessControlVersion>7.0.0</SystemThreadingAccessControlVersion>
     <runtimenativeSystemIOPortsVersion>10.0.0-preview.3.25152.4</runtimenativeSystemIOPortsVersion>
     <!-- Keep toolset versions in sync with dotnet/msbuild and dotnet/sdk -->
+    <!-- The framework targeted by and package release band for the minimum toolset version our tasks must support -->
+    <ToolsetTargetFramework>net8.0</ToolsetTargetFramework>
     <MicrosoftBclAsyncInterfacesToolsetVersion>8.0.0</MicrosoftBclAsyncInterfacesToolsetVersion>
     <SystemBuffersToolsetVersion>4.5.1</SystemBuffersToolsetVersion>
     <SystemCollectionsImmutableToolsetVersion>8.0.0</SystemCollectionsImmutableToolsetVersion>

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
@@ -30,7 +30,7 @@ By default, the dependency manifest contains information about the application's
     <InternalsVisibleTo Include="Microsoft.Extensions.DependencyModel.Tests" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(ToolsetTargetFramework)'))">
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebToolsetVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
@@ -37,7 +37,9 @@ By default, the dependency manifest contains information about the application's
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <!-- 4.6.1 is a temporary workaround to prevent failure coming from System.Runtime.CompilerServices.Unsafe
+         wrong assembly version - https://github.com/dotnet/maintenance-packages/pull/221 -->
+    <PackageReference Include="System.Memory" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
@@ -31,15 +31,13 @@ By default, the dependency manifest contains information about the application's
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Encodings.Web\src\System.Text.Encodings.Web.csproj" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Json\src\System.Text.Json.csproj" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebToolsetVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <!-- 4.6.1 is a temporary workaround to prevent failure coming from System.Runtime.CompilerServices.Unsafe
-         wrong assembly version - https://github.com/dotnet/maintenance-packages/pull/221 -->
-    <PackageReference Include="System.Memory" Version="4.6.1" />
+    <PackageReference Include="System.Buffers" Version="$(SystemBuffersToolsetVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryToolsetVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
Needed to address the failure found in the runtime deps flow https://github.com/dotnet/sdk/pull/48034

This will be done alongside the proper update in S.R.CS.Unsfae: https://github.com/dotnet/maintenance-packages/pull/221

I will generate a patch for the deps flow as well.