### PR TITLE
When parameter type has [ServiceKey] allow 'object' as the parameter type

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -613,14 +613,22 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 {
                     if (serviceIdentifier.ServiceKey != null && attribute is ServiceKeyAttribute)
                     {
-                        // Check if the parameter type matches
-                        if (parameterType != serviceIdentifier.ServiceKey.GetType())
+                        // Even though the parameter may be strongly typed, support 'object' if AnyKey is used.
+
+                        if (serviceIdentifier.ServiceKey == KeyedService.AnyKey)
+                        {
+                            parameterType = typeof(object);
+                        }
+                        else if (parameterType != serviceIdentifier.ServiceKey.GetType()
+                            && parameterType != typeof(object))
                         {
                             throw new InvalidOperationException(SR.InvalidServiceKeyType);
                         }
+
                         callSite = new ConstantCallSite(parameterType, serviceIdentifier.ServiceKey);
                         break;
                     }
+
                     if (attribute is FromKeyedServicesAttribute keyed)
                     {
                         var parameterSvcId = new ServiceIdentifier(keyed.Key, parameterType);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderValidationTests.cs
@@ -146,6 +146,131 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Assert.IsType<Bar3>(actual);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void BuildServiceProvider_AnyKey_ServiceKeyWithStronglyTypedArgument(bool validateOnBuild)
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedTransient<ServiceKeyWithStronglyTypedArgument>(KeyedService.AnyKey);
+            using var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateScopes = true,
+                ValidateOnBuild = validateOnBuild
+            });
+
+            // Act
+            var actual = serviceProvider.GetKeyedService<ServiceKeyWithStronglyTypedArgument>(42);
+
+            // Assert
+            Assert.Equal(42, actual.Key);
+            Assert.Throws<InvalidOperationException>(() => serviceProvider.GetKeyedService<ServiceKeyWithStronglyTypedArgument>("Hello"));
+        }
+
+        private class ServiceKeyWithStronglyTypedArgument
+        {
+            public int Key { get; set; }
+
+            public ServiceKeyWithStronglyTypedArgument([ServiceKey] int key)
+            {
+                Key = key;
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void BuildServiceProvider_AnyKey_ServiceKeyWithObjectTypedArgument(bool validateOnBuild)
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedTransient<ServiceKeyWithObjectTypedArgument>(KeyedService.AnyKey);
+            using var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateScopes = true,
+                ValidateOnBuild = validateOnBuild
+            });
+
+            // Act
+            var actualInt = serviceProvider.GetKeyedService<ServiceKeyWithObjectTypedArgument>(42);
+            var actualString = serviceProvider.GetKeyedService<ServiceKeyWithObjectTypedArgument>("hello");
+
+            // Assert
+            Assert.Equal(42, actualInt.Key);
+            Assert.Equal("hello", actualString.Key);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void BuildServiceProvider_ServiceKeyWithObjectTypedArgument(bool validateOnBuild)
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedTransient<ServiceKeyWithObjectTypedArgument>(42);
+            serviceCollection.AddKeyedTransient<ServiceKeyWithObjectTypedArgument>("hello");
+            using var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateScopes = true,
+                ValidateOnBuild = validateOnBuild
+            });
+
+            // Act
+            var actualInt = serviceProvider.GetKeyedService<ServiceKeyWithObjectTypedArgument>(42);
+            var actualString = serviceProvider.GetKeyedService<ServiceKeyWithObjectTypedArgument>("hello");
+            var notFound = serviceProvider.GetKeyedService<ServiceKeyWithObjectTypedArgument>(false);
+
+            // Assert
+            Assert.Equal(42, actualInt.Key);
+            Assert.Equal("hello", actualString.Key);
+            Assert.Null(notFound);
+        }
+
+        private class ServiceKeyWithObjectTypedArgument
+        {
+            public object Key { get; set; }
+
+            public ServiceKeyWithObjectTypedArgument([ServiceKey] object key)
+            {
+                Key = key;
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void BuildServiceProvider_AnyKey_ServiceKeyWithObjectAndIntTypedArguments(bool validateOnBuild)
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedTransient<ServiceKeyWithObjectAndIntTypedArguments>(KeyedService.AnyKey);
+            using var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateScopes = true,
+                ValidateOnBuild = validateOnBuild
+            });
+
+            // Act
+            var actual = serviceProvider.GetKeyedService<ServiceKeyWithObjectAndIntTypedArguments>(42);
+
+            // Assert
+            Assert.Equal(42, actual.Key);
+            Assert.Equal(42, actual.IntKey);
+        }
+
+        private class ServiceKeyWithObjectAndIntTypedArguments
+        {
+            public object Key { get; set; }
+            public int IntKey { get; set; }
+
+            public ServiceKeyWithObjectAndIntTypedArguments([ServiceKey] object key, [ServiceKey] int intKey)
+            {
+                Key = key;
+                IntKey = intKey;
+            }
+        }
+
         [Fact]
         public void ScopeValidation_ShouldBeAbleToDistingushGenericCollections_WhenGetServiceIsCalledOnRoot()
         {


### PR DESCRIPTION
When the `[ServiceKey]` attribute is applied to a constructor parameter (which sets the parameter value to the key that was used to resolve the service), support using `object` as the parameter type.

Before this PR, the parameter had to be the actual type the service is requested with, even when `AnyKey` is used. With this PR, the parameter can now also be `object` for both cases where the service is registered as the actual type or registered as `AnyKey`.

Supporting both cases helps decouple the service implementation from the registration key type when the service implementation elects to use `object` as the parameter type with `[ServiceKey]`.

Also fixed was a validation issue when `AnyKey` was used with `ValidateOnBuild=true` which caused `[ServiceKey]` not to work at all even if the parameter type was the actual type.

Fixes https://github.com/dotnet/runtime/issues/114780
Fixes https://github.com/dotnet/runtime/issues/93438