### PR TITLE
Prevent the runtime-diagnostics pipeline from running on PR's

### DIFF
--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 
 resources:
   repositories:
@@ -17,16 +18,6 @@ schedules:
     include:
     - main
   always: true
-
-pr:
-  branches:
-    include:
-    - main
-  paths:
-    include:
-    - '/eng/pipelines/**'
-    - '/src/coreclr/**'
-    - '/src/native/**'
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml


### PR DESCRIPTION
It should only run when manually triggered