### PR TITLE
Undo a few JIT layout workarounds

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -266,7 +266,7 @@ namespace System
                         value.Equals(Unsafe.Add(ref searchSpace, index + 6)) ||
                         value.Equals(Unsafe.Add(ref searchSpace, index + 7)))
                     {
-                        goto Found;
+                        return true;
                     }
 
                     index += 8;
@@ -281,7 +281,7 @@ namespace System
                         value.Equals(Unsafe.Add(ref searchSpace, index + 2)) ||
                         value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
                     {
-                        goto Found;
+                        return true;
                     }
 
                     index += 4;
@@ -292,7 +292,7 @@ namespace System
                     length--;
 
                     if (value.Equals(Unsafe.Add(ref searchSpace, index)))
-                        goto Found;
+                        return true;
 
                     index += 1;
                 }
@@ -304,15 +304,12 @@ namespace System
                 {
                     if ((object?)Unsafe.Add(ref searchSpace, index) is null)
                     {
-                        goto Found;
+                        return true;
                     }
                 }
             }
 
             return false;
-
-        Found:
-            return true;
         }
 
         public static int IndexOf<T>(ref T searchSpace, T value, int length) where T : IEquatable<T>?
@@ -329,21 +326,21 @@ namespace System
                     length -= 8;
 
                     if (value.Equals(Unsafe.Add(ref searchSpace, index)))
-                        goto Found;
+                        return (int)index;
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
-                        goto Found1;
+                        return (int)(index + 1);
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 2)))
-                        goto Found2;
+                        return (int)(index + 2);
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
-                        goto Found3;
+                        return (int)(index + 3);
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 4)))
-                        goto Found4;
+                        return (int)(index + 4);
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 5)))
-                        goto Found5;
+                        return (int)(index + 5);
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 6)))
-                        goto Found6;
+                        return (int)(index + 6);
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 7)))
-                        goto Found7;
+                        return (int)(index + 7);
 
                     index += 8;
                 }
@@ -353,13 +350,13 @@ namespace System
                     length -= 4;
 
                     if (value.Equals(Unsafe.Add(ref searchSpace, index)))
-                        goto Found;
+                        return (int)index;
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
-                        goto Found1;
+                        return (int)(index + 1);
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 2)))
-                        goto Found2;
+                        return (int)(index + 2);
                     if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
-                        goto Found3;
+                        return (int)(index + 3);
 
                     index += 4;
                 }
@@ -367,7 +364,7 @@ namespace System
                 while (length > 0)
                 {
                     if (value.Equals(Unsafe.Add(ref searchSpace, index)))
-                        goto Found;
+                        return (int)index;
 
                     index += 1;
                     length--;
@@ -380,28 +377,12 @@ namespace System
                 {
                     if ((object?)Unsafe.Add(ref searchSpace, index) is null)
                     {
-                        goto Found;
+                        return (int)index;
                     }
                 }
             }
-            return -1;
 
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return (int)index;
-        Found1:
-            return (int)(index + 1);
-        Found2:
-            return (int)(index + 2);
-        Found3:
-            return (int)(index + 3);
-        Found4:
-            return (int)(index + 4);
-        Found5:
-            return (int)(index + 5);
-        Found6:
-            return (int)(index + 6);
-        Found7:
-            return (int)(index + 7);
+            return -1;
         }
 
         public static int IndexOfAny<T>(ref T searchSpace, T value0, T value1, int length) where T : IEquatable<T>?
@@ -418,28 +399,28 @@ namespace System
                 {
                     lookUp = Unsafe.Add(ref searchSpace, index);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found;
+                        return index;
                     lookUp = Unsafe.Add(ref searchSpace, index + 1);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found1;
+                        return index + 1;
                     lookUp = Unsafe.Add(ref searchSpace, index + 2);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found2;
+                        return index + 2;
                     lookUp = Unsafe.Add(ref searchSpace, index + 3);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found3;
+                        return index + 3;
                     lookUp = Unsafe.Add(ref searchSpace, index + 4);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found4;
+                        return index + 4;
                     lookUp = Unsafe.Add(ref searchSpace, index + 5);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found5;
+                        return index + 5;
                     lookUp = Unsafe.Add(ref searchSpace, index + 6);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found6;
+                        return index + 6;
                     lookUp = Unsafe.Add(ref searchSpace, index + 7);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found7;
+                        return index + 7;
 
                     index += 8;
                 }
