### PR TITLE
SVE: Fix the mask values returned by Helper

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
@@ -7687,7 +7687,7 @@ namespace JIT.HardwareIntrinsics.Arm
             ulong acc = 0;
             for (var i = 0; i < op1.Length; i++)
             {
-                acc += (ulong)((BitConverter.SingleToInt32Bits(op1[i]) == 1 && BitConverter.SingleToInt32Bits(op2[i]) == 1) ? 1 : 0);
+                acc += (ulong)((op1[i] == 1) && (op2[i] == 1) ? 1 : 0);
             }
             return acc;
         }
@@ -7697,7 +7697,7 @@ namespace JIT.HardwareIntrinsics.Arm
             ulong acc = 0;
             for (var i = 0; i < op1.Length; i++)
             {
-                acc += (ulong)((BitConverter.DoubleToInt64Bits(op1[i]) == 1 && BitConverter.DoubleToInt64Bits(op2[i]) == 1) ? 1 : 0);
+                acc += (ulong)((op1[i] == 1) && (op2[i] == 1) ? 1 : 0);
             }
             return acc;
         }

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
@@ -7744,12 +7744,12 @@ namespace JIT.HardwareIntrinsics.Arm
 
         public static float getMaskSingle()
         {
-            return (float)(TestLibrary.Generator.GetInt32()%(int)2);
+            return (float)(TestLibrary.Generator.GetUInt32()%(int)2);
         }
 
         public static double getMaskDouble()
         {
-            return (double)(TestLibrary.Generator.GetInt64()%(long)2);
+            return (double)(TestLibrary.Generator.GetUInt64()%(long)2);
         }
 
         public static int MaskNumberOfElementsVector(int elems, SveMaskPattern pattern)

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
@@ -7709,12 +7709,12 @@ namespace JIT.HardwareIntrinsics.Arm
 
         public static sbyte getMaskSByte()
         {
-            return (sbyte)(TestLibrary.Generator.GetSByte() % 2);
+            return (sbyte)(TestLibrary.Generator.GetByte() % 2);
         }
 
         public static short getMaskInt16()
         {
-            return (short)(TestLibrary.Generator.GetInt16() % 2);
+            return (short)(TestLibrary.Generator.GetUInt16() % 2);
         }
 
         public static ushort getMaskUInt16()
@@ -7724,7 +7724,7 @@ namespace JIT.HardwareIntrinsics.Arm
 
         public static int getMaskInt32()
         {
-            return (int)(TestLibrary.Generator.GetInt32() % 2);
+            return (int)(TestLibrary.Generator.GetUInt32() % 2);
         }
 
         public static uint getMaskUInt32()
@@ -7734,7 +7734,7 @@ namespace JIT.HardwareIntrinsics.Arm
 
         public static long getMaskInt64()
         {
-            return (long)(TestLibrary.Generator.GetInt64() % 2);
+            return (long)(TestLibrary.Generator.GetUInt64() % 2);
         }
 
         public static ulong getMaskUInt64()

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
@@ -7704,52 +7704,52 @@ namespace JIT.HardwareIntrinsics.Arm
 
         public static byte getMaskByte()
         {
-            return (byte)(TestLibrary.Generator.GetByte()%(byte)2);
+            return (byte)(TestLibrary.Generator.GetByte() % 2);
         }
 
         public static sbyte getMaskSByte()
         {
-            return (sbyte)(TestLibrary.Generator.GetSByte()%(sbyte)2);
+            return (sbyte)(TestLibrary.Generator.GetSByte() % 2);
         }
 
         public static short getMaskInt16()
         {
-            return (short)(TestLibrary.Generator.GetInt16()%(short)2);
+            return (short)(TestLibrary.Generator.GetInt16() % 2);
         }
 
         public static ushort getMaskUInt16()
         {
-            return (ushort)(TestLibrary.Generator.GetUInt16()%(ushort)2);
+            return (ushort)(TestLibrary.Generator.GetUInt16() % 2);
         }
 
         public static int getMaskInt32()
         {
-            return (int)(TestLibrary.Generator.GetInt32()%(int)2);
+            return (int)(TestLibrary.Generator.GetInt32() % 2);
         }
 
         public static uint getMaskUInt32()
         {
-            return (uint)(TestLibrary.Generator.GetUInt32()%(uint)2);
+            return (uint)(TestLibrary.Generator.GetUInt32() % 2);
         }
 
         public static long getMaskInt64()
         {
-            return (long)(TestLibrary.Generator.GetInt64()%(long)2);
+            return (long)(TestLibrary.Generator.GetInt64() % 2);
         }
 
         public static ulong getMaskUInt64()
         {
-            return (ulong)(TestLibrary.Generator.GetUInt64()%(ulong)2);
+            return (ulong)(TestLibrary.Generator.GetUInt64() % 2);
         }
 
         public static float getMaskSingle()
         {
-            return (float)(TestLibrary.Generator.GetUInt32()%(int)2);
+            return (float)(TestLibrary.Generator.GetUInt32() % 2);
         }
 
         public static double getMaskDouble()
         {
-            return (double)(TestLibrary.Generator.GetUInt64()%(long)2);
+            return (double)(TestLibrary.Generator.GetUInt64() % 2);
         }
 
         public static int MaskNumberOfElementsVector(int elems, SveMaskPattern pattern)

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Helpers.cs
@@ -7744,12 +7744,12 @@ namespace JIT.HardwareIntrinsics.Arm
 
         public static float getMaskSingle()
         {
-            return (float)(BitConverter.Int32BitsToSingle(TestLibrary.Generator.GetInt32()%(int)2));
+            return (float)(TestLibrary.Generator.GetInt32()%(int)2);
         }
 
         public static double getMaskDouble()
         {
-            return (double)(BitConverter.Int64BitsToDouble(TestLibrary.Generator.GetInt64()%(long)2));
+            return (double)(TestLibrary.Generator.GetInt64()%(long)2);
         }
 
         public static int MaskNumberOfElementsVector(int elems, SveMaskPattern pattern)


### PR DESCRIPTION
As pointed in https://github.com/dotnet/runtime/issues/112264#issuecomment-2777581518, the mask values returned by helper methods `GetMaskDouble()` and `GetMaskSingle()` are incorrect and were getting returned using `BitConverter.DoubleToInt64Bits()` and `BitConverter.SingleToInt32Bits()` respectively. This might make a lane active or inactive, depending on the value of `bit 0` (on which mask registers operate on). However, in the validation, we just assume that anything that is non-zero is active. Fix it by returning strictly either 0 or 1.

Fixes: https://github.com/dotnet/runtime/issues/112264

These might also be related certain functional incorrect failures seen in https://github.com/dotnet/runtime/issues/112377. Note that in the issue, there was also a reference of getting ` Index was outside the bounds of the array` which might be unrelated and is not addressed by this fix.