### PR TITLE
Create a single copy of stub templates

### DIFF
--- a/src/coreclr/clrdefinitions.cmake
+++ b/src/coreclr/clrdefinitions.cmake
@@ -217,6 +217,8 @@ if (FEATURE_STUBPRECODE_DYNAMIC_HELPERS)
   add_definitions(-DFEATURE_STUBPRECODE_DYNAMIC_HELPERS)
 endif()
 
+add_definitions(-DFEATURE_MAP_THUNKS_FROM_IMAGE)
+
 # Use this function to enable building with a specific target OS and architecture set of defines
 # This is known to work for the set of defines used by the JIT and gcinfo, it is not likely correct for
 # other components of the runtime

--- a/src/coreclr/clrdefinitions.cmake
+++ b/src/coreclr/clrdefinitions.cmake
@@ -217,7 +217,9 @@ if (FEATURE_STUBPRECODE_DYNAMIC_HELPERS)
   add_definitions(-DFEATURE_STUBPRECODE_DYNAMIC_HELPERS)
 endif()
 
-add_definitions(-DFEATURE_MAP_THUNKS_FROM_IMAGE)
+if (CLR_CMAKE_TARGET_APPLE)
+  add_definitions(-DFEATURE_MAP_THUNKS_FROM_IMAGE)
+endif()
 
 # Use this function to enable building with a specific target OS and architecture set of defines
 # This is known to work for the set of defines used by the JIT and gcinfo, it is not likely correct for

--- a/src/coreclr/inc/executableallocator.h
+++ b/src/coreclr/inc/executableallocator.h
@@ -276,7 +276,7 @@ public:
     // If templateInImage is not null, it will attempt to use it as the template, otherwise it will create an temporary in memory file to serve as the template
     // Some OS/Architectures may/may not be able to work with this, so this api is permitted to return NULL, and callers should have an alternate approach using
     // the codePageGenerator directly.
-    void* CreateTemplate(void* templateInImage, size_t templateSize, void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size));
+    void* CreateTemplate(void* templateInImage, size_t templateSize, void (*codePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size));
 };
 
 #define ExecutableWriterHolder ExecutableWriterHolderNoLog

--- a/src/coreclr/inc/executableallocator.h
+++ b/src/coreclr/inc/executableallocator.h
@@ -265,6 +265,18 @@ public:
 
     // Unmap the RW mapping at the specified address
     void UnmapRW(void* pRW);
+
+    // Allocate thunks from a template. pTemplate is the return value from CreateTemplate
+    void* AllocateThunksFromTemplate(void *pTemplate, size_t templateSize);
+
+    // Free a set of thunks allocated from templates. pThunks must have been returned from AllocateThunksFromTemplate
+    void FreeThunksFromTemplate(void *pThunks, size_t templateSize);
+
+    // Create a template
+    // If templateInImage is not null, it will attempt to use it as the template, otherwise it will create an temporary in memory file to serve as the template
+    // Some OS/Architectures may/may not be able to work with this, so this api is permitted to return NULL, and callers should have an alternate approach using
+    // the codePageGenerator directly.
+    void* CreateTemplate(void* templateInImage, size_t templateSize, void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size));
 };
 
 #define ExecutableWriterHolder ExecutableWriterHolderNoLog

--- a/src/coreclr/inc/executableallocator.h
+++ b/src/coreclr/inc/executableallocator.h
@@ -183,7 +183,7 @@ private:
     static bool IsDoubleMappingEnabled();
 
     // Release memory allocated via DoubleMapping for either templates or normal double mapped data
-    void Release(void* pRX, bool releaseTemplate);
+    void ReleaseWorker(void* pRX, bool releaseTemplate);
 
     // Initialize the allocator instance
     bool Initialize();

--- a/src/coreclr/inc/executableallocator.h
+++ b/src/coreclr/inc/executableallocator.h
@@ -182,6 +182,9 @@ private:
     // Return true if double mapping is enabled.
     static bool IsDoubleMappingEnabled();
 
+    // Release memory allocated via DoubleMapping for either templates or normal double mapped data
+    void Release(void* pRX, bool releaseTemplate);
+
     // Initialize the allocator instance
     bool Initialize();
 

--- a/src/coreclr/inc/loaderheap.h
+++ b/src/coreclr/inc/loaderheap.h
@@ -455,10 +455,19 @@ private:
     static void WeGotAFaultNowWhat(UnlockedLoaderHeap *pHeap);
 };
 
+struct InterleavedLoaderHeapConfig
+{
+    uint32_t StubSize;
+    void* Template;
+    void (*CodePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size);
+};
+
+void InitializeLoaderHeapConfig(InterleavedLoaderHeapConfig *pConfig, size_t stubSize, void* templateInImage, void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size));
+
 //===============================================================================
 // This is the base class for InterleavedLoaderHeap It's used as a simple
 // allocator for stubs in a scheme where each stub is a small fixed size, and is paired
-// with memory which is GetOSStubPageSize() bytes away. In addition there is an
+// with memory which is GetStubCodePageSize() bytes away. In addition there is an
 // ability to free is via a "backout" mechanism that is not considered to have good performance.
 //
 //===============================================================================
@@ -492,16 +501,13 @@ private:
 
     InterleavedStubFreeListNode  *m_pFreeListHead;
 
-public:
-public:
-    void                (*m_codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size);
+    InterleavedLoaderHeapConfig *m_pConfig;
 
 #ifndef DACCESS_COMPILE
 protected:
     UnlockedInterleavedLoaderHeap(
         RangeList *pRangeList,
-        void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size),
-        DWORD dwGranularity);
+        InterleavedLoaderHeapConfig *pConfig);
 
     virtual ~UnlockedInterleavedLoaderHeap();
 #endif
@@ -1039,13 +1045,11 @@ private:
 public:
     InterleavedLoaderHeap(RangeList *pRangeList,
                BOOL fUnlocked,
-               void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size),
-               DWORD dwGranularity
+               InterleavedLoaderHeapConfig *pConfig,
                )
       : UnlockedInterleavedLoaderHeap(
                            pRangeList,
-                           codePageGenerator,
-                           dwGranularity),
+                           pConfig),
         m_CriticalSection(fUnlocked ? NULL : CreateLoaderHeapLock())
     {
         WRAPPER_NO_CONTRACT;

--- a/src/coreclr/inc/loaderheap.h
+++ b/src/coreclr/inc/loaderheap.h
@@ -459,10 +459,10 @@ struct InterleavedLoaderHeapConfig
 {
     uint32_t StubSize;
     void* Template;
-    void (*CodePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size);
+    void (*CodePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size);
 };
 
-void InitializeLoaderHeapConfig(InterleavedLoaderHeapConfig *pConfig, size_t stubSize, void* templateInImage, void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size));
+void InitializeLoaderHeapConfig(InterleavedLoaderHeapConfig *pConfig, size_t stubSize, void* templateInImage, void (*codePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size));
 
 //===============================================================================
 // This is the base class for InterleavedLoaderHeap It's used as a simple

--- a/src/coreclr/inc/loaderheap.h
+++ b/src/coreclr/inc/loaderheap.h
@@ -501,13 +501,13 @@ private:
 
     InterleavedStubFreeListNode  *m_pFreeListHead;
 
-    InterleavedLoaderHeapConfig *m_pConfig;
+    const InterleavedLoaderHeapConfig *m_pConfig;
 
 #ifndef DACCESS_COMPILE
 protected:
     UnlockedInterleavedLoaderHeap(
         RangeList *pRangeList,
-        InterleavedLoaderHeapConfig *pConfig);
+        const InterleavedLoaderHeapConfig *pConfig);
 
     virtual ~UnlockedInterleavedLoaderHeap();
 #endif