@@ -448,16 +429,16 @@ namespace System
                 {
                     lookUp = Unsafe.Add(ref searchSpace, index);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found;
+                        return index;
                     lookUp = Unsafe.Add(ref searchSpace, index + 1);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found1;
+                        return index + 1;
                     lookUp = Unsafe.Add(ref searchSpace, index + 2);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found2;
+                        return index + 2;
                     lookUp = Unsafe.Add(ref searchSpace, index + 3);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found3;
+                        return index + 3;
 
                     index += 4;
                 }
@@ -466,7 +447,7 @@ namespace System
                 {
                     lookUp = Unsafe.Add(ref searchSpace, index);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found;
+                        return index;
 
                     index++;
                 }
@@ -480,34 +461,17 @@ namespace System
                     {
                         if ((object?)value0 is null || (object?)value1 is null)
                         {
-                            goto Found;
+                            return index;
                         }
                     }
                     else if (lookUp.Equals(value0) || lookUp.Equals(value1))
                     {
-                        goto Found;
+                        return index;
                     }
                 }
             }
 
             return -1;
-
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return index;
-        Found1:
-            return index + 1;
-        Found2:
-            return index + 2;
-        Found3:
-            return index + 3;
-        Found4:
-            return index + 4;
-        Found5:
-            return index + 5;
-        Found6:
-            return index + 6;
-        Found7:
-            return index + 7;
         }
 
         public static int IndexOfAny<T>(ref T searchSpace, T value0, T value1, T value2, int length) where T : IEquatable<T>?
@@ -524,28 +488,28 @@ namespace System
                 {
                     lookUp = Unsafe.Add(ref searchSpace, index);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found;
+                        return index;
                     lookUp = Unsafe.Add(ref searchSpace, index + 1);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found1;
+                        return index + 1;
                     lookUp = Unsafe.Add(ref searchSpace, index + 2);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found2;
+                        return index + 2;
                     lookUp = Unsafe.Add(ref searchSpace, index + 3);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found3;
+                        return index + 3;
                     lookUp = Unsafe.Add(ref searchSpace, index + 4);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found4;
+                        return index + 4;
                     lookUp = Unsafe.Add(ref searchSpace, index + 5);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found5;
+                        return index + 5;
                     lookUp = Unsafe.Add(ref searchSpace, index + 6);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found6;
+                        return index + 6;
                     lookUp = Unsafe.Add(ref searchSpace, index + 7);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found7;
+                        return index + 7;
 
                     index += 8;
                 }
@@ -554,16 +518,16 @@ namespace System
                 {
                     lookUp = Unsafe.Add(ref searchSpace, index);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found;
+                        return index;
                     lookUp = Unsafe.Add(ref searchSpace, index + 1);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found1;
+                        return index + 1;
                     lookUp = Unsafe.Add(ref searchSpace, index + 2);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found2;
+                        return index + 2;
                     lookUp = Unsafe.Add(ref searchSpace, index + 3);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found3;
+                        return index + 3;
 
                     index += 4;
                 }
@@ -572,7 +536,7 @@ namespace System
                 {
                     lookUp = Unsafe.Add(ref searchSpace, index);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found;
+                        return index;
 
                     index++;
                 }
@@ -586,33 +550,17 @@ namespace System
                     {
                         if ((object?)value0 is null || (object?)value1 is null || (object?)value2 is null)
                         {
-                            goto Found;
+                            return index;
                         }
                     }
                     else if (lookUp.Equals(value0) || lookUp.Equals(value1) || lookUp.Equals(value2))
                     {
-                        goto Found;
+                        return index;
                     }
                 }
             }
