### PR TITLE
Check existing neutral flag on R2R rewrite

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -19,6 +19,7 @@ using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
 using ILCompiler.DependencyAnalysisFramework;
+using ILCompiler.Reflection.ReadyToRun;
 using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler
@@ -448,7 +449,7 @@ namespace ILCompiler
                 ReadyToRunFlags.READYTORUN_FLAG_Component |
                 ReadyToRunFlags.READYTORUN_FLAG_NonSharedPInvokeStubs;
 
-            if (inputModule.IsPlatformNeutral)
+            if (inputModule.IsPlatformNeutral || inputModule.PEReader.IsReadyToRunPlatformNeutralSource())
             {
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_PlatformNeutralSource;
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
 using ILCompiler.DependencyAnalysisFramework;
+using ILCompiler.Reflection.ReadyToRun;
 using ILCompiler.Win32Resources;
 using Internal.IL;
 using Internal.JitInterface;
@@ -247,7 +248,7 @@ namespace ILCompiler
             });
 
             ReadyToRunFlags flags = ReadyToRunFlags.READYTORUN_FLAG_NonSharedPInvokeStubs;
-            if (inputModules.All(module => module.IsPlatformNeutral))
+            if (inputModules.All(module => module.IsPlatformNeutral || module.PEReader.IsReadyToRunPlatformNeutralSource()))
             {
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_PlatformNeutralSource;
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
@@ -139,7 +139,12 @@ namespace ILCompiler.Reflection.ReadyToRun
             return reader.GetExportTable().TryGetValue("RTR_HEADER", out rva);
         }
 
-        internal static bool IsReadyToRunPlatformNeutralSource(this PEReader peReader)
+        /// <summary>
+        /// Check whether the file is a ReadyToRun image created from platform neutral (AnyCPU) IL image.
+        /// </summary>
+        /// <param name="reader">PEReader representing the executable to check</param>
+        /// <returns>true when the PEReader represents a ReadyToRun image created from AnyCPU IL image, false otherwise</returns>
+        public static bool IsReadyToRunPlatformNeutralSource(this PEReader peReader)
         {
             var managedNativeDirectory = peReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory;
             if (managedNativeDirectory.Size < 16 /* sizeof(ReadyToRunHeader) */)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
@@ -9,6 +9,9 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text;
 
+using Internal.Runtime;
+using Internal.ReadyToRunConstants;
+
 namespace ILCompiler.Reflection.ReadyToRun
 {
     public class PEExportTable
@@ -134,6 +137,22 @@ namespace ILCompiler.Reflection.ReadyToRun
         public static bool TryGetReadyToRunHeader(this PEReader reader, out int rva)
         {
             return reader.GetExportTable().TryGetValue("RTR_HEADER", out rva);
+        }
+
+        internal static bool IsReadyToRunPlatformNeutralSource(this PEReader peReader)
+        {
+            var managedNativeDirectory = peReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory;
+            if (managedNativeDirectory.Size < 16 /* sizeof(ReadyToRunHeader) */)
+                return false;
+
+            var reader = peReader.GetSectionData(managedNativeDirectory.RelativeVirtualAddress).GetReader();
+            if (reader.ReadUInt32() != ReadyToRunHeaderConstants.Signature)
+                return false;
+
+            reader.ReadUInt16(); // MajorVersion
+            reader.ReadUInt16(); // MinorVersion
+
+            return (reader.ReadUInt32() & (uint)ReadyToRunFlags.READYTORUN_FLAG_PlatformNeutralSource) != 0;
         }
     }
 }


### PR DESCRIPTION
Fixes PublishReadyToRun+PublishSingleFile on linux-loongarch64 and riscv64, but making R2R arch-neural on all platforms.

Tested with linux-riscv64 SDK: https://github.com/am11/dotnet-riscv/actions/runs/14564425491

Ref https://github.com/dotnet/runtime/pull/114666#discussion_r2051627512