### PR TITLE
Make host trace to `<exe_name>.<pid>.log` if `COREHOST_TRACEFILE` is set to a directory

### DIFF
--- a/docs/design/features/host-tracing.md
+++ b/docs/design/features/host-tracing.md
@@ -31,6 +31,8 @@ Starting with .NET Core 3, tracing can be redirected and its verbosity controlle
   * `COREHOST_TRACE_VERBOSITY=3` shows errors, warnings, and info
   * `COREHOST_TRACE_VERBOSITY=4` shows errors, warnings, info, and verbose. (currently the default and maximum level of detail)
 
+In .NET 10 and above, if `COREHOST_TRACEFILE` is set to a directory that exists, the host will trace to a file named `<exe_name>.<pid>.log` in that directory. If the specified path does not exist or is not a directory, tracing behaves the same as before .NET 10.
+
 ## Error routing
 
 The host components implement two routes for outputting errors:

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
@@ -451,7 +451,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             public TestApp CreateComponentWithDependencies(Action<NetCoreAppBuilder> customizer = null, string location = null)
             {
                 TestApp componentWithDependencies = CreateTestApp(location, "ComponentWithDependencies");
-                FileUtils.EnsureDirectoryExists(componentWithDependencies.Location);
+                Directory.CreateDirectory(componentWithDependencies.Location);
                 NetCoreAppBuilder builder = NetCoreAppBuilder.PortableForNETCoreApp(componentWithDependencies)
                     .WithProject(p => p.WithAssemblyGroup(null, g => g.WithMainAssembly()))
                     .WithProject("ComponentDependency", "1.0.0", p => p.WithAssemblyGroup(null, g => g.WithAsset("ComponentDependency.dll")))

--- a/src/installer/tests/TestUtils/Assertions/CommandResultExtensions.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 commandResult.StdErr);
             string filteredStdErr = commandResult.StdErr.Substring(i);
 
-            return new CommandResult(commandResult.StartInfo, commandResult.ExitCode, commandResult.StdOut, filteredStdErr);
+            return new CommandResult(commandResult.StartInfo, commandResult.ProcessId, commandResult.ExitCode, commandResult.StdOut, filteredStdErr);
         }
     }
 }

--- a/src/installer/tests/TestUtils/Command.cs
+++ b/src/installer/tests/TestUtils/Command.cs
@@ -232,11 +232,12 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             }
 
             ReportExecEnd(exitCode, expectedToFail);
-
+            int pid = Process.Id;
             Process.Dispose();
 
             return new CommandResult(
                 Process.StartInfo,
+                pid,
                 exitCode,
                 _stdOutCapture?.GetStringBuilder()?.ToString(),
                 _stdErrCapture?.GetStringBuilder()?.ToString());

--- a/src/installer/tests/TestUtils/CommandExtensions.cs
+++ b/src/installer/tests/TestUtils/CommandExtensions.cs
@@ -23,9 +23,14 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 File.Delete(filePath);
             }
 
+            return command.EnableHostTracingToPath(filePath);
+        }
+
+        public static Command EnableHostTracingToPath(this Command command, string path)
+        {
             return command
                 .EnableHostTracing()
-                .EnvironmentVariable(Constants.HostTracing.TraceFileEnvironmentVariable, filePath);
+                .EnvironmentVariable(Constants.HostTracing.TraceFileEnvironmentVariable, path);
         }
 
         public static Command EnableTracingAndCaptureOutputs(this Command command)

