### PR TITLE
Tar: Write unused GNU tar entry size, ctime and atime bytes in the expected format

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -629,7 +629,7 @@ namespace System.Formats.Tar
                 checksum += FormatNumeric(_gid, buffer.Slice(FieldLocations.Gid, FieldLengths.Gid));
             }
 
-            if (_dataStream != null && _size >= 0)
+            if (_size >= 0)
             {
                 checksum += FormatNumeric(_size, buffer.Slice(FieldLocations.Size, FieldLengths.Size));
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -1132,6 +1132,11 @@ namespace System.Formats.Tar
         // Writes the specified DateTimeOffset's Unix time seconds, and returns its checksum.
         private int WriteAsTimestamp(DateTimeOffset timestamp, Span<byte> destination)
         {
+            if (timestamp == DateTimeOffset.UnixEpoch)
+            {
+                return 0;
+            }
+
             long unixTimeSeconds = timestamp.ToUnixTimeSeconds();
             return FormatNumeric(unixTimeSeconds, destination);
         }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -330,7 +331,7 @@ namespace System.Formats.Tar.Tests
             long expectedDataOffset = canSeek ? 4608 : -1;
             Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
         }
-        
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -387,7 +388,7 @@ namespace System.Formats.Tar.Tests
             writer.WriteEntry(entry);
             Assert.Equal(1536, entry.DataOffset);
         }
-        
+
         [Fact]
         public async Task DataOffset_BeforeAndAfterArchive_Async()
         {
@@ -462,7 +463,7 @@ namespace System.Formats.Tar.Tests
             // Gnu header length is 512, data starts in the next position
             Assert.Equal(512, actualEntry.DataOffset);
         }
-        
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -477,7 +478,7 @@ namespace System.Formats.Tar.Tests
                 GnuTarEntry entry1 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
                 entry1.LinkName = veryLongLinkName;
                 writer.WriteEntry(entry1);
-                
+
                 GnuTarEntry entry2 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
                 entry2.LinkName = veryLongLinkName;
                 writer.WriteEntry(entry2);
@@ -501,7 +502,7 @@ namespace System.Formats.Tar.Tests
             // The regular file data section starts on the next byte.
             long firstExpectedDataOffset = canSeek ? 4608 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
-            
+
             TarEntry secondEntry = reader.GetNextEntry();
             Assert.NotNull(secondEntry);
             // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
@@ -509,7 +510,7 @@ namespace System.Formats.Tar.Tests
             long secondExpectedDataOffset = canSeek ? 9216 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
         }
-        
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -524,7 +525,7 @@ namespace System.Formats.Tar.Tests
                 GnuTarEntry entry1 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
                 entry1.LinkName = veryLongLinkName;
                 await writer.WriteEntryAsync(entry1);
-                
+
                 GnuTarEntry entry2 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
                 entry2.LinkName = veryLongLinkName;
                 await writer.WriteEntryAsync(entry2);
@@ -548,13 +549,123 @@ namespace System.Formats.Tar.Tests
             // The regular file data section starts on the next byte.
             long firstExpectedDataOffset = canSeek ? 4608 : -1;
             Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
-            
+
             TarEntry secondEntry = await reader.GetNextEntryAsync();
             Assert.NotNull(secondEntry);
             // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
             // Second entry (including its long link and long path entries) data section starts one byte after 4608 + 4608 = 9216
             long secondExpectedDataOffset = canSeek ? 9216 : -1;
             Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
