### PR TITLE
FromServiceKeyAttribute to support nullable (for unkeyed) and to use current service key

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
@@ -32,8 +32,10 @@ namespace Microsoft.Extensions.DependencyInjection
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
     public partial class FromKeyedServicesAttribute : System.Attribute
     {
-        public FromKeyedServicesAttribute(object key) { }
-        public object Key { get { throw null; } }
+        public static object FromServiceKey { get { throw null; } }
+        public FromKeyedServicesAttribute() { }
+        public FromKeyedServicesAttribute(object? key) { }
+        public object? Key { get { throw null; } }
     }
     public partial interface IServiceCollection : System.Collections.Generic.ICollection<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IEnumerable<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IList<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.IEnumerable
     {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Extensions.DependencyInjection
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter)]
     public partial class FromKeyedServicesAttribute : System.Attribute
     {
-        public static object FromServiceKey { get { throw null; } }
         public FromKeyedServicesAttribute() { }
         public FromKeyedServicesAttribute(object? key) { }
         public object? Key { get { throw null; } }
+        public Microsoft.Extensions.DependencyInjection.ServiceKeyLookupMode LookupMode { get { throw null; } }
     }
     public partial interface IServiceCollection : System.Collections.Generic.ICollection<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IEnumerable<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.Generic.IList<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, System.Collections.IEnumerable
     {
@@ -207,6 +207,12 @@ namespace Microsoft.Extensions.DependencyInjection
     public partial class ServiceKeyAttribute : System.Attribute
     {
         public ServiceKeyAttribute() { }
+    }
+    public enum ServiceKeyLookupMode
+    {
+        InheritKey = 0,
+        NullKey = 1,
+        ExplicitKey = 2,
     }
     public enum ServiceLifetime
     {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// Indicates that the parameter should be bound using the keyed service registered with the specified key.
     /// </summary>
+    /// <seealso cref="ServiceKeyAttribute"/>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromKeyedServicesAttribute : Attribute
     {
@@ -15,11 +16,26 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Creates a new <see cref="FromKeyedServicesAttribute"/> instance.
         /// </summary>
         /// <param name="key">The key of the keyed service to bind to.</param>
-        public FromKeyedServicesAttribute(object key) => Key = key;
+        public FromKeyedServicesAttribute(object? key) => Key = key;
+
+        /// <summary>
+        /// Creates a new <see cref="FromKeyedServicesAttribute"/> instance with <see cref="Key"/> set to <see cref="FromServiceKey"/>.
+        /// </summary>
+        public FromKeyedServicesAttribute() => Key = FromServiceKey;
 
         /// <summary>
         /// The key of the keyed service to bind to.
         /// </summary>
-        public object Key { get; }
+        /// <remarks>A <see langword="null"/> value indicates there is not a key and just the parameter type is used to resolve the service.
+        /// This is useful for DI implementations that require an explict way to declare that the parameter should be resolved for unkeyed services.
+        /// </remarks>
+        public object? Key { get; }
+
+        /// <summary>
+        /// Indicates that a parameter represents a service should be resolved from the same key that the current service was resolved with.
+        /// </summary>
+        public static object FromServiceKey { get; } = new FromServiceKeyObj();
+
+        private sealed class FromServiceKeyObj { }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// Indicates that the parameter should be bound using the keyed service registered with the specified key.
     /// </summary>
     /// <seealso cref="ServiceKeyAttribute"/>
+    /// <seealso cref="ServiceKeyLookupMode"/>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromKeyedServicesAttribute : Attribute
     {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
@@ -34,13 +34,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// The key of the keyed service to bind to.
         /// </summary>
-        /// <remarks>A <see langword="null"/> value indicates there is not a key and just the parameter type is used to resolve the service.
+        /// <remarks>A <see langword="null"/> value with indicates there is not a key and just the parameter type is used to resolve the service.
         /// This is useful for DI implementations that require an explict way to declare that the parameter should be resolved for unkeyed services.
+        /// A <see langword="null"/> value is also used along with <see cref="LookupMode"/> set to <see cref="ServiceKeyLookupMode.InheritKey"/> to indicate that the key should be inherited from the parent scope.
         /// </remarks>
         public object? Key { get; }
 
         /// <summary>
-        /// The mode used to look up the service key.
+        /// Gets the mode used to look up the service key.
         /// </summary>
         public ServiceKeyLookupMode LookupMode { get; }
     }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
@@ -16,12 +16,20 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Creates a new <see cref="FromKeyedServicesAttribute"/> instance.
         /// </summary>
         /// <param name="key">The key of the keyed service to bind to.</param>
-        public FromKeyedServicesAttribute(object? key) => Key = key;
+        public FromKeyedServicesAttribute(object? key)
+        {
+            Key = key;
+            LookupMode = key == null ? ServiceKeyLookupMode.NullKey : ServiceKeyLookupMode.ExplicitKey;
+        }
 
         /// <summary>
-        /// Creates a new <see cref="FromKeyedServicesAttribute"/> instance with <see cref="Key"/> set to <see cref="FromServiceKey"/>.
+        /// Creates a new <see cref="FromKeyedServicesAttribute"/> instance with <see cref="LookupMode"/> set to <see cref="ServiceKeyLookupMode.InheritKey"/>.
         /// </summary>
-        public FromKeyedServicesAttribute() => Key = FromServiceKey;
+        public FromKeyedServicesAttribute()
+        {
+            Key = null;
+            LookupMode = ServiceKeyLookupMode.InheritKey;
+        }
 
         /// <summary>
         /// The key of the keyed service to bind to.
@@ -32,10 +40,8 @@ namespace Microsoft.Extensions.DependencyInjection
         public object? Key { get; }
 
         /// <summary>
-        /// Indicates that a parameter represents a service should be resolved from the same key that the current service was resolved with.
+        /// The mode used to look up the service key.
         /// </summary>
-        public static object FromServiceKey { get; } = new FromServiceKeyObj();
-
-        private sealed class FromServiceKeyObj { }
+        public ServiceKeyLookupMode LookupMode { get; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceKeyAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceKeyAttribute.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// Specifies the parameter to inject the key that was used for registration or resolution.
     /// </summary>
+    /// <seealso cref="FromKeyedServicesAttribute"/>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class ServiceKeyAttribute : Attribute
     {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceKeyLookupMode.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceKeyLookupMode.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Specifies how to look up the service key for a parameter.
+    /// </summary>
+    public enum ServiceKeyLookupMode
+    {
+        /// <summary>
+        /// The key is inherited from the parent service.
+        /// </summary>
+        InheritKey,
+
+        /// <summary>
+        /// A null key indicates that the parameter should be resolved for unkeyed services.
+        /// This is useful for DI implementations that require an explicit way to declare that the parameter should be resolved for unkeyed services.
+        /// </summary>
+        NullKey,
+
+        /// <summary>
+        /// The key is explicitly specified.
+        /// </summary>
+        ExplicitKey
+    }
+}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceKeyLookupMode.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceKeyLookupMode.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Extensions.DependencyInjection
         InheritKey,
 
         /// <summary>
-        /// A null key indicates that the parameter should be resolved for unkeyed services.
-        /// This is useful for DI implementations that require an explicit way to declare that the parameter should be resolved for unkeyed services.
+        /// A <see langword="null" /> key indicates that the parameter should be resolved from unkeyed services.
+        /// This is useful for DI implementations that require an explicit way to declare that the parameter should be resolved from unkeyed services.
         /// </summary>
         NullKey,
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
@@ -518,7 +518,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
 
             Assert.Null(provider.GetService<IService>());
 
-            for (int i=0; i<3; i++)
+            for (int i = 0; i < 3; i++)
             {
                 var key = "service" + i;
                 var s1 = provider.GetKeyedService<IService>(key);
@@ -823,23 +823,23 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             public IServiceProvider ServiceProvider { get; }
         }
 
-            [Fact]
-            public void SimpleServiceKeyedResolution()
-            {
-                // Arrange
-                var services = new ServiceCollection();
-                services.AddKeyedTransient<ISimpleService, SimpleService>("simple");
-                services.AddKeyedTransient<ISimpleService, AnotherSimpleService>("another");
-                services.AddTransient<SimpleParentWithDynamicKeyedService>();
-                var provider = CreateServiceProvider(services);
-                var sut = provider.GetService<SimpleParentWithDynamicKeyedService>();
+        [Fact]
+        public void SimpleServiceKeyedResolution()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddKeyedTransient<ISimpleService, SimpleService>("simple");
+            services.AddKeyedTransient<ISimpleService, AnotherSimpleService>("another");
+            services.AddTransient<SimpleParentWithDynamicKeyedService>();
+            var provider = CreateServiceProvider(services);
+            var sut = provider.GetService<SimpleParentWithDynamicKeyedService>();
 
-                // Act
-                var result = sut!.GetService("simple");
+            // Act
+            var result = sut!.GetService("simple");
 
-                // Assert
-                Assert.True(result.GetType() == typeof(SimpleService));
-            }
+            // Assert
+            Assert.True(result.GetType() == typeof(SimpleService));
+        }
 
         public class SimpleParentWithDynamicKeyedService
         {
@@ -863,5 +863,89 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
         {
             public object GetService(Type serviceType) => throw new NotImplementedException();
         }
+
+#if NET10_0_OR_GREATER
+        [Fact]
+        public void ResolveKeyedServiceWithFromServiceKeyAttribute()
+        {
+            ServiceCollection services = new();
+            services.AddKeyedSingleton<ServiceUsingFromServiceKeyAttribute>("key");
+            services.AddKeyedSingleton<ServiceCreatedWithServiceKeyAttribute>("key");
+
+            IServiceProvider provider = CreateServiceProvider(services);
+
+            ServiceUsingFromServiceKeyAttribute service = provider.GetRequiredKeyedService<ServiceUsingFromServiceKeyAttribute>("key");
+            Assert.Equal("key", service.OtherService.MyKey);
+        }
+
+        [Fact]
+        public void ResolveKeyedServiceWithFromServiceKeyAttribute_NotFound()
+        {
+            ServiceCollection services = new();
+            services.AddKeyedSingleton<ServiceUsingFromServiceKeyAttribute>("key1");
+            services.AddKeyedSingleton<ServiceCreatedWithServiceKeyAttribute>("key2");
+
+            IServiceProvider provider = CreateServiceProvider(services);
+
+            Assert.Throws<InvalidOperationException>(() => provider.GetKeyedService<ServiceUsingFromServiceKeyAttribute>("key1"));
+        }
+
+        [Fact]
+        public void ResolveKeyedServiceWithFromServiceKeyAttribute_NotFound_WithUnkeyed()
+        {
+            ServiceCollection services = new();
+            services.AddKeyedSingleton<ServiceUsingFromServiceKeyAttribute>("key1");
+            services.AddSingleton<ServiceCreatedWithServiceKeyAttribute>();
+
+            IServiceProvider provider = CreateServiceProvider(services);
+
+            Assert.Throws<InvalidOperationException>(() => provider.GetKeyedService<ServiceUsingFromServiceKeyAttribute>("key1"));
+        }
+
+        private class ServiceUsingFromServiceKeyAttribute : IService
+        {
+            public ServiceCreatedWithServiceKeyAttribute OtherService { get; }
+
+            public ServiceUsingFromServiceKeyAttribute([FromKeyedServices] ServiceCreatedWithServiceKeyAttribute otherService)
+            {
+                OtherService = otherService;
+            }
+        }
+
+        private class ServiceCreatedWithServiceKeyAttribute : IService
+        {
+            public string MyKey { get; }
+
+            public ServiceCreatedWithServiceKeyAttribute([ServiceKey] string myKey)
+            {
+                MyKey = myKey;
+            }
+        }
+
+        [Fact]
+        public void ResolveUnkeyedServiceWithFromServiceKeyAttributeWithNullKey()
+        {
+            ServiceCollection services = new();
+            services.AddSingleton<UnkeyedServiceWithFromServiceKeyAttributeWithNullKey>();
+            services.AddSingleton<Service>();
+
+            IServiceProvider provider = CreateServiceProvider(services);
+
+            UnkeyedServiceWithFromServiceKeyAttributeWithNullKey service =
+                provider.GetRequiredService<UnkeyedServiceWithFromServiceKeyAttributeWithNullKey>();
+
+            Assert.NotNull(service.OtherService);
+        }
+
+        private class UnkeyedServiceWithFromServiceKeyAttributeWithNullKey : IService
+        {
+            public Service OtherService { get; }
+
+            public UnkeyedServiceWithFromServiceKeyAttributeWithNullKey([FromKeyedServices(null)] Service otherService)
+            {
+                OtherService = otherService;
+            }
+        }
+#endif
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -631,18 +631,17 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
                     if (attribute is FromKeyedServicesAttribute fromKeyedServicesAttribute)
                     {
-                        if (fromKeyedServicesAttribute.LookupMode == ServiceKeyLookupMode.InheritKey)
+                        object? serviceKey = fromKeyedServicesAttribute.LookupMode switch
                         {
-                            ServiceIdentifier parameterSvcId = new(serviceIdentifier.ServiceKey, parameterType);
-                            callSite = GetCallSite(parameterSvcId, callSiteChain);
-                            isKeyedParameter = true;
-                            break;
-                        }
+                            ServiceKeyLookupMode.InheritKey => serviceIdentifier.ServiceKey,
+                            ServiceKeyLookupMode.ExplicitKey => fromKeyedServicesAttribute.Key,
+                            ServiceKeyLookupMode.NullKey => null,
+                            _ => null
+                        };
 
-                        if (fromKeyedServicesAttribute.LookupMode == ServiceKeyLookupMode.ExplicitKey)
+                        if (serviceKey is not null)
                         {
-                            ServiceIdentifier parameterSvcId = new(fromKeyedServicesAttribute.Key, parameterType);
-                            callSite = GetCallSite(parameterSvcId, callSiteChain);
+                            callSite = GetCallSite(new ServiceIdentifier(serviceKey, parameterType), callSiteChain);
                             isKeyedParameter = true;
                             break;
                         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -629,12 +629,23 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         break;
                     }
 
-                    if (attribute is FromKeyedServicesAttribute keyed)
+                    if (attribute is FromKeyedServicesAttribute fromKeyedServicesAttribute)
                     {
-                        var parameterSvcId = new ServiceIdentifier(keyed.Key, parameterType);
-                        callSite = GetCallSite(parameterSvcId, callSiteChain);
-                        isKeyedParameter = true;
-                        break;
+                        if (fromKeyedServicesAttribute.Key == FromKeyedServicesAttribute.FromServiceKey)
+                        {
+                            ServiceIdentifier parameterSvcId = new(serviceIdentifier.ServiceKey, parameterType);
+                            callSite = GetCallSite(parameterSvcId, callSiteChain);
+                            isKeyedParameter = true;
+                            break;
+                        }
+
+                        if (fromKeyedServicesAttribute.Key is not null)
+                        {
+                            ServiceIdentifier parameterSvcId = new(fromKeyedServicesAttribute.Key, parameterType);
+                            callSite = GetCallSite(parameterSvcId, callSiteChain);
+                            isKeyedParameter = true;
+                            break;
+                        }
                     }
                 }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -631,7 +631,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
                     if (attribute is FromKeyedServicesAttribute fromKeyedServicesAttribute)
                     {
-                        if (fromKeyedServicesAttribute.Key == FromKeyedServicesAttribute.FromServiceKey)
+                        if (fromKeyedServicesAttribute.LookupMode == ServiceKeyLookupMode.InheritKey)
                         {
                             ServiceIdentifier parameterSvcId = new(serviceIdentifier.ServiceKey, parameterType);
                             callSite = GetCallSite(parameterSvcId, callSiteChain);
@@ -639,7 +639,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                             break;
                         }
 
-                        if (fromKeyedServicesAttribute.Key is not null)
+                        if (fromKeyedServicesAttribute.LookupMode == ServiceKeyLookupMode.ExplicitKey)
                         {
                             ServiceIdentifier parameterSvcId = new(fromKeyedServicesAttribute.Key, parameterType);
                             callSite = GetCallSite(parameterSvcId, callSiteChain);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/113585

(draft to verify tests)

This is API approved except for this which is being done via email:
```cs
public static object FromServiceKey { get; }
```
