### PR TITLE
Make specifying just `DllImportSearchPath.AssemblyDirectory` only search in assembly directory

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -310,6 +310,7 @@ namespace Internal.Runtime.CompilerHelpers
 
                 hModule = NativeLibrary.LoadBySearch(
                     callingAssembly,
+                    hasDllImportSearchPath,
                     searchAssemblyDirectory: (dllImportSearchPath & (uint)DllImportSearchPath.AssemblyDirectory) != 0,
                     dllImportSearchPathFlags: (int)(dllImportSearchPath & ~(uint)DllImportSearchPath.AssemblyDirectory),
                     ref loadLibErrorTracker,

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
@@ -32,7 +32,7 @@ namespace System.Runtime.InteropServices
             {
                 searchPath = GetDllImportSearchPath(assembly, out userSpecifiedSearchFlags);
             }
-            return LoadLibraryByName(libraryName, assembly, userSpecifiedSearchFlags, searchPath.Value, throwOnError);
+            return LoadLibraryByName(libraryName, assembly, userSpecifiedSearchFlags, searchPath!.Value, throwOnError);
         }
 
         private static IntPtr LoadLibraryByName(string libraryName, Assembly assembly, bool userSpecifiedSearchFlags, DllImportSearchPath searchPath, bool throwOnError)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
@@ -28,7 +28,7 @@ namespace System.Runtime.InteropServices
             // Otherwise checks if the assembly has the DefaultDllImportSearchPathsAttribute attribute.
             // If so, use that value.
             bool userSpecifiedSearchFlags = searchPath.HasValue;
-            if (!searchPath.HasValue)
+            if (!userSpecifiedSearchFlags)
             {
                 searchPath = GetDllImportSearchPath(assembly, out userSpecifiedSearchFlags);
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
@@ -16,6 +16,7 @@ namespace System.Runtime.InteropServices
         {
             handle = LoadLibraryByName(libraryName,
                                 assembly,
+                                userSpecifiedSearchFlags: true,
                                 searchPath,
                                 throwOnError: false);
             return handle != IntPtr.Zero;
@@ -26,21 +27,21 @@ namespace System.Runtime.InteropServices
             // First checks if a default dllImportSearchPathFlags was passed in, if so, use that value.
             // Otherwise checks if the assembly has the DefaultDllImportSearchPathsAttribute attribute.
             // If so, use that value.
-
+            bool userSpecifiedSearchFlags = searchPath.HasValue;
             if (!searchPath.HasValue)
             {
-                searchPath = GetDllImportSearchPath(assembly);
+                searchPath = GetDllImportSearchPath(assembly, out userSpecifiedSearchFlags);
             }
-            return LoadLibraryByName(libraryName, assembly, searchPath.Value, throwOnError);
+            return LoadLibraryByName(libraryName, assembly, userSpecifiedSearchFlags, searchPath.Value, throwOnError);
         }
 
-        internal static IntPtr LoadLibraryByName(string libraryName, Assembly assembly, DllImportSearchPath searchPath, bool throwOnError)
+        private static IntPtr LoadLibraryByName(string libraryName, Assembly assembly, bool userSpecifiedSearchFlags, DllImportSearchPath searchPath, bool throwOnError)
         {
             int searchPathFlags = (int)(searchPath & ~DllImportSearchPath.AssemblyDirectory);
             bool searchAssemblyDirectory = (searchPath & DllImportSearchPath.AssemblyDirectory) != 0;
 
             LoadLibErrorTracker errorTracker = default;
-            IntPtr ret = LoadBySearch(assembly, searchAssemblyDirectory, searchPathFlags, ref errorTracker, libraryName);
+            IntPtr ret = LoadBySearch(assembly, userSpecifiedSearchFlags, searchAssemblyDirectory, searchPathFlags, ref errorTracker, libraryName);
             if (throwOnError && ret == IntPtr.Zero)
             {
                 errorTracker.Throw(libraryName);
@@ -49,20 +50,22 @@ namespace System.Runtime.InteropServices
             return ret;
         }
 
-        internal static DllImportSearchPath GetDllImportSearchPath(Assembly callingAssembly)
+        private static DllImportSearchPath GetDllImportSearchPath(Assembly callingAssembly, out bool userSpecifiedSearchFlags)
         {
             foreach (CustomAttributeData cad in callingAssembly.CustomAttributes)
             {
                 if (cad.AttributeType == typeof(DefaultDllImportSearchPathsAttribute))
                 {
+                    userSpecifiedSearchFlags = true;
                     return (DllImportSearchPath)cad.ConstructorArguments[0].Value!;
                 }
             }
 
+            userSpecifiedSearchFlags = false;
             return DllImportSearchPath.AssemblyDirectory;
         }
 
-        internal static IntPtr LoadBySearch(Assembly callingAssembly, bool searchAssemblyDirectory, int dllImportSearchPathFlags, ref LoadLibErrorTracker errorTracker, string libraryName)
+        internal static IntPtr LoadBySearch(Assembly callingAssembly, bool userSpecifiedSearchFlags, bool searchAssemblyDirectory, int dllImportSearchPathFlags, ref LoadLibErrorTracker errorTracker, string libraryName)
         {
             IntPtr ret;
 
@@ -107,10 +110,20 @@ namespace System.Runtime.InteropServices
                     }
                 }
 
-                ret = LoadLibraryHelper(currLibNameVariation, dllImportSearchPathFlags, ref errorTracker);
-                if (ret != IntPtr.Zero)
+                // Internally, search path flags and whether or not to search the assembly directory are
+                // tracked separately. However, on the API level, DllImportSearchPath represents them both.
+                // When unspecified, the default is to search the assembly directory and all OS defaults,
+                // which maps to searchAssemblyDirectory being true and dllImportSearchPathFlags being 0.
+                // When a user specifies DllImportSearchPath.AssemblyDirectory, searchAssemblyDirectory is
+                // true, dllImportSearchPathFlags is 0, and the desired logic is to only search the assembly
+                // directory (handled above), so we avoid doing any additional load search in that case.
+                if (!userSpecifiedSearchFlags || !searchAssemblyDirectory || dllImportSearchPathFlags != 0)
                 {
-                    return ret;
+                    ret = LoadLibraryHelper(currLibNameVariation, dllImportSearchPathFlags, ref errorTracker);
+                    if (ret != IntPtr.Zero)
+                    {
+                        return ret;
+                    }
                 }
             }
 

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -621,7 +621,7 @@ namespace
 #endif // TARGET_UNIX
 
     // Search for the library and variants of its name in probing directories.
