### PR TITLE
ML-KEM: EncryptedPrivateKeyInfo exports

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -933,20 +933,11 @@ namespace System.Security.Cryptography
             PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, password, ReadOnlySpan<byte>.Empty);
             ThrowIfDisposed();
 
-            AsnWriter? writer = null;
-
-            try
-            {
-                writer = TryExportEncryptedPkcs8PrivateKeyCore<char>(
-                    password,
-                    pbeParameters,
-                    KeyFormatHelper.WriteEncryptedPkcs8);
-                return writer.TryEncode(destination, out bytesWritten);
-            }
-            finally
-            {
-                writer?.Reset();
-            }
+            AsnWriter writer = ExportEncryptedPkcs8PrivateKeyCore<char>(
+                password,
+                pbeParameters,
+                KeyFormatHelper.WriteEncryptedPkcs8);
+            return writer.TryEncode(destination, out bytesWritten);
         }
 
         /// <summary>
@@ -995,20 +986,11 @@ namespace System.Security.Cryptography
             PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, ReadOnlySpan<char>.Empty, passwordBytes);
             ThrowIfDisposed();
 
-            AsnWriter? writer = null;
-
-            try
-            {
-                writer = TryExportEncryptedPkcs8PrivateKeyCore<byte>(
-                    passwordBytes,
-                    pbeParameters,
-                    KeyFormatHelper.WriteEncryptedPkcs8);
-                return writer.TryEncode(destination, out bytesWritten);
-            }
-            finally
-            {
-                writer?.Reset();
-            }
+            AsnWriter writer = ExportEncryptedPkcs8PrivateKeyCore<byte>(
+                passwordBytes,
+                pbeParameters,
+                KeyFormatHelper.WriteEncryptedPkcs8);
+            return writer.TryEncode(destination, out bytesWritten);
         }
 
         /// <summary>
@@ -1044,20 +1026,11 @@ namespace System.Security.Cryptography
             PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, ReadOnlySpan<char>.Empty, passwordBytes);
             ThrowIfDisposed();
 
-            AsnWriter? writer = null;
-
-            try
-            {
-                writer = TryExportEncryptedPkcs8PrivateKeyCore<byte>(
-                    passwordBytes,
-                    pbeParameters,
-                    KeyFormatHelper.WriteEncryptedPkcs8);
-                return writer.Encode();
-            }
-            finally
-            {
-                writer?.Reset();
-            }
+            AsnWriter writer = ExportEncryptedPkcs8PrivateKeyCore<byte>(
+                passwordBytes,
+                pbeParameters,
+                KeyFormatHelper.WriteEncryptedPkcs8);
+            return writer.Encode();
         }
 
         /// <summary>
@@ -1093,20 +1066,11 @@ namespace System.Security.Cryptography
             PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, password, ReadOnlySpan<byte>.Empty);
             ThrowIfDisposed();
 
-            AsnWriter? writer = null;
-
-            try
-            {
-                writer = TryExportEncryptedPkcs8PrivateKeyCore<char>(
-                    password,
-                    pbeParameters,
-                    KeyFormatHelper.WriteEncryptedPkcs8);
-                return writer.Encode();
-            }
-            finally
-            {
-                writer?.Reset();
-            }
+            AsnWriter writer = ExportEncryptedPkcs8PrivateKeyCore<char>(
+                password,
+                pbeParameters,
+                KeyFormatHelper.WriteEncryptedPkcs8);
+            return writer.Encode();
         }
 
         /// <summary>
@@ -1708,7 +1672,7 @@ namespace System.Security.Cryptography
 #endif
         }
 
