### PR TITLE
Bugfix/113926 fix invalid jsonnode deserialization

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -126,6 +126,8 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\RootLevelListConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\StackOrQueueConverterWithReflection.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonMetadataServicesConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Node\JsonValuePrimitiveConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Node\JsonValuePrimitiveFactory.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Object\ObjectWithParameterizedConstructorConverter.Large.Reflection.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\MemoryConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\ReadOnlyMemoryByteConverter.cs" />

--- a/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
+++ b/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
@@ -6,12 +6,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace System.Text.Json.Reflection
 {
     internal static partial class ReflectionExtensions
     {
+        private static readonly Type s_jsonValuePrimitiveType = typeof(JsonValuePrimitive<>);
         private static readonly Type s_nullableType = typeof(Nullable<>);
 
         /// <summary>
@@ -164,5 +166,12 @@ namespace System.Text.Json.Reflection
 
             return member;
         }
+
+        /// <summary>
+        /// Returns <see langword="true" /> when the given type is of type <see cref="JsonValuePrimitive{TValue}"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsJsonValuePrimitiveOfT(this Type type) =>
+            type.IsGenericType && type.GetGenericTypeDefinition() == s_jsonValuePrimitiveType;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValuePrimitiveConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValuePrimitiveConverter.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
+
+namespace System.Text.Json.Serialization.Converters.Node
+{
+    internal sealed class JsonValuePrimitiveConverter<T> : JsonConverter<JsonValuePrimitive<T>?>
+    {
+        private readonly JsonConverter<T> _elementConverter;
+
+        public override bool HandleNull => true;
+        internal override bool CanPopulate => _elementConverter.CanPopulate;
+        internal override bool ConstructorIsParameterized => _elementConverter.ConstructorIsParameterized;
+        internal override Type? ElementType => typeof(JsonValuePrimitive<T>);
+        internal override JsonConverter? NullableElementConverter => _elementConverter;
+
+        public JsonValuePrimitiveConverter(JsonConverter<T> elementConverter)
+        {
+            _elementConverter = elementConverter;
+        }
+
+        public override JsonValuePrimitive<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            T value = _elementConverter.Read(ref reader, typeof(T), options)!;
+            JsonValuePrimitive<T> returnValue = new JsonValuePrimitive<T>(value, _elementConverter, null);
+
+            return returnValue;
+        }
+
+        public override void Write(Utf8JsonWriter writer, JsonValuePrimitive<T>? value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.WriteTo(writer, options);
+        }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) => _elementConverter.GetSchema(numberHandling);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValuePrimitiveFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValuePrimitiveFactory.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text.Json.Reflection;
+using System.Text.Json.Serialization.Converters.Node;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+    internal sealed class JsonValuePrimitiveFactory : JsonConverterFactory
+    {
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert.IsJsonValuePrimitiveOfT();
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            Debug.Assert(typeToConvert.IsJsonValuePrimitiveOfT());
+
+            Type valueTypeToConvert = typeToConvert.GetGenericArguments()[0];
+            JsonConverter valueConverter = options.GetConverterInternal(valueTypeToConvert);
+
+            return CreateValueConverter(valueTypeToConvert, valueConverter);
+        }
+
+        public static JsonConverter CreateValueConverter(Type valueTypeToConvert, JsonConverter valueConverter)
+        {
+            return (JsonConverter)Activator.CreateInstance(
+                GetJsonValuePrimitiveConverterType(valueTypeToConvert),
+                BindingFlags.Instance | BindingFlags.Public,
+                binder: null,
+                args: new object[] { valueConverter },
+                culture: null)!;
+        }
+
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        private static Type GetJsonValuePrimitiveConverterType(Type valueTypeToConvert) => typeof(JsonValuePrimitiveConverter<>).MakeGenericType(valueTypeToConvert);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
@@ -26,6 +26,7 @@ namespace System.Text.Json.Serialization.Metadata
                 // Nullable converter should always be next since it forwards to any nullable type.
                 new NullableConverterFactory(),
                 new EnumConverterFactory(),
+                new JsonValuePrimitiveFactory(),
                 new JsonNodeConverterFactory(),
                 new FSharpTypeConverterFactory(),
                 new MemoryConverterFactory(),

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -12,6 +13,116 @@ namespace System.Text.Json.Nodes.Tests
 {
     public static class JsonValueTests
     {
+        public static IEnumerable<object[]> GetPrimitiveTypesTwoWaySerializationCases
+        {
+            get
+            {
+                return Enumerable.Empty<object[]>();
+#if NET
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(new DateOnly(2025, 4, 16))
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(Half.MaxValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(Int128.MaxValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(new TimeOnly(17, 18, 19))
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(UInt128.MaxValue)
+                //};
+#endif
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(new DateTime(2025, 4, 16, 17, 18, 19))
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(new DateTimeOffset(2025, 4, 16, 17, 18, 19, new TimeSpan(10, 0, 0)))
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(new Guid("CA79F1AC-AA0B-4704-8F7F-5A95DF0E4FD2"))
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(new TimeSpan(1, 2, 3, 4, 5))
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(new Uri("http://contoso.com"))
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(new Version(1, 2, 3, 4))
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(true)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(byte.MinValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create('X')
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(decimal.MinValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(double.MinValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(float.MaxValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(111)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(long.MaxValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(sbyte.MaxValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(short.MinValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create("HelloWorld")
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(uint.MaxValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(ulong.MaxValue)
+                //};
+                //yield return new object[]
+                //{
+                //    JsonValue.Create(ushort.MaxValue)
+                //};
+            }
+        }
+
         [Fact]
         public static void CreateFromNull()
         {
@@ -583,6 +694,19 @@ namespace System.Text.Json.Nodes.Tests
             Assert.True(JsonNode.DeepEquals(clone, clone));
             Assert.True(JsonNode.DeepEquals(node, clone));
             Assert.True(JsonNode.DeepEquals(clone, node));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetPrimitiveTypesTwoWaySerializationCases))]
+        public static void PrimitiveTypes_TwoWaySerialization<T>(JsonValue value)
+        {
+            string serialized = JsonSerializer.Serialize(value);
+
+            object deserialized = JsonSerializer.Deserialize(serialized, value.GetType());
+
+            Assert.IsType(value.GetType(), deserialized);
+
+            JsonNodeTests.AssertDeepEqual(value, deserialized as JsonNode);
         }
 
         public static IEnumerable<object[]> GetPrimitiveTypes()

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -17,109 +16,108 @@ namespace System.Text.Json.Nodes.Tests
         {
             get
             {
-                return Enumerable.Empty<object[]>();
 #if NET
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(new DateOnly(2025, 4, 16))
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(Half.MaxValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(Int128.MaxValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(new TimeOnly(17, 18, 19))
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(UInt128.MaxValue)
-                //};
+                yield return new object[]
+                {
+                    JsonValue.Create(new DateOnly(2025, 4, 16))
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(Half.MaxValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(Int128.MaxValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(new TimeOnly(17, 18, 19))
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(UInt128.MaxValue)
+                };
 #endif
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(new DateTime(2025, 4, 16, 17, 18, 19))
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(new DateTimeOffset(2025, 4, 16, 17, 18, 19, new TimeSpan(10, 0, 0)))
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(new Guid("CA79F1AC-AA0B-4704-8F7F-5A95DF0E4FD2"))
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(new TimeSpan(1, 2, 3, 4, 5))
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(new Uri("http://contoso.com"))
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(new Version(1, 2, 3, 4))
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(true)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(byte.MinValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create('X')
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(decimal.MinValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(double.MinValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(float.MaxValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(111)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(long.MaxValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(sbyte.MaxValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(short.MinValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create("HelloWorld")
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(uint.MaxValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(ulong.MaxValue)
-                //};
-                //yield return new object[]
-                //{
-                //    JsonValue.Create(ushort.MaxValue)
-                //};
+                yield return new object[]
+                {
+                    JsonValue.Create(new DateTime(2025, 4, 16, 17, 18, 19))
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(new DateTimeOffset(2025, 4, 16, 17, 18, 19, new TimeSpan(10, 0, 0)))
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(new Guid("CA79F1AC-AA0B-4704-8F7F-5A95DF0E4FD2"))
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(new TimeSpan(1, 2, 3, 4, 5))
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(new Uri("http://contoso.com"))
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(new Version(1, 2, 3, 4))
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(true)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(byte.MinValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create('X')
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(decimal.MinValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(double.MinValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(float.MaxValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(111)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(long.MaxValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(sbyte.MaxValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(short.MinValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create("HelloWorld")
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(uint.MaxValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(ulong.MaxValue)
+                };
+                yield return new object[]
+                {
+                    JsonValue.Create(ushort.MaxValue)
+                };
             }
         }
 
@@ -698,15 +696,16 @@ namespace System.Text.Json.Nodes.Tests
 
         [Theory]
         [MemberData(nameof(GetPrimitiveTypesTwoWaySerializationCases))]
-        public static void PrimitiveTypes_TwoWaySerialization<T>(JsonValue value)
+        public static void PrimitiveTypes_TwoWaySerialization(JsonValue value)
         {
             string serialized = JsonSerializer.Serialize(value);
 
             object deserialized = JsonSerializer.Deserialize(serialized, value.GetType());
+            string serializedSecondTime = JsonSerializer.Serialize(deserialized);
 
             Assert.IsType(value.GetType(), deserialized);
-
             JsonNodeTests.AssertDeepEqual(value, deserialized as JsonNode);
+            Assert.Equal(serialized, serializedSecondTime);
         }
 
         public static IEnumerable<object[]> GetPrimitiveTypes()

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
@@ -742,7 +742,7 @@ namespace System.Text.Json.Nodes.Tests
 #if NET
             yield return Wrap(Half.MaxValue, JsonValueKind.Number);
             yield return Wrap((Int128)42, JsonValueKind.Number);
-            yield return Wrap((Int128)42, JsonValueKind.Number);
+            yield return Wrap((UInt128)42, JsonValueKind.Number);
             yield return Wrap((Memory<byte>)new byte[] { 1, 2, 3 }, JsonValueKind.String);
             yield return Wrap((ReadOnlyMemory<byte>)new byte[] { 1, 2, 3 }, JsonValueKind.String);
             yield return Wrap(new DateOnly(2024, 06, 20), JsonValueKind.String);


### PR DESCRIPTION
Current PR fix https://github.com/dotnet/runtime/issues/113926 .
Please pay attention on next lines:

1. https://github.com/Maximys/runtime/blob/cf9d968699c1427227d3e43e32fac187dd0c88d8/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs#L1482
2. https://github.com/Maximys/runtime/blame/cf9d968699c1427227d3e43e32fac187dd0c88d8/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs#L1528
3. https://github.com/Maximys/runtime/blame/cf9d968699c1427227d3e43e32fac187dd0c88d8/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs#L1648

which was extracted from existed classes:

1. https://github.com/dotnet/runtime/blob/c0c5520b7b79747ca903a0ca59125bf3dede1307/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/HalfConverter.cs#L43
2. https://github.com/dotnet/runtime/blob/c0c5520b7b79747ca903a0ca59125bf3dede1307/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int128Converter.cs#L41
3. https://github.com/dotnet/runtime/blob/c0c5520b7b79747ca903a0ca59125bf3dede1307/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt128Converter.cs#L41

If I correctly understand, this lines is dead and represend result of copy-paste. If so, I can delete this condition, but may be I does not understand some corner case.