### PR TITLE
Do not set the salt or info if they are NULL for OpenSSL HKDF.

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_kdf.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_kdf.c
@@ -201,18 +201,26 @@ static int32_t HkdfCore(
 
         size_t keyLengthT = Int32ToSizeT(keyLength);
         size_t destinationLengthT = Int32ToSizeT(destinationLength);
-        size_t saltLengthT = Int32ToSizeT(saltLength);
-        size_t infoLengthT = Int32ToSizeT(infoLength);
 
-        OSSL_PARAM params[] =
+        OSSL_PARAM params[6] = {{0}};
+        int i = 0;
+        params[i++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, (void*)key, keyLengthT);
+        params[i++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, algorithm, 0);
+
+        if (salt != NULL && saltLength > 0)
         {
-            OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, (void*)key, keyLengthT),
-            OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, algorithm, 0),
-            OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, (void*)salt, saltLengthT),
-            OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO, (void*)info, infoLengthT),
-            OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &operation),
-            OSSL_PARAM_construct_end(),
-        };
+            size_t saltLengthT = Int32ToSizeT(saltLength);
+            params[i++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, (void*)salt, saltLengthT);
+        }
+
+        if (info != NULL && infoLength > 0)
+        {
+            size_t infoLengthT = Int32ToSizeT(infoLength);
+            params[i++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO, (void*)info, infoLengthT);
+        }
+
+        params[i++] = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &operation);
+        params[i++] = OSSL_PARAM_construct_end();
 
         if (EVP_KDF_derive(ctx, destination, destinationLengthT, params) <= 0)
         {

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_kdf.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_kdf.c
@@ -7,6 +7,8 @@
 
 #include <assert.h>
 
+#define HKDF_MAX_PARAMETERS 6
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-noreturn"
 void CryptoNative_EvpKdfFree(EVP_KDF* kdf)
@@ -202,7 +204,7 @@ static int32_t HkdfCore(
         size_t keyLengthT = Int32ToSizeT(keyLength);
         size_t destinationLengthT = Int32ToSizeT(destinationLength);
 
-        OSSL_PARAM params[6] = {{0}};
+        OSSL_PARAM params[HKDF_MAX_PARAMETERS] = {{0}};
         int i = 0;
         params[i++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, (void*)key, keyLengthT);
         params[i++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, algorithm, 0);
@@ -220,7 +222,8 @@ static int32_t HkdfCore(
         }
 
         params[i++] = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &operation);
-        params[i++] = OSSL_PARAM_construct_end();
+        params[i] = OSSL_PARAM_construct_end();
+        assert(i < HKDF_MAX_PARAMETERS);
 
         if (EVP_KDF_derive(ctx, destination, destinationLengthT, params) <= 0)
         {

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_kdf.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_kdf.c
@@ -7,8 +7,6 @@
 
 #include <assert.h>
 
-#define HKDF_MAX_PARAMETERS 6
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-noreturn"
 void CryptoNative_EvpKdfFree(EVP_KDF* kdf)
@@ -204,7 +202,7 @@ static int32_t HkdfCore(
         size_t keyLengthT = Int32ToSizeT(keyLength);
         size_t destinationLengthT = Int32ToSizeT(destinationLength);
 
-        OSSL_PARAM params[HKDF_MAX_PARAMETERS] = {{0}};
+        OSSL_PARAM params[6] = {{0}};
         int i = 0;
         params[i++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, (void*)key, keyLengthT);
         params[i++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, algorithm, 0);
@@ -223,7 +221,7 @@ static int32_t HkdfCore(
 
         params[i++] = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &operation);
         params[i] = OSSL_PARAM_construct_end();
-        assert(i < HKDF_MAX_PARAMETERS);
+        assert(i < 6);
 
         if (EVP_KDF_derive(ctx, destination, destinationLengthT, params) <= 0)
         {


### PR DESCRIPTION
OpenSSL 3.x has introduced a change that stops allowing HKDF's salt to be set to `NULL` in https://github.com/openssl/openssl/pull/27305.

This breaks our HKDF implementation which sets a NULL salt and info, depending on the mode.

This broke plenty of existing tests with failures like:

```plain
Error Message:
   Interop+Crypto+OpenSslCryptographicException : error:078C0102:common libcrypto routines::passed a null parameter
  Stack Trace:
     at Interop.Crypto.HkdfExpand(SafeEvpKdfHandle kdf, ReadOnlySpan`1 prk, String algorithm, ReadOnlySpan`1 info, Span`1 destination) in /__w/runtime-ci/runtime-ci/runtime/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Kdf.cs:line 113
   at System.Security.Cryptography.HKDF.Expand(HashAlgorithmName hashAlgorithmName, Int32 hashLength, ReadOnlySpan`1 prk, Span`1 output, ReadOnlySpan`1 info) in /__w/runtime-ci/runtime-ci/runtime/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.OpenSsl.cs:line 44
```

In this case, we no longer set the info or salt if they are NULL, and tests are green again.

This was found in a nightly run against OpenSSL 3.5. https://github.com/vcsjones/runtime-ci/actions/runs/14574054040/job/40876380622

Fixes https://github.com/vcsjones/runtime-ci/issues/5