### PR TITLE
Only remove publishing workload manifests in the runtime join job

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <!-- remove the manifest packages, they are built in the SDK repo now -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetFinalPublish)' == 'true'">
     <Artifact Remove="$(ArtifactsShippingPackagesDir)*.Manifest-*.nupkg" />
   </ItemGroup>
 


### PR DESCRIPTION
We still need it temporarily for the worklods build job.