### PR TITLE
[H/3] Clean up and fix Alt-Svc handling

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
@@ -190,9 +190,9 @@ namespace System.Net.Http.Headers
 
             if (tokenLength == 0)
             {
-                result = null;
+                result = "";
                 readLength = 0;
-                return false;
+                return true;
             }
 
             ReadOnlySpan<char> span = value.AsSpan(startIndex, tokenLength);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
@@ -43,7 +43,7 @@ namespace System.Net.Http.Headers
 
             idx += alpnProtocolNameLength;
 
-            if (alpnProtocolName == "clear")
+            if (alpnProtocolName == AltSvcHeaderValue.ClearString)
             {
                 if (idx != value.Length)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderValue.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http.Headers
     /// </remarks>
     internal sealed class AltSvcHeaderValue
     {
-        public static string ClearString { get; } = "clear";
+        public const string ClearString = "clear";
 
         public static AltSvcHeaderValue Clear { get; } = new AltSvcHeaderValue(ClearString, host: null, port: 0, maxAge: TimeSpan.Zero, persist: false);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderValue.cs
@@ -13,7 +13,9 @@ namespace System.Net.Http.Headers
     /// </remarks>
     internal sealed class AltSvcHeaderValue
     {
-        public static AltSvcHeaderValue Clear { get; } = new AltSvcHeaderValue("clear", host: null, port: 0, maxAge: TimeSpan.Zero, persist: false);
+        public static string ClearString { get; } = "clear";
+
+        public static AltSvcHeaderValue Clear { get; } = new AltSvcHeaderValue(ClearString, host: null, port: 0, maxAge: TimeSpan.Zero, persist: false);
 
         public AltSvcHeaderValue(string alpnProtocolName, string? host, int port, TimeSpan maxAge, bool persist)
         {
@@ -50,6 +52,11 @@ namespace System.Net.Http.Headers
 
         public override string ToString()
         {
+            if (ReferenceEquals(Clear, this))
+            {
+                return ClearString;
+            }
+
             var sb = new ValueStringBuilder(stackalloc char[256]);
 
             sb.Append(AlpnProtocolName);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
@@ -59,5 +59,12 @@ namespace System.Net.Http
         {
             return IdnHost != null ? $"{IdnHost}:{Port}" : "<empty>";
         }
+
+        public static bool operator ==(HttpAuthority? left, HttpAuthority? right)
+        {
+            return left is null ? right is null : left.Equals(right);
+        }
+        public static bool operator !=(HttpAuthority? left, HttpAuthority? right)
+            => !(left == right);
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1896,8 +1896,7 @@ namespace System.Net.Http.Functional.Tests
         public static TheoryData<string> InteropUris() =>
             new TheoryData<string>
             {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/83775")]
-                //{ "https://www.litespeedtech.com/" }, // LiteSpeed
+                { "https://www.litespeedtech.com/" }, // LiteSpeed
                 { "https://quic.tech:8443/" }, // Cloudflare
                 { "https://quic.aiortc.org:443/" }, // aioquic
                 { "https://h2o.examp1e.net/" } // h2o/quicly

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/AltSvcHeaderParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/AltSvcHeaderParserTest.cs
@@ -98,6 +98,17 @@ namespace System.Net.Http.Tests
                 }
             };
 
+            yield return new object[]
+            {
+                "=\":443\"; ma=2592000, h3=\":443\"; ma=2592000, h3-29=\":443\"; ma=2592000, quic=\":443\"; ma=2592000; v=\"43,46\"", new[]
+                {
+                    new AltSvcHeaderValue("", host: null, port: 443, TimeSpan.FromTicks(TimeSpan.TicksPerSecond * 2592000), persist: false),
+                    new AltSvcHeaderValue("h3", host: null, port: 443, TimeSpan.FromTicks(TimeSpan.TicksPerSecond * 2592000), persist: false),
+                    new AltSvcHeaderValue("h3-29", host: null, port: 443, TimeSpan.FromTicks(TimeSpan.TicksPerSecond * 2592000), persist: false),
+                    new AltSvcHeaderValue("quic", host: null, port: 443, TimeSpan.FromTicks(TimeSpan.TicksPerSecond * 2592000), persist: false),
+                }
+            };
+
             // "clear".
             yield return new object[]
             {

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpRequestHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpRequestHeadersTest.cs
@@ -268,6 +268,16 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
+        public void AltSvc_Clear_RoundTrip_Success()
+        {
+            headers.Add("Alt-Svc", "clear");
+            string value = headers.GetValues("Alt-Svc").Single();
+            Assert.Equal("clear", value);
+            headers.Clear();
+            headers.Add("Alt-Svc", value);
+        }
+
+        [Fact]
         public void Expect_Add100Continue_Success()
         {
             // use non-default casing to make sure we do case-insensitive comparison.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/83775
- This change is not strictly necessary, it's making us being more lenient by accepting Alt-Svc with empty ALPN (RFC is more strict) and ignoring it.

Fixes https://github.com/dotnet/runtime/issues/83874
- Fixed `ToString` for "Alt-Svc: clear".
- Fixed handling of "clear" - clears out Alt-Svc including anything from the current response.
- Fixed `HttpAuthority` comparison by overloading  `==`  operator (class is internal, not public).
- The last point about NRE is irrelevant since the H/3 connection pooling was refactored to support multiple connections.