### PR TITLE
Strip trailing slash from source dir for cmake4

### DIFF
--- a/src/native/corehost/build.cmd
+++ b/src/native/corehost/build.cmd
@@ -6,7 +6,6 @@ setlocal
 set "__sourceDir=%~dp0"
 :: remove trailing slash
 if "%__sourceDir:~-1%"=="\" set "__sourceDir=%__sourceDir:~0,-1%"
-set "__ProjectDir=%__sourceDir%"
 
 set "__RepoRootDir=%__sourceDir%\..\..\.."
 :: normalize

--- a/src/native/corehost/build.cmd
+++ b/src/native/corehost/build.cmd
@@ -5,7 +5,8 @@ setlocal
 :: Initialize the args that will be passed to cmake
 set "__sourceDir=%~dp0"
 :: remove trailing slash
-if %__sourceDir:~-1%==\ set "__ProjectDir=%__sourceDir:~0,-1%"
+if "%__sourceDir:~-1%"=="\" set "__sourceDir=%__sourceDir:~0,-1%"
+set "__ProjectDir=%__sourceDir%"
 
 set "__RepoRootDir=%__sourceDir%\..\..\.."
 :: normalize


### PR DESCRIPTION
Alternative fix for https://github.com/dotnet/runtime/pull/114766.