### PR TITLE
Support W3C Propagator

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -311,6 +311,8 @@ namespace System.Diagnostics
       public static DistributedContextPropagator CreateDefaultPropagator() { throw null; }
       public static DistributedContextPropagator CreatePassThroughPropagator() { throw null; }
       public static DistributedContextPropagator CreateNoOutputPropagator() { throw null; }
+      public static DistributedContextPropagator CreatePreW3CPropagator() { throw null; }
+      public static DistributedContextPropagator CreateW3CPropagator() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public struct TagList : System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object?>>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -56,6 +56,7 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <Compile Include="System\Diagnostics\NoOutputPropagator.cs" />
     <Compile Include="System\Diagnostics\PassThroughPropagator.cs" />
     <Compile Include="System\Diagnostics\RandomNumberGenerator.cs" />
+    <Compile Include="System\Diagnostics\W3CPropagator.cs" />
     <Compile Include="System\Diagnostics\Metrics\AggregationManager.cs" />
     <Compile Include="System\Diagnostics\Metrics\Aggregator.cs" />
     <Compile Include="System\Diagnostics\Metrics\AggregatorStore.cs" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
@@ -88,8 +88,8 @@ namespace System.Diagnostics
         /// </summary>
         /// <remarks>
         /// CreateDefaultPropagator will create a propagator instance that can inject and extract the headers with field names "tracestate",
-        /// "traceparent" of the identifiers which are formatted as W3C trace parent, "Request-Id" of the identifiers which are formatted as a hierarchical identifier.
-        /// The returned propagator can inject the baggage key-value pair list with header name "Correlation-Context" and it can extract the baggage values mapped to header names "Correlation-Context" and "baggage".
+        /// "traceparent" of the identifiers which are formatted as W3C trace parent.
+        /// The returned propagator can inject the baggage key-value pair list with header name "baggage" and it can extract the baggage values mapped to header name "baggage".
         /// </remarks>
         public static DistributedContextPropagator CreateDefaultPropagator() => W3CPropagator.Instance;
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
@@ -91,7 +91,7 @@ namespace System.Diagnostics
         /// "traceparent" of the identifiers which are formatted as W3C trace parent, "Request-Id" of the identifiers which are formatted as a hierarchical identifier.
         /// The returned propagator can inject the baggage key-value pair list with header name "Correlation-Context" and it can extract the baggage values mapped to header names "Correlation-Context" and "baggage".
         /// </remarks>
-        public static DistributedContextPropagator CreateDefaultPropagator() => LegacyPropagator.Instance;
+        public static DistributedContextPropagator CreateDefaultPropagator() => W3CPropagator.Instance;
 
         /// <summary>
         /// Returns a propagator which attempts to act transparently, emitting the same data on outbound network requests that was received on the in-bound request.

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
@@ -100,6 +100,22 @@ namespace System.Diagnostics
         public static DistributedContextPropagator CreatePassThroughPropagator() => PassThroughPropagator.Instance;
 
         /// <summary>
+        /// Returns a propagator that encodes and decodes distributed context information in accordance with the W3C Trace Context and Baggage specifications.
+        /// </summary>
+        public static DistributedContextPropagator CreateW3CPropagator() => W3CPropagator.Instance;
+
+        /// <summary>
+        /// Returns a propagator that encodes and decodes distributed context and baggage information in a backward-compatible manner.
+        /// </summary>
+        /// <remarks>
+        /// This propagator is not fully compliant with the W3C specification.
+        /// It inserts baggage using the "Correlation-Context" header instead of "baggage".
+        /// It also takes a more relaxed approach to handling trace state and baggage key-value pairs, allowing characters that are not permitted by the W3C specification.
+        /// Additionally, this propagator supports injecting values from Activity objects that use the ActivityIdFormat.Hierarchical format, which is not supported by the W3C specification.
+        /// </remarks>
+        public static DistributedContextPropagator CreatePreW3CPropagator() => LegacyPropagator.Instance;
+
+        /// <summary>
         /// Returns a propagator which does not transmit any distributed context information in outbound network messages.
         /// </summary>
         public static DistributedContextPropagator CreateNoOutputPropagator() => NoOutputPropagator.Instance;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -426,12 +426,12 @@ namespace System.Diagnostics
         private const string TraceStateKeyValidChars = "*-/@_abcdefghijklmnopqrstuvwxyz";
         private static readonly SearchValues<char> s_validTraceStateChars = SearchValues.Create(TraceStateKeyValidChars);
 
-        private static bool IsInvalidTraceStateKey(ReadOnlySpan<char> span) => span.ContainsAnyExcept(s_validTraceStateChars);
+        private static bool IsInvalidTraceStateKey(ReadOnlySpan<char> key) => key.IsEmpty || (key[0] < 'a' || key[0] > 'z') || key.ContainsAnyExcept(s_validTraceStateChars);
 
         private const string TraceStateValueValidChars = "!\"#$%&'()*+-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
         private static readonly SearchValues<char> s_validTraceStateValueChars = SearchValues.Create(TraceStateValueValidChars);
 
