### PR TITLE
ML-KEM: PKCS#8 Exports

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -778,12 +778,33 @@ namespace System.Security.Cryptography
             return ExportSubjectPublicKeyInfoCore().Encode();
         }
 
+        /// <summary>
+        ///   Attempts to export the current key in the PKCS#8 PrivateKeyInfo format
+        ///   into the provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 PrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
         public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
         {
             ThrowIfDisposed();
 
             // An ML-KEM-512 "seed" export with no attributes is 86 bytes. A buffer smaller than that cannot hold a
-            // PKCS#8 encoded key.
+            // PKCS#8 encoded key. If we happen to get a buffer smaller than that, it won't export.
             const int MinimumPossiblePkcs8MLKemKey = 86;
 
             if (destination.Length < MinimumPossiblePkcs8MLKemKey)
@@ -795,6 +816,67 @@ namespace System.Security.Cryptography
             return TryExportPkcs8PrivateKeyCore(destination, out bytesWritten);
         }
 
+        /// <summary>
+        ///   Export the current key in the PKCS#8 PrivateKeyInfo format.
+        /// </summary>
+        /// <returns>
+        ///   A byte array containing the PKCS#8 PrivateKeyInfo representation of the this key.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
+        public byte[] ExportPkcs8PrivateKey()
+        {
+            ThrowIfDisposed();
+
+            // A PKCS#8 ML-KEM-1024 ExpandedKey has an ASN.1 overhead of 28 bytes, assuming no attributes.
+            // Make it an even 32 and that should give a good starting point for a buffer size.
+            // Decapsulation keys are always larger than the seed, so if we end up with a seed export it should
+            // fit in the initial buffer.
+            int size = Algorithm.DecapsulationKeySizeInBytes + 32;
+            byte[] buffer = CryptoPool.Rent(size);
+            int written = 0;
+
+            try
+            {
+                while (!TryExportPkcs8PrivateKeyCore(buffer, out written))
+                {
+                    CryptoPool.Return(buffer, written);
+                    size = checked(size * 2);
+                    buffer = CryptoPool.Rent(size);
+                }
+
+                return buffer.AsSpan(0, written).ToArray();
+            }
+            finally
+            {
+                CryptoPool.Return(buffer, written);
+            }
+        }
+
+        /// <summary>
+        ///   When overridden in a derived class, attempts to export the current key in the PKCS#8 PrivateKeyInfo format
+        ///   into the provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 PrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
         protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
 
         /// <summary>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -778,6 +778,25 @@ namespace System.Security.Cryptography
             return ExportSubjectPublicKeyInfoCore().Encode();
         }
 
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
+        {
+            ThrowIfDisposed();
+
+            // An ML-KEM-512 "seed" export with no attributes is 86 bytes. A buffer smaller than that cannot hold a
+            // PKCS#8 encoded key.
+            const int MinimumPossiblePkcs8MLKemKey = 86;
+
+            if (destination.Length < MinimumPossiblePkcs8MLKemKey)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            return TryExportPkcs8PrivateKeyCore(destination, out bytesWritten);
+        }
+
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+
         /// <summary>
         ///  Imports an ML-KEM encapsulation key from an X.509 SubjectPublicKeyInfo structure.
         /// </summary>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKemImplementation.NotSupported.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKemImplementation.NotSupported.cs
@@ -75,5 +75,11 @@ namespace System.Security.Cryptography
             Debug.Fail("Caller should have checked platform availability.");
             throw new PlatformNotSupportedException();
         }
