### PR TITLE
Make CertificateRequest et al work with ML-DSA

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
@@ -116,14 +116,16 @@ namespace Internal.Cryptography
         internal static CryptographicException CreateAlgorithmUnknownException(AsnWriter encodedId)
         {
 #if NET10_0_OR_GREATER
-            return encodedId.Encode(static encoded =>
-                new CryptographicException(
-                    SR.Format(SR.Cryptography_UnknownAlgorithmIdentifier, Convert.ToHexString(encoded))));
+            return encodedId.Encode(static encoded => CreateAlgorithmUnknownException(Convert.ToHexString(encoded)));
 #else
-            return new CryptographicException(
-                SR.Format(SR.Cryptography_UnknownAlgorithmIdentifier,
-                HexConverter.ToString(encodedId.Encode(), HexConverter.Casing.Upper)));
+            return CreateAlgorithmUnknownException(HexConverter.ToString(encodedId.Encode(), HexConverter.Casing.Upper));
 #endif
+        }
+
+        internal static CryptographicException CreateAlgorithmUnknownException(string algorithmId)
+        {
+            throw new CryptographicException(
+                SR.Format(SR.Cryptography_UnknownAlgorithmIdentifier, algorithmId));
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -753,7 +753,12 @@ namespace System.Security.Cryptography
                         AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
                         SubjectPublicKeyInfoAsn.Decode(ref reader, manager.Memory, out SubjectPublicKeyInfoAsn spki);
 
-                        MLDsaAlgorithm algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(spki.Algorithm.Algorithm);
+                        MLDsaAlgorithm? algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(spki.Algorithm.Algorithm);
+
+                        if (algorithm is null)
+                        {
+                            throw Helpers.CreateAlgorithmUnknownException(spki.Algorithm.Algorithm);
+                        }
 
                         if (spki.Algorithm.Parameters.HasValue)
                         {
@@ -803,7 +808,12 @@ namespace System.Security.Cryptography
                         AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
                         PrivateKeyInfoAsn.Decode(ref reader, manager.Memory, out PrivateKeyInfoAsn pki);
 
-                        MLDsaAlgorithm algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(pki.PrivateKeyAlgorithm.Algorithm);
+                        MLDsaAlgorithm? algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(pki.PrivateKeyAlgorithm.Algorithm);
+
+                        if (algorithm is null)
+                        {
+                            throw Helpers.CreateAlgorithmUnknownException(pki.PrivateKeyAlgorithm.Algorithm);
+                        }
 
                         if (pki.PrivateKeyAlgorithm.Parameters.HasValue)
                         {

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
@@ -107,22 +107,15 @@ namespace System.Security.Cryptography
         /// </value>
         public static MLDsaAlgorithm MLDsa87 { get; } = new MLDsaAlgorithm("ML-DSA-87", 4896, 2592, 4627, Oids.MLDsa87);
 
-        internal static MLDsaAlgorithm GetMLDsaAlgorithmFromOid(string oid)
+        internal static MLDsaAlgorithm? GetMLDsaAlgorithmFromOid(string? oid)
         {
             return oid switch
             {
                 Oids.MLDsa44 => MLDsa44,
                 Oids.MLDsa65 => MLDsa65,
                 Oids.MLDsa87 => MLDsa87,
-                _ => ThrowAlgorithmUnknown(oid),
+                _ => null,
             };
-        }
-
-        [DoesNotReturn]
-        private static MLDsaAlgorithm ThrowAlgorithmUnknown(string algorithmId)
-        {
-            throw new CryptographicException(
-                SR.Format(SR.Cryptography_UnknownAlgorithmIdentifier, algorithmId));
         }
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestImplementation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestImplementation.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    internal sealed class MLDsaTestImplementation : MLDsa
+    {
+        internal delegate void ExportAction(Span<byte> destination);
+        internal delegate void SignAction(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        internal delegate bool VerifyFunc(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+
+        internal ExportAction ExportMLDsaPrivateSeedHook { get; set; }
+        internal ExportAction ExportMLDsaPublicKeyHook { get; set; }
+        internal ExportAction ExportMLDsaSecretKeyHook { get; set; }
+        internal SignAction SignDataHook { get; set; }
+        internal VerifyFunc VerifyDataHook { get; set; }
+        internal Action<bool> DisposeHook { get; set; } = _ => { };
+
+        private MLDsaTestImplementation(MLDsaAlgorithm algorithm) : base(algorithm)
+        {
+        }
+
+        protected override void Dispose(bool disposing) => DisposeHook(disposing);
+
+        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) => ExportMLDsaPrivateSeedHook(destination);
+        protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) => ExportMLDsaPublicKeyHook(destination);
+        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination) => ExportMLDsaSecretKeyHook(destination);
+
+        protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) =>
+            SignDataHook(data, context, destination);
+
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) =>
+            VerifyDataHook(data, context, signature);
+
+        internal static MLDsaTestImplementation CreateOverriddenCoreMethodsFail(MLDsaAlgorithm algorithm)
+        {
+            return new MLDsaTestImplementation(algorithm)
+            {
+                ExportMLDsaPrivateSeedHook = _ => Assert.Fail(),
+                ExportMLDsaPublicKeyHook = _ => Assert.Fail(),
+                ExportMLDsaSecretKeyHook = _ => Assert.Fail(),
+                SignDataHook = (_, _, _) => Assert.Fail(),
+                VerifyDataHook = (_, _, _) => { Assert.Fail(); return false; },
+            };
+        }
+
+        internal static MLDsaTestImplementation CreateNoOp(MLDsaAlgorithm algorithm)
+        {
+            return new MLDsaTestImplementation(algorithm)
+            {
+                ExportMLDsaPrivateSeedHook = d => d.Clear(),
+                ExportMLDsaPublicKeyHook = d => d.Clear(),
+                ExportMLDsaSecretKeyHook = d => d.Clear(),
+                SignDataHook = (data, context, destination) => destination.Clear(),
+                VerifyDataHook = (data, context, signature) => signature.IndexOfAnyExcept((byte)0) == -1,
+            };
+        }
+
+        internal static MLDsaTestImplementation Wrap(MLDsa other)
+        {
+            return new MLDsaTestImplementation(other.Algorithm)
+            {
+                ExportMLDsaPrivateSeedHook = d => other.ExportMLDsaPrivateSeed(d),
+                ExportMLDsaPublicKeyHook = d => other.ExportMLDsaPublicKey(d),
+                ExportMLDsaSecretKeyHook = d => other.ExportMLDsaSecretKey(d),
+                SignDataHook = (data, context, destination) => other.SignData(data, destination, context),
+                VerifyDataHook = (data, context, signature) => other.VerifyData(data, signature, context),
+            };
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Formats.Asn1;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.Common
@@ -148,7 +149,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
         internal X509Certificate2 CreateSubordinateCA(
             string subject,
-            RSA publicKey,
+            PublicKey publicKey,
             int? depthLimit = null)
         {
             return CreateCertificate(
@@ -164,7 +165,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                     s_caKeyUsage });
         }
 
-        internal X509Certificate2 CreateEndEntity(string subject, RSA publicKey, X509ExtensionCollection extensions)
+        internal X509Certificate2 CreateEndEntity(string subject, PublicKey publicKey, X509ExtensionCollection extensions)
         {
             return CreateCertificate(
                 subject,
@@ -173,7 +174,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                 extensions);
         }
 
-        internal X509Certificate2 CreateOcspSigner(string subject, RSA publicKey)
+        internal X509Certificate2 CreateOcspSigner(string subject, RSA rsa)
+        {
+            return CreateOcspSigner(
+                subject,
+                X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1).PublicKey);
+        }
+
+        internal X509Certificate2 CreateOcspSigner(string subject, PublicKey publicKey)
         {
             return CreateCertificate(
                 subject,
@@ -207,7 +215,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                 throw new InvalidOperationException();
             }
 
-            var req = new CertificateRequest(subjectName, _cert.PublicKey, HashAlgorithmName.SHA256);
+            var req = new CertificateRequest(subjectName, _cert.PublicKey, HashAlgorithmIfNeeded(_cert.GetKeyAlgorithm()));
 
             foreach (X509Extension ext in _cert.Extensions)
             {
@@ -222,21 +230,21 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             X509Certificate2 dispose = _cert;
 
             using (dispose)
-            using (RSA rsa = _cert.GetRSAPrivateKey())
+            using (KeyHolder key = new KeyHolder(_cert))
             using (X509Certificate2 tmp = req.Create(
                 subjectName,
-                X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1),
+                key.GetGenerator(),
                 new DateTimeOffset(_cert.NotBefore),
                 new DateTimeOffset(_cert.NotAfter),
                 serial))
             {
-                _cert = tmp.CopyWithPrivateKey(rsa);
+                _cert = key.OntoCertificate(tmp);
             }
         }
 
         private X509Certificate2 CreateCertificate(
             string subject,
-            RSA publicKey,
+            PublicKey publicKey,
             TimeSpan nestingBuffer,
             X509ExtensionCollection extensions,
             bool ocspResponder = false)
@@ -257,9 +265,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             }
 
             CertificateRequest request = new CertificateRequest(
-                subject,
+                new X500DistinguishedName(subject),
                 publicKey,
-                HashAlgorithmName.SHA256,
+                HashAlgorithmIfNeeded(_cert.GetKeyAlgorithm()),
                 RSASignaturePadding.Pkcs1);
 
             foreach (X509Extension extension in extensions)
@@ -282,11 +290,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             byte[] serial = new byte[sizeof(long)];
             RandomNumberGenerator.Fill(serial);
 
-            return request.Create(
-                _cert,
-                _cert.NotBefore.Add(nestingBuffer),
-                _cert.NotAfter.Subtract(nestingBuffer),
-                serial);
+            using (KeyHolder key = new KeyHolder(_cert))
+            {
+                return request.Create(
+                    _cert.SubjectName,
+                    key.GetGenerator(),
+                    _cert.NotBefore.Add(nestingBuffer),
+                    _cert.NotAfter.Subtract(nestingBuffer),
+                    serial);
+            }
         }
 
         internal byte[] GetCertData()
@@ -337,14 +349,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                     nextUpdate = newExpiry;
                 }
 
-                using (RSA key = _cert.GetRSAPrivateKey())
+                using (KeyHolder key = new KeyHolder(_cert))
                 {
                     crl = builder.Build(
                         CorruptRevocationIssuerName ? s_nonParticipatingName : _cert.SubjectName,
-                        X509SignatureGenerator.CreateForRSA(key, RSASignaturePadding.Pkcs1),
+                        key.GetGenerator(),
                         _crlNumber,
                         nextUpdate,
-                        HashAlgorithmName.SHA256,
+                        HashAlgorithmIfNeeded(key.ToPublicKey().Oid.Value),
                         _akidExtension,
                         thisUpdate);
                 }
