### PR TITLE
Remove redundant 'freeList' field from HashLookup class

### DIFF
--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
@@ -22,7 +22,6 @@ namespace System.Linq.Parallel
         private int[] buckets;
         private Slot[] slots;
         private int count;
-        private int freeList;
         private readonly IEqualityComparer<TKey>? comparer;
 
         private const int HashCodeMask = 0x7fffffff;
@@ -36,7 +35,6 @@ namespace System.Linq.Parallel
             this.comparer = comparer;
             buckets = new int[7];
             slots = new Slot[7];
-            freeList = -1;
         }
 
         // If value is not in set, add it and return true; otherwise return false
@@ -97,18 +95,10 @@ namespace System.Linq.Parallel
 
             if (add)
             {
-                int index;
-                if (freeList >= 0)
-                {
-                    index = freeList;
-                    freeList = slots[index].next;
-                }
-                else
-                {
-                    if (count == slots.Length) Resize();
-                    index = count;
-                    count++;
-                }
+                if (count == slots.Length) Resize();
+
+                int index = count;
+                count++;
 
                 int bucket = hashCode % buckets.Length;
                 slots[index].hashCode = hashCode;


### PR DESCRIPTION
The `freeList` field is initialized to `-1` and is never modified.