### PR TITLE
Ensure the trailing slash is removed from the right variable

### DIFF
--- a/src/native/corehost/build.cmd
+++ b/src/native/corehost/build.cmd
@@ -5,7 +5,7 @@ setlocal
 :: Initialize the args that will be passed to cmake
 set "__sourceDir=%~dp0"
 :: remove trailing slash
-if %__sourceDir:~-1%==\ set "__ProjectDir=%__sourceDir:~0,-1%"
+if %__sourceDir:~-1%==\ set "__sourceDir=%__sourceDir:~0,-1%"
 
 set "__RepoRootDir=%__sourceDir%\..\..\.."
 :: normalize


### PR DESCRIPTION
This looks to have been incorrect for a long time (5+ years) and breaks building with CMake 4.0 or later if not resolved.