### PR TITLE
Prevent DynamicOptimization test from running with DOTNET_ForceRelocs=1

### DIFF
--- a/src/tests/profiler/dynamicoptimization/DynamicOptimization.csproj
+++ b/src/tests/profiler/dynamicoptimization/DynamicOptimization.csproj
@@ -23,5 +23,8 @@
     <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
     <ProjectReference Include="../../tracing/eventpipe/common/eventpipe_common.csproj" />
     <ProjectReference Include="../../tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+
+    <!-- Test does not work with DOTNET_ForceRelocs=1 -->
+    <CLRTestEnvironmentVariable Include="DOTNET_ForceRelocs" Value="0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
ForceRelocs causes the JIT to re-JIT every function on x64, which causes the test to fail because it is counting JIT compilations.

Simply force `DOTNET_ForceRelocs=0`.

Fixes #114314

Related: #114417
