### PR TITLE
Haiku: Define `libroot.so` as the `libc`

### DIFF
--- a/src/native/libs/System.Native/pal_dynamicload.c
+++ b/src/native/libs/System.Native/pal_dynamicload.c
@@ -21,6 +21,7 @@ void* SystemNative_LoadLibrary(const char* filename)
     //   As a result, we have to use the full name (i.e. lib.so.6) that is defined by LIBC_SO.
     // * For macOS, use constant value absolute path "/usr/lib/libc.dylib".
     // * For FreeBSD, use constant value "libc.so.7".
+    // * For Haiku, use constant value "libroot.so".
     // * For rest of Unices, use constant value "libc.so".
     if (strcmp(filename, "libc") == 0)
     {
@@ -28,6 +29,8 @@ void* SystemNative_LoadLibrary(const char* filename)
         filename = "/usr/lib/libc.dylib";
 #elif defined(__FreeBSD__)
         filename = "libc.so.7";
+#elif defined(__HAIKU__)
+        filename = "libroot.so";
 #elif defined(LIBC_SO)
         filename = LIBC_SO;
 #else


### PR DESCRIPTION
Make `SystemNative_LoadLibrary` look for `libroot.so` when `libc` is requested.

Part of #55803.