### PR TITLE
[browser] Use regex to match boot config placeholder

### DIFF
--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
@@ -16,7 +16,9 @@ namespace Microsoft.NET.Sdk.WebAssembly
 {
     public class BootJsonBuilderHelper(TaskLoggingHelper Log, string DebugLevel, bool IsMultiThreaded, bool IsPublish)
     {
+#pragma warning disable SYSLIB1045 // Convert to 'GeneratedRegexAttribute'.
         internal static readonly Regex mergeWithPlaceholderRegex = new Regex(@"/\*!\s*dotnetBootConfig\s*\*/\s*{}");
+#pragma warning restore SYSLIB1045 // Convert to 'GeneratedRegexAttribute'.
 
         private static readonly string[] coreAssemblyNames = [
             "System.Private.CoreLib",

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
@@ -9,12 +9,15 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Sdk.WebAssembly
 {
     public class BootJsonBuilderHelper(TaskLoggingHelper Log, string DebugLevel, bool IsMultiThreaded, bool IsPublish)
     {
+        internal static readonly Regex mergeWithPlaceholderRegex = new Regex(@"/\*!\s*dotnetBootConfig\s*\*/\s*{}");
+
         private static readonly string[] coreAssemblyNames = [
             "System.Private.CoreLib",
             "System.Runtime.InteropServices.JavaScript",
@@ -56,7 +59,7 @@ namespace Microsoft.NET.Sdk.WebAssembly
             if (mergeWith != null)
             {
                 string existingContent = File.ReadAllText(mergeWith);
-                output = existingContent.Replace("/*! dotnetBootConfig */{}", $"/*json-start*/{output}/*json-end*/");
+                output = mergeWithPlaceholderRegex.Replace(existingContent, e => $"/*json-start*/{output}/*json-end*/");
                 if (existingContent.Equals(output))
                     Log.LogError($"Merging boot config into '{mergeWith}' failed to find the placeholder.");
             }

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
@@ -14,9 +14,10 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Sdk.WebAssembly
 {
-    public class BootJsonBuilderHelper(TaskLoggingHelper Log, string DebugLevel, bool IsMultiThreaded, bool IsPublish)
+    public partial class BootJsonBuilderHelper(TaskLoggingHelper Log, string DebugLevel, bool IsMultiThreaded, bool IsPublish)
     {
-        internal static readonly Regex mergeWithPlaceholderRegex = new Regex(@"/\*!\s*dotnetBootConfig\s*\*/\s*{}");
+        [GeneratedRegex(@"/\*!\s*dotnetBootConfig\s*\*/\s*{}")]
+        internal static partial Regex MergeWithPlaceholderRegex();
 
         private static readonly string[] coreAssemblyNames = [
             "System.Private.CoreLib",
@@ -59,7 +60,7 @@ namespace Microsoft.NET.Sdk.WebAssembly
             if (mergeWith != null)
             {
                 string existingContent = File.ReadAllText(mergeWith);
-                output = mergeWithPlaceholderRegex.Replace(existingContent, e => $"/*json-start*/{output}/*json-end*/");
+                output = MergeWithPlaceholderRegex().Replace(existingContent, e => $"/*json-start*/{output}/*json-end*/");
                 if (existingContent.Equals(output))
                     Log.LogError($"Merging boot config into '{mergeWith}' failed to find the placeholder.");
             }

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
@@ -14,10 +14,9 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Sdk.WebAssembly
 {
-    public partial class BootJsonBuilderHelper(TaskLoggingHelper Log, string DebugLevel, bool IsMultiThreaded, bool IsPublish)
+    public class BootJsonBuilderHelper(TaskLoggingHelper Log, string DebugLevel, bool IsMultiThreaded, bool IsPublish)
     {
-        [GeneratedRegex(@"/\*!\s*dotnetBootConfig\s*\*/\s*{}")]
-        internal static partial Regex MergeWithPlaceholderRegex();
+        internal static readonly Regex mergeWithPlaceholderRegex = new Regex(@"/\*!\s*dotnetBootConfig\s*\*/\s*{}");
 
         private static readonly string[] coreAssemblyNames = [
             "System.Private.CoreLib",
@@ -60,7 +59,7 @@ namespace Microsoft.NET.Sdk.WebAssembly
             if (mergeWith != null)
             {
                 string existingContent = File.ReadAllText(mergeWith);
-                output = MergeWithPlaceholderRegex().Replace(existingContent, e => $"/*json-start*/{output}/*json-end*/");
+                output = mergeWithPlaceholderRegex.Replace(existingContent, e => $"/*json-start*/{output}/*json-end*/");
                 if (existingContent.Equals(output))
                     Log.LogError($"Merging boot config into '{mergeWith}' failed to find the placeholder.");
             }


### PR DESCRIPTION
Typescript **debug** build generates an extra space in the boot config placeholder.
This PR relaxes the strictness regarding spaces in the boot config placeholder.

Relates to https://github.com/dotnet/aspnetcore/issues/58875