### PR TITLE
ILLink : Fix and a couple tweaks

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Metadata/KeepTypeForwarderOnlyAssembliesAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Metadata/KeepTypeForwarderOnlyAssembliesAttribute.cs
@@ -10,7 +10,9 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 	{
 		public KeepTypeForwarderOnlyAssembliesAttribute (string value)
 		{
+#if NET // Avoid compile errors when targeting older TFMs
 			ArgumentException.ThrowIfNullOrEmpty (value);
+#endif
 		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileAfterAttribute.cs
@@ -11,9 +11,34 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
 	public class SetupCompileAfterAttribute : BaseMetadataAttribute
 	{
-		public SetupCompileAfterAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, object[] resources = null, string additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
+		public SetupCompileAfterAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, object[] resources = null, string[] additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
 		{
+#if NET // Avoid compile errors when targeting older TFMs
 			ArgumentNullException.ThrowIfNull (sourceFiles);
+#endif
+
+			if (string.IsNullOrEmpty (outputName))
+				throw new ArgumentException ("Value cannot be null or empty.", nameof (outputName));
+
+			if (resources != null) {
+				foreach (var res in resources) {
+					if (res is string)
+						continue;
+					if (res is string[] stringArray) {
+						if (stringArray.Length != 2)
+							throw new ArgumentException ("Entry in object[] cannot be a string[] unless it has exactly two elements, for the resource path and name", nameof (resources));
+						continue;
+					}
+					throw new ArgumentException ("Each value in the object[] must be a string or a string[], either a resource path, or a path and name", nameof (resources));
+				}
+			}
+		}
+
+		public SetupCompileAfterAttribute (string outputName, Type[] typesToIncludeSourceFor, string[] references = null, string[] defines = null, object[] resources = null, string[] additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
+		{
+#if NET // Avoid compile errors when targeting older TFMs
+			ArgumentNullException.ThrowIfNull (typesToIncludeSourceFor);
+#endif
 
 			if (string.IsNullOrEmpty (outputName))
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (outputName));

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupCompileBeforeAttribute.cs
@@ -13,7 +13,9 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 	{
 		public SetupCompileBeforeAttribute (string outputName, string[] sourceFiles, string[] references = null, string[] defines = null, object[] resources = null, string[] additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false, string outputSubFolder = null)
 		{
+#if NET // Avoid compile errors when targeting older TFMs
 			ArgumentNullException.ThrowIfNull (sourceFiles);
+#endif
 
 			if (string.IsNullOrEmpty (outputName))
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (outputName));
@@ -32,9 +34,11 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 			}
 		}
 
-		public SetupCompileBeforeAttribute (string outputName, Type[] typesToIncludeSourceFor, string[] references = null, string[] defines = null, object[] resources = null, string additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
+		public SetupCompileBeforeAttribute (string outputName, Type[] typesToIncludeSourceFor, string[] references = null, string[] defines = null, object[] resources = null, string[] additionalArguments = null, string compilerToUse = null, bool addAsReference = true, bool removeFromLinkerInput = false)
 		{
+#if NET // Avoid compile errors when targeting older TFMs
 			ArgumentNullException.ThrowIfNull (typesToIncludeSourceFor);
+#endif
 
 			if (string.IsNullOrEmpty (outputName))
 				throw new ArgumentException ("Value cannot be null or empty.", nameof (outputName));

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesUsingTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesUsingTypes.cs
@@ -3,7 +3,14 @@ using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.TestFramework
 {
-	[SetupCompileBefore ("library1.dll", new[] { typeof (CanCompileReferencesUsingTypes_LibSource1), typeof (CanCompileReferencesUsingTypes_LibSource2.Nested1.Nested2) })]
+	[SetupCompileBefore ("library1.dll", new[] { typeof (CanCompileReferencesUsingTypes_LibSource1), typeof (CanCompileReferencesUsingTypes_LibSource2.Nested1.Nested2) },
+		// Here to give coverage on the additional args parameter to ensure it is in sync with the more commonly used overload
+		additionalArguments: new [] { "/optimize+" })]
+
+	// Here to give coverage on SetupCompileAfter using types
+	[SetupCompileAfter ("library1.dll", new[] { typeof (CanCompileReferencesUsingTypes_LibSource1), typeof (CanCompileReferencesUsingTypes_LibSource2.Nested1.Nested2) },
+		// Here to give coverage on the additional args parameter to ensure it is in sync with the more commonly used overload
+		additionalArguments: new [] { "/optimize+" })]
 	public class CanCompileReferencesUsingTypes
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResources.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileReferencesWithResources.cs
@@ -6,12 +6,16 @@ namespace Mono.Linker.Tests.Cases.TestFramework
 {
 	[SetupCompileBefore ("library.dll",
 		new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.cs" },
-		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt" })]
+		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt" },
+		// Here to give coverage on the additional args parameter to ensure it is in sync with the more commonly used overload
+		additionalArguments: new [] { "/optimize+" })]
 
 	// Compile the same assembly again with another resource to get coverage on SetupCompileAfter
 	[SetupCompileAfter ("library.dll",
 		new[] { "Dependencies/CanCompileReferencesWithResources_Lib1.cs" },
-		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt", "Dependencies/CanCompileReferencesWithResources_Lib1.log" })]
+		resources: new object[] { "Dependencies/CanCompileReferencesWithResources_Lib1.txt", "Dependencies/CanCompileReferencesWithResources_Lib1.log" },
+		// Here to give coverage on the additional args parameter to ensure it is in sync with the more commonly used overload
+		additionalArguments: new [] { "/optimize+" })]
 
 	[KeptResourceInAssembly ("library.dll", "CanCompileReferencesWithResources_Lib1.txt")]
 	[KeptResourceInAssembly ("library.dll", "CanCompileReferencesWithResources_Lib1.log")]


### PR DESCRIPTION
* Fix the SetupCompileBeforeAttribute's ctor parameters being out of sync.  AdditionalArgs was changed to a `string[]` in one ctor but not the other.  Updated a test to give coverage.

* Put throw helpers inside of `#if NET`.  We are still compiling `Mono.Linker.Tests.Cases.Expectations` against `netstandard2.0` and `net471` and this