### PR TITLE
Remove unsafe code from WinHttpHandler TryGetHeaderName helper

### DIFF
--- a/src/libraries/Common/tests/Tests/System/Net/HttpKnownHeaderNamesTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/HttpKnownHeaderNamesTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -14,77 +13,30 @@ namespace Tests.System.Net
     public class HttpKnownHeaderNamesTests
     {
         [Theory]
-        [MemberData(nameof(UnknownHeaderNames))]
-        public void TryGetHeaderName_CharArray_UnknownStrings_NotFound(string shouldNotBeFound)
+        [InlineData("")]
+        [InlineData("this should not be found")]
+        public void TryGetHeaderName_UnknownStrings_NotFound(string shouldNotBeFound)
         {
-            char[] array = shouldNotBeFound.ToCharArray();
-
             string name;
-            Assert.False(HttpKnownHeaderNames.TryGetHeaderName(array, 0, array.Length, out name));
+            Assert.False(HttpKnownHeaderNames.TryGetHeaderName(shouldNotBeFound, out name));
             Assert.Null(name);
         }
 
         [Theory]
-        [MemberData(nameof(UnknownHeaderNames))]
-        public unsafe void TryGetHeaderName_IntPtrBuffer_UnknownStrings_NotFound(string shouldNotBeFound)
-        {
-            byte[] buffer = shouldNotBeFound.Select(c => checked((byte)c)).ToArray();
-
-            fixed (byte* pBuffer = buffer)
-            {
-                string name;
-                Assert.False(HttpKnownHeaderNames.TryGetHeaderName(new IntPtr(pBuffer), buffer.Length, out name));
-                Assert.Null(name);
-            }
-        }
-
-        public static readonly object[][] UnknownHeaderNames =
-        {
-            new object[] { string.Empty },
-            new object[] { "this should not be found" },
-        };
-
-        [Theory]
         [MemberData(nameof(HttpKnownHeaderNamesPublicStringConstants))]
-        public void TryGetHeaderName_CharArray_AllHttpKnownHeaderNamesPublicStringConstants_Found(string constant)
+        public void TryGetHeaderName_AllHttpKnownHeaderNamesPublicStringConstants_Found(string constant)
         {
-            char[] array = constant.ToCharArray();
-
             string name1;
-            Assert.True(HttpKnownHeaderNames.TryGetHeaderName(array, 0, array.Length, out name1));
+            Assert.True(HttpKnownHeaderNames.TryGetHeaderName(constant, out name1));
             Assert.NotNull(name1);
             Assert.Equal(constant, name1);
 
             string name2;
-            Assert.True(HttpKnownHeaderNames.TryGetHeaderName(array, 0, array.Length, out name2));
+            Assert.True(HttpKnownHeaderNames.TryGetHeaderName(constant, out name2));
             Assert.NotNull(name2);
             Assert.Equal(constant, name2);
 
             Assert.Same(name1, name2);
-        }
-
-        [Theory]
-        [MemberData(nameof(HttpKnownHeaderNamesPublicStringConstants))]
-        public unsafe void TryGetHeaderName_IntPtrBuffer_AllHttpKnownHeaderNamesPublicStringConstants_Found(string constant)
-        {
-            byte[] buffer = constant.Select(c => checked((byte)c)).ToArray();
-
-            fixed (byte* pBuffer = buffer)
-            {
-                Assert.True(pBuffer != null);
-
-                string name1;
-                Assert.True(HttpKnownHeaderNames.TryGetHeaderName(new IntPtr(pBuffer), buffer.Length, out name1));
-                Assert.NotNull(name1);
-                Assert.Equal(constant, name1);
-
-                string name2;
-                Assert.True(HttpKnownHeaderNames.TryGetHeaderName(new IntPtr(pBuffer), buffer.Length, out name2));
-                Assert.NotNull(name2);
-                Assert.Equal(constant, name2);
-
-                Assert.Same(name1, name2);
-            }
         }
 
         public static IEnumerable<object[]> HttpKnownHeaderNamesPublicStringConstants

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseHeaderReader.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseHeaderReader.cs
@@ -31,9 +31,7 @@ namespace System.Net.Http
         /// <returns>true if the next header was read successfully, or false if all characters have been read.</returns>
         public bool ReadHeader([NotNullWhen(true)] out string? name, [NotNullWhen(true)] out string? value)
         {
-            int startIndex;
-            int length;
-            while (ReadLine(out startIndex, out length))
+            while (ReadLine(out int startIndex, out int length))
             {
                 // Skip empty lines.
                 if (length == 0)
@@ -51,10 +49,12 @@ namespace System.Net.Http
 
                 int nameLength = colonIndex - startIndex;
 
+                ReadOnlySpan<char> nameSpan = _buffer.AsSpan(startIndex, nameLength);
+
                 // If it's a known header name, use the known name instead of allocating a new string.
-                if (!HttpKnownHeaderNames.TryGetHeaderName(_buffer, startIndex, nameLength, out name))
+                if (!HttpKnownHeaderNames.TryGetHeaderName(nameSpan, out name))
                 {
-                    name = new string(_buffer, startIndex, nameLength);
+                    name = nameSpan.ToString();
                 }
 
                 // Normalize header value by trimming whitespace.

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -390,8 +390,6 @@
              Link="Common\System\CharArrayHelpers.cs" />
     <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs"
              Link="Common\System\Net\HttpKnownHeaderNames.cs" />
-    <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs"
-             Link="Common\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs" />
     <Compile Include="$(CommonPath)\System\Net\UriScheme.cs"
              Link="Common\System\Net\UriScheme.cs" />
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs"

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -27,8 +27,6 @@
              Link="ProductionCode\Common\System\Net\HttpDateParser.cs" />
     <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.cs"
              Link="ProductionCode\Common\System\Net\HttpKnownHeaderNames.cs" />
-    <Compile Include="$(CommonPath)System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs"
-             Link="ProductionCode\Common\System\Net\HttpKnownHeaderNames.TryGetHeaderName.cs" />
     <Compile Include="$(CommonPath)System\Net\HttpStatusDescription.cs"
              Link="ProductionCode\Common\System\Net\HttpStatusDescription.cs" />
     <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs"


### PR DESCRIPTION
The byte-based overload is unused, which lets us delete a bunch of the (unsafe) helper code around it.
It should also be faster now since we don't have 100 delegate calls in that method anymore.

It's also only used from WinHttpHandler, so I removed the references from `System.Net.Http.csproj`.