### PR TITLE
[release/9.0-staging] [WinHTTP] Certificate caching on WinHttpHandler to eliminate extra call to Custom Certificate Validation

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
@@ -336,6 +336,16 @@ internal static partial class Interop
             public uint dwError;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct WINHTTP_CONNECTION_INFO
+        {
+            // This field is actually 4 bytes, but we use nuint to avoid alignment issues for x64.
+            // If we want to read this field in the future, we need to change type and make sure
+            // alignment is correct for necessary archs.
+            public nuint cbSize;
+            public fixed byte LocalAddress[128];
+            public fixed byte RemoteAddress[128];
+        }
 
         [StructLayout(LayoutKind.Sequential)]
         public struct tcp_keepalive

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -80,6 +80,7 @@ System.Net.Http.WinHttpHandler</PackageDescription>
              Link="Common\System\Runtime\ExceptionServices\ExceptionStackTrace.cs" />
     <Compile Include="$(CommonPath)\System\Threading\Tasks\RendezvousAwaitable.cs"
              Link="Common\System\Threading\Tasks\RendezvousAwaitable.cs" />
+    <Compile Include="System\Net\Http\CachedCertificateValue.cs" />
     <Compile Include="System\Net\Http\NetEventSource.WinHttpHandler.cs" />
     <Compile Include="System\Net\Http\NoWriteNoSeekStreamContent.cs" />
     <Compile Include="System\Net\Http\WinHttpAuthHelper.cs" />
@@ -117,6 +118,7 @@ System.Net.Http.WinHttpHandler</PackageDescription>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="$(MicrosoftBclHashCodeVersion)" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/CachedCertificateValue.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/CachedCertificateValue.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace System.Net.Http
+{
+    internal sealed class CachedCertificateValue(byte[] rawCertificateData, long lastUsedTime)
+    {
+        private long _lastUsedTime = lastUsedTime;
+        public byte[] RawCertificateData { get; } = rawCertificateData;
+        public long LastUsedTime
+        {
+            get => Volatile.Read(ref _lastUsedTime);
+            set => Volatile.Write(ref _lastUsedTime, value);
+        }
+    }
+
+    internal readonly struct CachedCertificateKey : IEquatable<CachedCertificateKey>
+    {
+        public CachedCertificateKey(IPAddress address, HttpRequestMessage message)
+        {
+            Debug.Assert(message.RequestUri != null);
+            Address = address;
+            Host = message.Headers.Host ?? message.RequestUri.Host;
+        }
+        public IPAddress Address { get; }
+        public string Host { get; }
+
+        public bool Equals(CachedCertificateKey other) =>
+            Address.Equals(other.Address) &&
+            Host == other.Host;
+
+        public override bool Equals(object? obj)
+        {
+            throw new Exception("Unreachable");
+        }
+
+        public override int GetHashCode() => HashCode.Combine(Address, Host);
+    }
+}

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -50,7 +50,7 @@ namespace System.Net.Http
         private static readonly StringWithQualityHeaderValue s_deflateHeaderValue = new StringWithQualityHeaderValue("deflate");
         private static readonly Lazy<bool> s_supportsTls13 = new Lazy<bool>(CheckTls13Support);
         private static readonly TimeSpan s_cleanCachedCertificateTimeout = TimeSpan.FromMilliseconds((int?)AppDomain.CurrentDomain.GetData("System.Net.Http.WinHttpCertificateCachingCleanupTimerInterval") ?? 60_000);
-        private static readonly long s_staleTimeout = (long)(s_cleanCachedCertificateTimeout.TotalSeconds * Stopwatch.Frequency / 1000);
+        private static readonly long s_staleTimeout = (long)(s_cleanCachedCertificateTimeout.TotalSeconds * Stopwatch.Frequency);
 
         [ThreadStatic]
         private static StringBuilder? t_requestHeadersBuilder;

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Net.Security;
@@ -41,11 +43,14 @@ namespace System.Net.Http
         internal static readonly Version HttpVersion20 = new Version(2, 0);
         internal static readonly Version HttpVersion30 = new Version(3, 0);
         internal static readonly Version HttpVersionUnknown = new Version(0, 0);
