### PR TITLE
[clr-interp] Add github notifications for code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,8 @@
 /src/coreclr/inc/corinfo.h @dotnet/jit-contrib
 /src/coreclr/inc/corjit.h @dotnet/jit-contrib
 /src/coreclr/jit/ @dotnet/jit-contrib
-/src/coreclr/interpreter/ @brzvlad @janvorli
-/src/coreclr/vm/interpexec* @brzvlad @janvorli
+/src/coreclr/interpreter/ @brzvlad @janvorli @kg
+/src/coreclr/vm/interpexec* @brzvlad @janvorli @kg
 /src/coreclr/nativeaot @MichalStrehovsky
 /src/coreclr/tools/Common @dotnet/crossgen-contrib @MichalStrehovsky
 /src/coreclr/tools/aot @dotnet/crossgen-contrib

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,8 @@
 /src/coreclr/inc/corinfo.h @dotnet/jit-contrib
 /src/coreclr/inc/corjit.h @dotnet/jit-contrib
 /src/coreclr/jit/ @dotnet/jit-contrib
+/src/coreclr/interpreter/ @brzvlad @janvorli
+/src/coreclr/vm/interpexec* @brzvlad @janvorli
 /src/coreclr/nativeaot @MichalStrehovsky
 /src/coreclr/tools/Common @dotnet/crossgen-contrib @MichalStrehovsky
 /src/coreclr/tools/aot @dotnet/crossgen-contrib

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -392,6 +392,7 @@ configuration:
             mentionees:
             - brzvlad
             - janvorli
+            - kg
             replyTemplate: >-
               Tagging subscribers to this area: ${mentionees}
 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -131,6 +131,8 @@ configuration:
         - labelAdded:
             label: area-Codegen-Interpreter-mono
         - labelAdded:
+            label: area-CodeGen-Interpreter-coreclr
+        - labelAdded:
             label: area-Codegen-JIT-Mono
         - labelAdded:
             label: area-CodeGen-LLVM-Mono
@@ -377,6 +379,19 @@ configuration:
             mentionees:
             - brzvlad
             - kotlarmilos
+            replyTemplate: >-
+              Tagging subscribers to this area: ${mentionees}
+
+              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+            assignMentionees: False
+      - if:
+        - hasLabel:
+            label: area-CodeGen-Interpreter-coreclr
+        then:
+        - mentionUsers:
+            mentionees:
+            - brzvlad
+            - janvorli
             replyTemplate: >-
               Tagging subscribers to this area: ${mentionees}
 


### PR DESCRIPTION
Add code owners for interpreter source files and notifications for the area label: `area-CodeGen-Interpreter-coreclr`