### PR TITLE
JIT: increase inline budget

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -11422,7 +11422,7 @@ public:
 
 #define DEFAULT_MAX_INLINE_DEPTH 20 // Methods at more than this level deep will not be inlined
 
-#define DEFAULT_INLINE_BUDGET 10 // Maximum estimated compile time increase via inlining
+#define DEFAULT_INLINE_BUDGET 20 // Maximum estimated compile time increase via inlining
 
 #define DEFAULT_MAX_FORCE_INLINE_DEPTH 1 // Methods at more than this level deep will not be force inlined
 


### PR DESCRIPTION
The current JIT inline strategy is prone to running out of budget at inopportune times, deeply inlining at some top-level sites and not inlining at all at others. This doesn't happen all that often, but when it does it has very adverse impact on performance.

While we await a better strategy, we can at least reduce how often this happens by increasing the budget.

Partially addresses regressions seen in #113913