### PR TITLE
Add HashSet check to Enumerable.Distinct

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Distinct.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Distinct.cs
@@ -22,6 +22,13 @@ namespace System.Linq
                 return [];
             }
 
+            if (source is HashSet<TSource> hashSet &&
+                ReferenceEquals(hashSet.Comparer, comparer ?? EqualityComparer<TSource>.Default))
+            {
+                // The collection is already distinct using the same equality comparer
+                return source;
+            }
+
             return new DistinctIterator<TSource>(source, comparer);
         }
 

--- a/src/libraries/System.Linq/tests/DistinctTests.cs
+++ b/src/libraries/System.Linq/tests/DistinctTests.cs
@@ -177,6 +177,37 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.RunOnce().Distinct(new AnagramEqualityComparer()), new AnagramEqualityComparer());
         }
 
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public void HashSetIsNoop(bool withDefaultHashSetComparer, bool withDefaultDistinctComparer)
+        {
+            HashSet<string> source = new(["Bob", "Tim", "bBo", "miT", "Robert", "iTm"], withDefaultHashSetComparer ? EqualityComparer<string>.Default : null);
+
+            Assert.Same(source, source.Distinct(withDefaultDistinctComparer ? EqualityComparer<string>.Default : null));
+        }
+
+        [Fact]
+        public void HashSetWithMatchingComparersIsNoop()
+        {
+            HashSet<string> source = new(["Bob", "Tim", "bBo", "miT", "Robert", "iTm"], StringComparer.OrdinalIgnoreCase);
+
+            Assert.Same(source, source.Distinct(StringComparer.OrdinalIgnoreCase));
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public void HashSetWithDifferentComparersIsNotNoop(bool withHashSetComparer, bool withDistinctComparer)
+        {
+            HashSet<string> source = new(["Bob", "Tim", "bBo", "miT", "Robert", "iTm"], withHashSetComparer ? StringComparer.InvariantCultureIgnoreCase : null);
+
+            Assert.NotSame(source, source.Distinct(withDistinctComparer ? StringComparer.InvariantCulture : null));
+        }
+
         [Theory, MemberData(nameof(SequencesWithDuplicates))]
         public void FindDistinctAndValidate<T>(IEnumerable<T> original)
         {


### PR DESCRIPTION
Libraries which are written to receive `IEnumerable<T>` as inputs may be performing `Enumerable.Distinct` operations on those inputs. `Distinct` is currently building a `HashSet<T>` that gradually fills as the returned `IEnumerable<T>` is iterated.

If the caller is passes a `HashSet<T>` that uses the same equality comparer as the `IEnumerable<T>`, this potentially expensive step is unnecessary. The input `HashSet<T>` is known to already be distinct based on the given comparer and may be returned directly as a no-op.