### PR TITLE
Update HttpTelemetry.Redirect helper visibility

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -179,7 +179,7 @@ namespace System.Net.Http
         }
 
         [Event(16, Level = EventLevel.Informational)]
-        public void Redirect(string redirectUri)
+        private void Redirect(string redirectUri)
         {
             WriteEvent(eventId: 16, redirectUri);
         }


### PR DESCRIPTION
We have 2 overloads of `Redirect` - one that does redaction and one that actually logs the information.

We are calling the correct overload from our redirect logic.
https://github.com/dotnet/runtime/blob/a87fd8bc2fe1bfa3a96d85b05d20a8341c1eb895/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs#L58

This change is making the other overload private to avoid accidentally bypassing redaction in the future when updating calling code.