### PR TITLE
[wasm][aot] Disable the AOT smoke tests on linux due to OOM failures

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -852,7 +852,8 @@ extends:
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
         parameters:
           platforms:
-            - browser_wasm
+# disable linux https://github.com/dotnet/runtime/issues/89402
+#            - browser_wasm
             - browser_wasm_win
           nameSuffix: _Smoke_AOT
           runAOT: true


### PR DESCRIPTION
We want to avoid doing this because we will have essentially zero linux aot test coverage if we do.