### PR TITLE
[mono][interp] Group all the System.Runtime.Intrinsics logic together

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2607,7 +2607,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			!strcmp (tm, "get_IsHardwareAccelerated")) {
 			*op = MINT_LDC_I4_0;
 		} else if (klass_name_space[25] == '.') {
-			if (strncmp ("Arm", klass_name_space + 26, 3) ||
+			if (!strncmp ("Arm", klass_name_space + 26, 3) ||
 				!strncmp ("X86", klass_name_space + 26, 3)) {
 					if (!strcmp (tm, "get_IsSupported"))
 						*op = MINT_LDC_I4_0;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2594,43 +2594,49 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 				*op = MINT_CEQ_I4;
 			}
 		}
-	}
-	else if (in_corlib &&
+	} else if (in_corlib &&
 			   !strcmp ("System.Runtime.CompilerServices", klass_name_space) &&
 			   !strcmp ("RuntimeFeature", klass_name)) {
 		// NOTE: on the interpreter, use the C# code in System.Private.CoreLib for IsDynamicCodeSupported
 		// and always return false for IsDynamicCodeCompiled
 		if (!strcmp (tm, "get_IsDynamicCodeCompiled"))
 			*op = MINT_LDC_I4_0;
+	} else if (in_corlib && (!strncmp ("System.Runtime.Intrinsics", klass_name_space, 25))) {
+		if (klass_name_space[25] == '\0' &&
+			!strncmp ("Vector", klass_name, 6) &&
+			!strcmp (tm, "get_IsHardwareAccelerated")) {
+			*op = MINT_LDC_I4_0;
+		} else if (klass_name_space[25] == '.') {
+			if (strncmp ("Arm", klass_name_space + 26, 3) ||
+				!strncmp ("X86", klass_name_space + 26, 3)) {
+					if (!strcmp (tm, "get_IsSupported"))
+						*op = MINT_LDC_I4_0;
+					else
+						interp_generate_void_throw (td, MONO_JIT_ICALL_mono_throw_platform_not_supported);
+			} else if (!strncmp ("Wasm", klass_name_space + 26, 4)) {
+				if (!strcmp (tm, "get_IsSupported")) {
+					*op = MINT_LDC_I4_0;
+				}
 #if defined(TARGET_WASM)
-	} else if (in_corlib &&
-			!strncmp ("System.Runtime.Intrinsics.Wasm", klass_name_space, 30) &&
-			!strcmp (klass_name, "WasmBase")) {
-		if (!strcmp (tm, "get_IsSupported")) {
-			*op = MINT_LDC_I4_1;
-		} else if (!strcmp (tm, "LeadingZeroCount")) {
-			if (csignature->params [0]->type == MONO_TYPE_U4 || csignature->params [0]->type == MONO_TYPE_I4)
-				*op = MINT_CLZ_I4;
-			else if (csignature->params [0]->type == MONO_TYPE_U8 || csignature->params [0]->type == MONO_TYPE_I8)
-				*op = MINT_CLZ_I8;
-		} else if (!strcmp (tm, "TrailingZeroCount")) {
-			if (csignature->params [0]->type == MONO_TYPE_U4 || csignature->params [0]->type == MONO_TYPE_I4)
-				*op = MINT_CTZ_I4;
-			else if (csignature->params [0]->type == MONO_TYPE_U8 || csignature->params [0]->type == MONO_TYPE_I8)
-				*op = MINT_CTZ_I8;
-		}
+				if (!strcmp (klass_name, "WasmBase")) {
+					if (!strcmp (tm, "get_IsSupported")) {
+						// overide the value set above
+						*op = MINT_LDC_I4_1;
+					} else if (!strcmp (tm, "LeadingZeroCount")) {
+						if (csignature->params [0]->type == MONO_TYPE_U4 || csignature->params [0]->type == MONO_TYPE_I4)
+							*op = MINT_CLZ_I4;
+						else if (csignature->params [0]->type == MONO_TYPE_U8 || csignature->params [0]->type == MONO_TYPE_I8)
+							*op = MINT_CLZ_I8;
+					} else if (!strcmp (tm, "TrailingZeroCount")) {
+						if (csignature->params [0]->type == MONO_TYPE_U4 || csignature->params [0]->type == MONO_TYPE_I4)
+							*op = MINT_CTZ_I4;
+						else if (csignature->params [0]->type == MONO_TYPE_U8 || csignature->params [0]->type == MONO_TYPE_I8)
+							*op = MINT_CTZ_I8;
+					}
+				}
 #endif
-	} else if (in_corlib &&
-			(!strncmp ("System.Runtime.Intrinsics.Arm", klass_name_space, 29) ||
-			!strncmp ("System.Runtime.Intrinsics.PackedSimd", klass_name_space, 36) ||
-			!strncmp ("System.Runtime.Intrinsics.X86", klass_name_space, 29) ||
-			!strncmp ("System.Runtime.Intrinsics.Wasm", klass_name_space, 30)) &&
-			!strcmp (tm, "get_IsSupported")) {
-		*op = MINT_LDC_I4_0;
-	} else if (in_corlib &&
-		(!strncmp ("System.Runtime.Intrinsics.Arm", klass_name_space, 29) ||
-		!strncmp ("System.Runtime.Intrinsics.X86", klass_name_space, 29))) {
-		interp_generate_void_throw (td, MONO_JIT_ICALL_mono_throw_platform_not_supported);
+			}
+		}
 	} else if (in_corlib && !strncmp ("System.Numerics", klass_name_space, 15)) {
 		if (!strcmp ("Vector", klass_name) &&
 				!strcmp (tm, "get_IsHardwareAccelerated")) {
@@ -2683,11 +2689,6 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 					*op = MINT_LOG2_I8;
 			}
 		}
-	} else if (in_corlib &&
-			   (!strncmp ("System.Runtime.Intrinsics", klass_name_space, 25) &&
-				!strncmp ("Vector", klass_name, 6) &&
-				!strcmp (tm, "get_IsHardwareAccelerated"))) {
-		*op = MINT_LDC_I4_0;
 	} else if ((target_method->klass == mono_defaults.double_class) || (target_method->klass == mono_defaults.single_class)) {
 		MonoGenericContext *method_context = mono_method_get_context (target_method);
 		bool isDouble = target_method->klass == mono_defaults.double_class;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2620,7 +2620,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 #if defined(TARGET_WASM)
 				if (!strcmp (klass_name, "WasmBase")) {
 					if (!strcmp (tm, "get_IsSupported")) {
-						// overide the value set above
+						// override the value set above
 						*op = MINT_LDC_I4_1;
 					} else if (!strcmp (tm, "LeadingZeroCount")) {
 						if (csignature->params [0]->type == MONO_TYPE_U4 || csignature->params [0]->type == MONO_TYPE_I4)


### PR DESCRIPTION
Remove nonexistent namespace check and avoid comparing the same 25 characters over and over for every System.Runtime.Intrinsics method.