+        internal static bool CertificateCachingAppContextSwitchEnabled { get; } = AppContext.TryGetSwitch("System.Net.Http.UseWinHttpCertificateCaching", out bool enabled) && enabled;
         private static readonly TimeSpan s_maxTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
 
         private static readonly StringWithQualityHeaderValue s_gzipHeaderValue = new StringWithQualityHeaderValue("gzip");
         private static readonly StringWithQualityHeaderValue s_deflateHeaderValue = new StringWithQualityHeaderValue("deflate");
         private static readonly Lazy<bool> s_supportsTls13 = new Lazy<bool>(CheckTls13Support);
+        private static readonly TimeSpan s_cleanCachedCertificateTimeout = TimeSpan.FromMilliseconds((int?)AppDomain.CurrentDomain.GetData("System.Net.Http.WinHttpCertificateCachingCleanupTimerInterval") ?? 60_000);
+        private static readonly long s_staleTimeout = (long)(s_cleanCachedCertificateTimeout.TotalSeconds * Stopwatch.Frequency / 1000);
 
         [ThreadStatic]
         private static StringBuilder? t_requestHeadersBuilder;
@@ -93,9 +98,44 @@ namespace System.Net.Http
         private volatile bool _disposed;
         private SafeWinHttpHandle? _sessionHandle;
         private readonly WinHttpAuthHelper _authHelper = new WinHttpAuthHelper();
+        private readonly Timer? _certificateCleanupTimer;
+        private bool _isTimerRunning;
+        private readonly ConcurrentDictionary<CachedCertificateKey, CachedCertificateValue> _cachedCertificates = new();
 
         public WinHttpHandler()
         {
+            if (CertificateCachingAppContextSwitchEnabled)
+            {
+                WeakReference<WinHttpHandler> thisRef = new(this);
+                bool restoreFlow = false;
+                try
+                {
+                    if (!ExecutionContext.IsFlowSuppressed())
+                    {
+                        ExecutionContext.SuppressFlow();
+                        restoreFlow = true;
+                    }
+
+                    _certificateCleanupTimer = new Timer(
+                    static s =>
+                    {
+                        if (((WeakReference<WinHttpHandler>)s!).TryGetTarget(out WinHttpHandler? thisRef))
+                        {
+                            thisRef.ClearStaleCertificates();
+                        }
+                    },
+                    thisRef,
+                    Timeout.Infinite,
+                    Timeout.Infinite);
+                }
+                finally
+                {
+                    if (restoreFlow)
+                    {
+                        ExecutionContext.RestoreFlow();
+                    }
+                }
+            }
         }
 
         #region Properties
@@ -543,9 +583,12 @@ namespace System.Net.Http
             {
                 _disposed = true;
 
-                if (disposing && _sessionHandle != null)
+                if (disposing)
                 {
-                    SafeWinHttpHandle.DisposeAndClearHandle(ref _sessionHandle);
+                    if (_sessionHandle is not null) {
+                        SafeWinHttpHandle.DisposeAndClearHandle(ref _sessionHandle);
+                    }
+                    _certificateCleanupTimer?.Dispose();
                 }
             }
 
@@ -1644,7 +1687,8 @@ namespace System.Net.Http
                 Interop.WinHttp.WINHTTP_CALLBACK_FLAG_ALL_COMPLETIONS |
                 Interop.WinHttp.WINHTTP_CALLBACK_FLAG_HANDLES |
                 Interop.WinHttp.WINHTTP_CALLBACK_FLAG_REDIRECT |