@@ -1045,7 +1045,7 @@ private:
 public:
     InterleavedLoaderHeap(RangeList *pRangeList,
                BOOL fUnlocked,
-               InterleavedLoaderHeapConfig *pConfig,
+               const InterleavedLoaderHeapConfig *pConfig
                )
       : UnlockedInterleavedLoaderHeap(
                            pRangeList,

--- a/src/coreclr/minipal/Unix/doublemapping.cpp
+++ b/src/coreclr/minipal/Unix/doublemapping.cpp
@@ -398,6 +398,10 @@ TemplateThunkMappingData *InitializeTemplateThunkMappingData(void* pTemplate)
             {
                 locals.data.fdImage = fd;
                 locals.data.offsetInFileOfStartOfSection = 0;
+                // We simulate the template thunk mapping data existing in mapped ram, by declaring that it exists at at
+                // an address which is not NULL, and which is naturally aligned on the largest page size supported by any
+                // architecture we support (0x10000). We do this, as the generalized logic here is designed around remapping
+                // already mapped memory, and by doing this we are able to share that logic.
                 locals.data.addrOfStartOfSection = (void*)0x10000;
                 locals.data.addrOfEndOfSection = ((uint8_t*)locals.data.addrOfStartOfSection) + maxFileSize;
                 locals.data.imageTemplates = false;
@@ -485,7 +489,7 @@ void* VMToOSInterface::AllocateThunksFromTemplate(void* pTemplate, size_t templa
     vm_prot_t prot, max_prot;
     kern_return_t ret;
 
-    // Allocate two contiguous ranges of memory: the first range will contain the trampolines
+    // Allocate two contiguous ranges of memory: the first range will contain the stubs
     // and the second range will contain their data.
     do
     {

--- a/src/coreclr/minipal/Windows/doublemapping.cpp
+++ b/src/coreclr/minipal/Windows/doublemapping.cpp
@@ -211,6 +211,11 @@ bool VMToOSInterface::ReleaseRWMapping(void* pStart, size_t size)
     return UnmapViewOfFile(pStart);
 }
 
+void* VMToOSInterface::CreateTemplate(void* pImageTemplate, size_t templateSize, void (*codePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size))
+{
+    return NULL;
+}
+
 bool VMToOSInterface::AllocateThunksFromTemplateRespectsStartAddress()
 {
     return false;

--- a/src/coreclr/minipal/Windows/doublemapping.cpp
+++ b/src/coreclr/minipal/Windows/doublemapping.cpp
@@ -210,3 +210,18 @@ bool VMToOSInterface::ReleaseRWMapping(void* pStart, size_t size)
 {
     return UnmapViewOfFile(pStart);
 }
+
+bool VMToOSInterface::AllocateThunksFromTemplateRespectsStartAddress()
+{
+    return false;
+}
+
+void* VMToOSInterface::AllocateThunksFromTemplate(void* pTemplate, size_t templateSize, void* pStart)
+{
+    return NULL;
+}
+
+bool VMToOSInterface::FreeThunksFromTemplate(void* thunks, size_t templateSize)
+{
+    return false;
+}

--- a/src/coreclr/minipal/minipal.h
+++ b/src/coreclr/minipal/minipal.h
@@ -85,7 +85,7 @@ public:
     // Return:
     //  NULL if creating the template fails
     //  Non-NULL, a pointer to the template
-    void* CreateTemplate(void* pImageTemplate, size_t templateSize, void (*codePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size))
+    static void* CreateTemplate(void* pImageTemplate, size_t templateSize, void (*codePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size));
 
     // Indicate if the AllocateThunksFromTemplate function respects the pStart address on this platform
     // Return:

--- a/src/coreclr/minipal/minipal.h
+++ b/src/coreclr/minipal/minipal.h
@@ -76,6 +76,17 @@ public:
     //  true if it succeeded, false if it failed
     static bool ReleaseRWMapping(void* pStart, size_t size);
 
+    // Create a template for use by AllocateThunksFromTemplate
+    // Parameters:
+    //  pImageTemplate    - Address of start of template in the image for coreclr. (All addresses passed to the api in a process must be from the same module, if any call uses a pImageTemplate, all calls MUST)
+    //  templateSize      - Size of the template
+    //  codePageGenerator - If the system is unable to use pImageTemplate, use this parameter to generate the code page instead
+    //
+    // Return:
+    //  NULL if creating the template fails
+    //  Non-NULL, a pointer to the template
+    void* CreateTemplate(void* pImageTemplate, size_t templateSize, void (*codePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size))
+
     // Indicate if the AllocateThunksFromTemplate function respects the pStart address on this platform
     // Return:
     //  true if the parameter is respected, false if not
@@ -83,7 +94,7 @@ public:
 
     // Allocate thunks from template
     // Parameters:
-    //  pTemplate    - Address of start of templates for coreclr (All addresses passed to the api in a process must be from the same module)
+    //  pTemplate    - Value returned from CreateTemplate
     //  templateSize - Size of the templates block in the image
     //  pStart       - Where to allocate (Specify NULL if no particular address is required). If non-null, this must be an address returned by ReserveDoubleMappedMemory
     //

--- a/src/coreclr/minipal/minipal.h
+++ b/src/coreclr/minipal/minipal.h
@@ -75,6 +75,30 @@ public:
     // Return:
     //  true if it succeeded, false if it failed
     static bool ReleaseRWMapping(void* pStart, size_t size);
+
+    // Indicate if the AllocateThunksFromTemplate function respects the pStart address on this platform
+    // Return:
+    //  true if the parameter is respected, false if not
+    static bool AllocateThunksFromTemplateRespectsStartAddress();
+
+    // Allocate thunks from template
+    // Parameters:
+    //  pTemplate    - Address of start of templates for coreclr (All addresses passed to the api in a process must be from the same module)
+    //  templateSize - Size of the templates block in the image
+    //  pStart       - Where to allocate (Specify NULL if no particular address is required). If non-null, this must be an address returned by ReserveDoubleMappedMemory
+    //
+    // Return:
+    //  NULL if the allocation fails
+    //  Non-NULL, a pointer to the allocated region.
+    static void* AllocateThunksFromTemplate(void* pTemplate, size_t templateSize, void* pStart);
+
+    // Free thunks allocated from template
+    // Parameters:
+    //  pThunks      - Address previously returned by AllocateThunksFromTemplate
+    //  templateSize - Size of the templates block in the image
+    // Return:
+    //  true if it succeeded, false if it failed
+    static bool FreeThunksFromTemplate(void* thunks, size_t templateSize);
 };
 
 #if defined(HOST_64BIT) && defined(FEATURE_CACHED_INTERFACE_DISPATCH)

--- a/src/coreclr/minipal/minipal.h
+++ b/src/coreclr/minipal/minipal.h
@@ -87,7 +87,7 @@ public:
     //  Non-NULL, a pointer to the template
     static void* CreateTemplate(void* pImageTemplate, size_t templateSize, void (*codePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size));
 
-    // Indicate if the AllocateThunksFromTemplate function respects the pStart address on this platform
+    // Indicate if the AllocateThunksFromTemplate function respects the pStart address passed to AllocateThunksFromTemplate on this platform
     // Return:
     //  true if the parameter is respected, false if not
     static bool AllocateThunksFromTemplateRespectsStartAddress();

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -526,7 +526,7 @@ REDHAWK_PALEXPORT UInt32_BOOL REDHAWK_PALAPI PalAllocateThunksFromTemplate(HANDL
     vm_prot_t prot, max_prot;
     kern_return_t ret;
 
-    // Allocate two contiguous ranges of memory: the first range will contain the trampolines
+    // Allocate two contiguous ranges of memory: the first range will contain the stubs
     // and the second range will contain their data.
     do
     {

--- a/src/coreclr/utilcode/executableallocator.cpp
+++ b/src/coreclr/utilcode/executableallocator.cpp
@@ -1022,7 +1022,6 @@ void ExecutableAllocator::FreeThunksFromTemplate(void *pThunks, size_t templateS
 {
     if (IsDoubleMappingEnabled() && VMToOSInterface::AllocateThunksFromTemplateRespectsStartAddress())
     {
-        CRITSEC_Holder csh(m_CriticalSection);
         ReleaseWorker(pThunks, true /* This is a release of template allocated memory */);
     }
     else

--- a/src/coreclr/utilcode/executableallocator.cpp
+++ b/src/coreclr/utilcode/executableallocator.cpp
@@ -1031,7 +1031,7 @@ void ExecutableAllocator::FreeThunksFromTemplate(void *pThunks, size_t templateS
     }
 }
 
-void* ExecutableAllocator::CreateTemplate(void* templateInImage, size_t templateSize, void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size))
+void* ExecutableAllocator::CreateTemplate(void* templateInImage, size_t templateSize, void (*codePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size))
 {
     return VMToOSInterface::CreateTemplate(templateInImage, templateSize, codePageGenerator);
 }

--- a/src/coreclr/utilcode/interleavedloaderheap.cpp
+++ b/src/coreclr/utilcode/interleavedloaderheap.cpp
@@ -539,7 +539,7 @@ void *UnlockedInterleavedLoaderHeap::UnlockedAllocStub(
     return pResult;
 }
 
-void InitializeLoaderHeapConfig(InterleavedLoaderHeapConfig *pConfig, size_t stubSize, void* templateInImage, void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size))
+void InitializeLoaderHeapConfig(InterleavedLoaderHeapConfig *pConfig, size_t stubSize, void* templateInImage, void (*codePageGenerator)(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size))
 {
     pConfig->StubSize = (uint32_t)stubSize;
     pConfig->Template = ExecutableAllocator::Instance()->CreateTemplate(templateInImage, GetStubCodePageSize(), codePageGenerator);

--- a/src/coreclr/utilcode/interleavedloaderheap.cpp
+++ b/src/coreclr/utilcode/interleavedloaderheap.cpp
@@ -80,7 +80,14 @@ UnlockedInterleavedLoaderHeap::~UnlockedInterleavedLoaderHeap()
         pVirtualAddress = pSearch->pVirtualAddress;
         pNext = pSearch->pNext;
 
-        ExecutableAllocator::Instance()->Release(pVirtualAddress);
+        if (m_pConfig->Template != NULL)
+        {
+            ExecutableAllocator::Instance()->FreeThunksFromTemplate(pVirtualAddress, GetStubCodePageSize());
+        }
+        else
+        {
+            ExecutableAllocator::Instance()->Release(pVirtualAddress);
+        }
 
         delete pSearch;
     }
@@ -101,6 +108,7 @@ size_t UnlockedInterleavedLoaderHeap::GetBytesAvailReservedRegion()
 
 BOOL UnlockedInterleavedLoaderHeap::CommitPages(void* pData, size_t dwSizeToCommitPart)
 {
+    _ASSERTE(m_pConfig->Template == NULL); // This path should only be used for LoaderHeaps which use the standard ExecutableAllocator functions
     // Commit first set of pages, since it will contain the LoaderHeapBlock
     {
         void *pTemp = ExecutableAllocator::Instance()->Commit(pData, dwSizeToCommitPart, IsExecutable());
@@ -136,6 +144,8 @@ BOOL UnlockedInterleavedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
         INJECT_FAULT(return FALSE;);
     }
     CONTRACTL_END;
+
+    _ASSERTE(m_pConfig->Template == NULL); // This path should only be used for LoaderHeaps which use the standard ExecutableAllocator functions
 
     size_t dwSizeToReserve;
 
@@ -222,6 +232,14 @@ BOOL UnlockedInterleavedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
     return TRUE;
 }
 
+void ReleaseAllocatedThunks(BYTE* thunks)
+{
+    ExecutableAllocator::Instance()->FreeThunksFromTemplate(thunks, GetStubCodePageSize());
+}
+
+using ThunkMemoryHolder = SpecializedWrapper<BYTE, ReleaseAllocatedThunks>;
+
+
 // Get some more committed pages - either commit some more in the current reserved region, or, if it
 // has run out, reserve another set of pages.
 // Returns: FALSE if we can't get any more memory
@@ -236,6 +254,57 @@ BOOL UnlockedInterleavedLoaderHeap::GetMoreCommittedPages(size_t dwMinSize)
         INJECT_FAULT(return FALSE;);
     }
     CONTRACTL_END;
+
+    if (m_pConfig->Template != NULL)
+    {
+        ThunkMemoryHolder newAllocatedThunks = (BYTE*)ExecutableAllocator::Instance()->AllocateThunksFromTemplate(m_pConfig->Template, GetStubCodePageSize());
+        if (newAllocatedThunks == NULL)
+        {
+            return FALSE;
+        }
+
+        NewHolder<LoaderHeapBlock> pNewBlock = new (nothrow) LoaderHeapBlock;
+        if (pNewBlock == NULL)
+        {
+            return FALSE;
+        }
+
+        size_t dwSizeToReserve = GetStubCodePageSize() * 2;
+    
+        // Record reserved range in range list, if one is specified
+        // Do this AFTER the commit - otherwise we'll have bogus ranges included.
+        if (m_pRangeList != NULL)
+        {
+            if (!m_pRangeList->AddRange((const BYTE *) newAllocatedThunks,
+                                        ((const BYTE *) newAllocatedThunks) + dwSizeToReserve,
+                                        (void *) this))
+            {
+                return FALSE;
+            }
+        }
+    
+        m_dwTotalAlloc += dwSizeToCommit;
+    
+        pNewBlock.SuppressRelease();
+        newAllocatedThunks.SuppressRelease();
+    
+        pNewBlock->dwVirtualSize    = dwSizeToReserve;
+        pNewBlock->pVirtualAddress  = newAllocatedThunks;
+        pNewBlock->pNext            = m_pFirstBlock;
+        pNewBlock->m_fReleaseMemory = TRUE;
+    
+        // Add to the linked list
+        m_pFirstBlock = pNewBlock;
+    
+        m_pAllocPtr = (BYTE*)newAllocatedThunks;
+        m_pPtrToEndOfCommittedRegion = m_pAllocPtr + GetStubCodePageSize();
+        m_pEndReservedRegion = m_pAllocPtr + dwSizeToReserve; // For consistency with the non-template path m_pEndReservedRegion is after the end of the data area
+        m_dwTotalAlloc += GetStubCodePageSize();
+
+        return TRUE;
+    }
+
+    // From here, all work is only for the dynamically allocated InterleavedLoaderHeap path
 
     // If we have memory we can use, what are you doing here!
     _ASSERTE(dwMinSize > (SIZE_T)(m_pPtrToEndOfCommittedRegion - m_pAllocPtr));
@@ -474,5 +543,11 @@ void *UnlockedInterleavedLoaderHeap::UnlockedAllocStub(
 
     return pResult;
 }
+
+void InitializeLoaderHeapConfig(InterleavedLoaderHeapConfig *pConfig, size_t stubSize, void* templateInImage, void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size))
+{
+    
+}
+
 #endif // #ifndef DACCESS_COMPILE
 

--- a/src/coreclr/utilcode/interleavedloaderheap.cpp
+++ b/src/coreclr/utilcode/interleavedloaderheap.cpp
@@ -541,7 +541,7 @@ void *UnlockedInterleavedLoaderHeap::UnlockedAllocStub(
 
 void InitializeLoaderHeapConfig(InterleavedLoaderHeapConfig *pConfig, size_t stubSize, void* templateInImage, void (*codePageGenerator)(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size))
 {
-    pConfig->StubSize = stubSize;
+    pConfig->StubSize = (uint32_t)stubSize;
     pConfig->Template = ExecutableAllocator::Instance()->CreateTemplate(templateInImage, GetStubCodePageSize(), codePageGenerator);
     pConfig->CodePageGenerator = codePageGenerator;
 }

--- a/src/coreclr/vm/amd64/thunktemplates.S
+++ b/src/coreclr/vm/amd64/thunktemplates.S
@@ -21,17 +21,25 @@
 // StubPrecode
 // ----------
 
-#define STUB_PRECODE_CODESIZE 0x10 // 3 instructions, 4 bytes each (and we also have 4 bytes of padding)
-#define STUB_PRECODE_DATASIZE 0x10 // 2 qwords
-#define STUB_PRECODE_NUM_THUNKS_PER_MAPPING 1024 // (THUNKS_MAP_SIZE / STUB_PRECODE_CODESIZE)
+#define STUB_PRECODE_CODESIZE 0x18 // 3 instructions, 13 bytes encoded + 11 bytes of padding
+#define STUB_PRECODE_DATASIZE 0x18 // 2 qwords + a BYTE
+.set STUB_PRECODE_NUM_THUNKS_PER_MAPPING,(THUNKS_MAP_SIZE / STUB_PRECODE_CODESIZE)
 
 .macro THUNKS_BLOCK_STUB_PRECODE
     IN_PAGE_INDEX = 0
     .rept STUB_PRECODE_NUM_THUNKS_PER_MAPPING
 
-    mov    r10, [rip + DATA_SLOT(StubPrecode, SecretParam, STUB_PRECODE_CODESIZE, StubPrecodeCode)]
-    jmp    [rip + DATA_SLOT(StubPrecode, Target, STUB_PRECODE_CODESIZE, StubPrecodeCode)]
-    // The above is 19 bytes
+    mov    r10, [rip + DATA_SLOT(StubPrecode, SecretParam, STUB_PRECODE_CODESIZE, StubPrecodeCodeTemplate)]
+    jmp    [rip + DATA_SLOT(StubPrecode, Target, STUB_PRECODE_CODESIZE, StubPrecodeCodeTemplate)]
+    // The above is 13 bytes
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
     int 3
     int 3
     int 3
@@ -41,9 +49,9 @@
 
     .text
     .p2align PAGE_SIZE_LOG2
-LEAF_ENTRY StubPrecodeCode
+LEAF_ENTRY StubPrecodeCodeTemplate
     THUNKS_BLOCK_STUB_PRECODE
-LEAF_END_MARKED StubPrecodeCode, _TEXT
+LEAF_END_MARKED StubPrecodeCodeTemplate, _TEXT
 
 // ----------
 // FixupPrecode
@@ -51,15 +59,15 @@ LEAF_END_MARKED StubPrecodeCode, _TEXT
 
 #define FIXUP_PRECODE_CODESIZE 0x18 
 #define FIXUP_PRECODE_DATASIZE 0x18 // 3 qwords
-#define FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING 682 // (THUNKS_MAP_SIZE / FIXUP_PRECODE_CODESIZE)
+.set FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING,(THUNKS_MAP_SIZE / FIXUP_PRECODE_CODESIZE)
 
 .macro THUNKS_BLOCK_FIXUP_PRECODE
     IN_PAGE_INDEX = 0
     .rept FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING
 
-        jmp    [rip + DATA_SLOT(FixupPrecode, Target, FIXUP_PRECODE_CODESIZE, FixupPrecodeCode)]
-        mov    r10, [rip + DATA_SLOT(FixupPrecode, MethodDesc, FIXUP_PRECODE_CODESIZE, FixupPrecodeCode)]
-        jmp    [rip + DATA_SLOT(FixupPrecode, PrecodeFixupThunk, FIXUP_PRECODE_CODESIZE, FixupPrecodeCode)]
+        jmp    [rip + DATA_SLOT(FixupPrecode, Target, FIXUP_PRECODE_CODESIZE, FixupPrecodeCodeTemplate)]
+        mov    r10, [rip + DATA_SLOT(FixupPrecode, MethodDesc, FIXUP_PRECODE_CODESIZE, FixupPrecodeCodeTemplate)]
+        jmp    [rip + DATA_SLOT(FixupPrecode, PrecodeFixupThunk, FIXUP_PRECODE_CODESIZE, FixupPrecodeCodeTemplate)]
         // The above is 19 bytes
         int 3
         int 3
@@ -72,7 +80,7 @@ LEAF_END_MARKED StubPrecodeCode, _TEXT
 
     .text
     .p2align PAGE_SIZE_LOG2
-LEAF_ENTRY FixupPrecodeCode
+LEAF_ENTRY FixupPrecodeCodeTemplate
     THUNKS_BLOCK_FIXUP_PRECODE
     // We need 16 bytes of padding to pad this out
     int 3
@@ -91,7 +99,7 @@ LEAF_ENTRY FixupPrecodeCode
     int 3
     int 3
     int 3
-LEAF_END_MARKED FixupPrecodeCode, _TEXT
+LEAF_END_MARKED FixupPrecodeCodeTemplate, _TEXT
 
 // ----------
 // CallCountingStub
@@ -99,25 +107,24 @@ LEAF_END_MARKED FixupPrecodeCode, _TEXT
 
 #define CALLCOUNTING_CODESIZE 0x18
 #define CALLCOUNTING_DATASIZE 0x18 // 3 qwords
-#define CALLCOUNTING_NUM_THUNKS_PER_MAPPING 682 // (THUNKS_MAP_SIZE / CALLCOUNTING_CODESIZE)
-
+.set CALLCOUNTING_NUM_THUNKS_PER_MAPPING, (THUNKS_MAP_SIZE / CALLCOUNTING_CODESIZE)
 .macro THUNKS_BLOCK_CALLCOUNTING
     IN_PAGE_INDEX = 0
     .rept CALLCOUNTING_NUM_THUNKS_PER_MAPPING
 
-        mov    rax,QWORD PTR [rip + DATA_SLOT(CallCountingStub, RemainingCallCountCell, CALLCOUNTING_CODESIZE, CallCountingStubCode)]
+        mov    rax,QWORD PTR [rip + DATA_SLOT(CallCountingStub, RemainingCallCountCell, CALLCOUNTING_CODESIZE, CallCountingStubCodeTemplate)]
         dec    WORD PTR [rax]
         je     0f
-        jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForMethod, CALLCOUNTING_CODESIZE, CallCountingStubCode)]
+        jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForMethod, CALLCOUNTING_CODESIZE, CallCountingStubCodeTemplate)]
     0:
