### PR TITLE
Interpreter EH support in the runtime

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -58,9 +58,14 @@ class AsmOffsets
 
 #if TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x8;
+#if FEATURE_INTERPRETER
     public const int SIZEOF__StackFrameIterator = 0x170;
-    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x132;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x168;
+#else
+    public const int SIZEOF__StackFrameIterator = 0x150;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x148;
+#endif
+    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x132;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
     public const int SIZEOF__StackFrameIterator = 0x3cc;
@@ -119,9 +124,14 @@ class AsmOffsets
 
 #if TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x8;
+#if FEATURE_INTERPRETER
     public const int SIZEOF__StackFrameIterator = 0x168;
-    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x12a;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x160;
+#else
+    public const int SIZEOF__StackFrameIterator = 0x148;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x140;
+#endif
+    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x12a;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
     public const int SIZEOF__StackFrameIterator = 0x3c4;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -58,9 +58,9 @@ class AsmOffsets
 
 #if TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x8;
-    public const int SIZEOF__StackFrameIterator = 0x150;
+    public const int SIZEOF__StackFrameIterator = 0x170;
     public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x132;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x148;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x168;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
     public const int SIZEOF__StackFrameIterator = 0x3cc;
@@ -119,9 +119,9 @@ class AsmOffsets
 
 #if TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x8;
-    public const int SIZEOF__StackFrameIterator = 0x148;
+    public const int SIZEOF__StackFrameIterator = 0x168;
     public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x12a;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x140;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x160;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
     public const int SIZEOF__StackFrameIterator = 0x3c4;

--- a/src/coreclr/clr.featuredefines.props
+++ b/src/coreclr/clr.featuredefines.props
@@ -26,6 +26,10 @@
         <FeatureEHFunclets>true</FeatureEHFunclets>
     </PropertyGroup>
 
+    <PropertyGroup Condition="('$(Platform)' == 'x64' OR '$(Platform)' == 'arm64') AND ('$(Configuration)' == 'debug' OR '$(Configuration)' == 'checked')">
+        <FeatureInterpreter>true</FeatureInterpreter>
+    </PropertyGroup>
+
     <PropertyGroup>
         <DefineConstants Condition="'$(FeatureComWrappers)' == 'true'">$(DefineConstants);FEATURE_COMWRAPPERS</DefineConstants>
         <DefineConstants Condition="'$(FeatureCominterop)' == 'true'">$(DefineConstants);FEATURE_COMINTEROP</DefineConstants>
@@ -36,6 +40,7 @@
         <DefineConstants Condition="'$(FeatureXplatEventSource)' == 'true'">$(DefineConstants);FEATURE_EVENTSOURCE_XPLAT</DefineConstants>
         <DefineConstants Condition="'$(FeatureTypeEquivalence)' == 'true'">$(DefineConstants);FEATURE_TYPEEQUIVALENCE</DefineConstants>
         <DefineConstants Condition="'$(FeatureEHFunclets)' == 'true'">$(DefineConstants);FEATURE_EH_FUNCLETS</DefineConstants>
+        <DefineConstants Condition="'$(FeatureInterpreter)' == 'true'">$(DefineConstants);FEATURE_INTERPRETER</DefineConstants>
 
         <DefineConstants Condition="'$(ProfilingSupportedBuild)' == 'true'">$(DefineConstants);PROFILING_SUPPORTED</DefineConstants>
     </PropertyGroup>

--- a/src/coreclr/inc/eetwain.h
+++ b/src/coreclr/inc/eetwain.h
@@ -307,7 +307,7 @@ virtual void            LeaveCatch(GCInfoToken gcInfoToken,
                                    PCONTEXT pCtx)=0;
 #else // FEATURE_EH_FUNCLETS
 virtual DWORD_PTR CallFunclet(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter) = 0;
-virtual void PrepareForResumeAfterCatch(CONTEXT *pContext) = 0;
+virtual void ResumeAfterCatch(CONTEXT *pContext, size_t targetSSP, bool fIntercepted) = 0;
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
 virtual void UpdateSSP(PREGDISPLAY pRD) = 0;
 #endif // HOST_AMD64 && HOST_WINDOWS
@@ -557,10 +557,7 @@ virtual void LeaveCatch(GCInfoToken gcInfoToken,
                          PCONTEXT pCtx);
 #else // FEATURE_EH_FUNCLETS
 virtual DWORD_PTR CallFunclet(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter);
-virtual void PrepareForResumeAfterCatch(CONTEXT *pContext)
-{
-    // Nothing to do for non-interpreter code manager.
-}
+virtual void ResumeAfterCatch(CONTEXT *pContext, size_t targetSSP, bool fIntercepted);
 
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
 virtual void UpdateSSP(PREGDISPLAY pRD);
@@ -774,7 +771,7 @@ virtual void LeaveCatch(GCInfoToken gcInfoToken,
 }
 #else // FEATURE_EH_FUNCLETS
 virtual DWORD_PTR CallFunclet(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter);
-virtual void PrepareForResumeAfterCatch(CONTEXT *pContext);
+virtual void ResumeAfterCatch(CONTEXT *pContext, size_t targetSSP, bool fIntercepted);
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
 virtual void UpdateSSP(PREGDISPLAY pRD);
 #endif // HOST_AMD64 && HOST_WINDOWS

--- a/src/coreclr/inc/eetwain.h
+++ b/src/coreclr/inc/eetwain.h
@@ -307,6 +307,10 @@ virtual void            LeaveCatch(GCInfoToken gcInfoToken,
                                    PCONTEXT pCtx)=0;
 #else // FEATURE_EH_FUNCLETS
 virtual DWORD_PTR CallFunclet(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter) = 0;
+virtual void PrepareForResumeAfterCatch(CONTEXT *pContext) = 0;
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+virtual void UpdateSSP(PREGDISPLAY pRD) = 0;
+#endif // HOST_AMD64 && HOST_WINDOWS
 #endif // FEATURE_EH_FUNCLETS
 
 #ifdef FEATURE_REMAP_FUNCTION
@@ -553,6 +557,14 @@ virtual void LeaveCatch(GCInfoToken gcInfoToken,
                          PCONTEXT pCtx);
 #else // FEATURE_EH_FUNCLETS
 virtual DWORD_PTR CallFunclet(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter);
+virtual void PrepareForResumeAfterCatch(CONTEXT *pContext)
+{
+    // Nothing to do for non-interpreter code manager.
+}
+
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+virtual void UpdateSSP(PREGDISPLAY pRD);
+#endif // HOST_AMD64 && HOST_WINDOWS
 #endif // FEATURE_EH_FUNCLETS
 
 #ifdef FEATURE_REMAP_FUNCTION
@@ -762,6 +774,10 @@ virtual void LeaveCatch(GCInfoToken gcInfoToken,
 }
 #else // FEATURE_EH_FUNCLETS
 virtual DWORD_PTR CallFunclet(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter);
+virtual void PrepareForResumeAfterCatch(CONTEXT *pContext);
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+virtual void UpdateSSP(PREGDISPLAY pRD);
+#endif // HOST_AMD64 && HOST_WINDOWS
 #endif // FEATURE_EH_FUNCLETS
 
 #ifdef FEATURE_REMAP_FUNCTION

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3263,6 +3263,12 @@ retry_emit:
                 }
                 break;
 
+            case CEE_THROW:
+                AddIns(INTOP_THROW);
+                m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
+                m_ip += 1;
+                break;
+
             default:
                 assert(0);
                 break;

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -272,7 +272,7 @@ private:
     CORINFO_METHOD_INFO* m_methodInfo;
 #ifdef DEBUG
     const char *m_methodName;
-    bool m_verbose;
+    bool m_verbose = false;
 #endif
 
     static int32_t InterpGetMovForType(InterpType interpType, bool signExtend);

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -261,6 +261,9 @@ OPDEF(INTOP_CALL_HELPER_PP, "call.helper.pp", 5, 1, 0, InterpOpThreeInts)
 OPDEF(INTOP_ZEROBLK_IMM, "zeroblk.imm", 3, 0, 1, InterpOpInt)
 OPDEF(INTOP_LOCALLOC, "localloc", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_BREAKPOINT, "breakpoint", 1, 0, 0, InterpOpNoArgs)
+
+OPDEF(INTOP_THROW, "throw", 4, 0, 1, InterpOpInt)
+
 OPDEF(INTOP_FAILFAST, "failfast", 1, 0, 0, InterpOpNoArgs)
 OPDEF(INTOP_GC_COLLECT, "gc.collect", 1, 0, 0, InterpOpNoArgs)
 

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -450,6 +450,26 @@ inline TADDR GetFP(const CONTEXT * context)
     return (TADDR)(context->Rbp);
 }
 
+inline void SetFirstArgReg(CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+#ifdef UNIX_AMD64_ABI
+    context->Rdi = (DWORD64)value;
+#else
+    context->Rcx = (DWORD64)value;
+#endif
+}
+
+inline TADDR GetFirstArgReg(CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+#ifdef UNIX_AMD64_ABI
+    return (TADDR)(context->Rdi);
+#else
+    return (TADDR)(context->Rcx);
+#endif
+}
+
 extern "C" TADDR GetCurrentSP();
 
 // Emits:

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -470,6 +470,26 @@ inline TADDR GetFirstArgReg(CONTEXT *context)
 #endif
 }
 
+inline void SetSecondArgReg(CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+#ifdef UNIX_AMD64_ABI
+    context->Rsi = (DWORD64)value;
+#else
+    context->Rdx = (DWORD64)value;
+#endif
+}
+
+inline TADDR GetSecondArgReg(CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+#ifdef UNIX_AMD64_ABI
+    return (TADDR)(context->Rsi);
+#else
+    return (TADDR)(context->Rdx);
+#endif
+}
+
 extern "C" TADDR GetCurrentSP();
 
 // Emits:

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -255,6 +255,30 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return (TADDR)(context->R11);
 }
 
+inline void SetFirstArgReg(T_CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    context->R0 = DWORD(value);
+}
+
+inline TADDR GetFirstArgReg(T_CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return (TADDR)(context->R0);
+}
+
+inline void SetSecondArgReg(T_CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    context->R1 = DWORD(value);
+}
+
+inline TADDR GetSecondArgReg(T_CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return (TADDR)(context->R1);
+}
+
 inline void ClearITState(T_CONTEXT *context) {
     LIMITED_METHOD_DAC_CONTRACT;
     context->Cpsr = context->Cpsr & 0xf9ff03ff;

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -279,6 +279,17 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return (TADDR)(context->Fp);
 }
 
+inline void SetFirstArgReg(CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    SetReg(context, 0, reg);
+}
+
+inline TADDR GetFirstArgReg(CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return GetReg(context, 0);
+}
 
 inline TADDR GetMem(PCODE address, SIZE_T size, bool signExtend)
 {

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -279,13 +279,13 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return (TADDR)(context->Fp);
 }
 
-inline void SetFirstArgReg(CONTEXT *context, TADDR value)
+inline void SetFirstArgReg(T_CONTEXT *context, TADDR value)
 {
     LIMITED_METHOD_DAC_CONTRACT;
     SetReg(context, 0, value);
 }
 
-inline TADDR GetFirstArgReg(CONTEXT *context)
+inline TADDR GetFirstArgReg(T_CONTEXT *context)
 {
     LIMITED_METHOD_DAC_CONTRACT;
     return GetReg(context, 0);

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -291,6 +291,18 @@ inline TADDR GetFirstArgReg(T_CONTEXT *context)
     return GetReg(context, 0);
 }
 
