### PR TITLE
Don't use BaseOS as the RID for publishing NativeAOT'd assets when OutputRID is the SDK's RID

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler_publish.csproj
@@ -3,7 +3,11 @@
   <PropertyGroup>
     <_IsPublishing>true</_IsPublishing>
     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifier>
+    <!--
+      If the output RID isn't the current SDK RID and we have a "base" RID, then the output RID isn't known to the SDK.
+      In that case, we need to set the RuntimeIdentifier to the base RID so the SDK can find a runtime pack for publishing.
+    -->
+    <RuntimeIdentifier Condition="'$(OutputRID)' != '$(NETCoreSdkRuntimeIdentifier)' and '$(BaseOS)' != '' ">$(BaseOS)</RuntimeIdentifier>
     <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
@@ -3,7 +3,11 @@
   <PropertyGroup>
     <_IsPublishing>true</_IsPublishing>
     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifier>
+    <!--
+      If the output RID isn't the current SDK RID and we have a "base" RID, then the output RID isn't known to the SDK.
+      In that case, we need to set the RuntimeIdentifier to the base RID so the SDK can find a runtime pack for publishing.
+    -->
+    <RuntimeIdentifier Condition="'$(OutputRID)' != '$(NETCoreSdkRuntimeIdentifier)' and '$(BaseOS)' != '' ">$(BaseOS)</RuntimeIdentifier>
     <PublishDir>$(RuntimeBinDir)crossgen2-published/</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>


### PR DESCRIPTION
This fixes SourceBuild Stage2 failures currently making all SourceBuild/VMR builds red