### PR TITLE
Force storing GC state until we see a labeled IG

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1007,14 +1007,14 @@ insGroup* emitter::emitSavIG(bool emitAdd)
         VarSetOps::Assign(emitComp, emitPrevGCrefVars, emitThisGCrefVars);
         emitPrevGCrefRegs = emitThisGCrefRegs;
         emitPrevByrefRegs = emitThisByrefRegs;
-    }
 
-    if (emitAddedLabel)
-    {
-        // Reset emitForceStoreGCState only after seeing label. It will keep
-        // marking IGs with IGF_GC_VARS flag until that.
-        emitForceStoreGCState = false;
-        emitAddedLabel        = false;
+        if (emitAddedLabel)
+        {
+            // Reset emitForceStoreGCState only after seeing label. It will keep
+            // marking IGs with IGF_GC_VARS flag until that.
+            emitForceStoreGCState = false;
+            emitAddedLabel        = false;
+        }
     }
 
 #ifdef DEBUG
@@ -1283,6 +1283,7 @@ void emitter::emitBegFN(bool hasFramePtr
     emitPrevByrefRegs = RBM_NONE;
 
     emitForceStoreGCState = false;
+    emitAddedLabel        = false;
 
 #ifdef DEBUG
 
@@ -2845,10 +2846,7 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
         }
     }
 
-    if (emitForceStoreGCState)
-    {
-        emitAddedLabel = true;
-    }
+    emitAddedLabel = true;
 
     /* Create a new IG if the current one is non-empty */
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1007,8 +1007,14 @@ insGroup* emitter::emitSavIG(bool emitAdd)
         VarSetOps::Assign(emitComp, emitPrevGCrefVars, emitThisGCrefVars);
         emitPrevGCrefRegs = emitThisGCrefRegs;
         emitPrevByrefRegs = emitThisByrefRegs;
+    }
 
+    if (emitAddedLabel)
+    {
+        // Reset emitForceStoreGCState only after seeing label. It will keep
+        // marking IGs with IGF_GC_VARS flag until that.
         emitForceStoreGCState = false;
+        emitAddedLabel        = false;
     }
 
 #ifdef DEBUG
@@ -2837,6 +2843,11 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
                 emitIns(INS_nop);
             }
         }
+    }
+
+    if (emitForceStoreGCState)
+    {
+        emitAddedLabel = true;
     }
 
     /* Create a new IG if the current one is non-empty */

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2761,6 +2761,14 @@ private:
 
     bool emitForceStoreGCState;
 
+    // This flag is used together with `emitForceStoreGCState`. After we set
+    // emitForceStoreGCState = true, we will mark `emitAddedLabel` to true whenever
+    // we see a label IG. In emitSavIG, we will reset `emitForceStoreGCState = false`
+    // only after seeing `emitAddedLabel == true`. Until then, we will keep recording
+    // GC_VARS on the IGs.
+
+    bool emitAddedLabel;
+
     // emitThis* variables are used during emission, to track GC updates
     // on a per-instruction basis. During code generation, per-instruction
     // tracking is done with variables gcVarPtrSetCur, gcRegGCrefSetCur,


### PR DESCRIPTION
This is very odd and corner case scenario. We have a loop after epilog (with stress block layout, we might have something like that). If there are IGs after epilog, the epilog creates additional dummy IG to store GC state in it. We also update the GC vars global variables `emitPrevGCrefVars` and `emitInitGCrefVars` to have most up to date information. Whenever their values are different, we mark such IGs with `IGF_GC_VARS` stating that the IG contains gc information that the gcinfo should record. 

The loop that is immediately after the epilog is marked for alignment, and so we create a new label IG for it. At this point, the GC vars information `emitPrevGCrefVars == emitInitGCrefVars` and so we skip marking this IG with `IGF_GC_VARS`. As a result, it inherits the GC var liveness information from the previous block (which is the dummy block after the epilog) which is wrong.

The fix is to force store the GC state on all IGs until we come across a valid labeled IG. 

Attached is the dump from failing test. Here, `IG14` is the epilog and `IG15` is the dummy IG for which we add all the GC-vars like `V73` etc. When we create `IG16`, we do not add any new GC vars and hence inherit those from `IG15`

[617.dump.asm.zip](https://github.com/user-attachments/files/19678864/617.dump.asm.zip)

Here is the diff after the fix:

![image](https://github.com/user-attachments/assets/f2923cb8-1d0b-4eb4-bc4c-686795f71e6b)

Thanks @BruceForstall for brainstorming this scenario with me.

Fixes: https://github.com/dotnet/runtime/issues/113553