+inline void SetSecondArgReg(T_CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    SetReg(context, 1, value);
+}
+
+inline TADDR GetSecondArgReg(T_CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return GetReg(context, 1);
+}
+
 inline TADDR GetMem(PCODE address, SIZE_T size, bool signExtend)
 {
     TADDR mem;

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -282,7 +282,7 @@ inline TADDR GetFP(const T_CONTEXT * context)
 inline void SetFirstArgReg(CONTEXT *context, TADDR value)
 {
     LIMITED_METHOD_DAC_CONTRACT;
-    SetReg(context, 0, reg);
+    SetReg(context, 0, value);
 }
 
 inline TADDR GetFirstArgReg(CONTEXT *context)

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4339,25 +4339,8 @@ BOOL InterpreterJitManager::JitCodeToMethodInfo(
 
 TADDR InterpreterJitManager::GetFuncletStartAddress(EECodeInfo * pCodeInfo)
 {
-    EH_CLAUSE_ENUMERATOR    EnumState;
-    unsigned                EHCount;
-
-    IJitManager *pJitMan = pCodeInfo->GetJitManager();
-    EHCount = pJitMan->InitializeEHEnumeration(pCodeInfo->GetMethodToken(), &EnumState);
-    DWORD relOffset = pCodeInfo->GetRelOffset();
-
-    for (unsigned i = 0; i < EHCount; i++)
-    {
-        EE_ILEXCEPTION_CLAUSE EHClause;
-        pJitMan->GetNextEHClause(&EnumState, &EHClause);
-
-        if (EHClause.HandlerStartPC <= relOffset && relOffset < EHClause.HandlerEndPC)
-        {
-            return pCodeInfo->GetCodeAddress() - relOffset + EHClause.HandlerStartPC;
-        }
-    }
-
-    return pCodeInfo->GetCodeAddress() - relOffset;
+    // Interpreter-TODO: Verify that this is correct
+    return pCodeInfo->GetCodeAddress() - pCodeInfo->GetRelOffset();
 }
 
 void InterpreterJitManager::JitTokenToMethodRegionInfo(const METHODTOKEN& MethodToken, MethodRegionInfo * methodRegionInfo)

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -22,6 +22,7 @@
 #endif // FEATURE_INTERPRETER
 
 #include "exinfo.h"
+#include "excep.h"
 
 #ifdef TARGET_X86
 
@@ -2075,21 +2076,68 @@ DWORD_PTR EECodeManager::CallFunclet(OBJECTREF throwable, void* pHandler, REGDIS
     return dwResult;
 }
 
+void EECodeManager::ResumeAfterCatch(CONTEXT *pContext, size_t targetSSP, bool fIntercepted)
+{
+    Thread *pThread = GetThread();
+    DWORD_PTR dwResumePC = GetIP(pContext);
+    UINT_PTR uAbortAddr = 0;
+    if (!fIntercepted)
+    {
+        CopyOSContext(pThread->m_OSContext, pContext);
+        uAbortAddr = (UINT_PTR)COMPlusCheckForAbort(dwResumePC);
+    }
+
+    if (uAbortAddr)
+    {
+        STRESS_LOG2(LF_EH, LL_INFO10, "Thread abort in progress, resuming under control: IP=%p, SP=%p\n", dwResumePC, GetSP(pContext));
+
+        // The dwResumePC is passed to the THROW_CONTROL_FOR_THREAD_FUNCTION ASM helper so that
+        // it can establish it as its return address and native stack unwinding can work properly.
+#ifdef TARGET_AMD64
+#ifdef TARGET_UNIX
+        pContext->Rdi = dwResumePC;
+#else
+        pContext->Rcx = dwResumePC;
+#endif
+#elif defined(TARGET_ARM) || defined(TARGET_ARM64)
+        // On ARM & ARM64, we save off the original PC in Lr. This is the same as done
+        // in HandleManagedFault for H/W generated exceptions.
+        pContext->Lr = dwResumePC;
+#elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+        pContext->Ra = dwResumePC;
+#endif
+
+        SetIP(pContext, uAbortAddr);
+    }
+    else
+    {
+        STRESS_LOG2(LF_EH, LL_INFO100, "Resuming after exception at IP=%p, SP=%p\n", GetIP(pContext), GetSP(pContext));
+    }
+
+    ClrRestoreNonvolatileContext(pContext, targetSSP);
+}
+
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
-void EECodeManager::UpdateSSP(PREGDISPLAY pRD)
+
+size_t GetSSPForFrameOnCurrentStack(TADDR ip)
 {
     size_t *targetSSP = (size_t *)_rdsspq();
     // The SSP we search is pointing to the return address of the frame represented
-    // by the pRD->ControlPC. So we search for the instruction pointer from
+    // by the passed in IP. So we search for the instruction pointer from
     // the context and return one slot up from there.
     if (targetSSP != NULL)
     {
-        while (*targetSSP++ != pRD->ControlPC)
+        while (*targetSSP++ != ip)
         {
         }
     }
 
-    pRD->SSP = (size_t)targetSSP;
+    return (size_t)targetSSP;
+}
+
+void EECodeManager::UpdateSSP(PREGDISPLAY pRD)
+{
+    pRD->SSP = GetSSPForFrameOnCurrentStack(pRD->ControlPC);
 }
 #endif // HOST_AMD64 && HOST_WINDOWS
 
@@ -2101,13 +2149,64 @@ DWORD_PTR InterpreterCodeManager::CallFunclet(OBJECTREF throwable, void* pHandle
     return 0;
 }
 
-void InterpreterCodeManager::PrepareForResumeAfterCatch(CONTEXT *pContext)
+void InterpreterCodeManager::ResumeAfterCatch(CONTEXT *pContext, size_t targetSSP, bool fIntercepted)
 {
     Thread *pThread = GetThread();
     InterpreterFrame * pInterpreterFrame = (InterpreterFrame*)pThread->GetFrame();
-    pInterpreterFrame->SetResumeContext(GetSP(pContext), GetIP(pContext));
-    pInterpreterFrame->RestoreInterpExecMethodContext(pContext);
+    TADDR resumeSP = GetSP(pContext);
+    TADDR resumeIP = GetIP(pContext);
+
+    ClrCaptureContext(pContext);
+
+    // Unwind to the caller of the Ex.RhThrowEx / Ex.RhThrowHwEx
+    Thread::VirtualUnwindToFirstManagedCallFrame(pContext);
+
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+    targetSSP = GetSSPForFrameOnCurrentStack(GetIP(pContext));
+#endif // HOST_AMD64 && HOST_WINDOWS
+
+    CONTEXT firstNativeContext;
+    size_t firstNativeSSP;
+
+    // Find the native frames chain that contains the resumeSP
+    do
+    {
+        // Skip all managed frames upto a native frame
+        while (ExecutionManager::IsManagedCode(GetIP(pContext)))
+        {
+            Thread::VirtualUnwindCallFrame(pContext);
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+            if (targetSSP != 0)
+            {
+                targetSSP += sizeof(size_t);
+            }
+#endif
+        }
+
+        // Save the first native context after managed frames. This will be the context where we throw the resume after catch exception from.
+        firstNativeContext = *pContext;
+        firstNativeSSP = targetSSP;
+        // Move over all native frames until we move over the resumeSP
+        while ((GetSP(pContext) < resumeSP) && !ExecutionManager::IsManagedCode(GetIP(pContext)))
+        {
+#ifdef TARGET_UNIX
+            PAL_VirtualUnwind(pContext, NULL);
+#else
+            Thread::VirtualUnwindCallFrame(pContext);
+#endif
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+            if (targetSSP != 0)
+            {
+                targetSSP += sizeof(size_t);
+            }
+#endif
+        }
+    }
+    while (GetSP(pContext) < resumeSP);
+
+    ExecuteFunctionBelowContext((PCODE)ThrowResumeAfterCatchException, &firstNativeContext, firstNativeSSP, resumeSP, resumeIP);
 }
+
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
 void InterpreterCodeManager::UpdateSSP(PREGDISPLAY pRD)
 {
@@ -2306,7 +2405,7 @@ bool InterpreterCodeManager::UnwindStackFrame(PREGDISPLAY     pRD,
     return true;
 }
 
-void InterpreterCodeManager::EnsureCallerContextIsValid( PREGDISPLAY  pRD, EECodeInfo * pCodeInfo /*= NULL*/, unsigned flags /*= 0*/)
+void InterpreterCodeManager::EnsureCallerContextIsValid(PREGDISPLAY  pRD, EECodeInfo * pCodeInfo /*= NULL*/, unsigned flags /*= 0*/)
 {
     CONTRACTL
     {
@@ -2322,9 +2421,7 @@ void InterpreterCodeManager::EnsureCallerContextIsValid( PREGDISPLAY  pRD, EECod
         *(pRD->pCallerContext) = *(pRD->pCurrentContext);
         TADDR sp = (TADDR)GetRegdisplaySP(pRD);
         VirtualUnwindInterpreterCallFrame(sp, pRD->pCallerContext);
-        // Preserve the context pointers, besides the SP, IP, FP and the first argument register, all the registers are
-        // kept untouched and keep the state it the InterpExecMethod. We use the context pointers to update the registers
-        // before resuming after a catch using the original context.
+        // Preserve the context pointers, they are used by floating point registers unwind starting at the original context.
         memcpy(pRD->pCallerContextPointers, pRD->pCurrentContextPointers, sizeof(KNONVOLATILE_CONTEXT_POINTERS));
 
         pRD->IsCallerContextValid = TRUE;

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7307,6 +7307,48 @@ VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFra
     }
 }
 
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+size_t GetSSPForFrameOnCurrentStack(TADDR ip);
+#endif // HOST_AMD64 && HOST_WINDOWS
+
+#ifdef FEATURE_INTERPRETER
+void ThrowResumeAfterCatchException(TADDR resumeSP, TADDR resumeIP)
+{
+    throw ResumeAfterCatchException(resumeSP, resumeIP);
+}
+
+VOID DECLSPEC_NORETURN UnwindAndContinueResumeAfterCatch(TADDR resumeSP, TADDR resumeIP)
+{
+    STATIC_CONTRACT_NOTHROW;
+    STATIC_CONTRACT_GC_TRIGGERS;
+    STATIC_CONTRACT_MODE_ANY;
+
+    CONTEXT context;
+    ClrCaptureContext(&context);
+
+    // Unwind to the caller of the Ex.RhThrowEx / Ex.RhThrowHwEx
+    Thread::VirtualUnwindToFirstManagedCallFrame(&context);
+
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+    size_t targetSSP = GetSSPForFrameOnCurrentStack(GetIP(&context));
+#endif // HOST_AMD64 && HOST_WINDOWS
+
+    // Skip all managed frames upto a native frame
+    while (ExecutionManager::IsManagedCode(GetIP(&context)))
+    {
+        Thread::VirtualUnwindCallFrame(&context);
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+        if (targetSSP != 0)
+        {
+            targetSSP += sizeof(size_t);
+        }
+#endif
+    }
+
+    ExecuteFunctionBelowContext((PCODE)ThrowResumeAfterCatchException, &context, targetSSP, resumeSP, resumeIP);
+}
+#endif // FEATURE_INTERPRETER
+
 thread_local DWORD t_dwCurrentExceptionCode;
 thread_local PEXCEPTION_RECORD t_pCurrentExceptionRecord;
 thread_local PCONTEXT t_pCurrentExceptionContext;

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7331,7 +7331,9 @@ VOID DECLSPEC_NORETURN UnwindAndContinueResumeAfterCatch(TADDR resumeSP, TADDR r
 
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
     size_t targetSSP = GetSSPForFrameOnCurrentStack(GetIP(&context));
-#endif // HOST_AMD64 && HOST_WINDOWS
+#else
+    size_t targetSSP = 0;
+#endif
 
     // Skip all managed frames upto a native frame
     while (ExecutionManager::IsManagedCode(GetIP(&context)))

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -807,6 +807,10 @@ X86_ONLY(EXCEPTION_REGISTRATION_RECORD* GetNextCOMPlusSEHRecord(EXCEPTION_REGIST
 VOID DECLSPEC_NORETURN ContinueExceptionInterceptionUnwind();
 #endif // FEATURE_EH_FUNCLETS
 
+#ifdef FEATURE_INTERPRETER
+void ThrowResumeAfterCatchException(TADDR resumeSP, TADDR resumeIP);
+#endif // FEATURE_INTERPRETER
+
 #endif // !DACCESS_COMPILE
 
 #endif // __excep_h__

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3038,29 +3038,8 @@ void ExecuteFunctionBelowContext(PCODE functionPtr, CONTEXT *pContext, size_t ta
     pContext->Ra = GetIP(pContext);
 #endif
 
-// The SECOND_ARG_REG is defined only for Windows, it is used to handle longjmp propagation over managed frames
-#ifdef HOST_AMD64
-#ifdef UNIX_AMD64_ABI
-#define FIRST_ARG_REG Rdi
-#else
-#define FIRST_ARG_REG Rcx
-#define SECOND_ARG_REG Rdx
-#endif
-#elif defined(HOST_X86)
-#define FIRST_ARG_REG Ecx
-#define SECOND_ARG_REG Edx
-#elif defined(HOST_ARM64)
-#define FIRST_ARG_REG X0
-#define SECOND_ARG_REG X1
-#elif defined(HOST_ARM)
-#define FIRST_ARG_REG R0
-#elif defined(HOST_RISCV64) || defined(HOST_LOONGARCH64)
-#define FIRST_ARG_REG A0
-#endif
-    pContext->FIRST_ARG_REG = arg1;
-#ifdef HOST_WINDOWS
-    pContext->SECOND_ARG_REG = arg2;
-#endif
+    SetFirstArgReg(pContext, arg1);
+    SetSecondArgReg(pContext, arg2);
     SetIP(pContext, functionPtr);
 
     ClrRestoreNonvolatileContext(pContext, targetSSP);

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3936,6 +3936,7 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
         goto Exit;
     }
 
+    #ifdef FEATURE_INTERPRETER
     if ((pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME) && (GetIP(pThis->m_crawl.GetRegisterSet()->pCurrentContext) == 0))
     {
         // The callerIP is 0 when we are going to unwind from the first interpreted frame belonging to an InterpreterFrame.
@@ -3948,6 +3949,7 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
         retVal = pThis->Next();
         _ASSERTE(retVal != SWA_FAILED);
     }
+#endif // FEATURE_INTERPRETER
 
     // Check for reverse pinvoke or CallDescrWorkerInternal.
     if (pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME)

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3060,16 +3060,17 @@ extern "C" void * QCALLTYPE CallCatchFunclet(QCall::ObjectHandleOnStack exceptio
     // in that case. The shadow stack contains the return address of the DispatchManagedException call, but the ControlPC is the
     // value captured to the exception context before the DispatchManagedException call.
     _ASSERTE(targetSSP == 0 ||
-        exInfo->m_frameIter.m_crawl.GetCodeManager() == ExecutionManager::GetInterpreterCodeManager() ||
+        (pHandlerIP != NULL) && (exInfo->m_frameIter.m_crawl.GetCodeManager() == ExecutionManager::GetInterpreterCodeManager()) ||
         (*(size_t*)(targetSSP-8) == exInfo->m_frameIter.m_crawl.GetRegisterSet()->ControlPC));
 #else
     size_t targetSSP = 0;
 #endif
 
-    ICodeManager* pCodeManager = exInfo->m_frameIter.m_crawl.GetCodeManager();
+    ICodeManager* pCodeManager = NULL;
 
     if (pHandlerIP != NULL)
     {
+        pCodeManager = exInfo->m_frameIter.m_crawl.GetCodeManager();
 #ifdef _DEBUG
         pCodeManager->EnsureCallerContextIsValid(pvRegDisplay);
         _ASSERTE(exInfo->m_sfCallerOfActualHandlerFrame == GetSP(pvRegDisplay->pCallerContext));
@@ -3936,7 +3937,7 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
         goto Exit;
     }
 
-    #ifdef FEATURE_INTERPRETER
+#ifdef FEATURE_INTERPRETER
     if ((pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME) && (GetIP(pThis->m_crawl.GetRegisterSet()->pCurrentContext) == 0))
     {
         // The callerIP is 0 when we are going to unwind from the first interpreted frame belonging to an InterpreterFrame.

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3002,13 +3002,6 @@ extern "C" void QCALLTYPE AppendExceptionStackFrame(QCall::ObjectHandleOnStack e
     END_QCALL;
 }
 
-#ifdef HOST_WINDOWS
-VOID DECLSPEC_NORETURN PropagateLongJmpThroughNativeFrames(jmp_buf *pJmpBuf, int retVal)
-{
-    WRAPPER_NO_CONTRACT;
-    longjmp(*pJmpBuf, retVal);
-}
-
 void ExecuteFunctionBelowContext(PCODE functionPtr, CONTEXT *pContext, size_t targetSSP, size_t arg1, size_t arg2)
 {
     UINT_PTR targetSp = GetSP(pContext);
@@ -3065,11 +3058,22 @@ void ExecuteFunctionBelowContext(PCODE functionPtr, CONTEXT *pContext, size_t ta
 #define FIRST_ARG_REG A0
 #endif
     pContext->FIRST_ARG_REG = arg1;
+#ifdef HOST_WINDOWS
     pContext->SECOND_ARG_REG = arg2;
+#endif
     SetIP(pContext, functionPtr);
 
     ClrRestoreNonvolatileContext(pContext, targetSSP);
+    UNREACHABLE();
 }
+
+#ifdef HOST_WINDOWS
+VOID DECLSPEC_NORETURN PropagateLongJmpThroughNativeFrames(jmp_buf *pJmpBuf, int retVal)
+{
+    WRAPPER_NO_CONTRACT;
+    longjmp(*pJmpBuf, retVal);
+}
+
 // This is a personality routine that the RtlRestoreContext calls when it is called with
 // pExceptionRecord->ExceptionCode == STATUS_UNWIND_CONSOLIDATE.
 // Before calling this function, it creates a machine frame that hides all the frames

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3854,7 +3854,7 @@ extern "C" CLR_BOOL QCALLTYPE SfiInit(StackFrameIterator* pThis, CONTEXT* pStack
         // the catch handler.
         // For hardware exceptions and thread abort exceptions propagated from ThrowControlForThread,
         // the SSP is already known. For other cases, find it by scanning the shadow stack.
-        if ((pExInfo->m_passNumber == 2) && (pThis->m_crawl.GetRegisterSet()->SSP == 0) && pThis->m_crawl.GetCodeInfo()->GetCodeManager() != ExecutionManager::GetInterpreterCodeManager())
+        if ((pExInfo->m_passNumber == 2) && (pThis->m_crawl.GetRegisterSet()->SSP == 0))
         {
             pThis->m_crawl.GetCodeInfo()->GetCodeManager()->UpdateSSP(pThis->m_crawl.GetRegisterSet());
         }

--- a/src/coreclr/vm/exceptionhandling.h
+++ b/src/coreclr/vm/exceptionhandling.h
@@ -64,6 +64,27 @@ enum class InlinedCallFrameMarker
     Mask = ExceptionHandlingHelper | SecondPassFuncletCaller
 };
 
+#ifdef FEATURE_INTERPRETER
+class ResumeAfterCatchException
+{
+    TADDR m_resumeSP;
+    TADDR m_resumeIP;
+public:
+    ResumeAfterCatchException(TADDR resumeSP, TADDR resumeIP)
+        : m_resumeSP(resumeSP),
+          m_resumeIP(resumeIP)
+    {}
+
+    void GetResumeContext(TADDR * pResumeSP, TADDR * pResumeIP) const
+    {
+        *pResumeSP = m_resumeSP;
+        *pResumeIP = m_resumeIP;
+    }
+};
+#endif // FEATURE_INTERPRETER
+
+void ExecuteFunctionBelowContext(PCODE functionPtr, CONTEXT *pContext, size_t targetSSP, size_t arg1 = 0, size_t arg2 = 0);
+
 #endif // FEATURE_EH_FUNCLETS
 
 #if defined(TARGET_X86)

--- a/src/coreclr/vm/exceptionhandling.h
+++ b/src/coreclr/vm/exceptionhandling.h
@@ -83,7 +83,7 @@ public:
 };
 #endif // FEATURE_INTERPRETER
 
-void ExecuteFunctionBelowContext(PCODE functionPtr, CONTEXT *pContext, size_t targetSSP, size_t arg1 = 0, size_t arg2 = 0);
+void DECLSPEC_NORETURN ExecuteFunctionBelowContext(PCODE functionPtr, CONTEXT *pContext, size_t targetSSP, size_t arg1 = 0, size_t arg2 = 0);
 
 #endif // FEATURE_EH_FUNCLETS
 

--- a/src/coreclr/vm/exceptmacros.h
+++ b/src/coreclr/vm/exceptmacros.h
@@ -425,32 +425,6 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
 #define UNINSTALL_UNWIND_AND_CONTINUE_HANDLER                                               \
     UNINSTALL_UNWIND_AND_CONTINUE_HANDLER_EX(false);
 
-#ifdef FEATURE_INTERPRETER
-
-#define INSTALL_RESUME_AFTER_CATCH_HANDLER \
-{                                                                                       \
-    bool       __fResumeAfterCatchExceptionCaught = false;                              \
-    TADDR      __interpreterResumeSP = 0;                                               \
-    TADDR      __interpreterResumeIP = 0;                                               \
-    PAL_CPP_TRY                                                                         \
-    {
-
-#define UNINSTALL_RESUME_AFTER_CATCH_HANDLER                                            \
-    }                                                                                   \
-    PAL_CPP_CATCH_NON_DERIVED_NOARG (const ResumeAfterCatchException& ex)               \
-    {                                                                                   \
-        __fResumeAfterCatchExceptionCaught = true;                                      \
-        ex.GetResumeContext(&__interpreterResumeSP, &__interpreterResumeIP);            \
-    }                                                                                   \
-    PAL_CPP_ENDTRY                                                                      \
-    if (__fResumeAfterCatchExceptionCaught)                                             \
-    {                                                                                   \
-        UnwindAndContinueResumeAfterCatch(__interpreterResumeSP, __interpreterResumeIP);\
-    }                                                                                   \
-}
-
-#endif // FEATURE_INTERPRETER
-
 #endif // DACCESS_COMPILE
 
 

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -2140,11 +2140,6 @@ PTR_InterpMethodContextFrame InterpreterFrame::GetTopInterpMethodContextFrame()
 
 void InterpreterFrame::SetContextToInterpMethodContextFrame(T_CONTEXT * pContext)
 {
-    // Save the registers we reuse for interpreter stack frames.
-    m_interpExecMethodIP = (TADDR)::GetIP(pContext);
-    m_interpExecMethodSP = (TADDR)::GetSP(pContext);
-    m_interpExecMethodFP = (TADDR)::GetFP(pContext);
-    m_interpExecMethodFirstArgReg = (TADDR)::GetFirstArgReg(pContext);
     PTR_InterpMethodContextFrame pFrame = GetTopInterpMethodContextFrame();
     SetIP(pContext, (TADDR)pFrame->ip);
     SetSP(pContext, dac_cast<TADDR>(pFrame));
@@ -2154,7 +2149,6 @@ void InterpreterFrame::SetContextToInterpMethodContextFrame(T_CONTEXT * pContext
 
 void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    RestoreInterpExecMethodContext(pRD->pCurrentContext);
     SyncRegDisplayToCurrentContext(pRD);
     TransitionFrame::UpdateRegDisplay_Impl(pRD, updateFloats);
 }

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -2153,6 +2153,24 @@ void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
     SyncRegDisplayToCurrentContext(pRD);
     TransitionFrame::UpdateRegDisplay_Impl(pRD, updateFloats);
 }
+
+#ifndef DACCESS_COMPILE
+void InterpreterFrame::ExceptionUnwind_Impl()
+{
+    WRAPPER_NO_CONTRACT;
+    InterpThreadContext *pThreadContext = InterpGetThreadContext();
+    InterpMethodContextFrame *pInterpMethodContextFrame = m_pTopInterpMethodContextFrame;
+    // Find the bottom-most InterpMethodContextFrame belonging to the current InterpreterFrame and
+    // reset the stack pointer in the InterpThreadContext to it. This effectively unwinds
+    // the interpreter stack.
+    while (pInterpMethodContextFrame->pParent != NULL)
+    {
+        pInterpMethodContextFrame = pInterpMethodContextFrame->pParent;
+    }
+    pThreadContext->pStackPointer = pInterpMethodContextFrame->pStack;
+}
+#endif // !DACCESS_COMPILE
+
 #endif // FEATURE_INTERPRETER
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -2132,6 +2132,27 @@ PTR_InterpMethodContextFrame InterpreterFrame::GetTopInterpMethodContextFrame()
     return pFrame;
 }
 
+void InterpreterFrame::SetContextToInterpMethodContextFrame(T_CONTEXT * pContext)
+{
+    // Save the registers we reuse for interpreter stack frames. We need the original values 
+    // to resume after catch.
+    m_interpExecMethodIP = (TADDR)::GetIP(pContext);
+    m_interpExecMethodSP = (TADDR)::GetSP(pContext);
+    m_interpExecMethodFP = (TADDR)::GetFP(pContext);
+    m_interpExecMethodFirstArgReg = (TADDR)::GetFirstArgReg(pContext);
+    PTR_InterpMethodContextFrame pFrame = GetTopInterpMethodContextFrame();
+    SetIP(pContext, (TADDR)pFrame->ip);
+    SetSP(pContext, dac_cast<TADDR>(pFrame));
+    SetFP(pContext, (TADDR)pFrame->pStack);
+    SetFirstArgReg(pContext, (TADDR)this);
+}
+
+void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
+{
+    RestoreInterpExecMethodContext(pRD->pCurrentContext);
+    SyncRegDisplayToCurrentContext(pRD);
+    TransitionFrame::UpdateRegDisplay_Impl(pRD, updateFloats);
+}
 #endif // FEATURE_INTERPRETER
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1136,19 +1136,25 @@ GCFrame::~GCFrame()
     }
     CONTRACTL_END;
 
-    // Do a manual switch to the GC cooperative mode instead of using the GCX_COOP_THREAD_EXISTS
-    // macro so that this function isn't slowed down by having to deal with FS:0 chain on x86 Windows.
-    BOOL wasCoop = m_pCurThread->PreemptiveGCDisabled();
-    if (!wasCoop)
+    // m_pNext is NULL when the frame was already popped from the stack.
+    if (m_Next != NULL)
     {
-        m_pCurThread->DisablePreemptiveGC();
-    }
+        // This is a GCFrame that was not popped.  This is a problem.
+        // We should have popped it before we destruct
+        // Do a manual switch to the GC cooperative mode instead of using the GCX_COOP_THREAD_EXISTS
+        // macro so that this function isn't slowed down by having to deal with FS:0 chain on x86 Windows.
+        BOOL wasCoop = m_pCurThread->PreemptiveGCDisabled();
+        if (!wasCoop)
+        {
+            m_pCurThread->DisablePreemptiveGC();
+        }
 
-    Pop();
+        Pop();
 
-    if (!wasCoop)
-    {
-        m_pCurThread->EnablePreemptiveGC();
+        if (!wasCoop)
+        {
+            m_pCurThread->EnablePreemptiveGC();
+        }
     }
 }
 
@@ -1174,7 +1180,7 @@ void GCFrame::Push(Thread* pThread)
     // in which the compiler will lay them out in the stack frame.
     // So GetOsPageSize() is a guess of the maximum stack frame size of any method
     // with multiple GCFrames in coreclr.dll
-    _ASSERTE(((m_Next == NULL) ||
+    _ASSERTE(((m_Next == GCFRAME_TOP) ||
               (PBYTE(m_Next) + (2 * GetOsPageSize())) > PBYTE(this)) &&
              "Pushing a GCFrame out of order ?");
 
@@ -1221,7 +1227,7 @@ void GCFrame::Remove()
 
     GCFrame *pPrevFrame = NULL;
     GCFrame *pFrame = m_pCurThread->GetGCFrame();
-    while (pFrame != NULL)
+    while (pFrame != GCFRAME_TOP)
     {
         if (pFrame == this)
         {
@@ -1333,7 +1339,7 @@ BOOL IsProtectedByGCFrame(OBJECTREF *ppObjectRef)
     GetThread()->StackWalkFrames(IsProtectedByGCFrameStackWalkFramesCallback, &d);
 
     GCFrame* pGCFrame = GetThread()->GetGCFrame();
-    while (pGCFrame != NULL)
+    while (pGCFrame != GCFRAME_TOP)
     {
         if (pGCFrame->Protects(ppObjectRef)) {
             d.count++;
@@ -2134,8 +2140,7 @@ PTR_InterpMethodContextFrame InterpreterFrame::GetTopInterpMethodContextFrame()
 
 void InterpreterFrame::SetContextToInterpMethodContextFrame(T_CONTEXT * pContext)
 {
-    // Save the registers we reuse for interpreter stack frames. We need the original values 
-    // to resume after catch.
+    // Save the registers we reuse for interpreter stack frames.
     m_interpExecMethodIP = (TADDR)::GetIP(pContext);
     m_interpExecMethodSP = (TADDR)::GetSP(pContext);
     m_interpExecMethodFP = (TADDR)::GetFP(pContext);
@@ -2158,16 +2163,18 @@ void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 void InterpreterFrame::ExceptionUnwind_Impl()
 {
     WRAPPER_NO_CONTRACT;
-    InterpThreadContext *pThreadContext = InterpGetThreadContext();
+
+    Thread *pThread = GetThread();
+    InterpThreadContext *pThreadContext = pThread->GetInterpThreadContext();
     InterpMethodContextFrame *pInterpMethodContextFrame = m_pTopInterpMethodContextFrame;
-    // Find the bottom-most InterpMethodContextFrame belonging to the current InterpreterFrame and
-    // reset the stack pointer in the InterpThreadContext to it. This effectively unwinds
-    // the interpreter stack.
-    while (pInterpMethodContextFrame->pParent != NULL)
+
+    // Unwind the interpreter frames belonging to the current InterpreterFrame.
+    while (pInterpMethodContextFrame != NULL)
     {
+        pThreadContext->frameDataAllocator.PopInfo(pInterpMethodContextFrame);
+        pThreadContext->pStackPointer = pInterpMethodContextFrame->pStack;
         pInterpMethodContextFrame = pInterpMethodContextFrame->pParent;
     }
-    pThreadContext->pStackPointer = pInterpMethodContextFrame->pStack;
 }
 #endif // !DACCESS_COMPILE
 

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2908,13 +2908,13 @@ public:
     BOOL NeedsUpdateRegDisplay_Impl()
     {
         LIMITED_METHOD_CONTRACT;
-        return GetTransitionBlock() != NULL;
+        return GetTransitionBlock() != 0;
     }
 
     PCODE GetReturnAddressPtr_Impl()
     {
         WRAPPER_NO_CONTRACT;
-        if (GetTransitionBlock() == NULL)
+        if (GetTransitionBlock() == 0)
             return 0;
 
         return FramedMethodFrame::GetReturnAddressPtr_Impl();
@@ -2928,22 +2928,6 @@ public:
     PTR_InterpMethodContextFrame GetTopInterpMethodContextFrame();
 
     void SetContextToInterpMethodContextFrame(T_CONTEXT * pContext);
-
-    // Restore the context to the native context of the InterpExecMethod
-    void RestoreInterpExecMethodContext(T_CONTEXT * pContext)
-    {
-        LIMITED_METHOD_CONTRACT;
-        SetSP(pContext, m_interpExecMethodSP);
-        SetIP(pContext, m_interpExecMethodIP);
-        SetFP(pContext, m_interpExecMethodFP);
-        SetFirstArgReg(pContext, m_interpExecMethodFirstArgReg);
-    }
-
-    TADDR GetInterpExecMethodIP()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_interpExecMethodIP;
-    }
 
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
     void SetInterpExecMethodSSP(TADDR ssp)
@@ -2963,12 +2947,6 @@ private:
     // The last known topmost interpreter frame in the InterpExecMethod belonging to
     // this InterpreterFrame.
     PTR_InterpMethodContextFrame m_pTopInterpMethodContextFrame;
-    // Saved IP, SP and FP of the context of the InterpExecMethod. These registers are reused for interpreter frames,
-    // but we need the original values for resuming after catch into interpreter frames.
-    TADDR m_interpExecMethodIP;
-    TADDR m_interpExecMethodSP;
-    TADDR m_interpExecMethodFP;
-    TADDR m_interpExecMethodFirstArgReg;
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
     // Saved SSP of the InterpExecMethod for resuming after catch into interpreter frames.
     TADDR m_SSP;

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -220,6 +220,7 @@ class ComCallMethodDesc;
 // whenever we compare it to a PTR_Frame value (the usual use of the value).
 #define FRAME_TOP_VALUE  ~0     // we want to say -1 here, but gcc has trouble with the signed value
 #define FRAME_TOP (PTR_Frame(FRAME_TOP_VALUE))
+#define GCFRAME_TOP (PTR_GCFrame(FRAME_TOP_VALUE))
 
 
 enum class FrameIdentifier : TADDR
@@ -2888,9 +2889,7 @@ public:
 #ifndef DACCESS_COMPILE
     InterpreterFrame(TransitionBlock* pTransitionBlock, InterpMethodContextFrame* pContextFrame)
         : FramedMethodFrame(FrameIdentifier::InterpreterFrame, pTransitionBlock, NULL),
-        m_pTopInterpMethodContextFrame(pContextFrame),
-        m_resumeIP(0),
-        m_resumeSP(0)
+        m_pTopInterpMethodContextFrame(pContextFrame)
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
         , m_SSP(0)
 #endif
@@ -2905,6 +2904,21 @@ public:
     }
 
 #endif // DACCESS_COMPILE
+
+    BOOL NeedsUpdateRegDisplay_Impl()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return GetTransitionBlock() != NULL;
+    }
+
+    PCODE GetReturnAddressPtr_Impl()
+    {
+        WRAPPER_NO_CONTRACT;
+        if (GetTransitionBlock() == NULL)
+            return 0;
+
+        return FramedMethodFrame::GetReturnAddressPtr_Impl();
+    }
 
     void UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats = false);
 #ifndef DACCESS_COMPILE
@@ -2923,22 +2937,6 @@ public:
         SetIP(pContext, m_interpExecMethodIP);
         SetFP(pContext, m_interpExecMethodFP);
         SetFirstArgReg(pContext, m_interpExecMethodFirstArgReg);
-    }
-
-    void SetResumeContext(TADDR resumeSP, TADDR resumeIP)
-    {
-        LIMITED_METHOD_CONTRACT;
-        m_resumeSP = resumeSP;
-        m_resumeIP = resumeIP;
-    }
-
-    void GetAndClearResumeContext(TADDR * pResumeSP, TADDR * pResumeIP)
-    {
-        LIMITED_METHOD_CONTRACT;
-        *pResumeSP = m_resumeSP;
-        *pResumeIP = m_resumeIP;
-        m_resumeSP = 0;
-        m_resumeIP = 0;
     }
 
     TADDR GetInterpExecMethodIP()
@@ -2971,9 +2969,6 @@ private:
     TADDR m_interpExecMethodSP;
     TADDR m_interpExecMethodFP;
     TADDR m_interpExecMethodFirstArgReg;
-    // Interpreter IP and SP for resuming after catch into interpreter frames.
-    TADDR m_resumeIP;
-    TADDR m_resumeSP;
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
     // Saved SSP of the InterpExecMethod for resuming after catch into interpreter frames.
     TADDR m_SSP;

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2890,8 +2890,10 @@ public:
         : FramedMethodFrame(FrameIdentifier::InterpreterFrame, pTransitionBlock, NULL),
         m_pTopInterpMethodContextFrame(pContextFrame),
         m_resumeIP(0),
-        m_resumeSP(0),
-        m_SSP(0)
+        m_resumeSP(0)
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+        , m_SSP(0)
+#endif
     {
         WRAPPER_NO_CONTRACT;
         Push();

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2905,6 +2905,9 @@ public:
 #endif // DACCESS_COMPILE
 
     void UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats = false);
+#ifndef DACCESS_COMPILE
+    void ExceptionUnwind_Impl();
+#endif
 
     PTR_InterpMethodContextFrame GetTopInterpMethodContextFrame();
 

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -207,7 +207,7 @@ static void ScanStackRoots(Thread * pThread, promote_func* fn, ScanContext* sc)
     }
 
     GCFrame* pGCFrame = pThread->GetGCFrame();
-    while (pGCFrame != NULL)
+    while (pGCFrame != GCFRAME_TOP)
     {
         pGCFrame->GcScanRoots(fn, sc);
         pGCFrame = pGCFrame->PtrNextFrame();

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -165,30 +165,6 @@ struct EHContext {
         return (LPVOID)(UINT_PTR)Ebp;
     }
 
-    inline void SetFirstArgReg(CONTEXT *context, TADDR value)
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        context->Ecx = (DWORD)value;
-    }
-
-    inline TADDR GetFirstArgReg(CONTEXT *context)
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        return (TADDR)(context->Ecx);
-    }
-
-    inline void SetSecondArgReg(CONTEXT *context, TADDR value)
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        context->Edx = (DWORD)value;
-    }
-
-    inline TADDR GetSecondArgReg(CONTEXT *context)
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        return (TADDR)(context->Edx);
-    }
-
     inline void SetArg(LPVOID arg) {
         LIMITED_METHOD_CONTRACT;
         Eax = (INT32)(size_t)arg;
@@ -253,6 +229,30 @@ inline TADDR GetFP(const CONTEXT * context)
     LIMITED_METHOD_DAC_CONTRACT;
 
     return (TADDR)context->Ebp;
+}
+
+inline void SetFirstArgReg(CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    context->Ecx = (DWORD)value;
+}
+
+inline TADDR GetFirstArgReg(CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return (TADDR)(context->Ecx);
+}
+
+inline void SetSecondArgReg(CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    context->Edx = (DWORD)value;
+}
+
+inline TADDR GetSecondArgReg(CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return (TADDR)(context->Edx);
 }
 
 // Get Rel32 destination, emit jumpStub if necessary

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -165,6 +165,30 @@ struct EHContext {
         return (LPVOID)(UINT_PTR)Ebp;
     }
 
+    inline void SetFirstArgReg(CONTEXT *context, TADDR value)
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        context->Ecx = (DWORD)value;
+    }
+
+    inline TADDR GetFirstArgReg(CONTEXT *context)
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return (TADDR)(context->Ecx);
+    }
+
+    inline void SetSecondArgReg(CONTEXT *context, TADDR value)
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        context->Edx = (DWORD)value;
+    }
+
+    inline TADDR GetSecondArgReg(CONTEXT *context)
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return (TADDR)(context->Edx);
+    }
+
     inline void SetArg(LPVOID arg) {
         LIMITED_METHOD_CONTRACT;
         Eax = (INT32)(size_t)arg;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -53,244 +53,248 @@ void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFr
 MAIN_LOOP:
     while (true)
     {
-        // Interpreter-TODO: This is only needed to enable SOS see the exact location in the interpreted method.
-        // Neither the GC nor the managed debugger needs that as they walk the stack when the runtime is suspended
-        // and we can save the IP to the frame at the suspension time.
-        // It will be useful for testing e.g. the debug info at various locations in the current method, so let's
-        // keep it for such purposes until we don't need it anymore.
-        pFrame->ip = (int32_t*)ip;
-
-        switch (*ip)
+        try
         {
-#ifdef DEBUG
-            case INTOP_BREAKPOINT:
-                InterpBreakpoint();
-                ip++;
-                break;
-#endif
-            case INTOP_INITLOCALS:
-                memset(stack + ip[1], 0, ip[2]);
-                ip += 3;
-                break;
-            case INTOP_MEMBAR:
-                MemoryBarrier();
-                ip++;
-                break;
-            case INTOP_LDC_I4:
-                LOCAL_VAR(ip[1], int32_t) = ip[2];
-                ip += 3;
-                break;
-            case INTOP_LDC_I4_0:
-                LOCAL_VAR(ip[1], int32_t) = 0;
-                ip += 2;
-                break;
-            case INTOP_LDC_I8_0:
-                LOCAL_VAR(ip[1], int64_t) = 0;
-                ip += 2;
-                break;
-            case INTOP_LDC_I8:
-                LOCAL_VAR(ip[1], int64_t) = (int64_t)ip[2] + ((int64_t)ip[3] << 32);
-                ip += 4;
-                break;
-            case INTOP_LDC_R4:
-                LOCAL_VAR(ip[1], int32_t) = ip[2];
-                ip += 3;
-                break;
-            case INTOP_LDC_R8:
-                LOCAL_VAR(ip[1], int64_t) = (int64_t)ip[2] + ((int64_t)ip[3] << 32);
-                ip += 4;
-                break;
-            case INTOP_LDPTR:
-                LOCAL_VAR(ip[1], void*) = pMethod->pDataItems[ip[2]];
-                ip += 3;
-                break;
-            case INTOP_RET:
-                // Return stack slot sized value
-                *(int64_t*)pFrame->pRetVal = LOCAL_VAR(ip[1], int64_t);
-                goto EXIT_FRAME;
-            case INTOP_RET_VT:
-                memmove(pFrame->pRetVal, stack + ip[1], ip[2]);
-                goto EXIT_FRAME;
-            case INTOP_RET_VOID:
-                goto EXIT_FRAME;
+            INSTALL_MANAGED_EXCEPTION_DISPATCHER;
+            INSTALL_UNWIND_AND_CONTINUE_HANDLER;
+            // Interpreter-TODO: This is only needed to enable SOS see the exact location in the interpreted method.
+            // Neither the GC nor the managed debugger needs that as they walk the stack when the runtime is suspended
+            // and we can save the IP to the frame at the suspension time.
+            // It will be useful for testing e.g. the debug info at various locations in the current method, so let's
+            // keep it for such purposes until we don't need it anymore.
+            pFrame->ip = (int32_t*)ip;
 
-            case INTOP_LDLOCA:
-                LOCAL_VAR(ip[1], void*) = stack + ip[2];
-                ip += 3;
-                break;;
+            switch (*ip)
+            {
+#ifdef DEBUG
+                case INTOP_BREAKPOINT:
+                    InterpBreakpoint();
+                    ip++;
+                    break;
+#endif
+                case INTOP_INITLOCALS:
+                    memset(stack + ip[1], 0, ip[2]);
+                    ip += 3;
+                    break;
+                case INTOP_MEMBAR:
+                    MemoryBarrier();
+                    ip++;
+                    break;
+                case INTOP_LDC_I4:
+                    LOCAL_VAR(ip[1], int32_t) = ip[2];
+                    ip += 3;
+                    break;
+                case INTOP_LDC_I4_0:
+                    LOCAL_VAR(ip[1], int32_t) = 0;
+                    ip += 2;
+                    break;
+                case INTOP_LDC_I8_0:
+                    LOCAL_VAR(ip[1], int64_t) = 0;
+                    ip += 2;
+                    break;
+                case INTOP_LDC_I8:
+                    LOCAL_VAR(ip[1], int64_t) = (int64_t)ip[2] + ((int64_t)ip[3] << 32);
+                    ip += 4;
+                    break;
+                case INTOP_LDC_R4:
+                    LOCAL_VAR(ip[1], int32_t) = ip[2];
+                    ip += 3;
+                    break;
+                case INTOP_LDC_R8:
+                    LOCAL_VAR(ip[1], int64_t) = (int64_t)ip[2] + ((int64_t)ip[3] << 32);
+                    ip += 4;
+                    break;
+                case INTOP_LDPTR:
+                    LOCAL_VAR(ip[1], void*) = pMethod->pDataItems[ip[2]];
+                    ip += 3;
+                    break;
+                case INTOP_RET:
+                    // Return stack slot sized value
+                    *(int64_t*)pFrame->pRetVal = LOCAL_VAR(ip[1], int64_t);
+                    goto EXIT_FRAME;
+                case INTOP_RET_VT:
+                    memmove(pFrame->pRetVal, stack + ip[1], ip[2]);
+                    goto EXIT_FRAME;
+                case INTOP_RET_VOID:
+                    goto EXIT_FRAME;
+
+                case INTOP_LDLOCA:
+                    LOCAL_VAR(ip[1], void*) = stack + ip[2];
+                    ip += 3;
+                    break;;
 
 #define MOV(argtype1,argtype2) \
     LOCAL_VAR(ip [1], argtype1) = LOCAL_VAR(ip [2], argtype2); \
     ip += 3;
-            // When loading from a local, we might need to sign / zero extend to 4 bytes
-            // which is our minimum "register" size in interp. They are only needed when
-            // the address of the local is taken and we should try to optimize them out
-            // because the local can't be propagated.
-            case INTOP_MOV_I4_I1: MOV(int32_t, int8_t); break;
-            case INTOP_MOV_I4_U1: MOV(int32_t, uint8_t); break;
-            case INTOP_MOV_I4_I2: MOV(int32_t, int16_t); break;
-            case INTOP_MOV_I4_U2: MOV(int32_t, uint16_t); break;
-            // Normal moves between vars
-            case INTOP_MOV_4: MOV(int32_t, int32_t); break;
-            case INTOP_MOV_8: MOV(int64_t, int64_t); break;
+                // When loading from a local, we might need to sign / zero extend to 4 bytes
+                // which is our minimum "register" size in interp. They are only needed when
+                // the address of the local is taken and we should try to optimize them out
+                // because the local can't be propagated.
+                case INTOP_MOV_I4_I1: MOV(int32_t, int8_t); break;
+                case INTOP_MOV_I4_U1: MOV(int32_t, uint8_t); break;
+                case INTOP_MOV_I4_I2: MOV(int32_t, int16_t); break;
+                case INTOP_MOV_I4_U2: MOV(int32_t, uint16_t); break;
+                // Normal moves between vars
+                case INTOP_MOV_4: MOV(int32_t, int32_t); break;
+                case INTOP_MOV_8: MOV(int64_t, int64_t); break;
 
-            case INTOP_MOV_VT:
-                memmove(stack + ip[1], stack + ip[2], ip[3]);
-                ip += 4;
-                break;
+                case INTOP_MOV_VT:
+                    memmove(stack + ip[1], stack + ip[2], ip[3]);
+                    ip += 4;
+                    break;
 
-            case INTOP_CONV_R_UN_I4:
-                LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], uint32_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_R_UN_I8:
-                LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], uint64_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_I1_I4:
-                LOCAL_VAR(ip[1], int32_t) = (int8_t)LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_I1_I8:
-                LOCAL_VAR(ip[1], int32_t) = (int8_t)LOCAL_VAR(ip[2], int64_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_I1_R4:
-                LOCAL_VAR(ip[1], int32_t) = (int8_t)(int32_t)LOCAL_VAR(ip[2], float);
-                ip += 3;
-                break;
-            case INTOP_CONV_I1_R8:
-                LOCAL_VAR(ip[1], int32_t) = (int8_t)(int32_t)LOCAL_VAR(ip[2], double);
-                ip += 3;
-                break;
-            case INTOP_CONV_U1_I4:
-                LOCAL_VAR(ip[1], int32_t) = (uint8_t)LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_U1_I8:
-                LOCAL_VAR(ip[1], int32_t) = (uint8_t)LOCAL_VAR(ip[2], int64_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_U1_R4:
-                LOCAL_VAR(ip[1], int32_t) = (uint8_t)(uint32_t)LOCAL_VAR(ip[2], float);
-                ip += 3;
-                break;
-            case INTOP_CONV_U1_R8:
-                LOCAL_VAR(ip[1], int32_t) = (uint8_t)(uint32_t)LOCAL_VAR(ip[2], double);
-                ip += 3;
-                break;
-            case INTOP_CONV_I2_I4:
-                LOCAL_VAR(ip[1], int32_t) = (int16_t)LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_I2_I8:
-                LOCAL_VAR(ip[1], int32_t) = (int16_t)LOCAL_VAR(ip[2], int64_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_I2_R4:
-                LOCAL_VAR(ip[1], int32_t) = (int16_t)(int32_t)LOCAL_VAR(ip[2], float);
-                ip += 3;
-                break;
-            case INTOP_CONV_I2_R8:
-                LOCAL_VAR(ip[1], int32_t) = (int16_t)(int32_t)LOCAL_VAR(ip[2], double);
-                ip += 3;
-                break;
-            case INTOP_CONV_U2_I4:
-                LOCAL_VAR(ip[1], int32_t) = (uint16_t)LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_U2_I8:
-                LOCAL_VAR(ip[1], int32_t) = (uint16_t)LOCAL_VAR(ip[2], int64_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_U2_R4:
-                LOCAL_VAR(ip[1], int32_t) = (uint16_t)(uint32_t)LOCAL_VAR(ip[2], float);
-                ip += 3;
-                break;
-            case INTOP_CONV_U2_R8:
-                LOCAL_VAR(ip[1], int32_t) = (uint16_t)(uint32_t)LOCAL_VAR(ip[2], double);
-                ip += 3;
-                break;
-            case INTOP_CONV_I4_R4:
-                LOCAL_VAR(ip[1], int32_t) = (int32_t)LOCAL_VAR(ip[2], float);
-                ip += 3;
-                break;;
-            case INTOP_CONV_I4_R8:
-                LOCAL_VAR(ip[1], int32_t) = (int32_t)LOCAL_VAR(ip[2], double);
-                ip += 3;
-                break;;
+                case INTOP_CONV_R_UN_I4:
+                    LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], uint32_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_R_UN_I8:
+                    LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], uint64_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I1_I4:
+                    LOCAL_VAR(ip[1], int32_t) = (int8_t)LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I1_I8:
+                    LOCAL_VAR(ip[1], int32_t) = (int8_t)LOCAL_VAR(ip[2], int64_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I1_R4:
+                    LOCAL_VAR(ip[1], int32_t) = (int8_t)(int32_t)LOCAL_VAR(ip[2], float);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I1_R8:
+                    LOCAL_VAR(ip[1], int32_t) = (int8_t)(int32_t)LOCAL_VAR(ip[2], double);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_U1_I4:
+                    LOCAL_VAR(ip[1], int32_t) = (uint8_t)LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_U1_I8:
+                    LOCAL_VAR(ip[1], int32_t) = (uint8_t)LOCAL_VAR(ip[2], int64_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_U1_R4:
+                    LOCAL_VAR(ip[1], int32_t) = (uint8_t)(uint32_t)LOCAL_VAR(ip[2], float);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_U1_R8:
+                    LOCAL_VAR(ip[1], int32_t) = (uint8_t)(uint32_t)LOCAL_VAR(ip[2], double);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I2_I4:
+                    LOCAL_VAR(ip[1], int32_t) = (int16_t)LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I2_I8:
+                    LOCAL_VAR(ip[1], int32_t) = (int16_t)LOCAL_VAR(ip[2], int64_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I2_R4:
+                    LOCAL_VAR(ip[1], int32_t) = (int16_t)(int32_t)LOCAL_VAR(ip[2], float);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I2_R8:
+                    LOCAL_VAR(ip[1], int32_t) = (int16_t)(int32_t)LOCAL_VAR(ip[2], double);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_U2_I4:
+                    LOCAL_VAR(ip[1], int32_t) = (uint16_t)LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_U2_I8:
+                    LOCAL_VAR(ip[1], int32_t) = (uint16_t)LOCAL_VAR(ip[2], int64_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_U2_R4:
+                    LOCAL_VAR(ip[1], int32_t) = (uint16_t)(uint32_t)LOCAL_VAR(ip[2], float);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_U2_R8:
+                    LOCAL_VAR(ip[1], int32_t) = (uint16_t)(uint32_t)LOCAL_VAR(ip[2], double);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I4_R4:
+                    LOCAL_VAR(ip[1], int32_t) = (int32_t)LOCAL_VAR(ip[2], float);
+                    ip += 3;
+                    break;;
+                case INTOP_CONV_I4_R8:
+                    LOCAL_VAR(ip[1], int32_t) = (int32_t)LOCAL_VAR(ip[2], double);
+                    ip += 3;
+                    break;;
 
-            case INTOP_CONV_U4_R4:
-            case INTOP_CONV_U4_R8:
-                assert(0);
-                break;
+                case INTOP_CONV_U4_R4:
+                case INTOP_CONV_U4_R8:
+                    assert(0);
+                    break;
 
-            case INTOP_CONV_I8_I4:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_I8_U4:
-                LOCAL_VAR(ip[1], int64_t) = (uint32_t)LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;;
-            case INTOP_CONV_I8_R4:
-                LOCAL_VAR(ip[1], int64_t) = (int64_t)LOCAL_VAR(ip[2], float);
-                ip += 3;
-                break;
-            case INTOP_CONV_I8_R8:
-                LOCAL_VAR(ip[1], int64_t) = (int64_t)LOCAL_VAR(ip[2], double);
-                ip += 3;
-                break;
-            case INTOP_CONV_R4_I4:
-                LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;;
-            case INTOP_CONV_R4_I8:
-                LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], int64_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_R4_R8:
-                LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], double);
-                ip += 3;
-                break;
-            case INTOP_CONV_R8_I4:
-                LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_R8_I8:
-                LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], int64_t);
-                ip += 3;
-                break;
-            case INTOP_CONV_R8_R4:
-                LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], float);
-                ip += 3;
-                break;
-            case INTOP_CONV_U8_R4:
-            case INTOP_CONV_U8_R8:
-                // TODO
-                assert(0);
-                break;
+                case INTOP_CONV_I8_I4:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I8_U4:
+                    LOCAL_VAR(ip[1], int64_t) = (uint32_t)LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;;
+                case INTOP_CONV_I8_R4:
+                    LOCAL_VAR(ip[1], int64_t) = (int64_t)LOCAL_VAR(ip[2], float);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_I8_R8:
+                    LOCAL_VAR(ip[1], int64_t) = (int64_t)LOCAL_VAR(ip[2], double);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_R4_I4:
+                    LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;;
+                case INTOP_CONV_R4_I8:
+                    LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], int64_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_R4_R8:
+                    LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], double);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_R8_I4:
+                    LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_R8_I8:
+                    LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], int64_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_R8_R4:
+                    LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], float);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_U8_R4:
+                case INTOP_CONV_U8_R8:
+                    // TODO
+                    assert(0);
+                    break;
 
