### PR TITLE
Make CertificateRequest et al work with ML-DSA

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -753,7 +753,12 @@ namespace System.Security.Cryptography
                         AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
                         SubjectPublicKeyInfoAsn.Decode(ref reader, manager.Memory, out SubjectPublicKeyInfoAsn spki);
 
-                        MLDsaAlgorithm algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(spki.Algorithm.Algorithm);
+                        MLDsaAlgorithm? algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(spki.Algorithm.Algorithm);
+
+                        if (algorithm is null)
+                        {
+                            throw Helpers.CreateAlgorithmUnknownException(spki.Algorithm.Algorithm);
+                        }
 
                         if (spki.Algorithm.Parameters.HasValue)
                         {
@@ -803,7 +808,12 @@ namespace System.Security.Cryptography
                         AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
                         PrivateKeyInfoAsn.Decode(ref reader, manager.Memory, out PrivateKeyInfoAsn pki);
 
-                        MLDsaAlgorithm algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(pki.PrivateKeyAlgorithm.Algorithm);
+                        MLDsaAlgorithm? algorithm = MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(pki.PrivateKeyAlgorithm.Algorithm);
+
+                        if (algorithm is null)
+                        {
+                            throw Helpers.CreateAlgorithmUnknownException(pki.PrivateKeyAlgorithm.Algorithm);
+                        }
 
                         if (pki.PrivateKeyAlgorithm.Parameters.HasValue)
                         {

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaAlgorithm.cs
@@ -107,22 +107,15 @@ namespace System.Security.Cryptography
         /// </value>
         public static MLDsaAlgorithm MLDsa87 { get; } = new MLDsaAlgorithm("ML-DSA-87", 4896, 2592, 4627, Oids.MLDsa87);
 
-        internal static MLDsaAlgorithm GetMLDsaAlgorithmFromOid(string oid)
+        internal static MLDsaAlgorithm? GetMLDsaAlgorithmFromOid(string? oid)
         {
             return oid switch
             {
                 Oids.MLDsa44 => MLDsa44,
                 Oids.MLDsa65 => MLDsa65,
                 Oids.MLDsa87 => MLDsa87,
-                _ => ThrowAlgorithmUnknown(oid),
+                _ => null,
             };
-        }
-
-        [DoesNotReturn]
-        private static MLDsaAlgorithm ThrowAlgorithmUnknown(string algorithmId)
-        {
-            throw new CryptographicException(
-                SR.Format(SR.Cryptography_UnknownAlgorithmIdentifier, algorithmId));
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.NotSupported.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.NotSupported.cs
@@ -26,19 +26,19 @@ namespace System.Security.Cryptography
         protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa GenerateKeyImpl(MLDsaAlgorithm algorithm) =>
+        internal static partial MLDsaImplementation GenerateKeyImpl(MLDsaAlgorithm algorithm) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial MLDsaImplementation ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial MLDsaImplementation ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial MLDsaImplementation ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
@@ -27,19 +27,19 @@ namespace System.Security.Cryptography
         protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa GenerateKeyImpl(MLDsaAlgorithm algorithm) =>
+        internal static partial MLDsaImplementation GenerateKeyImpl(MLDsaAlgorithm algorithm) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial MLDsaImplementation ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial MLDsaImplementation ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial MLDsaImplementation ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
@@ -17,10 +17,32 @@ namespace System.Security.Cryptography
 
         internal static partial bool SupportsAny();
 
-        internal static partial MLDsa GenerateKeyImpl(MLDsaAlgorithm algorithm);
-        internal static partial MLDsa ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
-        internal static partial MLDsa ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
-        internal static partial MLDsa ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
-        internal static partial MLDsa ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
+        internal static partial MLDsaImplementation GenerateKeyImpl(MLDsaAlgorithm algorithm);
+        internal static partial MLDsaImplementation ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
+        internal static partial MLDsaImplementation ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
+        internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
+        internal static partial MLDsaImplementation ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
+
+        internal static MLDsaImplementation DuplicatePrivateKey(MLDsa key)
+        {
+            MLDsaAlgorithm alg = key.Algorithm;
+            byte[] rented = CryptoPool.Rent(alg.SecretKeySizeInBytes);
+            int written = 0;
+
+            try
+            {
+                written = key.ExportMLDsaPrivateSeed(rented);
+                return ImportSeed(alg, new ReadOnlySpan<byte>(rented, 0, written));
+            }
+            catch (CryptographicException)
+            {
+                written = key.ExportMLDsaSecretKey(rented);
+                return ImportSecretKey(alg, new ReadOnlySpan<byte>(rented, 0, written));
+            }
+            finally
+            {
+                CryptoPool.Return(rented, written);
+            }
+        }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
@@ -23,8 +23,17 @@ namespace System.Security.Cryptography
         internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
         internal static partial MLDsaImplementation ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
 
+        /// <summary>
+        ///   Duplicates an ML-DSA private key by export/import.
+        ///   Only intended to be used when the key type is unknown.
+        /// </summary>
         internal static MLDsaImplementation DuplicatePrivateKey(MLDsa key)
         {
+            // The implementation type and any platform types (e.g. MLDsaOpenSsl)
+            // should inherently know how to clone themselves without the crudeness
+            // of export/import.
+            Debug.Assert(key is not MLDsaImplementation);
+
             MLDsaAlgorithm alg = key.Algorithm;
             byte[] rented = CryptoPool.Rent(alg.SecretKeySizeInBytes);
             int written = 0;

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestImplementation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestImplementation.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    internal sealed class MLDsaTestImplementation : MLDsa
+    {
+        internal delegate void ExportAction(Span<byte> destination);
+        internal delegate void SignAction(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        internal delegate bool VerifyFunc(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+
+        internal ExportAction ExportMLDsaPrivateSeedHook { get; set; }
+        internal ExportAction ExportMLDsaPublicKeyHook { get; set; }
+        internal ExportAction ExportMLDsaSecretKeyHook { get; set; }
+        internal SignAction SignDataHook { get; set; }
+        internal VerifyFunc VerifyDataHook { get; set; }
+        internal Action<bool> DisposeHook { get; set; } = _ => { };
+
+        private MLDsaTestImplementation(MLDsaAlgorithm algorithm) : base(algorithm)
+        {
+        }
+
+        protected override void Dispose(bool disposing) => DisposeHook(disposing);
+
+        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) => ExportMLDsaPrivateSeedHook(destination);
+        protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) => ExportMLDsaPublicKeyHook(destination);
+        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination) => ExportMLDsaSecretKeyHook(destination);
+
+        protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) =>
+            SignDataHook(data, context, destination);
+
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) =>
+            VerifyDataHook(data, context, signature);
+
+        internal static MLDsaTestImplementation CreateOverriddenCoreMethodsFail(MLDsaAlgorithm algorithm)
+        {
+            return new MLDsaTestImplementation(algorithm)
+            {
+                ExportMLDsaPrivateSeedHook = _ => Assert.Fail(),
+                ExportMLDsaPublicKeyHook = _ => Assert.Fail(),
+                ExportMLDsaSecretKeyHook = _ => Assert.Fail(),
+                SignDataHook = (_, _, _) => Assert.Fail(),
+                VerifyDataHook = (_, _, _) => { Assert.Fail(); return false; },
+            };
+        }
+
+        internal static MLDsaTestImplementation CreateNoOp(MLDsaAlgorithm algorithm)
+        {
+            return new MLDsaTestImplementation(algorithm)
+            {
+                ExportMLDsaPrivateSeedHook = d => d.Clear(),
+                ExportMLDsaPublicKeyHook = d => d.Clear(),
+                ExportMLDsaSecretKeyHook = d => d.Clear(),
+                SignDataHook = (data, context, destination) => destination.Clear(),
+                VerifyDataHook = (data, context, signature) => signature.IndexOfAnyExcept((byte)0) == -1,
+            };
+        }
+
+        internal static MLDsaTestImplementation Wrap(MLDsa other)
+        {
+            return new MLDsaTestImplementation(other.Algorithm)
+            {
+                ExportMLDsaPrivateSeedHook = d => other.ExportMLDsaPrivateSeed(d),
+                ExportMLDsaPublicKeyHook = d => other.ExportMLDsaPublicKey(d),
+                ExportMLDsaSecretKeyHook = d => other.ExportMLDsaSecretKey(d),
+                SignDataHook = (data, context, destination) => other.SignData(data, destination, context),
+                VerifyDataHook = (data, context, signature) => other.VerifyData(data, signature, context),
+            };
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -3062,10 +3062,14 @@ namespace System.Security.Cryptography.X509Certificates
     public sealed partial class CertificateRequest
     {
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.ECDsa key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.MLDsa key) { }
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.RSA key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { }
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.X509Certificates.PublicKey publicKey, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
         public CertificateRequest(System.Security.Cryptography.X509Certificates.X500DistinguishedName subjectName, System.Security.Cryptography.X509Certificates.PublicKey publicKey, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding? rsaSignaturePadding = null) { }
         public CertificateRequest(string subjectName, System.Security.Cryptography.ECDsa key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public CertificateRequest(string subjectName, System.Security.Cryptography.MLDsa key) { }
         public CertificateRequest(string subjectName, System.Security.Cryptography.RSA key, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { }
         public System.Collections.ObjectModel.Collection<System.Security.Cryptography.X509Certificates.X509Extension> CertificateExtensions { get { throw null; } }
         public System.Security.Cryptography.HashAlgorithmName HashAlgorithm { get { throw null; } }
@@ -3183,6 +3187,9 @@ namespace System.Security.Cryptography.X509Certificates
         public System.Security.Cryptography.ECDiffieHellman? GetECDiffieHellmanPublicKey() { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Cryptography.ECDsa? GetECDsaPublicKey() { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
+        public System.Security.Cryptography.MLDsa? GetMLDsaPublicKey() { throw null; }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Security.Cryptography.MLKem? GetMLKemPublicKey() { throw null; }
@@ -3497,6 +3504,8 @@ namespace System.Security.Cryptography.X509Certificates
         public string Thumbprint { get { throw null; } }
         public int Version { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 CopyWithPrivateKey(System.Security.Cryptography.ECDiffieHellman privateKey) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 CopyWithPrivateKey(System.Security.Cryptography.MLDsa privateKey) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static System.Security.Cryptography.X509Certificates.X509Certificate2 CreateFromEncryptedPem(System.ReadOnlySpan<char> certPem, System.ReadOnlySpan<char> keyPem, System.ReadOnlySpan<char> password) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -3516,6 +3525,10 @@ namespace System.Security.Cryptography.X509Certificates
         public static System.Security.Cryptography.X509Certificates.X509ContentType GetCertContentType(string fileName) { throw null; }
         public System.Security.Cryptography.ECDiffieHellman? GetECDiffieHellmanPrivateKey() { throw null; }
         public System.Security.Cryptography.ECDiffieHellman? GetECDiffieHellmanPublicKey() { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public System.Security.Cryptography.MLDsa? GetMLDsaPrivateKey() { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public System.Security.Cryptography.MLDsa? GetMLDsaPublicKey() { throw null; }
         public string GetNameInfo(System.Security.Cryptography.X509Certificates.X509NameType nameType, bool forIssuer) { throw null; }
         [System.ObsoleteAttribute("X509Certificate and X509Certificate2 are immutable. Use X509CertificateLoader to create a new certificate.", DiagnosticId="SYSLIB0026", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public override void Import(byte[] rawData) { }
@@ -3905,6 +3918,8 @@ namespace System.Security.Cryptography.X509Certificates
         public System.Security.Cryptography.X509Certificates.PublicKey PublicKey { get { throw null; } }
         protected abstract System.Security.Cryptography.X509Certificates.PublicKey BuildPublicKey();
         public static System.Security.Cryptography.X509Certificates.X509SignatureGenerator CreateForECDsa(System.Security.Cryptography.ECDsa key) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006")]
+        public static System.Security.Cryptography.X509Certificates.X509SignatureGenerator CreateForMLDsa(System.Security.Cryptography.MLDsa key) { throw null; }
         public static System.Security.Cryptography.X509Certificates.X509SignatureGenerator CreateForRSA(System.Security.Cryptography.RSA key, System.Security.Cryptography.RSASignaturePadding signaturePadding) { throw null; }
         public abstract byte[] GetSignatureAlgorithmIdentifier(System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
         public abstract byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -291,6 +291,9 @@
   <data name="Cryptography_CertReq_NoKeyProvided" xml:space="preserve">
     <value>This method cannot be used since no signing key was provided via a constructor, use an overload accepting an X509SignatureGenerator instead.</value>
   </data>
+  <data name="Cryptography_CertReq_NoHashAlgorithmProvided" xml:space="preserve">
+    <value>The intended signature algorithm requires a HashAlgorithmName, but one was not provided when building the CertificatRequest object.</value>
+  </data>
   <data name="Cryptography_CertReq_NotAfterNotNested" xml:space="preserve">
     <value>The requested notAfter value ({0}) is later than issuerCertificate.NotAfter ({1}).</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -292,7 +292,7 @@
     <value>This method cannot be used since no signing key was provided via a constructor, use an overload accepting an X509SignatureGenerator instead.</value>
   </data>
   <data name="Cryptography_CertReq_NoHashAlgorithmProvided" xml:space="preserve">
-    <value>The intended signature algorithm requires a HashAlgorithmName, but one was not provided when building the CertificatRequest object.</value>
+    <value>The intended signature algorithm requires a HashAlgorithmName, but one was not provided when building the CertificateRequest object.</value>
   </data>
   <data name="Cryptography_CertReq_NotAfterNotNested" xml:space="preserve">
     <value>The requested notAfter value ({0}) is later than issuerCertificate.NotAfter ({1}).</value>

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -673,6 +673,7 @@
     <Compile Include="System\Security\Cryptography\X509Certificates\ILoaderPal.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\IStorePal.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\IX509Pal.cs" />
+    <Compile Include="System\Security\Cryptography\X509Certificates\MLDsaX509SignatureGenerator.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\OpenFlags.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\Pkcs10CertificationRequestInfo.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\Pkcs12ExportPbeParameters.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaImplementation.OpenSsl.cs
@@ -36,6 +36,27 @@ namespace System.Security.Cryptography
             Interop.Crypto.EvpPKeyMLDsaAlgs.MLDsa65 != null ||
             Interop.Crypto.EvpPKeyMLDsaAlgs.MLDsa87 != null;
 
+        internal MLDsaImplementation Duplicate()
+        {
+            return new MLDsaImplementation(Algorithm, _key.DuplicateHandle());
+        }
+
+        internal SafeEvpPKeyHandle DuplicateHandle()
+        {
+            return _key.DuplicateHandle();
+        }
+
+        // TODO: Delete this when public MLDsaOpenSsl is added.
+        internal static MLDsaImplementation FromHandle(MLDsaAlgorithm algorithm, SafeEvpPKeyHandle key)
+        {
+            Debug.Assert(key is not null);
+            Debug.Assert(!key.IsInvalid);
+            Debug.Assert(algorithm is not null);
+
+            ThrowIfNotSupported();
+            return new MLDsaImplementation(algorithm, key.DuplicateHandle());
+        }
+
         protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) =>
             Interop.Crypto.MLDsaSignPure(_key, data, context, destination);
 
@@ -51,30 +72,30 @@ namespace System.Security.Cryptography
         protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) =>
             Interop.Crypto.MLDsaExportSeed(_key, destination);
 
-        internal static partial MLDsa GenerateKeyImpl(MLDsaAlgorithm algorithm)
+        internal static partial MLDsaImplementation GenerateKeyImpl(MLDsaAlgorithm algorithm)
         {
             SafeEvpPKeyHandle key = Interop.Crypto.MLDsaGenerateKey(algorithm.Name, ReadOnlySpan<byte>.Empty);
             return new MLDsaImplementation(algorithm, key);
         }
 
-        internal static partial MLDsa ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
+        internal static partial MLDsaImplementation ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             Debug.Assert(source.Length == algorithm.PublicKeySizeInBytes, $"Public key was expected to be {algorithm.PublicKeySizeInBytes} bytes, but was {source.Length} bytes.");
             SafeEvpPKeyHandle key = Interop.Crypto.EvpPKeyFromData(algorithm.Name, source, privateKey: false);
             return new MLDsaImplementation(algorithm, key);
         }
 
-        internal static partial MLDsa ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial MLDsaImplementation ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial MLDsa ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
+        internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             Debug.Assert(source.Length == algorithm.SecretKeySizeInBytes, $"Secret key was expected to be {algorithm.SecretKeySizeInBytes} bytes, but was {source.Length} bytes.");
             SafeEvpPKeyHandle key = Interop.Crypto.EvpPKeyFromData(algorithm.Name, source, privateKey: true);
             return new MLDsaImplementation(algorithm, key);
         }
 
-        internal static partial MLDsa ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
+        internal static partial MLDsaImplementation ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             Debug.Assert(source.Length == algorithm.PrivateSeedSizeInBytes, $"Seed was expected to be {algorithm.PrivateSeedSizeInBytes} bytes, but was {source.Length} bytes.");
             SafeEvpPKeyHandle key = Interop.Crypto.MLDsaGenerateKey(algorithm.Name, source);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
@@ -447,6 +447,12 @@ namespace System.Security.Cryptography.X509Certificates
             return new ECDiffieHellmanImplementation.ECDiffieHellmanAndroid(ecKey);
         }
 
+        public MLDsa? GetMLDsaPrivateKey()
+        {
+            // MLDsa is not supported on Android
+            return null;
+        }
+
         public ICertificatePal CopyWithPrivateKey(DSA privateKey)
         {
             DSAImplementation.DSAAndroid? typedKey = privateKey as DSAImplementation.DSAAndroid;
@@ -496,6 +502,12 @@ namespace System.Security.Cryptography.X509Certificates
                 typedKey.ImportParameters(ecParameters);
                 return CopyWithPrivateKeyHandle(typedKey.DuplicateKeyHandle());
             }
+        }
+
+        public ICertificatePal CopyWithPrivateKey(MLDsa privateKey)
+        {
+            throw new PlatformNotSupportedException(
+                SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(MLDsa)));
         }
 
         public ICertificatePal CopyWithPrivateKey(RSA privateKey)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.iOS.cs
@@ -28,6 +28,12 @@ namespace System.Security.Cryptography.X509Certificates
             return ImportPkcs12(this, privateKey);
         }
 
+        public ICertificatePal CopyWithPrivateKey(MLDsa privateKey)
+        {
+            throw new PlatformNotSupportedException(
+                SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(MLDsa)));
+        }
+
         public ICertificatePal CopyWithPrivateKey(RSA privateKey)
         {
             return ImportPkcs12(this, privateKey);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.macOS.cs
@@ -122,6 +122,12 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
+        public ICertificatePal CopyWithPrivateKey(MLDsa privateKey)
+        {
+            throw new PlatformNotSupportedException(
+                SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(MLDsa)));
+        }
+
         public ICertificatePal CopyWithPrivateKey(RSA privateKey)
         {
             var typedKey = privateKey as RSAImplementation.RSASecurityTransforms;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
@@ -364,6 +364,12 @@ namespace System.Security.Cryptography.X509Certificates
             return new ECDiffieHellmanImplementation.ECDiffieHellmanSecurityTransforms(publicKey, privateKey);
         }
 
+        public MLDsa? GetMLDsaPrivateKey()
+        {
+            // MLDsa is not supported on Apple platforms.
+            return null;
+        }
+
         public string GetNameInfo(X509NameType nameType, bool forIssuer)
         {
             EnsureCertData();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
@@ -80,6 +80,12 @@ namespace System.Security.Cryptography.X509Certificates
             );
         }
 
+        public MLDsa? GetMLDsaPrivateKey()
+        {
+            // MLDsa is not supported on Windows.
+            return null;
+        }
+
         public ICertificatePal CopyWithPrivateKey(DSA dsa)
         {
             DSACng? dsaCng = dsa as DSACng;
@@ -166,6 +172,12 @@ namespace System.Security.Cryptography.X509Certificates
 
                 return CopyWithEphemeralKey(clonedKey.Key);
             }
+        }
+
+        public ICertificatePal CopyWithPrivateKey(MLDsa privateKey)
+        {
+            throw new PlatformNotSupportedException(
+                SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(MLDsa)));
         }
 
         public ICertificatePal CopyWithPrivateKey(RSA rsa)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Formats.Asn1;
 using System.Runtime.Versioning;
 using System.Security.Cryptography.Asn1;
@@ -20,7 +21,7 @@ namespace System.Security.Cryptography.X509Certificates
     [UnsupportedOSPlatform("browser")]
     public sealed partial class CertificateRequest
     {
-        private readonly AsymmetricAlgorithm? _key;
+        private readonly object? _key;
         private readonly X509SignatureGenerator? _generator;
         private readonly RSASignaturePadding? _rsaPadding;
 
@@ -179,7 +180,57 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        /// Create a CertificateRequest for the specified subject name, encoded public key, and hash algorithm.
+        ///   Create a CertificateRequest for the specified subject name and ML-DSA key.
+        /// </summary>
+        /// <param name="subjectName">
+        ///   The parsed representation of the subject name for the certificate or certificate request.
+        /// </param>
+        /// <param name="key">
+        ///   An ML-DSA key whose public key material will be included in the certificate or certificate request.
+        ///   This key will be used as a private key if <see cref="CreateSelfSigned" /> is called.
+        /// </param>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        public CertificateRequest(
+            string subjectName,
+            MLDsa key)
+        {
+            ArgumentNullException.ThrowIfNull(subjectName);
+            ArgumentNullException.ThrowIfNull(key);
+
+            SubjectName = new X500DistinguishedName(subjectName);
+
+            _key = key;
+            _generator = X509SignatureGenerator.CreateForMLDsa(key);
+            PublicKey = _generator.PublicKey;
+        }
+
+        /// <summary>
+        ///   Create a CertificateRequest for the specified subject name and ML-DSA key.
+        /// </summary>
+        /// <param name="subjectName">
+        ///   The parsed representation of the subject name for the certificate or certificate request.
+        /// </param>
+        /// <param name="key">
+        ///   An ML-DSA key whose public key material will be included in the certificate or certificate request.
+        ///   This key will be used as a private key if <see cref="CreateSelfSigned" /> is called.
+        /// </param>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        public CertificateRequest(
+            X500DistinguishedName subjectName,
+            MLDsa key)
+        {
+            ArgumentNullException.ThrowIfNull(subjectName);
+            ArgumentNullException.ThrowIfNull(key);
+
+            SubjectName = subjectName;
+
+            _key = key;
+            _generator = X509SignatureGenerator.CreateForMLDsa(key);
+            PublicKey = _generator.PublicKey;
+        }
+
+        /// <summary>
+        ///   Create a CertificateRequest for the specified subject name, encoded public key, and hash algorithm.
         /// </summary>
         /// <param name="subjectName">
         ///   The parsed representation of the subject name for the certificate or certificate request.