-        private AsnWriter TryExportEncryptedPkcs8PrivateKeyCore<TChar>(
+        private AsnWriter ExportEncryptedPkcs8PrivateKeyCore<TChar>(
             ReadOnlySpan<TChar> password,
             PbeParameters pbeParameters,
             WriteEncryptedPkcs8Func<TChar> encryptor)

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -888,6 +888,261 @@ namespace System.Security.Cryptography
         protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
 
         /// <summary>
+        ///  Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
+        ///  using a char-based password.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 EncryptedPrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///    <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>This instance only represents a public key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The private key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        /// </exception>
+        public bool TryExportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<char> password,
+            PbeParameters pbeParameters,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, password, ReadOnlySpan<byte>.Empty);
+            ThrowIfDisposed();
+
+            AsnWriter? writer = null;
+
+            try
+            {
+                writer = TryExportEncryptedPkcs8PrivateKeyCore<char>(
+                    password,
+                    pbeParameters,
+                    KeyFormatHelper.WriteEncryptedPkcs8);
+                return writer.TryEncode(destination, out bytesWritten);
+            }
+            finally
+            {
+                writer?.Reset();
+            }
+        }
+
+        /// <summary>
+        ///  Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
+        ///  using a byte-based password.
+        /// </summary>
+        /// <param name="passwordBytes">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 EncryptedPrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///    <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>This instance only represents a public key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The private key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        /// </exception>
+        public bool TryExportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<byte> passwordBytes,
+            PbeParameters pbeParameters,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, ReadOnlySpan<char>.Empty, passwordBytes);
+            ThrowIfDisposed();
+
+            AsnWriter? writer = null;
+
+            try
+            {
+                writer = TryExportEncryptedPkcs8PrivateKeyCore<byte>(
+                    passwordBytes,
+                    pbeParameters,
+                    KeyFormatHelper.WriteEncryptedPkcs8);
+                return writer.TryEncode(destination, out bytesWritten);
+            }
+            finally
+            {
+                writer?.Reset();
+            }
+        }
+
+        /// <summary>
+        ///  Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a byte-based password.
+        /// </summary>
+        /// <param name="passwordBytes">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   A byte array containing the PKCS#8 EncryptedPrivateKeyInfo representation of the this key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///    <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>This instance only represents a public key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The private key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        /// </exception>
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters)
+        {
+            ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, ReadOnlySpan<char>.Empty, passwordBytes);
+            ThrowIfDisposed();
+
+            AsnWriter? writer = null;
+
+            try
+            {
+                writer = TryExportEncryptedPkcs8PrivateKeyCore<byte>(
+                    passwordBytes,
+                    pbeParameters,
+                    KeyFormatHelper.WriteEncryptedPkcs8);
+                return writer.Encode();
+            }
+            finally
+            {
+                writer?.Reset();
+            }
+        }
+
+        /// <summary>
+        ///  Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   A byte array containing the PKCS#8 EncryptedPrivateKeyInfo representation of the this key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///    <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>This instance only represents a public key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The private key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        /// </exception>
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters)
+        {
+            ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, password, ReadOnlySpan<byte>.Empty);
+            ThrowIfDisposed();
+
+            AsnWriter? writer = null;
+
+            try
+            {
+                writer = TryExportEncryptedPkcs8PrivateKeyCore<char>(
+                    password,
+                    pbeParameters,
+                    KeyFormatHelper.WriteEncryptedPkcs8);
+                return writer.Encode();
+            }
+            finally
+            {
+                writer?.Reset();
+            }
+        }
+
+        /// <summary>
+        ///  Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   A byte array containing the PKCS#8 EncryptedPrivateKeyInfo representation of the this key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///    <paramref name="pbeParameters" /> or <paramref name="password" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>This instance only represents a public key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The private key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        /// </exception>
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters)
+        {
+            ThrowIfNull(password);
+            return ExportEncryptedPkcs8PrivateKey(password.AsSpan(), pbeParameters);
+        }
+
+        /// <summary>
         ///  Imports an ML-KEM encapsulation key from an X.509 SubjectPublicKeyInfo structure.
         /// </summary>
         /// <param name="source">
@@ -1452,5 +1707,41 @@ namespace System.Security.Cryptography
             }
 #endif
         }
+
+        private AsnWriter TryExportEncryptedPkcs8PrivateKeyCore<TChar>(
+            ReadOnlySpan<TChar> password,
+            PbeParameters pbeParameters,
+            WriteEncryptedPkcs8Func<TChar> encryptor)
+        {
+            // There are 28 bytes of overhead on a plain PKCS#8 export for an expanded key. Add a little extra for
+            // some extra space.
+            int initialSize = Algorithm.DecapsulationKeySizeInBytes + 32;
+            byte[] rented = CryptoPool.Rent(initialSize);
+            int written;
+
+            while (!TryExportPkcs8PrivateKey(rented, out written))
+            {
+                CryptoPool.Return(rented, 0);
+                rented = CryptoPool.Rent(rented.Length * 2);
+            }
+
+            AsnWriter tmp = new(AsnEncodingRules.BER, initialCapacity: written);
+
+            try
+            {
+                tmp.WriteEncodedValueForCrypto(rented.AsSpan(0, written));
+                return encryptor(password, tmp, pbeParameters);
+            }
+            finally
+            {
+                tmp.Reset();
+                CryptoPool.Return(rented, written);
+            }
+        }
+
+        private delegate AsnWriter WriteEncryptedPkcs8Func<TChar>(
+            ReadOnlySpan<TChar> password,
+            AsnWriter writer,
+            PbeParameters pbeParameters);
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Formats.Asn1;
+using System.Security.Cryptography.Asn1;
 using System.Text;
 using Microsoft.DotNet.XUnitExtensions;
 using Test.Cryptography;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.Security.Cryptography.Tests
 {
@@ -564,6 +567,28 @@ namespace System.Security.Cryptography.Tests
                 s_aes128Pbe));
         }
 
