### PR TITLE
Fix warning in pal_x509_ios.c on newer clang

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509_ios.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509_ios.c
@@ -40,7 +40,7 @@ int32_t AppleCryptoNative_X509ImportCertificate(uint8_t* pbData,
     {
         *pCertOut = SecCertificateCreateWithData(NULL, cfData);
         CFRelease(cfData);
-        return *pCertOut == NULL ? errSecUnknownFormat : noErr;
+        return *pCertOut == NULL ? errSecUnknownFormat : (OSStatus)noErr;
     }
     else // PAL_Pkcs12
     {


### PR DESCRIPTION
This is the same change that we applied to pal_x509.c in https://github.com/dotnet/runtime/pull/108888#discussion_r1801332711, just for the iOS version of the file.