### PR TITLE
[wasm][interp] Jiterp packedsimd shifts

### DIFF
--- a/src/libraries/System.Runtime.Intrinsics/tests/Wasm/PackedSimdTests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Wasm/PackedSimdTests.cs
@@ -589,5 +589,27 @@ namespace System.Runtime.Intrinsics.Wasm.Tests
 
             Assert.Equal(Vector128.Create((ushort)65535, (ushort)65535, (ushort)0, (ushort)0, (ushort)100, (ushort)200, (ushort)300, (ushort)400), result);
         }
+
+        [Fact]
+        public unsafe void BitmaskTest()
+        {
+            var v1 = Vector128.Create((byte)0b00000001, (byte)0b00000010, (byte)0b00000100, (byte)0b00001000,
+                                       (byte)0b00010000, (byte)0b00100000, (byte)0b01000000, (byte)0b10000000,
+                                       (byte)0b00000001, (byte)0b00000010, (byte)0b00000100, (byte)0b00001000,
+                                    (byte)0b00010000, (byte)0b10100000, (byte)0b01000000, (byte)0b10000000);
+
+            var v2 = Vector128.Create((ushort)0b1100001001100001, (ushort)0b0000000000000010, (ushort)0b0000000000000100, (ushort)0b0000000000001000,
+                                       (ushort)0b0000000000010000, (ushort)0b0000000000100000, (ushort)0b0000000001000000, (ushort)0b0000000010000000);
+
+            var v3 = Vector128.Create(0b10000000000000000000000000000001, 0b00000000000111111000000000000010,
+                                   0b00000000000000000000000000000100, 0b10000000000000000000000000001000);
+
+            var bitmask1 = PackedSimd.Bitmask(v1);
+            var bitmask2 = PackedSimd.Bitmask(v2);
+            var bitmask3 = PackedSimd.Bitmask(v3);
+            Assert.Equal(0b1010000010000000, bitmask1);
+            Assert.Equal(0b1, bitmask2);
+            Assert.Equal(0b1001, bitmask3);
+        }
     }
 }