+
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKemPkcs8.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKemPkcs8.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Formats.Asn1;
+using System.Security.Cryptography.Asn1;
+
+namespace System.Security.Cryptography
+{
+    internal static class MLKemPkcs8
+    {
+        internal static bool TryExportPkcs8PrivateKey(
+            MLKem kem,
+            bool hasSeed,
+            bool hasDecapsulationKey,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            AlgorithmIdentifierAsn algorithmIdentifier = new()
+            {
+                Algorithm = kem.Algorithm.Oid,
+                Parameters = default(ReadOnlyMemory<byte>?),
+            };
+
+            MLKemPrivateKeyAsn privateKeyAsn = default;
+            byte[]? rented = null;
+            int written = 0;
+
+            try
+            {
+                if (hasSeed)
+                {
+                    int seedSize = kem.Algorithm.PrivateSeedSizeInBytes;
+                    rented = CryptoPool.Rent(seedSize);
+                    Memory<byte> buffer = rented.AsMemory(0, seedSize);
+                    kem.ExportPrivateSeed(buffer.Span);
+                    written = buffer.Length;
+                    privateKeyAsn.Seed = buffer;
+                }
+                else if (hasDecapsulationKey)
+                {
+                    int decapsulationKeySize = kem.Algorithm.DecapsulationKeySizeInBytes;
+                    rented = CryptoPool.Rent(decapsulationKeySize);
+                    Memory<byte> buffer = rented.AsMemory(0, decapsulationKeySize);
+                    kem.ExportDecapsulationKey(buffer.Span);
+                    written = buffer.Length;
+                    privateKeyAsn.ExpandedKey = buffer;
+                }
+                else
+                {
+                    throw new CryptographicException(SR.Cryptography_NotValidPrivateKey);
+                }
+
+                AsnWriter algorithmWriter = new(AsnEncodingRules.DER);
+                algorithmIdentifier.Encode(algorithmWriter);
+                AsnWriter privateKeyWriter = new(AsnEncodingRules.DER);
+                privateKeyAsn.Encode(privateKeyWriter);
+                AsnWriter pkcs8Writer = KeyFormatHelper.WritePkcs8(algorithmWriter, privateKeyWriter);
+
+                bool result = pkcs8Writer.TryEncode(destination, out bytesWritten);
+                privateKeyWriter.Reset();
+                pkcs8Writer.Reset();
+                return result;
+            }
+            finally
+            {
+                if (rented is not null)
+                {
+                    CryptoPool.Return(rented, written);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
@@ -463,22 +463,28 @@ namespace System.Security.Cryptography.Tests
         public void TryExportPkcs8PrivateKey_Seed_Roundtrip()
         {
             using MLKem kem = ImportPrivateSeed(MLKemAlgorithm.MLKem512, MLKemTestData.IncrementalSeed);
-            byte[] pkcs8 = DoTryUntilDone(kem.TryExportPkcs8PrivateKey);
-            using MLKem imported = MLKem.ImportPkcs8PrivateKey(pkcs8);
-            Assert.Equal(MLKemAlgorithm.MLKem512, imported.Algorithm);
-            AssertExtensions.SequenceEqual(MLKemTestData.IncrementalSeed, kem.ExportPrivateSeed());
+
+            AssertExportPkcs8PrivateKey(kem, pkcs8 =>
+            {
+                using MLKem imported = MLKem.ImportPkcs8PrivateKey(pkcs8);
+                Assert.Equal(MLKemAlgorithm.MLKem512, imported.Algorithm);
+                AssertExtensions.SequenceEqual(MLKemTestData.IncrementalSeed, kem.ExportPrivateSeed());
+            });
         }
 
         [Fact]
-        public void TryExportPkcs8PrivateKey_DecapsulationKey_Roundtrip()
+        public void ExportPkcs8PrivateKey_DecapsulationKey_Roundtrip()
         {
             using MLKem kem = ImportDecapsulationKey(MLKemAlgorithm.MLKem512, MLKemTestData.MLKem512DecapsulationKey);
-            byte[] pkcs8 = DoTryUntilDone(kem.TryExportPkcs8PrivateKey);
-            using MLKem imported = MLKem.ImportPkcs8PrivateKey(pkcs8);
-            Assert.Equal(MLKemAlgorithm.MLKem512, imported.Algorithm);
 
-            Assert.ThrowsAny<CryptographicException>(() => kem.ExportPrivateSeed());
-            AssertExtensions.SequenceEqual(MLKemTestData.MLKem512DecapsulationKey, kem.ExportDecapsulationKey());
+            AssertExportPkcs8PrivateKey(kem, pkcs8 =>
+            {
+                using MLKem imported = MLKem.ImportPkcs8PrivateKey(pkcs8);
+                Assert.Equal(MLKemAlgorithm.MLKem512, imported.Algorithm);
+
+                Assert.Throws<CryptographicException>(() => kem.ExportPrivateSeed());
+                AssertExtensions.SequenceEqual(MLKemTestData.MLKem512DecapsulationKey, kem.ExportDecapsulationKey());
+            });
         }
 
         [Fact]
@@ -486,6 +492,14 @@ namespace System.Security.Cryptography.Tests
         {
             using MLKem kem = ImportEncapsulationKey(MLKemAlgorithm.MLKem512, MLKemTestData.MLKem512EncapsulationKey);
             Assert.Throws<CryptographicException>(() => DoTryUntilDone(kem.TryExportPkcs8PrivateKey));
+            Assert.Throws<CryptographicException>(() => kem.ExportPkcs8PrivateKey());
+        }
+
+        private static void AssertExportPkcs8PrivateKey(MLKem kem, Action<byte[]> callback)
+        {
+            byte[] pkcs8 = DoTryUntilDone(kem.TryExportPkcs8PrivateKey);
+            callback(pkcs8);
+            callback(kem.ExportPkcs8PrivateKey());
         }
 
         private delegate bool TryExportFunc(Span<byte> destination, out int bytesWritten);

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
@@ -514,7 +514,7 @@ namespace System.Security.Cryptography.Tests
                 Array.Resize(ref buffer, buffer.Length * 2);
             }
 
-            return buffer[0..written];
+            return buffer.AsSpan(0, written).ToArray();
         }
 
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
@@ -459,14 +459,13 @@ namespace System.Security.Cryptography.Tests
             AssertExtensions.SequenceEqual(sharedSecret.Slice(0, sharedSecretWritten), decapsulated);
         }
 
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public void TryExportPkcs8PrivateKey_Seed_Roundtrip(MLKemAlgorithm algorithm)
+        [Fact]
+        public void TryExportPkcs8PrivateKey_Seed_Roundtrip()
         {
-            using MLKem kem = ImportPrivateSeed(algorithm, MLKemTestData.IncrementalSeed);
+            using MLKem kem = ImportPrivateSeed(MLKemAlgorithm.MLKem512, MLKemTestData.IncrementalSeed);
             byte[] pkcs8 = DoTryUntilDone(kem.TryExportPkcs8PrivateKey);
             using MLKem imported = MLKem.ImportPkcs8PrivateKey(pkcs8);
-            Assert.Equal(algorithm, imported.Algorithm);
+            Assert.Equal(MLKemAlgorithm.MLKem512, imported.Algorithm);
             AssertExtensions.SequenceEqual(MLKemTestData.IncrementalSeed, kem.ExportPrivateSeed());
         }
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
@@ -789,6 +789,106 @@ namespace System.Security.Cryptography.Tests
             Assert.Throws<ObjectDisposedException>(() => kem.ExportSubjectPublicKeyInfo());
         }
 
+        [Fact]
+        public static void TryExportPkcs8PrivateKey_EarlyExitForSmallBuffer()
+        {
+            MLKemContract kem = new(MLKemAlgorithm.MLKem512);
+            byte[] destination = new byte[85];
+            AssertExtensions.FalseExpression(kem.TryExportPkcs8PrivateKey(destination, out int written));
+            Assert.Equal(0, written);
+        }
+
+        [Fact]
+        public static void TryExportPkcs8PrivateKey()
+        {
+            int bufferSize = RandomNumberGenerator.GetInt32(87, 1024);
+            int writtenSize = RandomNumberGenerator.GetInt32(86, bufferSize);
+            bool success = (writtenSize & 1) == 1;
+            byte[] buffer = new byte[bufferSize];
+            MLKemContract kem = new(MLKemAlgorithm.MLKem512)
+            {
+                OnTryExportPkcs8PrivateKeyCore = (Span<byte> destination, out int bytesWritten) =>
+                {
+                    AssertSameBuffer(buffer, destination);
+                    bytesWritten = writtenSize;
+                    return success;
+                }
+            };
+
+            AssertExtensions.TrueExpression(success == kem.TryExportPkcs8PrivateKey(buffer, out int written));
+            Assert.Equal(writtenSize, written);
+        }
+
+        [Fact]
+        public static void ExportPkcs8PrivateKey_OneExportCall()
+        {
+            int size = -1;
+            MLKemContract kem = new(MLKemAlgorithm.MLKem512)
+            {
+                OnTryExportPkcs8PrivateKeyCore = (Span<byte> destination, out int bytesWritten) =>
+                {
+                    destination.Fill(0x88);
+                    bytesWritten = destination.Length;
+                    size = destination.Length;
+                    return true;
+                }
+            };
+
+            byte[] exported = kem.ExportPkcs8PrivateKey();
+            AssertExtensions.FilledWith<byte>(0x88, exported);
+            Assert.Equal(size, exported.Length);
+        }
+
+        [Fact]
+        public static void ExportPkcs8PrivateKey_DoublesAndRetry()
+        {
+            const int TargetSize = 4567;
+            MLKemContract kem = new(MLKemAlgorithm.MLKem512)
+            {
+                OnTryExportPkcs8PrivateKeyCore = (Span<byte> destination, out int bytesWritten) =>
+                {
+                    if (destination.Length < TargetSize)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
+                    destination.Fill(0x88);
+                    bytesWritten = TargetSize;
+                    return true;
+                }
+            };
+
+            byte[] exported = kem.ExportPkcs8PrivateKey();
+            AssertExtensions.FilledWith<byte>(0x88, exported);
+            Assert.Equal(TargetSize, exported.Length);
+
+            // The exact number of calls that made varies depending on the behavior of how the ArrayPool
+            // behaves. Though the algorithm is to double the buffer size, the pool may rent more than requested from
+            // the doubling. However we know it should be more than one.
+            AssertExtensions.GreaterThan(kem.TryExportPkcs8PrivateKeyCoreCount, 1);
+
+            // If the implementation follows a doubling scheme exactly, the ML-KEM 512 decapsulation key size
+            // should take no more than 3 calls to reach 4567. The initial size is 1,664 bytes.
+            AssertExtensions.LessThan(kem.TryExportPkcs8PrivateKeyCoreCount, 4);
+        }
+
+        [Fact]
+        public static void ExportPkcs8PrivateKey_MisbehavingBytesWritten()
+        {
+            MLKemContract kem = new(MLKemAlgorithm.MLKem512)
+            {
+                OnTryExportPkcs8PrivateKeyCore = (Span<byte> destination, out int bytesWritten) =>
+                {
+                    // This is not possible and indiciates a derived type is misimplemented.
+                    bytesWritten = destination.Length + 1;
+                    return true;
+                }
+            };
+
+            Assert.Throws<CryptographicException>(() => kem.ExportPkcs8PrivateKey());
+        }
+
         private static string MapAlgorithmOid(MLKemAlgorithm algorithm)
         {
             if (algorithm == MLKemAlgorithm.MLKem512)
@@ -863,12 +963,12 @@ namespace System.Security.Cryptography.Tests
         internal TryExportPkcs8PrivateKeyCoreCallback OnTryExportPkcs8PrivateKeyCore { get; set; }
         internal Action<bool> OnDispose { get; set; } = (bool disposing) => { };
 
-        private int DecapsulateCoreCount { get; set; }
-        private int EncapsulateCoreCount { get; set; }
-        private int ExportPrivateSeedCoreCount { get; set; }
-        private int ExportEncapsulationKeyCoreCount { get; set; }
-        private int ExportDecapsulationKeyCoreCount { get; set; }
-        private int TryExportPkcs8PrivateKeyCoreCount { get; set; }
+        internal int DecapsulateCoreCount { get; set; }
+        internal int EncapsulateCoreCount { get; set; }
+        internal int ExportPrivateSeedCoreCount { get; set; }
+        internal int ExportEncapsulationKeyCoreCount { get; set; }
+        internal int ExportDecapsulationKeyCoreCount { get; set; }
+        internal int TryExportPkcs8PrivateKeyCoreCount { get; set; }
 
         private bool _disposed;
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
@@ -840,7 +840,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
-        public static void ExportPkcs8PrivateKey_DoublesAndRetry()
+        public static void ExportPkcs8PrivateKey_ExpandAndRetry()
         {
             const int TargetSize = 4567;
             MLKemContract kem = new(MLKemAlgorithm.MLKem512)
@@ -887,6 +887,15 @@ namespace System.Security.Cryptography.Tests
             };
 
             Assert.Throws<CryptographicException>(() => kem.ExportPkcs8PrivateKey());
+        }
+
+        [Fact]
+        public static void ExportPkcs8PrivateKey_Disposed()
+        {
+            MLKemContract kem = new(MLKemAlgorithm.MLKem512);
+            kem.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportPkcs8PrivateKey());
+            Assert.Throws<ObjectDisposedException>(() => kem.TryExportPkcs8PrivateKey(new byte[512], out _));
         }
 
         private static string MapAlgorithmOid(MLKemAlgorithm algorithm)

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
@@ -801,8 +801,14 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public static void TryExportPkcs8PrivateKey()
         {
-            int bufferSize = RandomNumberGenerator.GetInt32(87, 1024);
-            int writtenSize = RandomNumberGenerator.GetInt32(86, bufferSize);
+            Random random;
+#if NET
+            random = Random.Shared;
+#else
+            random = new Random();
+#endif
+            int bufferSize = random.Next(87, 1024);
+            int writtenSize = random.Next(86, bufferSize);
             bool success = (writtenSize & 1) == 1;
             byte[] buffer = new byte[bufferSize];
             MLKemContract kem = new(MLKemAlgorithm.MLKem512)

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1898,6 +1898,8 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.MLKem ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source) { throw null; }
         protected void ThrowIfDisposed() { }
