### PR TITLE
Defer RemoteCertificate assignment after X509 Chain build

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -1056,8 +1056,7 @@ namespace System.Net.Security
                     return true;
                 }
 
-                _remoteCertificate = certificate;
-                if (_remoteCertificate == null)
+                if (certificate == null)
                 {
                     if (NetEventSource.Log.IsEnabled() && RemoteCertRequired) NetEventSource.Error(this, $"Remote certificate required, but no remote certificate received");
                     sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNotAvailable;
@@ -1099,15 +1098,17 @@ namespace System.Net.Security
                     sslPolicyErrors |= CertificateValidationPal.VerifyCertificateProperties(
                         _securityContext!,
                         chain,
-                        _remoteCertificate,
+                        certificate,
                         _sslAuthenticationOptions.CheckCertName,
                         _sslAuthenticationOptions.IsServer,
                         TargetHostNameHelper.NormalizeHostName(_sslAuthenticationOptions.TargetHost));
                 }
 
+                _remoteCertificate = certificate;
+
                 if (remoteCertValidationCallback != null)
                 {
-                    success = remoteCertValidationCallback(this, _remoteCertificate, chain, sslPolicyErrors);
+                    success = remoteCertValidationCallback(this, certificate, chain, sslPolicyErrors);
                 }
                 else
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -1056,6 +1056,8 @@ namespace System.Net.Security
                     return true;
                 }
 
+                // don't assign to _remoteCertificate yet, this prevents weird exceptions if SslStream is disposed in parallel with X509Chain building
+
                 if (certificate == null)
                 {
                     if (NetEventSource.Log.IsEnabled() && RemoteCertRequired) NetEventSource.Error(this, $"Remote certificate required, but no remote certificate received");


### PR DESCRIPTION
Defer the assignment of the remote certificate until after the X509 chain validation process, this prevents weird exceptions being thrown if SslStream is disposed in parallel with chain building, as in:

```
    System.Net.Security.Tests.SslStreamDisposeTest.Dispose_ParallelWithHandshake_ThrowsODE [FAIL]
      System.ArgumentException : The chain context handle is invalid. (Parameter 'certificate')
      Stack Trace:
        /_/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs(99,0): at System.Security.Cryptography.X509Certificates.X509Chain.Build(X509Certificate2 certificate, Boolean throwOnException)
        /_/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs(91,0): at System.Security.Cryptography.X509Certificates.X509Chain.Build(X509Certificate2 certificate)
        /_/src/libraries/Common/src/System/Net/Security/CertificateValidation.Unix.cs(22,0): at System.Net.Security.CertificateValidation.BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, Boolean checkCertName, Boolean _, String hostName)
        /_/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs(1099,0): at System.Net.Security.SslStream.VerifyRemoteCertificate(RemoteCertificateValidationCallback remoteCertValidationCallback, SslCertificateTrust trust, ProtocolToken& alertToken, SslPolicyErrors& sslPolicyErrors, X509ChainStatusFlags& chainStatus)
        /_/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs(579,0): at System.Net.Security.SslStream.CompleteHandshake(ProtocolToken& alertToken, SslPolicyErrors& sslPolicyErrors, X509ChainStatusFlags& chainStatus)
        /_/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs(592,0): at System.Net.Security.SslStream.CompleteHandshake(SslAuthenticationOptions sslAuthenticationOptions)
        /_/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs(379,0): at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs(150,0): at System.Net.Security.Tests.SslStreamDisposeTest.<Dispose_ParallelWithHandshake_ThrowsODE>g__ValidateExceptionAsync|3_1(Task task)
        /_/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs(142,0): at System.Net.Security.Tests.SslStreamDisposeTest.<>c__DisplayClass3_0.<<Dispose_ParallelWithHandshake_ThrowsODE>b__0>d.MoveNext()
        --- End of stack trace from previous location ---
        /_/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs(301,0): at System.Threading.Tasks.Parallel.<>c__53`1.<<ForEachAsync>b__53_0>d.MoveNext()
        --- End of stack trace from previous location ---
        /_/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs(115,0): at System.Net.Security.Tests.SslStreamDisposeTest.Dispose_ParallelWithHandshake_ThrowsODE()
        --- End of stack trace from previous location ---
```