### PR TITLE
Fix stack trashing in CallCatchFunclet

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3246,7 +3246,7 @@ extern "C" void * QCALLTYPE CallCatchFunclet(QCall::ObjectHandleOnStack exceptio
 #endif // HOST_WINDOWS
 
 #if defined(HOST_AMD64)
-        ULONG64* returnAddress = (ULONG64*)targetSp;
+        ULONG64* returnAddress = (ULONG64*)(targetSp - 8);
         *returnAddress = pvRegDisplay->pCurrentContext->Rip;
 #ifdef HOST_WINDOWS
         if (targetSSP != 0)


### PR DESCRIPTION
I noticed the bug when doing the x86/funclet bring-up but I thought of it as mostly harmless. Turns out it's not, with `CallEHFilterFunclet` helper added in #114630 using a specific stack layout it was trashing one of the saved registers. This doesn't affect win-x64 because it uses argument scratch space and overriding values in there is harmless in this case.