-            return -1;
 
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return index;
-        Found1:
-            return index + 1;
-        Found2:
-            return index + 2;
-        Found3:
-            return index + 3;
-        Found4:
-            return index + 4;
-        Found5:
-            return index + 5;
-        Found6:
-            return index + 6;
-        Found7:
-            return index + 7;
+            return -1;
         }
 
         public static int IndexOfAny<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength) where T : IEquatable<T>?
@@ -739,21 +687,21 @@ namespace System
                     length -= 8;
 
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 7)))
-                        goto Found7;
+                        return length + 7;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 6)))
-                        goto Found6;
+                        return length + 6;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 5)))
-                        goto Found5;
+                        return length + 5;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 4)))
-                        goto Found4;
+                        return length + 4;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 3)))
-                        goto Found3;
+                        return length + 3;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 2)))
-                        goto Found2;
+                        return length + 2;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 1)))
-                        goto Found1;
+                        return length + 1;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length)))
-                        goto Found;
+                        return length;
                 }
 
                 if (length >= 4)
@@ -761,13 +709,13 @@ namespace System
                     length -= 4;
 
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 3)))
-                        goto Found3;
+                        return length + 3;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 2)))
-                        goto Found2;
+                        return length + 2;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length + 1)))
-                        goto Found1;
+                        return length + 1;
                     if (value.Equals(Unsafe.Add(ref searchSpace, length)))
-                        goto Found;
+                        return length;
                 }
 
                 while (length > 0)
@@ -775,7 +723,7 @@ namespace System
                     length--;
 
                     if (value.Equals(Unsafe.Add(ref searchSpace, length)))
-                        goto Found;
+                        return length;
                 }
             }
             else
@@ -784,29 +732,12 @@ namespace System
                 {
                     if ((object?)Unsafe.Add(ref searchSpace, length) is null)
                     {
-                        goto Found;
+                        return length;
                     }
                 }
             }
 
             return -1;
-
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return length;
-        Found1:
-            return length + 1;
-        Found2:
-            return length + 2;
-        Found3:
-            return length + 3;
-        Found4:
-            return length + 4;
-        Found5:
-            return length + 5;
-        Found6:
-            return length + 6;
-        Found7:
-            return length + 7;
         }
 
         public static int LastIndexOfAny<T>(ref T searchSpace, T value0, T value1, int length) where T : IEquatable<T>?
@@ -824,28 +755,28 @@ namespace System
 
                     lookUp = Unsafe.Add(ref searchSpace, length + 7);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found7;
+                        return length + 7;
                     lookUp = Unsafe.Add(ref searchSpace, length + 6);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found6;
+                        return length + 6;
                     lookUp = Unsafe.Add(ref searchSpace, length + 5);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found5;
+                        return length + 5;
                     lookUp = Unsafe.Add(ref searchSpace, length + 4);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found4;
+                        return length + 4;
                     lookUp = Unsafe.Add(ref searchSpace, length + 3);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found3;
+                        return length + 3;
                     lookUp = Unsafe.Add(ref searchSpace, length + 2);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found2;
+                        return length + 2;
                     lookUp = Unsafe.Add(ref searchSpace, length + 1);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found1;
+                        return length + 1;
                     lookUp = Unsafe.Add(ref searchSpace, length);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found;
+                        return length;
                 }
 
                 if (length >= 4)
@@ -854,16 +785,16 @@ namespace System
 
                     lookUp = Unsafe.Add(ref searchSpace, length + 3);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found3;
+                        return length + 3;
                     lookUp = Unsafe.Add(ref searchSpace, length + 2);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found2;
+                        return length + 2;
                     lookUp = Unsafe.Add(ref searchSpace, length + 1);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found1;
+                        return length + 1;
                     lookUp = Unsafe.Add(ref searchSpace, length);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found;
+                        return length;
                 }
 
                 while (length > 0)
@@ -872,7 +803,7 @@ namespace System
 
                     lookUp = Unsafe.Add(ref searchSpace, length);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp))
