### PR TITLE
Only run runtime-diagnostics pipeline on a subset of file changes

### DIFF
--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -18,6 +18,16 @@ schedules:
     - main
   always: true
 
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - '/eng/pipelines/**'
+    - '/src/coreclr/**'
+    - '/src/native/**'
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:
@@ -48,7 +58,7 @@ extends:
                 archiveExtension: $(archiveExtension)
                 tarCompression: $(tarCompression)
                 artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
-                displayName: Build Assets            
+                displayName: Build Assets
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -60,7 +70,7 @@ extends:
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             liveRuntimeDir: $(Build.SourcesDirectory)/artifacts/runtime
             timeoutInMinutes: 360
-            dependsOn: 
+            dependsOn:
             - build_windows_x64_release_AllSubsets_CoreCLR
             preBuildSteps:
               - template: /eng/pipelines/common/download-artifact-step.yml


### PR DESCRIPTION
This pipeline only tests the diagnostics test suites against CoreCLR changes, so don't run against changes that wouldn't change CoreCLR.