-        jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForThresholdReached, CALLCOUNTING_CODESIZE, CallCountingStubCode)]
+        jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForThresholdReached, CALLCOUNTING_CODESIZE, CallCountingStubCodeTemplate)]
     IN_PAGE_INDEX = IN_PAGE_INDEX + 1
     .endr
 .endm
 
     .text
     .p2align PAGE_SIZE_LOG2
-LEAF_ENTRY CallCountingStubCode
+LEAF_ENTRY CallCountingStubCodeTemplate
     THUNKS_BLOCK_CALLCOUNTING
     // We need 16 bytes of padding to pad this out
     int 3
@@ -136,32 +143,36 @@ LEAF_ENTRY CallCountingStubCode
     int 3
     int 3
     int 3
-LEAF_END_MARKED CallCountingStubCode, _TEXT
+LEAF_END_MARKED CallCountingStubCodeTemplate, _TEXT
 
-//#else
+#endif
+
 // STUB_PAGE_SIZE must match the behavior of GetStubCodePageSize() on this architecture/os
 STUB_PAGE_SIZE = 16384
-#undef DATA_SLOT
-#define DATA_SLOT(stub, field) C_FUNC(stub##Code2) + STUB_PAGE_SIZE + stub##Data__##field
 
-LEAF_ENTRY StubPrecodeCode2, _TEXT
+#ifdef DATA_SLOT
+#undef DATA_SLOT
+#endif
+
+#define DATA_SLOT(stub, field) C_FUNC(stub##Code) + STUB_PAGE_SIZE + stub##Data__##field
+
+LEAF_ENTRY StubPrecodeCode, _TEXT
         mov    r10, [rip + DATA_SLOT(StubPrecode, SecretParam)]
         jmp    [rip + DATA_SLOT(StubPrecode, Target)]
