### PR TITLE
Add ShutdownGuard in DynamicOptimizations test

### DIFF
--- a/src/tests/profiler/native/dynamicjitoptimization/dynamicjitoptimization.cpp
+++ b/src/tests/profiler/native/dynamicjitoptimization/dynamicjitoptimization.cpp
@@ -47,6 +47,8 @@ HRESULT DynamicJitOptimizations::JITInlining(
     FunctionID calleeId,
     BOOL      *pfShouldInline)
 {
+    SHUTDOWNGUARD();
+
     if (*pfShouldInline)
     {
         // filter for testee module
@@ -83,7 +85,6 @@ HRESULT DynamicJitOptimizations::JITInlining(
 HRESULT DynamicJitOptimizations::Shutdown()
 {
     Profiler::Shutdown();
-
     gInstance = nullptr;
     return S_OK;
 }


### PR DESCRIPTION
Other profiler tests also have `SHUTDOWNGUARD`, without it the test added in #113924 (profiler/dynamicoptimization/DynamicOptimization) segfaulted (null `pCorProfilerInfo`) intermittently on RISC-V.

Part of #84834, cc @dotnet/samsung