-                        goto Found;
+                        return length;
                 }
             }
             else
@@ -884,34 +815,17 @@ namespace System
                     {
                         if ((object?)value0 is null || (object?)value1 is null)
                         {
-                            goto Found;
+                            return length;
                         }
                     }
                     else if (lookUp.Equals(value0) || lookUp.Equals(value1))
                     {
-                        goto Found;
+                        return length;
                     }
                 }
             }
 
             return -1;
-
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return length;
-        Found1:
-            return length + 1;
-        Found2:
-            return length + 2;
-        Found3:
-            return length + 3;
-        Found4:
-            return length + 4;
-        Found5:
-            return length + 5;
-        Found6:
-            return length + 6;
-        Found7:
-            return length + 7;
         }
 
         public static int LastIndexOfAny<T>(ref T searchSpace, T value0, T value1, T value2, int length) where T : IEquatable<T>?
@@ -929,28 +843,28 @@ namespace System
 
                     lookUp = Unsafe.Add(ref searchSpace, length + 7);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found7;
+                        return length + 7;
                     lookUp = Unsafe.Add(ref searchSpace, length + 6);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found6;
+                        return length + 6;
                     lookUp = Unsafe.Add(ref searchSpace, length + 5);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found5;
+                        return length + 5;
                     lookUp = Unsafe.Add(ref searchSpace, length + 4);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found4;
+                        return length + 4;
                     lookUp = Unsafe.Add(ref searchSpace, length + 3);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found3;
+                        return length + 3;
                     lookUp = Unsafe.Add(ref searchSpace, length + 2);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found2;
+                        return length + 2;
                     lookUp = Unsafe.Add(ref searchSpace, length + 1);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found1;
+                        return length + 1;
                     lookUp = Unsafe.Add(ref searchSpace, length);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found;
+                        return length;
                 }
 
                 if (length >= 4)
@@ -959,16 +873,16 @@ namespace System
 
                     lookUp = Unsafe.Add(ref searchSpace, length + 3);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found3;
+                        return length + 3;
                     lookUp = Unsafe.Add(ref searchSpace, length + 2);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found2;
+                        return length + 2;
                     lookUp = Unsafe.Add(ref searchSpace, length + 1);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found1;
+                        return length + 1;
                     lookUp = Unsafe.Add(ref searchSpace, length);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found;
+                        return length;
                 }
 
                 while (length > 0)
@@ -977,7 +891,7 @@ namespace System
 
                     lookUp = Unsafe.Add(ref searchSpace, length);
                     if (value0.Equals(lookUp) || value1.Equals(lookUp) || value2.Equals(lookUp))
-                        goto Found;
+                        return length;
                 }
             }
             else
@@ -989,34 +903,17 @@ namespace System
                     {
                         if ((object?)value0 is null || (object?)value1 is null || (object?)value2 is null)
                         {
-                            goto Found;
+                            return length;
                         }
                     }
                     else if (lookUp.Equals(value0) || lookUp.Equals(value1) || lookUp.Equals(value2))
                     {
-                        goto Found;
+                        return length;
                     }
                 }
             }
 
             return -1;
-
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return length;
-        Found1:
-            return length + 1;
-        Found2:
-            return length + 2;
-        Found3:
-            return length + 3;
-        Found4:
-            return length + 4;
-        Found5:
-            return length + 5;
-        Found6:
-            return length + 6;
-        Found7:
-            return length + 7;
         }
 
         public static int LastIndexOfAny<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength) where T : IEquatable<T>?
@@ -1216,7 +1113,7 @@ namespace System
             Debug.Assert(length >= 0);
 
             if (Unsafe.AreSame(ref first, ref second))
-                goto Equal;
+                return true;
 
             nint index = 0; // Use nint for arithmetic to avoid unnecessary 64->32->64 truncations
             T lookUp0;
