### PR TITLE
ML-KEM: PEM Exports (and missing overloads)

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -761,7 +761,7 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Exports the public-key portion of the current key in the X.509 SubjectPublicKeyInfo format.
+        ///   Exports the public-key portion of the current key in the X.509 SubjectPublicKeyInfo format.
         /// </summary>
         /// <returns>
         ///   A byte array containing the X.509 SubjectPublicKeyInfo representation of the public-key portion of this key.
@@ -779,8 +779,8 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Exports the public-key portion of the current key in a PEM-encoded representation of
-        ///  the X.509 SubjectPublicKeyInfo format.
+        ///   Exports the public-key portion of the current key in a PEM-encoded representation of
+        ///   the X.509 SubjectPublicKeyInfo format.
         /// </summary>
         /// <returns>
         ///   A string containing the PEM-encoded representation of the X.509 SubjectPublicKeyInfo
@@ -857,11 +857,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Exports the current key in a PEM-encoded representation of the PKCS#8 PrivateKeyInfo format.
+        ///   Exports the current key in a PEM-encoded representation of the PKCS#8 PrivateKeyInfo format.
         /// </summary>
         /// <returns>
-        ///   A string containing the PEM-encoded representation of the PKCS#8 PrivateKeyInfo
-        ///   representation of the public-key portion of this key.
+        ///   A string containing the PEM-encoded representation of the PKCS#8 PrivateKeyInfo.
         /// </returns>
         /// <exception cref="ObjectDisposedException">
         ///   This instance has been disposed.
@@ -898,8 +897,8 @@ namespace System.Security.Cryptography
         protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
 
         /// <summary>
-        ///  Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
-        ///  using a char-based password.
+        ///   Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
+        ///   using a char-based password.
         /// </summary>
         /// <param name="password">
         ///   The password to use when encrypting the key material.
@@ -951,8 +950,8 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
-        ///  using a char-based password.
+        ///   Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
+        ///   using a char-based password.
         /// </summary>
         /// <param name="password">
         ///   The password to use when encrypting the key material.
@@ -997,8 +996,8 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
-        ///  using a byte-based password.
+        ///   Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
+        ///   using a byte-based password.
         /// </summary>
         /// <param name="passwordBytes">
         ///   The password to use when encrypting the key material.
@@ -1050,7 +1049,7 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a byte-based password.
+        ///   Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a byte-based password.
         /// </summary>
         /// <param name="passwordBytes">
         ///   The password to use when encrypting the key material.
@@ -1090,7 +1089,7 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password.
+        ///   Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password.
         /// </summary>
         /// <param name="password">
         ///   The password to use when encrypting the key material.
@@ -1130,7 +1129,7 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password.
+        ///   Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password.
         /// </summary>
         /// <param name="password">
         ///   The password to use when encrypting the key material.
@@ -1163,8 +1162,8 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Exports the current key in a PEM-encoded representation of the PKCS#8 EncryptedPrivateKeyInfo
-        /// representation of this key, using a byte-based password.
+        ///   Exports the current key in a PEM-encoded representation of the PKCS#8 EncryptedPrivateKeyInfo
+        ///   representation of this key, using a byte-based password.
         /// </summary>
         /// <param name="passwordBytes">
         ///   The bytes to use as a password when encrypting the key material.
@@ -1173,10 +1172,10 @@ namespace System.Security.Cryptography
         ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
         /// </param>
         /// <returns>
-        ///   A byte array containing the PKCS#8 PrivateKeyInfo representation of the this key.
+        ///   A string containing the PEM-encoded PKCS#8 EncryptedPrivateKeyInfo.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        ///    <paramref name="pbeParameters"/> is <see langword="null"/>.
+        ///   <paramref name="pbeParameters"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="ObjectDisposedException">
         ///   This instance has been disposed.
@@ -1206,8 +1205,8 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Exports the current key in a PEM-encoded representation of the PKCS#8 EncryptedPrivateKeyInfo
-        /// representation of this key, using a char-based password.
+        ///   Exports the current key in a PEM-encoded representation of the PKCS#8 EncryptedPrivateKeyInfo
+        ///   representation of this key, using a char-based password.
         /// </summary>
         /// <param name="password">
         ///   The password to use when encrypting the key material.
@@ -1216,7 +1215,7 @@ namespace System.Security.Cryptography
         ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
         /// </param>
         /// <returns>
-        ///   A byte array containing the PKCS#8 PrivateKeyInfo representation of the this key.
+        ///   A string containing the PEM-encoded PKCS#8 EncryptedPrivateKeyInfo.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///    <paramref name="pbeParameters"/> is <see langword="null"/>.
@@ -1247,8 +1246,8 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Exports the current key in a PEM-encoded representation of the PKCS#8 EncryptedPrivateKeyInfo
-        /// representation of this key, using a string password.
+        ///   Exports the current key in a PEM-encoded representation of the PKCS#8 EncryptedPrivateKeyInfo
+        ///   representation of this key, using a string password.
         /// </summary>
         /// <param name="password">
         ///   The password to use when encrypting the key material.
@@ -1257,7 +1256,7 @@ namespace System.Security.Cryptography
         ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
         /// </param>
         /// <returns>
