### PR TITLE
Reduce background GC allocations

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -60,11 +60,7 @@ namespace System
     public static partial class GC
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern void GetMemoryInfo(GCMemoryInfoData data, int kind);
-
-        // Used to avoid allocating in GetGCMemoryInfo after the first call.
-        [ThreadStatic]
-        private static GCMemoryInfoData? t_gCMemoryInfoData;
+        private static extern unsafe void GetMemoryInfo(GCMemoryInfo* data, int kind);
 
         /// <summary>Gets garbage collection memory information.</summary>
         /// <returns>An object that contains information about the garbage collector's memory usage.</returns>
@@ -73,7 +69,7 @@ namespace System
         /// <summary>Gets garbage collection memory information.</summary>
         /// <param name="kind">The kind of collection for which to retrieve memory information.</param>
         /// <returns>An object that contains information about the garbage collector's memory usage.</returns>
-        public static GCMemoryInfo GetGCMemoryInfo(GCKind kind)
+        public static unsafe GCMemoryInfo GetGCMemoryInfo(GCKind kind)
         {
             if ((kind < GCKind.Any) || (kind > GCKind.Background))
             {
@@ -84,9 +80,9 @@ namespace System
                                           GCKind.Background));
             }
 
-            var data = t_gCMemoryInfoData ??= new GCMemoryInfoData();
-            GetMemoryInfo(data, (int)kind);
-            return new GCMemoryInfo(data);
+            GCMemoryInfo data = default;
+            GetMemoryInfo(&data, (int)kind);
+            return data;
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_StartNoGCRegion")]

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -62,6 +62,10 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern void GetMemoryInfo(GCMemoryInfoData data, int kind);
 
+        // Used to avoid allocating in GetGCMemoryInfo after the first call.
+        [ThreadStatic]
+        private static GCMemoryInfoData? t_gCMemoryInfoData;
+
         /// <summary>Gets garbage collection memory information.</summary>
         /// <returns>An object that contains information about the garbage collector's memory usage.</returns>
         public static GCMemoryInfo GetGCMemoryInfo() => GetGCMemoryInfo(GCKind.Any);
@@ -80,7 +84,7 @@ namespace System
                                           GCKind.Background));
             }
 
-            var data = new GCMemoryInfoData();
+            var data = t_gCMemoryInfoData ??= new GCMemoryInfoData();
             GetMemoryInfo(data, (int)kind);
             return new GCMemoryInfo(data);
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -60,7 +60,7 @@ namespace System
     public static partial class GC
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern unsafe void GetMemoryInfo(GCMemoryInfo* data, int kind);
+        private static extern unsafe void GetMemoryInfo(GCMemoryInfoData* data, int kind);
 
         /// <summary>Gets garbage collection memory information.</summary>
         /// <returns>An object that contains information about the garbage collector's memory usage.</returns>
@@ -80,9 +80,9 @@ namespace System
                                           GCKind.Background));
             }
 
-            GCMemoryInfo data = default;
+            GCMemoryInfoData data = default;
             GetMemoryInfo(&data, (int)kind);
-            return data;
+            return new GCMemoryInfo(data);
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_StartNoGCRegion")]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
@@ -764,7 +764,7 @@ namespace System
         /// <summary>Gets garbage collection memory information.</summary>
         /// <param name="kind">The kind of collection for which to retrieve memory information.</param>
         /// <returns>An object that contains information about the garbage collector's memory usage.</returns>
-        public static GCMemoryInfo GetGCMemoryInfo(GCKind kind)
+        public static unsafe GCMemoryInfo GetGCMemoryInfo(GCKind kind)
         {
             if ((kind < GCKind.Any) || (kind > GCKind.Background))
             {
@@ -775,8 +775,8 @@ namespace System
                                           GCKind.Background));
             }
 
-            var data = new GCMemoryInfoData();
-            RuntimeImports.RhGetMemoryInfo(ref data.GetRawData(), kind);
+            GCMemoryInfoData data = default;
+            RuntimeImports.RhGetMemoryInfo(&data, kind);
             return new GCMemoryInfo(data);
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -241,7 +241,7 @@ namespace System.Runtime
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetMemoryInfo")]
-        internal static extern void RhGetMemoryInfo(ref byte info, GCKind kind);
+        internal static extern unsafe void RhGetMemoryInfo(GCMemoryInfoData* data, GCKind kind);
 
         [LibraryImport(RuntimeLibrary)]
         internal static unsafe partial void RhAllocateNewArray(MethodTable* pArrayEEType, uint numElements, uint flags, void* pResult);

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -584,32 +584,30 @@ FCIMPL0(INT64, GCInterface::GetTotalPauseDuration)
 }
 FCIMPLEND
 
