### PR TITLE
Fix link to documentation file

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -147,7 +147,7 @@ namespace System.Threading
         {
             // Note: ExecutionContext.RunInternal is an extremely hot function and used by every await, ThreadPool execution, etc.
             // Note: Manual enregistering may be addressed by "Exception Handling Write Through Optimization"
-            //       https://github.com/dotnet/runtime/blob/main/docs/design/features/eh-writethru.md
+            //       https://github.com/dotnet/runtime/blob/main/docs/design/coreclr/jit/eh-writethru.md
 
             // Enregister previousExecutionCtx0 so they can be used in registers without EH forcing them to stack
 


### PR DESCRIPTION
While browsing the code I noticed that this link points to a file which no longer exists at that url, due to being moved in commit a21da8f6d945002bbb7cdb426c148867f60be528. Unfortunately, GitHub doesn't provide this information in the UI, it only displays a 404 page.