### PR TITLE
Fix issue when logging stack overflow in WinForm apps.

### DIFF
--- a/src/native/minipal/log.c
+++ b/src/native/minipal/log.c
@@ -3,6 +3,7 @@
 
 #include "minipalconfig.h"
 #include "log.h"
+#include <stddef.h>
 #include <string.h>
 #include <limits.h>
 #include <assert.h>
@@ -220,6 +221,9 @@ void minipal_log_flush_all(void)
 #ifdef HOST_WINDOWS
 #include <Windows.h>
 #include <io.h>
+
+typedef ptrdiff_t ssize_t;
+
 static int sync_file(minipal_log_flags flags)
 {
     switch(flags)
@@ -239,9 +243,19 @@ static int sync_file(minipal_log_flags flags)
 
     return 0;
 }
+
+static ssize_t write_file(int fd, const char* msg, size_t bytes_to_write)
+{
+    if (fd == -1 || fd == -2)
+        return 0;
+
+    assert(bytes_to_write < INT_MAX);
+    return _write(fd, msg, (unsigned int)bytes_to_write);
+}
+
 #define fileno _fileno
-#define write _write
-#elif defined(__APPLE__)
+#else
+#if defined(__APPLE__)
 #include <fcntl.h>
 #include <unistd.h>
 static int sync_file(minipal_log_flags flags)
@@ -269,16 +283,14 @@ static int sync_file(minipal_log_flags flags)
 }
 #endif
 
-static int write_file(int fd, const char* msg, size_t bytes_to_write)
+static ssize_t write_file(int fd, const char* msg, size_t bytes_to_write)
 {
     if (fd == -1)
         return 0;
 
-    assert(msg != NULL && msg[0] != '\0');
-    assert(bytes_to_write < INT_MAX);
-
-    return write(fd, msg, (int)bytes_to_write);
+    return write(fd, msg, bytes_to_write);
 }
+#endif
 
 int minipal_log_write(minipal_log_flags flags, const char* msg)
 {
@@ -290,11 +302,11 @@ int minipal_log_write(minipal_log_flags flags, const char* msg)
     int fd = fileno(get_std_file(flags));
     while (bytes_to_write > 0)
     {
-        size_t chunk_to_write = bytes_to_write < MINIPAL_LOG_MAX_PAYLOAD ? bytes_to_write : MINIPAL_LOG_MAX_PAYLOAD;
-        size_t chunk_written = write_file(fd, msg, chunk_to_write);
-
-        if (chunk_written == 0)
+        ssize_t chunk_written = write_file(fd, msg, bytes_to_write < MINIPAL_LOG_MAX_PAYLOAD ? bytes_to_write : MINIPAL_LOG_MAX_PAYLOAD);
+        if (chunk_written <= 0)
             break;
+
+        assert ((size_t)chunk_written <= bytes_to_write);
 
         msg = msg + chunk_written;
         bytes_to_write -= chunk_written;

--- a/src/native/minipal/log.c
+++ b/src/native/minipal/log.c
@@ -246,9 +246,6 @@ static int sync_file(minipal_log_flags flags)
 
 static ssize_t write_file(int fd, const char* msg, size_t bytes_to_write)
 {
-    if (fd == -1 || fd == -2)
-        return 0;
-
     assert(bytes_to_write < INT_MAX);
     return _write(fd, msg, (unsigned int)bytes_to_write);
 }
@@ -285,9 +282,6 @@ static int sync_file(minipal_log_flags flags)
 
 static ssize_t write_file(int fd, const char* msg, size_t bytes_to_write)
 {
-    if (fd == -1)
-        return 0;
-
     return write(fd, msg, bytes_to_write);
 }
 #endif

--- a/src/native/minipal/log.c
+++ b/src/native/minipal/log.c
@@ -282,7 +282,9 @@ static int sync_file(minipal_log_flags flags)
 
 static ssize_t write_file(int fd, const char* msg, size_t bytes_to_write)
 {
-    return write(fd, msg, bytes_to_write);
+    ssize_t ret = 0;
+    while ((ret = write(fd, msg, bytes_to_write)) < 0 && errno == EINTR);
+    return ret;
 }
 #endif
 


### PR DESCRIPTION
WinForm apps doesn't have a console and apparently, Windows implementation of `fileno` doesn't have same behavior as POSIX implementation where a return of -1 means error. On Windows, `fileno` will return -2 when there is no console attached to the app. This bypass the check in `write_file` that should have return 0, instead it will call `_write` that will return an error that was not fully accounted for leading to an infinite loop.

Fix makes sure Windows implementation sees -1 and -2 as invalid file descriptors. Fix also account for errors returned by `_write` breaking out of the loop.

Fixes https://github.com/dotnet/runtime/issues/114412.