--- a/src/installer/tests/TestUtils/CommandResult.cs
+++ b/src/installer/tests/TestUtils/CommandResult.cs
@@ -10,13 +10,15 @@ namespace Microsoft.DotNet.Cli.Build.Framework
     public struct CommandResult
     {
         public ProcessStartInfo StartInfo { get; }
+        public int ProcessId { get; }
         public int ExitCode { get; }
         public string StdOut { get; }
         public string StdErr { get; }
 
-        public CommandResult(ProcessStartInfo startInfo, int exitCode, string stdOut, string stdErr)
+        public CommandResult(ProcessStartInfo startInfo, int pid, int exitCode, string stdOut, string stdErr)
         {
             StartInfo = startInfo;
+            ProcessId = pid;
             ExitCode = exitCode;
             StdOut = stdOut;
             StdErr = stdErr;

--- a/src/installer/tests/TestUtils/FileUtils.cs
+++ b/src/installer/tests/TestUtils/FileUtils.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.IO;
-using System.IO.MemoryMappedFiles;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
@@ -11,15 +9,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
     {
         public static void EnsureFileDirectoryExists(string filePath)
         {
-            EnsureDirectoryExists(Path.GetDirectoryName(filePath));
-        }
-
-        public static void EnsureDirectoryExists(string path)
-        {
-            if (!Directory.Exists(path))
-            {
-                Directory.CreateDirectory(path);
-            }
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath));
         }
 
         public static void CreateEmptyFile(string filePath)
@@ -37,20 +27,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
             catch (System.IO.IOException)
             {
             }
-        }
-
-        /// <summary>
-        /// Copies a file into a directory.
-        ///
-        /// This is a drop-in replacement for File.Copy usages that rely on non-Windows platforms
-        /// allowing a directory as a target path. This behavior was corrected in CoreFX:
-        /// https://github.com/dotnet/runtime/issues/29204
-        /// </summary>
-        public static void CopyIntoDirectory(string filePath, string directoryPath)
-        {
-            File.Copy(
-                filePath,
-                Path.Combine(directoryPath, Path.GetFileName(filePath)));
         }
     }
 }

--- a/src/installer/tests/TestUtils/TestArtifact.cs
+++ b/src/installer/tests/TestUtils/TestArtifact.cs
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         protected static void CopyRecursive(string sourceDirectory, string destinationDirectory, bool overwrite = false)
         {
-            FileUtils.EnsureDirectoryExists(destinationDirectory);
+            Directory.CreateDirectory(destinationDirectory);
 
             foreach (var dir in Directory.EnumerateDirectories(sourceDirectory))
             {

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -274,6 +274,7 @@ namespace pal
     // Fullpath resolves a fully-qualified path to the target. It may resolve through symlinks, depending on platform.
     bool fullpath(string_t* path, bool skip_error_logging = false);
     bool file_exists(const string_t& path);
+    bool is_directory(const pal::string_t& path);
     inline bool directory_exists(const string_t& path) { return file_exists(path); }
     void readdir(const string_t& path, const string_t& pattern, std::vector<string_t>* list);
     void readdir(const string_t& path, std::vector<string_t>* list);

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -985,6 +985,15 @@ bool pal::file_exists(const pal::string_t& path)
     return (::access(path.c_str(), F_OK) == 0);
 }
 
+bool pal::is_directory(const pal::string_t& path)
+{
+    struct stat sb;
+    if (::stat(path.c_str(), &sb) != 0)
+        return false;
+
+    return S_ISDIR(sb.st_mode);
+}
+
 static void readdir(const pal::string_t& path, const pal::string_t& pattern, bool onlydirectories, std::vector<pal::string_t>* list)
 {
     assert(list != nullptr);

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -996,6 +996,12 @@ bool pal::file_exists(const string_t& path)
     return pal::fullpath(&tmp, true);
 }
 
+bool pal::is_directory(const pal::string_t& path)
+{
+    DWORD attributes = ::GetFileAttributesW(path.c_str());
+    return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY);
+}
+
 static void readdir(const pal::string_t& path, const pal::string_t& pattern, bool onlydirectories, std::vector<pal::string_t>* list)
 {
     assert(list != nullptr);


### PR DESCRIPTION
Currently, host tracing can output to a file specified by the `COREHOST_TRACEFILE` environment variable. With multiple concurrent processes, the tracing gets interleaved in the resulting log.

I was trying to do something with VS - the trace file was basically unusable.

With this change, if `COREHOST_TRACEFILE` is set to a directory that exists, the host will trace to a file named `<exe_name>.<pid>.log` in that directory. If the specified path does not exist or is not a directory, the host uses the existing behavior of tracing to the file specified.

Resolves #3474 

cc @dotnet/appmodel @AaronRobinsonMSFT 