### PR TITLE
Call DisposeAsync on SocketsHttpHandler HttpConnection Stream

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -111,7 +111,7 @@ namespace System.Net.Http
                 if (disposing)
                 {
                     GC.SuppressFinalize(this);
-                    _stream.Dispose();
+                    _stream.DisposeAsync().AsTask().GetAwaiter().GetResult();
                 }
             }
         }


### PR DESCRIPTION
Most of the time, this should return an already-completed ValueTask, and not make much of a difference, but it can make a difference for someone using the ConnectCallback with a Stream type that implements DisposeAsync instead of Dispose(bool).

You can take a look at https://github.com/modelcontextprotocol/csharp-sdk/pull/225 to see the conversation when I first noticed that SocketsHttpHandler wasn't calling DisposeAsync. If it had, it would have saved me some debugging.