### PR TITLE
[mono][interp] Avoid doing extra lookups when not needed

### DIFF
--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -506,6 +506,9 @@ emit_vector_create (TransformData *td, MonoMethodSignature *csignature, MonoClas
 static gboolean
 emit_sri_vector128 (TransformData *td, MonoMethod *cmethod, MonoMethodSignature *csignature)
 {
+	if (csignature->hasthis)
+		return FALSE;
+
 #ifdef HOST_BROWSER
 	if (emit_sri_packedsimd (td, cmethod, csignature))
 		return TRUE;
@@ -1076,6 +1079,9 @@ lookup_packedsimd_intrinsic (const char *name, MonoType *arg1)
 static gboolean
 emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature *csignature)
 {
+	if (csignature->hasthis)
+		return FALSE;
+
 	const char *cmethod_name = cmethod->name;
 	int id = lookup_intrins (sri_packedsimd_methods, sizeof (sri_packedsimd_methods), cmethod_name);
 	MonoClass *vector_klass;
@@ -1122,9 +1128,7 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 	if (!is_packedsimd) {
 		// transform the method name from the Vector(128|) name to the packed simd name
 		// FIXME: This is a hack, but it works for now.
-		if (csignature->hasthis) {
-			return FALSE;
-		}
+
 		int scalar_arg = -1;
 		for (int i = 0; i < csignature->param_count; i++) {
 			if (csignature->params [i]->type != MONO_TYPE_GENERICINST)


### PR DESCRIPTION
micro optimization to reduce the cost of not finding a match for an intrinsic that has a name match but an invalid signature.