-    NATIVE_LIBRARY_HANDLE LoadNativeLibraryBySearch(Assembly *callingAssembly,
+    NATIVE_LIBRARY_HANDLE LoadNativeLibraryBySearch(Assembly *callingAssembly, BOOL userSpecifiedSearchFlags,
                                                     BOOL searchAssemblyDirectory, DWORD dllImportSearchPathFlags,
                                                     LoadLibErrorTracker * pErrorTracker, LPCWSTR wszLibName)
     {
@@ -719,10 +719,20 @@ namespace
                 }
             }
 
-            hmod = LocalLoadLibraryHelper(currLibNameVariation, dllImportSearchPathFlags, pErrorTracker);
-            if (hmod != NULL)
+            // Internally, search path flags and whether or not to search the assembly directory are
+            // tracked separately. However, on the API level, DllImportSearchPath represents them both.
+            // When unspecified, the default is to search the assembly directory and all OS defaults,
+            // which maps to searchAssemblyDirectory being true and dllImportSearchPathFlags being 0.
+            // When a user specifies DllImportSearchPath.AssemblyDirectory, searchAssemblyDirectory is
+            // true, dllImportSearchPathFlags is 0, and the desired logic is to only search the assembly
+            // directory (handled above), so we avoid doing any additional load search in that case.
+            if (!userSpecifiedSearchFlags || !searchAssemblyDirectory || dllImportSearchPathFlags != 0)
             {
-                return hmod;
+                hmod = LocalLoadLibraryHelper(currLibNameVariation, dllImportSearchPathFlags, pErrorTracker);
+                if (hmod != NULL)
+                {
+                    return hmod;
+                }
             }
         }
 
@@ -736,10 +746,10 @@ namespace
         BOOL searchAssemblyDirectory;
         DWORD dllImportSearchPathFlags;
 
-        GetDllImportSearchPathFlags(pMD, &dllImportSearchPathFlags, &searchAssemblyDirectory);
+        BOOL userSpecifiedSearchFlags = GetDllImportSearchPathFlags(pMD, &dllImportSearchPathFlags, &searchAssemblyDirectory);
 
         Assembly *pAssembly = pMD->GetMethodTable()->GetAssembly();
