### PR TITLE
ILLink : Test API expsure

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestCase.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestCase.cs
@@ -24,7 +24,7 @@ namespace Mono.Linker.Tests.TestCases
 
 			// A little hacky, but good enough for name.  No reason why namespace & type names
 			// should not follow the directory structure
-			reconstructedFullTypeName = $"{sourceFile.Parent.RelativeTo (rootCasesDirectory.Parent).ToString (SlashMode.Forward).Replace ('/', '.')}.{sourceFile.FileNameWithoutExtension}";
+			ReconstructedFullTypeName = $"{sourceFile.Parent.RelativeTo (rootCasesDirectory.Parent).ToString (SlashMode.Forward).Replace ('/', '.')}.{sourceFile.FileNameWithoutExtension}";
 
 			var firstParentRelativeToRoot = SourceFile.RelativeTo (rootCasesDirectory).Elements.First ();
 			TestSuiteDirectory = rootCasesDirectory.Combine (firstParentRelativeToRoot);
@@ -40,7 +40,7 @@ namespace Mono.Linker.Tests.TestCases
 
 		public NPath OriginalTestCaseAssemblyPath { get; }
 
-		private string reconstructedFullTypeName;
+		public string ReconstructedFullTypeName { get; }
 
 		public bool HasLinkXmlFile {
 			get { return SourceFile.ChangeExtension ("xml").FileExists (); }
@@ -59,7 +59,7 @@ namespace Mono.Linker.Tests.TestCases
 
 		public TypeDefinition FindTypeDefinition (AssemblyDefinition caseAssemblyDefinition)
 		{
-			var typeDefinition = caseAssemblyDefinition.MainModule.GetType (reconstructedFullTypeName);
+			var typeDefinition = caseAssemblyDefinition.MainModule.GetType (ReconstructedFullTypeName);
 
 			// For all of the Test Cases, the full type name we constructed from the directory structure will be correct and we can successfully find
 			// the type from GetType.

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -135,7 +135,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			}
 		}
 
-		void VerifyILOfOtherAssemblies (TrimmedTestCaseResult linkResult)
+		protected virtual void VerifyILOfOtherAssemblies (TrimmedTestCaseResult linkResult)
 		{
 			foreach (var linkedAssemblyPath in linkResult.Sandbox.OutputDirectory.Files ("*.dll")) {
 				if (linkedAssemblyPath == linkResult.OutputAssemblyPath)


### PR DESCRIPTION
Re-expose `ReconstructedFullTypeName`.  We rely on this in our test framework

Expose `VerifyILOfOtherAssemblies`.  This causes us problems for our tests that verify the old mono BCL.  There's a goofy circular reference with Mono.Security.dll and System.dll which results in references to System.dll with two different PublicKeyTokens.  Exposing this method let's us disable this asserting behavior for our old mono tests