### PR TITLE
ML-KEM: Change public API surface from API review

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemContractTests.cs
@@ -148,130 +148,6 @@ namespace System.Security.Cryptography.Tests
 
         [Theory]
         [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Encapsulate_Written_DistinctBufferSameLength_Works(MLKemAlgorithm algorithm)
-        {
-            byte[] ciphertextBuffer = new byte[algorithm.CiphertextSizeInBytes];
-            byte[] sharedSecretBuffer = new byte[algorithm.SharedSecretSizeInBytes];
-            using MLKemContract kem = new(algorithm)
-            {
-                OnEncapsulateCore = (Span<byte> ciphertext, Span<byte> sharedSecret) =>
-                {
-                    AssertSameBuffer(ciphertext, ciphertextBuffer);
-                    AssertSameBuffer(sharedSecret, sharedSecretBuffer);
-                }
-            };
-
-            kem.Encapsulate(
-                ciphertextBuffer,
-                sharedSecretBuffer,
-                out int ciphertextBytesWritten,
-                out int sharedSecretBytesWritten);
-
-            Assert.Equal(algorithm.CiphertextSizeInBytes, ciphertextBytesWritten);
-            Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecretBytesWritten);
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Encapsulate_Written_DistinctBufferOversized_Works(MLKemAlgorithm algorithm)
-        {
-            byte[] ciphertextBuffer = new byte[algorithm.CiphertextSizeInBytes + 42];
-            byte[] sharedSecretBuffer = new byte[algorithm.SharedSecretSizeInBytes + 42];
-            using MLKemContract kem = new(algorithm)
-            {
-                OnEncapsulateCore = (Span<byte> ciphertext, Span<byte> sharedSecret) =>
-                {
-                    AssertSameBuffer(ciphertext, ciphertextBuffer.AsSpan(0, algorithm.CiphertextSizeInBytes));
-                    AssertSameBuffer(sharedSecret, sharedSecretBuffer.AsSpan(0, algorithm.SharedSecretSizeInBytes));
-                }
-            };
-
-            kem.Encapsulate(
-                ciphertextBuffer,
-                sharedSecretBuffer,
-                out int ciphertextBytesWritten,
-                out int sharedSecretBytesWritten);
-
-            Assert.Equal(algorithm.CiphertextSizeInBytes, ciphertextBytesWritten);
-            Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecretBytesWritten);
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Encapsulate_Written_UndersizedCiphertextBuffer(MLKemAlgorithm algorithm)
-        {
-            byte[] ciphertextBuffer = new byte[algorithm.CiphertextSizeInBytes - 1];
-            byte[] sharedSecretBuffer = new byte[algorithm.SharedSecretSizeInBytes];
-            using MLKemContract kem = new(algorithm);
-
-            Assert.Throws<ArgumentException>("ciphertext", () => kem.Encapsulate(
-                ciphertextBuffer,
-                sharedSecretBuffer,
-                out _,
-                out _));
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Encapsulate_Written_UndersizedSharedSecretBuffer(MLKemAlgorithm algorithm)
-        {
-            byte[] ciphertextBuffer = new byte[algorithm.CiphertextSizeInBytes];
-            byte[] sharedSecretBuffer = new byte[algorithm.SharedSecretSizeInBytes - 1];
-            using MLKemContract kem = new(algorithm);
-
-            Assert.Throws<ArgumentException>("sharedSecret", () => kem.Encapsulate(
-                ciphertextBuffer,
-                sharedSecretBuffer,
-                out _,
-                out _));
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Encapsulate_Written_Overlaps_WhenTrimmed_Works(MLKemAlgorithm algorithm)
-        {
-            // sharedSecret does overlap ciphertext in this test. However, the part that overlaps will never
-            // be written to because it is trimmed to the exact size, which ends up with the buffers beside each
-            // other, which should work.
-            byte[] buffer = new byte[algorithm.SharedSecretSizeInBytes + algorithm.CiphertextSizeInBytes + 10];
-            Memory<byte> sharedSecretBuffer = buffer.AsMemory(0, algorithm.SharedSecretSizeInBytes + 10);
-            Memory<byte> ciphertextBuffer = buffer.AsMemory(algorithm.SharedSecretSizeInBytes);
-            AssertExtensions.TrueExpression(sharedSecretBuffer.Span.Overlaps(ciphertextBuffer.Span));
-
-            using MLKemContract kem = new(algorithm)
-            {
-                OnEncapsulateCore = (Span<byte> ciphertext, Span<byte> sharedSecret) =>
-                {
-                    AssertSameBuffer(ciphertext, ciphertextBuffer.Span.Slice(0, algorithm.CiphertextSizeInBytes));
-                    AssertSameBuffer(sharedSecret, sharedSecretBuffer.Span.Slice(0, algorithm.SharedSecretSizeInBytes));
-                    AssertExtensions.FalseExpression(ciphertext.Overlaps(sharedSecret));
-                }
-            };
-
-            kem.Encapsulate(
-                ciphertextBuffer.Span,
-                sharedSecretBuffer.Span,
-                out int ciphertextWritten,
-                out int sharedSecretWritten);
-
-            Assert.Equal(algorithm.CiphertextSizeInBytes, ciphertextWritten);
-            Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecretWritten);
-        }
-
-        [Fact]
-        public static void Encapsulate_Written_Disposed()
-        {
-            MLKemContract kem = new(MLKemAlgorithm.MLKem512);
-            kem.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => kem.Encapsulate(
-                new byte[kem.Algorithm.CiphertextSizeInBytes],
-                new byte[kem.Algorithm.SharedSecretSizeInBytes],
-                out _,
-                out _));
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
         public static void Encapsulate_Allocated(MLKemAlgorithm algorithm)
         {
             using MLKemContract kem = new(algorithm)
@@ -283,7 +159,7 @@ namespace System.Security.Cryptography.Tests
                 }
             };
 
-            byte[] ciphertext = kem.Encapsulate(out byte[] sharedSecret);
+            kem.Encapsulate(out byte[] ciphertext, out byte[] sharedSecret);
 
             Assert.Equal(algorithm.CiphertextSizeInBytes, ciphertext.Length);
             Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecret.Length);