@@ -1228,35 +1125,35 @@ namespace System
                 lookUp0 = Unsafe.Add(ref first, index);
                 lookUp1 = Unsafe.Add(ref second, index);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 1);
                 lookUp1 = Unsafe.Add(ref second, index + 1);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 2);
                 lookUp1 = Unsafe.Add(ref second, index + 2);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 3);
                 lookUp1 = Unsafe.Add(ref second, index + 3);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 4);
                 lookUp1 = Unsafe.Add(ref second, index + 4);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 5);
                 lookUp1 = Unsafe.Add(ref second, index + 5);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 6);
                 lookUp1 = Unsafe.Add(ref second, index + 6);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 7);
                 lookUp1 = Unsafe.Add(ref second, index + 7);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
 
                 index += 8;
             }
@@ -1268,19 +1165,19 @@ namespace System
                 lookUp0 = Unsafe.Add(ref first, index);
                 lookUp1 = Unsafe.Add(ref second, index);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 1);
                 lookUp1 = Unsafe.Add(ref second, index + 1);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 2);
                 lookUp1 = Unsafe.Add(ref second, index + 2);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 lookUp0 = Unsafe.Add(ref first, index + 3);
                 lookUp1 = Unsafe.Add(ref second, index + 3);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
 
                 index += 4;
             }
@@ -1290,16 +1187,12 @@ namespace System
                 lookUp0 = Unsafe.Add(ref first, index);
                 lookUp1 = Unsafe.Add(ref second, index);
                 if (!(lookUp0?.Equals(lookUp1) ?? (object?)lookUp1 is null))
-                    goto NotEqual;
+                    return false;
                 index += 1;
                 length--;
             }
 
-        Equal:
             return true;
-
-        NotEqual: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return false;
         }
 
         public static int SequenceCompareTo<T>(ref T first, int firstLength, ref T second, int secondLength)
@@ -1318,6 +1211,7 @@ namespace System
                 if (result != 0)
                     return result;
             }
+
             return firstLength.CompareTo(secondLength);
         }
 
@@ -1525,14 +1419,14 @@ namespace System
                 {
                     length -= 8;
 
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) goto Found;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 1) == value)) goto Found1;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 2) == value)) goto Found2;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 3) == value)) goto Found3;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 4) == value)) goto Found4;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 5) == value)) goto Found5;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 6) == value)) goto Found6;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 7) == value)) goto Found7;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)(offset);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 1) == value)) return (int)(offset + 1);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 2) == value)) return (int)(offset + 2);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 3) == value)) return (int)(offset + 3);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 4) == value)) return (int)(offset + 4);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 5) == value)) return (int)(offset + 5);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 6) == value)) return (int)(offset + 6);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 7) == value)) return (int)(offset + 7);
 
                     offset += 8;
                 }
@@ -1541,10 +1435,10 @@ namespace System
                 {
                     length -= 4;
 
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) goto Found;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 1) == value)) goto Found1;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 2) == value)) goto Found2;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 3) == value)) goto Found3;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)(offset);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 1) == value)) return (int)(offset + 1);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 2) == value)) return (int)(offset + 2);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 3) == value)) return (int)(offset + 3);
 
                     offset += 4;
                 }
@@ -1553,27 +1447,12 @@ namespace System
                 {
                     length -= 1;
 
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) goto Found;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)(offset);
 
                     offset += 1;
                 }
+
                 return -1;
-            Found7:
-                return (int)(offset + 7);
-            Found6:
-                return (int)(offset + 6);
-            Found5:
-                return (int)(offset + 5);
-            Found4:
-                return (int)(offset + 4);
-            Found3:
-                return (int)(offset + 3);
-            Found2:
-                return (int)(offset + 2);
-            Found1:
-                return (int)(offset + 1);
-            Found:
-                return (int)(offset);
             }
             else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
             {
@@ -1736,21 +1615,21 @@ namespace System
 
                         ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                         lookUp = current;
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset);
                         lookUp = Unsafe.Add(ref current, 1);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found1;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 1);
                         lookUp = Unsafe.Add(ref current, 2);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found2;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 2);
                         lookUp = Unsafe.Add(ref current, 3);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found3;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 3);
                         lookUp = Unsafe.Add(ref current, 4);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found4;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 4);
                         lookUp = Unsafe.Add(ref current, 5);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found5;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 5);
                         lookUp = Unsafe.Add(ref current, 6);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found6;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 6);
                         lookUp = Unsafe.Add(ref current, 7);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found7;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 7);
 
                         offset += 8;
                     }