@@ -366,16 +378,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             DateTimeOffset newExpiry,
             X509AuthorityKeyIdentifierExtension akidExtension)
         {
+            using KeyHolder key = new KeyHolder(_cert);
+            byte[] signatureAlgId = key.GetSignatureAlgorithmIdentifier();
+
             AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-
-            using (writer.PushSequence())
-            {
-                writer.WriteObjectIdentifier("1.2.840.113549.1.1.11");
-                writer.WriteNull();
-            }
-
-            byte[] signatureAlgId = writer.Encode();
-            writer.Reset();
 
             // TBSCertList
             using (writer.PushSequence())
@@ -473,17 +479,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             byte[] tbsCertList = writer.Encode();
             writer.Reset();
 
-            byte[] signature;
+            byte[] signature = key.Sign(tbsCertList);
 
-            using (RSA key = _cert.GetRSAPrivateKey())
+            if (CorruptRevocationSignature)
             {
-                signature =
-                    key.SignData(tbsCertList, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-
-                if (CorruptRevocationSignature)
-                {
-                    signature[5] ^= 0xFF;
-                }
+                signature[5] ^= 0xFF;
             }
 
             // CertificateList
@@ -568,7 +568,7 @@ SingleResponse ::= SEQUENCE {
                         {
                             writer.PushSequence(s_context1);
 
-                            // Fracational seconds "MUST NOT" be used here. Android and macOS 13+ enforce this and
+                            // Fractional seconds "MUST NOT" be used here. Android and macOS 13+ enforce this and
                             // reject GeneralizedTime's with fractional seconds, so omit them.
                             // RFC 6960: 4.2.2.1:
                             // The format for GeneralizedTime is as specified in Section 4.1.2.5.2 of [RFC5280].
@@ -630,18 +630,11 @@ SingleResponse ::= SEQUENCE {
             {
                 writer.WriteEncodedValue(tbsResponseData);
 
-                using (writer.PushSequence())
+                using (KeyHolder key = new KeyHolder(responder))
                 {
-                    writer.WriteObjectIdentifier("1.2.840.113549.1.1.11");
-                    writer.WriteNull();
-                }
+                    writer.WriteEncodedValue(key.GetSignatureAlgorithmIdentifier());
 
-                using (RSA rsa = responder.GetRSAPrivateKey())
-                {
-                    byte[] signature = rsa.SignData(
-                        tbsResponseData,
-                        HashAlgorithmName.SHA256,
-                        RSASignaturePadding.Pkcs1);
+                    byte[] signature = key.Sign(tbsResponseData);
 
                     if (CorruptRevocationSignature)
                     {
@@ -794,6 +787,7 @@ SingleResponse ::= SEQUENCE {
             Revoked,
         }
 
+        [OverloadResolutionPriority(-1)]
         internal static void BuildPrivatePki(
             PkiOptions pkiOptions,
             out RevocationResponder responder,
@@ -806,6 +800,35 @@ SingleResponse ::= SEQUENCE {
             bool pkiOptionsInSubject = false,
             string subjectName = null,
             int keySize = DefaultKeySize,
+            X509ExtensionCollection extensions = null)
+        {
+            BuildPrivatePki(
+                pkiOptions,
+                out responder,
+                out rootAuthority,
+                out intermediateAuthorities,
+                out endEntityCert,
+                intermediateAuthorityCount,
+                testName,
+                registerAuthorities,
+                pkiOptionsInSubject,
+                subjectName,
+                KeyFactory.RSASize(keySize),
+                extensions);
+        }
+
+        internal static void BuildPrivatePki(
+            PkiOptions pkiOptions,
+            out RevocationResponder responder,
+            out CertificateAuthority rootAuthority,
+            out CertificateAuthority[] intermediateAuthorities,
+            out X509Certificate2 endEntityCert,
+            int intermediateAuthorityCount,
+            string testName = null,
+            bool registerAuthorities = true,
+            bool pkiOptionsInSubject = false,
+            string subjectName = null,
+            KeyFactory keyFactory = null,
             X509ExtensionCollection extensions = null)
         {
             bool rootDistributionViaHttp = !pkiOptions.HasFlag(PkiOptions.NoRootCertDistributionUri);
@@ -823,14 +846,19 @@ SingleResponse ::= SEQUENCE {
             // default to client
             extensions ??= new X509ExtensionCollection() { s_eeConstraints, s_eeKeyUsage, s_tlsClientEku };
 
-            using (RSA rootKey = RSA.Create(keySize))
-            using (RSA eeKey = RSA.Create(keySize))
+            if (keyFactory is null)
             {
-                var rootReq = new CertificateRequest(
-                    BuildSubject("A Revocation Test Root", testName, pkiOptions, pkiOptionsInSubject),
-                    rootKey,
-                    HashAlgorithmName.SHA256,
-                    RSASignaturePadding.Pkcs1);
+                // Should we add variance here?  Sometimes default to ML-DSA, sometimes EC-DSA, sometimes RSA?
+                // Fully randomized (after an IsSupported check) feels too chaotic.
+
+                keyFactory = KeyFactory.RSA;
+            }
+
+            using (KeyHolder rootKey = KeyHolder.CreateKey(keyFactory))
+            using (KeyHolder eeKey = KeyHolder.CreateKey(keyFactory))
+            {
+                CertificateRequest rootReq = rootKey.CreateRequest(
+                    BuildSubject("A Revocation Test Root", testName, pkiOptions, pkiOptionsInSubject));
 
                 X509BasicConstraintsExtension caConstraints =
                     new X509BasicConstraintsExtension(true, false, 0, true);
@@ -862,7 +890,7 @@ SingleResponse ::= SEQUENCE {
 
                 for (int intermediateIndex = 0; intermediateIndex < intermediateAuthorityCount; intermediateIndex++)
                 {
-                    using RSA intermediateKey = RSA.Create(keySize);
+                    using KeyHolder intermediateKey = KeyHolder.CreateKey(keyFactory);
 
                     // Don't dispose this, it's being transferred to the CertificateAuthority
                     X509Certificate2 intermedCert;
@@ -870,8 +898,8 @@ SingleResponse ::= SEQUENCE {
                     {
                         X509Certificate2 intermedPub = issuingAuthority.CreateSubordinateCA(
                             BuildSubject($"A Revocation Test CA {intermediateIndex}", testName, pkiOptions, pkiOptionsInSubject),
-                            intermediateKey);
-                        intermedCert = intermedPub.CopyWithPrivateKey(intermediateKey);
+                            intermediateKey.ToPublicKey());
+                        intermedCert = intermediateKey.OntoCertificate(intermedPub);
                         intermedPub.Dispose();
                     }
 
@@ -894,11 +922,11 @@ SingleResponse ::= SEQUENCE {
 
                 endEntityCert = issuingAuthority.CreateEndEntity(
                     BuildSubject(subjectName ?? "A Revocation Test Cert", testName, pkiOptions, pkiOptionsInSubject),
-                    eeKey,
+                    eeKey.ToPublicKey(),
                     extensions);
 
                 X509Certificate2 tmp = endEntityCert;
-                endEntityCert = endEntityCert.CopyWithPrivateKey(eeKey);
+                endEntityCert = eeKey.OntoCertificate(endEntityCert);
                 tmp.Dispose();
             }
 
@@ -913,6 +941,7 @@ SingleResponse ::= SEQUENCE {
             }
         }
 
+        [OverloadResolutionPriority(-1)]
         internal static void BuildPrivatePki(
             PkiOptions pkiOptions,
             out RevocationResponder responder,
@@ -926,7 +955,6 @@ SingleResponse ::= SEQUENCE {
             int keySize = DefaultKeySize,
             X509ExtensionCollection extensions = null)
         {
-
             BuildPrivatePki(
                 pkiOptions,
                 out responder,
@@ -944,6 +972,36 @@ SingleResponse ::= SEQUENCE {
             intermediateAuthority = intermediateAuthorities.Single();
         }
 
+        internal static void BuildPrivatePki(
+            PkiOptions pkiOptions,
+            out RevocationResponder responder,
+            out CertificateAuthority rootAuthority,
+            out CertificateAuthority intermediateAuthority,
+            out X509Certificate2 endEntityCert,
+            string testName = null,
+            bool registerAuthorities = true,
+            bool pkiOptionsInSubject = false,
+            string subjectName = null,
+            KeyFactory keyFactory = null,
+            X509ExtensionCollection extensions = null)
+        {
+            BuildPrivatePki(
+                pkiOptions,
+                out responder,
+                out rootAuthority,
+                out CertificateAuthority[] intermediateAuthorities,
+                out endEntityCert,
+                intermediateAuthorityCount: 1,
+                testName: testName,
+                registerAuthorities: registerAuthorities,
+                pkiOptionsInSubject: pkiOptionsInSubject,
+                subjectName: subjectName,
+                keyFactory: keyFactory,
+                extensions: extensions);
+
+            intermediateAuthority = intermediateAuthorities.Single();
+        }
+
         private static string BuildSubject(
             string cn,
             string testName,
@@ -954,6 +1012,137 @@ SingleResponse ::= SEQUENCE {
             string pkiOptionsPart = includePkiOptions ? $", OU=\"{pkiOptions}\"" : "";
 
             return $"CN=\"{cn}\"" + testNamePart + pkiOptionsPart;
+        }
+
+        private static HashAlgorithmName HashAlgorithmIfNeeded(string publicKeyOid)
+        {
+            const string Rsa = "1.2.840.113549.1.1.1";
+            const string RsaPss = "1.2.840.113549.1.1.10";
+            const string EcPublicKey = "1.2.840.10045.2.1";
+            const string Dsa = "1.2.840.10040.4.1";
+
+            return publicKeyOid switch
+            {
+                Rsa or RsaPss or EcPublicKey or Dsa => HashAlgorithmName.SHA256,
+                _ => default,
+            };
+        }
+
+        internal void Diag()
+        {
+            Console.WriteLine(_cert.ExportCertificatePem());
+
+            using (ECDsa ecdsa = _cert.GetECDsaPrivateKey())
+            {
+                Console.WriteLine(ecdsa.ExportPkcs8PrivateKeyPem());
+            }
+        }
+
+        internal sealed class KeyFactory
+        {
+            internal static KeyFactory RSA { get; } =
+                new(() => Cryptography.RSA.Create(DefaultKeySize));
+
+            internal static KeyFactory ECDsa { get; } =
+                new(() => Cryptography.ECDsa.Create(ECCurve.NamedCurves.nistP384));
+
+            internal static KeyFactory MLDsa { get; } =
+                new(() => Cryptography.MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa65));
+
+            private Func<IDisposable> _factory;
+
+            private KeyFactory(Func<IDisposable> factory)
+            {
+                _factory = factory;
+            }
+
+            internal IDisposable CreateKey()
+            {
+                return _factory();
+            }
+
+            internal static KeyFactory RSASize(int keySize)
+            {
+                return new KeyFactory(() => Cryptography.RSA.Create(keySize));
+            }
+        }
+
+        private sealed class KeyHolder : IDisposable
+        {
+            private readonly IDisposable _key;
+            private X509SignatureGenerator _generator;
+
+            internal KeyHolder(IDisposable key)
+            {
+                _key = key;
+            }
+
+            internal KeyHolder(X509Certificate2 cert)
+            {
+                // We're always in the context of signing something, so EC-DH does not apply.
+                _key =
+                    cert.GetRSAPrivateKey() ??
+                    cert.GetECDsaPrivateKey() ??
+                    cert.GetMLDsaPrivateKey() ??
+                    (IDisposable)cert.GetDSAPrivateKey() ??
+                    throw new NotSupportedException();
+            }
+
+            public void Dispose()
+            {
+                _key?.Dispose();
+            }
+
+            internal static KeyHolder CreateKey(KeyFactory factory)
+            {
+                return new KeyHolder(factory.CreateKey());
+            }
+
+            internal CertificateRequest CreateRequest(string subject)
+            {
+                return _key switch
+                {
+                    RSA rsa => new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
+                    ECDsa ecdsa => new CertificateRequest(subject, ecdsa, HashAlgorithmName.SHA256),
+                    MLDsa mldsa => new CertificateRequest(subject, mldsa),
+                    _ => throw new NotSupportedException(),
+                };
+            }
+
+            internal X509SignatureGenerator GetGenerator()
+            {
+                return _generator ??= _key switch
+                {
+                    RSA rsa => X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1),
+                    ECDsa ecdsa => X509SignatureGenerator.CreateForECDsa(ecdsa),
+                    MLDsa mldsa => X509SignatureGenerator.CreateForMLDsa(mldsa),
+                    _ => throw new NotSupportedException(),
+                };
+            }
+
+            internal PublicKey ToPublicKey()
+            {
+                return GetGenerator().PublicKey;
+            }
+
+            internal X509Certificate2 OntoCertificate(X509Certificate2 cert)
+            {
+                return CertificateCreation.CertificateRequestChainTests.CloneWithPrivateKey(cert, _key);
+            }
+
+            internal byte[] Sign(byte[] data)
+            {
+                X509SignatureGenerator generator = GetGenerator();
+                return generator.SignData(data, HashAlgorithmIfNeeded(generator.PublicKey.Oid.Value));
+            }
+
+            internal byte[] GetSignatureAlgorithmIdentifier()
+            {
+                X509SignatureGenerator generator = GetGenerator();
+
+                return generator.GetSignatureAlgorithmIdentifier(
+                    HashAlgorithmIfNeeded(generator.PublicKey.Oid.Value));
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -3050,10 +3050,14 @@ namespace System.Security.Cryptography.X509Certificates
     public sealed partial class CertificateRequest
     {
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.ECDsa key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.MLDsa key) { }
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.RSA key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { }
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.X509Certificates.PublicKey publicKey, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.X509Certificates.PublicKey publicKey, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding? rsaSignaturePadding = null) { }
         public CertificateRequest(string subjectName, System.Security.Cryptography.ECDsa key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public CertificateRequest(string subjectName, System.Security.Cryptography.MLDsa key) { }
         public CertificateRequest(string subjectName, System.Security.Cryptography.RSA key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { }
         public System.Collections.ObjectModel.Collection<System.Security.Cryptography.X509Certificates.X509Extension> CertificateExtensions { get { throw null; } }
         public System.Security.Cryptography.HashAlgorithmName HashAlgorithm { get { throw null; } }
@@ -3171,6 +3175,9 @@ namespace System.Security.Cryptography.X509Certificates
         public System.Security.Cryptography.ECDiffieHellman? GetECDiffieHellmanPublicKey() { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Cryptography.ECDsa? GetECDsaPublicKey() { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
+        public System.Security.Cryptography.MLDsa? GetMLDsaPublicKey() { throw null; }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Cryptography.MLKem? GetMLKemPublicKey() { throw null; }
@@ -3485,6 +3492,8 @@ namespace System.Security.Cryptography.X509Certificates
         public string Thumbprint { get { throw null; } }
         public int Version { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 CopyWithPrivateKey(System.Security.Cryptography.ECDiffieHellman privateKey) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 CopyWithPrivateKey(System.Security.Cryptography.MLDsa privateKey) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Security.Cryptography.X509Certificates.X509Certificate2 CreateFromEncryptedPem(System.ReadOnlySpan<char> certPem, System.ReadOnlySpan<char> keyPem, System.ReadOnlySpan<char> password) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -3504,6 +3513,10 @@ namespace System.Security.Cryptography.X509Certificates
         public static System.Security.Cryptography.X509Certificates.X509ContentType GetCertContentType(string fileName) { throw null; }
         public System.Security.Cryptography.ECDiffieHellman? GetECDiffieHellmanPrivateKey() { throw null; }
         public System.Security.Cryptography.ECDiffieHellman? GetECDiffieHellmanPublicKey() { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public System.Security.Cryptography.MLDsa? GetMLDsaPrivateKey() { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public System.Security.Cryptography.MLDsa? GetMLDsaPublicKey() { throw null; }
         public string GetNameInfo(System.Security.Cryptography.X509Certificates.X509NameType nameType, bool forIssuer) { throw null; }
         [System.ObsoleteAttribute("X509Certificate and X509Certificate2 are immutable. Use X509CertificateLoader to create a new certificate.", DiagnosticId="SYSLIB0026", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public override void Import(byte[] rawData) { }
@@ -3893,6 +3906,8 @@ namespace System.Security.Cryptography.X509Certificates
         public System.Security.Cryptography.X509Certificates.PublicKey PublicKey { get { throw null; } }
         protected abstract System.Security.Cryptography.X509Certificates.PublicKey BuildPublicKey();
         public static System.Security.Cryptography.X509Certificates.X509SignatureGenerator CreateForECDsa(System.Security.Cryptography.ECDsa key) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public static System.Security.Cryptography.X509Certificates.X509SignatureGenerator CreateForMLDsa(System.Security.Cryptography.MLDsa key) { throw null; }
         public static System.Security.Cryptography.X509Certificates.X509SignatureGenerator CreateForRSA(System.Security.Cryptography.RSA key, System.Security.Cryptography.RSASignaturePadding signaturePadding) { throw null; }
         public abstract byte[] GetSignatureAlgorithmIdentifier(System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
         public abstract byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <NoWarn>$(NoWarn);SYSLIB0026</NoWarn>
+    <NoWarn>$(NoWarn);SYSLIB0026;SYSLIB5006</NoWarn>
     <!-- PasswordDeriveBytes.GetBytes is obsolete but DeriveBytes.GetBytes intentionally isn't. -->
     <NoWarn>$(NoWarn);CS0809</NoWarn>
   </PropertyGroup>

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -291,6 +291,9 @@
   <data name="Cryptography_CertReq_NoKeyProvided" xml:space="preserve">
     <value>This method cannot be used since no signing key was provided via a constructor, use an overload accepting an X509SignatureGenerator instead.</value>
   </data>
+  <data name="Cryptography_CertReq_NoHashAlgorithmProvided" xml:space="preserve">
+    <value>The intended signature algorithm requires a HashAlgorithmName, but one was not provided when building the CertificatRequest object.</value>
+  </data>
   <data name="Cryptography_CertReq_NotAfterNotNested" xml:space="preserve">
     <value>The requested notAfter value ({0}) is later than issuerCertificate.NotAfter ({1}).</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -673,6 +673,7 @@
     <Compile Include="System\Security\Cryptography\X509Certificates\ILoaderPal.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\IStorePal.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\IX509Pal.cs" />
+    <Compile Include="System\Security\Cryptography\X509Certificates\MLDsaX509SignatureGenerator.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\OpenFlags.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\Pkcs10CertificationRequestInfo.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\Pkcs12ExportPbeParameters.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
@@ -447,6 +447,12 @@ namespace System.Security.Cryptography.X509Certificates
             return new ECDiffieHellmanImplementation.ECDiffieHellmanAndroid(ecKey);
         }
 
+        public MLDsa? GetMLDsaPrivateKey()
+        {
+            // MLDsa is not supported on Android
+            return null;
+        }
+
         public ICertificatePal CopyWithPrivateKey(DSA privateKey)
         {
             DSAImplementation.DSAAndroid? typedKey = privateKey as DSAImplementation.DSAAndroid;
@@ -496,6 +502,12 @@ namespace System.Security.Cryptography.X509Certificates
                 typedKey.ImportParameters(ecParameters);
                 return CopyWithPrivateKeyHandle(typedKey.DuplicateKeyHandle());
             }
+        }
+
+        public ICertificatePal CopyWithPrivateKey(MLDsa privateKey)
+        {
+            throw new PlatformNotSupportedException(
+                SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(MLDsa)));
         }
 
         public ICertificatePal CopyWithPrivateKey(RSA privateKey)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.iOS.cs
@@ -28,6 +28,12 @@ namespace System.Security.Cryptography.X509Certificates
             return ImportPkcs12(this, privateKey);
         }
 
+        public ICertificatePal CopyWithPrivateKey(MLDsa privateKey)
+        {
+            throw new PlatformNotSupportedException(
+                SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(MLDsa)));
+        }
+
         public ICertificatePal CopyWithPrivateKey(RSA privateKey)
         {
             return ImportPkcs12(this, privateKey);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.macOS.cs
@@ -122,6 +122,12 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
+        public ICertificatePal CopyWithPrivateKey(MLDsa privateKey)
+        {
+            throw new PlatformNotSupportedException(
+                SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(MLDsa)));
+        }
+
         public ICertificatePal CopyWithPrivateKey(RSA privateKey)
         {
             var typedKey = privateKey as RSAImplementation.RSASecurityTransforms;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
@@ -364,6 +364,12 @@ namespace System.Security.Cryptography.X509Certificates
             return new ECDiffieHellmanImplementation.ECDiffieHellmanSecurityTransforms(publicKey, privateKey);
         }
 
+        public MLDsa? GetMLDsaPrivateKey()
+        {
+            // MLDsa is not supported on Apple platforms.
+            return null;
+        }
+
         public string GetNameInfo(X509NameType nameType, bool forIssuer)
         {
             EnsureCertData();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
@@ -80,6 +80,12 @@ namespace System.Security.Cryptography.X509Certificates
             );
         }
 
+        public MLDsa? GetMLDsaPrivateKey()
+        {
+            // MLDsa is not supported on Windows.
+            return null;
+        }
+
         public ICertificatePal CopyWithPrivateKey(DSA dsa)
         {
             DSACng? dsaCng = dsa as DSACng;
@@ -166,6 +172,12 @@ namespace System.Security.Cryptography.X509Certificates
 
                 return CopyWithEphemeralKey(clonedKey.Key);
             }
+        }
+
+        public ICertificatePal CopyWithPrivateKey(MLDsa privateKey)
+        {
+            throw new PlatformNotSupportedException(
+                SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(MLDsa)));
         }
 
         public ICertificatePal CopyWithPrivateKey(RSA rsa)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Formats.Asn1;
 using System.Runtime.Versioning;
 using System.Security.Cryptography.Asn1;
@@ -20,7 +21,7 @@ namespace System.Security.Cryptography.X509Certificates
     [UnsupportedOSPlatform("browser")]
     public sealed partial class CertificateRequest
     {
-        private readonly AsymmetricAlgorithm? _key;
+        private readonly object? _key;
         private readonly X509SignatureGenerator? _generator;
         private readonly RSASignaturePadding? _rsaPadding;
 
@@ -179,7 +180,57 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        /// Create a CertificateRequest for the specified subject name, encoded public key, and hash algorithm.
+        ///   Create a CertificateRequest for the specified subject name and ML-DSA key.
+        /// </summary>
+        /// <param name="subjectName">
+        ///   The parsed representation of the subject name for the certificate or certificate request.
+        /// </param>
+        /// <param name="key">
+        ///   An ML-DSA key whose public key material will be included in the certificate or certificate request.
+        ///   This key will be used as a private key if <see cref="CreateSelfSigned" /> is called.
+        /// </param>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        public CertificateRequest(
+            string subjectName,
+            MLDsa key)
+        {
+            ArgumentNullException.ThrowIfNull(subjectName);
+            ArgumentNullException.ThrowIfNull(key);
+
+            SubjectName = new X500DistinguishedName(subjectName);
+
+            _key = key;
+            _generator = X509SignatureGenerator.CreateForMLDsa(key);
+            PublicKey = _generator.PublicKey;
+        }
+
+        /// <summary>
+        ///   Create a CertificateRequest for the specified subject name and ML-DSA key.
+        /// </summary>
+        /// <param name="subjectName">
+        ///   The parsed representation of the subject name for the certificate or certificate request.
+        /// </param>
+        /// <param name="key">
+        ///   An ML-DSA key whose public key material will be included in the certificate or certificate request.
+        ///   This key will be used as a private key if <see cref="CreateSelfSigned" /> is called.
+        /// </param>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        public CertificateRequest(
+            X500DistinguishedName subjectName,
+            MLDsa key)
+        {
+            ArgumentNullException.ThrowIfNull(subjectName);
+            ArgumentNullException.ThrowIfNull(key);
+
+            SubjectName = subjectName;
+
+            _key = key;
+            _generator = X509SignatureGenerator.CreateForMLDsa(key);
+            PublicKey = _generator.PublicKey;
+        }
+
+        /// <summary>
+        ///   Create a CertificateRequest for the specified subject name, encoded public key, and hash algorithm.
         /// </summary>
         /// <param name="subjectName">
         ///   The parsed representation of the subject name for the certificate or certificate request.
@@ -194,7 +245,10 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ArgumentNullException.ThrowIfNull(subjectName);
             ArgumentNullException.ThrowIfNull(publicKey);
-            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+
+            // Since ML-DSA (and others) don't require a hash algorithm, but we don't
+            // know what signature algorithm is being used until the call to Create,
+            // we can't check here.
 
             SubjectName = subjectName;
             PublicKey = publicKey;
@@ -225,7 +279,10 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ArgumentNullException.ThrowIfNull(subjectName);
             ArgumentNullException.ThrowIfNull(publicKey);
-            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+
+            // Since ML-DSA (and others) don't require a hash algorithm, but we don't
+            // know what signature algorithm is being used until the call to Create,
+            // we can't check here.
 
             SubjectName = subjectName;
             PublicKey = publicKey;
@@ -320,6 +377,11 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <para>
         ///     This object was created with a constructor which did not accept a signing key.
         ///   </para>
+        ///   <para>- or -</para>
+        ///   <para>
+        ///     The signature generator requires a non-default value for <see cref="HashAlgorithm"/>,
+        ///     but this object was created without one being provided.
+        ///   </para>
         /// </exception>
         /// <exception cref="CryptographicException">
         ///   A cryptographic error occurs while creating the signing request.
@@ -333,6 +395,12 @@ namespace System.Security.Cryptography.X509Certificates
         public byte[] CreateSigningRequest(X509SignatureGenerator signatureGenerator)
         {
             ArgumentNullException.ThrowIfNull(signatureGenerator);
+
+            if (string.IsNullOrEmpty(HashAlgorithm.Name) &&
+                CertificateRevocationListBuilder.HashAlgorithmRequired(signatureGenerator.PublicKey.Oid.Value))
+            {
+                throw new InvalidOperationException(SR.Cryptography_CertReq_NoHashAlgorithmProvided);
+            }
 
             X501Attribute[] attributes = Array.Empty<X501Attribute>();
             bool hasExtensions = CertificateExtensions.Count > 0;
@@ -456,6 +524,11 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <para>
         ///     This object was created with a constructor which did not accept a signing key.
         ///   </para>
+        ///   <para>- or -</para>
+        ///   <para>
+        ///     The signature generator requires a non-default value for <see cref="HashAlgorithm"/>,
+        ///     but this object was created without one being provided.
+        ///   </para>
         /// </exception>
         /// <exception cref="CryptographicException">
         ///   A cryptographic error occurs while creating the signing request.
@@ -525,6 +598,13 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     return certificate.CopyWithPrivateKey(ecdsa);
                 }
+
+                MLDsa? mldsa = _key as MLDsa;
+
+                if (mldsa is not null)
+                {
+                    return certificate.CopyWithPrivateKey(mldsa);
+                }
             }
 
             Debug.Fail($"Key was of no known type: {_key?.GetType().FullName ?? "null"}");
@@ -568,8 +648,15 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <paramref name="issuerCertificate"/> has a different key algorithm than the requested certificate.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   <paramref name="issuerCertificate"/> is an RSA certificate and this object was created without
-        ///   specifying an <see cref="RSASignaturePadding"/> value in the constructor.
+        ///   <para>
+        ///     <paramref name="issuerCertificate"/> is an RSA certificate and this object was created via a constructor
+        ///     which does not accept a <see cref="RSASignaturePadding"/> value.
+        ///   </para>
+        ///   <para>- or -</para>
+        ///   <para>
+        ///     <paramref name="issuerCertificate"/> uses a public key algorithm which requires a non-default value
+        ///     for <see cref="HashAlgorithm"/>, but this object was created without one being provided.
+        ///   </para>
         /// </exception>
         public X509Certificate2 Create(
             X509Certificate2 issuerCertificate,
@@ -619,8 +706,15 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <paramref name="issuerCertificate"/> has a different key algorithm than the requested certificate.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   <paramref name="issuerCertificate"/> is an RSA certificate and this object was created via a constructor
-        ///   which does not accept a <see cref="RSASignaturePadding"/> value.
+        ///   <para>
+        ///     <paramref name="issuerCertificate"/> is an RSA certificate and this object was created via a constructor
+        ///     which does not accept a <see cref="RSASignaturePadding"/> value.
+        ///   </para>
+        ///   <para>- or -</para>
+        ///   <para>
+        ///     <paramref name="issuerCertificate"/> uses a public key algorithm which requires a non-default value
+        ///     for <see cref="HashAlgorithm"/>, but this object was created without one being provided.
+        ///   </para>
         /// </exception>
         public X509Certificate2 Create(
             X509Certificate2 issuerCertificate,
@@ -759,6 +853,10 @@ namespace System.Security.Cryptography.X509Certificates
         /// </exception>
         /// <exception cref="ArgumentException"><paramref name="serialNumber"/> is null or has length 0.</exception>
         /// <exception cref="CryptographicException">Any error occurs during the signing operation.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The signature generator requires a non-default value for <see cref="HashAlgorithm"/>,
+        ///   but this object was created without one being provided.
+        /// </exception>
         public X509Certificate2 Create(
             X500DistinguishedName issuerName,
             X509SignatureGenerator generator,
@@ -800,6 +898,10 @@ namespace System.Security.Cryptography.X509Certificates
         /// </exception>
         /// <exception cref="ArgumentException"><paramref name="serialNumber"/> has length 0.</exception>
         /// <exception cref="CryptographicException">Any error occurs during the signing operation.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The signature generator requires a non-default value for <see cref="HashAlgorithm"/>,
+        ///   but this object was created without one being provided.
+        /// </exception>
         public X509Certificate2 Create(
             X500DistinguishedName issuerName,
             X509SignatureGenerator generator,
@@ -814,6 +916,12 @@ namespace System.Security.Cryptography.X509Certificates
                 throw new ArgumentException(SR.Cryptography_CertReq_DatesReversed);
             if (serialNumber.Length < 1)
                 throw new ArgumentException(SR.Arg_EmptyOrNullArray, nameof(serialNumber));
+
+            if (string.IsNullOrEmpty(HashAlgorithm.Name) &&
+                CertificateRevocationListBuilder.HashAlgorithmRequired(generator.PublicKey.Oid.Value))
+            {
+                throw new InvalidOperationException(SR.Cryptography_CertReq_NoHashAlgorithmProvided);
+            }
 
             byte[] signatureAlgorithm = generator.GetSignatureAlgorithmIdentifier(HashAlgorithm);
             AlgorithmIdentifierAsn signatureAlgorithmAsn;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ICertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ICertificatePal.cs
@@ -31,12 +31,14 @@ namespace System.Security.Cryptography.X509Certificates
         DSA? GetDSAPrivateKey();
         ECDsa? GetECDsaPrivateKey();
         ECDiffieHellman? GetECDiffieHellmanPrivateKey();
+        MLDsa? GetMLDsaPrivateKey();
         string GetNameInfo(X509NameType nameType, bool forIssuer);
         void AppendPrivateKeyInfo(StringBuilder sb);
         ICertificatePal CopyWithPrivateKey(DSA privateKey);
         ICertificatePal CopyWithPrivateKey(ECDsa privateKey);
         ICertificatePal CopyWithPrivateKey(RSA privateKey);
         ICertificatePal CopyWithPrivateKey(ECDiffieHellman privateKey);
+        ICertificatePal CopyWithPrivateKey(MLDsa privateKey);
         PolicyData GetPolicyData();
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/MLDsaX509SignatureGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/MLDsaX509SignatureGenerator.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Formats.Asn1;
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    internal sealed class MLDsaX509SignatureGenerator : X509SignatureGenerator
+    {
+        private readonly MLDsa _key;
+
+        internal MLDsaX509SignatureGenerator(MLDsa key)
+        {
+            Debug.Assert(key != null);
+
+            _key = key;
+        }
+
+        public override byte[] GetSignatureAlgorithmIdentifier(HashAlgorithmName hashAlgorithm)
+        {
+            // Ignore the hashAlgorithm parameter.
+            // This generator only supports ML-DSA "Pure" signatures, but the overall design of
+            // CertificateRequest makes it easy for a hashAlgorithm value to get here.
+
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(_key.Algorithm.Oid);
+            writer.PopSequence();
+            return writer.Encode();
+        }
+
+        public override byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+
+            // Ignore the hashAlgorithm parameter.
+            // This generator only supports ML-DSA "Pure" signatures, but the overall design of
+            // CertificateRequest makes it easy for a hashAlgorithm value to get here.
+
+            byte[] signature = new byte[_key.Algorithm.SignatureSizeInBytes];
+            int written = _key.SignData(data, signature);
+            Debug.Assert(written == signature.Length);
+            return signature;
+        }
+
+        protected override PublicKey BuildPublicKey()
+        {
+            Oid oid = new Oid(_key.Algorithm.Oid, null);
+            byte[] pkBytes = new byte[_key.Algorithm.PublicKeySizeInBytes];
+            int written = _key.ExportMLDsaPublicKey(pkBytes);
+            Debug.Assert(written == pkBytes.Length);
+
+            return new PublicKey(
+                oid,
+                null,
+                new AsnEncodedData(oid, pkBytes, skipCopy: true));
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -314,6 +314,16 @@ namespace System.Security.Cryptography.X509Certificates
             return MLKem.ImportSubjectPublicKeyInfo(ExportSubjectPublicKeyInfo());
         }
 
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        [UnsupportedOSPlatform("browser")]
+        public MLDsa? GetMLDsaPublicKey()
+        {
+            if (MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(_oid.Value) is null)
+                return null;
+
+            return MLDsa.ImportSubjectPublicKeyInfo(ExportSubjectPublicKeyInfo());
+        }
+
         internal AsnWriter EncodeSubjectPublicKeyInfo()
         {
             SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Formats.Asn1;
 using System.IO;
 using System.Net;
@@ -769,6 +770,116 @@ namespace System.Security.Cryptography.X509Certificates
                 }
 
                 if (!Helpers.AreSamePublicECParameters(publicKey.ExportParameters(false), privateKey.ExportParameters(false)))
+                {
+                    throw new ArgumentException(SR.Cryptography_PrivateKey_DoesNotMatch, nameof(privateKey));
+                }
+            }
+
+            ICertificatePal pal = Pal.CopyWithPrivateKey(privateKey);
+            return new X509Certificate2(pal);
+        }
+
+        /// <summary>
+        ///   Get the <see cref="MLDsa"/> public key from this certificate.
+        /// </summary>
+        /// <returns>
+        ///   The public key, or <see langword="null"/> if this certificate does not have an ML-DSA public key.
+        /// </returns>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The certificate has an ML-DSA public key, but the platform does not support ML-DSA.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   The public key was invalid, or otherwise could not be imported.
+        /// </exception>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        public MLDsa? GetMLDsaPublicKey()
+        {
+            MLDsaAlgorithm? algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(GetKeyAlgorithm());
+
+            if (algorithm is null)
+            {
+                return null;
+            }
+
+            byte[] publicKey = Pal.PublicKeyValue;
+
+            if (publicKey.Length != algorithm.PublicKeySizeInBytes)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            return MLDsa.ImportMLDsaPublicKey(algorithm, Pal.PublicKeyValue);
+        }
+
+        /// <summary>
+        ///   Get the <see cref="MLDsa"/> private key from this certificate.
+        /// </summary>
+        /// <returns>
+        ///   The private key, or <see langword="null"/> if this certificate does not have an ML-DSA private key.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred accessing the private key.
+        /// </exception>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        public MLDsa? GetMLDsaPrivateKey()
+        {
+            MLDsaAlgorithm? algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(GetKeyAlgorithm());
+
+            if (algorithm is null)
+            {
+                return null;
+            }
+
+            return Pal.GetMLDsaPrivateKey();
+        }
+
+        /// <summary>
+        ///   Combines a private key with a certificate containing the associated public key into a
+        ///   new instance that can access the private key.
+        /// </summary>
+        /// <param name="privateKey">
+        ///   The ML-DSA private key that corresponds to the ML-DSA public key in this certificate.
+        /// </param>
+        /// <returns>
+        ///   A new certificate with the <see cref="HasPrivateKey" /> property set to <see langword="true"/>.
+        ///   The current certificate isn't modified.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="privateKey"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   The specified private key doesn't match the public key for this certificate.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The certificate already has an associated private key.
+        /// </exception>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        public X509Certificate2 CopyWithPrivateKey(MLDsa privateKey)
+        {
+            ArgumentNullException.ThrowIfNull(privateKey);
+
+            if (HasPrivateKey)
+                throw new InvalidOperationException(SR.Cryptography_Cert_AlreadyHasPrivateKey);
+
+            using (MLDsa? publicKey = GetMLDsaPublicKey())
+            {
+                if (publicKey is null)
+                {
+                    throw new ArgumentException(SR.Cryptography_PrivateKey_WrongAlgorithm);
+                }
+
+                if (publicKey.Algorithm != privateKey.Algorithm)
+                {
+                    throw new ArgumentException(SR.Cryptography_PrivateKey_DoesNotMatch, nameof(privateKey));
+                }
+
+                byte[] pk1 = new byte[publicKey.Algorithm.PublicKeySizeInBytes];
+                byte[] pk2 = new byte[pk1.Length];
+
+                int w1 = publicKey.ExportMLDsaPublicKey(pk1);
+                int w2 = privateKey.ExportMLDsaPublicKey(pk2);
+
+                if (w1 != w2 || !pk1.AsSpan().SequenceEqual(pk2))
                 {
                     throw new ArgumentException(SR.Cryptography_PrivateKey_DoesNotMatch, nameof(privateKey));
                 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SignatureGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SignatureGenerator.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Security.Cryptography.X509Certificates
 {
     public abstract class X509SignatureGenerator
@@ -31,6 +33,14 @@ namespace System.Security.Cryptography.X509Certificates
                 return new RSAPssX509SignatureGenerator(key, signaturePadding);
 
             throw new ArgumentException(SR.Cryptography_InvalidPaddingMode);
+        }
+
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        public static X509SignatureGenerator CreateForMLDsa(MLDsa key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return new MLDsaX509SignatureGenerator(key);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -284,6 +284,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaTestImplementation.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaTestImplementation.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs"

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestApiTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestApiTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Tests;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreation
@@ -147,6 +148,50 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        public static void CtorValidation_MLDSA_string()
+        {
+            string subjectName = null;
+            MLDsa key = null;
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "subjectName",
+                () => new CertificateRequest(subjectName, key));
+
+            subjectName = "";
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "key",
+                () => new CertificateRequest(subjectName, key));
+        }
+
+        [Fact]
+        public static void CtorValidation_MLDSA_X500DN()
+        {
+            X500DistinguishedName subjectName = null;
+            MLDsa key = null;
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "subjectName",
+                () => new CertificateRequest(subjectName, key));
+
+            subjectName = new X500DistinguishedName("");
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "key",
+                () => new CertificateRequest(subjectName, key));
+        }
+
+        [Fact]
+        public static void MLDSA_DoesNotSetHashAlgorithm()
+        {
+            using (MLDsa key = MLDsaTestImplementation.CreateNoOp(MLDsaAlgorithm.MLDsa65))
+            {
+                CertificateRequest req = new CertificateRequest("CN=Test", key);
+                Assert.Null(req.HashAlgorithm.Name);
+            }
+        }
+
+        [Fact]
         public static void CtorValidation_RSA_string()
         {
             string subjectName = null;
@@ -233,14 +278,36 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 X509SignatureGenerator generator = X509SignatureGenerator.CreateForECDsa(ecdsa);
                 publicKey = generator.PublicKey;
             }
+        }
 
-            AssertExtensions.Throws<ArgumentNullException>(
-                "hashAlgorithm",
-                () => new CertificateRequest(subjectName, publicKey, default(HashAlgorithmName)));
+        [Fact]
+        public static void PublicKeyCtor_HashAlgorithm_LateVerification()
+        {
+            X500DistinguishedName name = new X500DistinguishedName("CN=Test");
 
-            AssertExtensions.Throws<ArgumentException>(
-                "hashAlgorithm",
-                () => new CertificateRequest(subjectName, publicKey, new HashAlgorithmName("")));
+            using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp384r1Data.KeyParameters))
+            {
+                X509SignatureGenerator gen = X509SignatureGenerator.CreateForECDsa(ecdsa);
+
+                CertificateRequest req = new CertificateRequest(name, gen.PublicKey, default);
+                Assert.Null(req.HashAlgorithm.Name);
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                Assert.Throws<InvalidOperationException>(
+                    () => req.Create(name, gen, now.AddMinutes(-1), now.AddMinutes(1), new byte[] { 1, 2, 3 }));
+            }
+
+            using (RSA rsa = RSA.Create(TestData.RsaBigExponentParams))
+            {
+                X509SignatureGenerator gen = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+
+                CertificateRequest req = new CertificateRequest(name, gen.PublicKey, default);
+                Assert.Null(req.HashAlgorithm.Name);
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                Assert.Throws<InvalidOperationException>(
+                    () => req.Create(name, gen, now.AddMinutes(-1), now.AddMinutes(1), new byte[] { 1, 2, 3 }));
+            }
         }
 
         [Fact]
@@ -414,70 +481,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             Assert.Throws<ArgumentNullException>(
                 "pkcs10Pem",
                 () => CertificateRequest.LoadSigningRequestPem((string)null, HashAlgorithmName.SHA256));
-        }
-
-        [Fact]
-        public static void LoadWithDefaultHashAlgorithm()
-        {
-            Assert.Throws<ArgumentNullException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequest(Array.Empty<byte>(), default(HashAlgorithmName)));
-
-            {
-                int consumed = -1;
-
-                Assert.Throws<ArgumentNullException>(
-                    "signerHashAlgorithm",
-                    () => CertificateRequest.LoadSigningRequest(
-                        ReadOnlySpan<byte>.Empty,
-                        default(HashAlgorithmName),
-                        out consumed));
-
-                Assert.Equal(-1, consumed);
-            }
-
-            Assert.Throws<ArgumentNullException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequestPem(string.Empty, default(HashAlgorithmName)));
-
-            Assert.Throws<ArgumentNullException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequestPem(
-                    ReadOnlySpan<char>.Empty,
-                    default(HashAlgorithmName)));
-        }
-
-        [Fact]
-        public static void LoadWithEmptyHashAlgorithm()
-        {
-            HashAlgorithmName hashAlgorithm = new HashAlgorithmName("");
-
-            Assert.Throws<ArgumentException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequest(Array.Empty<byte>(), hashAlgorithm));
-
-            {
-                int consumed = -1;
-
-                Assert.Throws<ArgumentException>(
-                    "signerHashAlgorithm",
-                    () => CertificateRequest.LoadSigningRequest(
-                        ReadOnlySpan<byte>.Empty,
-                        hashAlgorithm,
-                        out consumed));
-
-                Assert.Equal(-1, consumed);
-            }
-
-            Assert.Throws<ArgumentException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequestPem(string.Empty, hashAlgorithm));
-
-            Assert.Throws<ArgumentException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequestPem(
-                    ReadOnlySpan<char>.Empty,
-                    hashAlgorithm));
         }
 
         [Theory]

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestChainTests.cs
@@ -342,17 +342,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
-        internal static X509Certificate2 CloneWithPrivateKey(X509Certificate2 cert, object key)
+        private static X509Certificate2 CloneWithPrivateKey(X509Certificate2 cert, object key)
         {
-            return key switch
-            {
-                RSA rsa => cert.CopyWithPrivateKey(rsa),
-                ECDsa ecdsa => cert.CopyWithPrivateKey(ecdsa),
-                MLDsa mldsa => cert.CopyWithPrivateKey(mldsa),
-                DSA dsa => cert.CopyWithPrivateKey(dsa),
-                _ => throw new InvalidOperationException(
-                    $"Had no handler for key of type {key?.GetType().FullName ?? "null"}")
-            };
+            return Common.CertificateAuthority.CloneWithPrivateKey(cert, key);
         }
 
         private static void CreateAndTestChain(

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestChainTests.cs
@@ -29,6 +29,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
+        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        public static void CreateChain_MLDSA()
+        {
+            using (MLDsa rootKey = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa87))
+            using (MLDsa intermed1Key = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa65))
+            using (MLDsa intermed2Key = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa65))
+            using (MLDsa leafKey = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa44))
+            {
+                byte[] pubKey = new byte[leafKey.Algorithm.PublicKeySizeInBytes];
+                leafKey.ExportMLDsaPublicKey(pubKey);
+
+                using (MLDsa leafPubKey = MLDsa.ImportMLDsaPublicKey(leafKey.Algorithm, pubKey))
+                {
+                    CreateAndTestChain(
+                        rootKey,
+                        intermed1Key,
+                        intermed2Key,
+                        leafPubKey);
+                }
+            }
+        }
+
         [Fact]
         public static void CreateChain_RSA()
         {
@@ -203,7 +225,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
 
         private static CertificateRequest OpenCertRequest(
             string dn,
-            AsymmetricAlgorithm key,
+            object key,
             HashAlgorithmName hashAlgorithm)
         {
             X500DistinguishedName x500dn = new X500DistinguishedName(dn);
@@ -211,30 +233,27 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 RSA rsa => new CertificateRequest(x500dn, rsa, hashAlgorithm, RSASignaturePadding.Pkcs1),
                 ECDsa ecdsa => new CertificateRequest(x500dn, ecdsa, hashAlgorithm),
                 ECDiffieHellman ecdh => new CertificateRequest(x500dn, new PublicKey(ecdh), hashAlgorithm),
+                MLDsa mldsa => new CertificateRequest(x500dn, mldsa),
                 _ => throw new InvalidOperationException(
                     $"Had no handler for key of type {key?.GetType().FullName ?? "null"}")
             };
         }
 
-        private static X509SignatureGenerator OpenGenerator(AsymmetricAlgorithm key)
+        private static X509SignatureGenerator OpenGenerator(object key)
         {
-            RSA rsa = key as RSA;
-
-            if (rsa != null)
-                return X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
-
-            ECDsa ecdsa = key as ECDsa;
-
-            if (ecdsa != null)
-                return X509SignatureGenerator.CreateForECDsa(ecdsa);
-
-            throw new InvalidOperationException(
-                $"Had no handler for key of type {key?.GetType().FullName ?? "null"}");
+            return key switch
+            {
+                RSA rsa => X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1),
+                ECDsa ecdsa => X509SignatureGenerator.CreateForECDsa(ecdsa),
+                MLDsa mldsa => X509SignatureGenerator.CreateForMLDsa(mldsa),
+                _ => throw new InvalidOperationException(
+                    $"Had no handler for key of type {key?.GetType().FullName ?? "null"}")
+            };
         }
 
         private static CertificateRequest CreateChainRequest(
             string dn,
-            AsymmetricAlgorithm key,
+            object key,
             HashAlgorithmName hashAlgorithm,
             bool isCa,
             int? pathLen)
@@ -323,32 +342,24 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
-        private static X509Certificate2 CloneWithPrivateKey(X509Certificate2 cert, AsymmetricAlgorithm key)
+        internal static X509Certificate2 CloneWithPrivateKey(X509Certificate2 cert, object key)
         {
-            RSA rsa = key as RSA;
-
-            if (rsa != null)
-                return cert.CopyWithPrivateKey(rsa);
-
-            ECDsa ecdsa = key as ECDsa;
-
-            if (ecdsa != null)
-                return cert.CopyWithPrivateKey(ecdsa);
-
-            DSA dsa = key as DSA;
-
-            if (dsa != null)
-                return cert.CopyWithPrivateKey(dsa);
-
-            throw new InvalidOperationException(
-                $"Had no handler for key of type {key?.GetType().FullName ?? "null"}");
+            return key switch
+            {
+                RSA rsa => cert.CopyWithPrivateKey(rsa),
+                ECDsa ecdsa => cert.CopyWithPrivateKey(ecdsa),
+                MLDsa mldsa => cert.CopyWithPrivateKey(mldsa),
+                DSA dsa => cert.CopyWithPrivateKey(dsa),
+                _ => throw new InvalidOperationException(
+                    $"Had no handler for key of type {key?.GetType().FullName ?? "null"}")
+            };
         }
 
         private static void CreateAndTestChain(
-            AsymmetricAlgorithm rootPrivKey,
-            AsymmetricAlgorithm intermed1PrivKey,
-            AsymmetricAlgorithm intermed2PrivKey,
-            AsymmetricAlgorithm leafPubKey)
+            object rootPrivKey,
+            object intermed1PrivKey,
+            object intermed2PrivKey,
+            object leafPubKey)
         {
             const string RootDN = "CN=Experimental Root Certificate";
             const string Intermed1DN = "CN=First Intermediate Certificate, O=Experimental";

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestLoadTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestLoadTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Formats.Asn1;
 using System.Net;
 using Test.Cryptography;
 using Xunit;
@@ -716,6 +717,181 @@ BgkqhkiG9w0BAQsFAAMBAA==
             attr = req.OtherRequestAttributes[1];
             Assert.Equal("1.2.840.113549.1.9.7", attr.Oid.Value);
             Assert.Equal("0C053132333435", attr.RawData.ByteArrayToHex());
+        }
+
+        [Fact]
+        public static void Load_NoHashAlgorithm_LateVerification()
+        {
+            CertificateRequest req = CertificateRequest.LoadSigningRequestPem(
+                TestData.BigExponentPkcs10Pem,
+                default,
+                CertificateRequestLoadOptions.SkipSignatureValidation);
+
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            DateTimeOffset notBefore = now.AddMonths(-1);
+            DateTimeOffset notAfter = now.AddMonths(1);
+
+            using (RSA key = RSA.Create(TestData.RsaBigExponentParams))
+            {
+                X509SignatureGenerator generator = X509SignatureGenerator.CreateForRSA(key, RSASignaturePadding.Pkcs1);
+
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                    () => req.Create(
+                        req.SubjectName,
+                        generator,
+                        notBefore,
+                        notAfter,
+                        new byte[] { 3, 1, 0, 1, 3, 3, 3 }));
+
+                Assert.Contains("HashAlgorithm", ex.Message);
+
+                ex = Assert.Throws<InvalidOperationException>(
+                    () => req.CreateSigningRequest(generator));
+
+                Assert.Contains("HashAlgorithm", ex.Message);
+
+                ex = Assert.Throws<InvalidOperationException>(
+                    () => req.CreateSigningRequestPem(generator));
+
+                Assert.Contains("HashAlgorithm", ex.Message);
+            }
+        }
+
+        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        public static void Load_NoHashAlgorithm_OKForMLDsa()
+        {
+            CertificateRequest req = CertificateRequest.LoadSigningRequestPem(
+                TestData.BigExponentPkcs10Pem,
+                default,
+                CertificateRequestLoadOptions.SkipSignatureValidation);
+
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            DateTimeOffset notBefore = now.AddMonths(-1);
+            DateTimeOffset notAfter = now.AddMonths(1);
+
+            using (MLDsa key = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa44))
+            {
+                // Assert.NoThrow
+                using X509Certificate2 cert = req.Create(
+                    req.SubjectName,
+                    X509SignatureGenerator.CreateForMLDsa(key),
+                    notBefore,
+                    notAfter,
+                    new byte[] { 3, 1, 0, 1, 3, 3, 3 });
+
+                Assert.Equal("2.16.840.1.101.3.4.3.17", cert.SignatureAlgorithm.Value);
+            }
+        }
+
+        [Fact]
+        public static void LoadCreate_MatchesCreate_RSAPkcs1()
+        {
+            using (RSA key = RSA.Create(2048))
+            {
+                LoadCreate_MatchesCreate(
+                    new CertificateRequest(
+                        "CN=Roundtrip, O=RSA, OU=PKCS1",
+                        key,
+                        HashAlgorithmName.SHA256,
+                        RSASignaturePadding.Pkcs1),
+                    X509SignatureGenerator.CreateForRSA(key, RSASignaturePadding.Pkcs1),
+                    deterministicSignature: true);
+            }
+        }
+
+        [Fact]
+        public static void LoadCreate_MatchesCreate_RSAPss()
+        {
+            using (RSA key = RSA.Create(2048))
+            {
+                LoadCreate_MatchesCreate(
+                    new CertificateRequest(
+                        "CN=Roundtrip, O=RSA, OU=PSS",
+                        key,
+                        HashAlgorithmName.SHA256,
+                        RSASignaturePadding.Pss),
+                    X509SignatureGenerator.CreateForRSA(key, RSASignaturePadding.Pss),
+                    deterministicSignature: false);
+            }
+        }
+
+        [Fact]
+        public static void LoadCreate_MatchesCreate_ECDsa()
+        {
+            using (ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP384))
+            {
+                LoadCreate_MatchesCreate(
+                    new CertificateRequest(
+                        "CN=Roundtrip, O=EC-DSA",
+                        key,
+                        HashAlgorithmName.SHA256),
+                    X509SignatureGenerator.CreateForECDsa(key),
+                    deterministicSignature: false);
+            }
+        }
+
+        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        public static void LoadCreate_MatchesCreate_MLDsa()
+        {
+            using (MLDsa key = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa65))
+            {
+                LoadCreate_MatchesCreate(
+                    new CertificateRequest("CN=Roundtrip, O=ML-DSA", key),
+                    X509SignatureGenerator.CreateForMLDsa(key),
+                    deterministicSignature: false);
+            }
+        }
+
+        private static void LoadCreate_MatchesCreate(
+            CertificateRequest request,
+            X509SignatureGenerator generator,
+            bool deterministicSignature)
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            DateTimeOffset notBefore = now.AddMonths(-1);
+            DateTimeOffset notAfter = now.AddMonths(1);
+            byte[] serial = new byte[] { 0x02, 0x04, 0x06, 0x08, 0x07, 0x05, 0x03, 0x01 };
+
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+            request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(new OidCollection { new Oid("0.0.1", null) }, false));
+
+            byte[] pkcs10 = request.CreateSigningRequest(generator);
+            CertificateRequest loaded = CertificateRequest.LoadSigningRequest(
+                pkcs10,
+                HashAlgorithmName.SHA256,
+                CertificateRequestLoadOptions.UnsafeLoadCertificateExtensions);
+
+            using (X509Certificate2 one = request.Create(request.SubjectName, generator, notBefore, notAfter, serial))
+            using (X509Certificate2 two = loaded.Create(request.SubjectName, generator, notBefore, notAfter, serial))
+            {
+                if (deterministicSignature)
+                {
+                    AssertExtensions.SequenceEqual(one.RawDataMemory.Span, two.RawDataMemory.Span);
+                }
+                else
+                {
+                    // tbsCertificate and signatureAlgorithm should match, signature should not.
+                    //
+                    // Certificate  ::=  SEQUENCE  {
+                    //      tbsCertificate       TBSCertificate,
+                    //      signatureAlgorithm   AlgorithmIdentifier,
+                    //      signature            BIT STRING  }
+
+                    AsnValueReader readerOne = new AsnValueReader(one.RawDataMemory.Span, AsnEncodingRules.DER);
+                    AsnValueReader readerTwo = new AsnValueReader(two.RawDataMemory.Span, AsnEncodingRules.DER);
+
+                    AsnValueReader certOne = readerOne.ReadSequence();
+                    AsnValueReader certTwo = readerTwo.ReadSequence();
+                    readerOne.ThrowIfNotEmpty();
+                    readerTwo.ThrowIfNotEmpty();
+
+                    AssertExtensions.SequenceEqual(certOne.ReadEncodedValue(), certTwo.ReadEncodedValue());
+                    AssertExtensions.SequenceEqual(certOne.ReadEncodedValue(), certTwo.ReadEncodedValue());
+                    AssertExtensions.SequenceNotEqual(certOne.ReadEncodedValue(), certTwo.ReadEncodedValue());
+                    certOne.ThrowIfNotEmpty();
+                    certTwo.ThrowIfNotEmpty();
+                }
+            }
         }
 
         private static void VerifyBigExponentRequest(

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CrlBuilderTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CrlBuilderTests.cs
@@ -16,6 +16,35 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
     {
         private const string CertParam = "issuerCertificate";
 
+        public enum CertKind
+        {
+            ECDsa,
+            MLDsa,
+            RsaPkcs1,
+            RsaPss,
+        }
+
+        public static IEnumerable<object[]> SupportedCertKinds()
+        {
+            yield return new object[] { CertKind.ECDsa };
+
+            if (MLDsa.IsSupported)
+            {
+                yield return new object[] { CertKind.MLDsa };
+            }
+
+            yield return new object[] { CertKind.RsaPkcs1 };
+            yield return new object[] { CertKind.RsaPss };
+        }
+
+        public static IEnumerable<object[]> NoHashAlgorithmCertKinds()
+        {
+            if (MLDsa.IsSupported)
+            {
+                yield return new object[] { CertKind.MLDsa };
+            }
+        }
+
         [Fact]
         public static void AddEntryArgumentValidation()
         {
@@ -153,63 +182,136 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 });
         }
 
