### PR TITLE
Increase libraries run timeouts from default 150 to 300 minutes.

### DIFF
--- a/eng/pipelines/coreclr/templates/superpmi-collect-pipeline.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-collect-pipeline.yml
@@ -326,6 +326,8 @@ extends:
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_Checked
             helixArtifactsName: LibrariesTestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_Checked
             unifiedBuildConfigOverride: checked
+            # Default timeout is 150 minutes, which is too low for osx-arm64 queue.
+            timeoutInMinutes: 300
 
       #
       # Collection of libraries test run: no_tiered_compilation
@@ -357,3 +359,5 @@ extends:
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_Checked
             helixArtifactsName: LibrariesTestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_Checked
             unifiedBuildConfigOverride: checked
+            # Default timeout is 150 minutes, which is too low for osx-arm64 queue.
+            timeoutInMinutes: 300


### PR DESCRIPTION
osx-arm64 queues have been timing out due to too many jobs sent to too few machines, by the superpmi-collect pipeline.