-LEAF_END_MARKED StubPrecodeCode2, _TEXT
+LEAF_END_MARKED StubPrecodeCode, _TEXT
 
-LEAF_ENTRY FixupPrecodeCode2, _TEXT
+LEAF_ENTRY FixupPrecodeCode, _TEXT
         jmp    [rip + DATA_SLOT(FixupPrecode, Target)]
 PATCH_LABEL FixupPrecodeCode_Fixup
         mov    r10, [rip + DATA_SLOT(FixupPrecode, MethodDesc)]
         jmp    [rip + DATA_SLOT(FixupPrecode, PrecodeFixupThunk)]
-LEAF_END_MARKED FixupPrecodeCode2, _TEXT
+LEAF_END_MARKED FixupPrecodeCode, _TEXT
 
-LEAF_ENTRY CallCountingStubCode2, _TEXT
+LEAF_ENTRY CallCountingStubCode, _TEXT
         mov    rax,QWORD PTR [rip + DATA_SLOT(CallCountingStub, RemainingCallCountCell)]
         dec    WORD PTR [rax]
         je     LOCAL_LABEL(CountReachedZero)
         jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForMethod)]
     LOCAL_LABEL(CountReachedZero):
         jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForThresholdReached)]
-LEAF_END_MARKED CallCountingStubCode2, _TEXT
-#endif
+LEAF_END_MARKED CallCountingStubCode, _TEXT

--- a/src/coreclr/vm/amd64/thunktemplates.S
+++ b/src/coreclr/vm/amd64/thunktemplates.S
@@ -5,28 +5,163 @@
 #include "unixasmmacros.inc"
 #include "asmconstants.h"
 
-// STUB_PAGE_SIZE must match the behavior of GetStubCodePageSize() on this architecture/os
-STUB_PAGE_SIZE = 16384
+#ifdef FEATURE_MAP_THUNKS_FROM_IMAGE
 
-#define DATA_SLOT(stub, field) C_FUNC(stub##Code) + STUB_PAGE_SIZE + stub##Data__##field
+#define POINTER_SIZE 0x08
 
-LEAF_ENTRY StubPrecodeCode, _TEXT
-        mov    r10, [rip + DATA_SLOT(StubPrecode, SecretParam)]
-        jmp    [rip + DATA_SLOT(StubPrecode, Target)]
+#define THUNKS_MAP_SIZE 0x4000
+
+#define PAGE_SIZE 0x4000
+#define PAGE_SIZE_LOG2 14
+
+
+#define DATA_SLOT(stub, field, thunkSize, thunkTemplateName) C_FUNC(thunkTemplateName) + THUNKS_MAP_SIZE + stub##Data__##field + IN_PAGE_INDEX * thunkSize
+
+// ----------
+// StubPrecode
+// ----------
+
+#define STUB_PRECODE_CODESIZE 0x10 // 3 instructions, 4 bytes each (and we also have 4 bytes of padding)
+#define STUB_PRECODE_DATASIZE 0x10 // 2 qwords
+#define STUB_PRECODE_NUM_THUNKS_PER_MAPPING 1024 // (THUNKS_MAP_SIZE / STUB_PRECODE_CODESIZE)
+
+.macro THUNKS_BLOCK_STUB_PRECODE
+    IN_PAGE_INDEX = 0
+    .rept STUB_PRECODE_NUM_THUNKS_PER_MAPPING
+
+    mov    r10, [rip + DATA_SLOT(StubPrecode, SecretParam, STUB_PRECODE_CODESIZE, StubPrecodeCode)]
+    jmp    [rip + DATA_SLOT(StubPrecode, Target, STUB_PRECODE_CODESIZE, StubPrecodeCode)]
+    // The above is 19 bytes
+    int 3
+    int 3
+    int 3
+    IN_PAGE_INDEX = IN_PAGE_INDEX + 1
+    .endr
+.endm
+
+    .text
+    .p2align PAGE_SIZE_LOG2
+LEAF_ENTRY StubPrecodeCode
+    THUNKS_BLOCK_STUB_PRECODE
 LEAF_END_MARKED StubPrecodeCode, _TEXT
 
-LEAF_ENTRY FixupPrecodeCode, _TEXT
+// ----------
+// FixupPrecode
+// ----------
+
+#define FIXUP_PRECODE_CODESIZE 0x18 
+#define FIXUP_PRECODE_DATASIZE 0x18 // 3 qwords
+#define FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING 682 // (THUNKS_MAP_SIZE / FIXUP_PRECODE_CODESIZE)
+
+.macro THUNKS_BLOCK_FIXUP_PRECODE
+    IN_PAGE_INDEX = 0
+    .rept FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING
+
+        jmp    [rip + DATA_SLOT(FixupPrecode, Target, FIXUP_PRECODE_CODESIZE, FixupPrecodeCode)]
+        mov    r10, [rip + DATA_SLOT(FixupPrecode, MethodDesc, FIXUP_PRECODE_CODESIZE, FixupPrecodeCode)]
+        jmp    [rip + DATA_SLOT(FixupPrecode, PrecodeFixupThunk, FIXUP_PRECODE_CODESIZE, FixupPrecodeCode)]
+        // The above is 19 bytes
+        int 3
+        int 3
+        int 3
+        int 3
+        int 3
+    IN_PAGE_INDEX = IN_PAGE_INDEX + 1
+    .endr
+.endm
+
+    .text
+    .p2align PAGE_SIZE_LOG2
+LEAF_ENTRY FixupPrecodeCode
+    THUNKS_BLOCK_FIXUP_PRECODE
+    // We need 16 bytes of padding to pad this out
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+LEAF_END_MARKED FixupPrecodeCode, _TEXT
+
+// ----------
+// CallCountingStub
+// ----------
+
+#define CALLCOUNTING_CODESIZE 0x18
+#define CALLCOUNTING_DATASIZE 0x18 // 3 qwords
+#define CALLCOUNTING_NUM_THUNKS_PER_MAPPING 682 // (THUNKS_MAP_SIZE / CALLCOUNTING_CODESIZE)
+
+.macro THUNKS_BLOCK_CALLCOUNTING
+    IN_PAGE_INDEX = 0
+    .rept CALLCOUNTING_NUM_THUNKS_PER_MAPPING
+
+        mov    rax,QWORD PTR [rip + DATA_SLOT(CallCountingStub, RemainingCallCountCell, CALLCOUNTING_CODESIZE, CallCountingStubCode)]
+        dec    WORD PTR [rax]
+        je     0f
+        jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForMethod, CALLCOUNTING_CODESIZE, CallCountingStubCode)]
+    0:
+        jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForThresholdReached, CALLCOUNTING_CODESIZE, CallCountingStubCode)]
+    IN_PAGE_INDEX = IN_PAGE_INDEX + 1
+    .endr
+.endm
+
+    .text
+    .p2align PAGE_SIZE_LOG2
+LEAF_ENTRY CallCountingStubCode
+    THUNKS_BLOCK_CALLCOUNTING
+    // We need 16 bytes of padding to pad this out
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+    int 3
+LEAF_END_MARKED CallCountingStubCode, _TEXT
+
+//#else
+// STUB_PAGE_SIZE must match the behavior of GetStubCodePageSize() on this architecture/os
+STUB_PAGE_SIZE = 16384
+#undef DATA_SLOT
+#define DATA_SLOT(stub, field) C_FUNC(stub##Code2) + STUB_PAGE_SIZE + stub##Data__##field
+
+LEAF_ENTRY StubPrecodeCode2, _TEXT
+        mov    r10, [rip + DATA_SLOT(StubPrecode, SecretParam)]
+        jmp    [rip + DATA_SLOT(StubPrecode, Target)]
+LEAF_END_MARKED StubPrecodeCode2, _TEXT
+
+LEAF_ENTRY FixupPrecodeCode2, _TEXT
         jmp    [rip + DATA_SLOT(FixupPrecode, Target)]
 PATCH_LABEL FixupPrecodeCode_Fixup
         mov    r10, [rip + DATA_SLOT(FixupPrecode, MethodDesc)]
         jmp    [rip + DATA_SLOT(FixupPrecode, PrecodeFixupThunk)]