-        [Fact]
-        public static void BuildWithNoHashAlgorithm()
+        [Theory]
+        [MemberData(nameof(SupportedCertKinds))]
+        public static void BuildWithNoHashAlgorithm(CertKind certKind)
         {
             BuildCertificateAndRun(
+                certKind,
                 new X509Extension[]
                 {
                     X509BasicConstraintsExtension.CreateForCertificateAuthority(),
                 },
-                static (cert, now) =>
+                static (certKind, cert, now) =>
                 {
                     HashAlgorithmName hashAlg = default;
                     CertificateRevocationListBuilder builder = new CertificateRevocationListBuilder();
 
-                    Assert.Throws<ArgumentNullException>(
-                        "hashAlgorithm",
-                        () => builder.Build(cert, 0, now.AddMinutes(5), hashAlg, null, now));
+                    Action certBuild = () => builder.Build(cert, 0, now.AddMinutes(5), hashAlg, null, now);
 
-                    using (ECDsa key = cert.GetECDsaPrivateKey())
+                    if (RequiresHashAlgorithm(certKind))
                     {
-                        X509SignatureGenerator gen = X509SignatureGenerator.CreateForECDsa(key);
-                        X500DistinguishedName dn = cert.SubjectName;
+                        Assert.Throws<ArgumentNullException>("hashAlgorithm", certBuild);
+                    }
+                    else
+                    {
+                        // Assert.NoThrow
+                        certBuild();
+                    }
 
-                        Assert.Throws<ArgumentNullException>(
-                            "hashAlgorithm",
-                            () => builder.Build(dn, gen, 0, now.AddMinutes(5), hashAlg, null, now));
+                    X509SignatureGenerator gen = GetSignatureGenerator(certKind, cert, out IDisposable key);
+
+                    using (key)
+                    {
+                        X500DistinguishedName dn = cert.SubjectName;
+                        X509AuthorityKeyIdentifierExtension akid =
+                            X509AuthorityKeyIdentifierExtension.CreateFromCertificate(cert, true, false);
+
+                        Action genBuild = () => builder.Build(dn, gen, 0, now.AddMinutes(5), hashAlg, akid, now);
+
+                        if (RequiresHashAlgorithm(certKind))
+                        {
+                            Assert.Throws<ArgumentNullException>("hashAlgorithm", genBuild);
+                        }
+                        else
+                        {
+                            // Assert.NoThrow
+                            genBuild();
+                        }
                     }
                 });
         }
 
