### PR TITLE
Disable the UTFStringConversionFailures test on CI runs

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/CollectionMarshallingFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/CollectionMarshallingFails.cs
@@ -110,6 +110,7 @@ namespace LibraryImportGenerator.IntegrationTests
     public class CollectionMarshallingFails
     {
         [Fact]
+        [SkipOnCI("Allocates enough memory that the OOM killer can kill the process on our Helix machines.")]
         public void UTFStringConversionFailures()
         {
             bool threw = false;

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/CollectionMarshallingFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/CollectionMarshallingFails.cs
@@ -111,7 +111,7 @@ namespace LibraryImportGenerator.IntegrationTests
     {
         [Fact]
         [SkipOnCI("Allocates enough memory that the OOM killer can kill the process on our Helix machines.")]
-        public void UTFStringConversionFailures()
+        public void BigUTFStringConversionFailures()
         {
             bool threw = false;
             try


### PR DESCRIPTION
Disable the UTFStringConversionFailures test on CI runs as our Helix machines can't handle the load from allocating 2 2GB strings and the OOM killer was killing the process.

Fixes #114241