### PR TITLE
[Profiler][Tests] Add shutdown guard and filter to classload test

### DIFF
--- a/src/tests/profiler/native/classload/classload.cpp
+++ b/src/tests/profiler/native/classload/classload.cpp
@@ -28,37 +28,67 @@ HRESULT ClassLoad::Initialize(IUnknown* pICorProfilerInfoUnk)
 
 HRESULT ClassLoad::ClassLoadStarted(ClassID classId)
 {
-    _classLoadStartedCount++;
+    SHUTDOWNGUARD();
+
+    // Increment only UnloadLibrary.TestClass classes
+    std::wstring className = GetClassIDName(classId).ToCStr();
+    if (className.find(L"UnloadLibrary.TestClass") != std::wstring::npos)
+    {
+        wprintf(L"ClassLoadStarted: %ls\n", className.c_str());
+        _classLoadStartedCount++;
+    }
+
     return S_OK;
 }
 
 HRESULT ClassLoad::ClassLoadFinished(ClassID classId, HRESULT hrStatus)
 {
-    _classLoadFinishedCount++;
+    SHUTDOWNGUARD();
+
+    // Increment only UnloadLibrary.TestClass classes
+    std::wstring className = GetClassIDName(classId).ToCStr();
+    if (className.find(L"UnloadLibrary.TestClass") != std::wstring::npos)
+    {
+        _classLoadFinishedCount++;
+    }
+
     return S_OK;
 }
 
 HRESULT ClassLoad::ClassUnloadStarted(ClassID classId)
 {
-    _classUnloadStartedCount++;
-    wprintf(L"ClassUnloadStarted: %s\n", GetClassIDName(classId).ToCStr());
+    SHUTDOWNGUARD();
+
+    // Increment only UnloadLibrary.TestClass classes
+    std::wstring className = GetClassIDName(classId).ToCStr();
+    if (className.find(L"UnloadLibrary.TestClass") != std::wstring::npos)
+    {
+        wprintf(L"ClassUnloadStarted: %ls\n", className.c_str());
+        _classUnloadStartedCount++;
+    }
 
     return S_OK;
 }
 
 HRESULT ClassLoad::ClassUnloadFinished(ClassID classID, HRESULT hrStatus)
 {
-    _classUnloadFinishedCount++;
+    SHUTDOWNGUARD();
+
+    // Increment only UnloadLibrary.TestClass classes
+    std::wstring className = GetClassIDName(classID).ToCStr();
+    if (className.find(L"UnloadLibrary.TestClass") != std::wstring::npos)
+    {
+        _classUnloadFinishedCount++;
+    }
+
     return S_OK;
 }
-
 
 HRESULT ClassLoad::Shutdown()
 {
     Profiler::Shutdown();
 
     if(_failures == 0 
-        && (_classLoadStartedCount != 0)
         // Expect unloading of UnloadLibrary.TestClass and
         // List<UnloadLibrary.TestClass> with all its base classes with everything used in List constructor:
         // - UnloadLibrary.TestClass
@@ -67,10 +97,11 @@ HRESULT ClassLoad::Shutdown()
         // - System.Collections.Generic.IReadOnlyCollection`1<UnloadLibrary.TestClass>
         // - System.Collections.Generic.IReadOnlyList`1<UnloadLibrary.TestClass>
         // - System.Collections.Generic.List`1<UnloadLibrary.TestClass>
-        // - System.Collections.Generic.ICollection`1<UnloadLibrary.TestClass>        
-        && (_classUnloadStartedCount == 7)
+        // - System.Collections.Generic.ICollection`1<UnloadLibrary.TestClass>
         && (_classLoadStartedCount == _classLoadFinishedCount)
-        && (_classUnloadStartedCount == _classUnloadFinishedCount))
+        && (_classLoadStartedCount == 7)
+        && (_classUnloadStartedCount == _classUnloadFinishedCount)
+        && (_classUnloadStartedCount == 7))
     {
         printf("PROFILER TEST PASSES\n");
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/114760

The test failed (once out of 250+ runs) possibly due to the profiler shutting down in the middle of a class load. Many class loads are occurring besides those from unloadlibrary.cs ( `classLoadStartedCount=995 classLoadFinishedCount=994 classUnloadStartedCount=7 classUnloadFinishedCount=7`), and I don't believe this test cares about any classes apart from those from unloadlibrary.cs.

This PR does the following:
- Adds Shutdown guards to avoid possible access violations when profiler resources are freed
- Scopes the counters to just those from UnloadLibrary.TestClass.

### Testing

```powershell
PS R:\> .\artifacts\tests\coreclr\windows.x64.Debug\profiler\unittest\classload\classload.cmd
BEGIN EXECUTION
 "R:\artifacts\tests\coreclr\windows.x64.Debug\Tests\Core_Root\corerun.exe" -p "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true"  classload.dll
Profiler path: R:\artifacts\tests\coreclr\windows.x64.Debug\profiler\unittest\classload\Profiler.dll
Profilee STDOUT: Profiler.dll!DllGetClassObject
Profilee STDOUT: Profiler.dll!Profiler::Initialize
Profilee STDOUT: TestClass constructed
Profilee STDOUT: 32854180
Profilee STDOUT: Setting COR_PRF_MONITOR_CLASS_LOADS mask
Profilee STDOUT: ClassLoadStarted: UnloadLibrary.TestClass
Profilee STDOUT: ClassLoadStarted: System.Collections.Generic.IEnumerable`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassLoadStarted: System.Collections.Generic.ICollection`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassLoadStarted: System.Collections.Generic.IList`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassLoadStarted: System.Collections.Generic.IReadOnlyCollection`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassLoadStarted: System.Collections.Generic.IReadOnlyList`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassLoadStarted: System.Collections.Generic.List`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassUnloadStarted: UnloadLibrary.TestClass
Profilee STDOUT: ClassUnloadStarted: System.Collections.Generic.List`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassUnloadStarted: System.Collections.Generic.IList`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassUnloadStarted: System.Collections.Generic.IReadOnlyCollection`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassUnloadStarted: System.Collections.Generic.IReadOnlyList`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassUnloadStarted: System.Collections.Generic.ICollection`1<UnloadLibrary.TestClass>
Profilee STDOUT: ClassUnloadStarted: System.Collections.Generic.IEnumerable`1<UnloadLibrary.TestClass>
Profilee STDOUT: Profiler.dll!Profiler::Shutdown
Profilee STDOUT: PROFILER TEST PASSES
Expected: 100
Actual: 100
END EXECUTION - PASSED
PASSED
```