-        private static bool IsInvalidTraceStateValue(ReadOnlySpan<char> span) => span.ContainsAnyExcept(s_validTraceStateValueChars);
+        private static bool IsInvalidTraceStateValue(ReadOnlySpan<char> value) => value.IsEmpty || value.ContainsAnyExcept(s_validTraceStateValueChars);
 #else
         private static ulong[] ValidTraceStateKeyCharsMask = [0x0000A40000000000, 0x07FFFFFE80000001];
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -701,8 +701,6 @@ namespace System.Diagnostics
         {
             const string hexChars = "0123456789ABCDEF";
 
-            Debug.Assert(b <= 127);
-
             vsb.Append(Percent);
             vsb.Append(hexChars[(b >> 4) & 0x0F]);
             vsb.Append(hexChars[b & 0x0F]);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -1,0 +1,743 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Diagnostics
+{
+    internal sealed class W3CPropagator : DistributedContextPropagator
+    {
+        internal static DistributedContextPropagator Instance { get; } = new W3CPropagator();
+
+        private const int MaxBaggageEntriesToEmit = 64;     // Suggested by W3C specs
+        private const int MaxBaggageEncodedLength = 8192;   // Suggested by W3C specs
+        private const int MaxTraceStateEncodedLength = 256; // Suggested by W3C specs
+
+        private const char Equal = '=';
+        private const char Percent = '%';
+        private const char Replacement = '\uFFFD'; // �
+
+        public override IReadOnlyCollection<string> Fields { get; } = new ReadOnlyCollection<string>(new[] { TraceParent, TraceState, Baggage });
+
+        public override void Inject(Activity? activity, object? carrier, PropagatorSetterCallback? setter)
+        {
+            if (activity is null || setter is null || activity.IdFormat != ActivityIdFormat.W3C)
+            {
+                return;
+            }
+
+            string? id = activity.Id;
+            if (id is null)
+            {
+                return;
+            }
+
+            setter(carrier, TraceParent, id);
+            if (!string.IsNullOrEmpty(activity.TraceStateString))
+            {
+                InjectTraceState(activity.TraceStateString, carrier, setter);
+            }
+
+            InjectW3CBaggage(carrier, activity.Baggage, setter);
+        }
+
+        public override void ExtractTraceIdAndState(object? carrier, PropagatorGetterCallback? getter, out string? traceId, out string? traceState)
+        {
+            if (getter is null)
+            {
+                traceId = null;
+                traceState = null;
+                return;
+            }
+
+            getter(carrier, TraceParent, out traceId, out _);
+            if (IsInvalidTraceParent(traceId))
+            {
+                traceId = null;
+            }
+
+            getter(carrier, TraceState, out string? traceStateValue, out _);
+            traceState = ValidateTraceState(traceStateValue);
+        }
+
+        public override IEnumerable<KeyValuePair<string, string?>>? ExtractBaggage(object? carrier, PropagatorGetterCallback? getter)
+        {
+            if (getter is null)
+            {
+                return null;
+            }
+
+            getter(carrier, Baggage, out string? theBaggage, out _);
+
+            TryExtractBaggage(theBaggage, out IEnumerable<KeyValuePair<string, string?>>? baggage);
+
+            return baggage;
+        }
+
+        internal static bool TryExtractBaggage(string? baggageString, out IEnumerable<KeyValuePair<string, string?>>? baggage)
+        {
+            baggage = null;
+            List<KeyValuePair<string, string?>>? baggageList = null;
+
+            if (string.IsNullOrEmpty(baggageString))
+            {
+                return true;
+            }
+
+            ReadOnlySpan<char> baggageSpan = baggageString;
+
+            do
+            {
+                int entrySeparator = baggageSpan.IndexOf(Comma);
+                ReadOnlySpan<char> currentEntry = entrySeparator >= 0 ? baggageSpan.Slice(0, entrySeparator) : baggageSpan;
+
+                int keyValueSeparator = currentEntry.IndexOf(Equal);
+                if (keyValueSeparator <= 0 || keyValueSeparator >= currentEntry.Length - 1)
+                {
+                    break; // invalid format
+                }
+
+                ReadOnlySpan<char> keySpan = currentEntry.Slice(0, keyValueSeparator);
+                ReadOnlySpan<char> valueSpan = currentEntry.Slice(keyValueSeparator + 1);
+
+                if (TryDecodeBaggageKey(keySpan, out string? key) && TryDecodeBaggageValue(valueSpan, out string value))
+                {
+                    baggageList ??= new List<KeyValuePair<string, string?>>();
+                    baggageList.Add(new KeyValuePair<string, string?>(key, value));
+                }
+
+                baggageSpan = entrySeparator >= 0 ? baggageSpan.Slice(entrySeparator + 1) : ReadOnlySpan<char>.Empty;
+            } while (baggageSpan.Length > 0);
+
+            baggage = baggageList;
+            return baggageList != null;
+        }
+
+        // list  = list-member 0*31( OWS "," OWS list-member )
+        // list-member = (key "=" value) / OWS
+        //
+        // key = ( lcalpha / DIGIT ) 0*255 ( keychar )
+        // keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/" / "@"
+        // lcalpha    = %x61-7A ; a-z
+        //
+        // value    = 0*255(chr) nblk-chr
+        // nblk-chr = %x21-2B / %x2D-3C / %x3E-7E
+        // chr      = %x20 / nblk-chr
+
+        internal static string? ValidateTraceState(string? traceState)
+        {
+            if (string.IsNullOrEmpty(traceState))
+            {
+                return null; // invalid format
+            }
+
+            int processed = 0;
+
+            while (processed < traceState.Length)
+            {
+                ReadOnlySpan<char> traceStateSpan = traceState.AsSpan(processed);
+                int commaIndex = traceStateSpan.IndexOf(Comma);
+                ReadOnlySpan<char> entry = commaIndex >= 0 ? traceStateSpan.Slice(0, commaIndex) : traceStateSpan;
+                int delta = entry.Length + (commaIndex >= 0 ? 1 : 0); // +1 for the comma
+
+                if (processed + delta > MaxTraceStateEncodedLength)
+                {
+                    break; // entry exceeds max length
+                }
+
+                int equalIndex = entry.IndexOf(Equal);
+                if (equalIndex <= 0 || equalIndex >= entry.Length - 1)
+                {
+                    break; // invalid format
+                }
+
+                if (IsInvalidTraceStateKey(Trim(entry.Slice(0, equalIndex))) || IsInvalidTraceStateValue(TrimSpaceOnly(entry.Slice(equalIndex + 1))))
+                {
+                    break; // entry exceeds max length or invalid key/value, skip current entry
+                }
+
+                processed += delta;
+            }
+
+            if (processed > 0)
+            {
+                if (traceState[processed - 1] == Comma)
+                {
+                    processed--; // remove the last comma
+                }
+
+                if (processed > 0)
+                {
+                    return processed >= traceState.Length ? traceState : traceState.AsSpan(0, processed).ToString();
+                }
+            }
+
+            return null;
+        }
+
+        internal static void InjectTraceState(string traceState, object? carrier, PropagatorSetterCallback setter)
+        {
+            Debug.Assert(traceState != null, "traceState cannot be null");
+            Debug.Assert(setter != null, "setter cannot be null");
+
+            string? traceStateValue = ValidateTraceState(traceState);
+            if (traceStateValue is not null)
+            {
+                setter(carrier, TraceState, traceStateValue);
+            }
+        }
+
+        internal static void InjectW3CBaggage(object? carrier, IEnumerable<KeyValuePair<string, string?>> baggage, PropagatorSetterCallback setter)
+        {
+            using (IEnumerator<KeyValuePair<string, string?>> e = baggage.GetEnumerator())
+            {
+                if (e.MoveNext())
+                {
+                    ValueStringBuilder encodedBaggage = new ValueStringBuilder(stackalloc char[256]);
+
+                    int entriesCount = 0;
+                    int lastGoodLength = 0;
+
+                    do
+                    {
+                        KeyValuePair<string, string?> item = e.Current;
+
+                        if (EncodeBaggageKey(item.Key, ref encodedBaggage))
+                        {
+                            encodedBaggage.Append(Space);
+                            encodedBaggage.Append(Equal);
+                            encodedBaggage.Append(Space);
+                            if (!string.IsNullOrEmpty(item.Value))
+                            {
+                                EncodeBaggageValue(item.Value, ref encodedBaggage);
+                            }
+                            encodedBaggage.Append(CommaWithSpace);
+
+                            entriesCount++;
+
+                            if (encodedBaggage.Length < MaxBaggageEncodedLength)
+                            {
+                                lastGoodLength = encodedBaggage.Length;
+                            }
+                        }
+                    } while (e.MoveNext() && entriesCount < MaxBaggageEntriesToEmit && encodedBaggage.Length < MaxBaggageEncodedLength);
+
+                    if (lastGoodLength - 2 > 0)
+                    {
+                        setter(carrier, Baggage, encodedBaggage.AsSpan(0, lastGoodLength - 2).ToString());
+                    }
+                    else
+                    {
+                        encodedBaggage.Dispose();
+                    }
+                }
+            }
+        }
+
+        private static bool TryDecodeBaggageKey(ReadOnlySpan<char> keySpan, out string key)
+        {
+            key = null!;
+            keySpan = Trim(keySpan);
+
+            foreach (char c in keySpan)
+            {
+                if (IsInvalidBaggageKeyCharacter(c))
+                {
+                    return false;
+                }
+            }
+
+            if (keySpan.IsEmpty)
+            {
+                return false;
+            }
+
+            key = keySpan.ToString();
+            return true;
+        }
+
+        private static bool TryDecodeBaggageValue(ReadOnlySpan<char> valueSpan, out string value)
+        {
+            value = null!;
+            valueSpan = Trim(valueSpan);
+
+            using ValueStringBuilder vsb = new ValueStringBuilder(stackalloc char[128]);
+
+            for (int i = 0; i < valueSpan.Length; i++)
+            {
+                char c = valueSpan[i];
+                if (c > 0x7F)
+                {
+                    return false; // we expect only ascii characters
+                }
+
+                if (c != Percent) // none escaped
+                {
+                    vsb.Append(c);
+                    continue;
+                }
+
+                if (!TryDecodeEscapedByte(valueSpan.Slice(i), out byte b0))
+                {
+                    return false;
+                }
+
+                if (b0 <= 0x7F)
+                {
+                    vsb.Append((char)b0);
+                    i += 2;
+                    continue;
+                }
+
+                // 2-byte sequence: 110xxxxx 10xxxxxx
+                if ((uint)(b0 - 0xC2) <=  (0xDF - 0xC2))
+                {
+                    if (i + 5 >= valueSpan.Length || valueSpan[i + 3] != Percent || !TryDecodeEscapedByte(valueSpan.Slice(i + 3), out byte b1) || (b1 & 0xC0) != 0x80)
+                    {
+                        // Malformed utf-8 sequence. emit U+FFFD and continue
+                        vsb.Append(Replacement);
+                        i += 2;
+                        continue;
+                    }
+
+                    vsb.Append((char)(((b0 & 0x1F) << 6) | (b1 & 0x3F)));
+                    i += 5;
+                    continue;
+                }
+
+                // 3-byte sequence: 1110xxxx 10xxxxxx 10xxxxxx
+                if ((uint)(b0 - 0xE0) <= (0xEF - 0xE0))
+                {
+                    if (i + 8 >= valueSpan.Length ||
+                        valueSpan[i + 3] != Percent ||
+                        valueSpan[i + 6] != Percent ||
+                        !TryDecodeEscapedByte(valueSpan.Slice(i + 3), out byte b1) ||
+                        !TryDecodeEscapedByte(valueSpan.Slice(i + 6), out byte b2) ||
+                        (b0 == 0xE0 && b1 < 0xA0) || (b0 == 0xED && b1 >= 0xA0))
+                    {
+                        // Malformed utf-8 sequence. emit U+FFFD and continue
+                        vsb.Append(Replacement);
+                        i += 2;
+                        continue;
+                    }
+
+                    vsb.Append((char)(((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F)));
+                    i += 8;
+                    continue;
+                }
+
+                // 4-byte sequence: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+                if ((uint)(b0 - 0xF0) <= (0xF4 - 0xF0))
+                {
+                    if (i + 11 >= valueSpan.Length ||
+                        valueSpan[i + 3] != Percent ||
+                        valueSpan[i + 6] != Percent ||
+                        valueSpan[i + 9] != Percent ||
+                        !TryDecodeEscapedByte(valueSpan.Slice(i + 3), out byte b1) ||
+                        !TryDecodeEscapedByte(valueSpan.Slice(i + 6), out byte b2) ||
+                        !TryDecodeEscapedByte(valueSpan.Slice(i + 9), out byte b3) ||
+                        (b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80)
+                    {
+                        // Malformed utf-8 sequence. emit U+FFFD and continue
+                        vsb.Append(Replacement);
+                        i += 2;
+                        continue;
+                    }
+
+                    int cp = (((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | ((b3 & 0x3F)));
+
+                    if (cp < 0x10000 || cp > 0x10FFFF)
+                    {
+                        // Malformed utf-8 sequence. emit U+FFFD and continue
+                        vsb.Append(Replacement);
+                        i += 2;
+                        continue;
+                    }
+
+                    cp -= 0x10000;
+                    vsb.Append((char)((cp >> 10) + 0xD800));
+                    vsb.Append((char)((cp & 0x3FF) + 0xDC00));
+
+                    i += 11;
+                    continue;
+                }
+
+                // invalid byte sequence. emit U+FFFD and continue
+                vsb.Append(Replacement);
+                i += 2;
+            }
+
+            value = vsb.ToString();
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryDecodeEscapedByte(ReadOnlySpan<char> span, out byte value)
+        {
+            Debug.Assert(span.Length > 0 && span[0] == Percent);
+
+            if (span.Length < 3 || !TryDecodeHexDigit(span[1], out byte byte1) || !TryDecodeHexDigit(span[2], out byte byte2))
+            {
+                value = 0;
+                return false;
+            }
+
+            value = (byte)(((uint)byte1 << 4) + byte2);
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryDecodeHexDigit(char c, out byte value)
+        {
+            if ((uint)(c - '0') <= ('9' - '0'))
+            {
+                value = (byte)(c - '0');
+                return true;
+            }
+
+            if ((uint)(c- 'a') <= ('f' - 'a'))
+            {
+                value = (byte)((c - 'a') + 10);
+                return true;
+            }
+
+            if ((uint)(c - 'A') <= ('F' - 'A'))
+            {
+                value = (byte)((c - 'A') + 10);
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        // Allowed baggage key characters:
+        //  tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+        //  DIGIT = 0-9
+        //  ALPHA = A-Z / a-z
+        private static ulong[] InvalidBaggageKeyCharsMask = [0xFC009305FFFFFFFF, 0x2800000038000001];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsInvalidBaggageKeyCharacter(char c)
+        {
+            if (c >= 0x07F) // key support only ascii characters according to the W3C specs
+            {
+                return true;
+            }
+
+            return (InvalidBaggageKeyCharsMask[c >> 6] & (ulong)((ulong)1 << ((int)c & 63))) != 0;
+        }
+
+        // key = ( lcalpha / DIGIT ) 0*255 ( keychar )
+        // keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/" / "@"
+        // lcalpha    = %x61-7A ; a-z
+        private static ulong[] InvalidTraceStateKeyCharsMask = [0x0000A40000000000, 0x07FFFFFE80000001];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsInvalidTraceStateKeyCharacter(char c)
+        {
+            if (c >= 0x07F) // key support only ascii characters according to the W3C specs
+            {
+                return true;
+            }
+
+            return (InvalidTraceStateKeyCharsMask[c >> 6] & (ulong)((ulong)1 << ((int)c & 63))) == 0;
+        }
+
+        private static bool IsInvalidTraceStateKey(ReadOnlySpan<char> key)
+        {
+            if (key.IsEmpty || (key[0] < 'a' || key[0] > 'z')) // Key has to start with a lowercase letter
+            {
+                return true; // invalid key character, skip current entry
+            }
+
+            foreach (char c in key)
+            {
+                if (IsInvalidTraceStateKeyCharacter(c))
+                {
+                    return true; // invalid key character, skip current entry
+                }
+            }
+
+            return false; // valid key
+        }
+
+        private static bool IsInvalidTraceStateValue(ReadOnlySpan<char> value)
+        {
+            if (value.IsEmpty)
+            {
+                return true;
+            }
+
+            foreach (char c in value)
+            {
+                if (IsInvalidTraceStateValueCharacter(c))
+                {
+                    return true; // invalid key character, skip current entry
+                }
+            }
+
+            return false; // valid key
+        }
+
+        //value = 0 * 255(chr) nblk - chr
+        //nblk - chr = % x21 - 2B / % x2D - 3C / % x3E - 7E
+        //chr = % x20 / nblk - chr
+        private static ulong[] traceStateValueMask = { 0xDFFFEFFE00000000, 0x7FFFFFFFFFFFFFFF };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsInvalidTraceStateValueCharacter(char c)
+        {
+            if (c >= 0x07F)
+            {
+                return true;
+            }
+
+            return (traceStateValueMask[c >> 6] & (ulong)((ulong)1 << ((int)c & 63))) == 0;
+        }
+
+        // baggage-string         =  list-member 0*179( OWS "," OWS list-member )
+        // list-member            =  key OWS "=" OWS value *( OWS ";" OWS property )
+        // property               =  key OWS "=" OWS value
+        // property               =/ key OWS
+        // key                    =  token ; as defined in RFC 7230, Section 3.2.6
+        // value                  =  *baggage-octet
+        // baggage-octet          =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+        //                         ; US-ASCII characters excluding CTLs,
+        //                         ; whitespace, DQUOTE, comma, semicolon,
+        //                         ; and backslash
+        // OWS                    =  *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
+
+        /// <summary>
+        /// Encode the baggage entry key according to the W3C Specification https://www.w3.org/TR/baggage/#key and https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6.
+        /// </summary>
+        /// <param name="key">The baggage entry key to encode.</param>
+        /// <param name="vsb">The string builder to store the encoded key.</param>
+        /// <returns>True if the key encoded correctly, False other wise.</returns>
+        /// <remarks>
+        /// Though the baggage header is a [UTF-8] encoded string, key is limited to the ASCII code points (code point in the range U+0000 NULL to U+007F DELETE, inclusive) allowed by the definition of token in [RFC7230].
+        /// This is due to the implementation details of stable implementations prior to the writing of this specification.
+        /// Allowed characters: HTAB / SP /%x21 / %x23-5B / %x5D-7E
+        /// </remarks>
+        internal static bool EncodeBaggageKey(ReadOnlySpan<char> key, ref ValueStringBuilder vsb)
+        {
+            key = Trim(key);
+
+            if (key.Length == 0)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < key.Length; i++)
+            {
+                if (IsInvalidBaggageKeyCharacter(key[i]))
+                {
+                    return false;
+                }
+            }
+
+            vsb.Append(key);
+            return true;
+        }
+
+        internal static void EncodeBaggageValue(ReadOnlySpan<char> value, ref ValueStringBuilder vsb)
+        {
+            value = Trim(value);
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+
+                if (!NeedToEscapeBaggageValueCharacter(c))
+                {
+                    vsb.Append(c);
+                    continue;
+                }
+
+                if (c <= 0x7Fu) // still in ascii range
+                {
+                    EmitEscapedByte((byte)c, ref vsb);
+                    continue;
+                }
+
+                if (c <= 0x7FFu)
+                {
+                    // Scalar 00000yyy yyxxxxxx -> bytes [ 110yyyyy 10xxxxxx ]
+                    EmitEscapedByte((byte)((c + (0b110u << 11)) >> 6), ref vsb);
+                    EmitEscapedByte((byte)((c & 0x3Fu) + 0x80u), ref vsb);
+                    continue;
+                }
+
+                if (char.IsSurrogate(c))
+                {
+                    if (i < value.Length - 1 && char.IsSurrogatePair((char)c, value[i + 1]))
+                    {
+                        // Scalar 000uuuuu zzzzyyyy yyxxxxxx -> bytes [ 11110uuu 10uuzzzz 10yyyyyy 10xxxxxx ]
+                        uint v = (uint)char.ConvertToUtf32((char)c, value[i + 1]);
+
+                        EmitEscapedByte((byte)((v + (0b11110 << 21)) >> 18), ref vsb);
+                        EmitEscapedByte((byte)(((v & (0x3Fu << 12)) >> 12) + 0x80u), ref vsb);
+                        EmitEscapedByte((byte)(((v & (0x3Fu << 6)) >> 6) + 0x80u), ref vsb);
+                        EmitEscapedByte((byte)((v & 0x3Fu) + 0x80u), ref vsb);
+                        i++;
+                    }
+                    else
+                    {
+                        // Wrong surrogate: emit 0xFFFD which has the UTF-8 encoding bytes 0xEF, 0xBF, and 0xBD.
+                        EmitEscapedByte(0xEF, ref vsb);
+                        EmitEscapedByte(0xBF, ref vsb);
+                        EmitEscapedByte(0xBD, ref vsb);
+                    }
+                    continue;
+                }
+
+                // Scalar zzzzyyyy yyxxxxxx -> bytes [ 1110zzzz 10yyyyyy 10xxxxxx ]
+                EmitEscapedByte((byte)((c + (0b1110 << 16)) >> 12), ref vsb);
+                EmitEscapedByte((byte)(((c & (0x3Fu << 6)) >> 6) + 0x80u), ref vsb);
+                EmitEscapedByte((byte)((c & 0x3Fu) + 0x80u), ref vsb);
+            }
+        }
+
+        // baggage-octet =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E (Exclude the `%` %x25)
+        // are the characters don't need to get escaped
+        private static ulong[] s_baggageOctet = [0xF7FFEFDA00000000, 0x7FFFFFFFEFFFFFFF];
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool NeedToEscapeBaggageValueCharacter(char c)
+        {
+            if (c >= 0x07F) // non-escapable characters are in ASCII range
+            {
+                return true;
+            }
+
+            return (s_baggageOctet[c >> 6] & (ulong)((ulong)1 << ((int)c & 63))) == 0;
+        }
+
+        // HEXDIGLC = DIGIT / "a" / "b" / "c" / "d" / "e" / "f"; lowercase hex character
+        // value           = version "-" version-format
+        // version = 2HEXDIGLC; this document assumes version 00. Version ff is forbidden
+        // version - format = trace - id "-" parent - id "-" trace - flags
+        // trace - id = 32HEXDIGLC; 16 bytes array identifier. All zeroes forbidden
+        // parent-id        = 16HEXDIGLC  ; 8 bytes array identifier. All zeroes forbidden
+        // trace-flags      = 2HEXDIGLC   ; 8 bit flags.
+        //         .         .         .         .         .         .
+        // Example 00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01
+        private static bool IsInvalidTraceParent(string? traceParent)
+        {
+            if (string.IsNullOrEmpty(traceParent) || traceParent.Length != 55)
+            {
+                return true;
+            }
+
+            if (traceParent[0] == 'f' || traceParent[1] == 'f' || IsInvalidTraceParentCharacter(traceParent[0]) || IsInvalidTraceParentCharacter(traceParent[1]))
+            {
+                return true;
+            }
+
+            if (traceParent[2] != '-' || traceParent[35] != '-' || traceParent[52] != '-')
+            {
+                return true;
+            }
+
+            bool isAllZeroes = true;
+            for (int i = 3; i < 35; i++)
+            {
+                if (IsInvalidTraceParentCharacter(traceParent[i]))
+                {
+                    return true;
+                }
+
+                isAllZeroes &= traceParent[i] == '0';
+            }
+
+            if (isAllZeroes)
+            {
+                return true; // all zeroes forbidden
+            }
+
+            isAllZeroes = true;
+            for (int i = 36; i < 52; i++)
+            {
+                if (IsInvalidTraceParentCharacter(traceParent[i]))
+                {
+                    return true;
+                }
+
+                isAllZeroes &= traceParent[i] == '0';
+            }
+
+            if (isAllZeroes)
+            {
+                return true; // all zeroes forbidden
+            }
+
+            if (IsInvalidTraceParentCharacter(traceParent[53]) || IsInvalidTraceParentCharacter(traceParent[54]))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static ulong[] s_traceParentMask = [0x03FF000000000000, 0x0000007E00000000];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsInvalidTraceParentCharacter(char c)
+        {
+            if (c >= 0x07F)
+            {
+                return true;
+            }
+
+            return (s_traceParentMask[c >> 6] & (ulong)((ulong)1 << ((int)c & 63))) == 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void EmitEscapedByte(byte b, ref ValueStringBuilder vsb)
+        {
+            const string hexChars = "0123456789ABCDEF";
+
+            Debug.Assert(b <= 127);
+
+            vsb.Append(Percent);
+            vsb.Append(hexChars[(b >> 4) & 0x0F]);
+            vsb.Append(hexChars[b & 0x0F]);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<char> TrimSpaceOnly(ReadOnlySpan<char> span)
+        {
+            while (span.Length > 0 && (span[0] == Space))
+            {
+                span = span.Slice(1);
+            }
+
+            while (span.Length > 0 && span[span.Length - 1] == Space)
+            {
+                span = span.Slice(0, span.Length - 1);
+            }
+
+            return span;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<char> Trim(ReadOnlySpan<char> span)
+        {
+            while (span.Length > 0 && (span[0] == Space || span[0] == Tab))
+            {
+                span = span.Slice(1);
+            }
+
+            while (span.Length > 0 && (span[span.Length - 1] == Space || span[span.Length - 1] == Tab))
+            {
+                span = span.Slice(0, span.Length - 1);
+            }
+
+            return span;
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/PropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/PropagatorTests.cs
@@ -1,10 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net;
-using System.Linq;
-using System.Collections.Generic;
 using Microsoft.DotNet.RemoteExecutor;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -21,20 +22,28 @@ namespace System.Diagnostics.Tests
         public void TestAllPropagators()
         {
             RemoteExecutor.Invoke(() => {
-                Assert.NotNull(DistributedContextPropagator.Current);
 
                 //
                 // Default Propagator
                 //
 
+                Assert.NotNull(DistributedContextPropagator.Current);
                 Assert.Same(DistributedContextPropagator.CreateDefaultPropagator(), DistributedContextPropagator.Current);
 
-                TestDefaultPropagatorUsingW3CActivity(
+                //
+                // Legacy Propagator
+                //
+
+                // Temporary till we expose a method to retun it.
+                DistributedContextPropagator.Current = typeof(Activity).Assembly.GetType("System.Diagnostics.LegacyPropagator")
+                                                            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null) as DistributedContextPropagator;
+
+                TestLegacyPropagatorUsingW3CActivity(
                                 DistributedContextPropagator.Current,
                                 "Legacy1=true",
                                 new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>("     LegacyKey1     ", "    LegacyValue1    ") });
 
-                TestDefaultPropagatorUsingHierarchicalActivity(
+                TestLegacyPropagatorUsingHierarchicalActivity(
                                 DistributedContextPropagator.Current,
                                 "Legacy2=true",
                                 new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>("LegacyKey2", "LegacyValue2") });
@@ -103,35 +112,35 @@ namespace System.Diagnostics.Tests
             }).Dispose();
         }
 
-        private void TestDefaultPropagatorUsingW3CActivity(DistributedContextPropagator propagator, string state, IEnumerable<KeyValuePair<string, string>> baggage)
+        private void TestLegacyPropagatorUsingW3CActivity(DistributedContextPropagator propagator, string state, IEnumerable<KeyValuePair<string, string>> baggage)
         {
             using Activity a = CreateW3CActivity("LegacyW3C1", "LegacyW3CState=1", baggage);
             using Activity b = CreateW3CActivity("LegacyW3C2", "LegacyW3CState=2", baggage);
 
             Assert.NotSame(Activity.Current, a);
 
-            TestDefaultPropagatorUsing(a, propagator, state, baggage);
+            TestLegacyPropagatorUsing(a, propagator, state, baggage);
 
             Assert.Same(Activity.Current, b);
 
-            TestDefaultPropagatorUsing(Activity.Current, propagator, state, baggage);
+            TestLegacyPropagatorUsing(Activity.Current, propagator, state, baggage);
         }
 
-        private void TestDefaultPropagatorUsingHierarchicalActivity(DistributedContextPropagator propagator, string state, IEnumerable<KeyValuePair<string, string>> baggage)
+        private void TestLegacyPropagatorUsingHierarchicalActivity(DistributedContextPropagator propagator, string state, IEnumerable<KeyValuePair<string, string>> baggage)
         {
             using Activity a = CreateHierarchicalActivity("LegacyHierarchical1", null, "LegacyHierarchicalState=1", baggage);
             using Activity b = CreateHierarchicalActivity("LegacyHierarchical2", null, "LegacyHierarchicalState=2", baggage);
 
             Assert.NotSame(Activity.Current, a);
 
-            TestDefaultPropagatorUsing(a, propagator, state, baggage);
+            TestLegacyPropagatorUsing(a, propagator, state, baggage);
 
             Assert.Same(Activity.Current, b);
 
-            TestDefaultPropagatorUsing(Activity.Current, propagator, state, baggage);
+            TestLegacyPropagatorUsing(Activity.Current, propagator, state, baggage);
         }
 
-        private void TestDefaultPropagatorUsing(Activity a, DistributedContextPropagator propagator, string state, IEnumerable<KeyValuePair<string, string>> baggage)
+        private void TestLegacyPropagatorUsing(Activity a, DistributedContextPropagator propagator, string state, IEnumerable<KeyValuePair<string, string>> baggage)
         {
             // Test with non-current
             propagator.Inject(a, null, (object carrier, string fieldName, string value) =>
@@ -483,7 +492,7 @@ namespace System.Diagnostics.Tests
             return a;
         }
 
-        private Activity CreateW3CActivity(string name, string state, IEnumerable<KeyValuePair<string, string?>>? baggage)
+        internal static Activity CreateW3CActivity(string name, string state, IEnumerable<KeyValuePair<string, string?>>? baggage)
         {
             Activity a = new Activity(name);
             a.SetIdFormat(ActivityIdFormat.W3C);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/PropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/PropagatorTests.cs
@@ -29,14 +29,14 @@ namespace System.Diagnostics.Tests
 
                 Assert.NotNull(DistributedContextPropagator.Current);
                 Assert.Same(DistributedContextPropagator.CreateDefaultPropagator(), DistributedContextPropagator.Current);
+                Assert.Same(DistributedContextPropagator.CreateDefaultPropagator(), DistributedContextPropagator.CreateW3CPropagator());
 
                 //
                 // Legacy Propagator
                 //
 
                 // Temporary till we expose a method to retun it.
-                DistributedContextPropagator.Current = typeof(Activity).Assembly.GetType("System.Diagnostics.LegacyPropagator")
-                                                            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null) as DistributedContextPropagator;
+                DistributedContextPropagator.Current = DistributedContextPropagator.CreatePreW3CPropagator();
 
                 TestLegacyPropagatorUsingW3CActivity(
                                 DistributedContextPropagator.Current,

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-browser;$(NetFrameworkCurrent)</TargetFrameworks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+    <NoWarn>NU1511</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
     <!-- Enable diagnostic features. They will add appropriate RuntimeHostConfigurationOption values to runtime config and ILLink.
-    https://github.com/dotnet/docs/blob/main/docs/core/deploying/trimming/trimming-options.md#trim-framework-library-features 
+    https://github.com/dotnet/docs/blob/main/docs/core/deploying/trimming/trimming-options.md#trim-framework-library-features
     -->
     <MetricsSupport>true</MetricsSupport>
   </PropertyGroup>
@@ -45,6 +46,7 @@
     <Compile Include="MetricsTests.cs" />
     <Compile Include="PropagatorTests.cs" />
     <Compile Include="TagListTests.cs" />
+    <Compile Include="W3CPropagatorTests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
@@ -60,9 +62,11 @@
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs" Link="Common\System\Net\Configuration.Http.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+  <ItemGroup>
     <ProjectReference Include="..\src\System.Diagnostics.DiagnosticSource.csproj" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -51,8 +51,8 @@ namespace System.Diagnostics.Tests
             // Invalid baggage key.
             yield return new object[] { null, null, new[]
                                                     {
-                                                        new KeyValuePair<string, string>("b 1", "v1"),    // '=' is not allowed
-                                                        new KeyValuePair<string, string>("b=2", "v2"),    // Space is not allowed
+                                                        new KeyValuePair<string, string>("b 1", "v1"),    // Space is not allowed
+                                                        new KeyValuePair<string, string>("b=2", "v2"),    // '=' is not allowed
                                                         new KeyValuePair<string, string>("b\t3", "v3"),   // Tab is not allowed
                                                         new KeyValuePair<string, string>("b(4", "v4"),    // '(' is not allowed
                                                         new KeyValuePair<string, string>("b:5", "v5"),    // ':' is not allowed

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -177,6 +177,32 @@ namespace System.Diagnostics.Tests
             Assert.Equal("W3CTest", a.OperationName);
         }
 
+        [Fact]
+        public void TestExtractingBaggageWithCorrelationContextHeader()
+        {
+            IEnumerable<KeyValuePair<string, string?>>? extractedBaggage = s_w3cPropagator.ExtractBaggage(null, (object carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
+            {
+                Assert.Null(carrier);
+                fieldValue = null;
+                fieldValues = null;
+
+                if (fieldName == PropagatorTests.Baggage)
+                {
+                    return;
+                }
+
+                if (fieldName == PropagatorTests.CorrelationContext)
+                {
+                    fieldValue = "key1=value1,key2=value2,key3=value3";
+                    return;
+                }
+
+                Assert.Fail($"Encountered wrong header name '{fieldName}' in W3C baggage propagatoration");
+            });
+
+            Assert.Equal(new[] { new KeyValuePair<string, string?>("key1", "value1"), new KeyValuePair<string, string?>("key2", "value2"), new KeyValuePair<string, string?>("key3", "value3") }, extractedBaggage);
+        }
+
         //
         // Tests ported from https://github.com/w3c/baggage/blob/main/test/test_baggage.py
         //

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -1,0 +1,337 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public class W3CPropagatorTests
+    {
+        private static DistributedContextPropagator s_w3cPropagator = DistributedContextPropagator.CreateDefaultPropagator();
+
+        [Fact]
+        public void TestW3CPropagatorBasics()
+        {
+            Assert.NotNull(s_w3cPropagator);
+            Assert.Equal(s_w3cPropagator, DistributedContextPropagator.CreateDefaultPropagator());
+            Assert.Equal(s_w3cPropagator, DistributedContextPropagator.Current);
+            Assert.Equal([ PropagatorTests.TraceParent, PropagatorTests.TraceState, PropagatorTests.Baggage ], s_w3cPropagator.Fields);
+        }
+
+        public static IEnumerable<object[]> W3CTestData()
+        {
+            // TraceState, Expected TraceState, input baggage, expected baggage string, expected baggage
+
+            // Simple case
+            yield return new object[] { "state=1", "state=1", new[] { new KeyValuePair<string, string>("b1", "v1") }, "b1 = v1", new[] { new KeyValuePair<string, string>("b1", "v1") } };
+
+            // Invalid trace state
+            yield return new object[] { "PassThroughW3CState=1", null, null, null, null }; // trace state key has to be lowercase
+
+            // Invalid trace state
+            yield return new object[] { "1start=1", null, null, null, null }; // trace state key has to start with lowercase
+
+            // Tabs is not allowed in trace state values. use only the valid entry
+            yield return new object[] { "start=1, end=\t1", "start=1", null, null, null }; // trace state key has to start with lowercase
+
+            // multiple trace states
+            yield return new object[] { "start=1, end=1", "start=1, end=1", null, null, null }; // trace state key has to start with lowercase
+
+            // trace state longer than the max limit
+            yield return new object[] { $"{new string('a', 255)}=1", null, null, null, null }; // trace state length max is 256
+
+            // trace state equal the max
+            yield return new object[] { $"{new string('a', 254)}=1", $"{new string('a', 254)}=1", null, null, null }; // trace state length max is 256
+
+            // Invalid baggage key.
+            yield return new object[] { null, null, new[]
+                                                    {
+                                                        new KeyValuePair<string, string>("b 1", "v1"),    // '=' is not allowed
+                                                        new KeyValuePair<string, string>("b=2", "v2"),    // Space is not allowed
+                                                        new KeyValuePair<string, string>("b\t3", "v3"),   // Tab is not allowed
+                                                        new KeyValuePair<string, string>("b(4", "v4"),    // '(' is not allowed
+                                                        new KeyValuePair<string, string>("b:5", "v5"),    // ':' is not allowed
+                                                        new KeyValuePair<string, string>("b;6", "v6"),    // ';' is not allowed
+                                                        new KeyValuePair<string, string>("b/7", "v7"),    // '/' is not allowed
+                                                        new KeyValuePair<string, string>("b\\8", "v8"),   // '\' is not allowed
+                                                        new KeyValuePair<string, string>("b,9", "v9"),    // ',' is not allowed
+                                                        new KeyValuePair<string, string>("b<10", "v10"),  // '<' is not allowed
+                                                        new KeyValuePair<string, string>("b>11", "v11"),  // '>' is not allowed
+                                                        new KeyValuePair<string, string>("b?12", "v12"),  // '?' is not allowed
+                                                        new KeyValuePair<string, string>("b@13", "v13"),  // '@' is not allowed
+                                                        new KeyValuePair<string, string>("b[14", "v14"),  // '[' is not allowed
+                                                        new KeyValuePair<string, string>("b]15", "v15"),  // ']' is not allowed
+                                                        new KeyValuePair<string, string>("b{16", "v16"),  // '{' is not allowed
+                                                        new KeyValuePair<string, string>("b}17", "v17"),  // '}' is not allowed
+                                                    },
+                                        null, null };
+
+            // Baggage Value containing non % escaped characters
+            // baggage-octet =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E (Exclusing '%')
+            yield return new object[] { null, null, new[] { new KeyValuePair<string, string>("key", "!#$&'()*+-/059:<@>[~]^_amxBNW") },
+                                                    "key = !#$&'()*+-/059:<@>[~]^_amxBNW",
+                                                    new[] { new KeyValuePair<string, string>("key", "!#$&'()*+-/059:<@>[~]^_amxBNW") } };
+
+            // Baggage Value containing `%` and space that should get escaped
+            yield return new object[] { null, null, new[] { new KeyValuePair<string, string>("key", "% \"") },
+                                                    "key = %25%20%22",
+                                                    new[] { new KeyValuePair<string, string>("key", "% \"") } };
+
+            // Baggage Value containing non ascii characters that should get escaped.
+            // 'à' encode to 2 bytes C3 A0. `€` encode to 3 bytes E2 82 AC. `😀` encode to 4 bytes F0 9F 98 80
+            yield return new object[] { null, null, new[] { new KeyValuePair<string, string>("key", "à€😀") },
+                                                    "key = %C3%A0%E2%82%AC%F0%9F%98%80",
+                                                    new[] { new KeyValuePair<string, string>("key", "à€😀") } };
+
+            // Baggage Value containing invalid UTF-16 sequence. Two high surrogate characters.
+            yield return new object[] { null, null, new[] { new KeyValuePair<string, string>("key", "\uD800\uD800") },
+                                                    "key = %EF%BF%BD%EF%BF%BD",
+                                                    new[] { new KeyValuePair<string, string>("key", "\uFFFD\uFFFD") } };
+        }
+
+        [Theory]
+        [MemberData(nameof(W3CTestData))]
+        public void W3CPropagatorValidationTests(string traceState, string? expectedTraceState, IEnumerable<KeyValuePair<string, string>> baggage,
+                                        string expectedBaggageString, IEnumerable<KeyValuePair<string, string>> expectedBaggage)
+        {
+            using Activity a = PropagatorTests.CreateW3CActivity("W3CTest", traceState, baggage);
+
+            s_w3cPropagator.Inject(a, null, (object carrier, string fieldName, string value) =>
+            {
+                if (fieldName == PropagatorTests.TraceParent)
+                {
+                    Assert.Equal(a.Id, value);
+                    return;
+                }
+
+                if (fieldName == PropagatorTests.TraceState)
+                {
+                    Assert.Equal(expectedTraceState, value);
+                    return;
+                }
+
+                if (fieldName == PropagatorTests.Baggage)
+                {
+                    Assert.Equal(expectedBaggageString, value);
+                    return;
+                }
+
+                Assert.Fail($"Encountered wrong header name '{fieldName}' in the W3C Propagator");
+            });
+
+            s_w3cPropagator.ExtractTraceIdAndState(null, (object carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
+            {
+                fieldValues = null;
+                fieldValue = null;
+
+                if (fieldName == PropagatorTests.TraceParent)
+                {
+                    fieldValue = Activity.Current.Id;
+                    return;
+                }
+
+                if (fieldName == PropagatorTests.TraceState)
+                {
+                    fieldValue = Activity.Current.TraceStateString;
+                    return;
+                }
+
+                Assert.Fail($"Encountered wrong header name '{fieldName}' in the W3C propagator");
+            }, out string? traceId, out string? state);
+
+            Assert.Equal(Activity.Current.Id, traceId);
+            Assert.Equal(expectedTraceState, state);
+
+            IEnumerable<KeyValuePair<string, string?>>? extractedBaggage = s_w3cPropagator.ExtractBaggage(null, (object carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
+            {
+                Assert.Null(carrier);
+                fieldValue = null;
+                fieldValues = null;
+
+                if (fieldName == PropagatorTests.Baggage)
+                {
+                    fieldValue = expectedBaggageString;
+                    return;
+                }
+
+                Assert.Fail($"Encountered wrong header name '{fieldName}' in W3C propagator");
+            });
+
+            Assert.Equal(expectedBaggage, extractedBaggage);
+
+            // Keep the activity alive till the end of the test
+            Assert.Equal("W3CTest", a.OperationName);
+        }
+
+        //
+        // Tests ported from https://github.com/w3c/baggage/blob/main/test/test_baggage.py
+        //
+
+        public static IEnumerable<object[]> W3CDecodeData()
+        {
+            // input to decode, decoded baggage entries
+
+            // Double equals
+            yield return new object[] { "key==value", new[] { new KeyValuePair<string, string?>("key", "=value") },  "key = =value" };
+
+            yield return new object[] { "SomeKey=SomeValue,SomeKey2=SomeValue2", new[] { new KeyValuePair<string, string?>("SomeKey", "SomeValue"), new KeyValuePair<string, string?>("SomeKey2", "SomeValue2") }, "SomeKey2 = SomeValue2, SomeKey = SomeValue" };
+
+            yield return new object[] { "SomeKey \t = \t SomeValue \t , \t SomeKey2 \t = \t SomeValue2 \t", new[] { new KeyValuePair<string, string?>("SomeKey", "SomeValue"), new KeyValuePair<string, string?>("SomeKey2", "SomeValue2") }, "SomeKey2 = SomeValue2, SomeKey = SomeValue" };
+
+            yield return new object[] { "SomeKey=SomeValue=equals", new[] { new KeyValuePair<string, string?>("SomeKey", "SomeValue=equals") }, "SomeKey = SomeValue=equals" };
+
+            yield return new object[] { "SomeKey=%09%20%22%27%3B%3Dasdf%21%40%23%24%25%5E%26%2A%28%29", new[] { new KeyValuePair<string, string?>("SomeKey", "\t \"\';=asdf!@#$%^&*()") }, "SomeKey = %22'%3B=asdf!@#$%25^&*()" };
+
+            yield return new object[] { "SomeKey \t = \t \t \"\';=asdf!@#$%^&*()\t", null, null }; // '%' should be escaped make the value invalid
+
+            yield return new object[] { "SomeKey \t = \t \t \"\';=asdf!@#$%25^&*()\t", new[] { new KeyValuePair<string, string?>("SomeKey", "\"\';=asdf!@#$%^&*()") }, "SomeKey = %22'%3B=asdf!@#$%25^&*()" };
+        }
+
+        [Theory]
+        [MemberData(nameof(W3CDecodeData))]
+        public void TestDecoding(string input, IEnumerable<KeyValuePair<string, string?>> expected, string encodedBack)
+        {
+            IEnumerable<KeyValuePair<string, string?>>? baggage = DecodeBaggage(input);
+            Assert.Equal(expected, baggage);
+            Assert.Equal(encodedBack, baggage is null ? null : EncodeBaggage(baggage));
+        }
+
+        [Theory]
+        [InlineData("invalid")] // Missing equals sign
+        [InlineData("=value")] // Empty key
+        [InlineData("key=")] // Empty value (allowed)
+        public void TestInvalidBaggage(string input)
+        {
+            IEnumerable<KeyValuePair<string, string>>? baggage = DecodeBaggage(input);
+            Assert.Null(baggage);
+        }
+
+        [Fact]
+        public void TestBaggagePropagationLimits()
+        {
+            const string CommaSpace = ", ";
+            //
+            // Test MaxBaggageEntriesToEmit
+            //
+
+            const int MaxBaggageEntriesToEmit = 64; // the max limit is 64 entries
+            List<KeyValuePair<string, string>> baggageEntries = new List<KeyValuePair<string, string>>();
+            string expectedBaggageString = string.Empty;
+            for (int i = 0; i < MaxBaggageEntriesToEmit + 1; i++)
+            {
+                if (i < MaxBaggageEntriesToEmit)
+                {
+                    expectedBaggageString += $"key{MaxBaggageEntriesToEmit - i} = value{MaxBaggageEntriesToEmit - i}";
+                    if (i < MaxBaggageEntriesToEmit - 1)
+                    {
+                        expectedBaggageString += CommaSpace;
+                    }
+                }
+
+                baggageEntries.Add(new KeyValuePair<string, string>($"key{i}", $"value{i}"));
+            }
+
+            string encodedValue = EncodeBaggage(baggageEntries);
+            Assert.Equal(expectedBaggageString, encodedValue);
+
+            IEnumerable<KeyValuePair<string, string?>>? decodedBaggage = DecodeBaggage(encodedValue);
+            Assert.Equal(MaxBaggageEntriesToEmit, decodedBaggage.Count());
+
+            //
+            // Test MaxBaggageEncodedLength
+            //
+
+            const int MaxBaggageEncodedLength = 8192; // the max limit is 8192 characters
+            baggageEntries.Clear();
+            expectedBaggageString = string.Empty;
+            int length = 0;
+
+            // long string to create baggage entries less than 64 entries to test the max length
+            const string longString = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+            int entryCount = 0;
+
+            for (int i = 0; ; i++)
+            {
+                string entry = $"{longString}{i} = {longString}{i}";
+
+                if (length + entry.Length + CommaSpace.Length <= MaxBaggageEncodedLength)
+                {
+                    expectedBaggageString += i == 0 ? entry : CommaSpace + entry;
+                    entryCount++;
+                }
+
+                baggageEntries.Insert(0, new KeyValuePair<string, string>($"{longString}{i}", $"{longString}{i}"));
+                length += i == 0 ? entry.Length : CommaSpace.Length + entry.Length;
+                if (length > MaxBaggageEncodedLength)
+                {
+                    // Now we have exceeded the limit, so we stop adding more entries.
+                    break;
+                }
+            }
+
+            encodedValue = EncodeBaggage(baggageEntries);
+            Assert.Equal(expectedBaggageString, encodedValue);
+
+            decodedBaggage = DecodeBaggage(encodedValue);
+            Assert.Equal(entryCount, decodedBaggage.Count());
+        }
+
+        private static string? EncodeBaggage(IEnumerable<KeyValuePair<string, string>> baggageEntries)
+        {
+            Activity? current = Activity.Current;
+            Activity.Current = null;
+
+            Activity activity = new Activity("W3CBaggageEncoding");
+            activity.SetIdFormat(ActivityIdFormat.W3C);
+            activity.Start();
+
+            try
+            {
+                foreach (var entry in baggageEntries)
+                {
+                    activity.AddBaggage(entry.Key, entry.Value);
+                }
+
+                string? encodedValue = null;
+
+                W3CPropagatorTests.s_w3cPropagator.Inject(activity, null, (object carrier, string fieldName, string value) =>
+                {
+                    if (fieldName == PropagatorTests.Baggage)
+                    {
+                        encodedValue = value;
+                    }
+                });
+
+                return encodedValue;
+            }
+            finally
+            {
+                activity.Stop();
+                // Restore the current activity
+                Activity.Current = current;
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<string, string?>> DecodeBaggage(string value)
+        {
+            return W3CPropagatorTests.s_w3cPropagator.ExtractBaggage(null,
+                (object carrier, string fieldName, out string? fieldValue, out IEnumerable<string>? fieldValues) =>
+                {
+                    Assert.Null(carrier);
+                    fieldValue = null;
+                    fieldValues = null;
+
+                    if (fieldName == PropagatorTests.Baggage)
+                    {
+                        fieldValue = value;
+                    }
+                });
+        }
+    }
+}
+

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -1336,7 +1336,7 @@ namespace System.Net.Http.Functional.Tests
                     {
                         // Hierarchical format is not supported with the default W3C propgator. Only Legacy propagator support it.
                         Assert.Null(GetHeaderValue(firstRequestData, "Request-Id"));
-                        Assert.Null(GetHeaderValue(firstRequestData, "Request-Id"));
+                        Assert.Null(GetHeaderValue(secondRequestData, "Request-Id"));
                     }
                 });
             });

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -1335,8 +1335,8 @@ namespace System.Net.Http.Functional.Tests
                     else
                     {
                         // Hierarchical format is not supported with the default W3C propgator. Only Legacy propagator support it.
-                        Assert.Null(GetHeaderValue(firstRequestData, "traceparent"));
-                        Assert.Null(GetHeaderValue(firstRequestData, "tracestate"));
+                        Assert.Null(GetHeaderValue(firstRequestData, "Request-Id"));
+                        Assert.Null(GetHeaderValue(firstRequestData, "Request-Id"));
                     }
                 });
             });

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -309,7 +309,7 @@ namespace System.Net.Http.Functional.Tests
                 parentActivity.AddBaggage("correlationId", Guid.NewGuid().ToString("N").ToString());
                 parentActivity.AddBaggage("moreBaggage", Guid.NewGuid().ToString("N").ToString());
                 parentActivity.AddTag("tag", "tag"); // add tag to ensure it is not injected into request
-                parentActivity.TraceStateString = "Foo";
+                parentActivity.TraceStateString = "foo=1";
 
                 parentActivity.Start();
 
@@ -616,7 +616,7 @@ namespace System.Net.Http.Functional.Tests
                         {
                             uri = new Uri($"{uri.Scheme}://localhost:{uri.Port}");
                         }
-                        
+
                         using HttpClient client = new HttpClient(CreateHttpClientHandler(allowAllCertificates: true));
 
                         await client.SendAsync(bool.Parse(testAsync), CreateRequest(HttpMethod.Get, uri, version, exactVersion: true));
@@ -733,7 +733,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 Version version = Version.Parse(useVersion);
 
-                using HttpClientHandler handler = CreateHttpClientHandler(allowAllCertificates: true);   
+                using HttpClientHandler handler = CreateHttpClientHandler(allowAllCertificates: true);
                 using HttpClient client = new HttpClient(handler);
 
                 Activity parentActivity = new Activity("parent").Start();
@@ -796,10 +796,10 @@ namespace System.Net.Http.Functional.Tests
                 else
                 {
                     Debug.Assert(failureType is "socket");
-                    
+
                     Assert.Equal(ActivityStatusCode.Error, conn.Status);
                     Assert.Equal(ActivityStatusCode.Error, wait.Status);
-                    
+
                     ActivityAssert.HasTag(conn, "error.type", "connection_error");
                     ActivityAssert.HasTag(wait, "error.type", "connection_error");
 
@@ -1288,7 +1288,7 @@ namespace System.Net.Http.Functional.Tests
         {
             Activity parent = new Activity("parent");
             parent.SetIdFormat(idFormat);
-            parent.TraceStateString = "Foo";
+            parent.TraceStateString = "foo=1";
             parent.Start();
 
             await GetFactoryForVersion(UseVersion).CreateServerAsync(async (originalServer, originalUri) =>
@@ -1539,7 +1539,7 @@ namespace System.Net.Http.Functional.Tests
                     }
                 }
                 return response;
-            }   
+            }
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -22,10 +22,6 @@ namespace System.Net.Http.Functional.Tests
 {
     public abstract class DiagnosticsTest : DiagnosticsTestBase
     {
-        // Temporary till we expose a method to retun it.
-        private static DistributedContextPropagator s_legacyPropagator = typeof(Activity).Assembly.GetType("System.Diagnostics.LegacyPropagator")
-                                                    .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null) as DistributedContextPropagator;
-
         private const string EnableActivityPropagationEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_ENABLEACTIVITYPROPAGATION";
         private const string EnableActivityPropagationAppCtxSettingName = "System.Net.Http.EnableActivityPropagation";
 
@@ -828,7 +824,7 @@ namespace System.Net.Http.Functional.Tests
                 TaskCompletionSource activityStopTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // To test the Hierarchical propagation format, we need to set the legacy propagator.
-                DistributedContextPropagator.Current = s_legacyPropagator;
+                DistributedContextPropagator.Current = DistributedContextPropagator.CreatePreW3CPropagator();
 
                 Activity parentActivity = new Activity("parent");
                 parentActivity.SetIdFormat(ActivityIdFormat.Hierarchical);
@@ -1367,7 +1363,14 @@ namespace System.Net.Http.Functional.Tests
 
         public static IEnumerable<object[]> SocketsHttpHandlerPropagators_WithIdFormat_MemberData()
         {
-            foreach (var propagator in new[] { null, DistributedContextPropagator.CreateDefaultPropagator(), s_legacyPropagator, DistributedContextPropagator.CreateNoOutputPropagator(), DistributedContextPropagator.CreatePassThroughPropagator() })
+            foreach (var propagator in new[]
+                                        {
+                                            null,
+                                            DistributedContextPropagator.CreateDefaultPropagator(),
+                                            DistributedContextPropagator.CreatePreW3CPropagator(),
+                                            DistributedContextPropagator.CreateNoOutputPropagator(),
+                                            DistributedContextPropagator.CreatePassThroughPropagator()
+                                        })
             {
                 foreach (ActivityIdFormat format in new[] { ActivityIdFormat.Hierarchical, ActivityIdFormat.W3C })
                 {


### PR DESCRIPTION
Contribute to https://github.com/dotnet/runtime/issues/103174

- Introducing the W3C Propagator conforming to the W3C specs of the [trace context](https://www.w3.org/TR/trace-context/) and [Baggage](https://www.w3.org/TR/baggage/).
- Changing the default propagator to W3C Propagator. i.e. `DistributedContextPropagator.Current` and `DistributedContextPropagator.CreateDefaultPropagator()` now will have the W3C Propagator as the default propagator.
- Created the [issue](https://github.com/dotnet/runtime/issues/114584) to track exposing `DistributedContextPropagator.CreateLegacyPropagator()` to allow user to opt-in to the legacy propagator.
- A breaking change https://github.com/dotnet/docs/issues/45793 is filled.