### PR TITLE
Share common Uri redaction logic in Http

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/UriRedactionHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/UriRedactionHelper.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Net.Http
+{
+    internal static class UriRedactionHelper
+    {
+        public static bool IsDisabled { get; } = GetDisableUriRedactionSettingValue();
+
+        private static bool GetDisableUriRedactionSettingValue()
+        {
+            if (AppContext.TryGetSwitch("System.Net.Http.DisableUriRedaction", out bool value))
+            {
+                return value;
+            }
+
+            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_DISABLEURIREDACTION");
+
+            if (bool.TryParse(envVar, out value))
+            {
+                return value;
+            }
+            else if (uint.TryParse(envVar, out uint intVal))
+            {
+                return intVal != 0;
+            }
+
+            return false;
+        }
+
+        public static string GetRedactedPathAndQuery(string pathAndQuery)
+        {
+            Debug.Assert(pathAndQuery is not null);
+
+            if (!IsDisabled)
+            {
+                int queryIndex = pathAndQuery.IndexOf('?');
+                if (queryIndex >= 0 && queryIndex < (pathAndQuery.Length - 1))
+                {
+                    pathAndQuery = $"{Slice(pathAndQuery, 0, queryIndex + 1)}*";
+                }
+            }
+
+            return pathAndQuery;
+        }
+
+        [return: NotNullIfNotNull(nameof(uri))]
+        public static string? GetRedactedUriString(Uri? uri)
+        {
+            if (uri is null)
+            {
+                return null;
+            }
+
+            if (IsDisabled)
+            {
+                return uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.ToString();
+            }
+
+            if (!uri.IsAbsoluteUri)
+            {
+                // We cannot guarantee the redaction of UserInfo for relative Uris without implementing some subset of Uri parsing in this package.
+                // To avoid this, we redact the whole Uri. Seeing a relative Uri here requires a custom handler chain with
+                // custom expansion logic implemented by the user's HttpMessageHandler.
+                // In such advanced scenarios we recommend users to log the Uri in their handler.
+                return "*";
+            }
+
+            string pathAndQuery = uri.PathAndQuery;
+            int queryIndex = pathAndQuery.IndexOf('?');
+
+            bool redactQuery = queryIndex >= 0 && // Query is present.
+                queryIndex < pathAndQuery.Length - 1; // Query is not empty.
+
+            return (redactQuery, uri.IsDefaultPort) switch
+            {
+                (true, true) => $"{uri.Scheme}://{uri.Host}{Slice(pathAndQuery, 0, queryIndex + 1)}*",
+                (true, false) => $"{uri.Scheme}://{uri.Host}:{uri.Port}{Slice(pathAndQuery, 0, queryIndex + 1)}*",
+                (false, true) => $"{uri.Scheme}://{uri.Host}{pathAndQuery}",
+                (false, false) => $"{uri.Scheme}://{uri.Host}:{uri.Port}{pathAndQuery}"
+            };
+        }
+
+#if NET
+        private static ReadOnlySpan<char> Slice(string text, int startIndex, int length) => text.AsSpan(startIndex, length);
+#else
+        private static string Slice(string text, int startIndex, int length) => text.Substring(startIndex, length);
+#endif
+    }
+}

