### PR TITLE
JIT: Skip rarely-run block expansion during flow opts when we have profile data

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2379,11 +2379,11 @@ PhaseStatus Compiler::optOptimizeFlow()
 
     bool modified = fgUpdateFlowGraph(/* doTailDuplication */ true);
 
-    // Skipping fgExpandRarelyRunBlocks when we have PGO data incurs diffs if the profile is inconsistent,
-    // as it will propagate missing profile weights throughout the flowgraph.
-    // Running profile synthesis beforehand should get rid of these diffs.
     // TODO: Always rely on profile synthesis to identify cold blocks.
-    modified |= fgExpandRarelyRunBlocks();
+    if (!fgIsUsingProfileWeights())
+    {
+        modified |= fgExpandRarelyRunBlocks();
+    }
 
     // Run branch optimizations for non-handler blocks.
     assert(!fgFuncletsCreated);


### PR DESCRIPTION
Follow-up to #113896. Since we now run profile repair before most of the profile-sensitive post-morph opts, `fgExpandRarelyRunBlocks` isn't very useful for PGO scenarios.