-FCIMPL2(void, GCInterface::GetMemoryInfo, Object* objUNSAFE, int kind)
+FCIMPL2(void, GCInterface::GetMemoryInfo, GCMemoryInfoData* pData, int kind)
 {
     FCALL_CONTRACT;
 
     FC_GC_POLL_NOT_NEEDED();
 
-    GCMEMORYINFODATAREF objGCMemoryInfo = (GCMEMORYINFODATAREF)(ObjectToOBJECTREF (objUNSAFE));
-
-    UINT64* genInfoRaw = (UINT64*)&(objGCMemoryInfo->generationInfo0);
-    UINT64* pauseInfoRaw = (UINT64*)&(objGCMemoryInfo->pauseDuration0);
+    UINT64* genInfoRaw = (UINT64*)&(pData->generationInfo0);
+    UINT64* pauseInfoRaw = (UINT64*)&(pData->pauseDuration0);
 
     return GCHeapUtilities::GetGCHeap()->GetMemoryInfo(
-        &(objGCMemoryInfo->highMemLoadThresholdBytes),
-        &(objGCMemoryInfo->totalAvailableMemoryBytes),
-        &(objGCMemoryInfo->lastRecordedMemLoadBytes),
-        &(objGCMemoryInfo->lastRecordedHeapSizeBytes),
-        &(objGCMemoryInfo->lastRecordedFragmentationBytes),
-        &(objGCMemoryInfo->totalCommittedBytes),
-        &(objGCMemoryInfo->promotedBytes),
-        &(objGCMemoryInfo->pinnedObjectCount),
-        &(objGCMemoryInfo->finalizationPendingCount),
-        &(objGCMemoryInfo->index),
-        &(objGCMemoryInfo->generation),
-        &(objGCMemoryInfo->pauseTimePercent),
-        (bool*)&(objGCMemoryInfo->isCompaction),
-        (bool*)&(objGCMemoryInfo->isConcurrent),
+        &(pData->highMemLoadThresholdBytes),
+        &(pData->totalAvailableMemoryBytes),
+        &(pData->lastRecordedMemLoadBytes),
+        &(pData->lastRecordedHeapSizeBytes),
+        &(pData->lastRecordedFragmentationBytes),
+        &(pData->totalCommittedBytes),
+        &(pData->promotedBytes),
+        &(pData->pinnedObjectCount),
+        &(pData->finalizationPendingCount),
+        &(pData->index),
+        &(pData->generation),
+        &(pData->pauseTimePercent),
+        (bool*)&(pData->isCompaction),
+        (bool*)&(pData->isConcurrent),
         genInfoRaw,
         pauseInfoRaw,
         kind);

--- a/src/coreclr/vm/comutilnative.h
+++ b/src/coreclr/vm/comutilnative.h
@@ -101,7 +101,7 @@ struct GCGenerationInfo
 };
 
 #include "pshpack4.h"
-class GCMemoryInfoData : public Object
+struct GCMemoryInfoData
 {
 public:
     UINT64 highMemLoadThresholdBytes;
@@ -131,14 +131,6 @@ public:
 };
 #include "poppack.h"
 
-#ifdef USE_CHECKED_OBJECTREFS
-typedef REF<GCMemoryInfoData> GCMEMORYINFODATA;
-typedef REF<GCMemoryInfoData> GCMEMORYINFODATAREF;
-#else // USE_CHECKED_OBJECTREFS
-typedef GCMemoryInfoData * GCMEMORYINFODATA;
-typedef GCMemoryInfoData * GCMEMORYINFODATAREF;
-#endif // USE_CHECKED_OBJECTREFS
-
 using EnumerateConfigurationValuesCallback = void (*)(void* context, void* name, void* publicKey, GCConfigurationType type, int64_t data);
 
 struct GCHeapHardLimitInfo