-            case INTOP_SWITCH:
-            {
-                uint32_t val = LOCAL_VAR(ip[1], uint32_t);
-                uint32_t n = ip[2];
-                ip += 3;
-                if (val < n)
+                case INTOP_SWITCH:
                 {
-                    ip += val;
-                    ip += *ip;
+                    uint32_t val = LOCAL_VAR(ip[1], uint32_t);
+                    uint32_t n = ip[2];
+                    ip += 3;
+                    if (val < n)
+                    {
+                        ip += val;
+                        ip += *ip;
+                    }
+                    else
+                    {
+                        ip += n;
+                    }
+                    break;
                 }
-                else
-                {
-                    ip += n;
-                }
-                break;
-            }
 
-            case INTOP_BR:
-                ip += ip[1];
-                break;
+                case INTOP_BR:
+                    ip += ip[1];
+                    break;
 
 #define BR_UNOP(datatype, op)           \
     if (LOCAL_VAR(ip[1], datatype) op)  \
@@ -298,18 +302,18 @@ MAIN_LOOP:
     else \
         ip += 3;
 
-            case INTOP_BRFALSE_I4:
-                BR_UNOP(int32_t, == 0);
-                break;
-            case INTOP_BRFALSE_I8:
-                BR_UNOP(int64_t, == 0);
-                break;
-            case INTOP_BRTRUE_I4:
-                BR_UNOP(int32_t, != 0);
-                break;
-            case INTOP_BRTRUE_I8:
-                BR_UNOP(int64_t, != 0);
-                break;
+                case INTOP_BRFALSE_I4:
+                    BR_UNOP(int32_t, == 0);
+                    break;
+                case INTOP_BRFALSE_I8:
+                    BR_UNOP(int64_t, == 0);
+                    break;
+                case INTOP_BRTRUE_I4:
+                    BR_UNOP(int32_t, != 0);
+                    break;
+                case INTOP_BRTRUE_I8:
+                    BR_UNOP(int64_t, != 0);
+                    break;
 
 #define BR_BINOP_COND(cond) \
     if (cond)               \
