### PR TITLE
Use 'ref readonly' in 'Unsafe.AsPointer'

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -1327,7 +1327,7 @@ namespace Internal.Runtime
     {
         private readonly int _value;
 
-        public unsafe IntPtr Value => (IntPtr)((byte*)Unsafe.AsPointer(ref Unsafe.AsRef(in _value)) + _value);
+        public unsafe IntPtr Value => (IntPtr)((byte*)Unsafe.AsPointer(in _value) + _value);
     }
 
     // Wrapper around relative pointers
@@ -1336,7 +1336,7 @@ namespace Internal.Runtime
     {
         private readonly int _value;
 
-        public T* Value => (T*)((byte*)Unsafe.AsPointer(ref Unsafe.AsRef(in _value)) + _value);
+        public T* Value => (T*)((byte*)Unsafe.AsPointer(in _value) + _value);
     }
 
     // Abstracts a list of MethodTable pointers that could either be relative

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -36,7 +36,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void* AsPointer<T>(ref T value)
+        public static void* AsPointer<T>(ref readonly T value)
         {
             throw new PlatformNotSupportedException();
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/MethodTable.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/MethodTable.Runtime.cs
@@ -18,9 +18,9 @@ namespace Internal.Runtime
             return MethodTable.Of<Array>();
         }
 
-        internal unsafe RuntimeTypeHandle ToRuntimeTypeHandle()
+        internal readonly unsafe RuntimeTypeHandle ToRuntimeTypeHandle()
         {
-            IntPtr result = (IntPtr)Unsafe.AsPointer(ref this);
+            IntPtr result = (IntPtr)Unsafe.AsPointer(in this);
             return *(RuntimeTypeHandle*)&result;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -26,7 +26,7 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void* AsPointer<T>(ref T value)
+        public static void* AsPointer<T>(ref readonly T value)
             where T : allows ref struct
         {
             throw new PlatformNotSupportedException();
@@ -748,7 +748,7 @@ namespace System.Runtime.CompilerServices
         public static bool IsNullRef<T>(ref readonly T source)
             where T : allows ref struct
         {
-            return AsPointer(ref Unsafe.AsRef(in source)) == null;
+            return AsPointer(in source) == null;
 
             // ldarg.0
             // ldc.i4.0
@@ -949,7 +949,7 @@ namespace System.Runtime.CompilerServices
             // GC will keep alignment when moving objects (up to sizeof(void*)),
             // otherwise alignment should be considered a hint if not pinned.
             Debug.Assert(nuint.IsPow2(alignment));
-            return ((nuint)AsPointer(ref AsRef(in address)) & (alignment - 1)) == 0;
+            return ((nuint)AsPointer(in address) & (alignment - 1)) == 0;
         }
 
         // Determines the misalignment of the address with respect to the specified `alignment`.
@@ -961,7 +961,7 @@ namespace System.Runtime.CompilerServices
             // GC will keep alignment when moving objects (up to sizeof(void*)),
             // otherwise alignment should be considered a hint if not pinned.
             Debug.Assert(nuint.IsPow2(alignment));
-            return (nuint)AsPointer(ref AsRef(in address)) & (alignment - 1);
+            return (nuint)AsPointer(in address) & (alignment - 1);
         }
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13933,7 +13933,7 @@ namespace System.Runtime.CompilerServices
         public static ref T Add<T>(ref T source, nuint elementOffset) where T : allows ref struct { throw null; }
         public static bool AreSame<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T left, [System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T right) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public unsafe static void* AsPointer<T>(ref T value) where T : allows ref struct { throw null; }
+        public unsafe static void* AsPointer<T>(ref readonly T value) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static ref T AsRef<T>(void* source) where T : allows ref struct { throw null; }
         public static ref T AsRef<T>(scoped ref readonly T source) where T : allows ref struct { throw null; }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
@@ -1043,7 +1043,7 @@ namespace System.Tests
             try
             {
                 // Unsafe.AsPointer is safe since it's pinned by the gc handle
-                Assert.Equal((IntPtr)Unsafe.AsPointer(ref Unsafe.AsRef(in rChar)), gcHandle.AddrOfPinnedObject());
+                Assert.Equal((IntPtr)Unsafe.AsPointer(in rChar), gcHandle.AddrOfPinnedObject());
             }
             finally
             {


### PR DESCRIPTION
### Closes #114189

This PR updates the signature of `Unsafe.AsPointer` to take a `ref readonly` instead.