### PR TITLE
Use regular casts for dictionary fallback in HttpHeaders

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -1435,7 +1435,7 @@ namespace System.Net.Http.Headers
             }
             else if (store is not null)
             {
-                valueRef = ref CollectionsMarshal.GetValueRefOrNullRef(Unsafe.As<Dictionary<HeaderDescriptor, object>>(store), key);
+                valueRef = ref CollectionsMarshal.GetValueRefOrNullRef((Dictionary<HeaderDescriptor, object>)store, key);
             }
 
             return ref valueRef;
@@ -1580,7 +1580,7 @@ namespace System.Net.Http.Headers
             }
             else if (store is not null)
             {
-                removed = Unsafe.As<Dictionary<HeaderDescriptor, object>>(store).Remove(key);
+                removed = ((Dictionary<HeaderDescriptor, object>)store).Remove(key);
             }
 
             if (removed)


### PR DESCRIPTION
While the current logic is totally correct as-is, the perf isn't critical here since we only use the dictionary as a fallback when storing many headers. It's not worth the risk of someone accidentally messing up the logic in the future, e.g. by moving the `.As` into a helper method that re-reads the field instead of using the local.