### PR TITLE
[mono] Workaround MSVC miscompiling sgen_clz

### DIFF
--- a/src/mono/mono/sgen/sgen-array-list.h
+++ b/src/mono/mono/sgen/sgen-array-list.h
@@ -60,7 +60,10 @@ static inline guint32
 sgen_clz (guint32 x)
 {
 	gulong leading_zero_bits;
-	return _BitScanReverse (&leading_zero_bits, (gulong)x) ? 31 - leading_zero_bits : 32;
+	if (_BitScanReverse (&leading_zero_bits, (gulong)x))
+		return 31 - leading_zero_bits;
+	else
+		return 32;
 }
 #elif defined(ENABLE_MSVC_LZCNT) && defined(_MSC_VER)
 static inline guint32


### PR DESCRIPTION
After the recent VS upgrade from 17.12.5 to 17.13.2 we started seeing access violations in the mono-aot-cross.exe when targetting wasm.

We tracked it down to sgen_clz being miscompiled, we can workaround the compiler bug by switching from ternary condition to if/else.

Thanks to @lateralusX for the great help :)