@@ -194,7 +245,10 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ArgumentNullException.ThrowIfNull(subjectName);
             ArgumentNullException.ThrowIfNull(publicKey);
-            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+
+            // Since ML-DSA (and others) don't require a hash algorithm, but we don't
+            // know what signature algorithm is being used until the call to Create,
+            // we can't check here.
 
             SubjectName = subjectName;
             PublicKey = publicKey;
@@ -225,7 +279,10 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ArgumentNullException.ThrowIfNull(subjectName);
             ArgumentNullException.ThrowIfNull(publicKey);
-            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+
+            // Since ML-DSA (and others) don't require a hash algorithm, but we don't
+            // know what signature algorithm is being used until the call to Create,
+            // we can't check here.
 
             SubjectName = subjectName;
             PublicKey = publicKey;
@@ -320,6 +377,11 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <para>
         ///     This object was created with a constructor which did not accept a signing key.
         ///   </para>
+        ///   <para>- or -</para>
+        ///   <para>
+        ///     The signature generator requires a non-default value for <see cref="HashAlgorithm"/>,
+        ///     but this object was created without one being provided.
+        ///   </para>
         /// </exception>
         /// <exception cref="CryptographicException">
         ///   A cryptographic error occurs while creating the signing request.
@@ -333,6 +395,12 @@ namespace System.Security.Cryptography.X509Certificates
         public byte[] CreateSigningRequest(X509SignatureGenerator signatureGenerator)
         {
             ArgumentNullException.ThrowIfNull(signatureGenerator);
+
+            if (string.IsNullOrEmpty(HashAlgorithm.Name) &&
+                Helpers.HashAlgorithmRequired(signatureGenerator.PublicKey.Oid.Value))
+            {
+                throw new InvalidOperationException(SR.Cryptography_CertReq_NoHashAlgorithmProvided);
+            }
 
             X501Attribute[] attributes = Array.Empty<X501Attribute>();
             bool hasExtensions = CertificateExtensions.Count > 0;
@@ -456,6 +524,11 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <para>
         ///     This object was created with a constructor which did not accept a signing key.
         ///   </para>
+        ///   <para>- or -</para>
+        ///   <para>
+        ///     The signature generator requires a non-default value for <see cref="HashAlgorithm"/>,
+        ///     but this object was created without one being provided.
+        ///   </para>
         /// </exception>
         /// <exception cref="CryptographicException">
         ///   A cryptographic error occurs while creating the signing request.
@@ -525,6 +598,13 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     return certificate.CopyWithPrivateKey(ecdsa);
                 }
