### PR TITLE
[mono][sgen] Fix initialization of can_reduce_color

### DIFF
--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -746,7 +746,7 @@ create_scc (ScanData *data)
 	for (i = dyn_array_ptr_size (&loop_stack) - 1; i >= 0; --i) {
 		ScanData *other = (ScanData *)dyn_array_ptr_get (&loop_stack, i);
 		found_bridge |= other->is_bridge;
-		if (dyn_array_ptr_size (&other->xrefs) > 0) {
+		if (dyn_array_ptr_size (&other->xrefs) > 0 || found_bridge) {
 			// This scc will have more xrefs than the ones from the color_merge_array,
 			// we will need to create a new color to store this information.
 			can_reduce_color = FALSE;

--- a/src/tests/GC/Features/Bridge/BridgeTester.csproj
+++ b/src/tests/GC/Features/Bridge/BridgeTester.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' != 'Mono'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' != 'Mono' or '$(TargetArchitecture)' == 'wasm' or '$(TargetsMobile)' == 'true'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BridgeTester.cs" />


### PR DESCRIPTION
Mark it as true also in the case when the SCC contains bridge objects. Code populating other_colors for this SCC depends on it.