### PR TITLE
Update LoopHeadPred to point to right loop IG

### DIFF
--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -20,7 +20,8 @@ Documentation for VS debugger format specifiers: https://learn.microsoft.com/vis
   </Type>
 
   <Type Name="BasicBlock">
-    <DisplayString Condition="bbKind==BBJ_COND || bbKind==BBJ_ALWAYS || bbKind==BBJ_LEAVE || bbKind==BBJ_EHCATCHRET || bbKind==BBJ_CALLFINALLY || bbKind==BBJ_CALLFINALLYRET || bbKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTargetEdge->m_destBlock->bbNum,d}; {bbKind,en}</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_ALWAYS || bbKind==BBJ_LEAVE || bbKind==BBJ_EHCATCHRET || bbKind==BBJ_CALLFINALLY || bbKind==BBJ_CALLFINALLYRET || bbKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTargetEdge->m_destBlock->bbNum,d}; {bbKind,en}</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_COND">BB{bbNum,d}-> (BB{bbTrueEdge->m_destBlock->bbNum,d}(T),BB{bbFalseEdge->m_destBlock->bbNum,d}(F)) ; {bbKind,en}</DisplayString>
     <DisplayString Condition="bbKind==BBJ_SWITCH">BB{bbNum,d}; {bbKind,en}; {bbSwtTargets->bbsCount} cases</DisplayString>
     <DisplayString Condition="bbKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbKind,en}; {bbEhfTargets->bbeCount} succs</DisplayString>
     <DisplayString>BB{bbNum,d}; {bbKind,en}</DisplayString>

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2856,8 +2856,8 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
     {
 #if FEATURE_LOOP_ALIGN
 
-        if (!currIGWasNonEmpty && (emitAlignLast != nullptr) && (emitAlignLast->idaLoopHeadPredIG != nullptr)
-            && (emitAlignLast->idaLoopHeadPredIG->igNext == emitCurIG))
+        if (!currIGWasNonEmpty && (emitAlignLast != nullptr) && (emitAlignLast->idaLoopHeadPredIG != nullptr) &&
+            (emitAlignLast->idaLoopHeadPredIG->igNext == emitCurIG))
         {
             // If the emitCurIG was thought to be a loop-head, but if it didn't turn out that way and we end up
             // creating a new IG from which the loop starts, make sure to update the LoopHeadPred of last align

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2818,6 +2818,8 @@ bool emitter::emitNoGChelper(CORINFO_METHOD_HANDLE methHnd)
 
 void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMaskTP byrefRegs, BasicBlock* prevBlock)
 {
+    bool currIGWasNonEmpty = emitCurIGnonEmpty();
+
     // if starting a new block that can be a target of a branch and the last instruction was GC-capable call.
     if ((prevBlock != nullptr) && emitComp->compCurBB->HasFlag(BBF_HAS_LABEL) && emitLastInsIsCallWithGC())
     {
@@ -2852,6 +2854,18 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
 
     if (emitCurIGnonEmpty())
     {
+        if (!currIGWasNonEmpty && (emitAlignLast != nullptr) && (emitAlignLast->idaLoopHeadPredIG != nullptr)
+            && (emitAlignLast->idaLoopHeadPredIG->igNext == emitCurIG))
+        {
+            // If the emitCurIG was thought to be a loop-head, but if it didn't turn out that way and we end up
+            // creating a new IG from which the loop starts, make sure to update the LoopHeadPred of last align
+            // instruction emitted. This will guarantee that the information stays up-to-date. Later if we
+            // notice a loop that encloses another loop, this information helps in removing the align field from
+            // such loops.
+            // We need to only update emitAlignLast because we do not align intermingled or overlapping loops.
+            emitAlignLast->idaLoopHeadPredIG = emitCurIG;
+        }
+
         emitNxtIG();
     }
     else

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2854,6 +2854,8 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
 
     if (emitCurIGnonEmpty())
     {
+#if FEATURE_LOOP_ALIGN
+
         if (!currIGWasNonEmpty && (emitAlignLast != nullptr) && (emitAlignLast->idaLoopHeadPredIG != nullptr)
             && (emitAlignLast->idaLoopHeadPredIG->igNext == emitCurIG))
         {
@@ -2865,6 +2867,7 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
             // We need to only update emitAlignLast because we do not align intermingled or overlapping loops.
             emitAlignLast->idaLoopHeadPredIG = emitCurIG;
         }
+#endif // FEATURE_LOOP_ALIGN
 
         emitNxtIG();
     }


### PR DESCRIPTION
Sometimes, we may create new IG with `nop` if the previous IG's last instruction was GC-capable call. However, if that IG was considered to be a loop head, `alignInstr`'s `idaLoopHeadPredIG` would still point to the pred of the new IG instead of the new IG itself. Update `idaLoopHeadPredIG` to point to the right loop IG.

The problem that we had was:

```
IG328:
  gc-capable call

IG329:
  ; idaLoopHeadPredIG for loop starting from IG330. However, we add `nop` and create new IG331
  ; In that case, align for loop IG331~IG343 was still pointing to IG229 as LoopPreHead instead of IG330

IG330:
  nop

IG331:
...
...
IG343:
   loop IG331
...
...
IG410:
   loop IG331
  ; since this encloses loop IG331~IG343, we want to disable alignment for it, but couldn't because it doesn't find the
  ; idaLoopHeadPredIG
```

The stress mode `STRESS_THREE_OPT_LAYOUT` exposed this. Without this mode, the issue doesn't repro.

Fixes: https://github.com/dotnet/runtime/issues/114569