@@ -1762,13 +1641,13 @@ namespace System
 
                     ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                     lookUp = current;
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset);
                     lookUp = Unsafe.Add(ref current, 1);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found1;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 1);
                     lookUp = Unsafe.Add(ref current, 2);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found2;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 2);
                     lookUp = Unsafe.Add(ref current, 3);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found3;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset + 3);
 
                     offset += 4;
                 }
@@ -1778,27 +1657,12 @@ namespace System
                     length -= 1;
 
                     lookUp = Unsafe.Add(ref searchSpace, offset);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset);
 
                     offset += 1;
                 }
+
                 return -1;
-            Found7:
-                return (int)(offset + 7);
-            Found6:
-                return (int)(offset + 6);
-            Found5:
-                return (int)(offset + 5);
-            Found4:
-                return (int)(offset + 4);
-            Found3:
-                return (int)(offset + 3);
-            Found2:
-                return (int)(offset + 2);
-            Found1:
-                return (int)(offset + 1);
-            Found:
-                return (int)(offset);
             }
             else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
             {
@@ -1943,21 +1807,21 @@ namespace System
 
                         ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                         lookUp = current;
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset);
                         lookUp = Unsafe.Add(ref current, 1);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found1;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 1);
                         lookUp = Unsafe.Add(ref current, 2);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found2;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 2);
                         lookUp = Unsafe.Add(ref current, 3);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found3;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 3);
                         lookUp = Unsafe.Add(ref current, 4);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found4;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 4);
                         lookUp = Unsafe.Add(ref current, 5);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found5;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 5);
                         lookUp = Unsafe.Add(ref current, 6);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found6;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 6);
                         lookUp = Unsafe.Add(ref current, 7);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found7;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 7);
 
                         offset += 8;
                     }
@@ -1969,13 +1833,13 @@ namespace System
 
                     ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                     lookUp = current;
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset);
                     lookUp = Unsafe.Add(ref current, 1);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found1;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 1);
                     lookUp = Unsafe.Add(ref current, 2);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found2;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 2);
                     lookUp = Unsafe.Add(ref current, 3);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found3;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset + 3);
 
                     offset += 4;
                 }
@@ -1985,27 +1849,12 @@ namespace System
                     length -= 1;
 
                     lookUp = Unsafe.Add(ref searchSpace, offset);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset);
 
                     offset += 1;
                 }
+
                 return -1;
-            Found7:
-                return (int)(offset + 7);
-            Found6:
-                return (int)(offset + 6);
-            Found5:
-                return (int)(offset + 5);
-            Found4:
-                return (int)(offset + 4);
-            Found3:
-                return (int)(offset + 3);
-            Found2:
-                return (int)(offset + 2);
-            Found1:
-                return (int)(offset + 1);
-            Found:
-                return (int)(offset);
             }
             else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
             {
@@ -2133,13 +1982,13 @@ namespace System
 
                     ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                     lookUp = current;
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset);
                     lookUp = Unsafe.Add(ref current, 1);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto Found1;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset + 1);
                     lookUp = Unsafe.Add(ref current, 2);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto Found2;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset + 2);
                     lookUp = Unsafe.Add(ref current, 3);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto Found3;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset + 3);
 
                     offset += 4;
                 }
@@ -2149,19 +1998,12 @@ namespace System
                     length -= 1;
 
                     lookUp = Unsafe.Add(ref searchSpace, offset);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset);
 
                     offset += 1;
                 }
+
                 return -1;