@@ -320,487 +324,487 @@ MAIN_LOOP:
 #define BR_BINOP(datatype, op) \
     BR_BINOP_COND(LOCAL_VAR(ip[1], datatype) op LOCAL_VAR(ip[2], datatype))
 
-            case INTOP_BEQ_I4:
-                BR_BINOP(int32_t, ==);
-                break;
-            case INTOP_BEQ_I8:
-                BR_BINOP(int64_t, ==);
-                break;
-            case INTOP_BEQ_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(!isunordered(f1, f2) && f1 == f2);
-                break;
-            }
-            case INTOP_BEQ_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(!isunordered(d1, d2) && d1 == d2);
-                break;
-            }
-            case INTOP_BGE_I4:
-                BR_BINOP(int32_t, >=);
-                break;
-            case INTOP_BGE_I8:
-                BR_BINOP(int64_t, >=);
-                break;
-            case INTOP_BGE_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(!isunordered(f1, f2) && f1 >= f2);
-                break;
-            }
-            case INTOP_BGE_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(!isunordered(d1, d2) && d1 >= d2);
-                break;
-            }
-            case INTOP_BGT_I4:
-                BR_BINOP(int32_t, >);
-                break;
-            case INTOP_BGT_I8:
-                BR_BINOP(int64_t, >);
-                break;
-            case INTOP_BGT_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(!isunordered(f1, f2) && f1 > f2);
-                break;
-            }
-            case INTOP_BGT_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(!isunordered(d1, d2) && d1 > d2);
-                break;
-            }
-            case INTOP_BLT_I4:
-                BR_BINOP(int32_t, <);
-                break;
-            case INTOP_BLT_I8:
-                BR_BINOP(int64_t, <);
-                break;
-            case INTOP_BLT_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(!isunordered(f1, f2) && f1 < f2);
-                break;
-            }
-            case INTOP_BLT_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(!isunordered(d1, d2) && d1 < d2);
-                break;
-            }
-            case INTOP_BLE_I4:
-                BR_BINOP(int32_t, <=);
-                break;
-            case INTOP_BLE_I8:
-                BR_BINOP(int64_t, <=);
-                break;
-            case INTOP_BLE_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(!isunordered(f1, f2) && f1 <= f2);
-                break;
-            }
-            case INTOP_BLE_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(!isunordered(d1, d2) && d1 <= d2);
-                break;
-            }
-            case INTOP_BNE_UN_I4:
-                BR_BINOP(uint32_t, !=);
-                break;
-            case INTOP_BNE_UN_I8:
-                BR_BINOP(uint64_t, !=);
-                break;
-            case INTOP_BNE_UN_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(isunordered(f1, f2) || f1 != f2);
-                break;
-            }
-            case INTOP_BNE_UN_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(isunordered(d1, d2) || d1 != d2);
-                break;
-            }
-            case INTOP_BGE_UN_I4:
-                BR_BINOP(uint32_t, >=);
-                break;
-            case INTOP_BGE_UN_I8:
-                BR_BINOP(uint64_t, >=);
-                break;
-            case INTOP_BGE_UN_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(isunordered(f1, f2) || f1 >= f2);
-                break;
-            }
-            case INTOP_BGE_UN_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(isunordered(d1, d2) || d1 >= d2);
-                break;
-            }
-            case INTOP_BGT_UN_I4:
-                BR_BINOP(uint32_t, >);
-                break;
-            case INTOP_BGT_UN_I8:
-                BR_BINOP(uint64_t, >);
-                break;
-            case INTOP_BGT_UN_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(isunordered(f1, f2) || f1 > f2);
-                break;
-            }
-            case INTOP_BGT_UN_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(isunordered(d1, d2) || d1 > d2);
-                break;
-            }
-            case INTOP_BLE_UN_I4:
-                BR_BINOP(uint32_t, <=);
-                break;
-            case INTOP_BLE_UN_I8:
-                BR_BINOP(uint64_t, <=);
-                break;
-            case INTOP_BLE_UN_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(isunordered(f1, f2) || f1 <= f2);
-                break;
-            }
-            case INTOP_BLE_UN_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(isunordered(d1, d2) || d1 <= d2);
-                break;
-            }
-            case INTOP_BLT_UN_I4:
-                BR_BINOP(uint32_t, <);
-                break;
-            case INTOP_BLT_UN_I8:
-                BR_BINOP(uint64_t, <);
-                break;
-            case INTOP_BLT_UN_R4:
-            {
-                float f1 = LOCAL_VAR(ip[1], float);
-                float f2 = LOCAL_VAR(ip[2], float);
-                BR_BINOP_COND(isunordered(f1, f2) || f1 < f2);
-                break;
-            }
-            case INTOP_BLT_UN_R8:
-            {
-                double d1 = LOCAL_VAR(ip[1], double);
-                double d2 = LOCAL_VAR(ip[2], double);
-                BR_BINOP_COND(isunordered(d1, d2) || d1 < d2);
-                break;
-            }
+                case INTOP_BEQ_I4:
+                    BR_BINOP(int32_t, ==);
+                    break;
+                case INTOP_BEQ_I8:
+                    BR_BINOP(int64_t, ==);
+                    break;
+                case INTOP_BEQ_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(!isunordered(f1, f2) && f1 == f2);
+                    break;
+                }
+                case INTOP_BEQ_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(!isunordered(d1, d2) && d1 == d2);
+                    break;
+                }
+                case INTOP_BGE_I4:
+                    BR_BINOP(int32_t, >=);
+                    break;
+                case INTOP_BGE_I8:
+                    BR_BINOP(int64_t, >=);
+                    break;
+                case INTOP_BGE_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(!isunordered(f1, f2) && f1 >= f2);
+                    break;
+                }
+                case INTOP_BGE_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(!isunordered(d1, d2) && d1 >= d2);
+                    break;
+                }
+                case INTOP_BGT_I4:
+                    BR_BINOP(int32_t, >);
+                    break;
+                case INTOP_BGT_I8:
+                    BR_BINOP(int64_t, >);
+                    break;
+                case INTOP_BGT_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(!isunordered(f1, f2) && f1 > f2);
+                    break;
+                }
+                case INTOP_BGT_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(!isunordered(d1, d2) && d1 > d2);
+                    break;
+                }
+                case INTOP_BLT_I4:
+                    BR_BINOP(int32_t, <);
+                    break;
+                case INTOP_BLT_I8:
+                    BR_BINOP(int64_t, <);
+                    break;
+                case INTOP_BLT_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(!isunordered(f1, f2) && f1 < f2);
+                    break;
+                }
+                case INTOP_BLT_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(!isunordered(d1, d2) && d1 < d2);
+                    break;
+                }
+                case INTOP_BLE_I4:
+                    BR_BINOP(int32_t, <=);
+                    break;
+                case INTOP_BLE_I8:
+                    BR_BINOP(int64_t, <=);
+                    break;
+                case INTOP_BLE_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(!isunordered(f1, f2) && f1 <= f2);
+                    break;
+                }
+                case INTOP_BLE_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(!isunordered(d1, d2) && d1 <= d2);
+                    break;
+                }
+                case INTOP_BNE_UN_I4:
+                    BR_BINOP(uint32_t, !=);
+                    break;
+                case INTOP_BNE_UN_I8:
+                    BR_BINOP(uint64_t, !=);
+                    break;
+                case INTOP_BNE_UN_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(isunordered(f1, f2) || f1 != f2);
+                    break;
+                }
+                case INTOP_BNE_UN_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(isunordered(d1, d2) || d1 != d2);
+                    break;
+                }
+                case INTOP_BGE_UN_I4:
+                    BR_BINOP(uint32_t, >=);
+                    break;
+                case INTOP_BGE_UN_I8:
+                    BR_BINOP(uint64_t, >=);
+                    break;
+                case INTOP_BGE_UN_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(isunordered(f1, f2) || f1 >= f2);
+                    break;
+                }
+                case INTOP_BGE_UN_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(isunordered(d1, d2) || d1 >= d2);
+                    break;
+                }
+                case INTOP_BGT_UN_I4:
+                    BR_BINOP(uint32_t, >);
+                    break;
+                case INTOP_BGT_UN_I8:
+                    BR_BINOP(uint64_t, >);
+                    break;
+                case INTOP_BGT_UN_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(isunordered(f1, f2) || f1 > f2);
+                    break;
+                }
+                case INTOP_BGT_UN_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(isunordered(d1, d2) || d1 > d2);
+                    break;
+                }
+                case INTOP_BLE_UN_I4:
+                    BR_BINOP(uint32_t, <=);
+                    break;
+                case INTOP_BLE_UN_I8:
+                    BR_BINOP(uint64_t, <=);
+                    break;
+                case INTOP_BLE_UN_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(isunordered(f1, f2) || f1 <= f2);
+                    break;
+                }
+                case INTOP_BLE_UN_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(isunordered(d1, d2) || d1 <= d2);
+                    break;
+                }
+                case INTOP_BLT_UN_I4:
+                    BR_BINOP(uint32_t, <);
+                    break;
+                case INTOP_BLT_UN_I8:
+                    BR_BINOP(uint64_t, <);
+                    break;
+                case INTOP_BLT_UN_R4:
+                {
+                    float f1 = LOCAL_VAR(ip[1], float);
+                    float f2 = LOCAL_VAR(ip[2], float);
+                    BR_BINOP_COND(isunordered(f1, f2) || f1 < f2);
+                    break;
+                }
+                case INTOP_BLT_UN_R8:
+                {
+                    double d1 = LOCAL_VAR(ip[1], double);
+                    double d2 = LOCAL_VAR(ip[2], double);
+                    BR_BINOP_COND(isunordered(d1, d2) || d1 < d2);
+                    break;
+                }
 