-LEAF_END_MARKED FixupPrecodeCode, _TEXT
+LEAF_END_MARKED FixupPrecodeCode2, _TEXT
 
-LEAF_ENTRY CallCountingStubCode, _TEXT
+LEAF_ENTRY CallCountingStubCode2, _TEXT
         mov    rax,QWORD PTR [rip + DATA_SLOT(CallCountingStub, RemainingCallCountCell)]
         dec    WORD PTR [rax]
         je     LOCAL_LABEL(CountReachedZero)
         jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForMethod)]
     LOCAL_LABEL(CountReachedZero):
         jmp    QWORD PTR [rip + DATA_SLOT(CallCountingStub, TargetForThresholdReached)]
-LEAF_END_MARKED CallCountingStubCode, _TEXT
+LEAF_END_MARKED CallCountingStubCode2, _TEXT
+#endif

--- a/src/coreclr/vm/arm64/thunktemplates.S
+++ b/src/coreclr/vm/arm64/thunktemplates.S
@@ -4,6 +4,110 @@
 #include "unixasmmacros.inc"
 #include "asmconstants.h"
 
+#ifdef FEATURE_MAP_THUNKS_FROM_IMAGE
+
+#define POINTER_SIZE 0x08
+
+#define THUNKS_MAP_SIZE 0x4000
+
+#define PAGE_SIZE 0x4000
+#define PAGE_SIZE_LOG2 14
+
+
+#define DATA_SLOT(stub, field, thunksPerPage, thunkTemplateName) . - (. - C_FUNC(thunkTemplateName)) + \THUNKS_MAP_SIZE + stub##Data__##field + IN_PAGE_INDEX * STUB_THUNK_CODESIZE
+
+// ----------
+// StubPrecode
+// ----------
+
+#define STUB_PRECODE_CODESIZE 0x10 // 3 instructions, 4 bytes each (and we also have 4 bytes of padding)
+#define STUB_PRECODE_DATASIZE 0x10 // 2 qwords
+#define STUB_PRECODE_NUM_THUNKS_PER_MAPPING (THUNKS_MAP_SIZE / STUB_PRECODE_CODESIZE)
+
+.macro THUNKS_BLOCK_STUB_PRECODE
+    IN_PAGE_INDEX = 0
+    .rept STUB_PRECODE_NUM_THUNKS_PER_MAP
+
+    ldr x10, DATA_SLOT(StubPrecode, Target, STUB_PRECODE_NUM_THUNKS_PER_MAPPING, StubPrecodeTemplate)
+    ldr x12, DATA_SLOT(StubPrecode, SecretParam, STUB_PRECODE_NUM_THUNKS_PER_MAPPING, StubPrecodeTemplate)
+    br x10
+
+    brk     0xf000      // Stubs need to be 16-byte in size to allow for the data to be 2 pointers
+
+    IN_PAGE_INDEX = IN_PAGE_INDEX + 1
+    .endr
+.endm
+
+    .text
+    .p2align PAGE_SIZE_LOG2
+LEAF_ENTRY StubPrecodeTemplate
+    THUNKS_BLOCK_STUB_PRECODE
+LEAF_END_MARKED StubPrecodeTemplate, _TEXT
+
+// ----------
+// FixupPrecode
+// ----------
+
+#define FIXUP_PRECODE_CODESIZE 0x18 // 5 instructions, 4 bytes each (and we also have 4 bytes of padding)
+#define FIXUP_PRECODE_DATASIZE 0x18 // 3 qwords
+#define FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING (THUNKS_MAP_SIZE / FIXUP_PRECODE_CODESIZE)
+
+.macro THUNKS_BLOCK_FIXUP_PRECODE
+    IN_PAGE_INDEX = 0
+    .rept FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING
+
+    ldr x11, DATA_SLOT(FixupPrecode, Target, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeTemplate)
+    br  x11
+    ldr x12, DATA_SLOT(FixupPrecode, MethodDesc, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeTemplate)
+    ldr x11, DATA_SLOT(FixupPrecode, PrecodeFixupThunk, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeTemplate)
+    br  x11        
+    brk     0xf000      // Stubs need to be 16-byte in size to allow for the data to be 2 pointers
+
+    IN_PAGE_INDEX = IN_PAGE_INDEX + 1
+    .endr
+.endm
+
+    .text
+    .p2align PAGE_SIZE_LOG2
+LEAF_ENTRY FixupPrecodeTemplate
+    THUNKS_BLOCK_FIXUP_PRECODE
+LEAF_END_MARKED FixupPrecodeTemplate, _TEXT
+
+// ----------
+// CallCountingStub
+// ----------
+
+#define CALLCOUNTING_CODESIZE 0x28 // 5 instructions, 4 bytes each (and we also have 4 bytes of padding)
+#define CALLCOUNTING_DATASIZE 0x18 // 3 qwords
+#define CALLCOUNTING_NUM_THUNKS_PER_MAPPING (THUNKS_MAP_SIZE / CALLCOUNTING_CODESIZE)
+
+.macro THUNKS_BLOCK_CALLCOUNTING
+    IN_PAGE_INDEX = 0
+    .rept CALLCOUNTING_NUM_THUNKS_PER_MAPPING
+
+        ldr  x9, DATA_SLOT(CallCountingStub, RemainingCallCountCell)
+        ldrh w10, [x9]
+        subs w10, w10, #1
+        strh w10, [x9]
+        beq LOCAL_LABEL(CountReachedZero\IN_PAGE_INDEX)
+        ldr  x9, DATA_SLOT(CallCountingStub, TargetForMethod)
+        br   x9
+LOCAL_LABEL(CountReachedZero\IN_PAGE_INDEX):
+        ldr  x10, DATA_SLOT(CallCountingStub, TargetForThresholdReached)
+        br   x10
+        brk     0xf000      // Stubs need to be 16-byte in size to allow for the data to be 2 pointers
+
+    IN_PAGE_INDEX = IN_PAGE_INDEX + 1
+    .endr
+.endm
+
+    .text
+    .p2align PAGE_SIZE_LOG2
+LEAF_ENTRY CallCountingStubTemplate
+    THUNKS_BLOCK_CALLCOUNTING
+LEAF_END_MARKED CallCountingStubTemplate, _TEXT
+
+#else
 #define DATA_SLOT(stub, field) . - (. - C_FUNC(stub##Code\STUB_PAGE_SIZE)) + \STUB_PAGE_SIZE + stub##Data__##field
 
     .irp STUB_PAGE_SIZE, 16384, 32768, 65536
@@ -37,3 +141,4 @@ LOCAL_LABEL(CountReachedZero\STUB_PAGE_SIZE):
     LEAF_END_MARKED CallCountingStubCode\STUB_PAGE_SIZE
 
     .endr
+#endif

--- a/src/coreclr/vm/arm64/thunktemplates.S
+++ b/src/coreclr/vm/arm64/thunktemplates.S
@@ -20,19 +20,21 @@
 // StubPrecode
 // ----------
 
-#define STUB_PRECODE_CODESIZE 0x10 // 3 instructions, 4 bytes each (and we also have 4 bytes of padding)
-#define STUB_PRECODE_DATASIZE 0x10 // 2 qwords
-#define STUB_PRECODE_NUM_THUNKS_PER_MAPPING (THUNKS_MAP_SIZE / STUB_PRECODE_CODESIZE)
+#define STUB_PRECODE_CODESIZE 0x18 // 3 instructions, 4 bytes each (and we also have 12 bytes of padding)
+#define STUB_PRECODE_DATASIZE 0x18 // 2 qwords + 1 byte
+.set STUB_PRECODE_NUM_THUNKS_PER_MAPPING,(THUNKS_MAP_SIZE / STUB_PRECODE_CODESIZE)
 
 .macro THUNKS_BLOCK_STUB_PRECODE
     IN_PAGE_INDEX = 0
     .rept STUB_PRECODE_NUM_THUNKS_PER_MAP
 