-            Found3:
-                return (int)(offset + 3);
-            Found2:
-                return (int)(offset + 2);
-            Found1:
-                return (int)(offset + 1);
-            Found:
-                return (int)(offset);
             }
             else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
             {
@@ -2295,13 +2137,13 @@ namespace System
 
                     ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                     lookUp = current;
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) return (int)(offset);
                     lookUp = Unsafe.Add(ref current, 1);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) goto Found1;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) return (int)(offset + 1);
                     lookUp = Unsafe.Add(ref current, 2);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) goto Found2;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) return (int)(offset + 2);
                     lookUp = Unsafe.Add(ref current, 3);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) goto Found3;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) return (int)(offset + 3);
 
                     offset += 4;
                 }
@@ -2311,20 +2153,12 @@ namespace System
                     length -= 1;
 
                     lookUp = Unsafe.Add(ref searchSpace, offset);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) return (int)(offset);
 
                     offset += 1;
                 }
 
                 return -1;
-            Found3:
-                return (int)(offset + 3);
-            Found2:
-                return (int)(offset + 2);
-            Found1:
-                return (int)(offset + 1);
-            Found:
-                return (int)(offset);
             }
             else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
             {
@@ -2458,14 +2292,14 @@ namespace System
                 {
                     length -= 8;
 
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) goto Found;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 1) == value)) goto FoundM1;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 2) == value)) goto FoundM2;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 3) == value)) goto FoundM3;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 4) == value)) goto FoundM4;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 5) == value)) goto FoundM5;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 6) == value)) goto FoundM6;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 7) == value)) goto FoundM7;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)(offset);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 1) == value)) return (int)(offset - 1);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 2) == value)) return (int)(offset - 2);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 3) == value)) return (int)(offset - 3);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 4) == value)) return (int)(offset - 4);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 5) == value)) return (int)(offset - 5);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 6) == value)) return (int)(offset - 6);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 7) == value)) return (int)(offset - 7);
 
                     offset -= 8;
                 }
@@ -2474,10 +2308,10 @@ namespace System
                 {
                     length -= 4;
 
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) goto Found;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 1) == value)) goto FoundM1;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 2) == value)) goto FoundM2;
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 3) == value)) goto FoundM3;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)(offset);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 1) == value)) return (int)(offset - 1);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 2) == value)) return (int)(offset - 2);
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 3) == value)) return (int)(offset - 3);
 
                     offset -= 4;
                 }
@@ -2486,27 +2320,12 @@ namespace System
                 {
                     length -= 1;
 
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) goto Found;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)(offset);
 
                     offset -= 1;
                 }
+
                 return -1;
-            FoundM7:
-                return (int)(offset - 7);
-            FoundM6:
-                return (int)(offset - 6);
-            FoundM5:
-                return (int)(offset - 5);
-            FoundM4:
-                return (int)(offset - 4);
-            FoundM3:
-                return (int)(offset - 3);
-            FoundM2:
-                return (int)(offset - 2);
-            FoundM1:
-                return (int)(offset - 1);
-            Found:
-                return (int)(offset);
             }
             else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
             {
@@ -2583,21 +2402,21 @@ namespace System
 
                         ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                         lookUp = current;
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset);
                         lookUp = Unsafe.Add(ref current, -1);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM1;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 1);
                         lookUp = Unsafe.Add(ref current, -2);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM2;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 2);
                         lookUp = Unsafe.Add(ref current, -3);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM3;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 3);
                         lookUp = Unsafe.Add(ref current, -4);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM4;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 4);
                         lookUp = Unsafe.Add(ref current, -5);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM5;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 5);
                         lookUp = Unsafe.Add(ref current, -6);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM6;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 6);
                         lookUp = Unsafe.Add(ref current, -7);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM7;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 7);
 
                         offset -= 8;
                     }
@@ -2609,13 +2428,13 @@ namespace System
 
                     ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                     lookUp = current;
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset);
                     lookUp = Unsafe.Add(ref current, -1);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM1;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 1);
                     lookUp = Unsafe.Add(ref current, -2);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM2;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 2);
                     lookUp = Unsafe.Add(ref current, -3);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto FoundM3;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset - 3);
 
                     offset -= 4;
                 }
