### PR TITLE
[cDAC] Handle non-mapped images correctly

### DIFF
--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
@@ -18,25 +18,21 @@ internal sealed class EcmaMetadata_1(Target target) : IEcmaMetadata
     public TargetSpan GetReadOnlyMetadataAddress(ModuleHandle handle)
     {
         ILoader loader = target.Contracts.Loader;
-        Data.Module module = target.ProcessedData.GetOrAdd<Data.Module>(handle.Address);
 
-        if (!loader.TryGetLoadedImageContents(handle, out _, out _, out uint imageFlags))
+        if (!loader.TryGetLoadedImageContents(handle, out TargetPointer baseAddress, out uint size, out uint imageFlags))
         {
             throw new InvalidOperationException("Module is not loaded.");
         }
         bool isMapped = (imageFlags & 0x1) != 0; // FLAG_MAPPED = 0x1
         PEStreamOptions isLoaded = isMapped ? PEStreamOptions.IsLoadedImage : PEStreamOptions.Default;
 
-        // Stream is backed by Target's read and doesn't have a definable size limit.
-        // For this use case we can use int.MaxValue to allow PEReader to read as much as it wants.
-        // As long as PEStreamOptions.PrefetchEntireImage is not set, PEReader will not read the entire stream.
-        TargetStream stream = new(target, module.Base, int.MaxValue);
+        TargetStream stream = new(target, baseAddress, size);
         using PEReader peReader = new PEReader(stream, PEStreamOptions.PrefetchMetadata | isLoaded);
 
         int metadataStartOffset = peReader.PEHeaders.MetadataStartOffset;
         int metadataSize = peReader.PEHeaders.MetadataSize;
 
-        return new TargetSpan(module.Base + (ulong)metadataStartOffset, (ulong)metadataSize);
+        return new TargetSpan(baseAddress + (ulong)metadataStartOffset, (ulong)metadataSize);
     }
 
     public MetadataReader? GetMetadata(ModuleHandle handle)

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
@@ -16,9 +16,16 @@ internal sealed class EcmaMetadata_1(Target target) : IEcmaMetadata
 
     public TargetSpan GetReadOnlyMetadataAddress(ModuleHandle handle)
     {
+        ILoader loader = target.Contracts.Loader;
         Data.Module module = target.ProcessedData.GetOrAdd<Data.Module>(handle.Address);
 
-        TargetPointer baseAddress = module.GetLoadedMetadata(out ulong size);
+        if (!loader.TryGetLoadedImageContents(handle, out _, out _, out uint imageFlags))
+        {
+            throw new InvalidOperationException("Module is not loaded.");
+        }
+
+        bool isMapped = (imageFlags & 0x1) != 0; // FLAG_MAPPED = 0x1
+        TargetPointer baseAddress = module.GetLoadedMetadata(isMapped, out ulong size);
 
         return new TargetSpan(baseAddress, size);
     }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
@@ -31,7 +31,7 @@ internal sealed class EcmaMetadata_1(Target target) : IEcmaMetadata
         // For this use case we can use int.MaxValue to allow PEReader to read as much as it wants.
         // As long as PEStreamOptions.PrefetchEntireImage is not set, PEReader will not read the entire stream.
         TargetStream stream = new(target, module.Base, int.MaxValue);
-        PEReader peReader = new PEReader(stream, PEStreamOptions.PrefetchMetadata | isLoaded);
+        using PEReader peReader = new PEReader(stream, PEStreamOptions.PrefetchMetadata | isLoaded);
 
         int metadataStartOffset = peReader.PEHeaders.MetadataStartOffset;
         int metadataSize = peReader.PEHeaders.MetadataSize;

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Module.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Module.cs
@@ -58,27 +58,58 @@ internal sealed class Module : IData<Module>
 
     private TargetPointer _metadataStart = TargetPointer.Null;
     private ulong _metadataSize;
