### PR TITLE
Multi-target Microsoft.NET.HostModel

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -143,7 +143,6 @@
     <SystemCollectionsImmutableToolsetVersion>8.0.0</SystemCollectionsImmutableToolsetVersion>
     <SystemMemoryToolsetVersion>4.5.5</SystemMemoryToolsetVersion>
     <SystemTextJsonToolsetVersion>8.0.5</SystemTextJsonToolsetVersion>
-    <SystemReflectionMetadataToolsetVersion>8.0.0</SystemReflectionMetadataToolsetVersion>
     <SystemReflectionMetadataLoadContextToolsetVersion>8.0.0</SystemReflectionMetadataLoadContextToolsetVersion>
     <SystemReflectionMetadataToolsetVersion>8.0.0</SystemReflectionMetadataToolsetVersion>
     <SystemTextEncodingsWebToolsetVersion>8.0.0</SystemTextEncodingsWebToolsetVersion>

--- a/src/installer/managed/Microsoft.NET.HostModel/ComHost/ConflictingGuidException.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ComHost/ConflictingGuidException.cs
@@ -14,6 +14,10 @@ namespace Microsoft.NET.HostModel.ComHost
     {
         public ConflictingGuidException(string typeName1, string typeName2, Guid guid)
         {
+#if NET
+            ArgumentNullException.ThrowIfNull(typeName1);
+            ArgumentNullException.ThrowIfNull(typeName2);
+#else
             if (typeName1 is null)
             {
                 throw new ArgumentNullException(nameof(typeName1));
@@ -22,6 +26,7 @@ namespace Microsoft.NET.HostModel.ComHost
             {
                 throw new ArgumentNullException(nameof(typeName2));
             }
+#endif
             TypeName1 = typeName1;
             TypeName2 = typeName2;
             Guid = guid;

--- a/src/installer/managed/Microsoft.NET.HostModel/ComHost/MissingGuidException.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ComHost/MissingGuidException.cs
@@ -14,10 +14,15 @@ namespace Microsoft.NET.HostModel.ComHost
     {
         public MissingGuidException(string typeName)
         {
+#if NET
+            ArgumentNullException.ThrowIfNull(typeName);
+#else
             if (typeName is null)
             {
+
                 throw new ArgumentNullException(nameof(typeName));
-            }
+        }
+#endif
             TypeName = typeName;
         }
 

--- a/src/installer/managed/Microsoft.NET.HostModel/ComHost/MissingGuidException.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ComHost/MissingGuidException.cs
@@ -19,9 +19,8 @@ namespace Microsoft.NET.HostModel.ComHost
 #else
             if (typeName is null)
             {
-
                 throw new ArgumentNullException(nameof(typeName));
-        }
+            }
 #endif
             TypeName = typeName;
         }

--- a/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
+++ b/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(NetCoreAppToolCurrent);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <Description>Abstractions for modifying .NET host binaries</Description>
     <IsShipping>false</IsShipping>
     <IsPackable Condition="'$(BuildOnlyPgoInstrumentedAssets)' != 'true'">true</IsPackable>
@@ -14,16 +14,16 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Historically, the key for the managed projects is the AspNetCore key Arcade carries. -->
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <DefineConstants>$(DefineConstants);HOST_MODEL</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- SDK pins this to a lower version https://github.com/dotnet/sdk/issues/43325 -->
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataToolsetVersion)" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Json\src\System.Text.Json.csproj" />
+  <!-- Manually reference these assemblies which are provided by MSBuild / .NET SDK -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageDownloadAndReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableToolsetVersion)" Folder="lib/net462" />
+    <PackageDownloadAndReference Include="System.Memory" Version="$(SystemMemoryToolsetVersion)" Folder="lib/net461" />
+    <PackageDownloadAndReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" Folder="lib/net462" />
+    <PackageDownloadAndReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataToolsetVersion)" Folder="lib/net462" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,5 +34,7 @@
     <Compile Include="$(CoreClrProjectRoot)tools\Common\Compiler\Win32Resources\ResourceData.Win32Structs.cs" Link="Win32Resources\ResourceData.Win32Structs.cs" />
     <Compile Include="$(CoreClrProjectRoot)tools\Common\System\Collections\Generic\ArrayBuilder.cs" Link="Common\ArrayBuilder.cs" />
   </ItemGroup>
+
+  <Import Project="$(RepositoryEngineeringDir)PackageDownloadAndReference.targets" />
 
 </Project>


### PR DESCRIPTION
Multi-targeting allows using latest on .NETCoreApp and LKG (toolset) on .NETFramework. Should partially unblock the m-p packages dependency flow in dotnet/sdk: https://github.com/dotnet/sdk/pull/48034