--- a/src/libraries/Common/src/System/Net/Http/UriRedactionHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/UriRedactionHelper.cs
@@ -62,7 +62,7 @@ namespace System.Net.Http
 
             if (!uri.IsAbsoluteUri)
             {
-                // We cannot guarantee the redaction of UserInfo for relative Uris without implementing some subset of Uri parsing in this package.
+                // We cannot guarantee the redaction of UserInfo for relative Uris without implementing some subset of Uri parsing.
                 // To avoid this, we redact the whole Uri. Seeing a relative Uri here requires a custom handler chain with
                 // custom expansion logic implemented by the user's HttpMessageHandler.
                 // In such advanced scenarios we recommend users to log the Uri in their handler.

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LogHelper.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LogHelper.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Http.Logging
@@ -15,7 +10,6 @@ namespace Microsoft.Extensions.Http.Logging
     internal static class LogHelper
     {
         private static readonly LogDefineOptions s_skipEnabledCheckLogDefineOptions = new LogDefineOptions() { SkipEnabledCheck = true };
-        private static readonly bool s_disableUriRedaction = GetDisableUriRedactionSettingValue();
 
         private static class EventIds
         {
@@ -71,33 +65,12 @@ namespace Microsoft.Extensions.Http.Logging
             EventIds.PipelineFailed,
             "HTTP request failed after {ElapsedMilliseconds}ms");
 
-        private static bool GetDisableUriRedactionSettingValue()
-        {
-            if (AppContext.TryGetSwitch("System.Net.Http.DisableUriRedaction", out bool value))
-            {
-                return value;
-            }
-
-            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_DISABLEURIREDACTION");
-
-            if (bool.TryParse(envVar, out value))
-            {
-                return value;
-            }
-            else if (uint.TryParse(envVar, out uint intVal))
-            {
-                return intVal != 0;
-            }
-
-            return false;
-        }
-
         public static void LogRequestStart(this ILogger logger, HttpRequestMessage request, Func<string, bool> shouldRedactHeaderValue)
         {
             // We check here to avoid allocating in the GetRedactedUriString call unnecessarily
             if (logger.IsEnabled(LogLevel.Information))
             {
-                _requestStart(logger, request.Method, GetRedactedUriString(request.RequestUri), null);
+                _requestStart(logger, request.Method, UriRedactionHelper.GetRedactedUriString(request.RequestUri), null);
             }
 
             if (logger.IsEnabled(LogLevel.Trace))
@@ -131,7 +104,7 @@ namespace Microsoft.Extensions.Http.Logging
 
         public static IDisposable? BeginRequestPipelineScope(this ILogger logger, HttpRequestMessage request, out string? formattedUri)
         {
-            formattedUri = GetRedactedUriString(request.RequestUri);
+            formattedUri = UriRedactionHelper.GetRedactedUriString(request.RequestUri);
             return _beginRequestPipelineScope(logger, request.Method, formattedUri);
         }
 
@@ -167,49 +140,5 @@ namespace Microsoft.Extensions.Http.Logging
 
         public static void LogRequestPipelineFailed(this ILogger logger, TimeSpan duration, HttpRequestException exception) =>
             _requestPipelineFailed(logger, duration.TotalMilliseconds, exception);
-
-        internal static string? GetRedactedUriString(Uri? uri)
-        {
-            if (uri is null)
-            {
-                return null;
-            }
-
-            if (s_disableUriRedaction)
-            {
-                return uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.ToString();
-            }
-
-            if (!uri.IsAbsoluteUri)
-            {
-                // We cannot guarantee the redaction of UserInfo for relative Uris without implementing some subset of Uri parsing in this package.
-                // To avoid this, we redact the whole Uri. Seeing a relative Uri in LoggingHttpMessageHandler or LoggingScopeHttpMessageHandler
-                // requires a custom handler chain with custom expansion logic implemented by the user's HttpMessageHandler.
-                // In such advanced scenarios we recommend users to log the Uri in their handler.
-                return "*";
-            }
-
-            string pathAndQuery = uri.PathAndQuery;
-            int queryIndex = pathAndQuery.IndexOf('?');
-
-            bool redactQuery = queryIndex >= 0 && // Query is present.
-                queryIndex < pathAndQuery.Length - 1; // Query is not empty.
-
-            return (redactQuery, uri.IsDefaultPort) switch
-            {
-                (true, true) => $"{uri.Scheme}://{uri.Host}{GetPath(pathAndQuery, queryIndex)}*",
-                (true, false) => $"{uri.Scheme}://{uri.Host}:{uri.Port}{GetPath(pathAndQuery, queryIndex)}*",
-                (false, true) => $"{uri.Scheme}://{uri.Host}{pathAndQuery}",
-                (false, false) => $"{uri.Scheme}://{uri.Host}:{uri.Port}{pathAndQuery}"
-            };
-
-#if NET
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static ReadOnlySpan<char> GetPath(string pathAndQuery, int queryIndex) => pathAndQuery.AsSpan(0, queryIndex + 1);
-#else
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static string GetPath(string pathAndQuery, int queryIndex) => pathAndQuery.Substring(0, queryIndex + 1);
-#endif
-        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Http/src/Microsoft.Extensions.Http.csproj
+++ b/src/libraries/Microsoft.Extensions.Http/src/Microsoft.Extensions.Http.csproj
@@ -17,6 +17,8 @@ System.Net.Http.IHttpClientFactory</PackageDescription>
              Link="Common\src\Extensions\TypeNameHelper\TypeNameHelper.cs" />
     <Compile Include="$(CommonPath)System\ThrowHelper.cs"
              Link="Common\System\ThrowHelper.cs" />
+    <Compile Include="$(CommonPath)System\Net\Http\UriRedactionHelper.cs"
+             Link="Common\System\Net\Http\UriRedactionHelper.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/LoggingUriOutputTests.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/LoggingUriOutputTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Http.Tests.Logging
         public void GetRedactedUriString_RedactsUriByDefault(string original, string expected)
         {
             Uri? uri = original != null ? new Uri(original, UriKind.RelativeOrAbsolute) : null;
-            string? actual = LogHelper.GetRedactedUriString(uri);
+            string? actual = UriRedactionHelper.GetRedactedUriString(uri);
 
             Assert.Equal(expected, actual);
         }
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.Http.Tests.Logging
                 foreach (Uri uri in uris)
                 {
                     string? expected = uri != null ? uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.ToString() : null;
-                    string? actual = LogHelper.GetRedactedUriString(uri);
+                    string? actual = UriRedactionHelper.GetRedactedUriString(uri);
                     Assert.Equal(expected, actual);
                 }
             }, queryRedactionDisabler).Dispose();

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-linux;$(NetCoreAppCurrent)-osx;$(NetCoreAppCurrent)-freebsd;$(NetCoreAppCurrent)-maccatalyst;$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos;$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-solaris;$(NetCoreAppCurrent)-haiku;$(NetCoreAppCurrent)-android;$(NetCoreAppCurrent)</TargetFrameworks>
@@ -143,6 +143,8 @@
              Link="Common\System\Net\Logging\NetEventSource.Common.Associate.cs" />
     <Compile Include="$(CommonPath)System\Net\HttpDateParser.cs"
              Link="Common\System\Net\HttpDateParser.cs" />
+    <Compile Include="$(CommonPath)System\Net\Http\UriRedactionHelper.cs"
+             Link="Common\System\Net\Http\UriRedactionHelper.cs" />
     <Compile Include="$(CommonPath)System\Text\SimpleRegex.cs"
              Link="Common\System\Text\SimpleRegex.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs"

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -129,7 +129,7 @@ namespace System.Net.Http
                     {
                         activity.SetTag("server.address", requestUri.Host);
                         activity.SetTag("server.port", requestUri.Port);
-                        activity.SetTag("url.full", DiagnosticsHelper.GetRedactedUriString(requestUri));
+                        activity.SetTag("url.full", UriRedactionHelper.GetRedactedUriString(requestUri));
                     }
                 }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHelper.cs
@@ -18,30 +18,6 @@ namespace System.Net.Http
             HistogramBucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]
         };
 
