### PR TITLE
Call build.cmd directly from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ if is_cygwin_or_mingw; then
   # if bash shell running on Windows (not WSL),
   # pass control to powershell build script.
   scriptroot=$(cygpath -d "$scriptroot")
-  powershell -c "$scriptroot\\build.cmd" $@
+  "$scriptroot/build.cmd" $@
 else
   "$scriptroot/eng/build.sh" $@
 fi

--- a/build.sh
+++ b/build.sh
@@ -25,8 +25,7 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
 if is_cygwin_or_mingw; then
   # if bash shell running on Windows (not WSL),
-  # pass control to powershell build script.
-  scriptroot=$(cygpath -d "$scriptroot")
+  # pass control to batch build script.
   "$scriptroot/build.cmd" $@
 else
   "$scriptroot/eng/build.sh" $@


### PR DESCRIPTION
# Description

On Cygwin or MinGW, `.bat` and `.cmd` files can be executed directly as long as they have execute permissions, so there's no need to go through PowerShell.  Direct execution is slightly faster.

Related #94