--- a/src/mono/browser/runtime/jiterpreter-tables.ts
+++ b/src/mono/browser/runtime/jiterpreter-tables.ts
@@ -443,6 +443,11 @@ export const bitmaskTable: { [intrinsic: number]: WasmSimdOpcode } = {
     [SimdIntrinsic2.V128_I2_EXTRACT_MSB]: WasmSimdOpcode.i16x8_bitmask,
     [SimdIntrinsic2.V128_I4_EXTRACT_MSB]: WasmSimdOpcode.i32x4_bitmask,
     [SimdIntrinsic2.V128_I8_EXTRACT_MSB]: WasmSimdOpcode.i64x2_bitmask,
+
+    [SimdIntrinsic2.BitmaskD1]: WasmSimdOpcode.i8x16_bitmask,
+    [SimdIntrinsic2.BitmaskD2]: WasmSimdOpcode.i16x8_bitmask,
+    [SimdIntrinsic2.BitmaskD4]: WasmSimdOpcode.i32x4_bitmask,
+    [SimdIntrinsic2.BitmaskD8]: WasmSimdOpcode.i64x2_bitmask,
 };
 
 export const createScalarTable: { [intrinsic: number]: [WasmOpcode, WasmSimdOpcode] } = {

--- a/src/mono/browser/runtime/jiterpreter-tables.ts
+++ b/src/mono/browser/runtime/jiterpreter-tables.ts
@@ -378,6 +378,21 @@ export const simdShiftTable = new Set<SimdIntrinsic3>([
     SimdIntrinsic3.V128_I2_URIGHT_SHIFT,
     SimdIntrinsic3.V128_I4_URIGHT_SHIFT,
     SimdIntrinsic3.V128_I8_URIGHT_SHIFT,
+
+    SimdIntrinsic3.ShiftLeftD1,
+    SimdIntrinsic3.ShiftLeftD2,
+    SimdIntrinsic3.ShiftLeftD4,
+    SimdIntrinsic3.ShiftLeftD8,
+
+    SimdIntrinsic3.ShiftRightArithmeticD1,
+    SimdIntrinsic3.ShiftRightArithmeticD2,
+    SimdIntrinsic3.ShiftRightArithmeticD4,
+    SimdIntrinsic3.ShiftRightArithmeticD8,
+
+    SimdIntrinsic3.ShiftRightLogicalD1,
+    SimdIntrinsic3.ShiftRightLogicalD2,
+    SimdIntrinsic3.ShiftRightLogicalD4,
+    SimdIntrinsic3.ShiftRightLogicalD8,
 ]);
 
 export const simdExtractTable: { [intrinsic: number]: [laneCount: number, laneStoreOpcode: WasmOpcode] } = {

--- a/src/mono/browser/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/browser/runtime/jiterpreter-trace-generator.ts
@@ -3697,7 +3697,7 @@ function emit_simd_2 (builder: WasmBuilder, ip: MintOpcodePtr, index: SimdIntrin
         return true;
     }
 
-    if (simple >= 0 && !bitmask) {
+    if (simple >= 0) {
         if (simdLoadTable.has(index)) {
             // Indirect load, so v1 is T** and res is Vector128*
             builder.local("pLocals");

--- a/src/mono/browser/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/browser/runtime/jiterpreter-trace-generator.ts
@@ -3688,7 +3688,16 @@ function append_simd_4_load (builder: WasmBuilder, ip: MintOpcodePtr) {
 
 function emit_simd_2 (builder: WasmBuilder, ip: MintOpcodePtr, index: SimdIntrinsic2): boolean {
     const simple = <WasmSimdOpcode>cwraps.mono_jiterp_get_simd_opcode(1, index);
-    if (simple >= 0) {
+    const bitmask = bitmaskTable[index];
+
+    if (bitmask) {
+        append_simd_2_load(builder, ip);
+        builder.appendSimd(bitmask);
+        append_stloc_tail(builder, getArgU16(ip, 1), WasmOpcode.i32_store);
+        return true;
+    }
+
+    if (simple >= 0 && !bitmask) {
         if (simdLoadTable.has(index)) {
             // Indirect load, so v1 is T** and res is Vector128*
             builder.local("pLocals");
@@ -3701,14 +3710,6 @@ function emit_simd_2 (builder: WasmBuilder, ip: MintOpcodePtr, index: SimdIntrin
             builder.appendSimd(simple);
             append_simd_store(builder, ip);
         }
-        return true;
-    }
-
-    const bitmask = bitmaskTable[index];
-    if (bitmask) {
-        append_simd_2_load(builder, ip);
-        builder.appendSimd(bitmask);
-        append_stloc_tail(builder, getArgU16(ip, 1), WasmOpcode.i32_store);
         return true;
     }
 

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -179,7 +179,6 @@ static guint16 packedsimd_alias_methods [] = {
 	SN_WidenUpper,
 	SN_Xor,
 // operators
-#if 0
 	SN_op_Addition,
 	SN_op_BitwiseAnd,
 	SN_op_BitwiseOr,
@@ -192,7 +191,6 @@ static guint16 packedsimd_alias_methods [] = {
 	SN_op_Subtraction,
 	SN_op_UnaryNegation,
 	SN_op_UnsignedRightShift,
-#endif
 };
 
 static MonoTypeEnum 
@@ -691,6 +689,7 @@ emit_sri_vector128 (TransformData *td, MonoMethod *cmethod, MonoMethodSignature 
 			else if (atype == MONO_TYPE_U1) simd_intrins = INTERP_SIMD_INTRINSIC_V128_I1_URIGHT_SHIFT;
 			else if (atype == MONO_TYPE_U2) simd_intrins = INTERP_SIMD_INTRINSIC_V128_I2_URIGHT_SHIFT;
 			else if (atype == MONO_TYPE_U4) simd_intrins = INTERP_SIMD_INTRINSIC_V128_I4_URIGHT_SHIFT;
+			else if (atype == MONO_TYPE_U8) simd_intrins = INTERP_SIMD_INTRINSIC_V128_I8_URIGHT_SHIFT;
 			break;
 		case SN_Shuffle:
 			simd_opcode = MINT_SIMD_INTRINS_P_PP;

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -1234,6 +1234,7 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 				break;
 			case SN_ConvertToInt32:
 				cmethod_name = "ConvertToInt32Saturate";
+				break;
 			case SN_ShiftLeft:
 			case SN_ShiftRightLogical:
 			case SN_ShiftRightArithmetic:

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -156,6 +156,7 @@ static guint16 packedsimd_alias_methods [] = {
 	SN_ConvertToSingle,
 	SN_Divide,
 	SN_Equals,
+	SN_ExtractMostSignificantBits,
 	SN_Floor,
 	SN_GreaterThan,
 	SN_GreaterThanOrEqual,
@@ -1161,6 +1162,9 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 				break;
 			case SN_Equals:
 				cmethod_name = "CompareEqual";
+				break;
+			case SN_ExtractMostSignificantBits:
+				cmethod_name = "Bitmask";
 				break;
 			case SN_BitwiseAnd:
 			case SN_op_BitwiseAnd:

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -1180,6 +1180,8 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 				break;
 			case SN_Load:
 			case SN_LoadUnsafe:
+				if (csignature->param_count != 1)
+					return FALSE;
 				cmethod_name = "LoadVector128";
 				break;
 			case SN_Round:

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -364,6 +364,7 @@ emit_common_simd_operations (TransformData *td, int id, int atype, int vector_si
 			else if (atype == MONO_TYPE_U1) *simd_intrins = INTERP_SIMD_INTRINSIC_V128_I1_URIGHT_SHIFT;
 			else if (atype == MONO_TYPE_U2) *simd_intrins = INTERP_SIMD_INTRINSIC_V128_I2_URIGHT_SHIFT;
 			else if (atype == MONO_TYPE_U4) *simd_intrins = INTERP_SIMD_INTRINSIC_V128_I4_URIGHT_SHIFT;
+			else if (atype == MONO_TYPE_U8) *simd_intrins = INTERP_SIMD_INTRINSIC_V128_I8_URIGHT_SHIFT;
 			break;
 		case SN_op_Subtraction:
 			*simd_opcode = MINT_SIMD_INTRINS_P_PP;


### PR DESCRIPTION
Fill in some of the Jiterp tables with the PackedSimd intrinsics so that both aliased and direct PackedSimd calls in the interpreter also benefit from the Jiterpreter.  Also reenable the aliased opcodes now that they will share the jiterpreter optimizations.