### PR TITLE
Fix the encoding for sve_mov

### DIFF
--- a/src/coreclr/jit/emitarm64sve.cpp
+++ b/src/coreclr/jit/emitarm64sve.cpp
@@ -10394,6 +10394,10 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             {
                 code |= insEncodeReg_V<20, 16>(id->idReg3()); // mmmmm
             }
+            else
+            {
+                code |= insEncodeReg_V<20, 16>(id->idReg2()); // mmmmm
+            }
             dst += emitOutput_Instr(dst, code);
             break;
 


### PR DESCRIPTION
My https://github.com/dotnet/runtime/pull/113860 exposed a bug in encoding of `sve_mov`, where we were wrongly skipping the encoding the `Zm` field and giving wrong instruction.

Fixes: https://github.com/dotnet/runtime/issues/113939