-        [Fact]
-        public static void BuildWithEmptyHashAlgorithm()
+        [Theory]
+        [MemberData(nameof(SupportedCertKinds))]
+        public static void BuildWithEmptyHashAlgorithm(CertKind certKind)
         {
             BuildCertificateAndRun(
+                certKind,
                 new X509Extension[]
                 {
                     X509BasicConstraintsExtension.CreateForCertificateAuthority(),
                 },
-                static (cert, now) =>
+                static (certKind, cert, now) =>
                 {
                     HashAlgorithmName hashAlg = new HashAlgorithmName("");
                     CertificateRevocationListBuilder builder = new CertificateRevocationListBuilder();
-                    ArgumentException e = Assert.Throws<ArgumentException>(
-                        "hashAlgorithm",
-                        () => builder.Build(cert, 0, now.AddMinutes(5), hashAlg, null, now));
 
-                    Assert.Contains("empty", e.Message);
+                    Action certAction = () => builder.Build(cert, 0, now.AddMinutes(5), hashAlg, null, now);
 
-                    using (ECDsa key = cert.GetECDsaPrivateKey())
+                    if (RequiresHashAlgorithm(certKind))
                     {
-                        X509SignatureGenerator gen = X509SignatureGenerator.CreateForECDsa(key);
-                        X500DistinguishedName dn = cert.SubjectName;
-
-                        e = Assert.Throws<ArgumentException>(
-                            "hashAlgorithm",
-                            () => builder.Build(dn, gen, 0, now.AddMinutes(5), hashAlg, null, now));
+                        ArgumentException e = Assert.Throws<ArgumentException>("hashAlgorithm", certAction);
 
                         Assert.Contains("empty", e.Message);
+                    }
+                    else
+                    {
+                        // Assert.NoThrow
+                        certAction();
+                    }
+
+                    X509SignatureGenerator gen = GetSignatureGenerator(certKind, cert, out IDisposable key);
+
+                    using (key)
+                    {
+                        X500DistinguishedName dn = cert.SubjectName;
+                        X509AuthorityKeyIdentifierExtension akid =
+                            X509AuthorityKeyIdentifierExtension.CreateFromCertificate(cert, true, false);
+
+                        Action genAction = () => builder.Build(dn, gen, 0, now.AddMinutes(5), hashAlg, akid, now);
+
+                        if (RequiresHashAlgorithm(certKind))
+                        {
+                            Assert.Throws<ArgumentException>("hashAlgorithm", genAction);
+                        }
+                        else
+                        {
+                            // Assert.NoThrow
+                            genAction();
+                        }
+                    }
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(NoHashAlgorithmCertKinds))]
+        public static void BuildPqcWithHashAlgorithm(CertKind certKind)
+        {
+            BuildCertificateAndRun(
+                certKind,
+                new X509Extension[]
+                {
+                    X509BasicConstraintsExtension.CreateForCertificateAuthority(),
+                },
+                static (certKind, cert, now) =>
+                {
+                    HashAlgorithmName hashAlg = new HashAlgorithmName("");
+                    CertificateRevocationListBuilder builder = new CertificateRevocationListBuilder();
+
+                    // Assert.NoThrow
+                    builder.Build(cert, 0, now.AddMinutes(5), HashAlgorithmName.SHA256);
+
+                    X509SignatureGenerator gen = GetSignatureGenerator(certKind, cert, out IDisposable key);
+
+                    using (key)
+                    {
+                        X500DistinguishedName dn = cert.SubjectName;
+                        X509AuthorityKeyIdentifierExtension akid =
+                            X509AuthorityKeyIdentifierExtension.CreateFromCertificate(cert, true, false);
+
+                        // Assert.NoThrow
+                        builder.Build(dn, gen, 0, now.AddMinutes(5), HashAlgorithmName.SHA256, akid);
                     }
                 });
         }
@@ -349,7 +451,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
-        public static void BuildEmpty()
+        public static void BuildEmptyRsaPkcs1()
         {
             BuildRsaCertificateAndRun(
                 new X509Extension[]
@@ -371,7 +473,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     // In fact, because RSASSA-PKCS1 is a deterministic algorithm, we can check it for a fixed output.
 
                     AssertExtensions.SequenceEqual(BuildEmptyExpectedCrl, built);
-                });
+                },
+                callerName: "BuildEmpty");
         }
 
         [Theory]