+        public bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten);
         public bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
@@ -1936,6 +1938,7 @@ namespace System.Security.Cryptography
         protected override void ExportDecapsulationKeyCore(System.Span<byte> destination) { }
         protected override void ExportEncapsulationKeyCore(System.Span<byte> destination) { }
         protected override void ExportPrivateSeedCore(System.Span<byte> destination) { }
+        protected override bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public sealed partial class Oid
     {

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1874,6 +1874,7 @@ namespace System.Security.Cryptography
         public byte[] ExportEncapsulationKey() { throw null; }
         public void ExportEncapsulationKey(System.Span<byte> destination) { }
         protected abstract void ExportEncapsulationKeyCore(System.Span<byte> destination);
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
         public byte[] ExportPrivateSeed() { throw null; }
         public void ExportPrivateSeed(System.Span<byte> destination) { }
         protected abstract void ExportPrivateSeedCore(System.Span<byte> destination);

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -400,6 +400,8 @@
             Link="Common\System\Security\Cryptography\MLKem.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemAlgorithm.cs"
             Link="Common\System\Security\Cryptography\MLKemAlgorithm.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemPkcs8.cs"
+            Link="Common\System\Security\Cryptography\MLKemPkcs8.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.cs"
              Link="Common\System\Security\Cryptography\Oids.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.Shared.cs"

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemImplementation.OpenSsl.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Formats.Asn1;
+using System.Security.Cryptography.Asn1;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography
@@ -13,9 +15,18 @@ namespace System.Security.Cryptography
         // OpenSSL is expected to give "all or none" support.
         internal static new bool IsSupported => Interop.Crypto.EvpKemAlgs.MlKem512 is not null;
 
-        private MLKemImplementation(MLKemAlgorithm algorithm, SafeEvpPKeyHandle key) : base(algorithm)
+        private readonly bool _hasSeed;
+        private readonly bool _hasDecapsulationKey;
+
+        private MLKemImplementation(
+            MLKemAlgorithm algorithm,
+            SafeEvpPKeyHandle key,
+            bool hasSeed,
+            bool hasDecapsulationKey) : base(algorithm)
         {
             _key = key;
+            _hasSeed = hasSeed;
+            _hasDecapsulationKey = hasDecapsulationKey;
         }
 
         internal static MLKem GenerateKeyImpl(MLKemAlgorithm algorithm)
@@ -23,7 +34,7 @@ namespace System.Security.Cryptography
             Debug.Assert(IsSupported);
             string kemName = MapAlgorithmToName(algorithm);
             SafeEvpPKeyHandle key = Interop.Crypto.EvpKemGeneratePkey(kemName);
-            return new MLKemImplementation(algorithm, key);
+            return new MLKemImplementation(algorithm, key, hasSeed: true, hasDecapsulationKey: true);
         }
 
         internal static MLKem ImportPrivateSeedImpl(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
@@ -32,7 +43,7 @@ namespace System.Security.Cryptography
             Debug.Assert(source.Length == algorithm.PrivateSeedSizeInBytes);
             string kemName = MapAlgorithmToName(algorithm);
             SafeEvpPKeyHandle key = Interop.Crypto.EvpKemGeneratePkey(kemName, source);
-            return new MLKemImplementation(algorithm, key);
+            return new MLKemImplementation(algorithm, key, hasSeed: true, hasDecapsulationKey: true);
         }
 
         internal static MLKem ImportDecapsulationKeyImpl(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
@@ -41,7 +52,7 @@ namespace System.Security.Cryptography
             Debug.Assert(source.Length == algorithm.DecapsulationKeySizeInBytes);
             string kemName = MapAlgorithmToName(algorithm);
             SafeEvpPKeyHandle key = Interop.Crypto.EvpPKeyFromData(kemName, source, privateKey: true);
-            return new MLKemImplementation(algorithm, key);
+            return new MLKemImplementation(algorithm, key, hasSeed: false, hasDecapsulationKey: true);
         }
 
         internal static MLKem ImportEncapsulationKeyImpl(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
@@ -50,7 +61,7 @@ namespace System.Security.Cryptography
             Debug.Assert(source.Length == algorithm.EncapsulationKeySizeInBytes);
             string kemName = MapAlgorithmToName(algorithm);
             SafeEvpPKeyHandle key = Interop.Crypto.EvpPKeyFromData(kemName, source, privateKey: false);
-            return new MLKemImplementation(algorithm, key);
+            return new MLKemImplementation(algorithm, key, hasSeed: false, hasDecapsulationKey: false);
         }
 
         protected override void Dispose(bool disposing)