+        }
+
+        [Fact]
+        public void UnusedBytesInSizeFieldShouldBeZeroChars()
+        {
+            // The GNU format sets the unused bytes in the size field to "0" characters.
+
+            using MemoryStream ms = new();
+
+            using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+            {
+                // Start with a regular file entry without data
+                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                writer.WriteEntry(entry);
+            }
+            ms.Position = 0;
+
+            using (TarReader reader = new(ms, leaveOpen: true))
+            {
+                GnuTarEntry entry = reader.GetNextEntry() as GnuTarEntry;
+                Assert.NotNull(entry);
+                Assert.Equal(0, entry.Length);
+            }
+            ms.Position = 0;
+            ValidateUnusedBytesInSizeField(ms, 0);
+
+            ms.SetLength(0); // Reset the stream
+            byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }; // 8 bytes of data means a size of 10 in octal
+            using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+            {
+                // Start with a regular file entry with data
+                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                entry.DataStream = new MemoryStream(data);
+                writer.WriteEntry(entry);
+            }
+
+            ms.Position = 0;
+            using (TarReader reader = new(ms, leaveOpen: true))
+            {
+                GnuTarEntry entry = reader.GetNextEntry() as GnuTarEntry;
+                Assert.NotNull(entry);
+                Assert.Equal(data.Length, entry.Length);
+            }
+            ms.Position = 0;
+            ValidateUnusedBytesInSizeField(ms, data.Length);
+        }
+
+        [Fact]
+        public async Task UnusedBytesInSizeFieldShouldBeZeroChars_Async()
+        {
+            // The GNU format sets the unused bytes in the size field to "0" characters.
+
+            await using MemoryStream ms = new();
+
+            await using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+            {
+                // Start with a regular file entry without data
+                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                await writer.WriteEntryAsync(entry);
+            }
+            ms.Position = 0;
+
+            await using (TarReader reader = new(ms, leaveOpen: true))
+            {
+                GnuTarEntry entry = await reader.GetNextEntryAsync() as GnuTarEntry;
+                Assert.NotNull(entry);
+                Assert.Equal(0, entry.Length);
+            }
+            ms.Position = 0;
+            ValidateUnusedBytesInSizeField(ms, 0);
+
+            ms.SetLength(0); // Reset the stream
+            byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }; // 8 bytes of data means a size of 10 in octal
+            await using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+            {
+                // Start with a regular file entry with data
+                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+                entry.DataStream = new MemoryStream(data);
+                await writer.WriteEntryAsync(entry);
+            }
+
+            ms.Position = 0;
+            await using (TarReader reader = new(ms, leaveOpen: true))
+            {
+                GnuTarEntry entry = await reader.GetNextEntryAsync() as GnuTarEntry;
+                Assert.NotNull(entry);
+                Assert.Equal(data.Length, entry.Length);
+            }
+            ms.Position = 0;
+            ValidateUnusedBytesInSizeField(ms, data.Length);
+        }
+
+        private void ValidateUnusedBytesInSizeField(MemoryStream ms, long size)
+        {
+            // internally, the unused bytes in the size field should be "0" characters,
+            // and the rest should be the octal value of the size field
+
+            // name, mode, uid, gid,
+            // size
+            int sizeStart = 100 + 8 + 8 + 8;
+            byte[] buffer = new byte[12]; // The size field is 12 bytes in length
+
+            ms.Seek(sizeStart, SeekOrigin.Begin);
+            ms.Read(buffer);
+
+            // Convert the base 10 value of size to base 8
+            string octalSize = Convert.ToString(size, 8).PadLeft(11, '0');
+            byte[] octalSizeBytes = Encoding.ASCII.GetBytes(octalSize);
+            // The last byte should be a null character
+            Assert.Equal(octalSizeBytes, buffer.Take(octalSizeBytes.Length).ToArray());
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
@@ -9,6 +9,9 @@ namespace System.Formats.Tar.Tests
 {
     public partial class TarWriter_Tests : TarTestsBase
     {
+        private readonly DateTimeOffset TimestampForChecksum = new DateTimeOffset(2022, 1, 2, 3, 45, 00, TimeSpan.Zero);
+        private readonly DateTimeOffset UnixEpochTimestampForChecksum = DateTimeOffset.UnixEpoch;
+
         [Fact]
         public void Constructors_NullStream()
         {
@@ -99,13 +102,10 @@ namespace System.Formats.Tar.Tests
             }
         }
 
-        private readonly DateTimeOffset TimestampForChecksum = new DateTimeOffset(2022, 1, 2, 3, 45, 00, TimeSpan.Zero);
-
         [Theory]
         [InlineData(TarEntryFormat.V7)]
         [InlineData(TarEntryFormat.Ustar)]
         [InlineData(TarEntryFormat.Pax)]
-        [InlineData(TarEntryFormat.Gnu)]
         public void Verify_Checksum_RegularFile(TarEntryFormat format) =>
             Verify_Checksum_Internal(
                 format,
@@ -114,36 +114,62 @@ namespace System.Formats.Tar.Tests
                 longLink: false,
                 longPath: false);
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Verify_Checksum_RegularFile_Gnu(bool testEpoch) =>
+            Verify_Checksum_Internal(TarEntryFormat.Gnu, TarEntryType.RegularFile, longPath: false, longLink: false, testEpoch);
+
         [Theory] // V7 does not support BlockDevice
         [InlineData(TarEntryFormat.Ustar)]
         [InlineData(TarEntryFormat.Pax)]
-        [InlineData(TarEntryFormat.Gnu)]
         public void Verify_Checksum_BlockDevice(TarEntryFormat format) =>
             Verify_Checksum_Internal(format, TarEntryType.BlockDevice, longPath: false, longLink: false);
 
         [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Verify_Checksum_BlockDevice_Gnu(bool testEpoch) =>
+            Verify_Checksum_Internal(TarEntryFormat.Gnu, TarEntryType.BlockDevice, longPath: false, longLink: false, testEpoch);
+
+        [Theory]
         [InlineData(TarEntryFormat.V7)]
         [InlineData(TarEntryFormat.Ustar)]
         [InlineData(TarEntryFormat.Pax)]
-        [InlineData(TarEntryFormat.Gnu)]
         public void Verify_Checksum_Directory_LongPath(TarEntryFormat format) =>
             Verify_Checksum_Internal(format, TarEntryType.Directory, longPath: true, longLink: false);
 
         [Theory]
-        [InlineData(TarEntryFormat.V7)]
-        [InlineData(TarEntryFormat.Ustar)]
-        [InlineData(TarEntryFormat.Pax)]
-        [InlineData(TarEntryFormat.Gnu)]
-        public void Verify_Checksum_SymbolicLink_LongLink(TarEntryFormat format) =>
-            Verify_Checksum_Internal(format, TarEntryType.SymbolicLink, longPath: false, longLink: true);
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Verify_Checksum_Directory_LongPath_Gnu(bool testEpoch) =>
+            Verify_Checksum_Internal(TarEntryFormat.Gnu, TarEntryType.Directory, longPath: true, longLink: false, testEpoch);
 
         [Theory]
         [InlineData(TarEntryFormat.V7)]
         [InlineData(TarEntryFormat.Ustar)]
         [InlineData(TarEntryFormat.Pax)]
-        [InlineData(TarEntryFormat.Gnu)]
+        public void Verify_Checksum_SymbolicLink_LongLink(TarEntryFormat format) =>
+            Verify_Checksum_Internal(format, TarEntryType.SymbolicLink, longPath: false, longLink: true);
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Verify_Checksum_SymbolicLink_LongLink_Gnu(bool testEpoch) =>
+            Verify_Checksum_Internal(TarEntryFormat.Gnu, TarEntryType.SymbolicLink, longPath: false, longLink: true, testEpoch);
+
+        [Theory]
+        [InlineData(TarEntryFormat.V7)]
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
         public void Verify_Checksum_SymbolicLink_LongLink_LongPath(TarEntryFormat format) =>
             Verify_Checksum_Internal(format, TarEntryType.SymbolicLink, longPath: true, longLink: true);
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Verify_Checksum_SymbolicLink_LongLink_LongPath_Gnu(bool testEpoch) =>
+            Verify_Checksum_Internal(TarEntryFormat.Gnu, TarEntryType.SymbolicLink, longPath: true, longLink: true, testEpoch);
 
         [Fact]
         public void Verify_Size_RegularFile_Empty()
@@ -217,13 +243,13 @@ namespace System.Formats.Tar.Tests
             Assert.Null(actualEntry.DataStream); // No stream created when size field's value is 0
         }
 
-        private void Verify_Checksum_Internal(TarEntryFormat format, TarEntryType entryType, bool longPath, bool longLink)
+        private void Verify_Checksum_Internal(TarEntryFormat format, TarEntryType entryType, bool longPath, bool longLink, bool testEpoch = false)
         {
             using MemoryStream archive = new MemoryStream();
             int expectedChecksum;
             using (TarWriter writer = new TarWriter(archive, format, leaveOpen: true))
             {
-                TarEntry entry = CreateTarEntryAndGetExpectedChecksum(format, entryType, longPath, longLink, out expectedChecksum);
+                TarEntry entry = CreateTarEntryAndGetExpectedChecksum(format, entryType, longPath, longLink, testEpoch, out expectedChecksum);
                 writer.WriteEntry(entry);
                 Assert.Equal(expectedChecksum, entry.Checksum);
             }
@@ -236,7 +262,7 @@ namespace System.Formats.Tar.Tests
             }
         }
 
-        private TarEntry CreateTarEntryAndGetExpectedChecksum(TarEntryFormat format, TarEntryType entryType, bool longPath, bool longLink, out int expectedChecksum)
+        private TarEntry CreateTarEntryAndGetExpectedChecksum(TarEntryFormat format, TarEntryType entryType, bool longPath, bool longLink, bool testEpoch, out int expectedChecksum)
         {
             expectedChecksum = 0;
 
@@ -251,7 +277,7 @@ namespace System.Formats.Tar.Tests
             }
 
             expectedChecksum += GetChecksumForCommonFields(entry, entryType);
-            expectedChecksum += GetChecksumForFormatSpecificFields(entry, format);
+            expectedChecksum += GetChecksumForFormatSpecificFields(entry, format, testEpoch);
 
             return entry;
         }