-    ldr x10, DATA_SLOT(StubPrecode, Target, STUB_PRECODE_NUM_THUNKS_PER_MAPPING, StubPrecodeTemplate)
-    ldr x12, DATA_SLOT(StubPrecode, SecretParam, STUB_PRECODE_NUM_THUNKS_PER_MAPPING, StubPrecodeTemplate)
+    ldr x10, DATA_SLOT(StubPrecode, Target, STUB_PRECODE_NUM_THUNKS_PER_MAPPING, StubPrecodeCodeTemplate)
+    ldr x12, DATA_SLOT(StubPrecode, SecretParam, STUB_PRECODE_NUM_THUNKS_PER_MAPPING, StubPrecodeCodeTemplate)
     br x10
 
-    brk     0xf000      // Stubs need to be 16-byte in size to allow for the data to be 2 pointers
+    brk     0xf000      // Stubs need to be 24-byte in size to allow for the data to be 2 pointers + 1 byte
+    brk     0xf000      // Stubs need to be 24-byte in size to allow for the data to be 2 pointers + 1 byte
+    brk     0xf000      // Stubs need to be 24-byte in size to allow for the data to be 2 pointers + 1 byte
 
     IN_PAGE_INDEX = IN_PAGE_INDEX + 1
     .endr
@@ -40,9 +42,9 @@
 
     .text
     .p2align PAGE_SIZE_LOG2
-LEAF_ENTRY StubPrecodeTemplate
+LEAF_ENTRY StubPrecodeCodeTemplate
     THUNKS_BLOCK_STUB_PRECODE
-LEAF_END_MARKED StubPrecodeTemplate, _TEXT
+LEAF_END_MARKED StubPrecodeCodeTemplate, _TEXT
 
 // ----------
 // FixupPrecode
@@ -50,18 +52,19 @@ LEAF_END_MARKED StubPrecodeTemplate, _TEXT
 
 #define FIXUP_PRECODE_CODESIZE 0x18 // 5 instructions, 4 bytes each (and we also have 4 bytes of padding)
 #define FIXUP_PRECODE_DATASIZE 0x18 // 3 qwords
+.set FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING,(THUNKS_MAP_SIZE / FIXUP_PRECODE_CODESIZE)
 #define FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING (THUNKS_MAP_SIZE / FIXUP_PRECODE_CODESIZE)
 
 .macro THUNKS_BLOCK_FIXUP_PRECODE
     IN_PAGE_INDEX = 0
     .rept FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING
 
-    ldr x11, DATA_SLOT(FixupPrecode, Target, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeTemplate)
+    ldr x11, DATA_SLOT(FixupPrecode, Target, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeCodeTemplate)
     br  x11
-    ldr x12, DATA_SLOT(FixupPrecode, MethodDesc, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeTemplate)
-    ldr x11, DATA_SLOT(FixupPrecode, PrecodeFixupThunk, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeTemplate)
+    ldr x12, DATA_SLOT(FixupPrecode, MethodDesc, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeCodeTemplate)
+    ldr x11, DATA_SLOT(FixupPrecode, PrecodeFixupThunk, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeCodeTemplate)
     br  x11        
-    brk     0xf000      // Stubs need to be 16-byte in size to allow for the data to be 2 pointers
+    brk     0xf000      // Stubs need to be 24-byte in size to allow for the data to be 2 pointers
 
     IN_PAGE_INDEX = IN_PAGE_INDEX + 1
     .endr
@@ -69,9 +72,9 @@ LEAF_END_MARKED StubPrecodeTemplate, _TEXT
 
     .text
     .p2align PAGE_SIZE_LOG2
-LEAF_ENTRY FixupPrecodeTemplate
+LEAF_ENTRY FixupPrecodeCodeTemplate
     THUNKS_BLOCK_FIXUP_PRECODE
-LEAF_END_MARKED FixupPrecodeTemplate, _TEXT
+LEAF_END_MARKED FixupPrecodeCodeTemplate, _TEXT
 
 // ----------
 // CallCountingStub
@@ -103,9 +106,9 @@ LOCAL_LABEL(CountReachedZero\IN_PAGE_INDEX):
 
     .text
     .p2align PAGE_SIZE_LOG2
-LEAF_ENTRY CallCountingStubTemplate
+LEAF_ENTRY CallCountingStubCodeTemplate
     THUNKS_BLOCK_CALLCOUNTING
-LEAF_END_MARKED CallCountingStubTemplate, _TEXT
+LEAF_END_MARKED CallCountingStubCodeTemplate, _TEXT
 
 #else
 #define DATA_SLOT(stub, field) . - (. - C_FUNC(stub##Code\STUB_PAGE_SIZE)) + \STUB_PAGE_SIZE + stub##Data__##field

--- a/src/coreclr/vm/arm64/thunktemplates.S
+++ b/src/coreclr/vm/arm64/thunktemplates.S
@@ -5,8 +5,10 @@
 #include "asmconstants.h"
 
 #ifdef FEATURE_MAP_THUNKS_FROM_IMAGE
-
 #define POINTER_SIZE 0x08
+// Since Arm64 supports 4KB, 16KB and 64KB page sizes, as the templates is only defined for 16KB page size, this cannot be used
+// in a general purpose Linux environment. However it CAN be used on Apple platforms, which specify that 16KB is the system standard
+// page size.
 
 #define THUNKS_MAP_SIZE 0x4000
 
@@ -14,7 +16,7 @@
 #define PAGE_SIZE_LOG2 14
 
 
-#define DATA_SLOT(stub, field, thunksPerPage, thunkTemplateName) . - (. - C_FUNC(thunkTemplateName)) + \THUNKS_MAP_SIZE + stub##Data__##field + IN_PAGE_INDEX * STUB_THUNK_CODESIZE
+#define DATA_SLOT(stub, field, thunkSize, thunkTemplateName) C_FUNC(thunkTemplateName) + THUNKS_MAP_SIZE + stub##Data__##field + IN_PAGE_INDEX * thunkSize
 
 // ----------
 // StubPrecode
@@ -22,14 +24,14 @@
 
 #define STUB_PRECODE_CODESIZE 0x18 // 3 instructions, 4 bytes each (and we also have 12 bytes of padding)
 #define STUB_PRECODE_DATASIZE 0x18 // 2 qwords + 1 byte
-.set STUB_PRECODE_NUM_THUNKS_PER_MAPPING,(THUNKS_MAP_SIZE / STUB_PRECODE_CODESIZE)
+.set STUB_PRECODE_NUM_THUNKS_PER_MAPPING, (THUNKS_MAP_SIZE / STUB_PRECODE_CODESIZE)
 
 .macro THUNKS_BLOCK_STUB_PRECODE
     IN_PAGE_INDEX = 0
-    .rept STUB_PRECODE_NUM_THUNKS_PER_MAP
+    .rept STUB_PRECODE_NUM_THUNKS_PER_MAPPING
 
-    ldr x10, DATA_SLOT(StubPrecode, Target, STUB_PRECODE_NUM_THUNKS_PER_MAPPING, StubPrecodeCodeTemplate)
-    ldr x12, DATA_SLOT(StubPrecode, SecretParam, STUB_PRECODE_NUM_THUNKS_PER_MAPPING, StubPrecodeCodeTemplate)
+    ldr x10, DATA_SLOT(StubPrecode, Target, STUB_PRECODE_CODESIZE, StubPrecodeCodeTemplate)
+    ldr x12, DATA_SLOT(StubPrecode, SecretParam, STUB_PRECODE_CODESIZE, StubPrecodeCodeTemplate)
     br x10
 
     brk     0xf000      // Stubs need to be 24-byte in size to allow for the data to be 2 pointers + 1 byte
@@ -53,18 +55,17 @@ LEAF_END_MARKED StubPrecodeCodeTemplate, _TEXT
 #define FIXUP_PRECODE_CODESIZE 0x18 // 5 instructions, 4 bytes each (and we also have 4 bytes of padding)
 #define FIXUP_PRECODE_DATASIZE 0x18 // 3 qwords
 .set FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING,(THUNKS_MAP_SIZE / FIXUP_PRECODE_CODESIZE)
-#define FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING (THUNKS_MAP_SIZE / FIXUP_PRECODE_CODESIZE)
 
 .macro THUNKS_BLOCK_FIXUP_PRECODE
     IN_PAGE_INDEX = 0
     .rept FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING
 
-    ldr x11, DATA_SLOT(FixupPrecode, Target, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeCodeTemplate)
+    ldr x11, DATA_SLOT(FixupPrecode, Target, FIXUP_PRECODE_CODESIZE, FixupPrecodeCodeTemplate)
     br  x11
-    ldr x12, DATA_SLOT(FixupPrecode, MethodDesc, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeCodeTemplate)
-    ldr x11, DATA_SLOT(FixupPrecode, PrecodeFixupThunk, FIXUP_PRECODE_NUM_THUNKS_PER_MAPPING, FixupPrecodeCodeTemplate)
+    ldr x12, DATA_SLOT(FixupPrecode, MethodDesc, FIXUP_PRECODE_CODESIZE, FixupPrecodeCodeTemplate)
+    ldr x11, DATA_SLOT(FixupPrecode, PrecodeFixupThunk, FIXUP_PRECODE_CODESIZE, FixupPrecodeCodeTemplate)
     br  x11        
-    brk     0xf000      // Stubs need to be 24-byte in size to allow for the data to be 2 pointers
+    brk     0xf000      // Stubs need to be 24-byte in size to allow for the data to be 3 pointers
 
     IN_PAGE_INDEX = IN_PAGE_INDEX + 1
     .endr