@@ -86,6 +97,64 @@ namespace System.Security.Cryptography
         protected override void ExportEncapsulationKeyCore(Span<byte> destination)
         {
             Interop.Crypto.EvpKemExportEncapsulationKey(_key, destination);
+        }
+
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            string oid = Algorithm.Oid;
+            AlgorithmIdentifierAsn algorithmIdentifier = new()
+            {
+                Algorithm = oid,
+                Parameters = default(ReadOnlyMemory<byte>?),
+            };
+
+            MLKemPrivateKeyAsn privateKeyAsn = default;
+            byte[]? rented = null;
+            int written = 0;
+
+            try
+            {
+                if (_hasSeed)
+                {
+                    int seedSize = Algorithm.PrivateSeedSizeInBytes;
+                    rented = CryptoPool.Rent(seedSize);
+                    Memory<byte> buffer = rented.AsMemory(0, seedSize);
+                    ExportPrivateSeedCore(buffer.Span);
+                    written = buffer.Length;
+                    privateKeyAsn.Seed = buffer;
+                }
+                else if (_hasDecapsulationKey)
+                {
+                    int decapsulationKeySize = Algorithm.DecapsulationKeySizeInBytes;
+                    rented = CryptoPool.Rent(decapsulationKeySize);
+                    Memory<byte> buffer = rented.AsMemory(0, decapsulationKeySize);
+                    ExportDecapsulationKeyCore(buffer.Span);
+                    written = buffer.Length;
+                    privateKeyAsn.ExpandedKey = buffer;
+                }
+                else
+                {
+                    throw new CryptographicException(SR.Cryptography_NotValidPrivateKey);
+                }
+
+                AsnWriter algorithmWriter = new(AsnEncodingRules.DER);
+                algorithmIdentifier.Encode(algorithmWriter);
+                AsnWriter privateKeyWriter = new(AsnEncodingRules.DER);
+                privateKeyAsn.Encode(privateKeyWriter);
+                AsnWriter pkcs8Writer = KeyFormatHelper.WritePkcs8(algorithmWriter, privateKeyWriter);
+
+                bool result = pkcs8Writer.TryEncode(destination, out bytesWritten);
+                privateKeyWriter.Reset();
+                pkcs8Writer.Reset();
+                return result;
+            }
+            finally
+            {
+                if (rented is not null)
+                {
+                    CryptoPool.Return(rented, written);
+                }
+            }
         }
 
         private static string MapAlgorithmToName(MLKemAlgorithm algorithm)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.NotSupported.cs
