### PR TITLE
Use NOTIFY_ON_U2M_TRANSITIONS in SfiInit/SfiNext

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3921,8 +3921,6 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
     ExInfo* pExInfo = pThis->GetNextExInfo();
     bool isCollided = false;
 
-    MethodDesc *pMD = pThis->m_crawl.GetFunction();
-
     do
     {
         *uExCollideClauseIdx = 0xffffffff;
@@ -3948,7 +3946,6 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
             codeInfo.DecodeGCHdrInfo(&hdrInfoBody);
             unwoundReversePInvoke = hdrInfoBody->revPInvokeOffset != INVALID_REV_PINVOKE_OFFSET;
 #endif // USE_GC_INFO_DECODER
-            bool isFilterFunclet = false;
             bool isPropagatingToExternalNativeCode = false;
         
             EH_LOG((LL_INFO100, "SfiNext: reached native frame at IP=%p, SP=%p, unwoundReversePInvoke=%d\n",
@@ -4089,7 +4086,7 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
             }
             else if (pTopExInfo->m_passNumber == 1)
             {
-                pMD = pFrame->GetFunction();
+                MethodDesc *pMD = pFrame->GetFunction();
                 if (pMD != NULL)
                 {
                     GCX_COOP();

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -4110,6 +4110,7 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
             }
 
             retVal = pThis->Next();
+            doingFuncletUnwind = false;
         }
     }
     while (retVal != SWA_FAILED && (pThis->GetFrameState() != StackFrameIterator::SFITER_FRAMELESS_METHOD));

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -4114,7 +4114,7 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
     }
     while (retVal != SWA_FAILED && (pThis->GetFrameState() != StackFrameIterator::SFITER_FRAMELESS_METHOD));
 
-    _ASSERTE(retVal == SWA_FAILED || invalidRevPInvoke || pThis->GetFrameState() == StackFrameIterator::SFITER_FRAMELESS_METHOD);
+    _ASSERTE(retVal == SWA_FAILED || pThis->GetFrameState() == StackFrameIterator::SFITER_FRAMELESS_METHOD);
 
     if (retVal == SWA_FAILED)
     {


### PR DESCRIPTION
This removes the dependency on caller context lookup from `SfiNext` which had to do a method lookup under a lock. Instead we move the cost under `pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME` branch where the same native->managed transition was already identified by the underlying stack frame iterator logic.

On x86/funclets this reduces the number of instructions on the hot path by about 5.5%:
```
Base: 710140034, Diff: 670761551, -5.5452%

_SfiNext@16                                                                             : -202000   : -0.96%   : 0.51%  : -0.0284%
__EH_epilog3                                                                            : -2221967  : -14.11%  : 5.64%  : -0.3129%
?IsManagedCodeWithLock@ExecutionManager@@CGHI@Z                                         : -2626000  : -100.00% : 6.67%  : -0.3698%
?GetScanFlags@ExecutionManager@@SG?AW4ScanFlag@1@XZ                                     : -2828000  : -98.54%  : 7.18%  : -0.3982%
?IsManagedCode@ExecutionManager@@SGHI@Z                                                 : -3232000  : -100.00% : 8.21%  : -0.4551%
__EH_prolog3                                                                            : -3433949  : -15.37%  : 8.72%  : -0.4836%
?IsManagedCodeWorker@ExecutionManager@@CGHIPAW4RangeSectionLockState@@@Z                : -6060000  : -100.00% : 15.39% : -0.8534%
?LookupRangeSection@RangeSectionMap@@QAEPAURangeSection@@IPAW4RangeSectionLockState@@@Z : -7878000  : -99.51%  : 20.00% : -1.1094%
?FindMethodCode@EECodeGenManager@@SGIPAURangeSection@@I@Z                               : -10898000 : -49.64%  : 27.67% : -1.5346%
```

The cold path (hitting `SFITER_NATIVE_MARKER_FRAME`) remains roughly the same. I assume the results are similar on other architectures.