-            case INTOP_ADD_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) + LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_ADD_I8:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) + LOCAL_VAR(ip[3], int64_t);
-                ip += 4;
-                break;
-            case INTOP_ADD_R4:
-                LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) + LOCAL_VAR(ip[3], float);
-                ip += 4;
-                break;
-            case INTOP_ADD_R8:
-                LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) + LOCAL_VAR(ip[3], double);
-                ip += 4;
-                break;
-            case INTOP_ADD_I4_IMM:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) + ip[3];
-                ip += 4;
-                break;
-            case INTOP_ADD_I8_IMM:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) + ip[3];
-                ip += 4;
-                break;
-            case INTOP_SUB_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) - LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_SUB_I8:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) - LOCAL_VAR(ip[3], int64_t);
-                ip += 4;
-                break;
-            case INTOP_SUB_R4:
-                LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) - LOCAL_VAR(ip[3], float);
-                ip += 4;
-                break;
-            case INTOP_SUB_R8:
-                LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) - LOCAL_VAR(ip[3], double);
-                ip += 4;
-                break;
+                case INTOP_ADD_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) + LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_ADD_I8:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) + LOCAL_VAR(ip[3], int64_t);
+                    ip += 4;
+                    break;
+                case INTOP_ADD_R4:
+                    LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) + LOCAL_VAR(ip[3], float);
+                    ip += 4;
+                    break;
+                case INTOP_ADD_R8:
+                    LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) + LOCAL_VAR(ip[3], double);
+                    ip += 4;
+                    break;
+                case INTOP_ADD_I4_IMM:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) + ip[3];
+                    ip += 4;
+                    break;
+                case INTOP_ADD_I8_IMM:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) + ip[3];
+                    ip += 4;
+                    break;
+                case INTOP_SUB_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) - LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_SUB_I8:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) - LOCAL_VAR(ip[3], int64_t);
+                    ip += 4;
+                    break;
+                case INTOP_SUB_R4:
+                    LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) - LOCAL_VAR(ip[3], float);
+                    ip += 4;
+                    break;
+                case INTOP_SUB_R8:
+                    LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) - LOCAL_VAR(ip[3], double);
+                    ip += 4;
+                    break;
 
-            case INTOP_MUL_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) * LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_MUL_I8:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) * LOCAL_VAR(ip[3], int64_t);
-                ip += 4;
-                break;
-            case INTOP_MUL_R4:
-                LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) * LOCAL_VAR(ip[3], float);
-                ip += 4;
-                break;
-            case INTOP_MUL_R8:
-                LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) * LOCAL_VAR(ip[3], double);
-                ip += 4;
-                break;
-            case INTOP_MUL_OVF_I4:
-            {
-                int32_t i1 = LOCAL_VAR(ip[2], int32_t);
-                int32_t i2 = LOCAL_VAR(ip[3], int32_t);
-                int32_t i3;
-                if (!ClrSafeInt<int32_t>::multiply(i1, i2, i3))
-                    assert(0); // Interpreter-TODO: OverflowException
-                LOCAL_VAR(ip[1], int32_t) = i3;
-                ip += 4;
-                break;
-            }
+                case INTOP_MUL_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) * LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_MUL_I8:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) * LOCAL_VAR(ip[3], int64_t);
+                    ip += 4;
+                    break;
+                case INTOP_MUL_R4:
+                    LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) * LOCAL_VAR(ip[3], float);
+                    ip += 4;
+                    break;
+                case INTOP_MUL_R8:
+                    LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) * LOCAL_VAR(ip[3], double);
+                    ip += 4;
+                    break;
+                case INTOP_MUL_OVF_I4:
+                {
+                    int32_t i1 = LOCAL_VAR(ip[2], int32_t);
+                    int32_t i2 = LOCAL_VAR(ip[3], int32_t);
+                    int32_t i3;
+                    if (!ClrSafeInt<int32_t>::multiply(i1, i2, i3))
+                        assert(0); // Interpreter-TODO: OverflowException
+                    LOCAL_VAR(ip[1], int32_t) = i3;
+                    ip += 4;
+                    break;
+                }
 
-            case INTOP_MUL_OVF_I8:
-            {
-                int64_t i1 = LOCAL_VAR(ip[2], int64_t);
-                int64_t i2 = LOCAL_VAR(ip[3], int64_t);
-                int64_t i3;
-                if (!ClrSafeInt<int64_t>::multiply(i1, i2, i3))
-                    assert(0); // Interpreter-TODO: OverflowException
-                LOCAL_VAR(ip[1], int64_t) = i3;
-                ip += 4;
-                break;
-            }
+                case INTOP_MUL_OVF_I8:
+                {
+                    int64_t i1 = LOCAL_VAR(ip[2], int64_t);
+                    int64_t i2 = LOCAL_VAR(ip[3], int64_t);
+                    int64_t i3;
+                    if (!ClrSafeInt<int64_t>::multiply(i1, i2, i3))
+                        assert(0); // Interpreter-TODO: OverflowException
+                    LOCAL_VAR(ip[1], int64_t) = i3;
+                    ip += 4;
+                    break;
+                }
 
-            case INTOP_MUL_OVF_UN_I4:
-            {
-                uint32_t i1 = LOCAL_VAR(ip[2], uint32_t);
-                uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
-                uint32_t i3;
-                if (!ClrSafeInt<uint32_t>::multiply(i1, i2, i3))
-                    assert(0); // Interpreter-TODO: OverflowException
-                LOCAL_VAR(ip[1], uint32_t) = i3;
-                ip += 4;
-                break;
-            }
+                case INTOP_MUL_OVF_UN_I4:
+                {
+                    uint32_t i1 = LOCAL_VAR(ip[2], uint32_t);
+                    uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
+                    uint32_t i3;
+                    if (!ClrSafeInt<uint32_t>::multiply(i1, i2, i3))
+                        assert(0); // Interpreter-TODO: OverflowException
+                    LOCAL_VAR(ip[1], uint32_t) = i3;
+                    ip += 4;
+                    break;
+                }
 
