### PR TITLE
[infra][iOS][tvOS] Use x64 Azdo images for internal iOS/tvOS jobs

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1018,7 +1018,9 @@ extends:
           jobParameters:
             testGroup: innerloop
             nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=false /p:EnableAggressiveTrimming=true
+            buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=false /p:EnableAggressiveTrimming=true
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              extraBuildArgs: /p:BuildTestsOnHelix=true
             timeoutInMinutes: 480
             condition: >-
               or(
@@ -1033,7 +1035,8 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-                  extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+                  ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                    extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
                   condition: >-
                     or(
                     eq(variables['librariesContainsChange'], true),
@@ -1063,7 +1066,9 @@ extends:
           jobParameters:
             testGroup: innerloop
             nameSuffix: AllSubsets_NativeAOT
-            buildArgs: --cross -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=- /p:BuildTestsOnHelix=true /p:UseNativeAOTRuntime=true /p:RunAOTCompilation=false /p:ContinuousIntegrationBuild=true
+            buildArgs: --cross -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=- /p:UseNativeAOTRuntime=true /p:RunAOTCompilation=false /p:ContinuousIntegrationBuild=true
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              extraBuildArgs: /p:BuildTestsOnHelix=true
             timeoutInMinutes: 180
             condition: >-
               or(
@@ -1077,7 +1082,8 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-                  extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+                  ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                    extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
                   condition: >-
                     or(
                     eq(variables['librariesContainsChange'], true),


### PR DESCRIPTION
On public CI, we are using x64 macOS azdo images, so the built AOT compiler is x64 which aligns with the host architecture of helix mac devices. However, on internal CI, the macOS images are arm64, causing a mismatch in architectures.

This PR switches the internal CI for iOS and tvOS jobs to use x64 macOS azdo images.

Alternative approaches:
- Build test apps on Azdo VMs for internal jobs.
- Force AOT compiler to be cross build for x64 architecture.

--- 

https://github.com/dotnet/runtime/issues/114327