@@ -291,42 +167,12 @@ namespace System.Security.Cryptography.Tests
             AssertExtensions.FilledWith<byte>(0xFE, sharedSecret);
         }
 
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Encapsulate_Allocated_DestinationSecret(MLKemAlgorithm algorithm)
-        {
-            using MLKemContract kem = new(algorithm)
-            {
-                OnEncapsulateCore = (Span<byte> ciphertext, Span<byte> sharedSecret) =>
-                {
-                    ciphertext.Fill(0xCA);
-                    sharedSecret.Fill(0xFE);
-                }
-            };
-
-            byte[] sharedSecret = new byte[algorithm.SharedSecretSizeInBytes];
-            byte[] ciphertext = kem.Encapsulate(sharedSecret);
-
-            Assert.Equal(algorithm.CiphertextSizeInBytes, ciphertext.Length);
-            AssertExtensions.FilledWith<byte>(0xCA, ciphertext);
-            AssertExtensions.FilledWith<byte>(0xFE, sharedSecret);
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Encapsulate_Allocated_DestinationSecret_WrongSecretBufferSize(MLKemAlgorithm algorithm)
-        {
-            using MLKemContract kem = new(algorithm);
-            byte[] sharedSecret = new byte[algorithm.SharedSecretSizeInBytes + 1];
-            AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Encapsulate(sharedSecret));
-        }
-
         [Fact]
         public static void Encapsulate_Allocated_Disposed()
         {
             MLKemContract kem = new(MLKemAlgorithm.MLKem512);
             kem.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => kem.Encapsulate(out _));
+            Assert.Throws<ObjectDisposedException>(() => kem.Encapsulate(out _, out _));
         }
 
         [Theory]
