### PR TITLE
Fix Baggage order in W3C propagator extraction

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -111,7 +111,9 @@ namespace System.Diagnostics
                 if (TryDecodeBaggageKey(keySpan, out string? key) && TryDecodeBaggageValue(valueSpan, out string value))
                 {
                     baggageList ??= new List<KeyValuePair<string, string?>>();
-                    baggageList.Add(new KeyValuePair<string, string?>(key, value));
+
+                    // Insert in reverse order for asp.net compatibility.
+                    baggageList.Insert(0, new KeyValuePair<string, string?>(key, value));
                 }
 
                 baggageSpan = entrySeparator >= 0 ? baggageSpan.Slice(entrySeparator + 1) : ReadOnlySpan<char>.Empty;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -111,13 +111,14 @@ namespace System.Diagnostics
                 if (TryDecodeBaggageKey(keySpan, out string? key) && TryDecodeBaggageValue(valueSpan, out string value))
                 {
                     baggageList ??= new List<KeyValuePair<string, string?>>();
-
-                    // Insert in reverse order for asp.net compatibility.
-                    baggageList.Insert(0, new KeyValuePair<string, string?>(key, value));
+                    baggageList.Add(new KeyValuePair<string, string?>(key, value));
                 }
 
                 baggageSpan = entrySeparator >= 0 ? baggageSpan.Slice(entrySeparator + 1) : ReadOnlySpan<char>.Empty;
             } while (baggageSpan.Length > 0);
+
+            // reverse order for asp.net compatibility.
+            baggageList?.Reverse();
 
             baggage = baggageList;
             return baggageList != null;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/W3CPropagatorTests.cs
@@ -193,11 +193,11 @@ namespace System.Diagnostics.Tests
 
                 if (fieldName == PropagatorTests.CorrelationContext)
                 {
-                    fieldValue = "key1=value1,key2=value2,key3=value3";
+                    fieldValue = "key3=value3,key2=value2,key1=value1";
                     return;
                 }
 
-                Assert.Fail($"Encountered wrong header name '{fieldName}' in W3C baggage propagatoration");
+                Assert.Fail($"Encountered wrong header name '{fieldName}' in W3C baggage propagation");
             });
 
             Assert.Equal(new[] { new KeyValuePair<string, string?>("key1", "value1"), new KeyValuePair<string, string?>("key2", "value2"), new KeyValuePair<string, string?>("key3", "value3") }, extractedBaggage);
@@ -214,9 +214,9 @@ namespace System.Diagnostics.Tests
             // Double equals
             yield return new object[] { "key==value", new[] { new KeyValuePair<string, string?>("key", "=value") },  "key = =value" };
 
-            yield return new object[] { "SomeKey=SomeValue,SomeKey2=SomeValue2", new[] { new KeyValuePair<string, string?>("SomeKey", "SomeValue"), new KeyValuePair<string, string?>("SomeKey2", "SomeValue2") }, "SomeKey2 = SomeValue2, SomeKey = SomeValue" };
+            yield return new object[] { "SomeKey=SomeValue,SomeKey2=SomeValue2", new[] { new KeyValuePair<string, string?>("SomeKey2", "SomeValue2"), new KeyValuePair<string, string?>("SomeKey", "SomeValue") }, "SomeKey = SomeValue, SomeKey2 = SomeValue2" };
 
-            yield return new object[] { "SomeKey \t = \t SomeValue \t , \t SomeKey2 \t = \t SomeValue2 \t", new[] { new KeyValuePair<string, string?>("SomeKey", "SomeValue"), new KeyValuePair<string, string?>("SomeKey2", "SomeValue2") }, "SomeKey2 = SomeValue2, SomeKey = SomeValue" };
+            yield return new object[] { "SomeKey \t = \t SomeValue \t , \t SomeKey2 \t = \t SomeValue2 \t", new[] { new KeyValuePair<string, string?>("SomeKey2", "SomeValue2"), new KeyValuePair<string, string?>("SomeKey", "SomeValue") }, "SomeKey = SomeValue, SomeKey2 = SomeValue2" };
 
             yield return new object[] { "SomeKey=SomeValue=equals", new[] { new KeyValuePair<string, string?>("SomeKey", "SomeValue=equals") }, "SomeKey = SomeValue=equals" };
 


### PR DESCRIPTION
ASP.NET Core includes tests to verify the order in which baggage is extracted during propagation. The order in the W3C propagator was fixed solely to minimize compatibility risks.