### PR TITLE
Remove useless assert from assertprop

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5722,24 +5722,7 @@ bool Compiler::optCreateJumpTableImpliedAssertions(BasicBlock* switchBb)
             // TODO-Cleanup: We shouldn't attach assertions to nodes in Global Assertion Prop.
             // It limits the ability to create multiple assertions for the same node.
             GenTree* tree = gtNewNothingNode();
-
-            // Skip all PHI def statements
-            Statement* curStmt = target->firstStmt();
-            while ((curStmt != nullptr) && curStmt->IsPhiDefnStmt())
-            {
-                curStmt = curStmt->GetNextStmt();
-            }
-
-            if (curStmt == nullptr)
-            {
-                // The block is either empty or contains only PHI stmt(s).
-                fgInsertStmtAtEnd(target, fgNewStmtFromTree(tree));
-            }
-            else
-            {
-                // Insert the NOP before the first non-PHI stmt.
-                fgInsertStmtBefore(target, curStmt, fgNewStmtFromTree(tree));
-            }
+            fgInsertStmtAtBeg(target, fgNewStmtFromTree(tree));
 
             modified = true;
             tree->SetAssertionInfo(newAssertIdx);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5657,14 +5657,6 @@ bool Compiler::optCreateJumpTableImpliedAssertions(BasicBlock* switchBb)
             continue;
         }
 
-        // Make sure we don't have any PHI nodes in the target block.
-#if DEBUG
-        for (Statement* stmt : target->Statements())
-        {
-            assert(!stmt->IsPhiDefnStmt());
-        }
-#endif
-
         AssertionInfo newAssertIdx = NO_ASSERTION_INDEX;
 
         // Is this target a default case?


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/114275

It seems like it's totally fine to have PHI in blocks with single predecessor being a single edge to BBJ_SWITCH. Such PHI statements usually appear after RBO phase, in this case it's:
```
------------ BB11 [0023] [104..10B) -> BB12(1) (always), preds={BB07} succs={BB12}

***** BB11 [0023]
STMT00034 ( ??? ... ??? )
N004 (  0,  0) [000166] DA---------                         *  STORE_LCL_VAR int    V16 tmp4         d:4 $VN.Void
N003 (  0,  0) [000165] -----------                         \--*  PHI       int    <l:$107, c:$108>
N001 (  0,  0) [000173] ----------- pred BB10                  +--*  PHI_ARG   int    V16 tmp4         u:2
N002 (  0,  0) [000168] ----------- pred BB07                  \--*  PHI_ARG   int    V16 tmp4         u:3 <l:$107, c:$108>
```
where BB07 is the switch root. BB10 was unlinked by Redundant branch opt phase