### PR TITLE
[release/8.0-staging] [infra][apple-mobile] Migrate MacCatalyst and iOS/tvOS simulator jobs to `osx.14.arm64.open` and `osx.15.amd64.open` queues

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -36,7 +36,7 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'maccatalyst_arm64', 'iossimulator_arm64') }}:
-      - OSX.15.Arm64.Open
+      - OSX.14.Arm64.Open
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iossimulator_x64', 'tvossimulator_x64', 'maccatalyst_x64') }}:

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -36,7 +36,7 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'maccatalyst_arm64', 'iossimulator_arm64') }}:
-      - OSX.14.Arm64.Open
+      - OSX.15.Arm64.Open
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iossimulator_x64', 'tvossimulator_x64', 'maccatalyst_x64') }}:

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -36,11 +36,11 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'maccatalyst_arm64', 'iossimulator_arm64') }}:
-      - OSX.1200.Arm64.Open
+      - OSX.15.Arm64.Open
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iossimulator_x64', 'tvossimulator_x64', 'maccatalyst_x64') }}:
-      - OSX.1200.Amd64.Open
+      - OSX.15.Amd64.Open
 
     # Android arm64
     - ${{ if in(parameters.platform, 'android_arm64') }}:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -25,9 +25,7 @@ jobs:
     platforms:
     - iossimulator_x64
     - tvossimulator_x64
-    # don't run tests on arm64 PRs until we can get significantly more devices
-    - ${{ if eq(variables['isRollingBuild'], true) }}:
-      - iossimulator_arm64
+    - iossimulator_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -61,9 +59,7 @@ jobs:
     platforms:
       - iossimulator_x64
       - tvossimulator_x64
-      # don't run tests on arm64 PRs until we can get significantly more devices
-      - ${{ if eq(variables['isRollingBuild'], true) }}:
-        - iossimulator_arm64
+      - iossimulator_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource
@@ -109,9 +105,7 @@ jobs:
     platforms:
       - iossimulator_x64
       - tvossimulator_x64
-      # don't run tests on arm64 PRs until we can get significantly more devices
-      - ${{ if eq(variables['isRollingBuild'], true) }}:
-        - iossimulator_arm64
+      - iossimulator_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -25,7 +25,9 @@ jobs:
     platforms:
     - iossimulator_x64
     - tvossimulator_x64
-    - iossimulator_arm64
+    # don't run tests on arm64 PRs until we can get significantly more devices
+    - ${{ if eq(variables['isRollingBuild'], true) }}:
+      - iossimulator_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -59,7 +61,9 @@ jobs:
     platforms:
       - iossimulator_x64
       - tvossimulator_x64
-      - iossimulator_arm64
+      # don't run tests on arm64 PRs until we can get significantly more devices
+      - ${{ if eq(variables['isRollingBuild'], true) }}:
+        - iossimulator_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource
@@ -105,7 +109,9 @@ jobs:
     platforms:
       - iossimulator_x64
       - tvossimulator_x64
-      - iossimulator_arm64
+      # don't run tests on arm64 PRs until we can get significantly more devices
+      - ${{ if eq(variables['isRollingBuild'], true) }}:
+        - iossimulator_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -105,11 +105,11 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'maccatalyst_arm64', 'iossimulator_arm64') }}:
-      - OSX.1200.Arm64.Open
+      - OSX.15.Arm64.Open
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iossimulator_x64', 'tvossimulator_x64', 'maccatalyst_x64') }}:
-      - OSX.1200.Amd64.Open
+      - OSX.15.Amd64.Open
 
     # iOS devices
     - ${{ if in(parameters.platform, 'ios_arm64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -105,7 +105,7 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'maccatalyst_arm64', 'iossimulator_arm64') }}:
-      - OSX.15.Arm64.Open
+      - OSX.14.Arm64.Open
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iossimulator_x64', 'tvossimulator_x64', 'maccatalyst_x64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -105,7 +105,7 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'maccatalyst_arm64', 'iossimulator_arm64') }}:
-      - OSX.14.Arm64.Open
+      - OSX.15.Arm64.Open
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iossimulator_x64', 'tvossimulator_x64', 'maccatalyst_x64') }}:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -721,8 +721,7 @@ extends:
           runtimeFlavor: mono
           platforms:
           - maccatalyst_x64
