### PR TITLE
[clr-interp] Fix emit of bb end var moves

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -402,7 +402,7 @@ void InterpCompiler::EmitBBEndVarMoves(InterpBasicBlock *pTargetBB)
 
     for (int i = 0; i < pTargetBB->stackHeight; i++)
     {
-        int sVar = m_pStackPointer[i].var;
+        int sVar = m_pStackBase[i].var;
         int dVar = pTargetBB->pStackState[i].var;
         if (sVar != dVar)
         {
@@ -410,8 +410,8 @@ void InterpCompiler::EmitBBEndVarMoves(InterpBasicBlock *pTargetBB)
             int32_t movOp = InterpGetMovForType(interpType, false);
 
             AddIns(movOp);
-            m_pLastNewIns->SetSVar(m_pStackPointer[i].var);
-            m_pLastNewIns->SetDVar(pTargetBB->pStackState[i].var);
+            m_pLastNewIns->SetSVar(sVar);
+            m_pLastNewIns->SetDVar(dVar);
 
             if (interpType == InterpTypeVT)
             {


### PR DESCRIPTION
This code makes the current stack state match the stack state expected by a bblock that we transition to. The code was accidentally offseting from the current stack pointer, rather than from the base of the stack.

Issue observed by @janvorli in some of the code bring up tests with code involving the ternary conditional operator.