### PR TITLE
Fix inadvertently upgrading compiler warnings to errors in libs.native

### DIFF
--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -110,7 +110,7 @@
       <_CoreClrBuildPreSource Condition="'$(TargetsBrowser)' == 'true' and !$([MSBuild]::IsOsPlatform(Windows))">source &quot;$(RepoRoot)src/mono/browser/emsdk/emsdk_env.sh&quot; &amp;&amp; </_CoreClrBuildPreSource>
     </PropertyGroup>
 
-    <!-- Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and there's an existing warning in the native build. -->
+    <!-- Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and we want to avoid upgrading compiler warnings to errors in release branches -->
     <Message Text="Executing $(_CoreClrBuildPreSource)$(MSBuildThisFileDirectory)&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')" Importance="High" />
     <Exec Command="$(_CoreClrBuildPreSource)$(MSBuildThisFileDirectory)&quot;$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')"
           IgnoreStandardErrorWarningFormat="true" />

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -84,8 +84,8 @@
     </PropertyGroup>
 
     <!--
-      Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and there's an existing
-      warning in the macOS build when dsymutil tries to strip symbols.
+      Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and we want to avoid
+      upgrading compiler warnings to errors in release branches.
     -->
     <Message Text="&quot;$(BuildScript)&quot; $(BuildArgs)" Importance="High"/>
     <Exec Command="&quot;$(BuildScript)&quot; $(BuildArgs)" IgnoreStandardErrorWarningFormat="true"/>
@@ -160,8 +160,8 @@
 
     <!--
       Run script that invokes Cmake to create VS files, and then calls msbuild to compile them. Use
-      IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and there's an existing
-      warning in the native build.
+      IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and we want to avoid
+      upgrading compiler warnings to errors in release branches.
     -->
     <Message Text="&quot;$(BuildScript)&quot; $(BuildArgs)" Importance="High"/>
     <Exec Command="&quot;$(BuildScript)&quot; $(BuildArgs)" IgnoreStandardErrorWarningFormat="true"/>

--- a/src/native/libs/build-native.proj
+++ b/src/native/libs/build-native.proj
@@ -70,8 +70,10 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(_IcuArtifacts)" DestinationFolder="$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(_BuildNativeOutConfig)'))" SkipUnchangedFiles="true" />
+
+    <!-- Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and we want to avoid upgrading compiler warnings to error in release branches -->
     <Message Text="$(MSBuildThisFileDirectory)build-native.sh $(_BuildNativeUnixArgs)" Importance="High"/>
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.sh&quot; $(_BuildNativeUnixArgs)" EnvironmentVariables="$(_BuildNativeEnvironmentVariables)" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.sh&quot; $(_BuildNativeUnixArgs)" EnvironmentVariables="$(_BuildNativeEnvironmentVariables)" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <!-- 
@@ -101,8 +103,9 @@
         <_BuildNativeArgs Condition="'$(CMakeArgs)' != '' or '$(_MonoWasmMTCMakeArgs)' != ''">$(_BuildNativeArgs) -cmakeargs "$(CMakeArgs)$(_MonoWasmMTCMakeArgs)"</_BuildNativeArgs>
     </PropertyGroup>
     <!-- Run script that uses CMake to generate and build the native files. -->
+    <!-- Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and we want to avoid upgrading compiler warnings to errors in release branches -->
     <Message Text="&quot;$(MSBuildThisFileDirectory)build-native.cmd&quot; $(_BuildNativeArgs)" Importance="High"/>
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.cmd&quot; $(_BuildNativeArgs)" EnvironmentVariables="$(_BuildNativeEnvironmentVariables)" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.cmd&quot; $(_BuildNativeArgs)" EnvironmentVariables="$(_BuildNativeEnvironmentVariables)" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <UsingTask TaskName="AndroidLibBuilderTask"


### PR DESCRIPTION
I noticed this while looking at an issue in the 9.0 branch with latest clang which runs into a couple warnings fixed in main with https://github.com/dotnet/runtime/pull/108888.

We intentionally don't set `-Werror` in release branches to avoid breaking the build when newer compilers add warnings via https://github.com/dotnet/runtime/blob/37e4d45236e68946db9d264593aa31a9c00534bc/eng/native/configurecompiler.cmake#L564-L567

However this didn't work because msbuild's WarnAsError was still reading the console output of the native build and upgrading any line with "warning: " to an msbuild error and breaking the build.

Suppress this by setting IgnoreStandardErrorWarningFormat="true" on the Exec call. We already did this in the coreclr and mono runtime builds, we just missed it in build-native.proj in libs.native.