### PR TITLE
[release/8.0-staging] Fix build break with cmake 4.0

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -49,9 +49,14 @@ if (NOT SWIFT_COMPILER_TARGET AND CLR_CMAKE_TARGET_OSX)
     set(SWIFT_COMPILER_TARGET "${CMAKE_OSX_ARCHITECTURES}-apple-${SWIFT_PLATFORM}${SWIFT_DEPLOYMENT_TARGET}${SWIFT_PLATFORM_SUFFIX}")
 endif()
 
+set(SWIFT_SDK_FLAG "")
+if (CMAKE_OSX_SYSROOT)
+    set(SWIFT_SDK_FLAG -sdk ${CMAKE_OSX_SYSROOT})
+endif()
+
 add_custom_command(
     OUTPUT pal_swiftbindings.o
-    COMMAND xcrun swiftc -emit-object -static -parse-as-library -runtime-compatibility-version none -sdk ${CMAKE_OSX_SYSROOT} -target ${SWIFT_COMPILER_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift -o pal_swiftbindings.o
+    COMMAND xcrun swiftc -emit-object -static -parse-as-library -runtime-compatibility-version none ${SWIFT_SDK_FLAG} -target ${SWIFT_COMPILER_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift -o pal_swiftbindings.o
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift
     COMMENT "Compiling Swift file pal_swiftbindings.swift"
 )


### PR DESCRIPTION
Backport of #114277 to release/8.0-staging

/cc @akoeplinger

## Customer Impact

- [ ] Customer reported
- [x] Found internally

This is an infrastructure/build-only change and required for us to build with cmake 4.0+.

## Regression

- [ ] Yes
- [x] No

No, it was caused by a change in cmake 4.0

## Testing

CI testing

## Risk

Low. This is a build-only change.