-            case INTOP_MUL_OVF_UN_I8:
-            {
-                uint64_t i1 = LOCAL_VAR(ip[2], uint64_t);
-                uint64_t i2 = LOCAL_VAR(ip[3], uint64_t);
-                uint64_t i3;
-                if (!ClrSafeInt<uint64_t>::multiply(i1, i2, i3))
-                    assert(0); // Interpreter-TODO: OverflowException
-                LOCAL_VAR(ip[1], uint64_t) = i3;
-                ip += 4;
-                break;
-            }
-            case INTOP_DIV_I4:
-            {
-                int32_t i1 = LOCAL_VAR(ip[2], int32_t);
-                int32_t i2 = LOCAL_VAR(ip[3], int32_t);
-                if (i2 == 0)
-                    assert(0); // Interpreter-TODO: DivideByZeroException
-                if (i2 == -1 && i1 == INT32_MIN)
-                    assert(0); // Interpreter-TODO: OverflowException
-                LOCAL_VAR(ip[1], int32_t) = i1 / i2;
-                ip += 4;
-                break;
-            }
-            case INTOP_DIV_I8:
-            {
-                int64_t l1 = LOCAL_VAR(ip[2], int64_t);
-                int64_t l2 = LOCAL_VAR(ip[3], int64_t);
-                if (l2 == 0)
-                    assert(0); // Interpreter-TODO: DivideByZeroException
-                if (l2 == -1 && l1 == INT64_MIN)
-                    assert(0); // Interpreter-TODO: OverflowException
-                LOCAL_VAR(ip[1], int64_t) = l1 / l2;
-                ip += 4;
-                break;
-            }
-            case INTOP_DIV_R4:
-                LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) / LOCAL_VAR(ip[3], float);
-                ip += 4;
-                break;
-            case INTOP_DIV_R8:
-                LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) / LOCAL_VAR(ip[3], double);
-                ip += 4;
-                break;
-            case INTOP_DIV_UN_I4:
-            {
-                uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
-                if (i2 == 0)
-                    assert(0); // Interpreter-TODO: DivideByZeroException
-                LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) / i2;
-                ip += 4;
-                break;
-            }
-            case INTOP_DIV_UN_I8:
-            {
-                uint64_t l2 = LOCAL_VAR(ip[3], uint64_t);
-                if (l2 == 0)
-                    assert(0); // Interpreter-TODO: DivideByZeroException
-                LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) / l2;
-                ip += 4;
-                break;
-            }
+                case INTOP_MUL_OVF_UN_I8:
+                {
+                    uint64_t i1 = LOCAL_VAR(ip[2], uint64_t);
+                    uint64_t i2 = LOCAL_VAR(ip[3], uint64_t);
+                    uint64_t i3;
+                    if (!ClrSafeInt<uint64_t>::multiply(i1, i2, i3))
+                        assert(0); // Interpreter-TODO: OverflowException
+                    LOCAL_VAR(ip[1], uint64_t) = i3;
+                    ip += 4;
+                    break;
+                }
+                case INTOP_DIV_I4:
+                {
+                    int32_t i1 = LOCAL_VAR(ip[2], int32_t);
+                    int32_t i2 = LOCAL_VAR(ip[3], int32_t);
+                    if (i2 == 0)
+                        assert(0); // Interpreter-TODO: DivideByZeroException
+                    if (i2 == -1 && i1 == INT32_MIN)
+                        assert(0); // Interpreter-TODO: OverflowException
+                    LOCAL_VAR(ip[1], int32_t) = i1 / i2;
+                    ip += 4;
+                    break;
+                }
+                case INTOP_DIV_I8:
+                {
+                    int64_t l1 = LOCAL_VAR(ip[2], int64_t);
+                    int64_t l2 = LOCAL_VAR(ip[3], int64_t);
+                    if (l2 == 0)
+                        assert(0); // Interpreter-TODO: DivideByZeroException
+                    if (l2 == -1 && l1 == INT64_MIN)
+                        assert(0); // Interpreter-TODO: OverflowException
+                    LOCAL_VAR(ip[1], int64_t) = l1 / l2;
+                    ip += 4;
+                    break;
+                }
+                case INTOP_DIV_R4:
+                    LOCAL_VAR(ip[1], float) = LOCAL_VAR(ip[2], float) / LOCAL_VAR(ip[3], float);
+                    ip += 4;
+                    break;
+                case INTOP_DIV_R8:
+                    LOCAL_VAR(ip[1], double) = LOCAL_VAR(ip[2], double) / LOCAL_VAR(ip[3], double);
+                    ip += 4;
+                    break;
+                case INTOP_DIV_UN_I4:
+                {
+                    uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
+                    if (i2 == 0)
+                        assert(0); // Interpreter-TODO: DivideByZeroException
+                    LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) / i2;
+                    ip += 4;
+                    break;
+                }
+                case INTOP_DIV_UN_I8:
+                {
+                    uint64_t l2 = LOCAL_VAR(ip[3], uint64_t);
+                    if (l2 == 0)
+                        assert(0); // Interpreter-TODO: DivideByZeroException
+                    LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) / l2;
+                    ip += 4;
+                    break;
+                }
 
-            case INTOP_REM_I4:
-            {
-                int32_t i1 = LOCAL_VAR(ip[2], int32_t);
-                int32_t i2 = LOCAL_VAR(ip[3], int32_t);
-                if (i2 == 0)
-                    assert(0); // Interpreter-TODO: DivideByZeroException
-                if (i2 == -1 && i1 == INT32_MIN)
-                    assert(0); // Interpreter-TODO: OverflowException
-                LOCAL_VAR(ip[1], int32_t) = i1 % i2;
-                ip += 4;
-                break;
-            }
-            case INTOP_REM_I8:
-            {
-                int64_t l1 = LOCAL_VAR(ip[2], int64_t);
-                int64_t l2 = LOCAL_VAR(ip[3], int64_t);
-                if (l2 == 0)
-                    assert(0); // Interpreter-TODO: DivideByZeroException
-                if (l2 == -1 && l1 == INT64_MIN)
-                    assert(0); // Interpreter-TODO: OverflowException
-                LOCAL_VAR(ip[1], int64_t) = l1 % l2;
-                ip += 4;
-                break;
-            }
-            case INTOP_REM_R4:
-                LOCAL_VAR(ip[1], float) = fmodf(LOCAL_VAR(ip[2], float), LOCAL_VAR(ip[3], float));
-                ip += 4;
-                break;
-            case INTOP_REM_R8:
-                LOCAL_VAR(ip[1], double) = fmod(LOCAL_VAR(ip[2], double), LOCAL_VAR(ip[3], double));
-                ip += 4;
-                break;
-            case INTOP_REM_UN_I4:
-            {
-                uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
-                if (i2 == 0)
-                    assert(0); // Interpreter-TODO: DivideByZeroException
-                LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) % i2;
-                ip += 4;
-                break;
-            }
-            case INTOP_REM_UN_I8:
-            {
-                uint64_t l2 = LOCAL_VAR(ip[3], uint64_t);
-                if (l2 == 0)
-                    assert(0); // Interpreter-TODO: DivideByZeroException
-                LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) % l2;
-                ip += 4;
-                break;
-            }
+                case INTOP_REM_I4:
+                {
+                    int32_t i1 = LOCAL_VAR(ip[2], int32_t);
+                    int32_t i2 = LOCAL_VAR(ip[3], int32_t);
+                    if (i2 == 0)
+                        assert(0); // Interpreter-TODO: DivideByZeroException
+                    if (i2 == -1 && i1 == INT32_MIN)
+                        assert(0); // Interpreter-TODO: OverflowException
+                    LOCAL_VAR(ip[1], int32_t) = i1 % i2;
+                    ip += 4;
+                    break;
+                }
+                case INTOP_REM_I8:
+                {
+                    int64_t l1 = LOCAL_VAR(ip[2], int64_t);
+                    int64_t l2 = LOCAL_VAR(ip[3], int64_t);
+                    if (l2 == 0)
+                        assert(0); // Interpreter-TODO: DivideByZeroException
+                    if (l2 == -1 && l1 == INT64_MIN)
+                        assert(0); // Interpreter-TODO: OverflowException
+                    LOCAL_VAR(ip[1], int64_t) = l1 % l2;
+                    ip += 4;
+                    break;
+                }
+                case INTOP_REM_R4:
+                    LOCAL_VAR(ip[1], float) = fmodf(LOCAL_VAR(ip[2], float), LOCAL_VAR(ip[3], float));
+                    ip += 4;
+                    break;
+                case INTOP_REM_R8:
+                    LOCAL_VAR(ip[1], double) = fmod(LOCAL_VAR(ip[2], double), LOCAL_VAR(ip[3], double));
+                    ip += 4;
+                    break;
+                case INTOP_REM_UN_I4:
+                {
+                    uint32_t i2 = LOCAL_VAR(ip[3], uint32_t);
+                    if (i2 == 0)
+                        assert(0); // Interpreter-TODO: DivideByZeroException
+                    LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) % i2;
+                    ip += 4;
+                    break;
+                }
+                case INTOP_REM_UN_I8:
+                {
+                    uint64_t l2 = LOCAL_VAR(ip[3], uint64_t);
+                    if (l2 == 0)
+                        assert(0); // Interpreter-TODO: DivideByZeroException
+                    LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) % l2;
+                    ip += 4;
+                    break;
+                }
 
-            case INTOP_SHL_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) << LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_SHL_I8:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) << LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_SHR_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) >> LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_SHR_I8:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) >> LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_SHR_UN_I4:
-                LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) >> LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_SHR_UN_I8:
-                LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) >> LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
+                case INTOP_SHL_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) << LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_SHL_I8:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) << LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_SHR_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) >> LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_SHR_I8:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) >> LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_SHR_UN_I4:
+                    LOCAL_VAR(ip[1], uint32_t) = LOCAL_VAR(ip[2], uint32_t) >> LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_SHR_UN_I8:
+                    LOCAL_VAR(ip[1], uint64_t) = LOCAL_VAR(ip[2], uint64_t) >> LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
 
-            case INTOP_NEG_I4:
-                LOCAL_VAR(ip[1], int32_t) = - LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;
-            case INTOP_NEG_I8:
-                LOCAL_VAR(ip[1], int64_t) = - LOCAL_VAR(ip[2], int64_t);
-                ip += 3;
-                break;
-            case INTOP_NEG_R4:
-                LOCAL_VAR(ip[1], float) = - LOCAL_VAR(ip[2], float);
-                ip += 3;
-                break;
-            case INTOP_NEG_R8:
-                LOCAL_VAR(ip[1], double) = - LOCAL_VAR(ip[2], double);
-                ip += 3;
-                break;
-            case INTOP_NOT_I4:
-                LOCAL_VAR(ip[1], int32_t) = ~ LOCAL_VAR(ip[2], int32_t);
-                ip += 3;
-                break;
-            case INTOP_NOT_I8:
-                LOCAL_VAR(ip[1], int64_t) = ~ LOCAL_VAR(ip[2], int64_t);
-                ip += 3;
-                break;
+                case INTOP_NEG_I4:
+                    LOCAL_VAR(ip[1], int32_t) = - LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;
+                case INTOP_NEG_I8:
+                    LOCAL_VAR(ip[1], int64_t) = - LOCAL_VAR(ip[2], int64_t);
+                    ip += 3;
+                    break;
+                case INTOP_NEG_R4:
+                    LOCAL_VAR(ip[1], float) = - LOCAL_VAR(ip[2], float);
+                    ip += 3;
+                    break;
+                case INTOP_NEG_R8:
+                    LOCAL_VAR(ip[1], double) = - LOCAL_VAR(ip[2], double);
+                    ip += 3;
+                    break;
+                case INTOP_NOT_I4:
+                    LOCAL_VAR(ip[1], int32_t) = ~ LOCAL_VAR(ip[2], int32_t);
+                    ip += 3;
+                    break;
+                case INTOP_NOT_I8:
+                    LOCAL_VAR(ip[1], int64_t) = ~ LOCAL_VAR(ip[2], int64_t);
+                    ip += 3;
+                    break;
 
-            case INTOP_AND_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) & LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_AND_I8:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) & LOCAL_VAR(ip[3], int64_t);
-                ip += 4;
-                break;
-            case INTOP_OR_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) | LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_OR_I8:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) | LOCAL_VAR(ip[3], int64_t);
-                ip += 4;
-                break;
-            case INTOP_XOR_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) ^ LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_XOR_I8:
-                LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) ^ LOCAL_VAR(ip[3], int64_t);
-                ip += 4;
-                break;
+                case INTOP_AND_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) & LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_AND_I8:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) & LOCAL_VAR(ip[3], int64_t);
+                    ip += 4;
+                    break;
+                case INTOP_OR_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) | LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_OR_I8:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) | LOCAL_VAR(ip[3], int64_t);
+                    ip += 4;
+                    break;
+                case INTOP_XOR_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) ^ LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_XOR_I8:
+                    LOCAL_VAR(ip[1], int64_t) = LOCAL_VAR(ip[2], int64_t) ^ LOCAL_VAR(ip[3], int64_t);
+                    ip += 4;
+                    break;
 
 #define CMP_BINOP_FP(datatype, op, noOrderVal)      \
     do {                                            \
@@ -813,80 +817,80 @@ MAIN_LOOP:
         ip += 4;                                    \
     } while (0)
 
-            case INTOP_CEQ_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) == LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_CEQ_I8:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int64_t) == LOCAL_VAR(ip[3], int64_t);
-                ip += 4;
-                break;
-            case INTOP_CEQ_R4:
-                CMP_BINOP_FP(float, ==, 0);
-                break;
-            case INTOP_CEQ_R8:
-                CMP_BINOP_FP(double, ==, 0);
-                break;
+                case INTOP_CEQ_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) == LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_CEQ_I8:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int64_t) == LOCAL_VAR(ip[3], int64_t);
+                    ip += 4;
+                    break;
+                case INTOP_CEQ_R4:
+                    CMP_BINOP_FP(float, ==, 0);
+                    break;
+                case INTOP_CEQ_R8:
+                    CMP_BINOP_FP(double, ==, 0);
+                    break;
 
-            case INTOP_CGT_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) > LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_CGT_I8:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int64_t) > LOCAL_VAR(ip[3], int64_t);
-                ip += 4;
-                break;
-            case INTOP_CGT_R4:
-                CMP_BINOP_FP(float, >, 0);
-                break;
-            case INTOP_CGT_R8:
-                CMP_BINOP_FP(double, >, 0);
-                break;
+                case INTOP_CGT_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) > LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_CGT_I8:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int64_t) > LOCAL_VAR(ip[3], int64_t);
+                    ip += 4;
+                    break;
+                case INTOP_CGT_R4:
+                    CMP_BINOP_FP(float, >, 0);
+                    break;
+                case INTOP_CGT_R8:
+                    CMP_BINOP_FP(double, >, 0);
+                    break;
 
-            case INTOP_CGT_UN_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint32_t) > LOCAL_VAR(ip[3], uint32_t);
-                ip += 4;
-                break;
-            case INTOP_CGT_UN_I8:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint32_t) > LOCAL_VAR(ip[3], uint32_t);
-                ip += 4;
-                break;
-            case INTOP_CGT_UN_R4:
-                CMP_BINOP_FP(float, >, 1);
-                break;
-            case INTOP_CGT_UN_R8:
-                CMP_BINOP_FP(double, >, 1);
-                break;
+                case INTOP_CGT_UN_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint32_t) > LOCAL_VAR(ip[3], uint32_t);
+                    ip += 4;
+                    break;
+                case INTOP_CGT_UN_I8:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint32_t) > LOCAL_VAR(ip[3], uint32_t);
+                    ip += 4;
+                    break;
+                case INTOP_CGT_UN_R4:
+                    CMP_BINOP_FP(float, >, 1);
+                    break;
+                case INTOP_CGT_UN_R8:
+                    CMP_BINOP_FP(double, >, 1);
+                    break;
 
-            case INTOP_CLT_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) < LOCAL_VAR(ip[3], int32_t);
-                ip += 4;
-                break;
-            case INTOP_CLT_I8:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int64_t) < LOCAL_VAR(ip[3], int64_t);
-                ip += 4;
-                break;
-            case INTOP_CLT_R4:
-                CMP_BINOP_FP(float, <, 0);
-                break;
-            case INTOP_CLT_R8:
-                CMP_BINOP_FP(double, <, 0);
-                break;
+                case INTOP_CLT_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int32_t) < LOCAL_VAR(ip[3], int32_t);
+                    ip += 4;
+                    break;
+                case INTOP_CLT_I8:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], int64_t) < LOCAL_VAR(ip[3], int64_t);
+                    ip += 4;
+                    break;
+                case INTOP_CLT_R4:
+                    CMP_BINOP_FP(float, <, 0);
+                    break;
+                case INTOP_CLT_R8:
+                    CMP_BINOP_FP(double, <, 0);
+                    break;
 