@@ -421,20 +524,24 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 });
         }
 
-        [Fact]
-        public static void BuildEmptyEcdsa()
+        [Theory]
+        [MemberData(nameof(SupportedCertKinds))]
+        public static void BuildEmpty(CertKind certKind)
         {
             BuildCertificateAndRun(
+                certKind,
                 new X509Extension[]
                 {
                     X509BasicConstraintsExtension.CreateForCertificateAuthority(),
                 },
-                (cert, now) =>
+                (certKind, cert, now) =>
                 {
                     CertificateRevocationListBuilder builder = new CertificateRevocationListBuilder();
 
                     DateTimeOffset nextUpdate = now.AddHours(1);
-                    byte[] crl = builder.Build(cert, 2, nextUpdate, HashAlgorithmName.SHA256);
+                    HashAlgorithmName hashAlg = RequiresHashAlgorithm(certKind) ? HashAlgorithmName.SHA256 : default;
+
+                    byte[] crl = builder.Build(cert, 2, nextUpdate, hashAlg, GetRsaPadding(certKind));
 
                     AsnReader reader = new AsnReader(crl, AsnEncodingRules.DER);
                     reader = reader.ReadSequence();
@@ -444,16 +551,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     byte[] signature = reader.ReadBitString(out _);
                     reader.ThrowIfNotEmpty();
 
-                    using (ECDsa pubKey = cert.GetECDsaPublicKey())
-                    {
-                        Assert.True(
-                            pubKey.VerifyData(
-                                tbs.Span,
-                                signature,
-                                HashAlgorithmName.SHA256,
-                                DSASignatureFormat.Rfc3279DerSequence),
-                            "Certificate public key verifies CRL");
-                    }
+                    VerifySignature(certKind, cert, tbs.Span, signature, hashAlg);
 
                     VerifyCrlFields(
                         crl,
@@ -465,26 +563,30 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 });
         }
 
-        [Fact]
-        public static void BuildEmptyEcdsa_NoSubjectKeyIdentifier()
+        [Theory]
+        [MemberData(nameof(SupportedCertKinds))]
+        public static void BuildEmpty_NoSubjectKeyIdentifier(CertKind certKind)
         {
             BuildCertificateAndRun(
+                certKind,
                 new X509Extension[]
                 {
                     X509BasicConstraintsExtension.CreateForCertificateAuthority(),
                 },
-                (cert, now) =>
+                (certKind, cert, now) =>
                 {
                     CertificateRevocationListBuilder builder = new CertificateRevocationListBuilder();
                     DateTimeOffset nextUpdate = now.AddHours(1);
                     DateTimeOffset thisUpdate = now;
+                    HashAlgorithmName hashAlg = RequiresHashAlgorithm(certKind) ? HashAlgorithmName.SHA256 : default;
 
                     byte[] crl = builder.Build(
                         cert,
                         2,
                         nextUpdate,
-                        HashAlgorithmName.SHA256,
-                        thisUpdate: thisUpdate);
+                        hashAlg,
+                        GetRsaPadding(certKind),
+                        thisUpdate);
 
                     AsnReader reader = new AsnReader(crl, AsnEncodingRules.DER);
                     reader = reader.ReadSequence();
@@ -494,16 +596,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     byte[] signature = reader.ReadBitString(out _);
                     reader.ThrowIfNotEmpty();
 
-                    using (ECDsa pubKey = cert.GetECDsaPublicKey())
-                    {
-                        Assert.True(
-                            pubKey.VerifyData(
-                                tbs.Span,
-                                signature,
-                                HashAlgorithmName.SHA256,
-                                DSASignatureFormat.Rfc3279DerSequence),
-                            "Certificate public key verifies CRL");
-                    }
+                    VerifySignature(certKind, cert, tbs.Span, signature, hashAlg);
 
                     VerifyCrlFields(
                         crl,
@@ -1430,17 +1523,40 @@ PMzkCtzeqlHvuzIHHNcS1aNvlb94Tg8tPR5u/deYDrNg4NkbsqpG/QUMWse4T1Q7
         }
 
         private static void BuildCertificateAndRun(
+            CertKind certKind,
             IEnumerable<X509Extension> extensions,
-            Action<X509Certificate2, DateTimeOffset> action,
+            Action<CertKind, X509Certificate2, DateTimeOffset> action,
             bool addSubjectKeyIdentifier = true,
             [CallerMemberName] string callerName = null)
         {
-            using (ECDsa key = ECDsa.Create())
+            string subjectName = $"CN=\"{callerName}\"";
+            CertificateRequest req;
+            IDisposable key = null;
+
+            try
             {
-                CertificateRequest req = new CertificateRequest(
-                    $"CN=\"{callerName}\"",
-                    key,
-                    HashAlgorithmName.SHA384);
+                if (certKind == CertKind.ECDsa)
+                {
+                    ECDsa ecdsa = ECDsa.Create();
+                    key = ecdsa;
+                    req = new CertificateRequest(subjectName, ecdsa, HashAlgorithmName.SHA384);
+                }
+                else if (certKind == CertKind.RsaPkcs1 || certKind == CertKind.RsaPss)
+                {
+                    RSA rsa = RSA.Create(TestData.RsaBigExponentParams);
+                    key = rsa;
+                    req = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA384, GetRsaPadding(certKind));
+                }
+                else if (certKind == CertKind.MLDsa)
+                {
+                    MLDsa mldsa = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa44);
+                    key = mldsa;
+                    req = new CertificateRequest(subjectName, mldsa);
+                }
+                else
+                {
+                    throw new NotSupportedException($"Unsupported CertKind: {certKind}");
+                }
 
                 if (addSubjectKeyIdentifier)
                 {
@@ -1456,9 +1572,27 @@ PMzkCtzeqlHvuzIHHNcS1aNvlb94Tg8tPR5u/deYDrNg4NkbsqpG/QUMWse4T1Q7
 
                 using (X509Certificate2 cert = req.CreateSelfSigned(now.AddMonths(-1), now.AddMonths(1)))
                 {
-                    action(cert, now);
+                    action(certKind, cert, now);
                 }
             }
+            finally
+            {
+                key?.Dispose();
+            }
+        }
+
+        private static void BuildCertificateAndRun(
+            IEnumerable<X509Extension> extensions,
+            Action<X509Certificate2, DateTimeOffset> action,
+            bool addSubjectKeyIdentifier = true,
+            [CallerMemberName] string callerName = null)
+        {
+            BuildCertificateAndRun(
+                CertKind.ECDsa,
+                extensions,
+                (certKind, cert, now) => action(cert, now),
+                addSubjectKeyIdentifier,
+                callerName);
         }
 
         private static void BuildRsaCertificateAndRun(
@@ -1467,31 +1601,12 @@ PMzkCtzeqlHvuzIHHNcS1aNvlb94Tg8tPR5u/deYDrNg4NkbsqpG/QUMWse4T1Q7
             bool addSubjectKeyIdentifier = true,
             [CallerMemberName] string callerName = null)
         {
-            using (RSA key = RSA.Create(TestData.RsaBigExponentParams))
-            {
-                CertificateRequest req = new CertificateRequest(
-                    $"CN=\"{callerName}\"",
-                    key,
-                    HashAlgorithmName.SHA384,
-                    RSASignaturePadding.Pkcs1);
-
-                if (addSubjectKeyIdentifier)
-                {
-                    req.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(req.PublicKey, false));
-                }
-
-                foreach (X509Extension ext in extensions)
-                {
-                    req.CertificateExtensions.Add(ext);
-                }
-
-                DateTimeOffset now = DateTimeOffset.UtcNow;
-
-                using (X509Certificate2 cert = req.CreateSelfSigned(now.AddMonths(-1), now.AddMonths(1)))
-                {
-                    action(cert, now);
-                }
-            }
+            BuildCertificateAndRun(
+                CertKind.RsaPkcs1,
+                extensions,
+                (certKind, cert, now) => action(cert, now),
+                addSubjectKeyIdentifier,
+                callerName);
         }
 
         private static void VerifyCrlFields(
@@ -1577,6 +1692,90 @@ PMzkCtzeqlHvuzIHHNcS1aNvlb94Tg8tPR5u/deYDrNg4NkbsqpG/QUMWse4T1Q7
             }
 
             return reader.ReadGeneralizedTime();
+        }
+
+        private static X509SignatureGenerator GetSignatureGenerator(
+            CertKind certKind,
+            X509Certificate2 cert,
+            out IDisposable key)
+        {
+            if (certKind == CertKind.RsaPkcs1 || certKind == CertKind.RsaPss)
+            {
+                RSA rsa = cert.GetRSAPrivateKey();
+                key = rsa;
+                return X509SignatureGenerator.CreateForRSA(rsa, GetRsaPadding(certKind));
+            }
+            else if (certKind == CertKind.ECDsa)
+            {
+                ECDsa ecdsa = cert.GetECDsaPrivateKey();
+                key = ecdsa;
+                return X509SignatureGenerator.CreateForECDsa(ecdsa);
+            }
+            else if (certKind == CertKind.MLDsa)
+            {
+                MLDsa mldsa = cert.GetMLDsaPrivateKey();
+                key = mldsa;
+                return X509SignatureGenerator.CreateForMLDsa(mldsa);
+            }
+            else
+            {
+                throw new NotSupportedException($"Unsupported CertKind: {certKind}");
+            }
+        }
+
+        private static void VerifySignature(
+            CertKind certKind,
+            X509Certificate2 cert,
+            ReadOnlySpan<byte> data,
+            ReadOnlySpan<byte> signature,
+            HashAlgorithmName hashAlgorithm)
+        {
+            bool signatureValid;
+
+            if (certKind == CertKind.RsaPkcs1 || certKind == CertKind.RsaPss)
+            {
+                using RSA rsa = cert.GetRSAPublicKey();
+                signatureValid = rsa.VerifyData(data, signature, hashAlgorithm, GetRsaPadding(certKind));
+            }
+            else if (certKind == CertKind.ECDsa)
+            {
+                using ECDsa ecdsa = cert.GetECDsaPublicKey();
+                signatureValid = ecdsa.VerifyData(data, signature, hashAlgorithm, DSASignatureFormat.Rfc3279DerSequence);
+            }
+            else if (certKind == CertKind.MLDsa)
+            {
+                using MLDsa mldsa = cert.GetMLDsaPublicKey();
+                signatureValid = mldsa.VerifyData(data, signature);
+            }
+            else
+            {
+                throw new NotSupportedException($"Unsupported CertKind: {certKind}");
+            }
+
+            if (!signatureValid)
+            {
+                Assert.Fail($"{certKind} signature validation failed when it should have succeeded.");
+            }
+        }
+
+        private static bool RequiresHashAlgorithm(CertKind certKind)
+        {
+            return certKind switch
+            {
+                CertKind.ECDsa or CertKind.RsaPkcs1 or CertKind.RsaPss => true,
+                CertKind.MLDsa => false,
+                _ => throw new NotSupportedException(certKind.ToString())
+            };
+        }
+
+        private static RSASignaturePadding GetRsaPadding(CertKind certKind)
+        {
+            return certKind switch
+            {
+                CertKind.RsaPkcs1 => RSASignaturePadding.Pkcs1,
+                CertKind.RsaPss => RSASignaturePadding.Pss,
+                _ => null,
+            };
         }
 
         private static ReadOnlySpan<byte> BuildEmptyExpectedCrl => new byte[]

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using Test.Cryptography;
 using Xunit;
 
