### PR TITLE
Remove setting `$ORIGIN/netcoredeps` rpath

### DIFF
--- a/src/native/corehost/apphost/standalone/CMakeLists.txt
+++ b/src/native/corehost/apphost/standalone/CMakeLists.txt
@@ -1,16 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
-# Add RPATH to the apphost binary that allows using local copies of shared libraries
-# dotnet core depends on for special scenarios when system wide installation of such
-# dependencies is not possible for some reason.
-# This cannot be enabled for MacOS (Darwin) since its RPATH works in a different way,
-# doesn't apply to libraries loaded via dlopen and most importantly, it is not transitive.
-if (NOT CLR_CMAKE_TARGET_OSX)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-    set(CMAKE_INSTALL_RPATH "\$ORIGIN/netcoredeps")
-endif()
-
 include_directories(..)
 
 set(SOURCES

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -4,16 +4,6 @@
 project(singlefilehost)
 set(DOTNET_PROJECT_NAME "singlefilehost")
 
-# Add RPATH to the apphost binary that allows using local copies of shared libraries
-# dotnet core depends on for special scenarios when system wide installation of such
-# dependencies is not possible for some reason.
-# This cannot be enabled for MacOS (Darwin) since its RPATH works in a different way,
-# doesn't apply to libraries loaded via dlopen and most importantly, it is not transitive.
-if (NOT CLR_CMAKE_TARGET_APPLE)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-    set(CMAKE_INSTALL_RPATH "\$ORIGIN/netcoredeps")
-endif()
-
 include_directories(..)
 include_directories(../..)
 include_directories(../../hostmisc)
@@ -195,7 +185,7 @@ else()
         LIST(APPEND NATIVE_LIBS
             eventprovider
         )
-    endif(FEATURE_EVENT_TRACE) 
+    endif(FEATURE_EVENT_TRACE)
     LIST(APPEND NATIVE_LIBS
         nativeresourcestring
     )


### PR DESCRIPTION
The original use case for setting the `RPATH` was [self-contained Linux apps](https://github.com/dotnet/core/blob/main/Documentation/self-contained-linux-apps.md).

Some time between .NET 6 and .NET 8, we started using a newer linker, such that this setting sets `RUNPATH` instead of `RPATH`. This meant it only applied to the host executable, not the runtime libraries (like `coreclr`).

Per https://github.com/dotnet/runtime/issues/114393#issuecomment-2795239723, the `netcoredeps` behaviour was from a time when our dependencies were more complicated and even its intended use case has no support story.

See
- https://github.com/dotnet/runtime/issues/114393
- https://github.com/dotnet/docs/issues/45777

cc @am11 @jkotas @dotnet/interop-contrib 