### PR TITLE
Switch OSR patchpoint identity to <func version, IL offset>

### DIFF
--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -2389,7 +2389,7 @@ extern "C" void JIT_PatchpointWorkerWorkerWithPolicy(TransitionBlock * pTransiti
     MethodDesc* pMD = codeInfo.GetMethodDesc();
     LoaderAllocator* allocator = pMD->GetLoaderAllocator();
     OnStackReplacementManager* manager = allocator->GetOnStackReplacementManager();
-    PerPatchpointInfo * ppInfo = manager->GetPerPatchpointInfo(ip);
+    PerPatchpointInfo * ppInfo = manager->GetPerPatchpointInfo(codeInfo.GetStartAddress(), ilOffset);
 
 #ifdef _DEBUG
     const int ppId = ppInfo->m_patchpointId;

--- a/src/coreclr/vm/onstackreplacement.cpp
+++ b/src/coreclr/vm/onstackreplacement.cpp
@@ -40,7 +40,7 @@ OnStackReplacementManager::OnStackReplacementManager(LoaderAllocator * loaderAll
 }
 
 // Fetch or create patchpoint info for this patchpoint.
-PerPatchpointInfo* OnStackReplacementManager::GetPerPatchpointInfo(PCODE ip)
+PerPatchpointInfo* OnStackReplacementManager::GetPerPatchpointInfo(PCODE funcStart, int ilOffset)
 {
     CONTRACTL
     {
@@ -50,7 +50,10 @@ PerPatchpointInfo* OnStackReplacementManager::GetPerPatchpointInfo(PCODE ip)
     }
     CONTRACTL_END;
 
-    PTR_PCODE ppId = dac_cast<PTR_PCODE>(ip);
+    PtrPlusInt ppId;
+    ppId.pValue = (PVOID)funcStart;
+    ppId.iValue = ilOffset;
+
     PTR_PerPatchpointInfo ppInfo = NULL;
 
     BOOL hasData = m_jitPatchpointTable.GetValueSpeculative(ppId, (HashDatum*)&ppInfo);

--- a/src/coreclr/vm/onstackreplacement.h
+++ b/src/coreclr/vm/onstackreplacement.h
@@ -51,7 +51,7 @@ struct PerPatchpointInfo
 };
 
 typedef DPTR(PerPatchpointInfo) PTR_PerPatchpointInfo;
-typedef EEPtrHashTable JitPatchpointTable;
+typedef EEPtrPlusIntHashTable JitPatchpointTable;
 
 // OnStackReplacementManager keeps track of mapping from patchpoint id to 
 // per patchpoint info.
@@ -72,7 +72,7 @@ public:
     OnStackReplacementManager(LoaderAllocator * loaderHeaAllocator);
 
 public:
-    PerPatchpointInfo* GetPerPatchpointInfo(PCODE ip);
+    PerPatchpointInfo* GetPerPatchpointInfo(PCODE funcStart, int ilOffset);
 #endif // DACCESS_COMPILE
 
 private:


### PR DESCRIPTION
This PR changes the patchpoint cache identity to be a pair <function version, IL offset> instead of by IP of the return address. This is in preparation for runtime async changes where suspension inside OSR methods has to be resumed via resumption stub -> tier 0 -> OSR method. The latter step needs to retransition into the right OSR method from the tier 0 resumption code. With the current identity this is problematic because the return address is not going to be the same as the original patchpoint that induced the OSR transition.