@@ -410,86 +256,6 @@ namespace System.Security.Cryptography.Tests
             };
 
             kem.Decapsulate(ciphertextBuffer.Span, sharedSecretBuffer.Span);
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Decapsulate_Written_WrongCiphertextLength(MLKemAlgorithm algorithm)
-        {
-            using MLKemContract kem = new(algorithm);
-            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(
-                new byte[algorithm.CiphertextSizeInBytes - 1],
-                new byte[algorithm.SharedSecretSizeInBytes],
-                out _));
-
-            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(
-                new byte[algorithm.CiphertextSizeInBytes + 1],
-                new byte[algorithm.SharedSecretSizeInBytes],
-                out _));
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Decapsulate_Written_SharedSecretTooShort(MLKemAlgorithm algorithm)
-        {
-            using MLKemContract kem = new(algorithm);
-            AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Decapsulate(
-                new byte[algorithm.CiphertextSizeInBytes],
-                new byte[algorithm.SharedSecretSizeInBytes - 1],
-                out _));
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Decapsulate_Written_Diposed(MLKemAlgorithm algorithm)
-        {
-            MLKemContract kem = new(algorithm);
-            kem.Dispose();
-
-            Assert.Throws<ObjectDisposedException>(() => kem.Decapsulate(
-                new byte[algorithm.CiphertextSizeInBytes],
-                new byte[algorithm.SharedSecretSizeInBytes],
-                out _));
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Decapsulate_Written_Oversized_Works(MLKemAlgorithm algorithm)
-        {
-            byte[] ciphertextBuffer = new byte[algorithm.CiphertextSizeInBytes];
-            byte[] sharedSecretBuffer = new byte[algorithm.SharedSecretSizeInBytes + 42];
-
-            using MLKemContract kem = new(algorithm)
-            {
-                OnDecapsulateCore = (ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) =>
-                {
-                    AssertSameBuffer(ciphertextBuffer, ciphertext);
-                    AssertSameBuffer(sharedSecretBuffer.AsSpan(0, algorithm.SharedSecretSizeInBytes), sharedSecret);
-                }
-            };
-
-            kem.Decapsulate(ciphertextBuffer, sharedSecretBuffer, out int sharedSecretBytesWritten);
-            Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecretBytesWritten);
-        }
-
-        [Theory]
-        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void Decapsulate_Written_Exact_Works(MLKemAlgorithm algorithm)
-        {
-            byte[] ciphertextBuffer = new byte[algorithm.CiphertextSizeInBytes];
-            byte[] sharedSecretBuffer = new byte[algorithm.SharedSecretSizeInBytes];
-
-            using MLKemContract kem = new(algorithm)
-            {
-                OnDecapsulateCore = (ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) =>
-                {
-                    AssertSameBuffer(ciphertextBuffer, ciphertext);
-                    AssertSameBuffer(sharedSecretBuffer, sharedSecret);
-                }
-            };
-
-            kem.Decapsulate(ciphertextBuffer, sharedSecretBuffer, out int sharedSecretBytesWritten);
-            Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecretBytesWritten);
         }
 
         [Theory]

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1877,14 +1877,11 @@ namespace System.Security.Cryptography
         public static bool IsSupported { get { throw null; } }
         public byte[] Decapsulate(byte[] ciphertext) { throw null; }
         public void Decapsulate(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret) { }
-        public void Decapsulate(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret, out int sharedSecretBytesWritten) { throw null; }
         protected abstract void DecapsulateCore(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret);
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        public byte[] Encapsulate(out byte[] sharedSecret) { throw null; }
-        public byte[] Encapsulate(System.Span<byte> sharedSecret) { throw null; }
+        public void Encapsulate(out byte[] ciphertext, out byte[] sharedSecret) { throw null; }
         public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret) { }
-        public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret, out int ciphertextBytesWritten, out int sharedSecretBytesWritten) { throw null; }
         protected abstract void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret);
         public byte[] ExportDecapsulationKey() { throw null; }
         public void ExportDecapsulationKey(System.Span<byte> destination) { }
@@ -1925,7 +1922,6 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.MLKem ImportPrivateSeed(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source) { throw null; }
-        protected void ThrowIfDisposed() { }
         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryExportEncryptedPkcs8PrivateKey(string password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }


### PR DESCRIPTION
The reacts to the API changes made in #114453 (so far)

Diff:

```diff
- public void Decapsulate(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret, out int sharedSecretBytesWritten);
- public byte[] Encapsulate(System.Span<byte> sharedSecret);
- Encapsulate(Span<byte> ciphertext, Span<byte> sharedSecret, out int ciphertextBytesWritten, out int sharedSecretBytesWritten);
- protected void ThrowIfDisposed();

- public byte[] Encapsulate(out byte[] sharedSecret);
+ public void Encapsulate(out byte[] ciphertext, out byte[] sharedSecret);
```

Contributes to #113508 