-            case INTOP_CLT_UN_I4:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint32_t) < LOCAL_VAR(ip[3], uint32_t);
-                ip += 4;
-                break;
-            case INTOP_CLT_UN_I8:
-                LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint64_t) < LOCAL_VAR(ip[3], uint64_t);
-                ip += 4;
-                break;
-            case INTOP_CLT_UN_R4:
-                CMP_BINOP_FP(float, <, 1);
-                break;
-            case INTOP_CLT_UN_R8:
-                CMP_BINOP_FP(double, <, 1);
-                break;
+                case INTOP_CLT_UN_I4:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint32_t) < LOCAL_VAR(ip[3], uint32_t);
+                    ip += 4;
+                    break;
+                case INTOP_CLT_UN_I8:
+                    LOCAL_VAR(ip[1], int32_t) = LOCAL_VAR(ip[2], uint64_t) < LOCAL_VAR(ip[3], uint64_t);
+                    ip += 4;
+                    break;
+                case INTOP_CLT_UN_R4:
+                    CMP_BINOP_FP(float, <, 1);
+                    break;
+                case INTOP_CLT_UN_R8:
+                    CMP_BINOP_FP(double, <, 1);
+                    break;
 
 #define LDIND(dtype, ftype)                                 \
     do {                                                    \
@@ -896,38 +900,38 @@ MAIN_LOOP:
         ip += 4;                                            \
     } while (0)
 
-            case INTOP_LDIND_I1:
-                LDIND(int32_t, int8_t);
-                break;
-            case INTOP_LDIND_U1:
-                LDIND(int32_t, uint8_t);
-                break;
-            case INTOP_LDIND_I2:
-                LDIND(int32_t, int16_t);
-                break;
-            case INTOP_LDIND_U2:
-                LDIND(int32_t, uint16_t);
-                break;
-            case INTOP_LDIND_I4:
-                LDIND(int32_t, int32_t);
-                break;
-            case INTOP_LDIND_I8:
-                LDIND(int64_t, int64_t);
-                break;
-            case INTOP_LDIND_R4:
-                LDIND(float, float);
-                break;
-            case INTOP_LDIND_R8:
-                LDIND(double, double);
-                break;
-            case INTOP_LDIND_VT:
-            {
-                char *src = LOCAL_VAR(ip[2], char*);
-                NULL_CHECK(obj);
-                memcpy(stack + ip[1], (char*)src + ip[3], ip[4]);
-                ip += 5;
-                break;
-            }
+                case INTOP_LDIND_I1:
+                    LDIND(int32_t, int8_t);
+                    break;
+                case INTOP_LDIND_U1:
+                    LDIND(int32_t, uint8_t);
+                    break;
+                case INTOP_LDIND_I2:
+                    LDIND(int32_t, int16_t);
+                    break;
+                case INTOP_LDIND_U2:
+                    LDIND(int32_t, uint16_t);
+                    break;
+                case INTOP_LDIND_I4:
+                    LDIND(int32_t, int32_t);
+                    break;
+                case INTOP_LDIND_I8:
+                    LDIND(int64_t, int64_t);
+                    break;
+                case INTOP_LDIND_R4:
+                    LDIND(float, float);
+                    break;
+                case INTOP_LDIND_R8:
+                    LDIND(double, double);
+                    break;
+                case INTOP_LDIND_VT:
+                {
+                    char *src = LOCAL_VAR(ip[2], char*);
+                    NULL_CHECK(obj);
+                    memcpy(stack + ip[1], (char*)src + ip[3], ip[4]);
+                    ip += 5;
+                    break;
+                }
 
 #define STIND(dtype, ftype)                                         \
     do                                                              \
@@ -938,259 +942,253 @@ MAIN_LOOP:
         ip += 4;                                                    \
     } while (0)
 
-            case INTOP_STIND_I1:
-                STIND(int32_t, int8_t);
-                break;
-            case INTOP_STIND_U1:
-                STIND(int32_t, uint8_t);
-                break;
-            case INTOP_STIND_I2:
-                STIND(int32_t, int16_t);
-                break;
-            case INTOP_STIND_U2:
-                STIND(int32_t, uint16_t);
-                break;
-            case INTOP_STIND_I4:
-                STIND(int32_t, int32_t);
-                break;
-            case INTOP_STIND_I8:
-                STIND(int64_t, int64_t);
-                break;
-            case INTOP_STIND_R4:
-                STIND(float, float);
-                break;
-            case INTOP_STIND_R8:
-                STIND(double, double);
-                break;
-            case INTOP_STIND_O:
-            {
-                char *dst = LOCAL_VAR(ip[1], char*);
-                OBJECTREF storeObj = LOCAL_VAR(ip[2], OBJECTREF);
-                NULL_CHECK(obj);
-                SetObjectReferenceUnchecked((OBJECTREF*)(dst + ip[3]), storeObj);
-                ip += 4;
-                break;
-            }
-            case INTOP_STIND_VT_NOREF:
-            {
-                char *dest = LOCAL_VAR(ip[1], char*);
-                NULL_CHECK(dest);
-                memcpyNoGCRefs(dest + ip[3], stack + ip[2], ip[4]);
-                ip += 5;
-                break;
-            }
-            case INTOP_STIND_VT:
-            {
-                MethodTable *pMT = (MethodTable*)pMethod->pDataItems[ip[4]];
-                char *dest = LOCAL_VAR(ip[1], char*);
-                NULL_CHECK(dest);
-                CopyValueClassUnchecked(dest + ip[3], stack + ip[2], pMT);
-                ip += 5;
-                break;
-            }
-            case INTOP_LDFLDA:
-            {
-                char *src = LOCAL_VAR(ip[2], char*);
-                NULL_CHECK(src);
-                LOCAL_VAR(ip[1], char*) = src + ip[3];
-                ip += 4;
-                break;
-            }
-
-            case INTOP_CALL_HELPER_PP:
-            {
-                HELPER_FTN_PP helperFtn = (HELPER_FTN_PP)pMethod->pDataItems[ip[2]];
-                HELPER_FTN_PP* helperFtnSlot = (HELPER_FTN_PP*)pMethod->pDataItems[ip[3]];
-                void* helperArg = pMethod->pDataItems[ip[4]];
-
-                if (!helperFtn)
-                    helperFtn = *helperFtnSlot;
-                // This can call either native or compiled managed code. For an interpreter
-                // only configuration, this might be problematic, at least performance wise.
-                // FIXME We will need to handle exception throwing here.
-                LOCAL_VAR(ip[1], void*) = helperFtn(helperArg);
-
-                ip += 5;
-                break;
-            }
-            case INTOP_CALLVIRT:
-            {
-                returnOffset = ip[1];
-                callArgsOffset = ip[2];
-                methodSlot = ip[3];
-
-                MethodDesc *pMD = (MethodDesc*)pMethod->pDataItems[methodSlot];
-
-                OBJECTREF *pThisArg = LOCAL_VAR_ADDR(callArgsOffset, OBJECTREF);
-                NULL_CHECK(*pThisArg);
-
-                // Interpreter-TODO
-                // This needs to be optimized, not operating at MethodDesc level, rather with ftnptr
-                // slots containing the interpreter IR pointer
-                pMD = pMD->GetMethodDescOfVirtualizedCode(pThisArg, pMD->GetMethodTable());
-
-                PCODE code = pMD->GetNativeCode();
-                if (!code)
+                case INTOP_STIND_I1:
+                    STIND(int32_t, int8_t);
+                    break;
+                case INTOP_STIND_U1:
+                    STIND(int32_t, uint8_t);
+                    break;
+                case INTOP_STIND_I2:
+                    STIND(int32_t, int16_t);
+                    break;
+                case INTOP_STIND_U2:
+                    STIND(int32_t, uint16_t);
+                    break;
+                case INTOP_STIND_I4:
+                    STIND(int32_t, int32_t);
+                    break;
+                case INTOP_STIND_I8:
+                    STIND(int64_t, int64_t);
+                    break;
+                case INTOP_STIND_R4:
+                    STIND(float, float);
+                    break;
+                case INTOP_STIND_R8:
+                    STIND(double, double);
+                    break;
+                case INTOP_STIND_O:
                 {
-                    pInterpreterFrame->SetTopInterpMethodContextFrame(pFrame);
-                    GCX_PREEMP();
-                    pMD->PrepareInitialCode(CallerGCMode::Coop);
-                    code = pMD->GetNativeCode();
+                    char *dst = LOCAL_VAR(ip[1], char*);
+                    OBJECTREF storeObj = LOCAL_VAR(ip[2], OBJECTREF);
+                    NULL_CHECK(obj);
+                    SetObjectReferenceUnchecked((OBJECTREF*)(dst + ip[3]), storeObj);
+                    ip += 4;
+                    break;
                 }
-                targetIp = (const int32_t*)code;
-                ip += 4;
-                // Interpreter-TODO unbox if target method class is valuetype
-                goto CALL_TARGET_IP;
-            }
-
-            case INTOP_CALL:
-            {
-                returnOffset = ip[1];
-                callArgsOffset = ip[2];
-                methodSlot = ip[3];
-
-                ip += 4;
-CALL_INTERP_SLOT:
+                case INTOP_STIND_VT_NOREF:
                 {
-                size_t targetMethod = (size_t)pMethod->pDataItems[methodSlot];
-                if (targetMethod & INTERP_METHOD_DESC_TAG)
+                    char *dest = LOCAL_VAR(ip[1], char*);
+                    NULL_CHECK(dest);
+                    memcpyNoGCRefs(dest + ip[3], stack + ip[2], ip[4]);
+                    ip += 5;
+                    break;
+                }
+                case INTOP_STIND_VT:
                 {
-                    // First execution of this call. Ensure target method is compiled and
-                    // patch the data item slot with the actual method code.
-                    MethodDesc *pMD = (MethodDesc*)(targetMethod & ~INTERP_METHOD_DESC_TAG);
+                    MethodTable *pMT = (MethodTable*)pMethod->pDataItems[ip[4]];
+                    char *dest = LOCAL_VAR(ip[1], char*);
+                    NULL_CHECK(dest);
+                    CopyValueClassUnchecked(dest + ip[3], stack + ip[2], pMT);
+                    ip += 5;
+                    break;
+                }
+                case INTOP_LDFLDA:
+                {
+                    char *src = LOCAL_VAR(ip[2], char*);
+                    NULL_CHECK(src);
+                    LOCAL_VAR(ip[1], char*) = src + ip[3];
+                    ip += 4;
+                    break;
+                }
+
+                case INTOP_CALL_HELPER_PP:
+                {
+                    HELPER_FTN_PP helperFtn = (HELPER_FTN_PP)pMethod->pDataItems[ip[2]];
+                    HELPER_FTN_PP* helperFtnSlot = (HELPER_FTN_PP*)pMethod->pDataItems[ip[3]];
+                    void* helperArg = pMethod->pDataItems[ip[4]];
+
+                    if (!helperFtn)
+                        helperFtn = *helperFtnSlot;
+                    // This can call either native or compiled managed code. For an interpreter
+                    // only configuration, this might be problematic, at least performance wise.
+                    // FIXME We will need to handle exception throwing here.
+                    LOCAL_VAR(ip[1], void*) = helperFtn(helperArg);
+
+                    ip += 5;
+                    break;
+                }
+                case INTOP_CALLVIRT:
+                {
+                    returnOffset = ip[1];
+                    callArgsOffset = ip[2];
+                    methodSlot = ip[3];
+
+                    MethodDesc *pMD = (MethodDesc*)pMethod->pDataItems[methodSlot];
+
+                    OBJECTREF *pThisArg = LOCAL_VAR_ADDR(callArgsOffset, OBJECTREF);
+                    NULL_CHECK(*pThisArg);
+
+                    // Interpreter-TODO
+                    // This needs to be optimized, not operating at MethodDesc level, rather with ftnptr
+                    // slots containing the interpreter IR pointer
+                    pMD = pMD->GetMethodDescOfVirtualizedCode(pThisArg, pMD->GetMethodTable());
+
                     PCODE code = pMD->GetNativeCode();
-                    if (!code) {
-                        // This is an optimization to ensure that the stack walk will not have to search
-                        // for the topmost frame in the current InterpExecMethod. It is not required
-                        // for correctness, as the stack walk will find the topmost frame anyway. But it
-                        // would need to seek through the frames to find it.
-                        // An alternative approach would be to update the topmost frame during stack walk
-                        // to make the probability that the next stack walk will need to search only a
-                        // small subset of frames high.
+                    if (!code)
+                    {
                         pInterpreterFrame->SetTopInterpMethodContextFrame(pFrame);
                         GCX_PREEMP();
                         pMD->PrepareInitialCode(CallerGCMode::Coop);
                         code = pMD->GetNativeCode();
                     }
-                    pMethod->pDataItems[methodSlot] = (void*)code;
                     targetIp = (const int32_t*)code;
+                    ip += 4;
+                    // Interpreter-TODO unbox if target method class is valuetype
+                    goto CALL_TARGET_IP;
                 }
-                else
+
+                case INTOP_CALL:
                 {
-                    // At this stage in the implementation, we assume this is pointer to
-                    // interpreter code. In the future, this should probably be tagged pointer
-                    // for interpreter call or normal pointer for JIT/R2R call.
-                    targetIp = (const int32_t*)targetMethod;
-                }
-                }
+                    returnOffset = ip[1];
+                    callArgsOffset = ip[2];
+                    methodSlot = ip[3];
+
+                    ip += 4;
+CALL_INTERP_SLOT:
+                    {
+                    size_t targetMethod = (size_t)pMethod->pDataItems[methodSlot];
+                    if (targetMethod & INTERP_METHOD_DESC_TAG)
+                    {
+                        // First execution of this call. Ensure target method is compiled and
+                        // patch the data item slot with the actual method code.
+                        MethodDesc *pMD = (MethodDesc*)(targetMethod & ~INTERP_METHOD_DESC_TAG);
+                        PCODE code = pMD->GetNativeCode();
+                        if (!code) {
+                            // This is an optimization to ensure that the stack walk will not have to search
+                            // for the topmost frame in the current InterpExecMethod. It is not required
+                            // for correctness, as the stack walk will find the topmost frame anyway. But it
+                            // would need to seek through the frames to find it.
+                            // An alternative approach would be to update the topmost frame during stack walk
+                            // to make the probability that the next stack walk will need to search only a
+                            // small subset of frames high.
+                            pInterpreterFrame->SetTopInterpMethodContextFrame(pFrame);
+                            GCX_PREEMP();
+                            pMD->PrepareInitialCode(CallerGCMode::Coop);
+                            code = pMD->GetNativeCode();
+                        }
+                        pMethod->pDataItems[methodSlot] = (void*)code;
+                        targetIp = (const int32_t*)code;
+                    }
+                    else
+                    {
+                        // At this stage in the implementation, we assume this is pointer to
+                        // interpreter code. In the future, this should probably be tagged pointer
+                        // for interpreter call or normal pointer for JIT/R2R call.
+                        targetIp = (const int32_t*)targetMethod;
+                    }
+                    }
 CALL_TARGET_IP:
-                // Save current execution state for when we return from called method
-                pFrame->ip = ip;
+                    // Save current execution state for when we return from called method
+                    pFrame->ip = ip;
 
-                // Allocate child frame.
-                {
-                    InterpMethodContextFrame *pChildFrame = pFrame->pNext;
-                    if (!pChildFrame)
+                    // Allocate child frame.
                     {
-                        pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
-                        pChildFrame->pNext = NULL;
-                        pFrame->pNext = pChildFrame;
+                        InterpMethodContextFrame *pChildFrame = pFrame->pNext;
+                        if (!pChildFrame)
+                        {
+                            pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
+                            pChildFrame->pNext = NULL;
+                            pFrame->pNext = pChildFrame;
+                        }
+                        pChildFrame->ReInit(pFrame, targetIp, stack + returnOffset, stack + callArgsOffset);
+                        pFrame = pChildFrame;
                     }
-                    pChildFrame->ReInit(pFrame, targetIp, stack + returnOffset, stack + callArgsOffset);
-                    pFrame = pChildFrame;
+                    assert (((size_t)pFrame->pStack % INTERP_STACK_ALIGNMENT) == 0);
+
+                    // Set execution state for the new frame
+                    pMethod = *(InterpMethod**)pFrame->startIp;
+                    stack = pFrame->pStack;
+                    ip = pFrame->startIp + sizeof(InterpMethod*) / sizeof(int32_t);
+                    pThreadContext->pStackPointer = stack + pMethod->allocaSize;
+                    break;
                 }
-                assert (((size_t)pFrame->pStack % INTERP_STACK_ALIGNMENT) == 0);
-
-                // Set execution state for the new frame
-                pMethod = *(InterpMethod**)pFrame->startIp;
-                stack = pFrame->pStack;
-                ip = pFrame->startIp + sizeof(InterpMethod*) / sizeof(int32_t);
-                pThreadContext->pStackPointer = stack + pMethod->allocaSize;
-                break;
-            }
-            case INTOP_NEWOBJ:
-            {
-                returnOffset = ip[1];
-                callArgsOffset = ip[2];
-                methodSlot = ip[3];
-
-                OBJECTREF objRef = AllocateObject((MethodTable*)pMethod->pDataItems[ip[4]]);
-
-                // This is return value
-                LOCAL_VAR(returnOffset, OBJECTREF) = objRef;
-                // Set `this` arg for ctor call
-                LOCAL_VAR (callArgsOffset, OBJECTREF) = objRef;
-                ip += 5;
-
-                goto CALL_INTERP_SLOT;
-            }
-            case INTOP_NEWOBJ_VT:
-            {
-                returnOffset = ip[1];
-                callArgsOffset = ip[2];
-                methodSlot = ip[3];
-
-                int32_t vtSize = ip[4];
-                void *vtThis = stack + returnOffset;
-
-                // clear the valuetype
-                memset(vtThis, 0, vtSize);
-                // pass the address of the valuetype
-                LOCAL_VAR(callArgsOffset, void*) = vtThis;
-
-                ip += 5;
-                goto CALL_INTERP_SLOT;
-            }
-            case INTOP_ZEROBLK_IMM:
-                memset(LOCAL_VAR(ip[1], void*), 0, ip[2]);
-                ip += 3;
-                break;
-            case INTOP_LOCALLOC:
-            {
-                size_t len = LOCAL_VAR(ip[2], size_t);
-                void* pMemory = NULL;
-
-                if (len > 0)
+                case INTOP_NEWOBJ:
                 {
-                    pMemory = pThreadContext->frameDataAllocator.Alloc(pFrame, len);
-                    if (pMemory == NULL)
+                    returnOffset = ip[1];
+                    callArgsOffset = ip[2];
+                    methodSlot = ip[3];
+
+                    OBJECTREF objRef = AllocateObject((MethodTable*)pMethod->pDataItems[ip[4]]);
+
+                    // This is return value
+                    LOCAL_VAR(returnOffset, OBJECTREF) = objRef;
+                    // Set `this` arg for ctor call
+                    LOCAL_VAR (callArgsOffset, OBJECTREF) = objRef;
+                    ip += 5;
+
+                    goto CALL_INTERP_SLOT;
+                }
+                case INTOP_NEWOBJ_VT:
+                {
+                    returnOffset = ip[1];
+                    callArgsOffset = ip[2];
+                    methodSlot = ip[3];
+
+                    int32_t vtSize = ip[4];
+                    void *vtThis = stack + returnOffset;
+
+                    // clear the valuetype
+                    memset(vtThis, 0, vtSize);
+                    // pass the address of the valuetype
+                    LOCAL_VAR(callArgsOffset, void*) = vtThis;
+
+                    ip += 5;
+                    goto CALL_INTERP_SLOT;
+                }
+                case INTOP_ZEROBLK_IMM:
+                    memset(LOCAL_VAR(ip[1], void*), 0, ip[2]);
+                    ip += 3;
+                    break;
+                case INTOP_LOCALLOC:
+                {
+                    size_t len = LOCAL_VAR(ip[2], size_t);
+                    void* pMemory = NULL;
+
+                    if (len > 0)
                     {
-                        // Interpreter-TODO: OutOfMemoryException
-                        assert(0);
+                        pMemory = pThreadContext->frameDataAllocator.Alloc(pFrame, len);
+                        if (pMemory == NULL)
+                        {
+                            // Interpreter-TODO: OutOfMemoryException
+                            assert(0);
+                        }
+                        if (pMethod->initLocals)
+                        {
+                            memset(pMemory, 0, len);
+                        }
                     }
-                    if (pMethod->initLocals)
+
+                    LOCAL_VAR(ip[1], void*) = pMemory;
+                    ip += 3;
+                    break;
+                }
+                case INTOP_GC_COLLECT:
+                {
+                    // HACK: blocking gc of all generations to enable early stackwalk testing
+                    // Interpreter-TODO: Remove this
                     {
-                        memset(pMemory, 0, len);
+                        pInterpreterFrame->SetTopInterpMethodContextFrame(pFrame);
+                        GCX_COOP();
+                        GCHeapUtilities::GetGCHeap()->GarbageCollect(-1, false, 0x00000002);
                     }
+                    ip++;
+                    break;
                 }
-
-                LOCAL_VAR(ip[1], void*) = pMemory;
-                ip += 3;
-                break;
-            }
-            case INTOP_GC_COLLECT: {
-                // HACK: blocking gc of all generations to enable early stackwalk testing
-                // Interpreter-TODO: Remove this
+                case INTOP_THROW:
                 {
-                    pInterpreterFrame->SetTopInterpMethodContextFrame(pFrame);
-                    GCX_COOP();
-                    GCHeapUtilities::GetGCHeap()->GarbageCollect(-1, false, 0x00000002);
-                }
-                ip++;
-            case INTOP_THROW:
-            {
-                CONTEXT exceptionContext;
-                ClrCaptureContext(&exceptionContext);
+                    CONTEXT exceptionContext;
+                    ClrCaptureContext(&exceptionContext);
 
-                TADDR resumeSP;
-                TADDR resumeIP;
-                pInterpreterFrame->GetAndClearResumeContext(&resumeSP, &resumeIP);
-
-                // If the resumeSP is not 0, it means that exception handling restored CPU context after the ClrCaptureContext
-                // in order to resume execution after catch funclet returned. In this case, we need to restore the interpreter context.
-                // If it is 0 though, it means that we are throwing the exception here.
-                if (resumeSP == 0)
-                {
                     OBJECTREF throwable;
                     if (LOCAL_VAR(ip[1], OBJECTREF) == nullptr)
                     {
@@ -1203,33 +1201,46 @@ CALL_TARGET_IP:
                     }
                     DispatchManagedException(throwable, &exceptionContext);
                     UNREACHABLE();
+                    break;
                 }
-                else
-                {
-                    InterpMethodContextFrame* pResumeFrame = (InterpMethodContextFrame*)resumeSP;
-                    // Unwind the interpreter stack upto the resume frame
-                    while (pFrame != pResumeFrame)
-                    {
-                        pFrame->ip = 0;
-                        pFrame = pFrame->pParent;
-                    }
-
-                    // Set the current interpreter context to the resume one and continue execution from there
-                    ip = (int32_t*)resumeIP;
-
-                    stack = pFrame->pStack;
-                    pMethod = *(InterpMethod**)pFrame->startIp;
-                    pThreadContext->pStackPointer = pFrame->pStack + pMethod->allocaSize;
-                }
-
-                break;
+                case INTOP_FAILFAST:
+                    assert(0);
+                    break;
+                default:
+                    assert(0);
+                    break;
             }
-            case INTOP_FAILFAST:
-                assert(0);
-                break;
-            default:
-                assert(0);
-                break;
+            UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
+            UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
+        }
+        catch (const ResumeAfterCatchException& ex)
+        {
+            TADDR resumeSP;
+            TADDR resumeIP;
+            ex.GetResumeContext(&resumeSP, &resumeIP);
+            _ASSERTE(resumeSP != NULL && resumeIP != NULL);
+
+            InterpMethodContextFrame* pResumeFrame = (InterpMethodContextFrame*)resumeSP;
+            // Unwind the interpreter stack upto the resume frame
+            while ((pFrame != NULL) && (pFrame != pResumeFrame))
+            {
+                pThreadContext->frameDataAllocator.PopInfo(pFrame);
+                pFrame->ip = 0;
+                pFrame = pFrame->pParent;
+            }
+
+            if (pFrame == NULL)
+            {
+                // Continue propagating the resume exception, the resume frame is not in this block of interpreted frames.
+                throw;
+            }
+
+            // Set the current interpreter context to the resume one and continue execution from there
+            ip = (int32_t*)resumeIP;
+
+            stack = pFrame->pStack;
+            pMethod = *(InterpMethod**)pFrame->startIp;
+            pThreadContext->pStackPointer = pFrame->pStack + pMethod->allocaSize;
         }
     }
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1216,7 +1216,7 @@ CALL_TARGET_IP:
         TADDR resumeSP;
         TADDR resumeIP;
         ex.GetResumeContext(&resumeSP, &resumeIP);
