### PR TITLE
Add FrozenDictionary.Create

### DIFF
--- a/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -8,6 +8,8 @@ namespace System.Collections.Frozen
 {
     public static partial class FrozenDictionary
     {
+        public static System.Collections.Frozen.FrozenDictionary<TKey, TValue> Create<TKey, TValue>(params System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) where TKey : notnull { throw null; }
+        public static System.Collections.Frozen.FrozenDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey>? comparer, params System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) where TKey : notnull { throw null; }
         public static System.Collections.Frozen.FrozenDictionary<TKey, TValue> ToFrozenDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey>? comparer = null) where TKey : notnull { throw null; }
         public static System.Collections.Frozen.FrozenDictionary<TKey, TSource> ToFrozenDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer = null) where TKey : notnull { throw null; }
         public static System.Collections.Frozen.FrozenDictionary<TKey, TElement> ToFrozenDictionary<TSource, TKey, TElement>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer = null) where TKey : notnull { throw null; }

--- a/src/libraries/System.Collections.Immutable/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Collections.Immutable/src/CompatibilitySuppressions.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Collections.Frozen.FrozenDictionary`2:[T:System.Runtime.CompilerServices.CollectionBuilderAttribute]</Target>
+    <Left>ref/net10.0/System.Collections.Immutable.dll</Left>
+    <Right>lib/net10.0/System.Collections.Immutable.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Collections.Frozen.FrozenDictionary`2:[T:System.Runtime.CompilerServices.CollectionBuilderAttribute]</Target>
+    <Left>ref/net8.0/System.Collections.Immutable.dll</Left>
+    <Right>lib/net8.0/System.Collections.Immutable.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Collections.Frozen.FrozenDictionary`2:[T:System.Runtime.CompilerServices.CollectionBuilderAttribute]</Target>
+    <Left>ref/net9.0/System.Collections.Immutable.dll</Left>
+    <Right>lib/net9.0/System.Collections.Immutable.dll</Right>
+  </Suppression>
+</Suppressions>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
@@ -18,6 +18,50 @@ namespace System.Collections.Frozen
     {
         /// <summary>Creates a <see cref="FrozenDictionary{TKey, TValue}"/> with the specified key/value pairs.</summary>
         /// <param name="source">The key/value pairs to use to populate the dictionary.</param>
+        /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+        /// <remarks>
+        /// If the same key appears multiple times in the input, the latter one in the sequence takes precedence. This differs from
+        /// <see cref="M:System.Linq.Enumerable.ToDictionary"/>, with which multiple duplicate keys will result in an exception.
+        /// </remarks>
+        /// <returns>A <see cref="FrozenDictionary{TKey, TValue}"/> that contains the specified keys and values.</returns>
+        public static FrozenDictionary<TKey, TValue> Create<TKey, TValue>(params ReadOnlySpan<KeyValuePair<TKey, TValue>> source)
+            where TKey : notnull =>
+            Create(null, source);
+
+        /// <summary>Creates a <see cref="FrozenDictionary{TKey, TValue}"/> with the specified key/value pairs.</summary>
+        /// <param name="source">The key/value pairs to use to populate the dictionary.</param>
+        /// <param name="comparer">The comparer implementation to use to compare keys for equality. If <see langword="null"/>, <see cref="EqualityComparer{TKey}.Default"/> is used.</param>
+        /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+        /// <remarks>
+        /// If the same key appears multiple times in the input, the latter one in the sequence takes precedence. This differs from
+        /// <see cref="M:System.Linq.Enumerable.ToDictionary"/>, with which multiple duplicate keys will result in an exception.
+        /// </remarks>
+        /// <returns>A <see cref="FrozenDictionary{TKey, TValue}"/> that contains the specified keys and values.</returns>
+        public static FrozenDictionary<TKey, TValue> Create<TKey, TValue>(IEqualityComparer<TKey>? comparer, params ReadOnlySpan<KeyValuePair<TKey, TValue>> source)
+            where TKey : notnull
+        {
+            comparer ??= EqualityComparer<TKey>.Default;
+
+            if (source.IsEmpty)
+            {
+                return ReferenceEquals(comparer, FrozenDictionary<TKey, TValue>.Empty.Comparer) ?
+                    FrozenDictionary<TKey, TValue>.Empty :
+                    new EmptyFrozenDictionary<TKey, TValue>(comparer);
+            }
+
+            Dictionary<TKey, TValue> d = new(source.Length, comparer);
+            foreach (KeyValuePair<TKey, TValue> pair in source)
+            {
+                d[pair.Key] = pair.Value;
+            }
+
+            return CreateFromDictionary(d);
+        }
+
+        /// <summary>Creates a <see cref="FrozenDictionary{TKey, TValue}"/> with the specified key/value pairs.</summary>
+        /// <param name="source">The key/value pairs to use to populate the dictionary.</param>
         /// <param name="comparer">The comparer implementation to use to compare keys for equality. If null, <see cref="EqualityComparer{TKey}.Default"/> is used.</param>
         /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
         /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
@@ -259,6 +303,7 @@ namespace System.Collections.Frozen
     /// the remainder of the life of the application. <see cref="FrozenDictionary{TKey, TValue}"/> should only be
     /// initialized with trusted keys, as the details of the keys impacts construction time.
     /// </remarks>
+    [CollectionBuilder(typeof(FrozenDictionary), nameof(FrozenDictionary.Create))]
     [DebuggerTypeProxy(typeof(ImmutableDictionaryDebuggerProxy<,>))]
     [DebuggerDisplay("Count = {Count}")]
     public abstract partial class FrozenDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>, IDictionary


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/114090

Adds FrozenDictionary.Create for creating a FrozenDictionary from a span of key/value pairs. This can be used directly and enables creating FrozenDictionary instances using C# 14 dictionary expressions.