### PR TITLE
[browser] Consider WasmSDK projects RID agnostic

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.props
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.props
@@ -13,6 +13,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <!-- Avoid having the rid show up in output paths -->
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <IsRidAgnostic>true</IsRidAgnostic>
 
     <OutputType>exe</OutputType>
 


### PR DESCRIPTION
Setting the property prevents project reference protocol from passing RID to referenced project build. It means that when server project is being built for more then one RID, referenced wasm project will be built just once.

Fixes https://github.com/dotnet/sdk-container-builds/issues/625