-        ///   A byte array containing the PKCS#8 PrivateKeyInfo representation of the this key.
+        ///   A string containing the PEM-encoded PKCS#8 EncryptedPrivateKeyInfo.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///    <paramref name="password"/> or <paramref name="pbeParameters"/> is <see langword="null"/>.
@@ -1279,10 +1278,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Imports an ML-KEM encapsulation key from an X.509 SubjectPublicKeyInfo structure.
+        ///   Imports an ML-KEM encapsulation key from an X.509 SubjectPublicKeyInfo structure.
         /// </summary>
         /// <param name="source">
-        ///  The bytes of an X.509 SubjectPublicKeyInfo structure in the ASN.1-DER encoding.
+        ///   The bytes of an X.509 SubjectPublicKeyInfo structure in the ASN.1-DER encoding.
         /// </param>
         /// <returns>
         ///   The imported key.
@@ -1334,10 +1333,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Imports an ML-KEM private key from a PKCS#8 PrivateKeyInfo structure.
+        ///   Imports an ML-KEM private key from a PKCS#8 PrivateKeyInfo structure.
         /// </summary>
         /// <param name="source">
-        ///  The bytes of a PKCS#8 PrivateKeyInfo structure in the ASN.1-BER encoding.
+        ///   The bytes of a PKCS#8 PrivateKeyInfo structure in the ASN.1-BER encoding.
         /// </param>
         /// <returns>
         ///   The imported key.
@@ -1528,7 +1527,7 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Imports an ML-KEM key from an RFC 7468 PEM-encoded string.
+        ///   Imports an ML-KEM key from an RFC 7468 PEM-encoded string.
         /// </summary>
         /// <param name="source">
         ///   The text of the PEM key to import.
@@ -1728,7 +1727,7 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///  Releases all resources used by the <see cref="MLKem"/> class.
+        ///   Releases all resources used by the <see cref="MLKem"/> class.
         /// </summary>
         public void Dispose()
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -952,6 +952,52 @@ namespace System.Security.Cryptography
 
         /// <summary>
         ///  Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
+        ///  using a char-based password.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 EncryptedPrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///    <paramref name="password"/> or <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>This instance only represents a public key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The private key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        /// </exception>
+        public bool TryExportEncryptedPkcs8PrivateKey(
+            string password,
+            PbeParameters pbeParameters,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            ThrowIfNull(password);
+            return TryExportEncryptedPkcs8PrivateKey(password.AsSpan(), pbeParameters, destination, out bytesWritten);
+        }
+
+        /// <summary>
+        ///  Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
         ///  using a byte-based password.
         /// </summary>
         /// <param name="passwordBytes">

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -1479,6 +1479,55 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
+        ///   Imports an ML-KEM private key from a PKCS#8 EncryptedPrivateKeyInfo structure.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when decrypting the key material.
+        /// </param>
+        /// <param name="source">
+        ///   The bytes of a PKCS#8 EncryptedPrivateKeyInfo structure in the ASN.1-BER encoding.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="password" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The contents of <paramref name="source"/> do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified password is incorrect.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The value does not represent an ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific import failed.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The platform does not support ML-KEM. Callers can use the <see cref="IsSupported" /> property
+        ///   to determine if the platform supports ML-KEM.
+        /// </exception>
+        public static MLKem ImportEncryptedPkcs8PrivateKey(string password, ReadOnlySpan<byte> source)
+        {
+            ThrowIfNull(password);
+            ThrowIfTrailingData(source);
+            ThrowIfNotSupported();
+
+            return KeyFormatHelper.DecryptPkcs8(
+                password,
+                source,
+                ImportPkcs8PrivateKey,
+                out _);
+        }
+
+        /// <summary>
         ///  Imports an ML-KEM key from an RFC 7468 PEM-encoded string.
         /// </summary>
         /// <param name="source">

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
@@ -1304,22 +1304,22 @@ namespace System.Security.Cryptography.Tests
             {
                 case TryExportPkcs8PasswordKind.StringPassword:
                     return kem.TryExportEncryptedPkcs8PrivateKey(
-                    MLKemTestData.EncryptedPrivateKeyPassword,
-                    s_aes128Pbe,
-                    destination,
-                    out bytesWritten);
+                        MLKemTestData.EncryptedPrivateKeyPassword,
+                        s_aes128Pbe,
+                        destination,
+                        out bytesWritten);
                 case TryExportPkcs8PasswordKind.SpanOfCharsPassword:
                     return kem.TryExportEncryptedPkcs8PrivateKey(
-                    MLKemTestData.EncryptedPrivateKeyPassword.AsSpan(),
-                    s_aes128Pbe,
-                    destination,
-                    out bytesWritten);
+                        MLKemTestData.EncryptedPrivateKeyPassword.AsSpan(),
+                        s_aes128Pbe,
+                        destination,
+                        out bytesWritten);
                 case TryExportPkcs8PasswordKind.SpanOfBytesPassword:
                     return kem.TryExportEncryptedPkcs8PrivateKey(
-                    MLKemTestData.EncryptedPrivateKeyPasswordBytes,
-                    s_aes128Pbe,
-                    destination,
-                    out bytesWritten);
+                        MLKemTestData.EncryptedPrivateKeyPasswordBytes,
+                        s_aes128Pbe,
+                        destination,
+                        out bytesWritten);
                 default:
                     throw new XunitException($"Unknown password kind '{kind}'.");
             }

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
@@ -784,6 +784,43 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public static void ExportSubjectPublicKeyInfoPem()
+        {
+            using MLKemContract kem = new(MLKemAlgorithm.MLKem512)
+            {
+                 OnExportEncapsulationKeyCore = (Span<byte> destination) =>
+                 {
+                    destination.Fill(0x42);
+                    Assert.Equal(MLKemAlgorithm.MLKem512.EncapsulationKeySizeInBytes, destination.Length);
+                 }
+            };
+
+            string spkiPem = kem.ExportSubjectPublicKeyInfoPem();
+            const string ExpectedPem =
+                "-----BEGIN PUBLIC KEY-----\n" +
+                "MIIDMjALBglghkgBZQMEBAEDggMhAEJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJC\n" +
+                "QkJCQkJC\n" +
+                "-----END PUBLIC KEY-----";
+            Assert.Equal(ExpectedPem, spkiPem);
+        }
+
+        [Fact]
         public static void ExportSubjectPublicKeyInfo_Disposed()
         {
             MLKemContract kem = new(MLKemAlgorithm.MLKem512);
@@ -1121,6 +1158,8 @@ namespace System.Security.Cryptography.Tests
                     out _));
             Assert.Throws<CryptographicException>(() =>
                 kem.ExportEncryptedPkcs8PrivateKey(MLKemTestData.EncryptedPrivateKeyPasswordBytes, pbeParameters));