+
+                MLDsa? mldsa = _key as MLDsa;
+
+                if (mldsa is not null)
+                {
+                    return certificate.CopyWithPrivateKey(mldsa);
+                }
             }
 
             Debug.Fail($"Key was of no known type: {_key?.GetType().FullName ?? "null"}");
@@ -568,8 +648,15 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <paramref name="issuerCertificate"/> has a different key algorithm than the requested certificate.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   <paramref name="issuerCertificate"/> is an RSA certificate and this object was created without
-        ///   specifying an <see cref="RSASignaturePadding"/> value in the constructor.
+        ///   <para>
+        ///     <paramref name="issuerCertificate"/> is an RSA certificate and this object was created via a constructor
+        ///     which does not accept a <see cref="RSASignaturePadding"/> value.
+        ///   </para>
+        ///   <para>- or -</para>
+        ///   <para>
+        ///     <paramref name="issuerCertificate"/> uses a public key algorithm which requires a non-default value
+        ///     for <see cref="HashAlgorithm"/>, but this object was created without one being provided.
+        ///   </para>
         /// </exception>
         public X509Certificate2 Create(
             X509Certificate2 issuerCertificate,
@@ -619,8 +706,15 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <paramref name="issuerCertificate"/> has a different key algorithm than the requested certificate.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   <paramref name="issuerCertificate"/> is an RSA certificate and this object was created via a constructor
-        ///   which does not accept a <see cref="RSASignaturePadding"/> value.
+        ///   <para>
+        ///     <paramref name="issuerCertificate"/> is an RSA certificate and this object was created via a constructor
+        ///     which does not accept a <see cref="RSASignaturePadding"/> value.
+        ///   </para>
+        ///   <para>- or -</para>
+        ///   <para>
+        ///     <paramref name="issuerCertificate"/> uses a public key algorithm which requires a non-default value
+        ///     for <see cref="HashAlgorithm"/>, but this object was created without one being provided.
+        ///   </para>
         /// </exception>
         public X509Certificate2 Create(
             X509Certificate2 issuerCertificate,
@@ -759,6 +853,10 @@ namespace System.Security.Cryptography.X509Certificates
         /// </exception>
         /// <exception cref="ArgumentException"><paramref name="serialNumber"/> is null or has length 0.</exception>
         /// <exception cref="CryptographicException">Any error occurs during the signing operation.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The signature generator requires a non-default value for <see cref="HashAlgorithm"/>,
+        ///   but this object was created without one being provided.
+        /// </exception>
         public X509Certificate2 Create(
             X500DistinguishedName issuerName,
             X509SignatureGenerator generator,
@@ -800,6 +898,10 @@ namespace System.Security.Cryptography.X509Certificates
         /// </exception>
         /// <exception cref="ArgumentException"><paramref name="serialNumber"/> has length 0.</exception>
         /// <exception cref="CryptographicException">Any error occurs during the signing operation.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The signature generator requires a non-default value for <see cref="HashAlgorithm"/>,
+        ///   but this object was created without one being provided.
+        /// </exception>
         public X509Certificate2 Create(
             X500DistinguishedName issuerName,
             X509SignatureGenerator generator,
@@ -814,6 +916,12 @@ namespace System.Security.Cryptography.X509Certificates
                 throw new ArgumentException(SR.Cryptography_CertReq_DatesReversed);
             if (serialNumber.Length < 1)
                 throw new ArgumentException(SR.Arg_EmptyOrNullArray, nameof(serialNumber));
+
+            if (string.IsNullOrEmpty(HashAlgorithm.Name) &&
+                Helpers.HashAlgorithmRequired(generator.PublicKey.Oid.Value))
+            {
+                throw new InvalidOperationException(SR.Cryptography_CertReq_NoHashAlgorithmProvided);
+            }
 
             byte[] signatureAlgorithm = generator.GetSignatureAlgorithmIdentifier(HashAlgorithm);
             AlgorithmIdentifierAsn signatureAlgorithmAsn;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
@@ -189,6 +189,9 @@ namespace System.Security.Cryptography.X509Certificates
         ///   An ML-DSA key whose public key material will be included in the certificate or certificate request.
         ///   This key will be used as a private key if <see cref="CreateSelfSigned" /> is called.
         /// </param>
+        /// <exceotion cref="ArgumentNullException">
+        ///   <paramref name="subjectName" /> or <paramref name="key" /> is <see langword="null" />.
+        /// </exceotion>
         [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
         public CertificateRequest(
             string subjectName,
@@ -214,6 +217,9 @@ namespace System.Security.Cryptography.X509Certificates
         ///   An ML-DSA key whose public key material will be included in the certificate or certificate request.
         ///   This key will be used as a private key if <see cref="CreateSelfSigned" /> is called.
         /// </param>
+        /// <exceotion cref="ArgumentNullException">
+        ///   <paramref name="subjectName" /> or <paramref name="key" /> is <see langword="null" />.
+        /// </exceotion>
         [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
         public CertificateRequest(
             X500DistinguishedName subjectName,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRevocationListBuilder.Build.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRevocationListBuilder.Build.cs
@@ -92,7 +92,8 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <para>- or -</para>
         ///   <para>
         ///     <paramref name="hashAlgorithm" /> has the empty string as the value of
-        ///     <see cref="HashAlgorithmName.Name"/>.
+        ///     <see cref="HashAlgorithmName.Name"/> and <paramref name="issuerCertificate"/>
+        ///     uses a public key algorithm that requires a hash to be specified.
         ///   </para>
         ///   <para>- or -</para>
         ///   <para>
@@ -140,7 +141,8 @@ namespace System.Security.Cryptography.X509Certificates
             if (nextUpdate <= thisUpdate)
                 throw new ArgumentException(SR.Cryptography_CRLBuilder_DatesReversed);
 
-            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            if (Helpers.HashAlgorithmRequired(issuerCertificate.GetKeyAlgorithm()))
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             // Check the Basic Constraints and Key Usage extensions to help identify inappropriate certificates.
             // Note that this is not a security check. The system library backing X509Chain will use these same criteria
@@ -173,7 +175,7 @@ namespace System.Security.Cryptography.X509Certificates
                     nameof(issuerCertificate));
             }
 
-            AsymmetricAlgorithm? key = null;
+            IDisposable? key = null;
             string keyAlgorithm = issuerCertificate.GetKeyAlgorithm();
             X509SignatureGenerator generator;
 
@@ -195,6 +197,13 @@ namespace System.Security.Cryptography.X509Certificates
                         ECDsa? ecdsa = issuerCertificate.GetECDsaPrivateKey();
                         key = ecdsa;
                         generator = X509SignatureGenerator.CreateForECDsa(ecdsa!);
+                        break;
+                    case Oids.MLDsa44:
+                    case Oids.MLDsa65:
+                    case Oids.MLDsa87:
+                        MLDsa? mldsa = issuerCertificate.GetMLDsaPrivateKey();
+                        key = mldsa;
+                        generator = X509SignatureGenerator.CreateForMLDsa(mldsa!);
                         break;
                     default:
                         throw new ArgumentException(
@@ -280,7 +289,8 @@ namespace System.Security.Cryptography.X509Certificates
         ///   <para>- or -</para>
         ///   <para>
         ///     <paramref name="hashAlgorithm" /> has the empty string as the value of
-        ///     <see cref="HashAlgorithmName.Name"/>.
+        ///     <see cref="HashAlgorithmName.Name"/> and <paramref name="generator"/>
+        ///     uses a public key algorithm that requires a hash to be specified.
         ///   </para>
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
@@ -324,7 +334,9 @@ namespace System.Security.Cryptography.X509Certificates
             if (nextUpdate <= thisUpdate)
                 throw new ArgumentException(SR.Cryptography_CRLBuilder_DatesReversed);
 
-            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            if (Helpers.HashAlgorithmRequired(generator.PublicKey.Oid.Value))
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+
             ArgumentNullException.ThrowIfNull(authorityKeyIdentifier);
 
             byte[] signatureAlgId = generator.GetSignatureAlgorithmIdentifier(hashAlgorithm);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ICertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ICertificatePal.cs
@@ -31,12 +31,14 @@ namespace System.Security.Cryptography.X509Certificates
         DSA? GetDSAPrivateKey();
         ECDsa? GetECDsaPrivateKey();
         ECDiffieHellman? GetECDiffieHellmanPrivateKey();
+        MLDsa? GetMLDsaPrivateKey();
         string GetNameInfo(X509NameType nameType, bool forIssuer);
         void AppendPrivateKeyInfo(StringBuilder sb);
         ICertificatePal CopyWithPrivateKey(DSA privateKey);
         ICertificatePal CopyWithPrivateKey(ECDsa privateKey);
         ICertificatePal CopyWithPrivateKey(RSA privateKey);
         ICertificatePal CopyWithPrivateKey(ECDiffieHellman privateKey);
+        ICertificatePal CopyWithPrivateKey(MLDsa privateKey);
         PolicyData GetPolicyData();
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/MLDsaX509SignatureGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/MLDsaX509SignatureGenerator.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Formats.Asn1;
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    internal sealed class MLDsaX509SignatureGenerator : X509SignatureGenerator
+    {
+        private readonly MLDsa _key;
+
+        internal MLDsaX509SignatureGenerator(MLDsa key)
+        {
+            Debug.Assert(key != null);
+
+            _key = key;
+        }
+
+        public override byte[] GetSignatureAlgorithmIdentifier(HashAlgorithmName hashAlgorithm)
+        {
+            // Ignore the hashAlgorithm parameter.
+            // This generator only supports ML-DSA "Pure" signatures, but the overall design of
+            // CertificateRequest makes it easy for a hashAlgorithm value to get here.
+
+            const int InitialCapacity = 16;
+
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER, InitialCapacity);
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(_key.Algorithm.Oid);
+            writer.PopSequence();
+
+            Debug.Assert(writer.GetEncodedLength() <= InitialCapacity);
+            return writer.Encode();
+        }
+
+        public override byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+
+            // Ignore the hashAlgorithm parameter.
+            // This generator only supports ML-DSA "Pure" signatures, but the overall design of
+            // CertificateRequest makes it easy for a hashAlgorithm value to get here.
+
+            byte[] signature = new byte[_key.Algorithm.SignatureSizeInBytes];
+            int written = _key.SignData(data, signature);
+            Debug.Assert(written == signature.Length);
+            return signature;
+        }
+
+        protected override PublicKey BuildPublicKey()
+        {
+            Oid oid = new Oid(_key.Algorithm.Oid, null);
+            byte[] pkBytes = new byte[_key.Algorithm.PublicKeySizeInBytes];
+            int written = _key.ExportMLDsaPublicKey(pkBytes);
+            Debug.Assert(written == pkBytes.Length);
+
+            return new PublicKey(
+                oid,
+                null,
+                new AsnEncodedData(oid, pkBytes, skipCopy: true));
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509CertificateReader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509CertificateReader.cs
@@ -608,6 +608,19 @@ namespace System.Security.Cryptography.X509Certificates
             return new ECDiffieHellmanOpenSsl(_privateKey);
         }
 
+        public MLDsa? GetMLDsaPrivateKey()
+        {
+            if (_privateKey == null || _privateKey.IsInvalid)
+            {
+                return null;
+            }
+
+            // TODO: Use MLDsaOpenSsl when it is available.
+            return MLDsaImplementation.FromHandle(
+                MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(KeyAlgorithm)!,
+                _privateKey);
+        }
+
         private OpenSslX509CertificateReader CopyWithPrivateKey(SafeEvpPKeyHandle privateKey)
         {
             // This could be X509Duplicate for a full clone, but since OpenSSL certificates
@@ -674,6 +687,21 @@ namespace System.Security.Cryptography.X509Certificates
                 typedKey.ImportParameters(ecParameters);
 
                 return CopyWithPrivateKey(typedKey.DuplicateKeyHandle());
+            }
+        }
+
+        public ICertificatePal CopyWithPrivateKey(MLDsa privateKey)
+        {
+            if (privateKey is MLDsaImplementation impl)
+            {
+                return CopyWithPrivateKey(impl.DuplicateHandle());
+            }
+
+            // TODO: Special case MLDsaOpenSsl when it is available.
+
+            using (MLDsaImplementation clone = MLDsaImplementation.DuplicatePrivateKey(privateKey))
+            {
+                return CopyWithPrivateKey(clone.DuplicateHandle());
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -295,14 +295,17 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        /// Gets the <see cref="MLKem" /> public key, or <see langword="null" />
-        /// if the key is not an ML-KEM key.
+        ///   Gets the <see cref="MLKem" /> public key, or <see langword="null" />
+        ///   if the key is not an ML-KEM key.
         /// </summary>
         /// <returns>
-        /// The public key, or <see langword="null" /> if the key is not an ML-KEM key.
+        ///   The public key, or <see langword="null" /> if the key is not an ML-KEM key.
         /// </returns>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The object represents an ML-KEM public key, but the platform does not support the algorithm.
+        /// </exception>
         /// <exception cref="CryptographicException">
-        /// The key contents are corrupt or could not be read successfully.
+        ///   The key contents are corrupt or could not be read successfully.
         /// </exception>
         [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
         [UnsupportedOSPlatform("browser")]
@@ -311,7 +314,30 @@ namespace System.Security.Cryptography.X509Certificates
             if (MLKemAlgorithm.FromOid(_oid.Value) is null)
                 return null;
 
-            return MLKem.ImportSubjectPublicKeyInfo(ExportSubjectPublicKeyInfo());
+            return EncodeSubjectPublicKeyInfo().Encode(MLKem.ImportSubjectPublicKeyInfo);
+        }
+
+        /// <summary>
+        ///   Gets the <see cref="MLDsa"/> public key, or <see langword="null" />
+        ///   if the key is not an ML-DSA key.
+        /// </summary>
+        /// <returns>
+        ///   The public key, or <see langword="null"/> if the key is not an ML-DSA key.
+        /// </returns>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The object represents an ML-DSA public key, but the platform does not support the algorithm.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   The key contents are corrupt or could not be read successfully.
+        /// </exception>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        [UnsupportedOSPlatform("browser")]
+        public MLDsa? GetMLDsaPublicKey()
+        {
+            if (MLDsaAlgorithm.GetMLDsaAlgorithmFromOid(_oid.Value) is null)
+                return null;
+
+            return EncodeSubjectPublicKeyInfo().Encode(MLDsa.ImportSubjectPublicKeyInfo);
         }
 
         internal AsnWriter EncodeSubjectPublicKeyInfo()

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SignatureGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SignatureGenerator.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Security.Cryptography.X509Certificates
 {
     public abstract class X509SignatureGenerator
@@ -31,6 +33,23 @@ namespace System.Security.Cryptography.X509Certificates
                 return new RSAPssX509SignatureGenerator(key, signaturePadding);
 
             throw new ArgumentException(SR.Cryptography_InvalidPaddingMode);
+        }
+
+        /// <summary>
+        ///  Creates a signature generator for ML-DSA signatures using the specified key.
+        /// </summary>
+        /// <param name="key">
+        ///   The private key.
+        /// </param>
+        /// <returns>
+        ///   An <see cref="X509SignatureGenerator" /> object for ML-DSA signatures.
+        /// </returns>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
+        public static X509SignatureGenerator CreateForMLDsa(MLDsa key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return new MLDsaX509SignatureGenerator(key);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SignatureGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SignatureGenerator.cs
@@ -36,7 +36,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         /// <summary>
-        ///  Creates a signature generator for ML-DSA signatures using the specified key.
+        ///   Creates a signature generator for ML-DSA signatures using the specified key.
         /// </summary>
         /// <param name="key">
         ///   The private key.
@@ -44,6 +44,9 @@ namespace System.Security.Cryptography.X509Certificates
         /// <returns>
         ///   An <see cref="X509SignatureGenerator" /> object for ML-DSA signatures.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="key" /> is <see langword="null" />.
+        /// </exception>
         [Experimental(Experimentals.PostQuantumCryptographyDiagId)]
         public static X509SignatureGenerator CreateForMLDsa(MLDsa key)
         {

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -284,6 +284,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaTestsBase.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaXml.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaTestImplementation.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaTestImplementation.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2CipherTests.cs"

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestApiTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestApiTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Tests;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreation
@@ -147,6 +148,50 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        public static void CtorValidation_MLDSA_string()
+        {
+            string subjectName = null;
+            MLDsa key = null;
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "subjectName",
+                () => new CertificateRequest(subjectName, key));
+
+            subjectName = "";
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "key",
+                () => new CertificateRequest(subjectName, key));
+        }
+
+        [Fact]
+        public static void CtorValidation_MLDSA_X500DN()
+        {
+            X500DistinguishedName subjectName = null;
+            MLDsa key = null;
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "subjectName",
+                () => new CertificateRequest(subjectName, key));
+
+            subjectName = new X500DistinguishedName("");
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "key",
+                () => new CertificateRequest(subjectName, key));
+        }
+
+        [Fact]
+        public static void MLDSA_DoesNotSetHashAlgorithm()
+        {
+            using (MLDsa key = MLDsaTestImplementation.CreateNoOp(MLDsaAlgorithm.MLDsa65))
+            {
+                CertificateRequest req = new CertificateRequest("CN=Test", key);
+                Assert.Null(req.HashAlgorithm.Name);
+            }
+        }
+
+        [Fact]
         public static void CtorValidation_RSA_string()
         {
             string subjectName = null;
@@ -233,14 +278,36 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 X509SignatureGenerator generator = X509SignatureGenerator.CreateForECDsa(ecdsa);
                 publicKey = generator.PublicKey;
             }
+        }
 
-            AssertExtensions.Throws<ArgumentNullException>(
-                "hashAlgorithm",
-                () => new CertificateRequest(subjectName, publicKey, default(HashAlgorithmName)));
+        [Fact]
+        public static void PublicKeyCtor_HashAlgorithm_LateVerification()
+        {
+            X500DistinguishedName name = new X500DistinguishedName("CN=Test");
 
-            AssertExtensions.Throws<ArgumentException>(
-                "hashAlgorithm",
-                () => new CertificateRequest(subjectName, publicKey, new HashAlgorithmName("")));
+            using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp384r1Data.KeyParameters))
+            {
+                X509SignatureGenerator gen = X509SignatureGenerator.CreateForECDsa(ecdsa);
+
+                CertificateRequest req = new CertificateRequest(name, gen.PublicKey, default);
+                Assert.Null(req.HashAlgorithm.Name);
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                Assert.Throws<InvalidOperationException>(
+                    () => req.Create(name, gen, now.AddMinutes(-1), now.AddMinutes(1), new byte[] { 1, 2, 3 }));
+            }
+
+            using (RSA rsa = RSA.Create(TestData.RsaBigExponentParams))
+            {
+                X509SignatureGenerator gen = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+
+                CertificateRequest req = new CertificateRequest(name, gen.PublicKey, default);
+                Assert.Null(req.HashAlgorithm.Name);
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                Assert.Throws<InvalidOperationException>(
+                    () => req.Create(name, gen, now.AddMinutes(-1), now.AddMinutes(1), new byte[] { 1, 2, 3 }));
+            }
         }
 
         [Fact]
@@ -414,70 +481,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             Assert.Throws<ArgumentNullException>(
                 "pkcs10Pem",
                 () => CertificateRequest.LoadSigningRequestPem((string)null, HashAlgorithmName.SHA256));
-        }
-
-        [Fact]
-        public static void LoadWithDefaultHashAlgorithm()
-        {
-            Assert.Throws<ArgumentNullException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequest(Array.Empty<byte>(), default(HashAlgorithmName)));
-
-            {
-                int consumed = -1;
-
-                Assert.Throws<ArgumentNullException>(
-                    "signerHashAlgorithm",
-                    () => CertificateRequest.LoadSigningRequest(
-                        ReadOnlySpan<byte>.Empty,
-                        default(HashAlgorithmName),
-                        out consumed));
-
-                Assert.Equal(-1, consumed);
-            }
-
-            Assert.Throws<ArgumentNullException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequestPem(string.Empty, default(HashAlgorithmName)));
-
-            Assert.Throws<ArgumentNullException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequestPem(
-                    ReadOnlySpan<char>.Empty,
-                    default(HashAlgorithmName)));
-        }
-
-        [Fact]
-        public static void LoadWithEmptyHashAlgorithm()
-        {
-            HashAlgorithmName hashAlgorithm = new HashAlgorithmName("");
-
-            Assert.Throws<ArgumentException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequest(Array.Empty<byte>(), hashAlgorithm));
-
-            {
-                int consumed = -1;
-
-                Assert.Throws<ArgumentException>(
-                    "signerHashAlgorithm",
-                    () => CertificateRequest.LoadSigningRequest(
-                        ReadOnlySpan<byte>.Empty,
-                        hashAlgorithm,
-                        out consumed));
-
-                Assert.Equal(-1, consumed);
-            }
-
-            Assert.Throws<ArgumentException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequestPem(string.Empty, hashAlgorithm));
-
-            Assert.Throws<ArgumentException>(
-                "signerHashAlgorithm",
-                () => CertificateRequest.LoadSigningRequestPem(
-                    ReadOnlySpan<char>.Empty,
-                    hashAlgorithm));
         }
 
         [Theory]

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestApiTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestApiTests.cs
@@ -297,7 +297,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     () => req.Create(name, gen, now.AddMinutes(-1), now.AddMinutes(1), new byte[] { 1, 2, 3 }));
             }
 