@@ -318,7 +344,7 @@ namespace System.Formats.Tar.Tests
             int expectedChecksum = 256;
 
             // '0000744\0' = 48 + 48 + 48 + 48 + 55 + 52 + 52 + 0 = 351
-            entry.Mode = AssetMode; // octal 744 => u+rxw, g+r, o+r
+            entry.Mode = AssetMode; // decimal 484 (octal 744) => u+rxw, g+r, o+r
             expectedChecksum += 351;
 
             // '0017351\0' = 48 + 48 + 49 + 55 + 51 + 53 + 49 + 0 = 353
@@ -344,11 +370,16 @@ namespace System.Formats.Tar.Tests
                 entry.DataStream.Seek(0, SeekOrigin.Begin); // Rewind to ensure it gets written from the beginning
                 expectedChecksum += 533;
             }
+            else
+            {
+                // '0000000000\0' = 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 0 = 528
+                expectedChecksum += 528;
+            }
 
             // If V7 regular file:            '\0' = 0
-            // If Ustar/Pax/Gnu regular file: '0'  = 48
-            // If block device:               '4'  = 52
-            expectedChecksum += (byte)entryType;
+                // If Ustar/Pax/Gnu regular file: '0'  = 48
+                // If block device:               '4'  = 52
+                expectedChecksum += (byte)entryType;
 
             // Checksum so far: 256 + 351 + 353 + 359 + 571 = decimal 1890
             // If V7RegularFile: 1890 + 533 + 0  = 2423 (octal 4567) => '004567\0'
