### PR TITLE
Fix runtime build on Windows with CMake 4

### DIFF
--- a/src/native/corehost/build.cmd
+++ b/src/native/corehost/build.cmd
@@ -80,7 +80,7 @@ if %__Ninja% == 0 (
 set "__ResourcesDir=%__objDir%\%__OutputRid%.%CMAKE_BUILD_TYPE%\hostResourceFiles"
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 set "__IntermediatesDir=%__IntermediatesDir:\=/%"
-
+set "__sourceDir=%__sourceDir:\=/%"
 
 :: Check that the intermediate directory exists so we can place our cmake build tree there
 if /i "%__IncrementalNativeBuild%" == "1" goto CreateIntermediates


### PR DESCRIPTION
After upgrading to latest CMake, runtime fails to build:

```
"C:\source\dotnet\runtime\src\native\corehost\build.cmd" Debug x64 commit 6cb6016767d9e7370446994873caba76127083a4 outputrid win-x64 portable incremental-native-build rootdir C:\source\dotnet\runtime\ runtimeflavor CoreCLR runtimeconfiguration Release
  **********************************************************************
  ** Visual Studio 2022 Developer Command Prompt v17.13.4
  ** Copyright (c) 2022 Microsoft Corporation
  **********************************************************************
  [vcvarsall.bat] Environment initialized for: 'x64'
  Configuring corehost native components
  
  "Computed RID for native build is win-x64"
  Calling "C:\source\dotnet\runtime\eng\native\gen-buildsys.cmd "C:\source\dotnet\runtime\src\native\corehost\" "C:/source/dotnet/runtime//artifacts/obj/win-x64.Debug/corehost" vs2022 x64 windows  "-DCLI_CMAKE_PKG_RID=win-x64" "-DCLI_CMAKE_FALLBACK_OS=win10" "
  -DCLI_CMAKE_COMMIT_HASH=6cb6016767d9e7370446994873caba76127083a4" "-DCLI_CMAKE_RESOURCE_DIR=C:\source\dotnet\runtime\\artifacts\obj\win-x64.Debug\hostResourceFiles" "-DCMAKE_BUILD_TYPE=Debug""
  The CMake command line differs from the last run. Running CMake again.
  "C:\scoop\shims\cmake.exe "-DCMAKE_INSTALL_PREFIX=C:/source/dotnet/runtime//artifacts/bin/win-x64.Debug" "-DCLR_CMAKE_HOST_ARCH=x64"  "-DCLI_CMAKE_PKG_RID=win-x64" "-DCLI_CMAKE_FALLBACK_OS=win10" "-DCLI_CMAKE_COMMIT_HASH=6cb6016767d9e7370446994873caba7612708
  3a4" "-DCLI_CMAKE_RESOURCE_DIR=C:\source\dotnet\runtime\\artifacts\obj\win-x64.Debug\hostResourceFiles" "-DCMAKE_BUILD_TYPE=Debug"  "-DCMAKE_SYSTEM_VERSION=10.0" "-DCLI_CMAKE_PKG_RID=win-x64" "-DCLI_CMAKE_FALLBACK_OS=win10" "-DCLI_CMAKE_COMMIT_HASH=6cb601676 
  7d9e7370446994873caba76127083a4" "-DCLI_CMAKE_RESOURCE_DIR=C:\source\dotnet\runtime\\artifacts\obj\win-x64.Debug\hostResourceFiles" "-DCMAKE_BUILD_TYPE=Debug" --no-warn-unused-cli -G Ninja -B "C:/source/dotnet/runtime//artifacts/obj/win-x64.Debug/corehost" - 
  S "C:\source\dotnet\runtime\src\native\corehost\""
  Not searching for unused variables given on the command line.
  CMake Error: The source directory "C:/source/dotnet/runtime/src/native/corehost"" does not exist.
  Specify --help for usage, or press the help button on the CMake GUI.
  Failed to generate native component build project!
C:\source\dotnet\runtime\src\native\corehost\corehost.proj(167,5): error MSB3073: The command ""C:\source\dotnet\runtime\src\native\corehost\build.cmd" Debug x64 commit 6cb6016767d9e7370446994873caba76127083a4 outputrid win-x64 portable incremental-native-buil 
d rootdir C:\source\dotnet\runtime\ runtimeflavor CoreCLR runtimeconfiguration Release" exited with code 1.

Build FAILED.
```

Note the extra " in 

    CMake Error: The source directory "C:/source/dotnet/runtime/src/native/corehost"" does not exist.
    
Normalizing the source path seems to fix the problem for me