### PR TITLE
Fix NRE in GenericLookupResult.Equals method

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -81,7 +81,7 @@ namespace ILCompiler.DependencyAnalysis
         public sealed override bool Equals(object obj)
         {
             GenericLookupResult other = obj as GenericLookupResult;
-            if (obj == null)
+            if (other == null)
                 return false;
 
             return ClassCode == other.ClassCode && EqualsImpl(other);


### PR DESCRIPTION
There is a typo in the GenericLookupResult.Equals method. Instead of checking `other` for null, the argument `obj` is checked. If obj is not of `GenericLookupResult` type, then it will be NRE.