### PR TITLE
Fix debugger app hangs related to thread exit

### DIFF
--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -2896,6 +2896,12 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
 
         }
 
+        if (m_State & TS_DebugWillSync)
+        {
+            ResetThreadState(TS_DebugWillSync);
+            InterlockedDecrement(&m_DebugWillSyncCount);    
+        }
+
         SetThreadState(TS_Dead);
         ThreadStore::s_pThreadStore->m_DeadThreadCount++;
         ThreadStore::s_pThreadStore->IncrementDeadThreadCountForGCTrigger();


### PR DESCRIPTION
This fix correctly manages m_DebugWillSyncCount when thread exits before it is synchronized, addressing #112747