@@ -82,23 +83,23 @@ LEAF_END_MARKED FixupPrecodeCodeTemplate, _TEXT
 
 #define CALLCOUNTING_CODESIZE 0x28 // 5 instructions, 4 bytes each (and we also have 4 bytes of padding)
 #define CALLCOUNTING_DATASIZE 0x18 // 3 qwords
-#define CALLCOUNTING_NUM_THUNKS_PER_MAPPING (THUNKS_MAP_SIZE / CALLCOUNTING_CODESIZE)
+.set CALLCOUNTING_NUM_THUNKS_PER_MAPPING, (THUNKS_MAP_SIZE / CALLCOUNTING_CODESIZE)
 
 .macro THUNKS_BLOCK_CALLCOUNTING
     IN_PAGE_INDEX = 0
     .rept CALLCOUNTING_NUM_THUNKS_PER_MAPPING
 
-        ldr  x9, DATA_SLOT(CallCountingStub, RemainingCallCountCell)
+        ldr  x9, DATA_SLOT(CallCountingStub, RemainingCallCountCell, CALLCOUNTING_CODESIZE, CallCountingStubCodeTemplate)
         ldrh w10, [x9]
         subs w10, w10, #1
         strh w10, [x9]
-        beq LOCAL_LABEL(CountReachedZero\IN_PAGE_INDEX)
-        ldr  x9, DATA_SLOT(CallCountingStub, TargetForMethod)
+        beq 0f
+        ldr  x9, DATA_SLOT(CallCountingStub, TargetForMethod, CALLCOUNTING_CODESIZE, CallCountingStubCodeTemplate)
         br   x9
-LOCAL_LABEL(CountReachedZero\IN_PAGE_INDEX):
-        ldr  x10, DATA_SLOT(CallCountingStub, TargetForThresholdReached)
+0:
+        ldr  x10, DATA_SLOT(CallCountingStub, TargetForThresholdReached, CALLCOUNTING_CODESIZE, CallCountingStubCodeTemplate)
         br   x10
-        brk     0xf000      // Stubs need to be 16-byte in size to allow for the data to be 2 pointers
+        brk     0xf000      // Stubs need to be 40-byte in size to allow for the data to be pointer aligned
 
     IN_PAGE_INDEX = IN_PAGE_INDEX + 1
     .endr
@@ -109,8 +110,11 @@ LOCAL_LABEL(CountReachedZero\IN_PAGE_INDEX):
 LEAF_ENTRY CallCountingStubCodeTemplate
     THUNKS_BLOCK_CALLCOUNTING
 LEAF_END_MARKED CallCountingStubCodeTemplate, _TEXT
+#endif
 
-#else
+#ifdef DATA_SLOT
+#undef DATA_SLOT
+#endif
 #define DATA_SLOT(stub, field) . - (. - C_FUNC(stub##Code\STUB_PAGE_SIZE)) + \STUB_PAGE_SIZE + stub##Data__##field
 
     .irp STUB_PAGE_SIZE, 16384, 32768, 65536
@@ -144,4 +148,3 @@ LOCAL_LABEL(CountReachedZero\STUB_PAGE_SIZE):
     LEAF_END_MARKED CallCountingStubCode\STUB_PAGE_SIZE
 
     .endr
-#endif

--- a/src/coreclr/vm/callcounting.cpp
+++ b/src/coreclr/vm/callcounting.cpp
@@ -333,7 +333,7 @@ void CallCountingStub::StaticInitialize()
 
 #endif // DACCESS_COMPILE
 
-void CallCountingStub::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pageSize)
+void CallCountingStub::GenerateCodePage(uint8_t* pageBase, uint8_t* pageBaseRX, size_t pageSize)
 {
 #ifdef TARGET_X86
     int totalCodeSize = (pageSize / CallCountingStub::CodeSize) * CallCountingStub::CodeSize;
@@ -344,13 +344,13 @@ void CallCountingStub::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T
 
         // Set absolute addresses of the slots in the stub
         BYTE* pCounterSlot = pageBaseRX + i + pageSize + offsetof(CallCountingStubData, RemainingCallCountCell);
-        *(BYTE**)(pageBase + i + SYMBOL_VALUE(CallCountingStubCode_RemainingCallCountCell_Offset)) = pCounterSlot;
+        *(uint8_t**)(pageBase + i + SYMBOL_VALUE(CallCountingStubCode_RemainingCallCountCell_Offset)) = pCounterSlot;
 
         BYTE* pTargetSlot = pageBaseRX + i + pageSize + offsetof(CallCountingStubData, TargetForMethod);
-        *(BYTE**)(pageBase + i + SYMBOL_VALUE(CallCountingStubCode_TargetForMethod_Offset)) = pTargetSlot;
+        *(uint8_t**)(pageBase + i + SYMBOL_VALUE(CallCountingStubCode_TargetForMethod_Offset)) = pTargetSlot;
 
         BYTE* pCountReachedZeroSlot = pageBaseRX + i + pageSize + offsetof(CallCountingStubData, TargetForThresholdReached);
-        *(BYTE**)(pageBase + i + SYMBOL_VALUE(CallCountingStubCode_TargetForThresholdReached_Offset)) = pCountReachedZeroSlot;
+        *(uint8_t**)(pageBase + i + SYMBOL_VALUE(CallCountingStubCode_TargetForThresholdReached_Offset)) = pCountReachedZeroSlot;
     }
 #else // TARGET_X86
     FillStubCodePage(pageBase, (const void*)PCODEToPINSTR((PCODE)CallCountingStubCode), CallCountingStub::CodeSize, pageSize);

--- a/src/coreclr/vm/callcounting.cpp
+++ b/src/coreclr/vm/callcounting.cpp
@@ -318,6 +318,12 @@ void CallCountingStub::StaticInitialize()
             EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("Unsupported OS page size"));
     }
     #undef ENUM_PAGE_SIZE
+
+    if (CallCountingStubCodeTemplate != NULL && pageSize != 0x4000)
+    {
+        // This should fail if the template is used on a platform which doesn't support the supported page size for templates
+        ThrowHR(COR_E_EXECUTIONENGINE);
+    }
 #else
     _ASSERTE((SIZE_T)((BYTE*)CallCountingStubCode_End - (BYTE*)CallCountingStubCode) <= CallCountingStub::CodeSize);
 #endif

--- a/src/coreclr/vm/callcounting.h
+++ b/src/coreclr/vm/callcounting.h
@@ -150,7 +150,7 @@ public:
     static void StaticInitialize();
 #endif // !DACCESS_COMPILE
 
-    static void GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size);
+    static void GenerateCodePage(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size);
 
     PTR_CallCount GetRemainingCallCountCell() const;
     PCODE GetTargetForMethod() const;

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -1208,8 +1208,7 @@ void LoaderAllocator::Init(BYTE *pExecutableHeapMemory)
     m_pNewStubPrecodeHeap = new (&m_NewStubPrecodeHeapInstance) InterleavedLoaderHeap(
                                                                            &m_stubPrecodeRangeList,
                                                                            false /* fUnlocked */,
-                                                                           StubPrecode::GenerateCodePage,
-                                                                           StubPrecode::CodeSize);
+                                                                           &s_stubPrecodeHeapConfig);
 
 #if defined(FEATURE_STUBPRECODE_DYNAMIC_HELPERS) && defined(FEATURE_READYTORUN)
     if (IsCollectible())
@@ -1219,14 +1218,12 @@ void LoaderAllocator::Init(BYTE *pExecutableHeapMemory)
     m_pDynamicHelpersStubHeap = new (&m_DynamicHelpersHeapInstance) InterleavedLoaderHeap(
                                                                                &m_dynamicHelpersRangeList,
                                                                                false /* fUnlocked */,
-                                                                               StubPrecode::GenerateCodePage,
-                                                                               StubPrecode::CodeSize);
+                                                                               &s_stubPrecodeHeapConfig);
 #endif // defined(FEATURE_STUBPRECODE_DYNAMIC_HELPERS) && defined(FEATURE_READYTORUN)
 
     m_pFixupPrecodeHeap = new (&m_FixupPrecodeHeapInstance) InterleavedLoaderHeap(&m_fixupPrecodeRangeList,
                                                                        false /* fUnlocked */,
-                                                                       FixupPrecode::GenerateCodePage,
-                                                                       FixupPrecode::CodeSize);
+                                                                       &s_fixupStubPrecodeHeapConfig);
 
     // Initialize the EE marshaling data to NULL.
     m_pMarshalingData = NULL;

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -15,6 +15,11 @@
 #include "perfmap.h"
 #endif
 
+InterleavedLoaderHeapConfig s_stubPrecodeHeapConfig;
+#ifdef HAS_FIXUP_PRECODE
+InterleavedLoaderHeapConfig s_fixupStubPrecodeHeapConfig;
+#endif
+
 //==========================================================================================
 // class Precode
 //==========================================================================================
@@ -495,6 +500,12 @@ void (*StubPrecode::StubPrecodeCode)();
 void (*StubPrecode::StubPrecodeCode_End)();
 #endif
 
+#ifdef FEATURE_MAP_THUNKS_FROM_IMAGE
+extern "C" void StubPrecodeCodeTemplate();
+#else
+#define StubPrecodeCodeTemplate NULL
+#endif
+
 void StubPrecode::StaticInitialize()
 {
 #if defined(TARGET_ARM64) && defined(TARGET_UNIX)
@@ -524,6 +535,7 @@ void StubPrecode::StaticInitialize()
     _ASSERTE((*((BYTE*)PCODEToPINSTR((PCODE)StubPrecodeCode) + OFFSETOF_PRECODE_TYPE)) == StubPrecode::Type);
 #endif
 
+    InitializeLoaderHeapConfig(&s_stubPrecodeHeapConfig, StubPrecode::CodeSize, (void*)StubPrecodeCodeTemplate, StubPrecode::GenerateCodePage);
 }
 
 void StubPrecode::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pageSize)