-        return LoadNativeLibraryBySearch(pAssembly, searchAssemblyDirectory, dllImportSearchPathFlags, pErrorTracker, wszLibName);
+        return LoadNativeLibraryBySearch(pAssembly, userSpecifiedSearchFlags, searchAssemblyDirectory, dllImportSearchPathFlags, pErrorTracker, wszLibName);
     }
 }
 
@@ -776,12 +786,12 @@ NATIVE_LIBRARY_HANDLE NativeLibrary::LoadLibraryByName(LPCWSTR libraryName, Asse
     }
     else
     {
-        GetDllImportSearchPathFlags(callingAssembly->GetModule(),
+        hasDllImportSearchFlags = GetDllImportSearchPathFlags(callingAssembly->GetModule(),
                                     &dllImportSearchPathFlags, &searchAssemblyDirectory);
     }
 
     LoadLibErrorTracker errorTracker;
-    hmod = LoadNativeLibraryBySearch(callingAssembly, searchAssemblyDirectory, dllImportSearchPathFlags, &errorTracker, libraryName);
+    hmod = LoadNativeLibraryBySearch(callingAssembly, hasDllImportSearchFlags, searchAssemblyDirectory, dllImportSearchPathFlags, &errorTracker, libraryName);
     if (hmod != nullptr)
         return hmod;
 

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -901,7 +901,7 @@ retry_with_libcoreclr:
 			mono_custom_attrs_free (cinfo);
 	}
 	gboolean user_specified_flags = flags >= 0;
-	if (flags < 0)
+	if (!user_specified_flags)
 		flags = DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY;
 	module = netcore_lookup_native_library (alc, image, new_scope, user_specified_flags, flags);
 

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -324,7 +324,7 @@ netcore_probe_for_module_variations (const char *mdirname, const char *file_name
 }
 
 static MonoDl *