+            Assert.Throws<CryptographicException>(() => kem.ExportEncryptedPkcs8PrivateKeyPem(
+                MLKemTestData.EncryptedPrivateKeyPasswordBytes, pbeParameters));
         }
 
         [Fact]
@@ -1142,6 +1181,92 @@ namespace System.Security.Cryptography.Tests
 
             AssertExtensions.Throws<ArgumentNullException>("password", () => kem.ExportEncryptedPkcs8PrivateKey(
                 (string)null, s_aes128Pbe));
+
+            AssertExtensions.Throws<ArgumentNullException>("password", () => kem.ExportEncryptedPkcs8PrivateKeyPem(
+                (string)null, s_aes128Pbe));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.ExportEncryptedPkcs8PrivateKeyPem(
+                MLKemTestData.EncryptedPrivateKeyPassword, pbeParameters: null));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.ExportEncryptedPkcs8PrivateKeyPem(
+                MLKemTestData.EncryptedPrivateKeyPassword.AsSpan(), pbeParameters: null));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.ExportEncryptedPkcs8PrivateKeyPem(
+                MLKemTestData.EncryptedPrivateKeyPasswordBytes, pbeParameters: null));
+        }
+
+        [Fact]
+        public static void ExportEncryptedPkcs8PrivateKeyPem_Disposed()
+        {
+            MLKemContract kem = new(MLKemAlgorithm.MLKem512);
+            kem.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportEncryptedPkcs8PrivateKeyPem(
+                MLKemTestData.EncryptedPrivateKeyPassword, s_aes128Pbe));
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportEncryptedPkcs8PrivateKeyPem(
+                MLKemTestData.EncryptedPrivateKeyPassword, s_aes128Pbe));
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportEncryptedPkcs8PrivateKeyPem(
+                MLKemTestData.EncryptedPrivateKeyPassword.AsSpan(), s_aes128Pbe));
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportEncryptedPkcs8PrivateKeyPem(
+                MLKemTestData.EncryptedPrivateKeyPasswordBytes, s_aes128Pbe));
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser does not support symmetric encryption")]
+        public static void ExportEncryptedPkcs8PrivateKeyPem()
+        {
+            using MLKemContract kem = new(MLKemAlgorithm.MLKem512)
+            {
+                OnTryExportPkcs8PrivateKeyCore = (Span<byte> destination, out int bytesWritten) =>
+                {
+                    if (MLKemTestData.IetfMlKem512PrivateKeyExpandedKey.AsSpan().TryCopyTo(destination))
+                    {
+                        bytesWritten = MLKemTestData.IetfMlKem512PrivateKeyExpandedKey.Length;
+                        return true;
+                    }
+
+                    bytesWritten = 0;
+                    return false;
+                }
+            };
+
+            string pem = kem.ExportEncryptedPkcs8PrivateKeyPem(MLKemTestData.EncryptedPrivateKeyPassword, s_aes128Pbe);
+            AssertPem(pem);
+            pem = kem.ExportEncryptedPkcs8PrivateKeyPem(MLKemTestData.EncryptedPrivateKeyPasswordBytes, s_aes128Pbe);
+            AssertPem(pem);
+            pem = kem.ExportEncryptedPkcs8PrivateKeyPem(MLKemTestData.EncryptedPrivateKeyPassword.AsSpan(), s_aes128Pbe);
+            AssertPem(pem);
+
+            static void AssertPem(string pem)
+            {
+                PemFields fields = PemEncoding.Find(pem.AsSpan());
+                Assert.Equal(Index.FromStart(0), fields.Location.Start);
+                Assert.Equal(Index.FromStart(pem.Length), fields.Location.End);
+                Assert.Equal("ENCRYPTED PRIVATE KEY", pem.AsSpan()[fields.Label].ToString());
+            }
+        }
+
+        [Fact]
+        public static void ExportPkcs8PrivateKeyPem()
+        {
+            using MLKemContract kem = new(MLKemAlgorithm.MLKem512)
+            {
+                OnTryExportPkcs8PrivateKeyCore = (Span<byte> destination, out int bytesWritten) =>
+                {
+                    if (MLKemTestData.IetfMlKem512PrivateKeyExpandedKey.AsSpan().TryCopyTo(destination))
+                    {
+                        bytesWritten = MLKemTestData.IetfMlKem512PrivateKeyExpandedKey.Length;
+                        return true;
+                    }
+
+                    bytesWritten = 0;
+                    return false;
+                }
+            };
+
+            string pem = kem.ExportPkcs8PrivateKeyPem();
+            byte[] pkcs8 = kem.ExportPkcs8PrivateKey();
+            PemFields fields = PemEncoding.Find(pem.AsSpan());
+            Assert.Equal(Index.FromStart(0), fields.Location.Start);
+            Assert.Equal(Index.FromStart(pem.Length), fields.Location.End);
+            Assert.Equal("PRIVATE KEY", pem.AsSpan()[fields.Label].ToString());
+            AssertExtensions.SequenceEqual(pkcs8, Convert.FromBase64String(pem.AsSpan()[fields.Base64Data].ToString()));
         }
 
         private static string MapAlgorithmOid(MLKemAlgorithm algorithm)

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemNotSupportedTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemNotSupportedTests.cs
@@ -82,6 +82,9 @@ namespace System.Security.Cryptography.Tests
                 MLKemTestData.EncryptedPrivateKeyPassword, MLKemTestData.IetfMlKem512EncryptedPrivateKeySeed));
 
             Assert.Throws<PlatformNotSupportedException>(() => MLKem.ImportEncryptedPkcs8PrivateKey(
+                MLKemTestData.EncryptedPrivateKeyPassword.AsSpan(), MLKemTestData.IetfMlKem512EncryptedPrivateKeySeed));
+
+            Assert.Throws<PlatformNotSupportedException>(() => MLKem.ImportEncryptedPkcs8PrivateKey(
                 MLKemTestData.EncryptedPrivateKeyPasswordBytes, MLKemTestData.IetfMlKem512EncryptedPrivateKeySeed));
         }
 

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
@@ -84,6 +84,12 @@
   <data name="Argument_KemInvalidSeedLength" xml:space="preserve">
     <value>The specified private seed is not the correct length for the ML-KEM algorithm.</value>
   </data>