+        [Theory]
+        [MemberData(nameof(ExportPkcs8Parameters))]
+        public void ExportEncryptedPkcs8PrivateKey_PbeParameters(PbeParameters pbeParameters)
+        {
+            using MLKem kem = ImportPrivateSeed(MLKemAlgorithm.MLKem512, MLKemTestData.MLKem512PrivateSeed);
+            AssertEncryptedExportPkcs8PrivateKey(kem, MLKemTestData.EncryptedPrivateKeyPassword, pbeParameters, pkcs8 =>
+            {
+                AssertEncryptedPkcs8PrivateKeyContents(pbeParameters, pkcs8);
+            });
+        }
+
+        public static IEnumerable<object[]> ExportPkcs8Parameters
+        {
+            get
+            {
+                yield return new[] { new PbeParameters(PbeEncryptionAlgorithm.Aes128Cbc, HashAlgorithmName.SHA256, 42) };
+                yield return new[] { new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA512, 43) };
+                yield return new[] { new PbeParameters(PbeEncryptionAlgorithm.Aes192Cbc, HashAlgorithmName.SHA384, 44) };
+                yield return new[] { new PbeParameters(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 24) };
+            }
+        }
+
         private static void AssertExportPkcs8PrivateKey(MLKem kem, Action<byte[]> callback)
         {
             callback(DoTryUntilDone(kem.TryExportPkcs8PrivateKey));
@@ -587,18 +612,23 @@ namespace System.Security.Cryptography.Tests
                     out bytesWritten);
             }));
 
-            callback(DoTryUntilDone((Span<byte> destination, out int bytesWritten) =>
-            {
-                return kem.TryExportEncryptedPkcs8PrivateKey(
-                    new ReadOnlySpan<byte>(passwordBytes),
-                    pbeParameters,
-                    destination,
-                    out bytesWritten);
-            }));
-
             callback(kem.ExportEncryptedPkcs8PrivateKey(password, pbeParameters));
             callback(kem.ExportEncryptedPkcs8PrivateKey(password.AsSpan(), pbeParameters));
-            callback(kem.ExportEncryptedPkcs8PrivateKey(new ReadOnlySpan<byte>(passwordBytes), pbeParameters));
+
+            // PKCS12 PBE requires char-passwords, so don't run byte-password callbacks.
+            if (pbeParameters.EncryptionAlgorithm != PbeEncryptionAlgorithm.TripleDes3KeyPkcs12)
+            {
+                callback(DoTryUntilDone((Span<byte> destination, out int bytesWritten) =>
+                {
+                    return kem.TryExportEncryptedPkcs8PrivateKey(
+                        new ReadOnlySpan<byte>(passwordBytes),
+                        pbeParameters,
+                        destination,
+                        out bytesWritten);
+                }));
+
+                callback(kem.ExportEncryptedPkcs8PrivateKey(new ReadOnlySpan<byte>(passwordBytes), pbeParameters));
+            }
         }
 
         private delegate bool TryExportFunc(Span<byte> destination, out int bytesWritten);
@@ -645,6 +675,53 @@ namespace System.Security.Cryptography.Tests
             byte[] ciphertext = encapsulator.Encapsulate(out byte[] encapsulatorSharedSecret);
             byte[] decapsulatedSharedSecret = kem.Decapsulate(ciphertext);
             AssertExtensions.SequenceEqual(encapsulatorSharedSecret, decapsulatedSharedSecret);
