### PR TITLE
Fix build break with cmake 4.0

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -77,9 +77,14 @@ if (NOT SWIFT_COMPILER_TARGET)
     endif()
 endif()
 
+set(SWIFT_SDK_FLAG "")
+if (CMAKE_OSX_SYSROOT)
+    set(SWIFT_SDK_FLAG -sdk ${CMAKE_OSX_SYSROOT})
+endif()
+
 add_custom_command(
     OUTPUT pal_swiftbindings.o
-    COMMAND xcrun swiftc -emit-object -static -parse-as-library -enable-library-evolution -g ${SWIFT_OPTIMIZATION_FLAG} -runtime-compatibility-version none -sdk ${CMAKE_OSX_SYSROOT} -target ${SWIFT_COMPILER_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift -o pal_swiftbindings.o
+    COMMAND xcrun swiftc -emit-object -static -parse-as-library -enable-library-evolution -g ${SWIFT_OPTIMIZATION_FLAG} -runtime-compatibility-version none ${SWIFT_SDK_FLAG} -target ${SWIFT_COMPILER_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift -o pal_swiftbindings.o
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift
     COMMENT "Compiling Swift file pal_swiftbindings.swift"
 )


### PR DESCRIPTION
cmake 4.0 no longer sets the CMAKE_OSX_SYSROOT variable for macOS targets (this includes Mac Catalyst): https://cmake.org/cmake/help/v4.0/release/4.0.html#other-changes

> Builds targeting macOS no longer choose any SDK or pass an -isysroot flag to the compiler by default. Instead, compilers are expected to choose a default macOS SDK on their own. In order to use a compiler that does not do this, users must now specify -DCMAKE_OSX_SYSROOT=macosx when configuring their build.

We need to stop passing the variable to swiftc in that case and rely on the default behavior.

Fixes https://github.com/dotnet/runtime/issues/114235
Fixes https://github.com/dotnet/runtime/issues/114248