@@ -166,7 +158,7 @@ public:
     static FORCEINLINE UINT64 InterlockedSub(UINT64 *pMinuend, UINT64 subtrahend);
 
     static FCDECL0(INT64,   GetTotalPauseDuration);
-    static FCDECL2(void,    GetMemoryInfo, Object* objUNSAFE, int kind);
+    static FCDECL2(void,    GetMemoryInfo, GCMemoryInfoData* pData, int kind);
     static FCDECL0(UINT32,  GetMemoryLoad);
     static FCDECL0(int,     GetGcLatencyMode);
     static FCDECL1(int,     SetGcLatencyMode, int newLatencyMode);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/SharedArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/SharedArrayPool.cs
@@ -209,14 +209,14 @@ namespace System.Buffers
             {
                 if (!log.IsEnabled())
                 {
-                    foreach (KeyValuePair<SharedArrayPoolThreadLocalArray[], object?> tlsBuckets in _allTlsBuckets)
+                    foreach (KeyValuePair<SharedArrayPoolThreadLocalArray[], object?> tlsBuckets in _allTlsBuckets.EnumerateOnStack())
                     {
                         Array.Clear(tlsBuckets.Key);
                     }
                 }
                 else
                 {
-                    foreach (KeyValuePair<SharedArrayPoolThreadLocalArray[], object?> tlsBuckets in _allTlsBuckets)
+                    foreach (KeyValuePair<SharedArrayPoolThreadLocalArray[], object?> tlsBuckets in _allTlsBuckets.EnumerateOnStack())
                     {
                         SharedArrayPoolThreadLocalArray[] buckets = tlsBuckets.Key;
                         for (int i = 0; i < buckets.Length; i++)
@@ -241,7 +241,7 @@ namespace System.Buffers
                     _ => 30_000,
                 };
 
-                foreach (KeyValuePair<SharedArrayPoolThreadLocalArray[], object?> tlsBuckets in _allTlsBuckets)
+                foreach (KeyValuePair<SharedArrayPoolThreadLocalArray[], object?> tlsBuckets in _allTlsBuckets.EnumerateOnStack())
                 {
                     SharedArrayPoolThreadLocalArray[] buckets = tlsBuckets.Key;
                     for (int i = 0; i < buckets.Length; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/GCMemoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/GCMemoryInfo.cs
@@ -106,13 +106,11 @@ namespace System
         private readonly int _pauseTimePercentage;
         private readonly byte _compacted;
         private readonly byte _concurrent;
-
         private readonly GCGenerationInfo _generationInfo0;
         private readonly GCGenerationInfo _generationInfo1;
         private readonly GCGenerationInfo _generationInfo2;
         private readonly GCGenerationInfo _generationInfo3;
         private readonly GCGenerationInfo _generationInfo4;
-
         private readonly TimeSpan _pauseDuration0;
         private readonly TimeSpan _pauseDuration1;
 

--- a/src/libraries/System.Private.CoreLib/src/System/GCMemoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/GCMemoryInfo.cs
@@ -71,18 +71,14 @@ namespace System
         internal byte _compacted;
         internal byte _concurrent;
 
-        private GCGenerationInfo _generationInfo0;
-        private GCGenerationInfo _generationInfo1;
-        private GCGenerationInfo _generationInfo2;
-        private GCGenerationInfo _generationInfo3;
-        private GCGenerationInfo _generationInfo4;
+        internal GCGenerationInfo _generationInfo0;
+        internal GCGenerationInfo _generationInfo1;
+        internal GCGenerationInfo _generationInfo2;
+        internal GCGenerationInfo _generationInfo3;
+        internal GCGenerationInfo _generationInfo4;
 
-        internal ReadOnlySpan<GCGenerationInfo> GenerationInfoAsSpan => MemoryMarshal.CreateReadOnlySpan(ref _generationInfo0, 5);
-
-        private TimeSpan _pauseDuration0;
-        private TimeSpan _pauseDuration1;
-
-        internal ReadOnlySpan<TimeSpan> PauseDurationsAsSpan => MemoryMarshal.CreateReadOnlySpan(ref _pauseDuration0, 2);
+        internal TimeSpan _pauseDuration0;
+        internal TimeSpan _pauseDuration1;
     }
 
     /// <summary>Provides a set of APIs that can be used to retrieve garbage collection information.</summary>
@@ -96,22 +92,64 @@ namespace System
     /// </remarks>
     public readonly struct GCMemoryInfo
     {
-        private readonly GCMemoryInfoData _data;
+        private readonly long _highMemoryLoadThresholdBytes;
+        private readonly long _totalAvailableMemoryBytes;
+        private readonly long _memoryLoadBytes;
+        private readonly long _heapSizeBytes;
+        private readonly long _fragmentedBytes;
+        private readonly long _totalCommittedBytes;
+        private readonly long _promotedBytes;
+        private readonly long _pinnedObjectsCount;
+        private readonly long _finalizationPendingCount;
+        private readonly long _index;
+        private readonly int _generation;
+        private readonly int _pauseTimePercentage;
+        private readonly byte _compacted;
+        private readonly byte _concurrent;
+
+        private readonly GCGenerationInfo _generationInfo0;
+        private readonly GCGenerationInfo _generationInfo1;
+        private readonly GCGenerationInfo _generationInfo2;
+        private readonly GCGenerationInfo _generationInfo3;
+        private readonly GCGenerationInfo _generationInfo4;
+
+        private readonly TimeSpan _pauseDuration0;
+        private readonly TimeSpan _pauseDuration1;
 
         internal GCMemoryInfo(GCMemoryInfoData data)
         {
-            _data = data;
+            _highMemoryLoadThresholdBytes = data._highMemoryLoadThresholdBytes;
+            _totalAvailableMemoryBytes = data._totalAvailableMemoryBytes;
+            _memoryLoadBytes = data._memoryLoadBytes;
+            _heapSizeBytes = data._heapSizeBytes;
+            _fragmentedBytes = data._fragmentedBytes;
+            _totalCommittedBytes = data._totalCommittedBytes;
+            _promotedBytes = data._promotedBytes;
+            _pinnedObjectsCount = data._pinnedObjectsCount;
+            _finalizationPendingCount = data._finalizationPendingCount;
+            _index = data._index;
+            _generation = data._generation;
+            _pauseTimePercentage = data._pauseTimePercentage;
+            _compacted = data._compacted;
+            _concurrent = data._concurrent;
+            _generationInfo0 = data._generationInfo0;
+            _generationInfo1 = data._generationInfo1;
+            _generationInfo2 = data._generationInfo2;
+            _generationInfo3 = data._generationInfo3;
+            _generationInfo4 = data._generationInfo4;
+            _pauseDuration0 = data._pauseDuration0;
+            _pauseDuration1 = data._pauseDuration1;
         }
 
         /// <summary>
         /// High memory load threshold when this GC occurred
         /// </summary>
-        public long HighMemoryLoadThresholdBytes => _data._highMemoryLoadThresholdBytes;
+        public long HighMemoryLoadThresholdBytes => _highMemoryLoadThresholdBytes;
 
         /// <summary>
         /// Memory load when this GC occurred
         /// </summary>
-        public long MemoryLoadBytes => _data._memoryLoadBytes;
+        public long MemoryLoadBytes => _memoryLoadBytes;
 
         /// <summary>
         /// Total available memory for the GC to use when this GC occurred.
@@ -121,12 +159,12 @@ namespace System
         /// If the program is run in a container, this will be an implementation-defined fraction of the container's size.
         /// Else, this is the physical memory on the machine that was available for the GC to use when this GC occurred.
         /// </summary>
-        public long TotalAvailableMemoryBytes => _data._totalAvailableMemoryBytes;
+        public long TotalAvailableMemoryBytes => _totalAvailableMemoryBytes;
 
         /// <summary>
         /// The total heap size when this GC occurred
         /// </summary>
-        public long HeapSizeBytes => _data._heapSizeBytes;
+        public long HeapSizeBytes => _heapSizeBytes;
 
         /// <summary>
         /// The total fragmentation when this GC occurred
@@ -140,64 +178,64 @@ namespace System
         /// The memory between OBJ_A and OBJ_D marked `F` is considered part of the FragmentedBytes, and will be used to allocate new objects. The memory after OBJ_D will not be
         /// considered part of the FragmentedBytes, and will also be used to allocate new objects
         /// </summary>
-        public long FragmentedBytes => _data._fragmentedBytes;
+        public long FragmentedBytes => _fragmentedBytes;
 
         /// <summary>
         /// The index of this GC. GC indices start with 1 and get increased at the beginning of a GC.
         /// Since the info is updated at the end of a GC, this means you can get the info for a BGC
         /// with a smaller index than a foreground GC finished earlier.
         /// </summary>
-        public long Index => _data._index;
+        public long Index => _index;
 
         /// <summary>
         /// The generation this GC collected. Collecting a generation means all its younger generation(s)
         /// are also collected.
         /// </summary>
-        public int Generation => _data._generation;
+        public int Generation => _generation;
 
         /// <summary>
         /// Is this a compacting GC or not.
         /// </summary>
-        public bool Compacted => _data._compacted != 0;
+        public bool Compacted => _compacted != 0;
 
         /// <summary>
         /// Is this a concurrent GC (BGC) or not.
         /// </summary>
-        public bool Concurrent => _data._concurrent != 0;
+        public bool Concurrent => _concurrent != 0;
 
         /// <summary>
         /// Total committed bytes of the managed heap.
         /// </summary>
-        public long TotalCommittedBytes => _data._totalCommittedBytes;
+        public long TotalCommittedBytes => _totalCommittedBytes;
 
         /// <summary>
         /// Promoted bytes for this GC.
         /// </summary>
-        public long PromotedBytes => _data._promotedBytes;
+        public long PromotedBytes => _promotedBytes;
 
         /// <summary>
         /// Number of pinned objects this GC observed.
         /// </summary>
-        public long PinnedObjectsCount => _data._pinnedObjectsCount;
+        public long PinnedObjectsCount => _pinnedObjectsCount;
 
         /// <summary>
         /// Number of objects ready for finalization this GC observed.
         /// </summary>
-        public long FinalizationPendingCount => _data._finalizationPendingCount;
+        public long FinalizationPendingCount => _finalizationPendingCount;
 
         /// <summary>
         /// Pause durations. For blocking GCs there's only 1 pause; for BGC there are 2.
         /// </summary>
-        public ReadOnlySpan<TimeSpan> PauseDurations => _data.PauseDurationsAsSpan;
+        public ReadOnlySpan<TimeSpan> PauseDurations => MemoryMarshal.CreateReadOnlySpan(in _pauseDuration0, 2);
 
         /// <summary>
         /// This is the % pause time in GC so far. If it's 1.2%, this number is 1.2.
         /// </summary>
-        public double PauseTimePercentage => (double)_data._pauseTimePercentage / 100.0;
+        public double PauseTimePercentage => (double)_pauseTimePercentage / 100.0;
 
         /// <summary>
         /// Generation info for all generations.
         /// </summary>
-        public ReadOnlySpan<GCGenerationInfo> GenerationInfo => _data.GenerationInfoAsSpan;
+        public ReadOnlySpan<GCGenerationInfo> GenerationInfo => MemoryMarshal.CreateReadOnlySpan(in _generationInfo0, 5);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/GCMemoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/GCMemoryInfo.cs
@@ -54,7 +54,7 @@ namespace System
     };
 
     [StructLayout(LayoutKind.Sequential)]
-    internal sealed class GCMemoryInfoData
+    internal struct GCMemoryInfoData
     {
         internal long _highMemoryLoadThresholdBytes;
         internal long _totalAvailableMemoryBytes;
@@ -71,14 +71,18 @@ namespace System
         internal byte _compacted;
         internal byte _concurrent;
 
-        internal GCGenerationInfo _generationInfo0;
-        internal GCGenerationInfo _generationInfo1;
-        internal GCGenerationInfo _generationInfo2;
-        internal GCGenerationInfo _generationInfo3;
-        internal GCGenerationInfo _generationInfo4;
+        private GCGenerationInfo _generationInfo0;
+        private GCGenerationInfo _generationInfo1;
+        private GCGenerationInfo _generationInfo2;
+        private GCGenerationInfo _generationInfo3;
+        private GCGenerationInfo _generationInfo4;
 
-        internal TimeSpan _pauseDuration0;
-        internal TimeSpan _pauseDuration1;
+        internal ReadOnlySpan<GCGenerationInfo> GenerationInfoAsSpan => MemoryMarshal.CreateReadOnlySpan(ref _generationInfo0, 5);
+
+        private TimeSpan _pauseDuration0;
+        private TimeSpan _pauseDuration1;
+
+        internal ReadOnlySpan<TimeSpan> PauseDurationsAsSpan => MemoryMarshal.CreateReadOnlySpan(ref _pauseDuration0, 2);
     }
 
     /// <summary>Provides a set of APIs that can be used to retrieve garbage collection information.</summary>
@@ -92,62 +96,22 @@ namespace System
     /// </remarks>
     public readonly struct GCMemoryInfo
     {
-        private readonly long _highMemoryLoadThresholdBytes;
-        private readonly long _totalAvailableMemoryBytes;
-        private readonly long _memoryLoadBytes;
-        private readonly long _heapSizeBytes;
-        private readonly long _fragmentedBytes;
-        private readonly long _totalCommittedBytes;
-        private readonly long _promotedBytes;
-        private readonly long _pinnedObjectsCount;
-        private readonly long _finalizationPendingCount;
-        private readonly long _index;
-        private readonly int _generation;
-        private readonly int _pauseTimePercentage;
-        private readonly byte _compacted;
-        private readonly byte _concurrent;
-        private readonly GCGenerationInfo _generationInfo0;
-        private readonly GCGenerationInfo _generationInfo1;
-        private readonly GCGenerationInfo _generationInfo2;
-        private readonly GCGenerationInfo _generationInfo3;
-        private readonly GCGenerationInfo _generationInfo4;
-        private readonly TimeSpan _pauseDuration0;
-        private readonly TimeSpan _pauseDuration1;
+        private readonly GCMemoryInfoData _data;
 
         internal GCMemoryInfo(GCMemoryInfoData data)
         {
-            _highMemoryLoadThresholdBytes = data._highMemoryLoadThresholdBytes;
-            _totalAvailableMemoryBytes = data._totalAvailableMemoryBytes;
-            _memoryLoadBytes = data._memoryLoadBytes;
-            _heapSizeBytes = data._heapSizeBytes;
-            _fragmentedBytes = data._fragmentedBytes;
-            _totalCommittedBytes = data._totalCommittedBytes;
-            _promotedBytes = data._promotedBytes;
-            _pinnedObjectsCount = data._pinnedObjectsCount;
-            _finalizationPendingCount = data._finalizationPendingCount;
-            _index = data._index;
-            _generation = data._generation;
-            _pauseTimePercentage = data._pauseTimePercentage;
-            _compacted = data._compacted;
-            _concurrent = data._concurrent;
-            _generationInfo0 = data._generationInfo0;
-            _generationInfo1 = data._generationInfo1;
-            _generationInfo2 = data._generationInfo2;
-            _generationInfo3 = data._generationInfo3;
-            _generationInfo4 = data._generationInfo4;
-            _pauseDuration0 = data._pauseDuration0;
-            _pauseDuration1 = data._pauseDuration1;
+            _data = data;
         }
 
         /// <summary>
         /// High memory load threshold when this GC occurred
         /// </summary>
-        public long HighMemoryLoadThresholdBytes => _highMemoryLoadThresholdBytes;
+        public long HighMemoryLoadThresholdBytes => _data._highMemoryLoadThresholdBytes;
 
         /// <summary>
         /// Memory load when this GC occurred
         /// </summary>
-        public long MemoryLoadBytes => _memoryLoadBytes;
+        public long MemoryLoadBytes => _data._memoryLoadBytes;
 
         /// <summary>
         /// Total available memory for the GC to use when this GC occurred.
@@ -157,12 +121,12 @@ namespace System
         /// If the program is run in a container, this will be an implementation-defined fraction of the container's size.
         /// Else, this is the physical memory on the machine that was available for the GC to use when this GC occurred.
         /// </summary>
-        public long TotalAvailableMemoryBytes => _totalAvailableMemoryBytes;
+        public long TotalAvailableMemoryBytes => _data._totalAvailableMemoryBytes;
 
         /// <summary>
         /// The total heap size when this GC occurred
         /// </summary>
-        public long HeapSizeBytes => _heapSizeBytes;
+        public long HeapSizeBytes => _data._heapSizeBytes;
 
         /// <summary>
         /// The total fragmentation when this GC occurred
@@ -176,64 +140,64 @@ namespace System
         /// The memory between OBJ_A and OBJ_D marked `F` is considered part of the FragmentedBytes, and will be used to allocate new objects. The memory after OBJ_D will not be
         /// considered part of the FragmentedBytes, and will also be used to allocate new objects
         /// </summary>
-        public long FragmentedBytes => _fragmentedBytes;
+        public long FragmentedBytes => _data._fragmentedBytes;
 
         /// <summary>
         /// The index of this GC. GC indices start with 1 and get increased at the beginning of a GC.
         /// Since the info is updated at the end of a GC, this means you can get the info for a BGC
         /// with a smaller index than a foreground GC finished earlier.
         /// </summary>
-        public long Index => _index;
+        public long Index => _data._index;
 
         /// <summary>
         /// The generation this GC collected. Collecting a generation means all its younger generation(s)
         /// are also collected.
         /// </summary>
-        public int Generation => _generation;
+        public int Generation => _data._generation;
 
         /// <summary>
         /// Is this a compacting GC or not.
         /// </summary>
-        public bool Compacted => _compacted != 0;
+        public bool Compacted => _data._compacted != 0;
 
         /// <summary>
         /// Is this a concurrent GC (BGC) or not.
         /// </summary>
-        public bool Concurrent => _concurrent != 0;
+        public bool Concurrent => _data._concurrent != 0;
 
         /// <summary>
         /// Total committed bytes of the managed heap.
         /// </summary>
-        public long TotalCommittedBytes => _totalCommittedBytes;
+        public long TotalCommittedBytes => _data._totalCommittedBytes;
 
         /// <summary>
         /// Promoted bytes for this GC.
         /// </summary>
-        public long PromotedBytes => _promotedBytes;
+        public long PromotedBytes => _data._promotedBytes;
 
         /// <summary>
         /// Number of pinned objects this GC observed.
         /// </summary>
-        public long PinnedObjectsCount => _pinnedObjectsCount;
+        public long PinnedObjectsCount => _data._pinnedObjectsCount;
 
         /// <summary>
         /// Number of objects ready for finalization this GC observed.
         /// </summary>
-        public long FinalizationPendingCount => _finalizationPendingCount;
+        public long FinalizationPendingCount => _data._finalizationPendingCount;
 
         /// <summary>
         /// Pause durations. For blocking GCs there's only 1 pause; for BGC there are 2.
         /// </summary>
-        public ReadOnlySpan<TimeSpan> PauseDurations => MemoryMarshal.CreateReadOnlySpan(in _pauseDuration0, 2);
+        public ReadOnlySpan<TimeSpan> PauseDurations => _data.PauseDurationsAsSpan;
 
         /// <summary>
         /// This is the % pause time in GC so far. If it's 1.2%, this number is 1.2.
         /// </summary>
-        public double PauseTimePercentage => (double)_pauseTimePercentage / 100.0;
+        public double PauseTimePercentage => (double)_data._pauseTimePercentage / 100.0;
 
         /// <summary>
         /// Generation info for all generations.
         /// </summary>
-        public ReadOnlySpan<GCGenerationInfo> GenerationInfo => MemoryMarshal.CreateReadOnlySpan(in _generationInfo0, 5);
+        public ReadOnlySpan<GCGenerationInfo> GenerationInfo => _data.GenerationInfoAsSpan;
     }
 }

--- a/src/mono/System.Private.CoreLib/src/System/GC.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/GC.Mono.cs
@@ -248,7 +248,7 @@ namespace System
 
         public static GCMemoryInfo GetGCMemoryInfo()
         {
-            var data = new GCMemoryInfoData();
+            GCMemoryInfoData data = default;
 
             _GetGCMemoryInfo(out data._highMemoryLoadThresholdBytes,
                              out data._memoryLoadBytes,


### PR DESCRIPTION
Fixes #101536

I tried to build this to test locally, but was unable to.

Changes:
1. Added internal ref struct enumerator to enumerate `ConditionalWeakTable` objects without allocations.
2. Added a ThreadStatic `GCMemoryInfoData` to remove allocations after the first call to `GC.GetGCMemoryInfo()`.

Both of these are used by `SharedArrayPool.Trim()` which is called from Gen2GcCallback.

For 2, it looks like the `extern void GetMemoryInfo(GCMemoryInfoData data, int kind)` function could be `extern void GetMemoryInfo(GCMemoryInfo* data, int kind)`, passing a struct pointer instead of class to be always zero alloc, but I don't know enough about the system or C++. @Maoni0 

cc @jkotas