-        internal static string GetRedactedUriString(Uri uri)
-        {
-            Debug.Assert(uri.IsAbsoluteUri);
-
-            if (GlobalHttpSettings.DiagnosticsHandler.DisableUriRedaction)
-            {
-                return uri.AbsoluteUri;
-            }
-
-            string pathAndQuery = uri.PathAndQuery;
-            int queryIndex = pathAndQuery.IndexOf('?');
-
-            bool redactQuery = queryIndex >= 0 && // Query is present.
-                queryIndex < pathAndQuery.Length - 1; // Query is not empty.
-
-            return (redactQuery, uri.IsDefaultPort) switch
-            {
-                (true, true) => $"{uri.Scheme}://{uri.Host}{pathAndQuery.AsSpan(0, queryIndex + 1)}*",
-                (true, false) => $"{uri.Scheme}://{uri.Host}:{uri.Port}{pathAndQuery.AsSpan(0, queryIndex + 1)}*",
-                (false, true) => $"{uri.Scheme}://{uri.Host}{pathAndQuery}",
-                (false, false) => $"{uri.Scheme}://{uri.Host}:{uri.Port}{pathAndQuery}"
-            };
-        }
-
         internal static KeyValuePair<string, object?> GetMethodTag(HttpMethod method, out bool isUnknownMethod)
         {
             // Return canonical names for known methods and "_OTHER" for unknown ones.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
@@ -14,11 +14,6 @@ namespace System.Net.Http
                 "System.Net.Http.EnableActivityPropagation",
                 "DOTNET_SYSTEM_NET_HTTP_ENABLEACTIVITYPROPAGATION",
                 true);
-
-            public static bool DisableUriRedaction { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
-                "System.Net.Http.DisableUriRedaction",
-                "DOTNET_SYSTEM_NET_HTTP_DISABLEURIREDACTION",
-                false);
         }
 
         internal static class SocketsHttpHandler

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -38,14 +38,9 @@ namespace System.Net.Http
         private void RequestStart(string scheme, string host, int port, string pathAndQuery, byte versionMajor, byte versionMinor, HttpVersionPolicy versionPolicy)
         {
             Interlocked.Increment(ref _startedRequests);
-            if (!GlobalHttpSettings.DiagnosticsHandler.DisableUriRedaction)
-            {
-                int queryIndex = pathAndQuery.IndexOf('?');
-                if (queryIndex >= 0 && queryIndex < (pathAndQuery.Length - 1))
-                {
-                    pathAndQuery = $"{pathAndQuery.AsSpan(0, queryIndex + 1)}*";
-                }
-            }
+
+            pathAndQuery = UriRedactionHelper.GetRedactedPathAndQuery(pathAndQuery);
+
             WriteEvent(eventId: 1, scheme, host, port, pathAndQuery, versionMajor, versionMinor, versionPolicy);
         }
 
