### PR TITLE
Name native threads before start (macOS/Native AOT)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -82,7 +82,7 @@ namespace System.Threading
                     if (!string.IsNullOrEmpty(thread.Name))
                     {
                         // Name the underlying native thread to match the managed thread name.
-                        thread.ThreadNameChanged(thread.Name);
+                        // thread.ThreadNameChanged(thread.Name);
                     }
 #endif
                     if (start is ThreadStart threadStart)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -77,7 +77,6 @@ namespace System.Threading
                     // the thread name is set to the name of the managed thread by another thread.
                     // However, on OS X and NativeAOT (across all OSes), only the thread itself can set its name.
                     // Therefore, by this point the native thread is still unnamed as it has not started yet.
-                    // See https://github.com/dotnet/runtime/issues/106464.
                     Thread thread = Thread.CurrentThread;
                     if (!string.IsNullOrEmpty(thread.Name))
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -82,7 +82,7 @@ namespace System.Threading
                     if (!string.IsNullOrEmpty(thread.Name))
                     {
                         // Name the underlying native thread to match the managed thread name.
-                        // thread.ThreadNameChanged(thread.Name);
+                        thread.ThreadNameChanged(thread.Name);
                     }
 #endif
                     if (start is ThreadStart threadStart)

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -1298,34 +1298,5 @@ namespace System.Threading.Threads.Tests
         {
             Assert.True(Thread.GetCurrentProcessorId() >= 0);
         }
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern int GetThreadDescription(IntPtr hThread, out IntPtr threadDescription);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern IntPtr GetCurrentThread();
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static void NameNativeThreadBeforeStart()
-        {
-            string threadName = "Test thread name";
-
-            Thread t = new Thread(() =>
-            {
-                IntPtr threadHandle = GetCurrentThread();
-                GetThreadDescription(threadHandle, out IntPtr threadDescriptionPtr);
-
-                string nativeThreadName = Marshal.PtrToStringUni(threadDescriptionPtr);
-                Marshal.FreeHGlobal(threadDescriptionPtr); // Free the unmanaged memory
-                Assert.Equal(threadName, nativeThreadName);
-            }){
-                Name = threadName
-            };
-
-            t.IsBackground = true;
-            t.Start();
-            Assert.True(t.Join(UnexpectedTimeoutMilliseconds));
-        }
     }
 }

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -1306,6 +1306,7 @@ namespace System.Threading.Threads.Tests
         private static extern IntPtr GetCurrentThread();
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void NameNativeThreadBeforeStart()
         {
             string threadName = "Test thread name";


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/106464.