### PR TITLE
Update DllImportSearchPathTests to avoid relying on any previous cached load

### DIFF
--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -117,12 +118,15 @@ public class NativeLibraryPInvoke
     internal const string CopyName = $"{NativeLibraryToLoad.Name}-copy";
     internal const string DefaultFlagsName = $"{NativeLibraryToLoad.Name}-default-flags";
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Sum(int a, int b)
         => NativeSum(a, b);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Sum_Copy(int a, int b)
         => NativeSum_Copy(a, b);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Sum_DefaultFlags(int a, int b)
         => NativeSum_DefaultFlags(a, b);
 
@@ -140,10 +144,9 @@ public class NativeLibraryPInvoke
 
 public class NativeLibraryPInvokeAot
 {
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Sum(int a, int b)
-    {
-        return NativeSum(a, b);
-    }
+        => NativeSum(a, b);
 
     // For NativeAOT, validate the case where the native library is next to the AOT application.
     // The passing of DllImportSearchPath.System32 is done to ensure on Windows the runtime won't fallback
@@ -155,10 +158,9 @@ public class NativeLibraryPInvokeAot
 
 public class NativeLibraryWithDependency
 {
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Sum(int a, int b)
-    {
-        return CallDependencySum(a, b);
-    }
+        => CallDependencySum(a, b);
 
     // For LoadLibrary on Windows, search flags, like that represented by System32, are incompatible with
     // looking at a specific path (per AssemblyDirectory), so we specify both flags to validate that we do

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -69,7 +69,26 @@ public class DllImportSearchPathsTest
             Environment.CurrentDirectory = Subdirectory;
 
             // Library should not be found in the assembly directory, but should fall back to the default OS search which includes CWD on Windows
-            int sum = NativeLibraryPInvoke.Sum(1, 2);
+            int sum = NativeLibraryPInvoke.Sum_Copy(1, 2);
+            Assert.Equal(3, sum);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = currentDirectory;
+        }
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public static void DefaultFlags_Found()
+    {
+        string currentDirectory = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = Subdirectory;
+
+            // Library should not be found in the assembly directory, but should fall back to the default OS search which includes CWD on Windows
+            int sum = NativeLibraryPInvoke.Sum_DefaultFlags(1, 2);
             Assert.Equal(3, sum);
         }
         finally
@@ -95,14 +114,28 @@ public class DllImportSearchPathsTest
 
 public class NativeLibraryPInvoke
 {
+    internal const string CopyName = $"{NativeLibraryToLoad.Name}-copy";
+    internal const string DefaultFlagsName = $"{NativeLibraryToLoad.Name}-default-flags";
+
     public static int Sum(int a, int b)
-    {
-        return NativeSum(a, b);
-    }
+        => NativeSum(a, b);
+
+    public static int Sum_Copy(int a, int b)
+        => NativeSum_Copy(a, b);
+
+    public static int Sum_DefaultFlags(int a, int b)
+        => NativeSum_DefaultFlags(a, b);
 
     [DllImport(NativeLibraryToLoad.Name)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
     static extern int NativeSum(int arg1, int arg2);
+
+    [DllImport(CopyName, EntryPoint = nameof(NativeSum))]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+    static extern int NativeSum_Copy(int arg1, int arg2);
+
+    [DllImport(DefaultFlagsName, EntryPoint = nameof(NativeSum))]
+    static extern int NativeSum_DefaultFlags(int arg1, int arg2);
 }
 
 public class NativeLibraryPInvokeAot

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
@@ -23,7 +23,13 @@
       <NativeLibrariesToMove Include="$(OutDir)/NativeLibrary.*" />
       <NativeLibrariesToMove Include="$(OutDir)/NativeLibraryWithDependency.*" />
     </ItemGroup>
-    <Move SourceFiles="@(NativeLibrariesToMove)" DestinationFiles="@(NativeLibrariesToMove -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
+    <ItemGroup>
+      <NativeLibrariesToCopy Include="@(NativeLibrariesToMove)" Condition="'%(Filename)' == 'NativeLibrary' or '%(Filename)' == 'libNativeLibrary'" />
+    </ItemGroup>
+    <!-- NativeLibrary has multiple copies so tests can load different ones without using a cached load -->
+    <Copy SourceFiles="@(NativeLibrariesToCopy)" DestinationFiles="@(NativeLibrariesToCopy -> '$(LibrarySubdirectory)/%(Filename)-copy%(Extension)')" />
+    <Copy SourceFiles="@(NativeLibrariesToCopy)" DestinationFiles="@(NativeLibrariesToCopy -> '$(LibrarySubdirectory)/%(Filename)-default-flags%(Extension)')" />
+    <Move SourceFiles="@(NativeLibrariesToMove)" DestinationFiles="@(NativeLibrariesToMove -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')" />
   </Target>
 
   <Target Name="SetUpSubdirectoryManaged" AfterTargets="Build">


### PR DESCRIPTION
- Use different copies (library names) for p/invokes in the `DllImportSearchPathTests` so that we don't end up using the runtime cached of loaded unmanaged libraries
- Add a test for default search flags