### PR TITLE
Remove test project dir after test finished in trimmingTests.targets

### DIFF
--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -166,8 +166,14 @@
 
     <Error Condition="'$(ExecutionExitCode)' != '100'" Text="Error: [Failed Test]: %(TestConsoleApps.ProjectCompileItems). The Command %(TestConsoleApps.TestCommand) return a non-success exit code $(ExecutionExitCode)." ContinueOnError="ErrorAndContinue" />
  
-    <!-- remove test project dir to save disk space if the test was successful -->
-    <RemoveDir Condition="'$(ExecutionExitCode)' == '100'" Directories="%(TestConsoleApps.ProjectDir)"  />
+    <!-- Remove test projects dir to save disk space if the test was successful. Ignore failures as this is best effort.
+         Don't use Removedir as ContinueOnError on it doesn't work when using warnaserror/TreatWarningsAsErrors. -->
+    -->
+    <PropertyGroup>
+      <TestProjectCleanCommand Condition="'$(OS)' == 'Windows_NT'">rmdir "%(TestConsoleApps.ProjectDir.TrimEnd('\'))" /s /q</TestProjectCleanCommand>
+      <TestProjectCleanCommand Condition="'$(OS)' != 'Windows_NT'">rm -rf "%(TestConsoleApps.ProjectDir)"</TestProjectCleanCommand>
+    </PropertyGroup>
+    <Exec Condition="'$(ExecutionExitCode)' == '100'" Command="$(TestProjectCleanCommand)" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="ExecuteApplications" />

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -165,6 +165,9 @@
     </Exec>
 
     <Error Condition="'$(ExecutionExitCode)' != '100'" Text="Error: [Failed Test]: %(TestConsoleApps.ProjectCompileItems). The Command %(TestConsoleApps.TestCommand) return a non-success exit code $(ExecutionExitCode)." ContinueOnError="ErrorAndContinue" />
+ 
+    <!-- remove test project dir to save disk space if the test was successful -->
+    <RemoveDir Condition="'$(ExecutionExitCode)' == '100'" Directories="%(TestConsoleApps.ProjectDir)"  />
   </Target>
 
   <Target Name="Build" DependsOnTargets="ExecuteApplications" />

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -168,7 +168,6 @@
  
     <!-- Remove test projects dir to save disk space if the test was successful. Ignore failures as this is best effort.
          Don't use Removedir as ContinueOnError on it doesn't work when using warnaserror/TreatWarningsAsErrors. -->
-    -->
     <PropertyGroup>
       <TestProjectCleanCommand Condition="'$(OS)' == 'Windows_NT'">rmdir "%(TestConsoleApps.ProjectDir.TrimEnd('\'))" /s /q</TestProjectCleanCommand>
       <TestProjectCleanCommand Condition="'$(OS)' != 'Windows_NT'">rm -rf "%(TestConsoleApps.ProjectDir)"</TestProjectCleanCommand>


### PR DESCRIPTION
Should help with the out of disk space errors we've been seeing in the dotnet-linker-tests pipeline.