### PR TITLE
Never inline AllocateInstances in COM lifetime test

### DIFF
--- a/src/tests/Interop/COM/NETClients/Lifetime/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Lifetime/Program.cs
@@ -6,6 +6,7 @@ namespace NetClient
 {
     using System;
     using System.Threading;
+    using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
 
     using TestLibrary;
@@ -24,6 +25,7 @@ namespace NetClient
             GetAllocationCount = (delegate* unmanaged<int>)inst.GetAllocationCountCallback();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         static int AllocateInstances(int a)
         {
             var insts = new object[a];


### PR DESCRIPTION
Fixes #112334

JITStress_Random was picking JITStress values that forced at least one call of AllocateInstances to be inlined.

Never allow it to be inlined to avoid having lifetime extension issues that cause failures (and later asserts).