### PR TITLE
Add an IsFuncletCache to the EECodeInfo

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -59,14 +59,14 @@ class AsmOffsets
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x148;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
-    public const int SIZEOF__StackFrameIterator = 0x3c4;
-    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x3b2;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3c0;
+    public const int SIZEOF__StackFrameIterator = 0x3cc;
+    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x3ba;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3c8;
 #else // TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
-    public const int SIZEOF__StackFrameIterator = 0xc4;
-    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0xb2;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xc0;
+    public const int SIZEOF__StackFrameIterator = 0xcc;
+    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0xba;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xc8;
 #endif // TARGET_64BIT
 
 #else // DEBUG
@@ -116,14 +116,14 @@ class AsmOffsets
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x140;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
-    public const int SIZEOF__StackFrameIterator = 0x3bc;
-    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x3aa;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3b8;
+    public const int SIZEOF__StackFrameIterator = 0x3c4;
+    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x3b2;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3c0;
 #else // TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
-    public const int SIZEOF__StackFrameIterator = 0xbc;
-    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0xaa;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xb8;
+    public const int SIZEOF__StackFrameIterator = 0xc4;
+    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0xb2;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xc0;
 #endif // TARGET_64BIT
 
 #endif // DEBUG

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4294,6 +4294,7 @@ BOOL EECodeGenManager::JitCodeToMethodInfoWorker(
 #ifdef FEATURE_EH_FUNCLETS
         // Computed lazily by code:EEJitManager::LazyGetFunctionEntry
         pCodeInfo->m_pFunctionEntry = NULL;
+        pCodeInfo->m_isFuncletCache = pCHdr->ComputeInitialIsFuncletCacheValue(currentPC);
 #endif
     }
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1103,7 +1103,7 @@ TADDR IJitManager::GetFuncletStartAddress(EECodeInfo * pCodeInfo)
     return funcletStartAddress;
 }
 
-BOOL IJitManager::IsFunclet(EECodeInfo * pCodeInfo)
+BOOL IJitManager::LazyIsFunclet(EECodeInfo * pCodeInfo)
 {
     CONTRACTL {
         NOTHROW;
@@ -4293,8 +4293,17 @@ BOOL EECodeGenManager::JitCodeToMethodInfoWorker(
 
 #ifdef FEATURE_EH_FUNCLETS
         // Computed lazily by code:EEJitManager::LazyGetFunctionEntry
-        pCodeInfo->m_pFunctionEntry = NULL;
-        pCodeInfo->m_isFuncletCache = pCHdr->ComputeInitialIsFuncletCacheValue(currentPC);
+        if (pCHdr->MayHaveFunclets())
+        {
+            // Computed lazily by code:EEJitManager::LazyGetFunctionEntry
+            pCodeInfo->m_pFunctionEntry = NULL;
+            pCodeInfo->m_isFuncletCache = EECodeInfo::IsFuncletCache::NotSet;
+        }
+        else
+        {
+            pCodeInfo->m_pFunctionEntry = pCHdr->GetUnwindInfo(0);
+            pCodeInfo->m_isFuncletCache = EECodeInfo::IsFuncletCache::IsNotFunclet;
+        }
 #endif
     }
 
@@ -6509,7 +6518,7 @@ DWORD ReadyToRunJitManager::GetFuncletStartOffsets(const METHODTOKEN& MethodToke
     return nFunclets;
 }
 
-BOOL ReadyToRunJitManager::IsFunclet(EECodeInfo* pCodeInfo)
+BOOL ReadyToRunJitManager::LazyIsFunclet(EECodeInfo* pCodeInfo)
 {
     CONTRACTL {
         NOTHROW;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14748,6 +14748,7 @@ EECodeInfo::EECodeInfo()
 
 #ifdef FEATURE_EH_FUNCLETS
     m_pFunctionEntry = NULL;
+    m_isFuncletCache = IsFuncletCache::NotSet;
 #endif
 
 #ifdef TARGET_X86
@@ -14773,6 +14774,9 @@ void EECodeInfo::Init(PCODE codeAddress, ExecutionManager::ScanFlag scanFlag)
     } CONTRACTL_END;
 
     m_codeAddress = codeAddress;
+#ifdef FEATURE_EH_FUNCLETS
+    m_isFuncletCache = IsFuncletCache::NotSet;
+#endif
 
 #ifdef TARGET_X86
     m_hdrInfoTable = NULL;
@@ -14885,6 +14889,9 @@ EECodeInfo EECodeInfo::GetMainFunctionInfo()
     result.m_relOffset = 0;
     result.m_codeAddress = this->GetStartAddress();
     result.m_pFunctionEntry = NULL;
+#ifdef FEATURE_EH_FUNCLETS
+    m_isFuncletCache = IsFuncletCache::IsNotFunclet;
+#endif
 
     return result;
 }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14890,7 +14890,7 @@ EECodeInfo EECodeInfo::GetMainFunctionInfo()
     result.m_codeAddress = this->GetStartAddress();
     result.m_pFunctionEntry = NULL;
 #ifdef FEATURE_EH_FUNCLETS
-    m_isFuncletCache = IsFuncletCache::IsNotFunclet;
+    result.m_isFuncletCache = IsFuncletCache::IsNotFunclet;
 #endif
 
     return result;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14906,6 +14906,20 @@ PTR_RUNTIME_FUNCTION EECodeInfo::GetFunctionEntry()
     return m_pFunctionEntry;
 }
 
+BOOL EECodeInfo::IsFunclet()
+{
+    WRAPPER_NO_CONTRACT;
+    if (m_isFuncletCache == IsFuncletCache::NotSet)
+    {
+        m_isFuncletCache = GetJitManager()->LazyIsFunclet(this) ? IsFuncletCache::IsFunclet : IsFuncletCache::IsNotFunclet;
+    }
+
+    // At this point we know that m_isFuncletCache is either IsFunclet or IsNotFunclet, which is either 1 or 0. Just cast it to BOOL.
+    BOOL result = (BOOL)m_isFuncletCache;
+    _ASSERTE(!!GetJitManager()->LazyIsFunclet(this) == !!result);
+    return result;
+}
+
 #if defined(TARGET_AMD64)
 
 BOOL EECodeInfo::HasFrameRegister()


### PR DESCRIPTION
- Do a cheap computation in EECodeInfo::Init time to fill it in if there aren't any funclets in the method
- This avoids the fairly complex IsFunclet logic on the JitManager, as well as the virtual call to get there in some cases.

This should improve the performance of any EH stack trace operations that repeatedly call IsFunclet, especially if many of the methods on the stack are simple and do not have any EH constructs in them.

In a simple benchmark of EH throw performance, when running in the Windows X86 Funclets mode, the performance improves by about 15%.