-            using (RSA rsa = RSA.Create(TestData.RsaBigExponentParams))
+            using (RSA rsa = RSA.Create(Rsa.Tests.TestData.RSA2048Params))
             {
                 X509SignatureGenerator gen = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CrlBuilderTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CrlBuilderTests.cs
@@ -19,6 +19,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         public enum CertKind
         {
             ECDsa,
+            MLDsa,
             RsaPkcs1,
             RsaPss,
         }
@@ -26,8 +27,22 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         public static IEnumerable<object[]> SupportedCertKinds()
         {
             yield return new object[] { CertKind.ECDsa };
+
+            if (MLDsa.IsSupported)
+            {
+                yield return new object[] { CertKind.MLDsa };
+            }
+
             yield return new object[] { CertKind.RsaPkcs1 };
             yield return new object[] { CertKind.RsaPss };
+        }
+
+        public static IEnumerable<object[]> NoHashAlgorithmCertKinds()
+        {
+            if (MLDsa.IsSupported)
+            {
+                yield return new object[] { CertKind.MLDsa };
+            }
         }
 
         [Fact]
@@ -265,6 +280,38 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                             // Assert.NoThrow
                             genAction();
                         }
+                    }
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(NoHashAlgorithmCertKinds))]
+        public static void BuildPqcWithHashAlgorithm(CertKind certKind)
+        {
+            BuildCertificateAndRun(
+                certKind,
+                new X509Extension[]
+                {
+                    X509BasicConstraintsExtension.CreateForCertificateAuthority(),
+                },
+                static (certKind, cert, now) =>
+                {
+                    HashAlgorithmName hashAlg = new HashAlgorithmName("");
+                    CertificateRevocationListBuilder builder = new CertificateRevocationListBuilder();
+
+                    // Assert.NoThrow
+                    builder.Build(cert, 0, now.AddMinutes(5), HashAlgorithmName.SHA256);
+
+                    X509SignatureGenerator gen = GetSignatureGenerator(certKind, cert, out IDisposable key);
+
+                    using (key)
+                    {
+                        X500DistinguishedName dn = cert.SubjectName;
+                        X509AuthorityKeyIdentifierExtension akid =
+                            X509AuthorityKeyIdentifierExtension.CreateFromCertificate(cert, true, false);
+
+                        // Assert.NoThrow
+                        builder.Build(dn, gen, 0, now.AddMinutes(5), HashAlgorithmName.SHA256, akid);
                     }
                 });
         }