+        }
+
+        private static void AssertEncryptedPkcs8PrivateKeyContents(PbeParameters pbeParameters, ReadOnlyMemory<byte> contents)
+        {
+            EncryptedPrivateKeyInfoAsn epki = EncryptedPrivateKeyInfoAsn.Decode(contents, AsnEncodingRules.BER);
+            AlgorithmIdentifierAsn algorithmIdentifier = epki.EncryptionAlgorithm;
+
+            if (pbeParameters.EncryptionAlgorithm == PbeEncryptionAlgorithm.TripleDes3KeyPkcs12)
+            {
+                // pbeWithSHA1And3-KeyTripleDES-CBC
+                Assert.Equal("1.2.840.113549.1.12.1.3", algorithmIdentifier.Algorithm);
+                PBEParameter pbeParameterAsn = PBEParameter.Decode(algorithmIdentifier.Parameters.Value, AsnEncodingRules.BER);
+
+                Assert.Equal(pbeParameters.IterationCount, pbeParameterAsn.IterationCount);
+            }
+            else
+            {
+                Assert.Equal("1.2.840.113549.1.5.13", algorithmIdentifier.Algorithm); // PBES2
+                PBES2Params pbes2Params = PBES2Params.Decode(algorithmIdentifier.Parameters.Value, AsnEncodingRules.BER);
+                Assert.Equal("1.2.840.113549.1.5.12", pbes2Params.KeyDerivationFunc.Algorithm); // PBKDF2
+                Pbkdf2Params pbkdf2Params = Pbkdf2Params.Decode(
+                    pbes2Params.KeyDerivationFunc.Parameters.Value,
+                    AsnEncodingRules.BER);
+                string expectedEncryptionOid = pbeParameters.EncryptionAlgorithm switch
+                {
+                    PbeEncryptionAlgorithm.Aes128Cbc => "2.16.840.1.101.3.4.1.2",
+                    PbeEncryptionAlgorithm.Aes192Cbc => "2.16.840.1.101.3.4.1.22",
+                    PbeEncryptionAlgorithm.Aes256Cbc => "2.16.840.1.101.3.4.1.42",
+                    _ => throw new CryptographicException(),
+                };
+
+                Assert.Equal(pbeParameters.IterationCount, pbkdf2Params.IterationCount);
+                Assert.Equal(pbeParameters.HashAlgorithm, GetHashAlgorithmFromPbkdf2Params(pbkdf2Params));
+                Assert.Equal(expectedEncryptionOid, pbes2Params.EncryptionScheme.Algorithm);
+            }
+        }
+
+        private static HashAlgorithmName GetHashAlgorithmFromPbkdf2Params(Pbkdf2Params pbkdf2Params)
+        {
+            return pbkdf2Params.Prf.Algorithm switch
+            {
+                "1.2.840.113549.2.7" => HashAlgorithmName.SHA1,
+                "1.2.840.113549.2.9" => HashAlgorithmName.SHA256,
+                "1.2.840.113549.2.10" => HashAlgorithmName.SHA384,
+                "1.2.840.113549.2.11" => HashAlgorithmName.SHA512,
+                string other => throw new XunitException($"Unknown hash algorithm OID '{other}'."),
+            };
         }
 
         public record MLKemTestDecapsulationVector(MLKemAlgorithm Algorithm, string EncapsulationKey, string DecapsulationKey, string Ciphertext, string SharedSecret);

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
@@ -532,6 +532,38 @@ namespace System.Security.Cryptography.Tests
             });
         }
 
