### PR TITLE
[RISC-V] Extend register for slti

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3208,22 +3208,23 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
             switch (cmpSize)
             {
                 case EA_4BYTE:
+                {
+                    regNumber tmpRegOp1 = internalRegisters.GetSingle(tree);
+                    assert(regOp1 != tmpRegOp1);
                     if (isUnsigned)
                     {
                         imm = static_cast<uint32_t>(imm);
-
-                        regNumber tmpRegOp1 = internalRegisters.GetSingle(tree);
-                        assert(regOp1 != tmpRegOp1);
-
                         emit->emitIns_R_R_I(INS_slli, EA_8BYTE, tmpRegOp1, regOp1, 32);
                         emit->emitIns_R_R_I(INS_srli, EA_8BYTE, tmpRegOp1, tmpRegOp1, 32);
-                        regOp1 = tmpRegOp1;
                     }
                     else
                     {
                         imm = static_cast<int32_t>(imm);
+                        emit->emitIns_R_R(INS_sext_w, EA_8BYTE, tmpRegOp1, regOp1);
                     }
+                    regOp1 = tmpRegOp1;
                     break;
+                }
                 case EA_8BYTE:
                     break;
                 default:

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -445,17 +445,8 @@ int LinearScan::BuildNode(GenTree* tree)
             if (!varTypeIsFloating(op1Type))
             {
                 emitAttr cmpSize = EA_ATTR(genTypeSize(op1Type));
-                if (tree->gtGetOp2()->isContainedIntOrIImmed())
-                {
-                    bool isUnsigned = (tree->gtFlags & GTF_UNSIGNED) != 0;
-                    if (cmpSize == EA_4BYTE && isUnsigned)
-                        buildInternalIntRegisterDefForNode(tree);
-                }
-                else
-                {
-                    if (cmpSize == EA_4BYTE)
-                        buildInternalIntRegisterDefForNode(tree);
-                }
+                if (cmpSize == EA_4BYTE)
+                    buildInternalIntRegisterDefForNode(tree);
             }
             buildInternalRegisterUses();
         }

--- a/src/tests/JIT/Directed/Directed_2.csproj
+++ b/src/tests/JIT/Directed/Directed_2.csproj
@@ -4,6 +4,7 @@
     <MergedWrapperProjectReference Include="perffix/**/*.??proj" />
     <MergedWrapperProjectReference Include="PREFIX/**/*.??proj" />
     <MergedWrapperProjectReference Include="shift/**/*.??proj" />
+    <MergedWrapperProjectReference Include="compare/**/*.??proj" />
   </ItemGroup>
 
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />

--- a/src/tests/JIT/Directed/Directed_3.csproj
+++ b/src/tests/JIT/Directed/Directed_3.csproj
@@ -11,6 +11,7 @@
     <MergedWrapperProjectReference Remove="perffix/**/*.??proj" />
     <MergedWrapperProjectReference Remove="PREFIX/**/*.??proj" />
     <MergedWrapperProjectReference Remove="shift/**/*.??proj" />
+    <MergedWrapperProjectReference Remove="compare/**/*.??proj" />
   </ItemGroup>
 
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />

--- a/src/tests/JIT/Directed/compare/int32.cs
+++ b/src/tests/JIT/Directed/compare/int32.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class CompareTest
+{
+    [MethodImplAttribute(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool Lt2((int, float) x) => (x.Item1 < 2);
+    
+    [MethodImplAttribute(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool Gt2((int, float) x) => (x.Item1 > 2);
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool Le2((int, float) x) => (x.Item1 <= 2);
+    
+    [MethodImplAttribute(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool Ge2((int, float) x) => (x.Item1 >= 2);
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool Eq0((int, float) x) => (x.Item1 == 0);
+    
+    [MethodImplAttribute(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool Ne0((int, float) x) => (x.Item1 != 0);
+
+    [Fact]
+    public static void Test()
+    {
+        // The integer field of a struct passed in a register according to RISC-V floating-point calling convention is
+        // not extended. Comparisons on RISC-V, however, always operate on full registers.
+        // Note: reflection calls poison the undefined bits in runtime debug mode making it a better repro.
+        var type = typeof(CompareTest);
+        var args = new object[] {(2, 0f)};
+        Assert.False((bool)type.GetMethod("Lt2").Invoke(null, args));
+        Assert.False((bool)type.GetMethod("Gt2").Invoke(null, args));
+        Assert.True((bool)type.GetMethod("Le2").Invoke(null, args));
+        Assert.True((bool)type.GetMethod("Ge2").Invoke(null, args));
+        args = new object[] {(0, 0f)};
+        Assert.True((bool)type.GetMethod("Eq0").Invoke(null, args));
+        Assert.False((bool)type.GetMethod("Ne0").Invoke(null, args));
+    }
+}

--- a/src/tests/JIT/Directed/compare/int32.csproj
+++ b/src/tests/JIT/Directed/compare/int32.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="int32.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Sometimes the register for `slti` may be not extended. For now patch like other comparisons -- by sign-extending always.

Part of #84834, cc @dotnet/samsung