### PR TITLE
[clr-interp] Refactor passing of configuration environment variables

### DIFF
--- a/src/coreclr/interpreter/CMakeLists.txt
+++ b/src/coreclr/interpreter/CMakeLists.txt
@@ -3,6 +3,7 @@ set(INTERPRETER_SOURCES
   compiler.cpp
   compileropt.cpp
   intops.cpp
+  interpconfig.cpp
   eeinterp.cpp)
 
 set(INTERPRETER_LINK_LIBRARIES

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -827,14 +827,18 @@ int32_t* InterpCompiler::GetCode(int32_t *pCodeSize)
 }
 
 InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
-                                CORINFO_METHOD_INFO* methodInfo,
-                                bool verbose)
+                                CORINFO_METHOD_INFO* methodInfo)
 {
     m_methodHnd = methodInfo->ftn;
     m_compScopeHnd = methodInfo->scope;
     m_compHnd = compHnd;
     m_methodInfo = methodInfo;
-    m_verbose = verbose;
+
+#ifdef DEBUG
+    m_methodName = compHnd->getMethodNameFromMetadata(methodInfo->ftn, nullptr, nullptr, nullptr, 0);
+    if (m_methodName && InterpConfig.InterpDump() && !strcmp(m_methodName, InterpConfig.InterpDump()))
+        m_verbose = true;
+#endif
 }
 
 InterpMethod* InterpCompiler::CompileMethod()

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1803,9 +1803,15 @@ int InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
         goto exit_bad_code;
     }
 
+    m_currentILOffset = -1;
+
+#if DEBUG
+    if (m_methodName && InterpConfig.InterpHalt() && !strcmp(m_methodName, InterpConfig.InterpHalt()))
+        AddIns(INTOP_BREAKPOINT);
+#endif
+
     if ((methodInfo->options & CORINFO_OPT_INIT_LOCALS) && m_ILLocalsSize > 0)
     {
-        m_currentILOffset = 0;
         AddIns(INTOP_INITLOCALS);
         m_pLastNewIns->data[0] = m_ILLocalsOffset;
         m_pLastNewIns->data[1] = m_ILLocalsSize;

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -266,7 +266,10 @@ private:
     CORINFO_MODULE_HANDLE m_compScopeHnd;
     COMP_HANDLE m_compHnd;
     CORINFO_METHOD_INFO* m_methodInfo;
+#ifdef DEBUG
+    const char *m_methodName;
     bool m_verbose;
+#endif
 
     static int32_t InterpGetMovForType(InterpType interpType, bool signExtend);
 
@@ -424,7 +427,7 @@ private:
     void PrintCompiledIns(const int32_t *ip, const int32_t *start);
 public:
 
-    InterpCompiler(COMP_HANDLE compHnd, CORINFO_METHOD_INFO* methodInfo, bool verbose);
+    InterpCompiler(COMP_HANDLE compHnd, CORINFO_METHOD_INFO* methodInfo);
 
     InterpMethod* CompileMethod();
 

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -79,7 +79,7 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
         return CORJIT_SKIPPED;
     }
 
-    InterpCompiler compiler(compHnd, methodInfo, false /* verbose */);
+    InterpCompiler compiler(compHnd, methodInfo);
     InterpMethod *pMethod = compiler.CompileMethod();
 
     int32_t IRCodeSize;

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -26,7 +26,10 @@ extern "C" INTERP_API void jitStartup(ICorJitHost* jitHost)
         return;
     }
     g_interpHost = jitHost;
-    // TODO Interp intialization
+
+    assert(!InterpConfig.IsInitialized());
+    InterpConfig.Initialize(jitHost);
+
     g_interpInitialized = true;
 }
 /*****************************************************************************/
@@ -64,11 +67,9 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
     {
         const char *methodName = compHnd->getMethodNameFromMetadata(methodInfo->ftn, nullptr, nullptr, nullptr, 0);
 
-        // TODO: replace this by something like the JIT does to support multiple methods being specified and we don't
-        // keep fetching it on each call to compileMethod
-        const char *methodToInterpret = g_interpHost->getStringConfigValue("Interpreter");
+        // TODO: replace this by something like the JIT does to support multiple methods being specified
+        const char *methodToInterpret = InterpConfig.Interpreter();
         doInterpret = (methodName != NULL && strcmp(methodName, methodToInterpret) == 0);
-        g_interpHost->freeStringConfigValue(methodToInterpret);
         if (doInterpret)
             g_interpModule = methodInfo->scope;
     }