@@ -2625,27 +2444,12 @@ namespace System
                     length -= 1;
 
                     lookUp = Unsafe.Add(ref searchSpace, offset);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)(offset);
 
                     offset -= 1;
                 }
+
                 return -1;
-            FoundM7:
-                return (int)(offset - 7);
-            FoundM6:
-                return (int)(offset - 6);
-            FoundM5:
-                return (int)(offset - 5);
-            FoundM4:
-                return (int)(offset - 4);
-            FoundM3:
-                return (int)(offset - 3);
-            FoundM2:
-                return (int)(offset - 2);
-            FoundM1:
-                return (int)(offset - 1);
-            Found:
-                return (int)(offset);
             }
             else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
             {
@@ -2768,21 +2572,21 @@ namespace System
 
                         ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                         lookUp = current;
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset);
                         lookUp = Unsafe.Add(ref current, -1);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM1;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 1);
                         lookUp = Unsafe.Add(ref current, -2);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM2;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 2);
                         lookUp = Unsafe.Add(ref current, -3);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM3;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 3);
                         lookUp = Unsafe.Add(ref current, -4);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM4;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 4);
                         lookUp = Unsafe.Add(ref current, -5);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM5;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 5);
                         lookUp = Unsafe.Add(ref current, -6);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM6;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 6);
                         lookUp = Unsafe.Add(ref current, -7);
-                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM7;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 7);
 
                         offset -= 8;
                     }
@@ -2794,13 +2598,13 @@ namespace System
 
                     ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                     lookUp = current;
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset);
                     lookUp = Unsafe.Add(ref current, -1);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM1;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 1);
                     lookUp = Unsafe.Add(ref current, -2);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM2;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 2);
                     lookUp = Unsafe.Add(ref current, -3);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto FoundM3;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset - 3);
 
                     offset -= 4;
                 }
@@ -2810,27 +2614,12 @@ namespace System
                     length -= 1;
 
                     lookUp = Unsafe.Add(ref searchSpace, offset);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)(offset);
 
                     offset -= 1;
                 }
+
                 return -1;
-            FoundM7:
-                return (int)(offset - 7);
-            FoundM6:
-                return (int)(offset - 6);
-            FoundM5:
-                return (int)(offset - 5);
-            FoundM4:
-                return (int)(offset - 4);
-            FoundM3:
-                return (int)(offset - 3);
-            FoundM2:
-                return (int)(offset - 2);
-            FoundM1:
-                return (int)(offset - 1);
-            Found:
-                return (int)(offset);
             }
             else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
             {
@@ -2952,13 +2741,13 @@ namespace System
 
                     ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
                     lookUp = current;
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset);
                     lookUp = Unsafe.Add(ref current, -1);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto FoundM1;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset - 1);
                     lookUp = Unsafe.Add(ref current, -2);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto FoundM2;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset - 2);
                     lookUp = Unsafe.Add(ref current, -3);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto FoundM3;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset - 3);
 
                     offset -= 4;
                 }
@@ -2968,19 +2757,12 @@ namespace System
                     length -= 1;
 
                     lookUp = Unsafe.Add(ref searchSpace, offset);
-                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) goto Found;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)(offset);
 
                     offset -= 1;
                 }
+
                 return -1;
-            FoundM3:
-                return (int)(offset - 3);
-            FoundM2:
-                return (int)(offset - 2);
-            FoundM1:
-                return (int)(offset - 1);
-            Found:
-                return (int)(offset);
             }
             else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
             {


### PR DESCRIPTION
If I understand the following correctly:

- https://github.com/dotnet/runtime/issues/8795
- https://github.com/dotnet/coreclr/pull/13314
- https://github.com/dotnet/runtime/issues/7474
- https://github.com/dotnet/runtime/issues/8770

The `goto`s in this file are not needed anymore, which is why I removed them.
If this is not the case feel free to reject the PR.