### PR TITLE
Avoid some redundant casts in DefaultInterpolatedStringHandler.AppendFormatted

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -255,7 +255,7 @@ namespace System.Runtime.CompilerServices
             // if it only implements IFormattable, we come out even: only if it implements both do we
             // end up paying for an extra interface check.
             string? s;
-            if (value is IFormattable)
+            if (value is IFormattable formattable)
             {
                 // If the value can format itself directly into our buffer, do so.
 
@@ -271,10 +271,10 @@ namespace System.Runtime.CompilerServices
                     return;
                 }
 
-                if (value is ISpanFormattable)
+                if (value is ISpanFormattable spanFormattable)
                 {
                     int charsWritten;
-                    while (!((ISpanFormattable)value).TryFormat(_chars.Slice(_pos), out charsWritten, default, _provider)) // constrained call avoiding boxing for value types
+                    while (!spanFormattable.TryFormat(_chars.Slice(_pos), out charsWritten, default, _provider)) // constrained call avoiding boxing for value types
                     {
                         Grow();
                     }
@@ -283,7 +283,7 @@ namespace System.Runtime.CompilerServices
                     return;
                 }
 
-                s = ((IFormattable)value).ToString(format: null, _provider); // constrained call avoiding boxing for value types
+                s = formattable.ToString(format: null, _provider); // constrained call avoiding boxing for value types
             }
             else
             {
@@ -317,7 +317,7 @@ namespace System.Runtime.CompilerServices
             // if it only implements IFormattable, we come out even: only if it implements both do we
             // end up paying for an extra interface check.
             string? s;
-            if (value is IFormattable)
+            if (value is IFormattable formattable)
             {
                 // If the value can format itself directly into our buffer, do so.
 
@@ -333,10 +333,10 @@ namespace System.Runtime.CompilerServices
                     return;
                 }
 
-                if (value is ISpanFormattable)
+                if (value is ISpanFormattable spanFormattable)
                 {
                     int charsWritten;
-                    while (!((ISpanFormattable)value).TryFormat(_chars.Slice(_pos), out charsWritten, format, _provider)) // constrained call avoiding boxing for value types
+                    while (!spanFormattable.TryFormat(_chars.Slice(_pos), out charsWritten, format, _provider)) // constrained call avoiding boxing for value types
                     {
                         Grow();
                     }
@@ -345,7 +345,7 @@ namespace System.Runtime.CompilerServices
                     return;
                 }
 
-                s = ((IFormattable)value).ToString(format, _provider); // constrained call avoiding boxing for value types
+                s = formattable.ToString(format, _provider); // constrained call avoiding boxing for value types
             }
             else
             {


### PR DESCRIPTION
it is possible i am missing some edge case about how the compiler treats casts

so if this is worse for perf. i would love to know why :)