--- a/src/coreclr/interpreter/interpconfig.cpp
+++ b/src/coreclr/interpreter/interpconfig.cpp
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "interpreter.h"
+
+InterpConfigValues InterpConfig;
+
+void InterpConfigValues::Initialize(ICorJitHost* host)
+{
+    assert(!m_isInitialized);
+
+#define RELEASE_CONFIG_STRING(name, key)    m_##name = host->getStringConfigValue(key);
+
+#include "interpconfigvalues.h"
+
+    m_isInitialized = true;
+}
+
+void InterpConfigValues::Destroy(ICorJitHost* host)
+{
+    if (!m_isInitialized)
+        return;
+
+#define RELEASE_CONFIG_STRING(name, key)    host->freeStringConfigValue(m_##name);
+
+#include "interpconfigvalues.h"
+
+    m_isInitialized = false;
+}

--- a/src/coreclr/interpreter/interpconfig.h
+++ b/src/coreclr/interpreter/interpconfig.h
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef _INTERPCONFIG_H_
+#define _INTERPCONFIG_H_
+
+class ICorJitHost;
+
+class InterpConfigValues
+{
+private:
+    bool m_isInitialized;
+
+#define RELEASE_CONFIG_STRING(name, key)    const char* m_##name;
+
+#include "interpconfigvalues.h"
+
+public:
+
+#define RELEASE_CONFIG_STRING(name, key)    \
+    inline const char* name() const         \
+    {                                       \
+        return m_##name;                    \
+    }
+
+#include "interpconfigvalues.h"
+
+public:
+    InterpConfigValues()
+    {
+    }
+
+    inline bool IsInitialized() const
+    {
+        return m_isInitialized != 0;
+    }
+
+    void Initialize(ICorJitHost* host);
+    void Destroy(ICorJitHost* host);
+};
+
+extern InterpConfigValues InterpConfig;
+
+#endif

--- a/src/coreclr/interpreter/interpconfigvalues.h
+++ b/src/coreclr/interpreter/interpconfigvalues.h
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifdef DEBUG
+#define CONFIG_STRING(name, key)                RELEASE_CONFIG_STRING(name, key)
+#else
+#define CONFIG_STRING(name, key)
+#endif
+
+RELEASE_CONFIG_STRING(Interpreter, "Interpreter")
+CONFIG_STRING(InterpHalt, "InterpHalt");
+CONFIG_STRING(InterpDump, "InterpDump");
+
+#undef CONFIG_STRING
+#undef RELEASE_CONFIG_STRING

--- a/src/coreclr/interpreter/interpreter.h
+++ b/src/coreclr/interpreter/interpreter.h
@@ -22,6 +22,7 @@
 
 #include "interpretershared.h"
 #include "compiler.h"
+#include "interpconfig.h"
 
 #define ALIGN_UP_TO(val,align) ((((size_t)val) + (size_t)((align) - 1)) & (~((size_t)(align - 1))))
 

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -252,6 +252,7 @@ OPDEF(INTOP_NEWOBJ_VT, "newobj.vt", 5, 1, 1, InterpOpMethodToken)
 OPDEF(INTOP_CALL_HELPER_PP, "call.helper.pp", 5, 1, 0, InterpOpThreeInts)
 
 OPDEF(INTOP_ZEROBLK_IMM, "zeroblk.imm", 3, 0, 1, InterpOpInt)
+OPDEF(INTOP_BREAKPOINT, "breakpoint", 1, 0, 0, InterpOpNoArgs)
 OPDEF(INTOP_FAILFAST, "failfast", 1, 0, 0, InterpOpNoArgs)
 
 // All instructions after this point are IROPS, instructions that are not emitted/executed

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -31,6 +31,13 @@ InterpThreadContext* InterpGetThreadContext()
     }
 }
 
+#ifdef DEBUG
+static void InterpBreakpoint()
+{
+
+}
+#endif
+
 #define LOCAL_VAR_ADDR(offset,type) ((type*)(stack + (offset)))
 #define LOCAL_VAR(offset,type) (*LOCAL_VAR_ADDR(offset, type))
 // TODO once we have basic EH support
@@ -60,6 +67,12 @@ MAIN_LOOP:
 
         switch (*ip)
         {
+#ifdef DEBUG
+            case INTOP_BREAKPOINT:
+                InterpBreakpoint();
+                ip++;
+                break;
+#endif
             case INTOP_INITLOCALS:
                 memset(stack + ip[1], 0, ip[2]);
                 ip += 3;


### PR DESCRIPTION
This PR adds a `InterpConfigValues` class that holds all interpreter configuration knobs, in a similar fashion to RyuJIT's `JitConfigValues`. Support for method sets was not currently added, meaning that we can pass a single method currently and the match happens by comparing the name only, without support for regex like wildcards.

Added `DOTNET_InterpDump` which selects the method to have its compilation information dumped.
Added `DOTNET_InterpHalt` which facilitates breaking whenever the method in question starts executing.