@@ -548,6 +549,277 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 }
 
                 Assert.True(ecdsaOther.VerifyData(data, signature, hashAlgorithm));
+            }
+        }
+
+        [Fact]
+        public static void CheckCopyWithPrivateKey_RSA()
+        {
+            using (X509Certificate2 withKey = X509CertificateLoader.LoadPkcs12(TestData.PfxData, TestData.PfxDataPassword))
+            using (X509Certificate2 pubOnly = X509CertificateLoader.LoadCertificate(withKey.RawDataMemory.Span))
+            using (RSA privKey = withKey.GetRSAPrivateKey())
+            using (X509Certificate2 wrongAlg = X509Certificate2.CreateFromPem(TestData.EcDhCertificate))
+            {
+                CheckCopyWithPrivateKey(
+                    pubOnly,
+                    wrongAlg,
+                    privKey,
+                    [
+                        () => RSA.Create(2048),
+                        () => RSA.Create(4096)
+                    ],
+                    RSACertificateExtensions.CopyWithPrivateKey,
+                    RSACertificateExtensions.GetRSAPublicKey,
+                    RSACertificateExtensions.GetRSAPrivateKey,
+                    (priv, pub) =>
+                    {
+                        byte[] data = new byte[RandomNumberGenerator.GetInt32(97)];
+                        RandomNumberGenerator.Fill(data);
+
+                        byte[] signature = priv.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                        Assert.True(pub.VerifyData(data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+                    });
+            }
+        }
+
+        [Fact]
+        public static void CheckCopyWithPrivateKey_DSA()
+        {
+            using (X509Certificate2 withKey = X509CertificateLoader.LoadPkcs12(TestData.Dsa1024Pfx, TestData.Dsa1024PfxPassword))
+            using (X509Certificate2 pubOnly = X509CertificateLoader.LoadCertificate(withKey.RawDataMemory.Span))
+            using (DSA privKey = withKey.GetDSAPrivateKey())
+            using (X509Certificate2 wrongAlg = X509Certificate2.CreateFromPem(TestData.EcDhCertificate))
+            {
+                CheckCopyWithPrivateKey(
+                    pubOnly,
+                    wrongAlg,
+                    privKey,
+                    [
+                        () =>
+                        {
+                            DSA dsa = DSA.Create();
+                            dsa.ImportParameters(TestData.GetDSA1024Params());
+                            return dsa;
+                        },
+                        () =>
+                        {
+                            DSA dsa = DSA.Create();
+
+                            if (Dsa.Tests.DSASignVerify.SupportsFips186_3)
+                            {
+                                dsa.ImportParameters(Dsa.Tests.DSATestData.GetDSA2048Params());
+                            }
+                            else
+                            {
+                                dsa.ImportParameters(TestData.GetDSA1024Params());
+                            }
+
+                            return dsa;
+                        }
+                    ],
+                    DSACertificateExtensions.CopyWithPrivateKey,
+                    DSACertificateExtensions.GetDSAPublicKey,
+                    DSACertificateExtensions.GetDSAPrivateKey,
+                    (priv, pub) =>
+                    {
+                        byte[] data = new byte[RandomNumberGenerator.GetInt32(97)];
+                        RandomNumberGenerator.Fill(data);
+
+                        byte[] signature = priv.SignData(data, HashAlgorithmName.SHA1);
+                        Assert.True(pub.VerifyData(data, signature, HashAlgorithmName.SHA1));
+                    });
+            }
+        }
+
+        [Fact]
+        public static void CheckCopyWithPrivateKey_ECDSA()
+        {
+            // A plain "ecPublicKey" cert can be either ECDSA or ECDH, but EcDhCertificate has a KeyUsage that
+            // says it is not suitable for being ECDSA.
+            // that stop them from being interchangeable, making them a much better test case than (e.g.) RSA
+            using (X509Certificate2 pubOnly = X509Certificate2.CreateFromPem(TestData.ECDsaCertificate))
+            using (ECDsa privKey = ECDsa.Create())
+            using (X509Certificate2 wrongAlg = X509Certificate2.CreateFromPem(TestData.EcDhCertificate))
+            {
+                privKey.ImportFromPem(TestData.ECDsaECPrivateKey);
+
+                CheckCopyWithPrivateKey(
+                    pubOnly,
+                    wrongAlg,
+                    privKey,
+                    [
+                        () => ECDsa.Create(ECCurve.NamedCurves.nistP256),
+                        () => ECDsa.Create(ECCurve.NamedCurves.nistP384),
+                        () => ECDsa.Create(ECCurve.NamedCurves.nistP521),
+                    ],
+                    ECDsaCertificateExtensions.CopyWithPrivateKey,
+                    ECDsaCertificateExtensions.GetECDsaPublicKey,
+                    ECDsaCertificateExtensions.GetECDsaPrivateKey,
+                    (priv, pub) =>
+                    {
+                        byte[] data = new byte[RandomNumberGenerator.GetInt32(97)];
+                        RandomNumberGenerator.Fill(data);
+
+                        byte[] signature = priv.SignData(data, HashAlgorithmName.SHA256);
+                        Assert.True(pub.VerifyData(data, signature, HashAlgorithmName.SHA256));
+                    });
+            }
+        }
+
+        [Fact]
+        public static void CheckCopyWithPrivateKey_ECDH()
+        {
+            // The ECDH methods don't reject certs that lack the KeyAgreement KU, so test EC-DH vs RSA.
+            using (X509Certificate2 pubOnly = X509Certificate2.CreateFromPem(TestData.EcDhCertificate))
+            using (ECDiffieHellman privKey = ECDiffieHellman.Create())
+            using (X509Certificate2 wrongAlg = X509CertificateLoader.LoadCertificate(TestData.CertWithEnhancedKeyUsage))
+            {
+                privKey.ImportFromPem(TestData.EcDhPkcs8Key);
+
+                CheckCopyWithPrivateKey(
+                    pubOnly,
+                    wrongAlg,
+                    privKey,
+                    [
+                        () => ECDiffieHellman.Create(ECCurve.NamedCurves.nistP256),
+                        () => ECDiffieHellman.Create(ECCurve.NamedCurves.nistP384),
+                        () => ECDiffieHellman.Create(ECCurve.NamedCurves.nistP521),
+                    ],
+                    (cert, ecdh) => cert.CopyWithPrivateKey(ecdh),
+                    cert => cert.GetECDiffieHellmanPublicKey(),
+                    cert => cert.GetECDiffieHellmanPrivateKey(),
+                    (priv, pub) =>
+                    {
+                        ECParameters ecParams = pub.ExportParameters(false);
+
+                        using (ECDiffieHellman other = ECDiffieHellman.Create(ecParams.Curve))
+                        using (ECDiffieHellmanPublicKey otherPub = other.PublicKey)
+                        using (ECDiffieHellmanPublicKey usPub = pub.PublicKey)
+                        {
+                            byte[] otherToUs = other.DeriveKeyFromHash(usPub, HashAlgorithmName.SHA256);
+                            byte[] usToOther = priv.DeriveKeyFromHash(otherPub, HashAlgorithmName.SHA256);
+
+                            AssertExtensions.SequenceEqual(otherToUs, usToOther);
+                        }
+                    });
+            }
+        }
+
+        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        public static void CheckCopyWithPrivateKey_MLDSA()
+        {
+            using (MLDsa privKey = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa65))
+            {
+                CertificateRequest req = new CertificateRequest($"CN={nameof(CheckCopyWithPrivateKey_MLDSA)}", privKey);
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                X509Certificate2 pubOnly = req.Create(
+                    req.SubjectName,
+                    X509SignatureGenerator.CreateForMLDsa(privKey),
+                    now.AddMinutes(-10),
+                    now.AddMinutes(10),
+                    new byte[] { 2, 4, 6, 8, 9, 7, 5, 3, 1 });
+
+                using (pubOnly)
+                using (X509Certificate2 wrongAlg = X509CertificateLoader.LoadCertificate(TestData.CertWithEnhancedKeyUsage))
+                {
+                    CheckCopyWithPrivateKey(
+                    pubOnly,
+                    wrongAlg,
+                    privKey,
+                    [
+                        () => MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa44),
+                        () => MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa65),
+                        () => MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa87),
+                    ],
+                    (cert, key) => cert.CopyWithPrivateKey(key),
+                    cert => cert.GetMLDsaPublicKey(),
+                    cert => cert.GetMLDsaPrivateKey(),
+                    (priv, pub) =>
+                    {
+                        byte[] data = new byte[RandomNumberGenerator.GetInt32(97)];
+                        RandomNumberGenerator.Fill(data);
+
+                        byte[] signature = new byte[pub.Algorithm.SignatureSizeInBytes];
+                        int written = priv.SignData(data, signature);
+                        Assert.Equal(signature.Length, written);
+                        Assert.True(pub.VerifyData(data, signature));
+                    });
+                }
+            }
+        }
+
+        private static void CheckCopyWithPrivateKey<TKey>(
+            X509Certificate2 cert,
+            X509Certificate2 wrongAlgorithmCert,
+            TKey correctPrivateKey,
+            IEnumerable<Func<TKey>> incorrectKeys,
+            Func<X509Certificate2, TKey, X509Certificate2> copyWithPrivateKey,
+            Func<X509Certificate2, TKey> getPublicKey,
+            Func<X509Certificate2, TKey> getPrivateKey,
+            Action<TKey, TKey> keyProver)
+            where TKey : class, IDisposable
+        {
+            Exception e = Assert.Throws<ArgumentException>(
+                null,
+                () => copyWithPrivateKey(wrongAlgorithmCert, correctPrivateKey));
+
+            Assert.Contains("algorithm", e.Message);
+
+            List<TKey> generatedKeys = new();
+
+            foreach (Func<TKey> func in incorrectKeys)
+            {
+                TKey incorrectKey = func();
+                generatedKeys.Add(incorrectKey);
+
+                e = Assert.Throws<ArgumentException>(
+                    "privateKey",
+                    () => copyWithPrivateKey(cert, incorrectKey));
+
+                Assert.Contains("does not match", e.Message);
+                Assert.DoesNotContain("algorithm", e.Message);
+            }
+
+            using (X509Certificate2 withKey = copyWithPrivateKey(cert, correctPrivateKey))
+            {
+                e = Assert.Throws<InvalidOperationException>(() => copyWithPrivateKey(withKey, correctPrivateKey));
+
+                Assert.Contains("already has", e.Message);
+
+                foreach (TKey incorrectKey in generatedKeys)
+                {
+                    e = Assert.Throws<InvalidOperationException>(() => copyWithPrivateKey(withKey, incorrectKey));
+
+                    Assert.Contains("already has", e.Message);
+                }
+
+                using (TKey pub = getPublicKey(withKey))
+                using (TKey pub2 = getPublicKey(withKey))
+                using (TKey pubOnly = getPublicKey(cert))
+                using (TKey priv = getPrivateKey(withKey))
+                using (TKey priv2 = getPrivateKey(withKey))
+                {
+                    Assert.NotSame(pub, pub2);
+                    Assert.NotSame(pub, pubOnly);
+                    Assert.NotSame(pub2, pubOnly);
+                    Assert.NotSame(priv, priv2);
+
+                    keyProver(priv, pub2);
+                    keyProver(priv2, pub);
+                    keyProver(priv, pubOnly);
+
+                    priv.Dispose();
+                    pub2.Dispose();
+
+                    keyProver(priv2, pub);
+                    keyProver(priv2, pubOnly);
+                }
+            }
+
+            foreach (TKey incorrectKey in generatedKeys)
+            {
+                incorrectKey.Dispose();
             }
         }
     }


### PR DESCRIPTION
A few things happen in this PR:

* CRL Builder Tests now run for every supported signing algorithm
* CopyWithPrivateKey was under-tested for all algorithms (particularly around the exception model), that has been rectified
* Our test CertificateAuthority class gained algorithm agility
  * On my system where MLDsa.IsSupported reports true, I changed the default key algorithm from RSASSA-2048+SHA-2-256 to ML-DSA-65, and everything passed.

Those pieces could be broken out into a pure test enhancement change for cleanliness.

The impetus of the change, however, was to add first-class support for ML-DSA to CertificateRequest.

* Add ctors to CertificateRequest
* Enlighten CertificateRequest that future signing algorithms might not require a HashAlgorithmName
* Add support to CertificateRequestListBuilder
* Add cert.GetMLDsaPublicKey/GetMLDsaPrivateKey/CopyWithPrivateKey to power the above.

Contributes to #113502