@@ -187,20 +182,11 @@ namespace System.Net.Http
         [NonEvent]
         public void Redirect(Uri redirectUri)
         {
-            if (!GlobalHttpSettings.DiagnosticsHandler.DisableUriRedaction)
-            {
-                string pathAndQuery = redirectUri.PathAndQuery;
-                int queryIndex = pathAndQuery.IndexOf('?');
-                if (queryIndex >= 0 && queryIndex < (pathAndQuery.Length - 1))
-                {
-                    UriBuilder uriBuilder = new UriBuilder(redirectUri)
-                    {
-                        Query = "*"
-                    };
-                    redirectUri = uriBuilder.Uri;
-                }
-            }
-            Redirect(redirectUri.AbsoluteUri);
+            Debug.Assert(redirectUri.IsAbsoluteUri);
+
+            string uriString = UriRedactionHelper.GetRedactedUriString(redirectUri);
+
+            Redirect(uriString);
         }
 
         [NonEvent]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -52,7 +52,6 @@ namespace System.Net.Http.Functional.Tests
 
         public static IEnumerable<object[]> Redaction_MemberData()
         {
-            string[] uriTails = new string[] { "/test/path?q1=a&q2=b", "/test/path", "?q1=a&q2=b", "" };
             foreach (string uriTail in new[] { "/test/path?q1=a&q2=b", "/test/path", "?q1=a&q2=b", "" })
             {
                 foreach (string fragment in new[] { "", "#frag" })
@@ -934,15 +933,16 @@ namespace System.Net.Http.Functional.Tests
         {
             var psi = new ProcessStartInfo();
             psi.Environment.Add("DOTNET_SYSTEM_NET_HTTP_DISABLEURIREDACTION", disableRedaction.ToString());
-            var fragIndex = uriTail.IndexOf('#');
-            var expectedUriTail = uriTail.Substring(0, fragIndex >= 0 ? fragIndex : uriTail.Length);
+
+            string expectedUriTail = uriTail;
             if (!disableRedaction)
             {
                 var queryIndex = expectedUriTail.IndexOf('?');
                 expectedUriTail = expectedUriTail.Substring(0, queryIndex >= 0 ? queryIndex + 1 : expectedUriTail.Length);
                 expectedUriTail = queryIndex >= 0 ? expectedUriTail + '*' : expectedUriTail;
+
+                expectedUriTail = expectedUriTail.Split('#')[0];
             }
-            expectedUriTail = fragIndex >= 0 ? expectedUriTail + uriTail.Substring(fragIndex) : expectedUriTail;
 
             await RemoteExecutor.Invoke(static async (useVersionString, uriTail, expectedUriTail) =>
             {

--- a/src/libraries/System.Net.Http/tests/UnitTests/DiagnosticsHelperTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/DiagnosticsHelperTest.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http.Tests
         [MemberData(nameof(GetRedactedUriString_Data))]
         public void GetRedactedUriString_RedactsUriByDefault(string original, string expected)
         {
-            string redacted = DiagnosticsHelper.GetRedactedUriString(new Uri(original));
+            string redacted = UriRedactionHelper.GetRedactedUriString(new Uri(original));
             Assert.Equal(expected, redacted);
         }
 
@@ -42,7 +42,7 @@ namespace System.Net.Http.Tests
 
                 foreach (Uri uri in uris)
                 {
-                    string actual = DiagnosticsHelper.GetRedactedUriString(uri);
+                    string actual = UriRedactionHelper.GetRedactedUriString(uri);
                     Assert.Equal(uri.AbsoluteUri, actual);
                 }
             }).DisposeAsync();

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -35,6 +35,8 @@
              Link="ProductionCode\Common\System\Net\Logging\NetEventSource.Common.cs" />
     <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.Associate.cs"
              Link="Common\System\Net\Logging\NetEventSource.Common.Associate.cs" />
+    <Compile Include="$(CommonPath)System\Net\Http\UriRedactionHelper.cs"
+             Link="Common\System\Net\Http\UriRedactionHelper.cs" />
     <Compile Include="$(CommonPath)System\Net\UriScheme.cs"
              Link="ProductionCode\Common\System\Net\UriScheme.cs" />
     <Compile Include="$(CommonPath)System\Text\SimpleRegex.cs"


### PR DESCRIPTION
We had duplicate logic between the client factory and http, and the `Redirect` redaction was different (didn't account for user info & fragment).

This makes all the places share the same logic.