### PR TITLE
Enable alljitcommunity in CI

### DIFF
--- a/eng/pipelines/coreclr/superpmi-diffs.yml
+++ b/eng/pipelines/coreclr/superpmi-diffs.yml
@@ -55,7 +55,7 @@ extends:
           - windows_x64
           - windows_x86
           jobParameters:
-            buildArgs: -s clr.alljits+clr.spmi -c $(_BuildConfig)
+            buildArgs: -s clr.alljits+clr.alljitscommunity+clr.spmi -c $(_BuildConfig)
             postBuildSteps:
               - template: /eng/pipelines/common/upload-artifact-step.yml
                 parameters:

--- a/eng/pipelines/coreclr/superpmi-diffs.yml
+++ b/eng/pipelines/coreclr/superpmi-diffs.yml
@@ -20,6 +20,7 @@ pr:
     # If you are changing these and start including eng/common, adjust the Maestro subscriptions
     # so that this build can block dependency auto-updates (this build is currently ignored)
     include:
+    - eng/pipelines/coreclr/superpmi-diffs.yml
     - src/coreclr/jit/*
     - src/coreclr/gcinfo/*
 


### PR DESCRIPTION
`clr.alljitcommunity` subset is currently not built in the CI and it frequently breaks on Windows because development of riscv64/loongarch64 is mainly taking place on Unix. Last week, it broke twice: https://github.com/dotnet/runtime/pull/114062 and https://github.com/dotnet/runtime/pull/114292. The breakages are mainly due to different analysis warning threshold between llvm and msvc toolchains (explicit casts etc.).

This PR enables it in superpmi CI leg. As to the overhead, it is not too much: before `windows-x64 checked` [took](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1006308&view=logs&j=35d6a56c-45ed-5990-d6d7-83c0517ee7bd) 7m 5s, now it's 8m 2s. Also updated this pipeline to trigger when someone updates its yml configs.