### PR TITLE
JIT: remove dependence on GetThreadCycles

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9244,16 +9244,12 @@ void Compiler::PrintPerMethodLoopHoistStats()
 void Compiler::RecordStateAtEndOfInlining()
 {
 #if defined(DEBUG)
-
-    m_compCyclesAtEndOfInlining    = 0;
-    m_compTickCountAtEndOfInlining = 0;
-    bool b                         = CycleTimer::GetThreadCyclesS(&m_compCyclesAtEndOfInlining);
-    if (!b)
+    LARGE_INTEGER lpCycles;
+    BOOL          result = QueryPerformanceCounter(&lpCycles);
+    if (result == TRUE)
     {
-        return; // We don't have a thread cycle counter.
+        m_compCyclesAtEndOfInlining = (int64_t) lpCycles.QuadPart;
     }
-    m_compTickCountAtEndOfInlining = GetTickCount();
-
 #endif // defined(DEBUG)
 }
 
@@ -9264,19 +9260,24 @@ void Compiler::RecordStateAtEndOfInlining()
 void Compiler::RecordStateAtEndOfCompilation()
 {
 #if defined(DEBUG)
-
-    // Common portion
     m_compCycles = 0;
-    uint64_t compCyclesAtEnd;
-    bool     b = CycleTimer::GetThreadCyclesS(&compCyclesAtEnd);
-    if (!b)
+
+    LARGE_INTEGER lpCycles;
+    BOOL          result = QueryPerformanceCounter(&lpCycles);
+    if (result == TRUE)
     {
-        return; // We don't have a thread cycle counter.
+        if ((int64_t)lpCycles.QuadPart > m_compCyclesAtEndOfInlining)
+        {
+            LARGE_INTEGER lpFreq;
+            result = QueryPerformanceFrequency(&lpFreq);
+            if (result == TRUE)
+            {
+                m_compCycles = (int64_t)lpCycles.QuadPart - m_compCyclesAtEndOfInlining;
+                m_compCycles *= 1000000;
+                m_compCycles /= (int64_t)lpFreq.QuadPart;
+            }
+        }
     }
-    assert(compCyclesAtEnd >= m_compCyclesAtEndOfInlining);
-
-    m_compCycles = compCyclesAtEnd - m_compCyclesAtEndOfInlining;
-
 #endif // defined(DEBUG)
 }
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9248,7 +9248,7 @@ void Compiler::RecordStateAtEndOfInlining()
     BOOL          result = QueryPerformanceCounter(&lpCycles);
     if (result == TRUE)
     {
-        m_compCyclesAtEndOfInlining = (int64_t) lpCycles.QuadPart;
+        m_compCyclesAtEndOfInlining = (int64_t)lpCycles.QuadPart;
     }
 #endif // defined(DEBUG)
 }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -11453,12 +11453,10 @@ private:
 
 #if defined(DEBUG)
     // These variables are associated with maintaining SQM data about compile time.
-    uint64_t m_compCyclesAtEndOfInlining; // The thread-virtualized cycle count at the end of the inlining phase
-                                          // in the current compilation.
-    uint64_t m_compCycles;                // Net cycle count for current compilation
-    DWORD m_compTickCountAtEndOfInlining; // The result of GetTickCount() (# ms since some epoch marker) at the end of
-                                          // the inlining phase in the current compilation.
-#endif                                    // defined(DEBUG)
+    int64_t m_compCyclesAtEndOfInlining; // Raw timer count at the end of the inlining phase
+                                         // in the current compilation.
+    int64_t m_compCycles;                // Wall clock elapsed time for current compilation (microseconds)
+#endif                                   // defined(DEBUG)
 
     // Records the SQM-relevant (cycles and tick count).  Should be called after inlining is complete.
     // (We do this after inlining because this marks the last point at which the JIT is likely to cause


### PR DESCRIPTION
and hence on pal-provided QueryThreadCycleTime.

Use QueryPerformanceCounter/Frequency instead. This should be good enough for this feature (considering it exists only under DEBUG).

Fixes #105472