### PR TITLE
GetType: keep throwing same exceptions as .NET 8

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.CoreCLR.cs
@@ -80,7 +80,7 @@ namespace System.Reflection
             bool ignoreCase,
             Assembly topLevelAssembly)
         {
-            TypeName? parsed = TypeNameParser.Parse(typeName, throwOnError);
+            TypeName? parsed = TypeNameParser.Parse(typeName, throwOnError, new() { TopLevelAssemblyWasProvided = topLevelAssembly is not null });
 
             if (parsed is null)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.CoreCLR.cs
@@ -80,13 +80,13 @@ namespace System.Reflection
             bool ignoreCase,
             Assembly topLevelAssembly)
         {
-            TypeName? parsed = TypeNameParser.Parse(typeName, throwOnError, new() { TopLevelAssemblyWasProvided = topLevelAssembly is not null });
+            TypeName? parsed = TypeNameParser.Parse(typeName, throwOnError, new() { IsAssemblyGetType = true });
 
             if (parsed is null)
             {
                 return null;
             }
-            else if (topLevelAssembly is not null && parsed.AssemblyName is not null)
+            else if (parsed.AssemblyName is not null)
             {
                 return throwOnError ? throw new ArgumentException(SR.Argument_AssemblyGetTypeCannotSpecifyAssembly) : null;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Metadata
         }
 #pragma warning restore CA1822
 
-        internal bool TopLevelAssemblyWasProvided { get; set; }
+        internal bool IsAssemblyGetType { get; set; }
     }
 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.cs
@@ -20,6 +20,8 @@ namespace System.Reflection.Metadata
             }
         }
 #pragma warning restore CA1822
+
+        internal bool TopLevelAssemblyWasProvided { get; set; }
     }
 }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParser.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParser.cs
@@ -191,16 +191,18 @@ namespace System.Reflection.Metadata
                 // Backward compatibility: throw for non-empty invalid assembly names.
                 if (!_inputString.TrimStart().StartsWith(","))
                 {
-                    // No matter what throwOnError is set to, if top level assembly was not provided, CLR throws FileLoadException for invalid assembly names.
-                    if (!_parseOptions.TopLevelAssemblyWasProvided)
+                    // Reject attempt to provide top-level assembly name to Assembly.GetType
+                    if (_parseOptions.IsAssemblyGetType)
                     {
-                        throw new IO.FileLoadException(SR.InvalidAssemblyName, _inputString.ToString());
+                        if (_throwOnError)
+                        {
+                            throw new ArgumentException(SR.Argument_AssemblyGetTypeCannotSpecifyAssembly);
+                        }
+                        return null;
                     }
-                    // If top level was provided and user has requested for error, we throw ArgumentException.
-                    else if (_throwOnError)
-                    {
-                        throw new ArgumentException(SR.Argument_AssemblyGetTypeCannotSpecifyAssembly);
-                    }
+
+                    // Otherwise, no matter what throwOnError is set to, we throw FileLoadException for invalid assembly names.
+                    throw new IO.FileLoadException(SR.InvalidAssemblyName, _inputString.ToString());
                 }
 #endif
                 return null;

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
@@ -276,6 +276,8 @@ namespace System.Reflection.Tests
         {
             Assert.Equal(typeof(int), Type.GetType("System.Int32", throwOnError: true));
             Assert.Equal(typeof(int), Type.GetType("system.int32", throwOnError: true, ignoreCase: true));
+            Assert.Null(typeof(int).Assembly.GetType("a,b", throwOnError: false, ignoreCase: false));
+            Assert.Null(typeof(int).Assembly.GetType("a,b,c", throwOnError: false, ignoreCase: false));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
@@ -296,7 +296,15 @@ namespace System.Reflection.Tests
             Assert.Null(Type.GetType("MissingAssemblyName, "));
             Assert.Null(Type.GetType("ExtraComma, ,"));
             Assert.Null(Type.GetType("ExtraComma, , System.Runtime"));
-            Assert.Throws<FileLoadException>(() => Type.GetType("System.Object, System.Runtime, Version=x.y"));
+
+            // Backward compat: no matter what throwOnError is set to, CLR throws FileLoadException for invalid assembly names.
+            Assert.Throws<FileLoadException>(() => Type.GetType("System.Object, System.Runtime, Version=x.y", throwOnError: false));
+            Assert.Throws<FileLoadException>(() => Type.GetType("System.Object, System.Runtime, Version=x.y", throwOnError: true));
+
+            // Backward compat: when using Assembly.GetType, throwOnError is not ignored and ArgumentException can be thrown.
+            Assembly coreLib = typeof(int).Assembly;
+            Assert.Null(coreLib.GetType("System.Object, System.Runtime, Version=x.y", throwOnError: false));
+            Assert.Throws<ArgumentException>(() => coreLib.GetType("System.Object, System.Runtime, Version=x.y", throwOnError: true));
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsTypeEquivalenceSupported))]


### PR DESCRIPTION
Keep throwing the same exceptions as we did in .NET 8. Namely:
- When using `Type.GetType`, always throw `FileLoadException` for invalid assembly names no matter what `throwOnError` is set to.
- When using `Assembly.GetType`, throw only when `throwOnError` is set, and `ArgumentException` (not `FileLoadException`)

fixes #113534

FWIW The app I've used for testing:

<details>

```cs
using System;
using System.IO;

namespace GetTypeRepro
{
    internal class Program
    {
        static void Main(string[] args)
        {
            foreach (bool throwOnError in new[] { true, false })
            {
                try
                {
                    _ = Type.GetType("System.Object, System.Runtime, Version=x.y", throwOnError);
                }
                catch (FileLoadException)
                {
                    Console.WriteLine($"FileLoadException was thrown because provided assembly name was incorrect, despite throwOnError set to {throwOnError}.");
                }
            }

            string[] invalidTypeNames = ["System.Object, System.Runtime, Version=x.y", "a,b", "a,b,c"];

            foreach (string invalidTypeName in invalidTypeNames)
            {
                _ = typeof(string).Assembly.GetType(invalidTypeName, throwOnError: false);
                Console.WriteLine("No exception was thrown because throwOnError was set to false");
            }

            foreach (string invalidTypeName in invalidTypeNames)
            {
                try
                {
                    typeof(string).Assembly.GetType(invalidTypeName, throwOnError: true);
                }
                catch (ArgumentException)
                {
                    Console.WriteLine("ArgumentException was thrown because type names passed to Assembly.GetType() must not specify an assembly.");
                }
            }
        }
    }
}
```

</details>