### PR TITLE
Don't optimize prologues/epilogues in OptimizePostIndexed

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -17391,6 +17391,12 @@ bool emitter::OptimizePostIndexed(instruction ins, regNumber reg, ssize_t imm, e
         return false;
     }
 
+    if (emitComp->compGeneratingUnwindProlog || emitComp->compGeneratingUnwindEpilog)
+    {
+        // Don't remove instructions while generating "unwind" part of prologs or epilogs
+        return false;
+    }
+
     // Cannot allow post indexing if the load itself is already modifying the
     // register.
     regNumber loadStoreDataReg = emitLastIns->idReg1();


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/pull/114630#issuecomment-2817028082 

A similar check exists in `emitter::IsOptimizableLdrStrWithPair` for ldr/str to ldp/stp optimization.