@@ -357,7 +388,7 @@ namespace System.Formats.Tar.Tests
             return expectedChecksum;
         }
 
-        private int GetChecksumForFormatSpecificFields(TarEntry entry, TarEntryFormat format)
+        private int GetChecksumForFormatSpecificFields(TarEntry entry, TarEntryFormat format, bool testEpoch)
         {
             int checksum = 0;
             switch (format)
@@ -402,14 +433,29 @@ namespace System.Formats.Tar.Tests
 
                 if (posixEntry is GnuTarEntry gnuEntry)
                 {
-                    // '14164217674\0' = 49 + 52 + 49 + 54 + 52 + 50 + 49 + 55 + 54 + 55 + 52 + 0 = 571
-                    gnuEntry.AccessTime = TimestampForChecksum; // ToUnixTimeSeconds() = decimal 1641095100, octal 14164217674;
-                    checksum += 571;
+                    GetTimestampToTest(testEpoch, out DateTimeOffset expectedTimestampToTest, out int expectedTimestampChecksumToTest);
 
-                    // '14164217674\0' = 49 + 52 + 49 + 54 + 52 + 50 + 49 + 55 + 54 + 55 + 52 + 0 = 571
-                    gnuEntry.ChangeTime = TimestampForChecksum; // ToUnixTimeSeconds() = decimal 1641095100, octal 14164217674;
-                    checksum += 571;
-                    // Total: 1142
+                    gnuEntry.AccessTime = expectedTimestampToTest;
+                    checksum += expectedTimestampChecksumToTest;
+
+                    gnuEntry.ChangeTime = expectedTimestampToTest;
+                    checksum += expectedTimestampChecksumToTest;
+                    // Total: UnixEpoch = 0, otherwise = 1142
+
+                    void GetTimestampToTest(bool testEpoch, out DateTimeOffset expectedTimestampToTest, out int expectedTimestampChecksumToTest)
+                    {
+                        if (!testEpoch)
+                        {
+                            expectedTimestampChecksumToTest = 571;
+
+                            // '14164217674\0' = 49 + 52 + 49 + 54 + 52 + 50 + 49 + 55 + 54 + 55 + 52 + 0 = 571
+                            expectedTimestampToTest = TimestampForChecksum; // ToUnixTimeSeconds() = decimal 1641095100, octal 14164217674;
+                        }
+
+                        expectedTimestampChecksumToTest = 0;
+                        // '\0\0\0\0\0\0\0\0\0\0\0\0' = 0
+                        expectedTimestampToTest = UnixEpochTimestampForChecksum; // ToUnixTimeSeconds() = decimal 0, octal 0;
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR fixes two bugs in the GNU format:

1. The atime and ctime fields (unique to this format) need to be written as null characters if their value is the Unix Epoch. The bug was that we were writing them as "0" characters as other GNU metadata fields. This was causing tools like 7-zip to show an extra unexpected folder with a name formed by just "0" characters. Other tools were unable to read these archives as they were considered corrupt.

    Added sync and async tests to validate directly in the memory stream that when atime and ctime represent the Unix Epoch, they are indeed written as null characters.

2. The unused bytes of the size metadata field should be filled with "0" characters. The bug was that we were filling them with nulls like in the other formats.
    Added sync and async tests to validate directly in the memory stream that the unused bytes in the size field are indeed written as "0" characters.

    Added sync and async tests to validate directly in the memory stream that when atime and ctime represent the Unix Epoch, they are indeed written as null characters.

Manual test: reading entries in a GNU archive generated by another tool, then rewriting each entry into a new archive created with TarWriter. Then opening it with 7-zip.

Before - Note how 7-zip did its best to deduce the minimum required fields, but most was empty:
![image](https://github.com/user-attachments/assets/9a6ef1b0-8d43-4052-a9c8-61ea301c9978)

After - Note that 7-zip now shows many other fields that it was unable to read before:
![image](https://github.com/user-attachments/assets/372cda56-3c9a-492b-a4f9-1e598bee3e90)

