### PR TITLE
Place read-only non-GC static bases into read-only section

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -243,7 +243,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(_targetOS) != ''" Include="--targetos:$(_targetOS)" />
       <IlcArg Condition="$(_targetArchitectureWithAbi) != ''" Include="--targetarch:$(_targetArchitectureWithAbi)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
-      <IlcArg Condition="$(IlcMultiModule) != 'true' and '$(IlcDehydrate)' != 'false'" Include="--dehydrate" />
       <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
       <IlcArg Condition="$(NativeDebugSymbols) == 'true'" Include="-g" />
       <IlcArg Condition="$(IlcDwarfVersion) == '5'" Include="--gdwarf-5" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -243,6 +243,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(_targetOS) != ''" Include="--targetos:$(_targetOS)" />
       <IlcArg Condition="$(_targetArchitectureWithAbi) != ''" Include="--targetarch:$(_targetArchitectureWithAbi)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
+      <IlcArg Condition="$(IlcMultiModule) != 'true' and '$(IlcDehydrate)' != 'false'" Include="--dehydrate" />
       <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
       <IlcArg Condition="$(NativeDebugSymbols) == 'true'" Include="-g" />
       <IlcArg Condition="$(IlcDwarfVersion) == '5'" Include="--gdwarf-5" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -41,6 +41,10 @@ namespace ILCompiler.DependencyAnalysis
             }
             else if (_preinitializationManager.IsPreinitialized(_type))
             {
+                // Unix linkers don't like relocs to readonly data section
+                if (!factory.Target.IsWindows)
+                    return ObjectNodeSection.DataSection;
+
                 ReadOnlyFieldPolicy readOnlyPolicy = _preinitializationManager.ReadOnlyFieldPolicy;
 
                 bool allFieldsReadOnly = true;
@@ -55,8 +59,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
 
                 // If all fields are read only, we can place this into a read only section
-                if (allFieldsReadOnly
-                    && factory.Target.IsWindows /* Unix linkers don't like relocs to readonly data section */)
+                if (allFieldsReadOnly)
                     return ObjectNodeSection.ReadOnlyDataSection;
                 else
                     return ObjectNodeSection.DataSection;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
@@ -17,6 +17,8 @@ namespace ILCompiler
     {
         private readonly bool _supportsLazyCctors;
 
+        public ReadOnlyFieldPolicy ReadOnlyFieldPolicy => _preinitHashTable._readOnlyPolicy;
+
         public PreinitializationManager(TypeSystemContext context, CompilationModuleGroup compilationGroup, ILProvider ilprovider, TypePreinit.TypePreinitializationPolicy policy, ReadOnlyFieldPolicy readOnlyPolicy, FlowAnnotations flowAnnotations)
         {
             _supportsLazyCctors = context.SystemModule.GetType("System.Runtime.CompilerServices", "ClassConstructorRunner", throwIfNotFound: false) != null;
@@ -139,7 +141,7 @@ namespace ILCompiler
             private readonly CompilationModuleGroup _compilationGroup;
             private readonly ILProvider _ilProvider;
             internal readonly TypePreinit.TypePreinitializationPolicy _policy;
-            private readonly ReadOnlyFieldPolicy _readOnlyPolicy;
+            internal readonly ReadOnlyFieldPolicy _readOnlyPolicy;
             private readonly FlowAnnotations _flowAnnotations;
 
             public PreinitializationInfoHashtable(CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinit.TypePreinitializationPolicy policy, ReadOnlyFieldPolicy readOnlyPolicy, FlowAnnotations flowAnnotations)


### PR DESCRIPTION
If all fields that contribute to the base are effectively read only, place the base into read-only section.

This only takes effect if data dehydration is turned off.

Writing a test for this is annoying because we don't have catchable access violations, but I tried with the below and observed behavior in the comments.

```csharp
unsafe class TestPreinitializedReadonlyDataCannotBeWritten
{
    class PreinitializedClass
    {
        [FixedAddressValueType]
        public static readonly int Value = 42;

        public static int* GetData() => (int*)Unsafe.AsPointer(ref Unsafe.AsRef(in Value));
    }

    class WritableClass
    {
        [FixedAddressValueType]
        public static int Value = 42;

        public static int* GetData() => (int*)Unsafe.AsPointer(ref Unsafe.AsRef(in Value));
    }

    public static void Main()
    {
        WritableClass.Value = 123;

        *WritableClass.GetData() = 456;
        Console.WriteLine(WritableClass.Value);

        *PreinitializedClass.GetData() = 678; // AFTER THIS PR: access violation
        Console.WriteLine(PreinitializedClass.Value); // BEFORE THIS PR: prints 42
    }
}
```

Cc @dotnet/ilc-contrib @Sergio0694 