### PR TITLE
JIT: don't mark callees noinline for non-fatal observations with pgo

### DIFF
--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -792,15 +792,38 @@ void InlineResult::Report()
         // IS_NOINLINE, then we've uncovered a reason why this method
         // can't ever be inlined. Update the callee method attributes
         // so that future inline attempts for this callee fail faster.
-
+        //
         InlineObservation obs = m_Policy->GetObservation();
 
-        if ((m_Callee != nullptr) && (obs != InlineObservation::CALLEE_IS_NOINLINE))
+        bool report     = (m_Callee != nullptr);
+        bool suppress   = (obs == InlineObservation::CALLEE_IS_NOINLINE);
+        bool dynamicPgo = m_RootCompiler->fgPgoDynamic;
+
+        // If dynamic pgo is active, only propagate noinline back to metadata
+        // when there is a CALLEE FATAL observation. We want to make sure
+        // not to block future inlines based on performance or throughput considerations.
+        //
+        // Note fgPgoDyanmic (and hence dynamicPgo) is true iff TieredPGO is enabled globally.
+        // In particular this value does not depend on the root method having PGO data.
+        //
+        if (dynamicPgo)
         {
-            JITDUMP("\nINLINER: Marking %s as NOINLINE because of %s\n", callee, InlGetObservationString(obs));
+            InlineTarget target = InlGetTarget(obs);
+            InlineImpact impact = InlGetImpact(obs);
+            suppress            = (target != InlineTarget::CALLEE) || (impact != InlineImpact::FATAL);
+        }
+
+        if (report && !suppress)
+        {
+            JITDUMP("\nINLINER: Marking %s as NOINLINE (observation %s)\n", callee, InlGetObservationString(obs));
 
             COMP_HANDLE comp = m_RootCompiler->info.compCompHnd;
             comp->setMethodAttribs(m_Callee, CORINFO_FLG_BAD_INLINEE);
+        }
+        else if (suppress)
+        {
+            JITDUMP("\nINLINER: Not marking %s NOINLINE; %s (observation %s)\n", callee,
+                    dynamicPgo ? "pgo active" : "already known", InlGetObservationString(obs));
         }
     }
 

--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -803,7 +803,7 @@ void InlineResult::Report()
         // when there is a CALLEE FATAL observation. We want to make sure
         // not to block future inlines based on performance or throughput considerations.
         //
-        // Note fgPgoDyanmic (and hence dynamicPgo) is true iff TieredPGO is enabled globally.
+        // Note fgPgoDynamic (and hence dynamicPgo) is true iff TieredPGO is enabled globally.
         // In particular this value does not depend on the root method having PGO data.
         //
         if (dynamicPgo)


### PR DESCRIPTION
Some inline policy decisions are sensitive to the root method having valid PGO data.  And sometimes, with invalid PGO data, the decision is that a particular callee can never be a viable inline.  If so, the policy will have the runtime mark the method as `NoInlining` to short-circuit future inlining decisions and save some JIT throughput.

But if the method had valid PGO data the policy may have made a different decision. By marking this method noinline, the JIT will immediately reject all future inline attempts (say from other calling methods with valid PGO data).

For instance, without PGO, the policy may limit the number of basic blocks in a viable callee to 5. But with PGO the policy is willing to consider callees with many more blocks.

In this PR we modify the reporting policy so that if TieredPGO is active, we only ever report back methods with truly fatal inlining issues, not just "informational" or "performance" issues, regardless of the state of the PGO data for the method being jitted.