### PR TITLE
Remove useless argument from RedirectForThrowControl

### DIFF
--- a/src/coreclr/vm/amd64/redirectedhandledjitcase.S
+++ b/src/coreclr/vm/amd64/redirectedhandledjitcase.S
@@ -16,10 +16,10 @@
 
         //
         // IN: rdi: original IP before redirect
-        //     rsi: Rip from the Thread::GetAbortContext()
         //
 
         mov             rdx, rsp
+        mov             rsi, rdi
 
         // This push of the return address must not be recorded in the unwind
         // info.  After this push, unwinding will work.

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3185,7 +3185,7 @@ extern "C" void * QCALLTYPE CallCatchFunclet(QCall::ObjectHandleOnStack exceptio
 #ifdef TARGET_AMD64
 #ifdef TARGET_UNIX
             pvRegDisplay->pCurrentContext->Rdi = dwResumePC;
-            pvRegDisplay->pCurrentContext->Rsi = GetIP(pThread->GetAbortContext()); //How can this ever be different from dwResumePC?
+            _ASSERTE(GetIP(pThread->GetAbortContext()) == dwResumePC);
 #else
             pvRegDisplay->pCurrentContext->Rcx = dwResumePC;
 #endif

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3185,7 +3185,6 @@ extern "C" void * QCALLTYPE CallCatchFunclet(QCall::ObjectHandleOnStack exceptio
 #ifdef TARGET_AMD64
 #ifdef TARGET_UNIX
             pvRegDisplay->pCurrentContext->Rdi = dwResumePC;
-            _ASSERTE(GetIP(pThread->GetAbortContext()) == dwResumePC);
 #else
             pvRegDisplay->pCurrentContext->Rcx = dwResumePC;
 #endif


### PR DESCRIPTION
On Unix, this asm helper is passed two arguments, but both always have the same value, the resume PC. This change removes the second argument.