-    public TargetPointer GetLoadedMetadata(out ulong size)
+    public TargetPointer GetLoadedMetadata(bool isMapped, out ulong size)
     {
         if (Base != TargetPointer.Null && _metadataStart == TargetPointer.Null && _metadataSize == 0)
         {
             int peSignatureOffset = _target.Read<int>(Base + PEFormat.DosStub.PESignatureOffset);
             ulong headerOffset = Base + (ulong)peSignatureOffset;
             ushort magic = _target.Read<ushort>(headerOffset + PEFormat.PEHeader.MagicOffset);
-            ulong clrHeaderOffset = magic == (ushort)PEMagic.PE32
-                ? PEFormat.PEHeader.CLRRuntimeHeader32Offset
-                : PEFormat.PEHeader.CLRRuntimeHeader32PlusOffset;
+            bool is64Bit = magic == (ushort)PEMagic.PE32Plus;
+            ulong clrHeaderOffset = is64Bit
+                ? PEFormat.PEHeader.CLRRuntimeHeader32PlusOffset
+                : PEFormat.PEHeader.CLRRuntimeHeader32Offset;
             int corHeaderRva = _target.Read<int>(headerOffset + clrHeaderOffset);
+            ulong corHeaderOffset = isMapped ? (ulong)corHeaderRva : RVAToOffset((ulong)corHeaderRva, headerOffset, is64Bit);
 
             // Read RVA and size of the metadata
-            ulong metadataDirectoryAddress = Base + (ulong)corHeaderRva + PEFormat.CorHeader.MetadataOffset;
-            _metadataStart = Base + (ulong)_target.Read<int>(metadataDirectoryAddress);
+            ulong metadataDirectoryAddress = Base + corHeaderOffset + PEFormat.CorHeader.MetadataOffset;
+            ulong metadataRVA = (ulong)_target.Read<int>(metadataDirectoryAddress);
+            ulong offset = isMapped ? metadataRVA : RVAToOffset(metadataRVA, headerOffset, is64Bit);
+            _metadataStart = Base + offset;
             _metadataSize = (ulong)_target.Read<int>(metadataDirectoryAddress + sizeof(int));
         }
 
         size = _metadataSize;
         return _metadataStart;
     }
+
+    private ulong RVAToOffset(ulong rva, ulong headerOffset, bool is64Bit)
+    {
+        uint numberOfSections = _target.Read<uint>(headerOffset + PEFormat.CoffHeader.NumberOSectionsOffset);
+        uint sectionAlignment = _target.Read<uint>(headerOffset + PEFormat.PEHeader.SectionAlignmentOffset);
+        ulong sectionsStartOffset = headerOffset + (is64Bit ? PEFormat.PEHeader.SectionHeader32PlusOffset : PEFormat.PEHeader.SectionHeader32Offset);
+        for (uint i = 0; i < numberOfSections; i++)
+        {
+            ulong sectionHeaderOffset = sectionsStartOffset + (i * PEFormat.SectionHeader.Size);
+            PEFormat.SectionHeader sectionHeader = new(_target, sectionHeaderOffset);
+            if (rva < sectionHeader.VirtualAddress + AlignUp(sectionHeader.VirtualSize, sectionAlignment))
+            {
+                if (rva < sectionHeader.VirtualAddress)
+                {
+                    return 0;
+                }
+                else
+                {
+                    return rva - sectionHeader.VirtualAddress + sectionHeader.PointerToRawData;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    private static ulong AlignUp(ulong value, ulong alignment) => (value + alignment - 1) & ~(alignment - 1);
 
     // https://learn.microsoft.com/windows/win32/debug/pe-format
     private static class PEFormat
@@ -91,12 +122,28 @@ internal sealed class Module : IData<Module>
             public const int PESignatureOffset = 0x3c;
         }
 
+        public static class CoffHeader
+        {
+            public const ulong NumberOSectionsOffset = PESignatureSize + 2;
+        }
+
         public static class PEHeader
         {
             private const ulong OptionalHeaderOffset = PESignatureSize + CoffHeaderSize;
             public const ulong MagicOffset = OptionalHeaderOffset;
+            public const ulong SectionAlignmentOffset = OptionalHeaderOffset + 32;
             public const ulong CLRRuntimeHeader32Offset = OptionalHeaderOffset + 208;
             public const ulong CLRRuntimeHeader32PlusOffset = OptionalHeaderOffset + 224;
+            public const ulong SectionHeader32Offset = OptionalHeaderOffset + 224;
+            public const ulong SectionHeader32PlusOffset = OptionalHeaderOffset + 240;
+        }
+
+        public class SectionHeader(Target target, TargetPointer address)
+        {
+            public const int Size = 40;
+            public uint VirtualSize { get; init; } = target.Read<uint>(address + 8);
+            public uint VirtualAddress { get; init; } = target.Read<uint>(address + 12);
+            public uint PointerToRawData { get; init; } = target.Read<uint>(address + 20);
         }
 
         // See ECMA-335 II.25.3.3 CLI Header

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/TargetStream.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/TargetStream.cs
@@ -52,7 +52,7 @@ internal class TargetStream(Target target, ulong startPosition, long size) : Str
         return _offset;
     }
 
-    public override void Flush() => throw new NotImplementedException();
-    public override void SetLength(long value) => throw new NotImplementedException();
-    public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+    public override void Flush() { } // No-op for read-only stream
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 }

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/TargetStream.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/TargetStream.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Diagnostics.DataContractReader;
+
+internal class TargetStream(Target target, ulong startPosition, long size) : Stream
+{
+    private readonly ulong _startPosition = startPosition;
+    private long _offset;
+    private readonly long _size = size;
+    private readonly Target _target = target;
+
+    private ulong GlobalPosition => _startPosition + (ulong)_offset;
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => true;
+
+    public override bool CanWrite => false;
+
+    public override long Length => _size;
+
+    public override long Position { get => _offset; set => _offset = value; }
+
+    public override unsafe int Read(byte[] buffer, int offset, int count)
+    {
+        Span<byte> span = buffer;
+        return Read(span.Slice(start: offset, length: count));
+    }
+    public override unsafe int Read(Span<byte> buffer)
+    {
+        _target.ReadBuffer(GlobalPosition, buffer);
+        _offset += buffer.Length;
+        return buffer.Length;
+    }
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        switch (origin)
+        {
+            case SeekOrigin.Begin:
+                _offset = offset;
+                break;
+            case SeekOrigin.Current:
+                _offset += offset;
+                break;
+            case SeekOrigin.End:
+                throw new NotSupportedException();
+        }
+        return _offset;
+    }
+
+    public override void Flush() => throw new NotImplementedException();
+    public override void SetLength(long value) => throw new NotImplementedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+}