@@ -1500,6 +1547,12 @@ PMzkCtzeqlHvuzIHHNcS1aNvlb94Tg8tPR5u/deYDrNg4NkbsqpG/QUMWse4T1Q7
                     key = rsa;
                     req = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA384, GetRsaPadding(certKind));
                 }
+                else if (certKind == CertKind.MLDsa)
+                {
+                    MLDsa mldsa = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa44);
+                    key = mldsa;
+                    req = new CertificateRequest(subjectName, mldsa);
+                }
                 else
                 {
                     throw new NotSupportedException($"Unsupported CertKind: {certKind}");
@@ -1658,6 +1711,12 @@ PMzkCtzeqlHvuzIHHNcS1aNvlb94Tg8tPR5u/deYDrNg4NkbsqpG/QUMWse4T1Q7
                 key = ecdsa;
                 return X509SignatureGenerator.CreateForECDsa(ecdsa);
             }
+            else if (certKind == CertKind.MLDsa)
+            {
+                MLDsa mldsa = cert.GetMLDsaPrivateKey();
+                key = mldsa;
+                return X509SignatureGenerator.CreateForMLDsa(mldsa);
+            }
             else
             {
                 throw new NotSupportedException($"Unsupported CertKind: {certKind}");
@@ -1683,6 +1742,11 @@ PMzkCtzeqlHvuzIHHNcS1aNvlb94Tg8tPR5u/deYDrNg4NkbsqpG/QUMWse4T1Q7
                 using ECDsa ecdsa = cert.GetECDsaPublicKey();
                 signatureValid = ecdsa.VerifyData(data, signature, hashAlgorithm, DSASignatureFormat.Rfc3279DerSequence);
             }
