### PR TITLE
[release/8.0-staging] JIT: Fix loop recognition bug in .NET 8

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1801,7 +1801,7 @@ private:
     //
     BasicBlock* FindEntry(BasicBlock* head, BasicBlock* top, BasicBlock* bottom)
     {
-        if (head->bbJumpKind == BBJ_ALWAYS)
+        if ((head->bbJumpKind == BBJ_ALWAYS) && !head->isBBCallAlwaysPairTail())
         {
             if (head->bbJumpDest->bbNum <= bottom->bbNum && head->bbJumpDest->bbNum >= top->bbNum)
             {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_108811/Runtime_108811.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_108811/Runtime_108811.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+public class Runtime_108811
+{
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    [Fact]
+    public static int Test()
+    {
+        var hex = "3AE46205A50ED00E7612A91692552B7A";
+        var key = "abcdef1234567890";
+        var iv = "abcdef1234567890";
+        var bytes = Convert.FromHexString(hex);
+        int retval = 100;
+        for (int i = 0; i < 200; i++)
+        {
+            var result = new Runtime_108811().Decrypt(bytes, key, iv, out _);
+            Console.Write($"{result} ");
+            if (result != 9)
+            {
+                retval = -1;
+                break;
+            }
+            Thread.Sleep(10);
+        }
+        Console.WriteLine();
+        return retval;
+    }
+
+    public int Decrypt(byte[] buffer, string key, string iv, out byte[] decryptedData)
+    {
+        int decryptedByteCount = 0;
+        decryptedData = new byte[buffer.Length];
+
+        using var aes = Aes.Create();
+        aes.Mode = CipherMode.CBC;
+        aes.KeySize = 128;
+        aes.Padding = PaddingMode.Zeros;
+
+        var instPwdArray = Encoding.ASCII.GetBytes(key);
+        var instSaltArray = Encoding.ASCII.GetBytes(iv);
+
+        using (var decryptor = aes.CreateDecryptor(instPwdArray, instSaltArray))
+        {
+            using (var memoryStream = new MemoryStream(buffer))
+            {
+                using (var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read))
+                {
+                    int read;
+                    do
+                    {
+                        read = cryptoStream.Read(
+                            decryptedData,
+                            decryptedByteCount,
+                            decryptedData.Length - decryptedByteCount);
+                        decryptedByteCount += read;
+                    } while (read != 0);
+                }
+            }
+        }
+        // Found the accurate length of decrypted data
+        while (decryptedData[decryptedByteCount - 1] == 0 && decryptedByteCount > 0)
+            decryptedByteCount--;
+        return decryptedByteCount;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_108811/Runtime_108811.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_108811/Runtime_108811.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3241,6 +3241,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_90219/Runtime_90219/*">
             <Issue>Loads an assembly from file</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_108811/Runtime_108811/*">
+            <Issue>Requires AES</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetArchitecture)' == 'wasm'">


### PR DESCRIPTION
A loop preheader can't be a callfinally pair tail.

Fixes #108811.

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Silent bad code generation. Programs may return incorrect results after running for a while. Failure happens once key methods are tiered up.

At a source level this requires a `try/finally` (say from a `using`) with a loop with invariant expression immediately thereafter, for instance:
```C#
using (...)
{ 

}

while (...)
{
    = ... <some loop invariant computation>
}
```
In the JIT IR, the `using` is commonly followed with code to invoke the finally, and this finally invocation code sequence has special restrictions that are not always being honored.

In particular the optimizer may attempt to hoist the invariant computation out of the loop and inadvertently place the computation in a "callfinally pair tail" block that is supposed to remain empty. And doing hosting this way leads to improper code generation for the hoisted value.

Similar constructs can arise from other source patterns or via inlining.

## Regression

- [x] Yes
- [ ] No

From the linked bug, the customer indicates the program ran properly on .NET 6.

## Testing

Verified the customer test case is now fixed. Issue was flagged by a checked build of the jit, so we know it is uncommon.

We currently do not have SPMI artifacts for .NET 8 but can try and recreate them to verify that there are no unexpected changes.

This part of the JIT was substantially revised in .NET 9, which does not have this bug.

## Risk

Low, this inhibits recognition of certain problematic loops and ensuing loop optimizations.