### PR TITLE
[LoongArch64] Fix ld.lld relocation 'R_LARCH_PCALA_LO12' error when building NativeAOT testcases.

### DIFF
--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -2641,7 +2641,7 @@ unsigned emitter::emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t 
         size_t addr = (size_t)(id->idAddr()->iiaAddr); // get addr.
 
         int reg2 = (int)addr & 1;
-        addr     = addr ^ 1;
+        addr -= reg2;
 
         assert((addr & 3) == 0);
 

--- a/src/coreclr/jit/lowerloongarch64.cpp
+++ b/src/coreclr/jit/lowerloongarch64.cpp
@@ -38,8 +38,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 //
 bool Lowering::IsCallTargetInRange(void* addr)
 {
+    // The CallTarget is always in range on LA64.
     // TODO-LOONGARCH64-CQ: using B/BL for optimization.
-    return false;
+    return true;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
Fix the build error of the NativeAOT smoke tests which is mentioned in https://github.com/dotnet/runtime/issues/104661#issuecomment-2221912538