### PR TITLE
[RISC-V] Fix RISC-V Windows build

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -8469,7 +8469,10 @@ void emitter::emitDispDataSec(dataSecDsc* section, BYTE* dst)
                 switch (data->dsDataType)
                 {
                     case TYP_FLOAT:
-                        assert(data->dsSize >= 4);
+                        if (data->dsSize < 4)
+                        {
+                            printf("\t<Unexpected data size %d (expected >= 4)\n", data->dsSize);
+                        }
                         printf("\tdd\t%08llXh\t", (UINT64) * reinterpret_cast<uint32_t*>(&data->dsCont[i]));
                         printf("\t; %9.6g",
                                FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(&data->dsCont[i])));
@@ -8477,7 +8480,10 @@ void emitter::emitDispDataSec(dataSecDsc* section, BYTE* dst)
                         break;
 
                     case TYP_DOUBLE:
-                        assert(data->dsSize >= 8);
+                        if (data->dsSize < 8)
+                        {
+                            printf("\t<Unexpected data size %d (expected >= 8)\n", data->dsSize);
+                        }
                         printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsCont[i]));
                         printf("\t; %12.9g", *reinterpret_cast<double*>(&data->dsCont[i]));
                         i += 8;
@@ -8498,7 +8504,10 @@ void emitter::emitDispDataSec(dataSecDsc* section, BYTE* dst)
                                 break;
 
                             case 2:
-                                assert((data->dsSize % 2) == 0);
+                                if ((data->dsSize % 2) != 0)
+                                {
+                                    printf("\t<Unexpected data size %d (expected size%%2 == 0)\n", data->dsSize);
+                                }
                                 printf("\tdw\t%04Xh", *reinterpret_cast<uint16_t*>(&data->dsCont[i]));
                                 for (j = 2; j < 24; j += 2)
                                 {
@@ -8511,7 +8520,10 @@ void emitter::emitDispDataSec(dataSecDsc* section, BYTE* dst)
 
                             case 12:
                             case 4:
-                                assert((data->dsSize % 4) == 0);
+                                if ((data->dsSize % 4) != 0)
+                                {
+                                    printf("\t<Unexpected data size %d (expected size%%4 == 0)\n", data->dsSize);
+                                }
                                 printf("\tdd\t%08Xh", *reinterpret_cast<uint32_t*>(&data->dsCont[i]));
                                 for (j = 4; j < 24; j += 4)
                                 {
@@ -8526,7 +8538,10 @@ void emitter::emitDispDataSec(dataSecDsc* section, BYTE* dst)
                             case 32:
                             case 16:
                             case 8:
-                                assert((data->dsSize % 8) == 0);
+                                if ((data->dsSize % 8) != 0)
+                                {
+                                    printf("\t<Unexpected data size %d (expected size%%8 == 0)\n", data->dsSize);
+                                }
                                 printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsCont[i]));
                                 for (j = 8; j < 64; j += 8)
                                 {
@@ -8538,7 +8553,7 @@ void emitter::emitDispDataSec(dataSecDsc* section, BYTE* dst)
                                 break;
 
                             default:
-                                assert(!"unexpected elemSize");
+                                printf("\t<Unexpected elemSize %d)\n", elemSize);
                                 break;
                         }
                 }

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -1377,7 +1377,7 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
     }
 
     bool     utilizeSRLI = false;
-    int      srliShiftAmount;
+    int      srliShiftAmount = 0;
     uint64_t originalImm = imm;
     bool     cond1       = (y - x) > 31;
     if ((((uint64_t)imm >> 63) & 0b1) == 0 && cond1)
@@ -1429,8 +1429,8 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
      * See the following discussion:
      * https://github.com/dotnet/runtime/pull/113250#discussion_r1987576070 */
 
-    uint32_t offset1        = imm & WordMask(x);
-    uint32_t offset2        = (~(offset1 - 1)) & WordMask(x);
+    uint32_t offset1        = imm & WordMask((uint8_t)x);
+    uint32_t offset2        = (~(offset1 - 1)) & WordMask((uint8_t)x);
     uint32_t offset         = offset1;
     bool     isSubtractMode = false;
 
@@ -1440,8 +1440,8 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
          * Since adding 1 to it will change the sign bit. Instead, shift x and y
          * to the left by one. */
         int      newX       = x + 1;
-        uint32_t newOffset1 = imm & WordMask(newX);
-        uint32_t newOffset2 = (~(newOffset1 - 1)) & WordMask(newX);
+        uint32_t newOffset1 = imm & WordMask((uint8_t)newX);
+        uint32_t newOffset2 = (~(newOffset1 - 1)) & WordMask((uint8_t)newX);
         if (newOffset2 < offset1)
         {
             x              = newX;
@@ -1493,7 +1493,7 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
 
     int chunkLsbPos = (x < 11) ? 0 : (x - 11);
     int shift       = (x < 11) ? x : 11;
-    int chunkMask   = (x < 11) ? WordMask(x) : WordMask(11);
+    int chunkMask   = (x < 11) ? WordMask((uint8_t)x) : WordMask(11);
     while (true)
     {
         uint32_t chunk = (offset >> chunkLsbPos) & chunkMask;
@@ -1522,7 +1522,7 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
             if (isSubtractMode)
             {
                 ins[numberOfInstructions - 1]    = INS_addi;
-                values[numberOfInstructions - 1] = -chunk;
+                values[numberOfInstructions - 1] = -(int32_t)chunk;
             }
             else
             {

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -1376,10 +1376,10 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
         insCountLimit = absMaxInsCount;
     }
 
-    bool     utilizeSRLI = false;
+    bool     utilizeSRLI     = false;
     int      srliShiftAmount = 0;
-    uint64_t originalImm = imm;
-    bool     cond1       = (y - x) > 31;
+    uint64_t originalImm     = imm;
+    bool     cond1           = (y - x) > 31;
     if ((((uint64_t)imm >> 63) & 0b1) == 0 && cond1)
     {
         srliShiftAmount  = BitOperations::LeadingZeroCount((uint64_t)imm);


### PR DESCRIPTION
Also, convert some asserts in `emitDispDataSec` to `printf`: we generally don't want asserts in debug printing code, and I was hitting some of these when disassembling some RISC-V code.