### PR TITLE
Remove exclusion of WindowsRuntime attribute instantation

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1642,13 +1642,6 @@ namespace System.Reflection
             if (!AttributeUsageCheck(attributeType, mustBeInheritable, ref derivedAttributes))
                 return false;
 
-            // Windows Runtime attributes aren't real types - they exist to be read as metadata only, and as such
-            // should be filtered out of the GetCustomAttributes path.
-            if ((attributeType.Attributes & TypeAttributes.WindowsRuntime) == TypeAttributes.WindowsRuntime)
-            {
-                return false;
-            }
-
             // Resolve the attribute ctor
             ConstArray ctorSig = scope.GetMethodSignature(caCtorToken);
             isVarArg = (ctorSig[0] & 0x05) != 0;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeSearcher.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeSearcher.cs
@@ -108,18 +108,8 @@ namespace Internal.Reflection.Extensions.NonPortable
         //
         // Main iterator.
         //
-        private IEnumerable<CustomAttributeData> GetMatchingCustomAttributesIterator(E element, Func<Type, bool> rawPassesFilter, bool inherit)
+        private IEnumerable<CustomAttributeData> GetMatchingCustomAttributesIterator(E element, Func<Type, bool> passesFilter, bool inherit)
         {
-            Func<Type, bool> passesFilter =
-                delegate (Type attributeType)
-                {
-                    // Windows prohibits instantiating WinRT custom attributes. Filter them from the search as the desktop CLR does.
-                    TypeAttributes typeAttributes = attributeType.Attributes;
-                    if (0 != (typeAttributes & TypeAttributes.WindowsRuntime))
-                        return false;
-                    return rawPassesFilter(attributeType);
-                };
-
             LowLevelList<CustomAttributeData> immediateResults = new LowLevelList<CustomAttributeData>();
             foreach (CustomAttributeData cad in GetDeclaredCustomAttributes(element))
             {


### PR DESCRIPTION
WindowsRuntime types aren't supported since .NET 5 (all interop for those scenarios is provided by CsWinRT).