-netcore_probe_for_module (MonoImage *image, const char *file_name, int flags, MonoError *error)
+netcore_probe_for_module (MonoImage *image, const char *file_name, gboolean user_specified_flags, int flags, MonoError *error)
 {
 	MonoDl *module = NULL;
 	int lflags = convert_dllimport_flags (flags);
@@ -372,8 +372,9 @@ netcore_probe_for_module (MonoImage *image, const char *file_name, int flags, Mo
 		g_free (mdirname);
 	}
 
-	// Try without any path additions, if we didn't try it already
-	if (module == NULL && !probe_first_without_prepend)
+	// Try without any path additions, if we didn't try it already and the user did not
+	// explicitly specify to only look in the assembly directory.
+	if (module == NULL && !probe_first_without_prepend && (!user_specified_flags || flags != DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY))
 	{
 		module = netcore_probe_for_module_variations (NULL, file_name, lflags, error);
 		if (!module && !is_ok (error) && mono_error_get_error_code (error) == MONO_ERROR_BAD_IMAGE)
@@ -393,12 +394,12 @@ netcore_probe_for_module (MonoImage *image, const char *file_name, int flags, Mo
 }
 
 static MonoDl *
-netcore_probe_for_module_nofail (MonoImage *image, const char *file_name, int flags)
+netcore_probe_for_module_nofail (MonoImage *image, const char *file_name, gboolean user_specified_flags, int flags)
 {
 	MonoDl *result = NULL;
 
 	ERROR_DECL (error);
-	result = netcore_probe_for_module (image, file_name, flags, error);
+	result = netcore_probe_for_module (image, file_name, user_specified_flags, flags, error);
 	mono_error_cleanup (error);
 
 	return result;
@@ -661,7 +662,7 @@ netcore_check_alc_cache (MonoAssemblyLoadContext *alc, const char *scope)
 }
 
 static MonoDl *
-netcore_lookup_native_library (MonoAssemblyLoadContext *alc, MonoImage *image, const char *scope, guint32 flags)
+netcore_lookup_native_library (MonoAssemblyLoadContext *alc, MonoImage *image, const char *scope, gboolean user_specified_flags, guint32 flags)
 {
 	MonoDl *module = NULL;
 	MonoDl *cached;
@@ -726,7 +727,7 @@ netcore_lookup_native_library (MonoAssemblyLoadContext *alc, MonoImage *image, c
 		goto add_to_alc_cache;
 	}
 
-	module = netcore_probe_for_module_nofail (image, scope, flags);
+	module = netcore_probe_for_module_nofail (image, scope, user_specified_flags, flags);
 	if (module) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT, "Native library found via filesystem probing: '%s'.", scope);
 		goto add_to_global_cache;
@@ -899,9 +900,10 @@ retry_with_libcoreclr:
 		if (cinfo && !cinfo->cached)
 			mono_custom_attrs_free (cinfo);
 	}
+	gboolean user_specified_flags = flags >= 0;
 	if (flags < 0)
 		flags = DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY;
-	module = netcore_lookup_native_library (alc, image, new_scope, flags);
+	module = netcore_lookup_native_library (alc, image, new_scope, user_specified_flags, flags);
 
 	if (!module) {
 		mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_DLLIMPORT,
@@ -1167,7 +1169,7 @@ ves_icall_System_Runtime_InteropServices_NativeLibrary_LoadByName (MonoStringHan
 	// FIXME: implement search flag defaults properly
 	{
 		ERROR_DECL (load_error);
-		module = netcore_probe_for_module (image, lib_name, has_search_flag ? search_flag : DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY, load_error);
+		module = netcore_probe_for_module (image, lib_name, has_search_flag, has_search_flag ? search_flag : DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY, load_error);
 		if (!module) {
 			if (mono_error_get_error_code (load_error) == MONO_ERROR_BAD_IMAGE)
 				mono_error_set_generic_error (error, "System", "BadImageFormatException", "%s", lib_name);

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -62,16 +62,15 @@ public class DllImportSearchPathsTest
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
-    public static void AssemblyDirectory_Fallback_Found()
+    public static void AssemblyDirectory_NoFallback_NotFound()
     {
         string currentDirectory = Environment.CurrentDirectory;
         try
         {
             Environment.CurrentDirectory = Subdirectory;
 
-            // Library should not be found in the assembly directory, but should fall back to the default OS search which includes CWD on Windows
-            int sum = NativeLibraryPInvoke.Sum_Copy(1, 2);
-            Assert.Equal(3, sum);
+            // Library should not be found in the assembly directory and should not fall back to the default OS search
+            Assert.Throws<DllNotFoundException>(() => NativeLibraryPInvoke.Sum_Copy(1, 2));
         }
         finally
         {
@@ -149,10 +148,8 @@ public class NativeLibraryPInvokeAot
         => NativeSum(a, b);
 
     // For NativeAOT, validate the case where the native library is next to the AOT application.
-    // The passing of DllImportSearchPath.System32 is done to ensure on Windows the runtime won't fallback
-    // and try to search the application directory by default.
     [DllImport(NativeLibraryToLoad.Name + "-in-native")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
     static extern int NativeSum(int arg1, int arg2);
 }
 

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
@@ -49,7 +49,7 @@ public class NativeLibraryTests : IDisposable
     [Fact]
     public void LoadLibraryRelativePaths_NameOnly()
     {
-        
+
         {
             string libName = Path.Combine("..", NativeLibraryToLoad.InvalidName, NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.InvalidName));
             EXPECT(LoadLibrary_NameOnly(libName), TestResult.DllNotFound);
@@ -142,9 +142,9 @@ public class NativeLibraryTests : IDisposable
         EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32));
         EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32));
 
-        // Library should not be found in the assembly directory, but should fall back to the default OS search which includes CWD on Windows
-        EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory));
-        EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory));
+        // Library should not be found in the assembly directory and should not fall back to the default OS search which includes CWD on Windows
+        EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory), TestResult.DllNotFound);
+        EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory), TestResult.ReturnFailure);
 
         // Library should not be found in application directory
         EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.ApplicationDirectory), TestResult.DllNotFound);
@@ -208,8 +208,12 @@ public class NativeLibraryTests : IDisposable
                 Environment.CurrentDirectory = subdirectory;
 
                 // Library should not be found in the assembly directory, but should fall back to the default OS search which includes CWD on Windows
-                EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory));
-                EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory));
+                EXPECT(LoadLibrary_WithAssembly(libName, assembly, null));
+                EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, null));
+
+                // Library should not be found in the assembly directory and should not fall back to the default OS search which includes CWD on Windows
+                EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory), TestResult.DllNotFound);
+                EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory), TestResult.ReturnFailure);
             }
             finally
             {


### PR DESCRIPTION
Update coreclr, mono, and nativeaot to treat specifying only `DllImportSearchPath.AssemblyDirectory` as only searching the assembly directory - no fallback to the OS search behaviour.

Since the default behaviour (search assembly directory and then fall back to the OS search) is represented with the same flags/values as if the user specified only `DllImportSearchPath.AssemblyDirectory`, this implementation tracks whether the flags were user-specified.

Fixes #107040 