+  <data name="Argument_PemEncoding_InvalidLabel" xml:space="preserve">
+    <value>The specified label is not valid.</value>
+  </data>
+  <data name="Argument_PemEncoding_EncodedSizeTooLarge" xml:space="preserve">
+    <value>The encoded PEM size is too large to represent as a signed 32-bit integer.</value>
+  </data>
   <data name="Argument_PemEncoding_NoPemFound" xml:space="preserve">
     <value>No PEM encoded data found.</value>
   </data>
@@ -110,6 +116,9 @@
   </data>
   <data name="ArgumentOutOfRange_Generic_MustBeNonNegativeNonZero" xml:space="preserve">
     <value>{0} ('{1}') must be a non-negative and non-zero value.</value>
+  </data>
+  <data name="ArgumentOutOfRange_NeedPositiveNumber" xml:space="preserve">
+    <value>A positive number is required.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non-negative number required.</value>

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/PemEncoding.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/PemEncoding.cs
@@ -17,6 +17,7 @@ namespace System.Security.Cryptography
         private const string PreEBPrefix = "-----BEGIN ";
         private const string PostEBPrefix = "-----END ";
         private const string Ending = "-----";
+        private const int EncodedLineLength = 64;
 
         internal static PemFields Find(ReadOnlySpan<char> pemData)
         {
@@ -269,6 +270,145 @@ namespace System.Security.Cryptography
         {
             // Match white space characters from Convert.Base64
             return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
+        }
+
+        internal static int GetEncodedSize(int labelLength, int dataLength)
+        {
+            // The largest possible label is MaxLabelSize - when included in the posteb
+            // and preeb lines new lines, assuming the base64 content is empty.
+            //     -----BEGIN {char * MaxLabelSize}-----\n
+            //     -----END {char * MaxLabelSize}-----
+            const int MaxLabelSize = 1_073_741_808;
+
+            // The largest possible binary value to fit in a padded base64 string
+            // is 1,610,612,733 bytes. RFC 7468 states:
+            //   Generators MUST wrap the base64-encoded lines so that each line
+            //   consists of exactly 64 characters except for the final line
+            // We need to account for new line characters, every 64 characters.
+            // This works out to 1,585,834,053 maximum bytes in data when wrapping
+            // is accounted for assuming an empty label.
+            const int MaxDataLength = 1_585_834_053;
+
+            if (labelLength < 0)
+                throw new ArgumentOutOfRangeException(nameof(labelLength), SR.ArgumentOutOfRange_NeedPositiveNumber);
+            if (dataLength < 0)
+                throw new ArgumentOutOfRangeException(nameof(dataLength), SR.ArgumentOutOfRange_NeedPositiveNumber);
+            if (labelLength > MaxLabelSize)
+                throw new ArgumentOutOfRangeException(nameof(labelLength), SR.Argument_PemEncoding_EncodedSizeTooLarge);
+            if (dataLength > MaxDataLength)
+                throw new ArgumentOutOfRangeException(nameof(dataLength), SR.Argument_PemEncoding_EncodedSizeTooLarge);
+
+            int preebLength = PreEBPrefix.Length + labelLength + Ending.Length;
+            int postebLength = PostEBPrefix.Length + labelLength + Ending.Length;
+            int totalEncapLength = preebLength + postebLength + 1; //Add one for newline after preeb
+
+            // dataLength is already known to not overflow here
+            int encodedDataLength = ((dataLength + 2) / 3) << 2;
+            int lineCount = Math.DivRem(encodedDataLength, EncodedLineLength, out int remainder);
+
+            if (remainder > 0)
+                lineCount++;
+
+            int encodedDataLengthWithBreaks = encodedDataLength + lineCount;
+
+            if (int.MaxValue - encodedDataLengthWithBreaks < totalEncapLength)
+                throw new ArgumentException(SR.Argument_PemEncoding_EncodedSizeTooLarge);
+
+            return encodedDataLengthWithBreaks + totalEncapLength;
+        }
+
+        internal static bool TryWrite(ReadOnlySpan<char> label, ReadOnlySpan<byte> data, Span<char> destination, out int charsWritten)
+        {
+            static int Write(ReadOnlySpan<char> str, Span<char> dest, int offset)
+            {
+                str.CopyTo(dest.Slice(offset));
+                return str.Length;
+            }
+
+            static int WriteBase64(ReadOnlySpan<byte> bytes, Span<char> dest, int offset, byte[] bytesBuffer)
+            {
+                Debug.Assert(bytesBuffer.Length >= bytes.Length);
+                bytes.CopyTo(bytesBuffer);
+                string encoded = Convert.ToBase64String(bytesBuffer, 0, bytes.Length);
+                encoded.AsSpan().CopyTo(dest.Slice(offset));
+                return encoded.Length;
+            }
+
+            if (!IsValidLabel(label))
+            {
+                throw new ArgumentException(SR.Argument_PemEncoding_InvalidLabel, nameof(label));
+            }
+
+
+            const string NewLine = "\n";
+            const int BytesPerLine = 48;
+            byte[] bytesBuffer = CryptoPool.Rent(BytesPerLine);
+
+            try
+            {
+                int encodedSize = GetEncodedSize(label.Length, data.Length);
+
+                if (destination.Length < encodedSize)
+                {
+                    charsWritten = 0;
+                    return false;
+                }
+
+                charsWritten = 0;
+                charsWritten += Write(PreEBPrefix, destination, charsWritten);
+                charsWritten += Write(label, destination, charsWritten);
+                charsWritten += Write(Ending, destination, charsWritten);
+                charsWritten += Write(NewLine, destination, charsWritten);
+
+                ReadOnlySpan<byte> remainingData = data;
+                while (remainingData.Length >= BytesPerLine)
+                {
+                    charsWritten += WriteBase64(remainingData.Slice(0, BytesPerLine), destination, charsWritten, bytesBuffer);
+                    charsWritten += Write(NewLine, destination, charsWritten);
+                    remainingData = remainingData.Slice(BytesPerLine);
+                }
+
+                Debug.Assert(remainingData.Length < BytesPerLine);
+
+                if (remainingData.Length > 0)
+                {
+                    charsWritten += WriteBase64(remainingData, destination, charsWritten, bytesBuffer);
+                    charsWritten += Write(NewLine, destination, charsWritten);
+                }
+
+                charsWritten += Write(PostEBPrefix, destination, charsWritten);
+                charsWritten += Write(label, destination, charsWritten);
+                charsWritten += Write(Ending, destination, charsWritten);
+
+                return true;
+            }
+            finally
+            {
+                CryptoPool.Return(bytesBuffer, BytesPerLine);
+            }
+        }
+
+        internal static char[] Write(ReadOnlySpan<char> label, ReadOnlySpan<byte> data)
+        {
+            if (!IsValidLabel(label))
+                throw new ArgumentException(SR.Argument_PemEncoding_InvalidLabel, nameof(label));
+
+            int encodedSize = GetEncodedSize(label.Length, data.Length);
+            char[] buffer = new char[encodedSize];
+
+            if (!TryWrite(label, data, buffer, out int charsWritten))
+            {
+                Debug.Fail("TryWrite failed with a pre-sized buffer");
+                throw new ArgumentException(null, nameof(data));
+            }
+
+            Debug.Assert(charsWritten == encodedSize);
+            return buffer;
+        }
+
+        internal static string WriteString(ReadOnlySpan<char> label, ReadOnlySpan<byte> data)
+        {
+            return new string(Write(label, data));
         }
     }
 

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/PemEncoding.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/PemEncoding.cs
@@ -339,7 +339,6 @@ namespace System.Security.Cryptography
                 throw new ArgumentException(SR.Argument_PemEncoding_InvalidLabel, nameof(label));
             }
 