-                Interop.WinHttp.WINHTTP_CALLBACK_FLAG_SEND_REQUEST;
+                Interop.WinHttp.WINHTTP_CALLBACK_FLAG_SEND_REQUEST |
+                Interop.WinHttp.WINHTTP_CALLBACK_STATUS_CONNECTED_TO_SERVER;
 
             IntPtr oldCallback = Interop.WinHttp.WinHttpSetStatusCallback(
                 requestHandle,
@@ -1729,6 +1773,91 @@ namespace System.Net.Http
             }
 
             return state.LifecycleAwaitable;
+        }
+
+        internal bool GetCertificateFromCache(CachedCertificateKey key, [NotNullWhen(true)] out byte[]? rawCertificateBytes)
+        {
+            if (_cachedCertificates.TryGetValue(key, out CachedCertificateValue? cachedValue))
+            {
+                cachedValue.LastUsedTime = Stopwatch.GetTimestamp();
+                rawCertificateBytes = cachedValue.RawCertificateData;
+                return true;
+            }
+
+            rawCertificateBytes = null;
+            return false;
+        }
+
+        internal void AddCertificateToCache(CachedCertificateKey key, byte[] rawCertificateData)
+        {
+            if (_cachedCertificates.TryAdd(key, new CachedCertificateValue(rawCertificateData, Stopwatch.GetTimestamp())))
+            {
+                EnsureCleanupTimerRunning();
+            }
+        }
+
+        internal bool TryRemoveCertificateFromCache(CachedCertificateKey key)
+        {
+            bool result = _cachedCertificates.TryRemove(key, out _);
+            if (result)
+            {
+                StopCleanupTimerIfEmpty();
+            }
+            return result;
+        }
+
+        private void ChangeCleanerTimer(TimeSpan timeout)
+        {
+            Debug.Assert(Monitor.IsEntered(_lockObject));
+            Debug.Assert(_certificateCleanupTimer != null);
+            if (_certificateCleanupTimer!.Change(timeout, Timeout.InfiniteTimeSpan))
+            {
+                _isTimerRunning = timeout != Timeout.InfiniteTimeSpan;
+            }
+        }
+
+        private void ClearStaleCertificates()
+        {
+            foreach (KeyValuePair<CachedCertificateKey, CachedCertificateValue> kvPair in _cachedCertificates)
+            {
+                if (IsStale(kvPair.Value.LastUsedTime))
+                {
+                    _cachedCertificates.TryRemove(kvPair.Key, out _);
+                }
+            }
+
+            lock (_lockObject)
+            {
+                ChangeCleanerTimer(_cachedCertificates.IsEmpty ? Timeout.InfiniteTimeSpan : s_cleanCachedCertificateTimeout);
+            }
+
+            static bool IsStale(long lastUsedTime)
+            {
+                long now = Stopwatch.GetTimestamp();
+                return (now - lastUsedTime) > s_staleTimeout;
+            }
+        }
+
+        private void EnsureCleanupTimerRunning()
+        {
+            lock (_lockObject)
+            {
+                if (!_cachedCertificates.IsEmpty && !_isTimerRunning)
+                {
+                    ChangeCleanerTimer(s_cleanCachedCertificateTimeout);
+                }
+            }
+        }
+
+        private void StopCleanupTimerIfEmpty()
+        {
+            lock (_lockObject)
+            {
+                if (_cachedCertificates.IsEmpty && _isTimerRunning)
+                {
+                    ChangeCleanerTimer(Timeout.InfiniteTimeSpan);
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -9,7 +9,7 @@ using System.Net.Test.Common;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -26,6 +26,8 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         private const string SlowServer = "http://httpbin.org/drip?numbytes=1&duration=1&delay=40&code=200";
 
         private readonly ITestOutputHelper _output;
+
+        public static IEnumerable<object[]> HttpVersions = [[HttpVersion.Version11, Configuration.Http.SecureRemoteEchoServer], [HttpVersion20.Value, Configuration.Http.Http2RemoteEchoServer]];
 
         public WinHttpHandlerTest(ITestOutputHelper output)
         {
@@ -44,6 +46,75 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 var responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                 _output.WriteLine(responseContent);
             }
+        }
+
+        [OuterLoop]
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [MemberData(nameof(HttpVersions))]
+        public async Task SendAsync_ServerCertificateValidationCallback_CalledOnce(Version version, Uri uri)
+        {
+            await RemoteExecutor.Invoke(async (version, uri) =>
+            {
+                AppContext.SetSwitch("System.Net.Http.UseWinHttpCertificateCaching", true);
+                int callbackCount = 0;
+                var handler = new WinHttpHandler()
+                {
+                    ServerCertificateValidationCallback = (_, _, _, _) =>
+                    {
+                        Interlocked.Increment(ref callbackCount);
+                        return true;
+                    }
+                };
+                using (var client = new HttpClient(handler))
+                {
+                    for (int i = 0; i < 5; i++)
+                    {
+                        var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri)
+                        {
+                            Version = Version.Parse(version)
+                        });
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        _ = await response.Content.ReadAsStringAsync();
+                    }
+                    Assert.Equal(1, callbackCount);
+                }
+            }, version.ToString(), uri.ToString()).DisposeAsync();
+        }
+
+        [OuterLoop]
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [MemberData(nameof(HttpVersions))]
+        public async Task SendAsync_ServerCertificateValidationCallbackCertificateTimerTriggered_CalledTwice(Version version, Uri uri)
+        {
+            await RemoteExecutor.Invoke(async (version, uri) =>
+            {
+                const int certificateCacheCleanupInterval = 10;
+                AppContext.SetSwitch("System.Net.Http.UseWinHttpCertificateCaching", true);
+                AppDomain.CurrentDomain.SetData("System.Net.Http.WinHttpCertificateCachingCleanupTimerInterval", certificateCacheCleanupInterval);
+                int callbackCount = 0;
+                var handler = new WinHttpHandler()
+                {
+                    ServerCertificateValidationCallback = (_, _, _, _) =>
+                    {
+                        Interlocked.Increment(ref callbackCount);
+                        return true;
+                    }
+                };
+                using (var client = new HttpClient(handler))
+                {
+                    for (int i = 0; i < 5; i++)
+                    {
+                        var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri)
+                        {
+                            Version = Version.Parse(version)
+                        });
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        _ = await response.Content.ReadAsStringAsync();
+                        await Task.Delay(TimeSpan.FromMilliseconds(certificateCacheCleanupInterval * 3));
+                    }
+                    Assert.True(callbackCount > 1);
+                }
+            }, version.ToString(), uri.ToString()).DisposeAsync();
         }
 
         [OuterLoop]

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -56,6 +56,8 @@
              Link="Common\System\Text\SimpleRegex.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\RendezvousAwaitable.cs"
              Link="Common\System\Threading\Tasks\RendezvousAwaitable.cs" />
+    <Compile Include="..\..\src\System\Net\Http\CachedCertificateValue.cs"
+             Link="ProductionCode\CachedCertificateValue.cs" />
     <Compile Include="..\..\src\System\Net\Http\NoWriteNoSeekStreamContent.cs"
              Link="ProductionCode\NoWriteNoSeekStreamContent.cs" />
     <Compile Include="..\..\src\System\Net\Http\WinHttpAuthHelper.cs"


### PR DESCRIPTION
Backport of #111791 to release/9.0-staging

## Customer Impact

Reported by customer (Identity team) - it was blocking their migration to WinHttpHandler and gRPC on .NET Framework (as first step of migration to .NET).
They reported slow performance due to creation of certificate chain in `CertificateValidationCallback` on each request.
This change caches certificate chain per connection as an opt-in feature (the default path is not affected).
They observed perf improvements on privates from %17.2 CPU to %0.61.

## Regression

No - it was behaving this way since WinHttpHandler OOB package was introduced during .NET Core 1.0 shipping in 2016.

## Testing

CI + Manual testing
Customer validated private bits against 9.0 servicing branch.

## Risk

Low: This is under a feature switch (opt-in), it will not affect customers unless they enable the switch and opt-in into the feature.