### PR TITLE
Bugfix/113494 fix defaulthttpclientfactory memory leaks

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.LifetimeProcessing.Handlers;
+using Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientKeyedLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientKeyedLifetime.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Net.Http;
-using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Http.LifetimeProcessing.Handlers;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/ActiveHandlerTrackingEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/ActiveHandlerTrackingEntry.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 
-namespace Microsoft.Extensions.Http
+namespace Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries
 {
     // Thread-safety: We treat this class as immutable except for the timer. Creating a new object
     // for the 'expiry' pool simplifies the threading requirements significantly.

--- a/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/ActiveHandlerTrackingEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/ActiveHandlerTrackingEntry.cs
@@ -5,13 +5,14 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries.Base;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries
 {
     // Thread-safety: We treat this class as immutable except for the timer. Creating a new object
     // for the 'expiry' pool simplifies the threading requirements significantly.
-    internal sealed class ActiveHandlerTrackingEntry
+    internal sealed class ActiveHandlerTrackingEntry : HandlerTrackingEntryBase
     {
         private static readonly TimerCallback _timerCallback = (s) => ((ActiveHandlerTrackingEntry)s!).Timer_Tick();
         private readonly object _lock;
@@ -24,10 +25,9 @@ namespace Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries
             LifetimeTrackingHttpMessageHandler handler,
             IServiceScope? scope,
             TimeSpan lifetime)
+            : base(name, scope)
         {
-            Name = name;
             Handler = handler;
-            Scope = scope;
             Lifetime = lifetime;
 
             _lock = new object();
@@ -36,10 +36,6 @@ namespace Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries
         public LifetimeTrackingHttpMessageHandler Handler { get; }
 
         public TimeSpan Lifetime { get; }
-
-        public string Name { get; }
-
-        public IServiceScope? Scope { get; }
 
         public void StartExpiryTimer(TimerCallback callback)
         {

--- a/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/Base/HandlerTrackingEntryBase.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/Base/HandlerTrackingEntryBase.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries.Base
+{
+    internal abstract class HandlerTrackingEntryBase
+    {
+        protected HandlerTrackingEntryBase(
+            string name,
+            IServiceScope? scope)
+        {
+            Name = name;
+            Scope = scope;
+        }
+
+        public string Name { get; }
+
+        public IServiceScope? Scope { get; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/ExpiredHandlerTrackingEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/ExpiredHandlerTrackingEntry.cs
@@ -5,7 +5,7 @@ using System;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Extensions.Http
+namespace Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries
 {
     // Thread-safety: This class is immutable
     internal sealed class ExpiredHandlerTrackingEntry

--- a/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/ExpiredHandlerTrackingEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/Entries/ExpiredHandlerTrackingEntry.cs
@@ -3,22 +3,20 @@
 
 using System;
 using System.Net.Http;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries.Base;
 
 namespace Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries
 {
     // Thread-safety: This class is immutable
-    internal sealed class ExpiredHandlerTrackingEntry
+    internal sealed class ExpiredHandlerTrackingEntry : HandlerTrackingEntryBase
     {
         private readonly WeakReference _livenessTracker;
 
         // IMPORTANT: don't cache a reference to `other` or `other.Handler` here.
         // We need to allow it to be GC'ed.
         public ExpiredHandlerTrackingEntry(ActiveHandlerTrackingEntry other)
+            : base(other.Name, other.Scope)
         {
-            Name = other.Name;
-            Scope = other.Scope;
-
             _livenessTracker = new WeakReference(other.Handler);
             InnerHandler = other.Handler.InnerHandler!;
         }
@@ -26,9 +24,5 @@ namespace Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries
         public bool CanDispose => !_livenessTracker.IsAlive;
 
         public HttpMessageHandler InnerHandler { get; }
-
-        public string Name { get; }
-
-        public IServiceScope? Scope { get; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/LifetimeTrackingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/LifetimeProcessing/Handlers/LifetimeTrackingHttpMessageHandler.cs
@@ -3,7 +3,7 @@
 
 using System.Net.Http;
 
-namespace Microsoft.Extensions.Http
+namespace Microsoft.Extensions.Http.LifetimeProcessing.Handlers
 {
     // This is a marker used to check if the underlying handler should be disposed. HttpClients
     // share a reference to an instance of this class, and when it goes out of scope the inner handler

--- a/src/libraries/Microsoft.Extensions.Http/src/Microsoft.Extensions.Http.csproj
+++ b/src/libraries/Microsoft.Extensions.Http/src/Microsoft.Extensions.Http.csproj
@@ -11,8 +11,6 @@ System.Net.Http.IHttpClientFactory</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(CommonPath)Extensions\NonCapturingTimer\NonCapturingTimer.cs"
-             Link="Common\src\Extensions\NonCapturingTimer\NonCapturingTimer.cs" />
     <Compile Include="$(CommonPath)Extensions\TypeNameHelper\TypeNameHelper.cs"
              Link="Common\src\Extensions\TypeNameHelper\TypeNameHelper.cs" />
     <Compile Include="$(CommonPath)System\ThrowHelper.cs"

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpClientFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpClientFactoryTest.cs
@@ -9,6 +9,8 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.LifetimeProcessing.Handlers;
+using Microsoft.Extensions.Http.LifetimeProcessing.Handlers.Entries;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpMessageHandlerKeyedRegistrationTest.Lifetimes.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpMessageHandlerKeyedRegistrationTest.Lifetimes.cs
@@ -1,0 +1,183 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.Http;
+using Xunit;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public class HttpMessageHandlerKeyedRegistrationTest
+    {
+        private const string Test = $"test-{nameof(HttpMessageHandlerKeyedRegistrationTest)}";
+
+        [Fact]
+        public void HttpMessageHandler_ScopedLifetime_Success()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            AddConfiguredNamedClient(serviceCollection, Test)
+                .AddAsKeyed(ServiceLifetime.Scoped);
+
+            var rootServices = serviceCollection.BuildServiceProvider(false);
+
+            var clientFactory = (DefaultHttpClientFactory)rootServices.GetRequiredService<IHttpClientFactory>();
+
+            Assert.Same(
+                rootServices.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                rootServices.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+            Assert.NotSame(
+                clientFactory.CreateHandler(Test),
+                rootServices.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+            using (var scopeA = rootServices.CreateScope())
+            {
+                var servicesA = scopeA.ServiceProvider;
+
+                Assert.Same(
+                servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                Assert.NotSame(
+                    clientFactory.CreateHandler(Test),
+                    servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                Assert.NotSame(
+                    rootServices.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                    servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                using (var scopeB = rootServices.CreateScope())
+                {
+                    var servicesB = scopeB.ServiceProvider;
+
+                    Assert.Same(
+                        servicesB.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                        servicesB.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                    Assert.NotSame(
+                        servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                        servicesB.GetRequiredKeyedService<HttpMessageHandler>(Test));
+                }
+            }
+        }
+
+        [Fact]
+        public void HttpMessageHandler_ScopedLifetimeWithValidateScopes_Success()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            AddConfiguredNamedClient(serviceCollection, Test)
+                .AddAsKeyed(ServiceLifetime.Scoped);
+
+            var rootServices = serviceCollection.BuildServiceProvider(true);
+
+            var clientFactory = (DefaultHttpClientFactory)rootServices.GetRequiredService<IHttpClientFactory>();
+
+            using (var scopeA = rootServices.CreateScope())
+            {
+                var servicesA = scopeA.ServiceProvider;
+
+                Assert.Same(
+                    servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                    servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                Assert.NotSame(
+                    clientFactory.CreateHandler(Test),
+                    servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                using (var scopeB = rootServices.CreateScope())
+                {
+                    var servicesB = scopeB.ServiceProvider;
+
+                    Assert.Same(
+                        servicesB.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                        servicesB.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                    Assert.NotSame(
+                        servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                        servicesB.GetRequiredKeyedService<HttpMessageHandler>(Test));
+                }
+            }
+        }
+
+        [Fact]
+        public void HttpMessageHandler_ScopedLifetimeWithValidateScopes_ThrowsInvalidOperationException()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            AddConfiguredNamedClient(serviceCollection, Test)
+                .AddAsKeyed(ServiceLifetime.Scoped);
+
+            var rootServices = serviceCollection.BuildServiceProvider(true);
+
+            var clientFactory = (DefaultHttpClientFactory)rootServices.GetRequiredService<IHttpClientFactory>();
+
+            Assert.Throws<InvalidOperationException>(
+                () => rootServices.GetRequiredKeyedService<HttpMessageHandler>(Test));
+        }
+
+        [Fact]
+        public void HttpMessageHandler_SingletonLifetime_Success()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            AddConfiguredNamedClient(serviceCollection, Test)
+                .AddAsKeyed(ServiceLifetime.Singleton);
+
+            var rootServices = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            var clientFactory = (DefaultHttpClientFactory)rootServices.GetRequiredService<IHttpClientFactory>();
+
+            Assert.Same(
+                rootServices.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                rootServices.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+            Assert.NotSame(
+                clientFactory.CreateHandler(Test),
+                rootServices.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+            using (var scopeA = rootServices.CreateScope())
+            {
+                var servicesA = scopeA.ServiceProvider;
+
+                Assert.Same(
+                    servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                    servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                Assert.Same(
+                    rootServices.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                    servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                Assert.NotSame(
+                    clientFactory.CreateHandler(Test),
+                    servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                using (var scopeB = rootServices.CreateScope())
+                {
+                    var servicesB = scopeB.ServiceProvider;
+
+                    Assert.Same(
+                        servicesB.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                        servicesB.GetRequiredKeyedService<HttpMessageHandler>(Test));
+
+                    Assert.Same(
+                        servicesA.GetRequiredKeyedService<HttpMessageHandler>(Test),
+                        servicesB.GetRequiredKeyedService<HttpMessageHandler>(Test));
+                }
+            }
+        }
+
+        private static IHttpClientBuilder AddConfiguredNamedClient(ServiceCollection services, string name)
+        {
+            services.AddKeyedTransient(name, (_, _) => new KeyedPrimaryHandler(name));
+
+            return services
+                .AddHttpClient(name, c => c.BaseAddress = GetUri(name))
+                .ConfigurePrimaryHttpMessageHandler(sp => sp.GetRequiredKeyedService<KeyedPrimaryHandler>(name));
+        }
+
+        private static Uri GetUri(string name) => new Uri($"http://{name}.example.com");
+    }
+}


### PR DESCRIPTION
Current PR fix memory leaks, linked with requirements of _System.Threading.Timer_ recreation, but it does not fix root couse of https://github.com/dotnet/runtime/issues/113494 , which linked with scope creation by [this line](https://github.com/dotnet/runtime/blob/159f40e850839050ac09cb419d9830adeab22e2b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs#L139).
I think, the most applicable way for fix root couse is change of _IHttpClientFactory_ , which should be represented by two method groups:

1. for rent Client and Handler;
2. for return Client and Handler

like it represented by [ArrayPool<T>](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1?view=net-9.0). Then we can dispose created scope inside second method group.