-        _ASSERTE(resumeSP != NULL && resumeIP != NULL);
+        _ASSERTE(resumeSP != 0 && resumeIP != 0);
 
         InterpMethodContextFrame* pResumeFrame = (InterpMethodContextFrame*)resumeSP;
         // Unwind the interpreter stack upto the resume frame

--- a/src/coreclr/vm/loongarch64/cgencpu.h
+++ b/src/coreclr/vm/loongarch64/cgencpu.h
@@ -229,6 +229,30 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return (TADDR)(context->Fp);
 }
 
+inline void SetFirstArgReg(T_CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    context->A0 = DWORD64(value);
+}
+
+inline TADDR GetFirstArgReg(T_CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return (TADDR)(context->A0);
+}
+
+inline void SetSecondArgReg(T_CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    context->A1 = DWORD64(value);
+}
+
+inline TADDR GetSecondArgReg(T_CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return (TADDR)(context->A1);
+}
+
 inline TADDR GetMem(PCODE address, SIZE_T size, bool signExtend)
 {
     TADDR mem;

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1994,7 +1994,6 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
 #ifdef FEATURE_INTERPRETER
 extern "C" void STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBlock, TADDR byteCodeAddr)
 {
-    INSTALL_RESUME_AFTER_CATCH_HANDLER;
     // Argument registers are in the TransitionBlock
     // The stack arguments are right after the pTransitionBlock
     Thread *pThread = GetThread();
@@ -2026,7 +2025,6 @@ extern "C" void STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBlo
     InterpExecMethod(&frames.interpreterFrame, &frames.interpMethodContextFrame, threadContext);
 
     frames.interpreterFrame.Pop();
-    UNINSTALL_RESUME_AFTER_CATCH_HANDLER;
 }
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1994,6 +1994,7 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
 #ifdef FEATURE_INTERPRETER
 extern "C" void STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBlock, TADDR byteCodeAddr)
 {
+    INSTALL_RESUME_AFTER_CATCH_HANDLER;
     // Argument registers are in the TransitionBlock
     // The stack arguments are right after the pTransitionBlock
     Thread *pThread = GetThread();
@@ -2025,6 +2026,7 @@ extern "C" void STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBlo
     InterpExecMethod(&frames.interpreterFrame, &frames.interpMethodContextFrame, threadContext);
 
     frames.interpreterFrame.Pop();
+    UNINSTALL_RESUME_AFTER_CATCH_HANDLER;
 }
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/riscv64/cgencpu.h
+++ b/src/coreclr/vm/riscv64/cgencpu.h
@@ -237,6 +237,29 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return (TADDR)(context->Fp);
 }
 
+inline void SetFirstArgReg(T_CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    context->A0 = DWORD64(value);
+}
+
+inline TADDR GetFirstArgReg(T_CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return (TADDR)(context->A0);
+}
+
+inline void SetSecondArgReg(T_CONTEXT *context, TADDR value)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    context->A1 = DWORD64(value);
+}
+
+inline TADDR GetSecondArgReg(T_CONTEXT *context)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    return (TADDR)(context->A1);
+}
 
 inline TADDR GetMem(PCODE address, SIZE_T size, bool signExtend)
 {

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2892,6 +2892,7 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                     SetSP(pRD->pCurrentContext, m_interpExecMethodSP);
                     SetFP(pRD->pCurrentContext, m_interpExecMethodFP);
                     SetFirstArgReg(pRD->pCurrentContext, m_interpExecMethodFirstArgReg);
+                    SyncRegDisplayToCurrentContext(pRD);
                 }
             }
         }

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2863,12 +2863,21 @@ void StackFrameIterator::ProcessCurrentFrame(void)
         {
             if (m_crawl.pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
             {
+                PREGDISPLAY pRD = m_crawl.GetRegisterSet();
+
                 if (!m_walkingInterpreterFrames)
                 {
                     // We have hit the InterpreterFrame while we were not processing the interpreter frames.
                     // Switch to walking the underlying interpreted frames.
-                    PREGDISPLAY pRD = m_crawl.GetRegisterSet();
+                    // Save the registers the interpreter frames walking reuses so that we can restore them
+                    // after we are done with the interpreter frames.
+                    m_interpExecMethodIP = (TADDR)GetIP(pRD->pCurrentContext);
+                    m_interpExecMethodSP = (TADDR)GetSP(pRD->pCurrentContext);
+                    m_interpExecMethodFP = (TADDR)GetFP(pRD->pCurrentContext);
+                    m_interpExecMethodFirstArgReg = (TADDR)GetFirstArgReg(pRD->pCurrentContext);
+
                     ((PTR_InterpreterFrame)m_crawl.pFrame)->SetContextToInterpMethodContextFrame(pRD->pCurrentContext);
+
                     pRD->pCurrentContext->ContextFlags = CONTEXT_FULL;
                     SyncRegDisplayToCurrentContext(pRD);
                     ProcessIp(GetControlPC(pRD));
@@ -2878,6 +2887,11 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                 {
                     // We have finished walking the interpreted frames. Process the InterpreterFrame itself.
                     m_walkingInterpreterFrames = false;
+                    // Restore the registers to the values they had before we started walking the interpreter frames.
+                    SetIP(pRD->pCurrentContext, m_interpExecMethodIP);
+                    SetSP(pRD->pCurrentContext, m_interpExecMethodSP);
+                    SetFP(pRD->pCurrentContext, m_interpExecMethodFP);
+                    SetFirstArgReg(pRD->pCurrentContext, m_interpExecMethodFirstArgReg);
                 }
             }
         }

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2867,12 +2867,9 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                 {
                     // We have hit the InterpreterFrame while we were not processing the interpreter frames.
                     // Switch to walking the underlying interpreted frames.
-                    PTR_InterpMethodContextFrame pTOSInterpMethodContextFrame = ((PTR_InterpreterFrame)m_crawl.pFrame)->GetTopInterpMethodContextFrame();
                     PREGDISPLAY pRD = m_crawl.GetRegisterSet();
-                    SetIP(pRD->pCurrentContext, (TADDR)pTOSInterpMethodContextFrame->ip);
-                    SetSP(pRD->pCurrentContext, dac_cast<TADDR>(pTOSInterpMethodContextFrame));
-                    SetFP(pRD->pCurrentContext, (TADDR)pTOSInterpMethodContextFrame->pStack);
-                    pRD->pCurrentContext->ContextFlags = CONTEXT_CONTROL;
+                    ((PTR_InterpreterFrame)m_crawl.pFrame)->SetContextToInterpMethodContextFrame(pRD->pCurrentContext);
+                    pRD->pCurrentContext->ContextFlags = CONTEXT_FULL;
                     SyncRegDisplayToCurrentContext(pRD);
                     ProcessIp(GetControlPC(pRD));
                     m_walkingInterpreterFrames = m_crawl.isFrameless;

--- a/src/coreclr/vm/stackwalk.h
+++ b/src/coreclr/vm/stackwalk.h
@@ -770,6 +770,13 @@ private:
     bool          m_fFoundFirstFunclet;
 #ifdef FEATURE_INTERPRETER
     bool          m_walkingInterpreterFrames;
+    // Saved registers of the context of the InterpExecMethod. These registers are reused for interpreter frames,
+    // but we need to restore the original values after we are done with all the interpreted frames belonging to
+    // that InterpExecMethod.
+    TADDR         m_interpExecMethodIP;
+    TADDR         m_interpExecMethodSP;
+    TADDR         m_interpExecMethodFP;
+    TADDR         m_interpExecMethodFirstArgReg;
 #endif // FEATURE_INTERPRETER
 
 #if defined(RECORD_RESUMABLE_FRAME_SP)

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1330,7 +1330,7 @@ Thread::Thread()
     CONTRACTL_END;
 
     m_pFrame                = FRAME_TOP;
-    m_pGCFrame              = NULL;
+    m_pGCFrame              = GCFRAME_TOP;
 
     m_fPreemptiveGCDisabled = 0;
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1218,7 +1218,7 @@ public:
         {
             void* curSP;
             curSP = (void *)GetCurrentSP();
-            _ASSERTE((m_pGCFrame == NULL) || (curSP <= m_pGCFrame && m_pGCFrame < m_CacheStackBase));
+            _ASSERTE((m_pGCFrame == (GCFrame*)-1) || (curSP <= m_pGCFrame && m_pGCFrame < m_CacheStackBase));
         }
 #endif
 


### PR DESCRIPTION
This change adds support for exception handling for cases when interpreter frames either throw an exception or the exception is propagated through them. It doesn't add all the exception handling support to the interpreter itself, there is a follow up PR that contains that code.

I had to reorder the code around handling thread abort when resuming after catch for the case when the resume occurs in the interpreted code. The resuming goes to the native context of the `InterpExecMethod` in that case, so we need to update the current context in the `REGDISPLAY` to point there before we extract the `dwResumePC`. The `InterpreterFrame` stores copies of the registers that we reuse for interpreted frames stack walking and restores them before resuming there and at the same time stores the interpreter PC and SP for the resuming is stored in the `InterpreterFrame`

