### PR TITLE
CultureName "c" and "C" get mapped to Invariant Culture

### DIFF
--- a/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/AssemblyNameInfoFuzzer.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/AssemblyNameInfoFuzzer.cs
@@ -68,13 +68,23 @@ namespace DotnetFuzzing.Fuzzers
                     // When converting to AssemblyName, the culture name is lower-cased
                     // by the CultureInfo ctor that calls CultureData.GetCultureData
                     // which lowers the name for caching and normalization purposes.
-                    Assert.Equal(fromTryParse.CultureName.ToLower(), fromParse.ToAssemblyName().CultureName);
+
+                    string lowerCase = fromTryParse.CultureName.ToLower();
+                    if (lowerCase != "c")
+                    {
+                        Assert.Equal(lowerCase, fromParse.ToAssemblyName().CultureName);
+                    }
+                    else
+                    {
+                        // Cultures "c" and "C" get mapped to Invariant Culture.
+                        Assert.Equal("", fromParse.ToAssemblyName().CultureName);
+                        Assert.Equal(CultureInfo.InvariantCulture, fromParse.ToAssemblyName().CultureInfo);
+                    }
                 }
                 else
                 {
                     Assert.True(fromParse.ToAssemblyName().CultureName is null);
                 }
-                
 
                 // AssemblyNameInfo.FullName can be different than AssemblyName.FullName:
                 // AssemblyNameInfo includes public key, AssemblyName only its Token.

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/AssemblyNameInfoTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/AssemblyNameInfoTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Xunit;
 
 namespace System.Reflection.Metadata.Tests.Metadata
@@ -114,6 +115,19 @@ namespace System.Reflection.Metadata.Tests.Metadata
             // by the CultureInfo ctor that calls CultureData.GetCultureData
             // which lowers the name for caching and normalization purposes.
             Assert.Equal("aa", assemblyNameInfo.ToAssemblyName().CultureName);
+        }
+
+        [Theory]
+        // "c" is an invalid culture identifier in Full Framework
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [InlineData('c')]
+        [InlineData('C')]
+        public void Culture_C_IsMappedToInvariantCulture(char culture)
+        {
+            AssemblyNameInfo assemblyNameInfo = AssemblyNameInfo.Parse($"name,culture={culture}".AsSpan());
+            Assert.Equal(culture.ToString(), assemblyNameInfo.CultureName);
+            Assert.Equal("", assemblyNameInfo.ToAssemblyName().CultureName);
+            Assert.Equal(CultureInfo.InvariantCulture, assemblyNameInfo.ToAssemblyName().CultureInfo);
         }
 
         static void Roundtrip(AssemblyName source)


### PR DESCRIPTION
Fuzzer has helped me to learn one more thing about culture name mappings:

https://github.com/dotnet/runtime/blob/37e4d45236e68946db9d264593aa31a9c00534bc/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs#L800-L806