### PR TITLE
[release/9.0-staging] Fix inadvertently upgrading compiler warnings to errors

### DIFF
--- a/src/native/libs/build-native.proj
+++ b/src/native/libs/build-native.proj
@@ -70,7 +70,7 @@
 
     <Copy SourceFiles="@(_IcuArtifacts)" DestinationFolder="$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(_BuildNativeOutConfig)'))" SkipUnchangedFiles="true" />
     <Message Text="$(MSBuildThisFileDirectory)build-native.sh $(_BuildNativeUnixArgs)" Importance="High"/>
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.sh&quot; $(_BuildNativeUnixArgs)" EnvironmentVariables="$(_BuildNativeEnvironmentVariables)" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.sh&quot; $(_BuildNativeUnixArgs)" EnvironmentVariables="$(_BuildNativeEnvironmentVariables)" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Target Name="BuildNativeWindows"
@@ -82,7 +82,7 @@
     </PropertyGroup>
     <!-- Run script that uses CMake to generate and build the native files. -->
     <Message Text="&quot;$(MSBuildThisFileDirectory)build-native.cmd&quot; $(_BuildNativeArgs)" Importance="High"/>
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.cmd&quot; $(_BuildNativeArgs)" EnvironmentVariables="$(_BuildNativeEnvironmentVariables)" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.cmd&quot; $(_BuildNativeArgs)" EnvironmentVariables="$(_BuildNativeEnvironmentVariables)" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <UsingTask TaskName="AndroidLibBuilderTask"


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/114323 to release/9.0-staging.

Don't inadvertently upgrade compiler warnings to errors in libs.native.

## Customer Impact

- [ ] Customer reported
- [x] Found internally

Building with a newer compilers can introduce new warnings, breaking the build unintentionally even though we explicitly tried to avoid this by disabling this behavior in release branches. This could especially affect source-build partners which don't use our build infrastructure.

## Regression

- [ ] Yes
- [x] No

No, we just forgot to apply this fix to the libs.native subset. It was there for coreclr and mono runtime builds already.

## Testing

CI testing.

## Risk

Low, this is a build-only change.