@@ -626,6 +638,12 @@ void (*FixupPrecode::FixupPrecodeCode)();
 void (*FixupPrecode::FixupPrecodeCode_End)();
 #endif
 
+#ifdef FEATURE_MAP_THUNKS_FROM_IMAGE
+extern "C" void FixupPrecodeCodeTemplate();
+#else
+#define FixupPrecodeCodeTemplate NULL
+#endif
+
 void FixupPrecode::StaticInitialize()
 {
 #if defined(TARGET_ARM64) && defined(TARGET_UNIX)
@@ -655,6 +673,8 @@ void FixupPrecode::StaticInitialize()
 #else
     _ASSERTE(*((BYTE*)PCODEToPINSTR((PCODE)FixupPrecodeCode) + OFFSETOF_PRECODE_TYPE) == FixupPrecode::Type);
 #endif
+
+    InitializeLoaderHeapConfig(&s_fixupStubPrecodeHeapConfig, FixupPrecode::CodeSize, (void*)FixupPrecodeCodeTemplate, FixupPrecode::GenerateCodePage);
 }
 
 void FixupPrecode::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pageSize)

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -545,19 +545,19 @@ void StubPrecode::StaticInitialize()
     InitializeLoaderHeapConfig(&s_stubPrecodeHeapConfig, StubPrecode::CodeSize, (void*)StubPrecodeCodeTemplate, StubPrecode::GenerateCodePage);
 }
 
-void StubPrecode::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pageSize)
+void StubPrecode::GenerateCodePage(uint8_t* pageBase, uint8_t* pageBaseRX, size_t pageSize)
 {
 #ifdef TARGET_X86
     int totalCodeSize = (pageSize / StubPrecode::CodeSize) * StubPrecode::CodeSize;
     for (int i = 0; i < totalCodeSize; i += StubPrecode::CodeSize)
     {
-        memcpy(pageBase + i, (const void*)StubPrecodeCode, (BYTE*)StubPrecodeCode_End - (BYTE*)StubPrecodeCode);
+        memcpy(pageBase + i, (const void*)StubPrecodeCode, (uint8_t*)StubPrecodeCode_End - (uint8_t*)StubPrecodeCode);
 
-        BYTE* pTargetSlot = pageBaseRX + i + pageSize + offsetof(StubPrecodeData, Target);
-        *(BYTE**)(pageBase + i + SYMBOL_VALUE(StubPrecodeCode_Target_Offset)) = pTargetSlot;
+        uint8_t* pTargetSlot = pageBaseRX + i + pageSize + offsetof(StubPrecodeData, Target);
+        *(uint8_t**)(pageBase + i + SYMBOL_VALUE(StubPrecodeCode_Target_Offset)) = pTargetSlot;
 
         BYTE* pMethodDescSlot = pageBaseRX + i + pageSize + offsetof(StubPrecodeData, SecretParam);
-        *(BYTE**)(pageBase + i + SYMBOL_VALUE(StubPrecodeCode_MethodDesc_Offset)) = pMethodDescSlot;
+        *(uint8_t**)(pageBase + i + SYMBOL_VALUE(StubPrecodeCode_MethodDesc_Offset)) = pMethodDescSlot;
     }
 #else // TARGET_X86
     FillStubCodePage(pageBase, (const void*)PCODEToPINSTR((PCODE)StubPrecodeCode), StubPrecode::CodeSize, pageSize);
@@ -690,7 +690,7 @@ void FixupPrecode::StaticInitialize()
     InitializeLoaderHeapConfig(&s_fixupStubPrecodeHeapConfig, FixupPrecode::CodeSize, (void*)FixupPrecodeCodeTemplate, FixupPrecode::GenerateCodePage);
 }
 
-void FixupPrecode::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pageSize)
+void FixupPrecode::GenerateCodePage(uint8_t* pageBase, uint8_t* pageBaseRX, size_t pageSize)
 {
 #ifdef TARGET_X86
     int totalCodeSize = (pageSize / FixupPrecode::CodeSize) * FixupPrecode::CodeSize;
@@ -698,14 +698,14 @@ void FixupPrecode::GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T pag
     for (int i = 0; i < totalCodeSize; i += FixupPrecode::CodeSize)
     {
         memcpy(pageBase + i, (const void*)FixupPrecodeCode, FixupPrecode::CodeSize);
-        BYTE* pTargetSlot = pageBaseRX + i + pageSize + offsetof(FixupPrecodeData, Target);
-        *(BYTE**)(pageBase + i + SYMBOL_VALUE(FixupPrecodeCode_Target_Offset)) = pTargetSlot;
+        uint8_t* pTargetSlot = pageBaseRX + i + pageSize + offsetof(FixupPrecodeData, Target);
+        *(uint8_t**)(pageBase + i + SYMBOL_VALUE(FixupPrecodeCode_Target_Offset)) = pTargetSlot;
 
         BYTE* pMethodDescSlot = pageBaseRX + i + pageSize + offsetof(FixupPrecodeData, MethodDesc);
-        *(BYTE**)(pageBase + i + SYMBOL_VALUE(FixupPrecodeCode_MethodDesc_Offset)) = pMethodDescSlot;
+        *(uint8_t**)(pageBase + i + SYMBOL_VALUE(FixupPrecodeCode_MethodDesc_Offset)) = pMethodDescSlot;
 
         BYTE* pPrecodeFixupThunkSlot = pageBaseRX + i + pageSize + offsetof(FixupPrecodeData, PrecodeFixupThunk);
-        *(BYTE**)(pageBase + i + SYMBOL_VALUE(FixupPrecodeCode_PrecodeFixupThunk_Offset)) = pPrecodeFixupThunkSlot;
+        *(uint8_t**)(pageBase + i + SYMBOL_VALUE(FixupPrecodeCode_PrecodeFixupThunk_Offset)) = pPrecodeFixupThunkSlot;
     }
 #else // TARGET_X86
     FillStubCodePage(pageBase, (const void*)PCODEToPINSTR((PCODE)FixupPrecodeCode), FixupPrecode::CodeSize, pageSize);

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -523,6 +523,13 @@ void StubPrecode::StaticInitialize()
         default:
             EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("Unsupported OS page size"));
     }
+
+    if (StubPrecodeCodeTemplate != NULL && pageSize != 0x4000)
+    {
+        // This should fail if the template is used on a platform which doesn't support the supported page size for templates
+        ThrowHR(COR_E_EXECUTIONENGINE);
+    }
+
     #undef ENUM_PAGE_SIZE
 #else
     _ASSERTE((SIZE_T)((BYTE*)StubPrecodeCode_End - (BYTE*)StubPrecodeCode) <= StubPrecode::CodeSize);
@@ -663,6 +670,12 @@ void FixupPrecode::StaticInitialize()
             EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("Unsupported OS page size"));
     }
     #undef ENUM_PAGE_SIZE
+
+    if (FixupPrecodeCodeTemplate != NULL && pageSize != 0x4000)
+    {
+        // This should fail if the template is used on a platform which doesn't support the supported page size for templates
+        ThrowHR(COR_E_EXECUTIONENGINE);
+    }
 #else
     _ASSERTE((SIZE_T)((BYTE*)FixupPrecodeCode_End - (BYTE*)FixupPrecodeCode) <= FixupPrecode::CodeSize);
 #endif

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -868,4 +868,9 @@ public:
 };
 #endif //DACCESS_COMPILE
 
+extern InterleavedLoaderHeapConfig s_stubPrecodeHeapConfig;
+#ifdef HAS_FIXUP_PRECODE
+extern InterleavedLoaderHeapConfig s_fixupStubPrecodeHeapConfig;
+#endif
+
 #endif // __PRECODE_H__

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -225,7 +225,7 @@ struct StubPrecode
         pData->Target = (PCODE)target;
     }
 
-    static void GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size);
+    static void GenerateCodePage(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size);
 
 #endif // !DACCESS_COMPILE
 };
@@ -428,7 +428,7 @@ struct FixupPrecode
 
     static void StaticInitialize();
 
-    static void GenerateCodePage(BYTE* pageBase, BYTE* pageBaseRX, SIZE_T size);
+    static void GenerateCodePage(uint8_t* pageBase, uint8_t* pageBaseRX, size_t size);
 
     PTR_FixupPrecodeData GetData() const
     {


### PR DESCRIPTION
Instead of generating stub templates by running the code page generation function for each stub code region that is generated, map a single file into memory in multiple locations instead. This logic is architected so that it can fall back to the previous model of using the double mapping logic to generate the stubs.

We implement 3 schemes for finding the to use as mapping data.
1. On apple platforms, we compile the stubs into the coreclr Mach-O file, and use the virtual memory manager support for mapping memory from the coreclr binary into various locations on the heap.
2. On Linux platforms, we can compile the stubs into the coreclr ELF file, and then use the `dladdr` and `dl_iterate_phdr` functionality to find the file name of the coreclr binary and the section that contains it, and then we can use mmap to map from the file directly into memory. This mode is disabled by default as it doesn't support all scenarios, but it does allow for testing of the majority of the logic used on Apple platforms on a Linux machine.
3. On Unix platforms that are not Linux or Linux when mode 2 is not enabled, we use an anonymous in memory file just like our normal executable allocation path.
4. On Windows platforms, we currently do not yet support this mode.
