### PR TITLE
Enable jit optimization in crossgen testing

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -110,7 +110,8 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         done
 
         echo -o:"$__OutputFile" >> "$__ResponseFile"
-        echo -O >> "$__ResponseFile"
+        ## Enable once #114504 is fixed
+        ## echo -O >> "$__ResponseFile"
         echo --targetarch:$(TargetArchitecture) >> "$__ResponseFile"
         echo --targetos:$(TargetOS) >> "$__ResponseFile"
         echo --verify-type-and-field-layout >> "$__ResponseFile"

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -110,6 +110,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         done
 
         echo -o:"$__OutputFile" >> "$__ResponseFile"
+        echo -O >> "$__ResponseFile"
         echo --targetarch:$(TargetArchitecture) >> "$__ResponseFile"
         echo --targetos:$(TargetOS) >> "$__ResponseFile"
         echo --verify-type-and-field-layout >> "$__ResponseFile"
@@ -276,6 +277,7 @@ if defined RunCrossGen2 (
     set __Command=!__Command! !ExtraCrossGen2Args!
 
     echo !__InputFile!>>!__ResponseFile!
+    echo -O>!__ResponseFile!
     echo -o:!__OutputFile!>>!__ResponseFile!
     echo --targetarch:$(TargetArchitecture)>>!__ResponseFile!
     echo --targetos:$(TargetOS)>>!__ResponseFile!

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -277,7 +277,7 @@ if defined RunCrossGen2 (
     set __Command=!__Command! !ExtraCrossGen2Args!
 
     echo !__InputFile!>>!__ResponseFile!
-    echo -O>!__ResponseFile!
+    echo -O>>!__ResponseFile!
     echo -o:!__OutputFile!>>!__ResponseFile!
     echo --targetarch:$(TargetArchitecture)>>!__ResponseFile!
     echo --targetos:$(TargetOS)>>!__ResponseFile!

--- a/src/tests/JIT/Directed/debugging/poisoning/poison.csproj
+++ b/src/tests/JIT/Directed/debugging/poisoning/poison.csproj
@@ -3,6 +3,7 @@
     <DebugType>PdbOnly</DebugType>
     <Optimize>False</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Directed/debugging/poisoning/poison.csproj
+++ b/src/tests/JIT/Directed/debugging/poisoning/poison.csproj
@@ -3,6 +3,8 @@
     <DebugType>PdbOnly</DebugType>
     <Optimize>False</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <!-- Needed for CrossGenTest -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/throwbox/filter.il
+++ b/src/tests/JIT/Directed/throwbox/filter.il
@@ -14,7 +14,7 @@
   .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
-    .method public hidebysig static int32 Main() cil managed
+    .method public hidebysig static int32 Main() cil managed aggressiveinlining
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Directed/throwbox/filter.il
+++ b/src/tests/JIT/Directed/throwbox/filter.il
@@ -14,7 +14,7 @@
   .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
-    .method public hidebysig static int32 Main() cil managed aggressiveinlining
+    .method public hidebysig static int32 Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00


### PR DESCRIPTION
Also mark `filter` test entry point as `aggressiveinlining` to create a cross-assembly wrapped exception throw test when crossgen2 runs in composite mode.

(see  #113815 / #113849)