### PR TITLE
[crossgen2] Rename TryGetReadyToRunHeader to TryGetCompositeReadyToRunHeader

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PEReaderExtensions.cs
@@ -126,12 +126,12 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         /// <summary>
-        /// Check whether the file is a ReadyToRun image and returns the RVA of its ReadyToRun header if positive.
+        /// Check whether the file is a composite ReadyToRun image and returns the RVA of its ReadyToRun header if positive.
         /// </summary>
         /// <param name="reader">PEReader representing the executable to check for the presence of ReadyToRun header</param>
         /// <param name="rva">RVA of the ReadyToRun header if available, 0 when not</param>
         /// <returns>true when the PEReader represents a ReadyToRun image, false otherwise</returns>
-        public static bool TryGetReadyToRunHeader(this PEReader reader, out int rva)
+        public static bool TryGetCompositeReadyToRunHeader(this PEReader reader, out int rva)
         {
             return reader.GetExportTable().TryGetValue("RTR_HEADER", out rva);
         }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -455,7 +455,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
             if ((peReader.PEHeaders.CorHeader.Flags & CorFlags.ILLibrary) == 0)
             {
-                return peReader.TryGetReadyToRunHeader(out _);
+                return peReader.TryGetCompositeReadyToRunHeader(out _);
             }
             else
             {
@@ -611,7 +611,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private bool TryLocateNativeReadyToRunHeader()
         {
-            _composite = CompositeReader.TryGetReadyToRunHeader(out _readyToRunHeaderRVA);
+            _composite = CompositeReader.TryGetCompositeReadyToRunHeader(out _readyToRunHeaderRVA);
 
             return _composite;
         }

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -159,7 +159,7 @@ namespace ILCompiler
                     {
                         var module = _typeSystemContext.GetModuleFromPath(inputFile.Value);
                         if ((module.PEReader.PEHeaders.CorHeader.Flags & (CorFlags.ILLibrary | CorFlags.ILOnly)) == (CorFlags)0
-                            && module.PEReader.TryGetReadyToRunHeader(out int _))
+                            && module.PEReader.TryGetCompositeReadyToRunHeader(out int _))
                         {
                             Console.WriteLine(SR.IgnoringCompositeImage, inputFile.Value);
                             continue;


### PR DESCRIPTION
- Delete local definition that is no longer needed
- Rename method to make its name match what it actually does