+        [Fact]
+        public void ExportEncryptedPkcs8PrivateKey_EncapsulationKey_Fails()
+        {
+            using MLKem kem = ImportEncapsulationKey(MLKemAlgorithm.MLKem512, MLKemTestData.MLKem512EncapsulationKey);
+
+            Assert.Throws<CryptographicException>(() => DoTryUntilDone((Span<byte> destination, out int bytesWritten) =>
+                kem.TryExportEncryptedPkcs8PrivateKey(
+                    MLKemTestData.EncryptedPrivateKeyPassword.AsSpan(),
+                    s_aes128Pbe,
+                    destination,
+                    out bytesWritten)));
+
+            Assert.Throws<CryptographicException>(() => DoTryUntilDone((Span<byte> destination, out int bytesWritten) =>
+                kem.TryExportEncryptedPkcs8PrivateKey(
+                    MLKemTestData.EncryptedPrivateKeyPasswordBytes,
+                    s_aes128Pbe,
+                    destination,
+                    out bytesWritten)));
+
+            Assert.Throws<CryptographicException>(() => kem.ExportEncryptedPkcs8PrivateKey(
+                MLKemTestData.EncryptedPrivateKeyPassword,
+                s_aes128Pbe));
+
+            Assert.Throws<CryptographicException>(() => kem.ExportEncryptedPkcs8PrivateKey(
+                MLKemTestData.EncryptedPrivateKeyPassword.AsSpan(),
+                s_aes128Pbe));
+
+            Assert.Throws<CryptographicException>(() => kem.ExportEncryptedPkcs8PrivateKey(
+                MLKemTestData.EncryptedPrivateKeyPasswordBytes,
+                s_aes128Pbe));
+        }
+
         private static void AssertExportPkcs8PrivateKey(MLKem kem, Action<byte[]> callback)
         {
             callback(DoTryUntilDone(kem.TryExportPkcs8PrivateKey));

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
@@ -939,6 +939,7 @@ namespace System.Security.Cryptography.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser does not support symmetric encryption")]
         public static void TryExportEncryptedPkcs8PrivateKey_ExportsPkcs8(bool useCharPassword)
         {
             using MLKemContract kem = new(MLKemAlgorithm.MLKem512)
@@ -986,6 +987,7 @@ namespace System.Security.Cryptography.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser does not support symmetric encryption")]
         public static void TryExportEncryptedPkcs8PrivateKey_InnerBuffer_LargePkcs8(bool useCharPassword)
         {
             using MLKemContract kem = new(MLKemAlgorithm.MLKem512);
@@ -1036,6 +1038,7 @@ namespace System.Security.Cryptography.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser does not support symmetric encryption")]
         public static void TryExportEncryptedPkcs8PrivateKey_DestinationTooSmall(bool useCharPassword)
         {
             byte[] buffer = new byte[3];

--- a/src/libraries/Microsoft.Bcl.Cryptography/tests/Microsoft.Bcl.Cryptography.Tests.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/tests/Microsoft.Bcl.Cryptography.Tests.csproj
@@ -9,7 +9,76 @@
     <IncludeIndexRangeTypes>true</IncludeIndexRangeTypes>
   </PropertyGroup>
 
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" />
+  <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
+
   <ItemGroup>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs"
+             Link="Common\System\Security\Cryptography\CryptoPool.cs" />
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.manual.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\AlgorithmIdentifierAsn.xml</DependentUpon>
+    </Compile>
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</DependentUpon>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\AttributeAsn.manual.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\AttributeAsn.manual.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\AttributeAsn.xml</DependentUpon>
+    </Compile>
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\EncryptedPrivateKeyInfoAsn.xml</DependentUpon>
+    </Compile>
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBEParameter.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\PBEParameter.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\PBEParameter.xml</DependentUpon>
+    </Compile>
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PBES2Params.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\PBES2Params.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\PBES2Params.xml</DependentUpon>
+    </Compile>
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2Params.xml</DependentUpon>
+    </Compile>
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\Pbkdf2SaltChoice.xml</DependentUpon>
+    </Compile>
+    <AsnXml Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml">
+      <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</Link>
+    </AsnXml>
+    <Compile Include="$(CommonPath)System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs">
+      <Link>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml.cs</Link>
+      <DependentUpon>Common\System\Security\Cryptography\Asn1\PrivateKeyInfoAsn.xml</DependentUpon>
+    </Compile>
     <Compile Include="$(CommonPath)System\IO\MemoryMappedFiles\MemoryMappedFileMemoryManager.cs"
              Link="Common\System\IO\MemoryMappedFiles\MemoryMappedFileMemoryManager.cs" />
     <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs"

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1874,6 +1874,9 @@ namespace System.Security.Cryptography
         public byte[] ExportEncapsulationKey() { throw null; }
         public void ExportEncapsulationKey(System.Span<byte> destination) { }
         protected abstract void ExportEncapsulationKeyCore(System.Span<byte> destination);
+        public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
         public byte[] ExportPkcs8PrivateKey() { throw null; }
         public byte[] ExportPrivateSeed() { throw null; }
         public void ExportPrivateSeed(System.Span<byte> destination) { }
@@ -1899,6 +1902,8 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.MLKem ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source) { throw null; }
         protected void ThrowIfDisposed() { }
+        public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected abstract bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten);
         public bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }


### PR DESCRIPTION
This pull request adds PKCS#8 EncryptedPrivateKeyInfo exports.

Contributes to #113508 