--- a/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/TargetStream.cs
+++ b/src/native/managed/cdacreader/Microsoft.Diagnostics.DataContractReader.Contracts/TargetStream.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace Microsoft.Diagnostics.DataContractReader;
 
-internal class TargetStream(Target target, ulong startPosition, long size) : Stream
+internal sealed class TargetStream(Target target, ulong startPosition, long size) : Stream
 {
     private readonly ulong _startPosition = startPosition;
     private long _offset;

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -886,9 +886,20 @@ internal sealed unsafe partial class SOSDacImpl
             data->dwTransientFlags = (uint)flags;
 
             data->ilBase = contract.GetILBase(handle);
-            TargetSpan readOnlyMetadata = _target.Contracts.EcmaMetadata.GetReadOnlyMetadataAddress(handle);
-            data->metadataStart = readOnlyMetadata.Address;
-            data->metadataSize = readOnlyMetadata.Size;
+
+            try
+            {
+                TargetSpan readOnlyMetadata = _target.Contracts.EcmaMetadata.GetReadOnlyMetadataAddress(handle);
+                data->metadataStart = readOnlyMetadata.Address;
+                data->metadataSize = readOnlyMetadata.Size;
+            }
+            catch (System.Exception)
+            {
+                // if we are unable to read the metadata, to match the DAC behavior
+                // set metadataStart and metadataSize to 0
+                data->metadataStart = 0;
+                data->metadataSize = 0;
+            }
 
             data->LoaderAllocator = contract.GetLoaderAllocator(handle);
 


### PR DESCRIPTION
Fixes issue where cDAC could not load flat images correctly. Instead of using the RVA to find the correct section and offset, it would previously return the RVA of an unloaded image.

I went through an iteration where I parsed the RVAs manually depending on if the image was loaded, however I felt this was a lot of logic to have in the `Module : IData<Module>` class. The newest revision utilizes the libraries `PEReader` to fetch the module's metadata. In my view, the only issue with this current approach is some messiness around wrapping the Target in a Stream. The `size` doesn't really make sense for this use case.
See alternative fix: #114742

Tested on both loaded and unloaded images using `!clrma`