-          - ${{ if eq(variables['isRollingBuild'], true) }}:
-            - maccatalyst_arm64
+          - maccatalyst_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/RemoveTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/RemoveTests.cs
@@ -7,7 +7,8 @@ namespace System.IO.IsolatedStorage
 {
     public class RemoveTests : IsoStorageTest
     {
-        [Fact]
+        [ConditionalFact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/114403", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst))]
         public void RemoveUserStoreForApplication()
         {
             TestHelper.WipeStores();
@@ -22,7 +23,8 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/114403", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst))]
         public void RemoveUserStoreForAssembly()
         {
             TestHelper.WipeStores();
@@ -37,7 +39,8 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/114403", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst))]
         public void RemoveUserStoreForDomain()
         {
             TestHelper.WipeStores();
@@ -54,7 +57,9 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [Theory, MemberData(nameof(ValidStores))]
+        [ConditionalTheory]
+        [MemberData(nameof(ValidStores))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/114403", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst))]
         public void RemoveStoreWithContent(PresetScopes scope)
         {
             TestHelper.WipeStores();

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/RemoveTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/RemoveTests.cs
@@ -7,7 +7,7 @@ namespace System.IO.IsolatedStorage
 {
     public class RemoveTests : IsoStorageTest
     {
-        [ConditionalFact]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/114403", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst))]
         public void RemoveUserStoreForApplication()
         {
@@ -23,7 +23,7 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ConditionalFact]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/114403", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst))]
         public void RemoveUserStoreForAssembly()
         {
@@ -39,7 +39,7 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ConditionalFact]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/114403", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst))]
         public void RemoveUserStoreForDomain()
         {
@@ -57,7 +57,7 @@ namespace System.IO.IsolatedStorage
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(ValidStores))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/114403", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst))]
         public void RemoveStoreWithContent(PresetScopes scope)

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Win32.SafeHandles;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
@@ -56,24 +57,33 @@ namespace System.IO.MemoryMappedFiles.Tests
             }
         }
 
+        public static IEnumerable<object[]> AccessLevelCombinationsData()
+        {
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Write };
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWrite };
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.CopyOnWrite };  
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadExecute };
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWriteExecute };
+            yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.CopyOnWrite };
+            if (PlatformDetection.IsNotMacCatalyst)
+            {
+                // https://github.com/dotnet/runtime/issues/114403
+                yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadExecute };
+            }
+            yield return new object[] { MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.CopyOnWrite };
+            yield return new object[] { MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.Write };
+            yield return new object[] { MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWrite };
+            yield return new object[] { MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.CopyOnWrite };
+            yield return new object[] { MemoryMappedFileAccess.Read, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.Read, MemoryMappedFileAccess.CopyOnWrite };
+        }
+
         [ConditionalTheory]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Write)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.CopyOnWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWriteExecute)]
-        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.CopyOnWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.CopyOnWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.Write)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.CopyOnWrite)]
-        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.CopyOnWrite)]
+        [MemberData(nameof(AccessLevelCombinationsData))]
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -67,9 +67,9 @@ namespace System.IO.MemoryMappedFiles.Tests
             yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWriteExecute };
             yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.Read };
             yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.CopyOnWrite };
+            // https://github.com/dotnet/runtime/issues/114403
             if (PlatformDetection.IsNotMacCatalyst)
             {
-                // https://github.com/dotnet/runtime/issues/114403
                 yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadExecute };
             }
             yield return new object[] { MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.Read };

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Win32.SafeHandles;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
@@ -56,24 +57,33 @@ namespace System.IO.MemoryMappedFiles.Tests
             }
         }
 
+        public static IEnumerable<object[]> AccessLevelCombinationsData()
+        {
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Write };
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWrite };
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.CopyOnWrite };  
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadExecute };
+            yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWriteExecute };
+            yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.CopyOnWrite };
+            if (PlatformDetection.IsNotMacCatalyst)
+            {
+                // https://github.com/dotnet/runtime/issues/114403
+                yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadExecute };
+            }
+            yield return new object[] { MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.CopyOnWrite };
+            yield return new object[] { MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.Write };
+            yield return new object[] { MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWrite };
+            yield return new object[] { MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.CopyOnWrite };
+            yield return new object[] { MemoryMappedFileAccess.Read, MemoryMappedFileAccess.Read };
+            yield return new object[] { MemoryMappedFileAccess.Read, MemoryMappedFileAccess.CopyOnWrite };
+        }
+
         [ConditionalTheory]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Write)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.CopyOnWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWriteExecute)]
-        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.CopyOnWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadExecute)]
-        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.CopyOnWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.Write)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.ReadWrite)]
-        [InlineData(MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.CopyOnWrite)]
-        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.Read)]
-        [InlineData(MemoryMappedFileAccess.Read, MemoryMappedFileAccess.CopyOnWrite)]
+        [MemberData(nameof(AccessLevelCombinationsData))]
         public void ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
         {
             const int Capacity = 4096;

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -67,9 +67,9 @@ namespace System.IO.MemoryMappedFiles.Tests
             yield return new object[] { MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWriteExecute };
             yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.Read };
             yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.CopyOnWrite };
+            // https://github.com/dotnet/runtime/issues/114403
             if (PlatformDetection.IsNotMacCatalyst)
             {
-                // https://github.com/dotnet/runtime/issues/114403
                 yield return new object[] { MemoryMappedFileAccess.ReadExecute, MemoryMappedFileAccess.ReadExecute };
             }
             yield return new object[] { MemoryMappedFileAccess.CopyOnWrite, MemoryMappedFileAccess.Read };

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendTo.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendTo.cs
@@ -95,6 +95,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.FreeBSD, "FreeBSD allows sendto() to broadcast")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/114450", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst), nameof(PlatformDetection.IsX64Process))]
         public async Task Datagram_UDP_AccessDenied_Throws_DoesNotBind()
         {
             IPEndPoint invalidEndpoint = new IPEndPoint(IPAddress.Broadcast, 1234);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -65,6 +65,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/113827", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile))]
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
             // On all platforms, index 0 means "any interface"


### PR DESCRIPTION
Backport of #113313 to release/8.0-staging

Currently, we are using osx.1200.amd64.open and osx.1200.arm64.open for dotnet/runtime Apple simulator and MacCatalyst jobs. Since macOS 12 is after its EOL, we should migrate to queues with newer macOS version.

iOSSimulator, tvOSSimulator, MacCatalyst pipelines are migrated to:
- `osx.15.amd64.open`
- `osx.14.arm64.open` (until `osx.15.arm64.open` has enough machines)

Disabling failing tests against tracking issues.

## Customer Impact

- [ ] Customer reported
- [x] Found internally

No impact, CI testing infra change

## Regression

- [ ] Yes
- [x] No

[If yes, specify when the regression was introduced. Provide the PR or commit if known.]

## Testing

`runtime-extra-platforms`

## Risk

Low: CI testing infra change