-
             const string NewLine = "\n";
             const int BytesPerLine = 48;
             byte[] bytesBuffer = CryptoPool.Rent(BytesPerLine);

--- a/src/libraries/Microsoft.Bcl.Cryptography/tests/Microsoft.Bcl.Cryptography.Tests.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/tests/Microsoft.Bcl.Cryptography.Tests.csproj
@@ -149,6 +149,7 @@
              Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
     <Compile Include="$(LibrariesProjectRoot)\Microsoft.Bcl.Cryptography\src\System\Security\Cryptography\PemEncoding.cs"
              Link="System\Security\Cryptography\PemEncoding.cs" />
+    <Compile Include="PemEncodingTests.cs" />
     <Compile Include="PemEncodingFindTests.cs" />
   </ItemGroup>
 

--- a/src/libraries/Microsoft.Bcl.Cryptography/tests/PemEncodingTests.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/tests/PemEncodingTests.cs
@@ -1,0 +1,308 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    public static class PemEncodingTests
+    {
+        [Fact]
+        public static void GetEncodedSize_Empty()
+        {
+            int size = PemEncoding.GetEncodedSize(labelLength: 0, dataLength: 0);
+            Assert.Equal(31, size);
+        }
+
+        [Theory]
+        [InlineData(1, 0, 33)]
+        [InlineData(1, 1, 38)]
+        [InlineData(16, 2048, 2838)]
+        public static void GetEncodedSize_Simple(int labelLength, int dataLength, int expectedSize)
+        {
+            int size = PemEncoding.GetEncodedSize(labelLength, dataLength);
+            Assert.Equal(expectedSize, size);
+        }
+
+        [Theory]
+        [InlineData(1_073_741_808, 0, int.MaxValue)]
+        [InlineData(1_073_741_805, 1, int.MaxValue - 1)]
+        [InlineData(0, 1_585_834_053, int.MaxValue - 2)]
+        [InlineData(1, 1_585_834_053, int.MaxValue)]
+        public static void GetEncodedSize_Boundaries(int labelLength, int dataLength, int expectedSize)
+        {
+            int size = PemEncoding.GetEncodedSize(labelLength, dataLength);
+            Assert.Equal(expectedSize, size);
+        }
+
+        [Fact]
+        public static void GetEncodedSize_LabelLength_Overflow()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("labelLength",
+                () => PemEncoding.GetEncodedSize(labelLength: 1_073_741_809, dataLength: 0));
+        }
+
+        [Fact]
+        public static void GetEncodedSize_DataLength_Overflow()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("dataLength",
+                () => PemEncoding.GetEncodedSize(labelLength: 0, dataLength: 1_585_834_054));
+        }
+
+        [Fact]
+        public static void GetEncodedSize_Combined_Overflow()
+        {
+            Assert.Throws<ArgumentException>(
+                () => PemEncoding.GetEncodedSize(labelLength: 2, dataLength: 1_585_834_052));
+        }
+
+        [Fact]
+        public static void GetEncodedSize_DataLength_Negative()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("dataLength",
+                () => PemEncoding.GetEncodedSize(labelLength: 0, dataLength: -1));
+        }
+
+        [Fact]
+        public static void GetEncodedSize_LabelLength_Negative()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("labelLength",
+                () => PemEncoding.GetEncodedSize(labelLength: -1, dataLength: 0));
+        }
+
+        [Fact]
+        public static void TryWrite_Simple()
+        {
+            char[] buffer = new char[1000];
+            string label = "HELLO";
+            byte[] content = new byte[] { 0x66, 0x6F, 0x6F };
+            Assert.True(PemEncoding.TryWrite(label, content, buffer, out int charsWritten));
+            string pem = new string(buffer, 0, charsWritten);
+            Assert.Equal("-----BEGIN HELLO-----\nZm9v\n-----END HELLO-----", pem);
+        }
+
+        [Fact]
+        public static void Write_Simple()
+        {
+            string label = "HELLO";
+            byte[] content = new byte[] { 0x66, 0x6F, 0x6F };
+            char[] result = PemEncoding.Write(label, content);
+            string pem = new string(result);
+            Assert.Equal("-----BEGIN HELLO-----\nZm9v\n-----END HELLO-----", pem);
+        }
+
+        [Fact]
+        public static void TryWrite_Empty()
+        {
+            char[] buffer = new char[31];
+            Assert.True(PemEncoding.TryWrite(default, default, buffer, out int charsWritten));
+            string pem = new string(buffer, 0, charsWritten);
+            Assert.Equal("-----BEGIN -----\n-----END -----", pem);
+        }
+
+        [Fact]
+        public static void Write_Empty()
+        {
+            char[] result = PemEncoding.Write(default, default);
+            string pem = new string(result);
+            Assert.Equal("-----BEGIN -----\n-----END -----", pem);
+        }
+
+        [Fact]
+        public static void TryWrite_BufferTooSmall()
+        {
+            char[] buffer = new char[30];
+            Assert.False(PemEncoding.TryWrite(default, default, buffer, out _));
+        }
+
+        [Fact]
+        public static void TryWrite_ExactLineNoPadding()
+        {
+            char[] buffer = new char[1000];
+            ReadOnlySpan<byte> data = new byte[] {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7
+            };
+            string label = "FANCY DATA";
+            Assert.True(PemEncoding.TryWrite(label, data, buffer, out int charsWritten));
+            string pem = new string(buffer, 0, charsWritten);
+            string expected =
+                "-----BEGIN FANCY DATA-----\n" +
+                "AAECAwQFBgcICQABAgMEBQYHCAkAAQIDBAUGBwgJAAECAwQFBgcICQABAgMEBQYH\n" +
+                "-----END FANCY DATA-----";
+            Assert.Equal(expected, pem);
+        }
+
+        [Fact]
+        public static void Write_ExactLineNoPadding()
+        {
+            ReadOnlySpan<byte> data = new byte[] {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7
+            };
+            string label = "FANCY DATA";
+            char[] result = PemEncoding.Write(label, data);
+            string pem = new string(result);
+            string expected =
+                "-----BEGIN FANCY DATA-----\n" +
+                "AAECAwQFBgcICQABAgMEBQYHCAkAAQIDBAUGBwgJAAECAwQFBgcICQABAgMEBQYH\n" +
+                "-----END FANCY DATA-----";
+            Assert.Equal(expected, pem);
+        }
+
+        [Fact]
+        public static void TryWrite_DoesNotWriteOutsideBounds()
+        {
+            Span<char> buffer = new char[1000];
+            buffer.Fill('!');
+            ReadOnlySpan<byte> data = new byte[] {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7
+            };
+
+            Span<char> write = buffer[10..];
+            string label = "FANCY DATA";
+            Assert.True(PemEncoding.TryWrite(label, data, write, out int charsWritten));
+            string pem = buffer[..(charsWritten + 20)].ToString();
+            string expected =
+                "!!!!!!!!!!-----BEGIN FANCY DATA-----\n" +
+                "AAECAwQFBgcICQABAgMEBQYHCAkAAQIDBAUGBwgJAAECAwQFBgcICQABAgMEBQYH\n" +
+                "-----END FANCY DATA-----!!!!!!!!!!";
+            Assert.Equal(expected, pem);
+        }
+
+        [Fact]
+        public static void TryWrite_WrapPadding()
+        {
+            char[] buffer = new char[1000];
+            ReadOnlySpan<byte> data = new byte[] {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+            };
+            string label = "UNFANCY DATA";
+            Assert.True(PemEncoding.TryWrite(label, data, buffer, out int charsWritten));
+            string pem = new string(buffer, 0, charsWritten);
+            string expected =
+                "-----BEGIN UNFANCY DATA-----\n" +
+                "AAECAwQFBgcICQABAgMEBQYHCAkAAQIDBAUGBwgJAAECAwQFBgcICQABAgMEBQYH\n" +
+                "CAk=\n" +
+                "-----END UNFANCY DATA-----";
+            Assert.Equal(expected, pem);
+        }
+
+        [Fact]
+        public static void Write_WrapPadding()
+        {
+            ReadOnlySpan<byte> data = new byte[] {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+            };
+            string label = "UNFANCY DATA";
+            char[] result = PemEncoding.Write(label, data);
+            string pem = new string(result);
+            string expected =
+                "-----BEGIN UNFANCY DATA-----\n" +
+                "AAECAwQFBgcICQABAgMEBQYHCAkAAQIDBAUGBwgJAAECAwQFBgcICQABAgMEBQYH\n" +
+                "CAk=\n" +
+                "-----END UNFANCY DATA-----";
+            Assert.Equal(expected, pem);
+        }
+
+        [Fact]
+        public static void TryWrite_EcKey()
+        {
+            char[] buffer = new char[1000];
+            ReadOnlySpan<byte> data = new byte[] {
+                0x30, 0x74, 0x02, 0x01, 0x01, 0x04, 0x20, 0x20,
+                0x59, 0xef, 0xff, 0x13, 0xd4, 0x92, 0xf6, 0x6a,
+                0x6b, 0xcd, 0x07, 0xf4, 0x12, 0x86, 0x08, 0x6d,
+                0x81, 0x93, 0xed, 0x9c, 0xf0, 0xf8, 0x5b, 0xeb,
+                0x00, 0x70, 0x7c, 0x40, 0xfa, 0x12, 0x6c, 0xa0,
+                0x07, 0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x0a,
+                0xa1, 0x44, 0x03, 0x42, 0x00, 0x04, 0xdf, 0x23,
+                0x42, 0xe5, 0xab, 0x3c, 0x25, 0x53, 0x79, 0x32,
+                0x31, 0x7d, 0xe6, 0x87, 0xcd, 0x4a, 0x04, 0x41,
+                0x55, 0x78, 0xdf, 0xd0, 0x22, 0xad, 0x60, 0x44,
+                0x96, 0x7c, 0xf9, 0xe6, 0xbd, 0x3d, 0xe7, 0xf9,
+                0xc3, 0x0c, 0x25, 0x40, 0x7d, 0x95, 0x42, 0x5f,
+                0x76, 0x41, 0x4d, 0x81, 0xa4, 0x81, 0xec, 0x99,
+                0x41, 0xfa, 0x4a, 0xd9, 0x55, 0x55, 0x7c, 0x4f,
+                0xb1, 0xd9, 0x41, 0x75, 0x43, 0x44
+            };
+            string label = "EC PRIVATE KEY";
+            Assert.True(PemEncoding.TryWrite(label, data, buffer, out int charsWritten));
+            string pem = new string(buffer, 0, charsWritten);
+            string expected =
+                "-----BEGIN EC PRIVATE KEY-----\n" +
+                "MHQCAQEEICBZ7/8T1JL2amvNB/QShghtgZPtnPD4W+sAcHxA+hJsoAcGBSuBBAAK\n" +
+                "oUQDQgAE3yNC5as8JVN5MjF95ofNSgRBVXjf0CKtYESWfPnmvT3n+cMMJUB9lUJf\n" +
+                "dkFNgaSB7JlB+krZVVV8T7HZQXVDRA==\n" +
+                "-----END EC PRIVATE KEY-----";
+            Assert.Equal(expected, pem);
+        }
+
+        [Fact]
+        public static void Write_EcKey()
+        {
+            ReadOnlySpan<byte> data = new byte[] {
+                0x30, 0x74, 0x02, 0x01, 0x01, 0x04, 0x20, 0x20,
+                0x59, 0xef, 0xff, 0x13, 0xd4, 0x92, 0xf6, 0x6a,
+                0x6b, 0xcd, 0x07, 0xf4, 0x12, 0x86, 0x08, 0x6d,
+                0x81, 0x93, 0xed, 0x9c, 0xf0, 0xf8, 0x5b, 0xeb,
+                0x00, 0x70, 0x7c, 0x40, 0xfa, 0x12, 0x6c, 0xa0,
+                0x07, 0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x0a,
+                0xa1, 0x44, 0x03, 0x42, 0x00, 0x04, 0xdf, 0x23,
+                0x42, 0xe5, 0xab, 0x3c, 0x25, 0x53, 0x79, 0x32,
+                0x31, 0x7d, 0xe6, 0x87, 0xcd, 0x4a, 0x04, 0x41,
+                0x55, 0x78, 0xdf, 0xd0, 0x22, 0xad, 0x60, 0x44,
+                0x96, 0x7c, 0xf9, 0xe6, 0xbd, 0x3d, 0xe7, 0xf9,
+                0xc3, 0x0c, 0x25, 0x40, 0x7d, 0x95, 0x42, 0x5f,
+                0x76, 0x41, 0x4d, 0x81, 0xa4, 0x81, 0xec, 0x99,
+                0x41, 0xfa, 0x4a, 0xd9, 0x55, 0x55, 0x7c, 0x4f,
+                0xb1, 0xd9, 0x41, 0x75, 0x43, 0x44
+            };
+            string label = "EC PRIVATE KEY";
+            char[] result = PemEncoding.Write(label, data);
+            string pem = new string(result);
+            string expected =
+                "-----BEGIN EC PRIVATE KEY-----\n" +
+                "MHQCAQEEICBZ7/8T1JL2amvNB/QShghtgZPtnPD4W+sAcHxA+hJsoAcGBSuBBAAK\n" +
+                "oUQDQgAE3yNC5as8JVN5MjF95ofNSgRBVXjf0CKtYESWfPnmvT3n+cMMJUB9lUJf\n" +
+                "dkFNgaSB7JlB+krZVVV8T7HZQXVDRA==\n" +
+                "-----END EC PRIVATE KEY-----";
+            Assert.Equal(expected, pem);
+        }
+
+        [Fact]
+        public static void TryWrite_Throws_InvalidLabel()
+        {
+            char[] buffer = new char[50];
+            AssertExtensions.Throws<ArgumentException>("label", () =>
+                PemEncoding.TryWrite("\n", default, buffer, out _));
+        }
+
+        [Fact]
+        public static void Write_Throws_InvalidLabel()
+        {
+            AssertExtensions.Throws<ArgumentException>("label", () =>
+                PemEncoding.Write("\n", default));
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1909,6 +1909,7 @@ namespace System.Security.Cryptography
         protected void ThrowIfDisposed() { }
         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected abstract bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten);
         public bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1894,6 +1894,7 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.MLKem ImportEncapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(string password, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<byte> passwordBytes) { throw null; }
         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<char> password) { throw null; }
         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1878,6 +1878,7 @@ namespace System.Security.Cryptography
         public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
         public byte[] ExportEncryptedPkcs8PrivateKey(string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
         public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
         public byte[] ExportPrivateSeed() { throw null; }
         public void ExportPrivateSeed(System.Span<byte> destination) { }
         protected abstract void ExportPrivateSeedCore(System.Span<byte> destination);

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1877,12 +1877,16 @@ namespace System.Security.Cryptography
         public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
         public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
         public byte[] ExportEncryptedPkcs8PrivateKey(string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
         public byte[] ExportPkcs8PrivateKey() { throw null; }
         public string ExportPkcs8PrivateKeyPem() { throw null; }
         public byte[] ExportPrivateSeed() { throw null; }
         public void ExportPrivateSeed(System.Span<byte> destination) { }
         protected abstract void ExportPrivateSeedCore(System.Span<byte> destination);
         public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
         public static System.Security.Cryptography.MLKem GenerateKey(System.Security.Cryptography.MLKemAlgorithm algorithm) { throw null; }
         public static System.Security.Cryptography.MLKem ImportDecapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, byte[] source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportDecapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }


### PR DESCRIPTION
This adds PEM exports to ML-KEM.

* `ExportSubjectPublicKeyInfoPem`
* `ExportPkcs8PrivateKeyPem`
* `ExportEncryptedPkcs8PrivateKeyPem`

-----

This also adds two missing overloads, one for `ImportEncryptedPkcs8PrivateKey` and `TryExportEncryptedPkcs8PrivateKey`.

The general theme of the missing overloads is that there should be a `string` for `password` when dealing with importing and exporting Encrypted PKCS#8. Downlevel platforms (.NET Framework) do not have an implicit conversion from `string` to `ReadOnlySpan<char>`, so this adds a `string` overload to the two APIs so callers are not forced to put `.AsSpan()` at all of the callsites.

Contributes to #113508 