@@ -60,5 +60,11 @@ namespace System.Security.Cryptography
             Debug.Fail("Caller should have checked platform availability.");
             throw new PlatformNotSupportedException();
         }
+
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.NotSupported.cs
@@ -7,14 +7,11 @@ namespace System.Security.Cryptography
 {
     public sealed partial class MLKemOpenSsl : MLKem
     {
-#pragma warning disable CA1822 // Member does not access instance data and can be marked static
-        private partial void Initialize(SafeEvpPKeyHandle upRefHandle)
-#pragma warning restore CA1822
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        private static partial MLKemAlgorithm AlgorithmFromHandle(SafeEvpPKeyHandle pkeyHandle, out SafeEvpPKeyHandle upRefHandle)
+        private static partial MLKemAlgorithm AlgorithmFromHandle(
+            SafeEvpPKeyHandle pkeyHandle,
+            out SafeEvpPKeyHandle upRefHandle,
+            out bool hasSeed,
+            out bool hasDecapsulationKey)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.OpenSsl.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 
@@ -10,25 +9,27 @@ namespace System.Security.Cryptography
 {
     public sealed partial class MLKemOpenSsl
     {
-        private SafeEvpPKeyHandle _key;
-
-        [MemberNotNull(nameof(_key))]
-        private partial void Initialize(SafeEvpPKeyHandle upRefHandle) => _key = upRefHandle;
-
         public partial SafeEvpPKeyHandle DuplicateKeyHandle()
         {
             ThrowIfDisposed();
             return _key.DuplicateHandle();
         }
 
-        private static partial MLKemAlgorithm AlgorithmFromHandle(SafeEvpPKeyHandle pkeyHandle, out SafeEvpPKeyHandle upRefHandle)
+        private static partial MLKemAlgorithm AlgorithmFromHandle(
+            SafeEvpPKeyHandle pkeyHandle,
+            out SafeEvpPKeyHandle upRefHandle,
+            out bool hasSeed,
+            out bool hasDecapsulationKey)
         {
             ArgumentNullException.ThrowIfNull(pkeyHandle);
             upRefHandle = pkeyHandle.DuplicateHandle();
 
             try
             {
-                Interop.Crypto.PalKemAlgorithmId kemId = Interop.Crypto.EvpKemGetKemIdentifier(upRefHandle);
+                Interop.Crypto.PalKemAlgorithmId kemId = Interop.Crypto.EvpKemGetKemIdentifier(
+                    upRefHandle,
+                    out hasSeed,
+                    out hasDecapsulationKey);
 
                 switch (kemId)
                 {
@@ -93,7 +94,12 @@ namespace System.Security.Cryptography
         /// <inheritdoc />
         protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
         {
-            throw new NotImplementedException();
+            return MLKemPkcs8.TryExportPkcs8PrivateKey(
+                this,
+                _hasSeed,
+                _hasDecapsulationKey,
+                destination,
+                out bytesWritten);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.OpenSsl.cs
@@ -89,5 +89,11 @@ namespace System.Security.Cryptography
         {
             Interop.Crypto.EvpKemExportEncapsulationKey(_key, destination);
         }
+
+        /// <inheritdoc />
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.cs
@@ -23,6 +23,10 @@ namespace System.Security.Cryptography
     [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
     public sealed partial class MLKemOpenSsl : MLKem
     {
+        private readonly SafeEvpPKeyHandle _key;
+        private readonly bool _hasSeed;
+        private readonly bool _hasDecapsulationKey;
+
         /// <summary>
         ///   Initializes a new instance of the <see cref="MLKemOpenSsl" /> class from an existing OpenSSL key
         ///   represented as an <c>EVP_PKEY*</c>.
@@ -47,15 +51,19 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("osx")]
         [UnsupportedOSPlatform("tvos")]
         [UnsupportedOSPlatform("windows")]
-        public MLKemOpenSsl(SafeEvpPKeyHandle pkeyHandle) : base(AlgorithmFromHandle(pkeyHandle, out SafeEvpPKeyHandle upRefHandle))
+        public MLKemOpenSsl(SafeEvpPKeyHandle pkeyHandle) : base(
+            AlgorithmFromHandle(pkeyHandle, out SafeEvpPKeyHandle upRefHandle, out bool hasSeed, out bool hasDecapsulationKey))
         {
-            Initialize(upRefHandle);
+            _key = upRefHandle;
+            _hasSeed = hasSeed;
+            _hasDecapsulationKey = hasDecapsulationKey;
         }
 
-        // This partial can go away if partial constructors are available.
-        // https://github.com/dotnet/csharplang/issues/9058
-        private partial void Initialize(SafeEvpPKeyHandle upRefHandle);
-        private static partial MLKemAlgorithm AlgorithmFromHandle(SafeEvpPKeyHandle pkeyHandle, out SafeEvpPKeyHandle upRefHandle);
+        private static partial MLKemAlgorithm AlgorithmFromHandle(
+            SafeEvpPKeyHandle pkeyHandle,
+            out SafeEvpPKeyHandle upRefHandle,
+            out bool hasSeed,
+            out bool hasDecapsulationKey);
 
         /// <summary>
         /// Creates a duplicate handle.

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_kem.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_kem.c
@@ -30,10 +30,10 @@ int32_t CryptoNative_EvpKemAvailable(const char* algorithm)
     return 0;
 }
 
-int32_t CryptoNative_EvpKemGetPalId(const EVP_PKEY* pKey, int32_t* kemId)
+int32_t CryptoNative_EvpKemGetPalId(const EVP_PKEY* pKey, int32_t* kemId, int32_t* hasSeed, int32_t* hasDecapsulationKey)
 {
 #ifdef NEED_OPENSSL_3_0
-    assert(pKey && kemId);
+    assert(pKey && kemId && hasSeed && hasDecapsulationKey);
 
     if (API_EXISTS(EVP_PKEY_is_a))
     {
@@ -54,14 +54,20 @@ int32_t CryptoNative_EvpKemGetPalId(const EVP_PKEY* pKey, int32_t* kemId)
         else
         {
             *kemId = PalKemId_Unknown;
+            *hasSeed = 0;
+            *hasDecapsulationKey = 0;
+            return 1;
         }
 
+        *hasSeed = EvpPKeyHasKeyOctetStringParam(pKey, OSSL_PKEY_PARAM_ML_KEM_SEED);
+        *hasDecapsulationKey = EvpPKeyHasKeyOctetStringParam(pKey, OSSL_PKEY_PARAM_PRIV_KEY);
         return 1;
     }
 #endif
-
     (void)pKey;
     *kemId = PalKemId_Unknown;
+    *hasSeed = 0;
+    *hasDecapsulationKey = 0;
     return 0;
 }
 

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_kem.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_kem.h
@@ -14,7 +14,10 @@ typedef enum
 } PalKemId;
 
 PALEXPORT int32_t CryptoNative_EvpKemAvailable(const char* algorithm);
-PALEXPORT int32_t CryptoNative_EvpKemGetPalId(const EVP_PKEY* pKey, int32_t* kemId);
+PALEXPORT int32_t CryptoNative_EvpKemGetPalId(const EVP_PKEY* pKey,
+                                              int32_t* kemId,
+                                              int32_t* hasSeed,
+                                              int32_t* hasDecapsulationKey);
 PALEXPORT EVP_PKEY* CryptoNative_EvpKemGeneratePkey(const char* kemName, uint8_t* seed, int32_t seedLength);
 PALEXPORT int32_t CryptoNative_EvpKemExportPrivateSeed(const EVP_PKEY* pKey, uint8_t* destination, int32_t destinationLength);
 PALEXPORT int32_t CryptoNative_EvpKemExportDecapsulationKey(const EVP_PKEY* pKey, uint8_t* destination, int32_t destinationLength);

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey.c
@@ -828,6 +828,35 @@ done:
     return NULL;
 }
 
+int32_t EvpPKeyHasKeyOctetStringParam(const EVP_PKEY* pKey, const char* name)
+{
+    assert(pKey);
+    assert(name);
+
+#ifdef NEED_OPENSSL_3_0
+    if (API_EXISTS(EVP_PKEY_get_octet_string_param))
+    {
+        ERR_clear_error();
+        size_t outLength = 0;
+
+        int ret = EVP_PKEY_get_octet_string_param(pKey, name, NULL, 0, &outLength);
+
+        if (ret == 1)
+        {
+            return outLength > 0 ? 1 : 0;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+#endif
+
+    (void)pKey;
+    (void)name;
+    return 0;
+}
+
 int32_t EvpPKeyGetKeyOctetStringParam(const EVP_PKEY* pKey,
                                       const char* name,
                                       uint8_t* destination,

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey.h
@@ -147,3 +147,8 @@ int32_t EvpPKeyGetKeyOctetStringParam(const EVP_PKEY* pKey,
     const char* name,
     uint8_t* destination,
     int32_t destinationLength);
+
+/*
+Internal function to determine if an EVP_PKEY has a given octet string property.
+*/
+int32_t EvpPKeyHasKeyOctetStringParam(const EVP_PKEY* pKey, const char* name);


### PR DESCRIPTION
This adds PKCS#8 exports to `MLKem` and `MLKemOpenSsl`.

Contributes to #113508 