### PR TITLE
Mark InlineArrays as NonVersionable

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InlineArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InlineArray.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
@@ -8,6 +10,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(2)]
+    [NonVersionable]
     public struct InlineArray2<T>
     {
         private T t;
@@ -18,6 +21,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(3)]
+    [NonVersionable]
     public struct InlineArray3<T>
     {
         private T t;
@@ -28,6 +32,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(4)]
+    [NonVersionable]
     public struct InlineArray4<T>
     {
         private T t;
@@ -38,6 +43,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(5)]
+    [NonVersionable]
     public struct InlineArray5<T>
     {
         private T t;
@@ -48,6 +54,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(6)]
+    [NonVersionable]
     public struct InlineArray6<T>
     {
         private T t;
@@ -58,6 +65,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(7)]
+    [NonVersionable]
     public struct InlineArray7<T>
     {
         private T t;
@@ -68,6 +76,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(8)]
+    [NonVersionable]
     public struct InlineArray8<T>
     {
         private T t;
@@ -78,6 +87,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(9)]
+    [NonVersionable]
     public struct InlineArray9<T>
     {
         private T t;
@@ -88,6 +98,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(10)]
+    [NonVersionable]
     public struct InlineArray10<T>
     {
         private T t;
@@ -98,6 +109,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(11)]
+    [NonVersionable]
     public struct InlineArray11<T>
     {
         private T t;
@@ -108,6 +120,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(12)]
+    [NonVersionable]
     public struct InlineArray12<T>
     {
         private T t;
@@ -118,6 +131,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(13)]
+    [NonVersionable]
     public struct InlineArray13<T>
     {
         private T t;
@@ -128,6 +142,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(14)]
+    [NonVersionable]
     public struct InlineArray14<T>
     {
         private T t;
@@ -138,6 +153,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(15)]
+    [NonVersionable]
     public struct InlineArray15<T>
     {
         private T t;
@@ -148,6 +164,7 @@ namespace System.Runtime.CompilerServices
     /// </summary>
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     [InlineArray(16)]
+    [NonVersionable]
     public struct InlineArray16<T>
     {
         private T t;


### PR DESCRIPTION
It is safe to assume that the field layout of the recently introduced InlineArray helper types is never going to change. Marking the types as NonVersionable allows crossgen2 to omit CHECK_TYPE_LAYOUT fixup for these types.