+            else if (certKind == CertKind.MLDsa)
+            {
+                using MLDsa mldsa = cert.GetMLDsaPublicKey();
+                signatureValid = mldsa.VerifyData(data, signature);
+            }
             else
             {
                 throw new NotSupportedException($"Unsupported CertKind: {certKind}");
@@ -1699,6 +1763,7 @@ PMzkCtzeqlHvuzIHHNcS1aNvlb94Tg8tPR5u/deYDrNg4NkbsqpG/QUMWse4T1Q7
             return certKind switch
             {
                 CertKind.ECDsa or CertKind.RsaPkcs1 or CertKind.RsaPss => true,
+                CertKind.MLDsa => false,
                 _ => throw new NotSupportedException(certKind.ToString())
             };
         }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CrlBuilderTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CrlBuilderTests.cs
@@ -296,7 +296,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 },
                 static (certKind, cert, now) =>
                 {
-                    HashAlgorithmName hashAlg = new HashAlgorithmName("");
                     CertificateRevocationListBuilder builder = new CertificateRevocationListBuilder();
 
                     // Assert.NoThrow


### PR DESCRIPTION
* Add ctors to CertificateRequest
* Enlighten CertificateRequest that future signing algorithms might not require a HashAlgorithmName
* Add support to CertificateRequestListBuilder
* Add cert.GetMLDsaPublicKey/GetMLDsaPrivateKey/CopyWithPrivateKey to power the above.

This is the ML-DSA specific parts from #114357.
Contributes to #113502.