### PR TITLE
Improve error message when GetRequiredKeyedService() fails

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
@@ -713,6 +713,28 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
         }
 
         [Fact]
+        public void ResolveRequiredKeyedServiceThrowsIfNotFound()
+        {
+            var serviceCollection = new ServiceCollection();
+            var provider = CreateServiceProvider(serviceCollection);
+            var serviceKey = new object();
+
+            InvalidOperationException e;
+
+            e = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredKeyedService<IService>(serviceKey));
+            VerifyException();
+
+            e = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredKeyedService(typeof(IService), serviceKey));
+            VerifyException();
+
+            void VerifyException()
+            {
+                Assert.Contains(nameof(IService), e.Message);
+                Assert.Contains(serviceKey.GetType().FullName, e.Message);
+            }
+        }
+
+        [Fact]
         public void ResolveKeyedServiceThrowsIfNotSupported()
         {
             var provider = new NonKeyedServiceProvider();

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/Resources/Strings.resx
@@ -195,4 +195,7 @@
   <data name="KeyedServiceAnyKeyUsedToResolveService" xml:space="preserve">
     <value>KeyedService.AnyKey cannot be used to resolve a single service.</value>
   </data>
+  <data name="NoKeyedServiceRegistered" xml:space="preserve">
+    <value>No keyed service for type '{0}' using key type '{1}' has been registered.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ThrowHelper.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ThrowHelper.cs
@@ -22,5 +22,19 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             throw new InvalidOperationException(SR.Format(SR.KeyedServiceAnyKeyUsedToResolveService, nameof(IServiceProvider), nameof(IServiceScopeFactory)));
         }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowInvalidOperationException_NoServiceRegistered(Type serviceType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.NoServiceRegistered, serviceType));
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowInvalidOperationException_NoKeyedServiceRegistered(Type serviceType, Type keyType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.NoKeyedServiceRegistered, serviceType, keyType));
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -154,8 +154,16 @@ namespace Microsoft.Extensions.DependencyInjection
             object? service = GetKeyedService(serviceType, serviceKey, serviceProviderEngineScope);
             if (service == null)
             {
-                throw new InvalidOperationException(SR.Format(SR.NoServiceRegistered, serviceType));
+                if (serviceKey is null)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_NoServiceRegistered(serviceType);
+                }
+                else
+                {
+                    ThrowHelper.ThrowInvalidOperationException_NoKeyedServiceRegistered(serviceType, serviceKey.GetType());
+                }
             }
+
             return service;
         }
 


### PR DESCRIPTION
Adds "keyed" and the name of the key type to the message to help with diagnostics.

Fixes https://github.com/dotnet/runtime/issues/112702
