### PR TITLE
Fix GC hole with `rorx` instruction

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -15331,8 +15331,14 @@ DONE:
             {
                 case IF_RWR_ARD:
                 case IF_RRW_ARD:
+                case IF_RWR_ARD_CNS:
+                case IF_RRW_ARD_CNS:
+                case IF_RWR_ARD_RRD:
+                case IF_RRW_ARD_RRD:
                 case IF_RWR_RRD_ARD:
                 case IF_RRW_RRD_ARD:
+                case IF_RWR_RRD_ARD_CNS:
+                case IF_RWR_RRD_ARD_RRD:
                 {
                     emitGCregDeadUpd(id->idReg1(), dst);
                     break;


### PR DESCRIPTION
The `rorx` instruction uses format IF_RWR_ARD_CNS. This format was not handled when killing GC refs in `emitOutputAM`.

I added other cases of register write "ARD" address mode formats to the same case as "defense in depth" -- most or all of them are probably SIMD instructions with SIMD destination registers, and won't go down this code path.

Diffs include cases in the HardwareIntrinsics tests, but also in the libraries code, for both x64 and x86.

Fixes #114445
