### PR TITLE
Produce the productVersion.txt files in runtime in the "final publish" step so we don't need to munge them through the different runtime jobs

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -86,6 +86,9 @@
     <ShouldGenerateProductVersionFiles Condition="'$(OutputRID)' == 'win-x64' and ('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1')">true</ShouldGenerateProductVersionFiles>
     <ShouldGenerateProductVersionFiles Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</ShouldGenerateProductVersionFiles>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(DotNetBuildOrchestrator)' != 'true'">
+    <ShouldGenerateProductVersionFiles Condition="'$(DotNetFinalPublish)' == 'true'">true</ShouldGenerateProductVersionFiles>
+  </PropertyGroup>
 
   <Target Name="GenerateProductVersionFiles"
           DependsOnTargets="GetNonStableProductVersion"

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -473,7 +473,7 @@ extends:
                 targetFolder: $(Build.SourcesDirectory)/artifacts/workloadPackages
                 flattenFolders: true
 
-            buildArgs: -s mono.workloads -c $(_BuildConfig) -restore -build -publish /p:PackageSource=$(Build.SourcesDirectory)/artifacts/workloadPackages /p:WorkloadOutputPath=$(Build.SourcesDirectory)/artifacts/workloads /p:ShouldGenerateProductVersionFiles=true /p:EnableDefaultRidSpecificArtifacts=false
+            buildArgs: -s mono.workloads -c $(_BuildConfig) -restore -build -publish /p:PackageSource=$(Build.SourcesDirectory)/artifacts/workloadPackages /p:WorkloadOutputPath=$(Build.SourcesDirectory)/artifacts/workloads /p:EnableDefaultRidSpecificArtifacts=false
 
             isOfficialBuild: true
             timeoutInMinutes: 120


### PR DESCRIPTION
Contributes to fixing failures mentioned in https://github.com/dotnet/install-scripts/issues/586#issuecomment-2801730973