### PR TITLE
Tar: Adjust the way we write GNU longlink and longpath metadata

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -673,17 +673,25 @@ namespace System.Formats.Tar
 
             int checksum = 0;
 
-            int mode = Math.Max(0, _mode);
-            checksum += FormatNumeric(mode, buffer.Slice(FieldLocations.Mode, FieldLengths.Mode));
+            if (_mode >= 0)
+            {
+                checksum += FormatNumeric(_mode, buffer.Slice(FieldLocations.Mode, FieldLengths.Mode));
+            }
 
-            int uid = Math.Max(0, _uid);
-            checksum += FormatNumeric(uid, buffer.Slice(FieldLocations.Uid, FieldLengths.Uid));
+            if (_uid >= 0)
+            {
+                checksum += FormatNumeric(_uid, buffer.Slice(FieldLocations.Uid, FieldLengths.Uid));
+            }
 
-            int gid = Math.Max(0, _gid);
-            checksum += FormatNumeric(gid, buffer.Slice(FieldLocations.Gid, FieldLengths.Gid));
+            if (_gid >= 0)
+            {
+                checksum += FormatNumeric(_gid, buffer.Slice(FieldLocations.Gid, FieldLengths.Gid));
+            }
 
-            long size = Math.Max(0, _size);
-            checksum += FormatNumeric(size, buffer.Slice(FieldLocations.Size, FieldLengths.Size));
+            if (_size >= 0)
+            {
+                checksum += FormatNumeric(_size, buffer.Slice(FieldLocations.Size, FieldLengths.Size));
+            }
 
             checksum += WriteAsTimestamp(_mTime, buffer.Slice(FieldLocations.MTime, FieldLengths.MTime));
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -1167,8 +1167,6 @@ namespace System.Formats.Tar
             ulong remaining = (ulong)value;
             Span<byte> digits = stackalloc byte[32]; // longer than any possible octal formatting of a ulong
 
-            digits.Slice(0, digits.Length - 1).Fill(0x30); // Prefill with '0' chars except the last, which should remain 0x0 (null terminator)
-
             int i = digits.Length - 1;
 
             while (true)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -682,10 +682,18 @@ namespace System.Formats.Tar
             {
                 checksum += FormatNumeric(_uid, buffer.Slice(FieldLocations.Uid, FieldLengths.Uid));
             }
+            else if (_uid == 0 && _format is TarEntryFormat.Gnu)
+            {
+                FormatAsZeroChars(buffer.Slice(FieldLocations.Uid, FieldLengths.Uid));
+            }
 
             if (_gid > 0)
             {
                 checksum += FormatNumeric(_gid, buffer.Slice(FieldLocations.Gid, FieldLengths.Gid));
+            }
+            else if (_uid == 0 && _format is TarEntryFormat.Gnu)
+            {
+                FormatAsZeroChars(buffer.Slice(FieldLocations.Gid, FieldLengths.Gid));
             }
 
             if (_size >= 0)
@@ -1126,6 +1134,14 @@ namespace System.Formats.Tar
                 checksum += b;
             }
             return checksum;
+        }
+
+        private static int FormatAsZeroChars(Span<byte> destination)
+        {
+            Debug.Assert(destination.Length > 1);
+            destination.Slice(0, destination.Length - 1).Fill(0x30); // '0' char
+            destination[^1] = 0; // Null terminator
+            return Checksum(destination);
         }
 
         private int FormatNumeric(int value, Span<byte> destination)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -354,6 +354,13 @@ namespace System.Formats.Tar
                 await WriteWithSeekableDataStreamAsync(TarEntryFormat.Pax, archiveStream, buffer, cancellationToken).ConfigureAwait(false);
             }
         }
+        // Checks if the linkname string is too long to fit in the regular header field.
+        // .NET strings do not include a null terminator by default, need to add it manually and also consider it for the length.
+        private bool IsLinkNameTooLongForRegularField() => _linkName != null && (Encoding.UTF8.GetByteCount(_linkName) + 1) > FieldLengths.LinkName;
+
+        // Checks if the name string is too long to fit in the regular header field.
+        // .NET strings do not include a null terminator by default, need to add it manually and also consider it for the length.
+        private bool IsNameTooLongForRegularField() => (Encoding.UTF8.GetByteCount(_name) + 1) > FieldLengths.Name;
 
         // Writes the current header as a Gnu entry into the archive stream.
         // Makes sure to add the preceding LongLink and/or LongPath entries if necessary, before the actual entry.
@@ -361,19 +368,19 @@ namespace System.Formats.Tar
         {
             Debug.Assert(archiveStream.CanSeek || _dataStream == null || _dataStream.CanSeek);
 
-            // First, we determine if we need a preceding LongLink, and write it if needed
-            if (_linkName != null && Encoding.UTF8.GetByteCount(_linkName) > FieldLengths.LinkName)
+            if (IsLinkNameTooLongForRegularField())
             {
-                TarHeader longLinkHeader = GetGnuLongMetadataHeader(TarEntryType.LongLink, _linkName);
+                // Linkname is too long for the regular header field, create a longlink entry where the linkname will be stored.
+                TarHeader longLinkHeader = GetGnuLongLinkMetadataHeader();
                 Debug.Assert(longLinkHeader._dataStream != null && longLinkHeader._dataStream.CanSeek); // We generate the long metadata data stream, should always be seekable
                 longLinkHeader.WriteWithSeekableDataStream(TarEntryFormat.Gnu, archiveStream, buffer);
                 buffer.Clear(); // Reset it to reuse it
             }
 
-            // Second, we determine if we need a preceding LongPath, and write it if needed
-            if (Encoding.UTF8.GetByteCount(_name) > FieldLengths.Name)
+            if (IsNameTooLongForRegularField())
             {
-                TarHeader longPathHeader = GetGnuLongMetadataHeader(TarEntryType.LongPath, _name);
+                // Name is too long for the regular header field, create a longpath entry where the name will be stored.
+                TarHeader longPathHeader = GetGnuLongPathMetadataHeader();
                 Debug.Assert(longPathHeader._dataStream != null && longPathHeader._dataStream.CanSeek); // We generate the long metadata data stream, should always be seekable
                 longPathHeader.WriteWithSeekableDataStream(TarEntryFormat.Gnu, archiveStream, buffer);
                 buffer.Clear(); // Reset it to reuse it
@@ -397,19 +404,19 @@ namespace System.Formats.Tar
             Debug.Assert(archiveStream.CanSeek || _dataStream == null || _dataStream.CanSeek);
             cancellationToken.ThrowIfCancellationRequested();
 
-            // First, we determine if we need a preceding LongLink, and write it if needed
-            if (_linkName != null && Encoding.UTF8.GetByteCount(_linkName) > FieldLengths.LinkName)
+            if (IsLinkNameTooLongForRegularField())
             {
-                TarHeader longLinkHeader = GetGnuLongMetadataHeader(TarEntryType.LongLink, _linkName);
+                // Linkname is too long for the regular header field, create a longlink entry where the linkname will be stored.
+                TarHeader longLinkHeader = await GetGnuLongLinkMetadataHeaderAsync(cancellationToken).ConfigureAwait(false);
                 Debug.Assert(longLinkHeader._dataStream != null && longLinkHeader._dataStream.CanSeek); // We generate the long metadata data stream, should always be seekable
                 await longLinkHeader.WriteWithSeekableDataStreamAsync(TarEntryFormat.Gnu, archiveStream, buffer, cancellationToken).ConfigureAwait(false);
                 buffer.Span.Clear(); // Reset it to reuse it
             }
 
-            // Second, we determine if we need a preceding LongPath, and write it if needed
-            if (Encoding.UTF8.GetByteCount(_name) > FieldLengths.Name)
+            if (IsNameTooLongForRegularField())
             {
-                TarHeader longPathHeader = GetGnuLongMetadataHeader(TarEntryType.LongPath, _name);
+                // Name is too long for the regular header field, create a longpath entry where the name will be stored.
+                TarHeader longPathHeader = await GetGnuLongPathMetadataHeaderAsync(cancellationToken).ConfigureAwait(false);
                 Debug.Assert(longPathHeader._dataStream != null && longPathHeader._dataStream.CanSeek); // We generate the long metadata data stream, should always be seekable
                 await longPathHeader.WriteWithSeekableDataStreamAsync(TarEntryFormat.Gnu, archiveStream, buffer, cancellationToken).ConfigureAwait(false);
                 buffer.Span.Clear(); // Reset it to reuse it
@@ -426,8 +433,56 @@ namespace System.Formats.Tar
             }
         }
 
+        private static MemoryStream GetLongMetadataStream(string text)
+        {
+            MemoryStream data = new MemoryStream();
+            data.Write(Encoding.UTF8.GetBytes(text));
+            data.WriteByte(0); // Add a null terminator at the end of the string, _size will be calculated later
+            data.Position = 0;
+            return data;
+        }
+
+        private static async ValueTask<MemoryStream> GetLongMetadataStreamAsync(string text, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            MemoryStream data = new MemoryStream();
+            await data.WriteAsync(Encoding.UTF8.GetBytes(text), cancellationToken).ConfigureAwait(false);
+            data.WriteByte(0); // Add a null terminator at the end of the string, _size will be calculated later
+            data.Position = 0;
+            return data;
+        }
+
+        private TarHeader GetGnuLongLinkMetadataHeader()
+        {
+            Debug.Assert(_linkName != null);
+            MemoryStream dataStream = GetLongMetadataStream(_linkName);
+            return GetGnuLongMetadataHeader(dataStream, TarEntryType.LongLink, _uid, _gid, _uName, _gName);
+        }
+
+        private async Task<TarHeader> GetGnuLongLinkMetadataHeaderAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Debug.Assert(_linkName != null);
+            MemoryStream dataStream = await GetLongMetadataStreamAsync(_linkName, cancellationToken).ConfigureAwait(false);
+            return GetGnuLongMetadataHeader(dataStream, TarEntryType.LongLink, _uid, _gid, _uName, _gName);
+        }
+
+        private TarHeader GetGnuLongPathMetadataHeader()
+        {
+            MemoryStream dataStream = GetLongMetadataStream(_name);
+            return GetGnuLongMetadataHeader(dataStream, TarEntryType.LongPath, _uid, _gid, _uName, _gName);
+        }
+
+        private async Task<TarHeader> GetGnuLongPathMetadataHeaderAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            MemoryStream dataStream = await GetLongMetadataStreamAsync(_name, cancellationToken).ConfigureAwait(false);
+            return GetGnuLongMetadataHeader(dataStream, TarEntryType.LongPath, _uid, _gid, _uName, _gName);
+        }
+
         // Creates and returns a GNU long metadata header, with the specified long text written into its data stream (seekable).
-        private static TarHeader GetGnuLongMetadataHeader(TarEntryType entryType, string longText)
+        private static TarHeader GetGnuLongMetadataHeader(MemoryStream dataStream, TarEntryType entryType, int mainEntryUid, int mainEntryGid, string? mainEntryUname, string? mainEntryGname)
         {
             Debug.Assert(entryType is TarEntryType.LongPath or TarEntryType.LongLink);
 
@@ -435,11 +490,15 @@ namespace System.Formats.Tar
             {
                 _name = GnuLongMetadataName, // Same name for both longpath or longlink
                 _mode = TarHelpers.GetDefaultMode(entryType),
-                _uid = 0,
-                _gid = 0,
-                _mTime = DateTimeOffset.MinValue, // 0
+                _uid = mainEntryUid,
+                _gid = mainEntryGid,
+                _mTime = DateTimeOffset.UnixEpoch, // 0
                 _typeFlag = entryType,
-                _dataStream = new MemoryStream(Encoding.UTF8.GetBytes(longText))
+                _dataStream = dataStream,
+                _uName = mainEntryUname,
+                _gName = mainEntryGname,
+                _aTime = DateTimeOffset.UnixEpoch, // 0
+                _cTime = DateTimeOffset.UnixEpoch, // 0
             };
         }
 
@@ -634,7 +693,15 @@ namespace System.Formats.Tar
                 checksum += FormatNumeric(_size, buffer.Slice(FieldLocations.Size, FieldLengths.Size));
             }
 
-            checksum += WriteAsTimestamp(_mTime, buffer.Slice(FieldLocations.MTime, FieldLengths.MTime));
+            if (_format is TarEntryFormat.Gnu)
+            {
+                // Just like atime and ctime, mtime should be stored as zeros when the value is UnixEpoch.
+                checksum += WriteAsGnuTimestamp(_mTime, buffer.Slice(FieldLocations.MTime, FieldLengths.MTime));
+            }
+            else
+            {
+                checksum += WriteAsTimestamp(_mTime, buffer.Slice(FieldLocations.MTime, FieldLengths.MTime));
+            }
 
             char typeFlagChar = (char)actualEntryType;
             buffer[FieldLocations.TypeFlag] = (byte)typeFlagChar;

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
@@ -735,6 +735,7 @@ namespace System.Formats.Tar.Tests
             ChangeTime = DateTimeOffset.UnixEpoch,
             Uid = 0,
             Gid = 0,
+            Mode = 0,
             UserName = TestUName,
             GroupName = TestGName
         };
@@ -750,6 +751,7 @@ namespace System.Formats.Tar.Tests
         Assert.Equal(linkName, entry.LinkName);
         Assert.Equal(0, entry.Uid); // Should be '0' chars in the long header
         Assert.Equal(0, entry.Gid); // Should be '0' chars in the long header
+        Assert.Equal(UnixFileMode.None, entry.Mode); // Should be '0' chars in the long header
         Assert.Equal(TestUName, entry.UserName);
         Assert.Equal(TestGName, entry.GroupName);
         Assert.Equal(0, entry.Length); // No data in the main entry
@@ -821,7 +823,7 @@ namespace System.Formats.Tar.Tests
         {
             reportedSize = CheckHeaderMetadataAndGetReportedSize(ms, nextEntryStart, isLongLinkOrLongPath: true);
             CheckDataContainsExpectedString(ms, nextEntryStart + 512, reportedSize, linkName, shouldTrim: false); // Skip to the data section
-            nextEntryStart = nextEntryStart + 512 + 512; // Skip the current header and the long link entry
+            nextEntryStart += 512 + 512; // Skip the current header and the long link entry
             Assert.True(linkName.Length < 512, "Do not test paths longer than a 512 byte block");
         }
 
@@ -829,7 +831,7 @@ namespace System.Formats.Tar.Tests
         {
             reportedSize = CheckHeaderMetadataAndGetReportedSize(ms, nextEntryStart, isLongLinkOrLongPath: true);
             CheckDataContainsExpectedString(ms, nextEntryStart + 512, reportedSize, name, shouldTrim: false); // Skip to the data section
-            nextEntryStart = 512 + 512; // Skip the current header and the long path entry
+            nextEntryStart += 512 + 512; // Skip the current header and the long path entry
             Assert.True(name.Length < 512, "Do not test paths longer than a 512 byte block");
         }
 
@@ -867,6 +869,10 @@ namespace System.Formats.Tar.Tests
         {
             CheckBytesAreZeros(ms, buffer.AsSpan(0, 8), uidStart);
             CheckBytesAreZeros(ms, buffer.AsSpan(0, 8), gidStart);
+        }
+        else
+        {
+            CheckBytesAreZeros(ms, buffer.AsSpan(0, 8), modeStart);
         }
         CheckBytesAreZeros(ms, buffer, mTimeStart);
         CheckBytesAreZeros(ms, buffer, aTimeStart);

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Numerics;
 using System.Text;
@@ -12,925 +13,968 @@ using Xunit;
 
 namespace System.Formats.Tar.Tests
 {
-    public class GnuTarEntry_Tests : TarTestsBase
+
+    public class Carlos
     {
         [Fact]
-        public void Constructor_InvalidEntryName()
+        public void Test()
         {
-            Assert.Throws<ArgumentNullException>(() => new GnuTarEntry(TarEntryType.RegularFile, entryName: null));
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.RegularFile, entryName: string.Empty));
-        }
+            string inputFile = @"C:\Users\calope\source\repos\test\unpack-repack\input_official_good.gz";
+            string outputFile = @"C:\Users\calope\source\repos\test\unpack-repack\NEW-OUTPUT.tar.gz";
 
-        [Fact]
-        public void Constructor_UnsupportedEntryTypes()
-        {
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry((TarEntryType)byte.MaxValue, InitialEntryName));
+            File.Delete(outputFile);
 
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.ExtendedAttributes, InitialEntryName));
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.GlobalExtendedAttributes, InitialEntryName));
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.V7RegularFile, InitialEntryName));
-
-            // These are specific to GNU, but currently the user cannot create them manually
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.ContiguousFile, InitialEntryName));
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.DirectoryList, InitialEntryName));
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.MultiVolume, InitialEntryName));
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.RenamedOrSymlinked, InitialEntryName));
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.SparseFile, InitialEntryName));
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.TapeVolume, InitialEntryName));
-
-            // The user should not create these entries manually
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.LongLink, InitialEntryName));
-            Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.LongPath, InitialEntryName));
-        }
-
-        [Fact]
-        public void SupportedEntryType_RegularFile()
-        {
-            GnuTarEntry regularFile = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-            SetRegularFile(regularFile);
-            VerifyRegularFile(regularFile, isWritable: true);
-        }
-
-        [Fact]
-        public void SupportedEntryType_Directory()
-        {
-            GnuTarEntry directory = new GnuTarEntry(TarEntryType.Directory, InitialEntryName);
-            SetDirectory(directory);
-            VerifyDirectory(directory);
-        }
-
-        [Fact]
-        public void SupportedEntryType_HardLink()
-        {
-            GnuTarEntry hardLink = new GnuTarEntry(TarEntryType.HardLink, InitialEntryName);
-            SetHardLink(hardLink);
-            VerifyHardLink(hardLink);
-        }
-
-        [Fact]
-        public void SupportedEntryType_SymbolicLink()
-        {
-            GnuTarEntry symbolicLink = new GnuTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
-            SetSymbolicLink(symbolicLink);
-            VerifySymbolicLink(symbolicLink);
-        }
-
-        [Fact]
-        public void SupportedEntryType_BlockDevice()
-        {
-            GnuTarEntry blockDevice = new GnuTarEntry(TarEntryType.BlockDevice, InitialEntryName);
-            SetBlockDevice(blockDevice);
-            VerifyBlockDevice(blockDevice);
-        }
-
-        [Fact]
-        public void SupportedEntryType_CharacterDevice()
-        {
-            GnuTarEntry characterDevice = new GnuTarEntry(TarEntryType.CharacterDevice, InitialEntryName);
-            SetCharacterDevice(characterDevice);
-            VerifyCharacterDevice(characterDevice);
-        }
-
-        [Fact]
-        public void SupportedEntryType_Fifo()
-        {
-            GnuTarEntry fifo = new GnuTarEntry(TarEntryType.Fifo, InitialEntryName);
-            SetFifo(fifo);
-            VerifyFifo(fifo);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void DataOffset_RegularFile(bool canSeek)
-        {
-            using MemoryStream ms = new();
-            using (TarWriter writer = new(ms, leaveOpen: true))
+            using MemoryStream streamToCompress = new();
+            using (TarWriter writer = new (streamToCompress, leaveOpen: true))
             {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-                entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
-                entry.DataStream.Position = 0;
-                writer.WriteEntry(entry);
-            }
-            ms.Position = 0;
-
-            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            using TarReader reader = new(streamToRead);
-            TarEntry actualEntry = reader.GetNextEntry();
-            Assert.NotNull(actualEntry);
-
-            // Then it writes the actual regular file entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 2560.
-            // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 512 : -1;
-            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
-
-            if (canSeek)
-            {
-                ms.Position = actualEntry.DataOffset;
-                byte actualData = (byte)ms.ReadByte();
-                Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
-            }
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task DataOffset_RegularFile_Async(bool canSeek)
-        {
-            await using MemoryStream ms = new();
-            await using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-                entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
-                entry.DataStream.Position = 0;
-                await writer.WriteEntryAsync(entry);
-            }
-            ms.Position = 0;
-
-            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            await using TarReader reader = new(streamToRead);
-            TarEntry actualEntry = await reader.GetNextEntryAsync();
-            Assert.NotNull(actualEntry);
-
-            // Then it writes the actual regular file entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 2560.
-            // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 512 : -1;
-            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
-
-            if (canSeek)
-            {
-                ms.Position = actualEntry.DataOffset;
-                byte actualData = (byte)ms.ReadByte();
-                Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
-            }
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void DataOffset_RegularFile_LongPath(bool canSeek)
-        {
-            using MemoryStream ms = new();
-            using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, veryLongName);
-                entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
-                entry.DataStream.Position = 0;
-                writer.WriteEntry(entry);
-            }
-            ms.Position = 0;
-
-            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            using TarReader reader = new(streamToRead);
-            TarEntry actualEntry = reader.GetNextEntry();
-            Assert.NotNull(actualEntry);
-
-            // GNU first writes the long path entry, containing:
-            // * 512 bytes of the regular tar header
-            // * 1234 bytes for the data section containing the full long path
-            // * 302 bytes of padding
-            // Then it writes the actual regular file entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 2560.
-            // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 2560 : -1;
-            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task DataOffset_RegularFile_LongPath_Async(bool canSeek)
-        {
-            await using MemoryStream ms = new();
-            await using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, veryLongName);
-                entry.DataStream = new MemoryStream();
-                entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
-                entry.DataStream.Position = 0;
-                await writer.WriteEntryAsync(entry);
-            }
-            ms.Position = 0;
-
-            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            await using TarReader reader = new(streamToRead);
-            TarEntry actualEntry = await reader.GetNextEntryAsync();
-            Assert.NotNull(actualEntry);
-
-            // GNU first writes the long path entry, containing:
-            // * 512 bytes of the regular tar header
-            // * 1234 bytes for the data section containing the full long path
-            // * 302 bytes of padding
-            // Then it writes the actual regular file entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 2560.
-            // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 2560 : -1;
-            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void DataOffset_RegularFile_LongLink(bool canSeek)
-        {
-            using MemoryStream ms = new();
-            using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
-                entry.LinkName = new string('a', 1234); // Forces using a GNU LongLink entry
-                writer.WriteEntry(entry);
-            }
-            ms.Position = 0;
-
-            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            using TarReader reader = new(streamToRead);
-            TarEntry actualEntry = reader.GetNextEntry();
-            Assert.NotNull(actualEntry);
-
-            // GNU first writes the long link entry, containing:
-            // * 512 bytes of the regular tar header
-            // * 1234 bytes for the data section containing the full long link
-            // * 302 bytes of padding
-            // Then it writes the actual regular file entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 2560.
-            // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 2560 : -1;
-            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
-        }
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task DataOffset_RegularFile_LongLink_Async(bool canSeek)
-        {
-            await using MemoryStream ms = new();
-            await using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
-                entry.LinkName = new string('b', 1234); // Forces using a GNU LongLink entry
-                await writer.WriteEntryAsync(entry);
-            }
-            ms.Position = 0;
-
-            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            await using TarReader reader = new(streamToRead);
-            TarEntry actualEntry = await reader.GetNextEntryAsync();
-            Assert.NotNull(actualEntry);
-
-            // GNU first writes the long link entry, containing:
-            // * 512 bytes of the regular tar header
-            // * 1234 bytes for the data section containing the full long link
-            // * 302 bytes of padding
-            // Then it writes the actual regular file entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 2560.
-            // The regular file data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 2560 : -1;
-            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void DataOffset_RegularFile_LongLink_LongPath(bool canSeek)
-        {
-            using MemoryStream ms = new();
-            using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongName);
-                entry.LinkName = new string('b', 1234); // Forces using a GNU LongLink entry
-                writer.WriteEntry(entry);
-            }
-            ms.Position = 0;
-
-            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            using TarReader reader = new(streamToRead);
-            TarEntry actualEntry = reader.GetNextEntry();
-            Assert.NotNull(actualEntry);
-
-            // GNU first writes the long link and long path entries, containing:
-            // * 512 bytes of the regular long link tar header
-            // * 1234 bytes for the data section containing the full long link
-            // * 302 bytes of padding
-            // * 512 bytes of the regular long path tar header
-            // * 1234 bytes for the data section containing the full long path
-            // * 302 bytes of padding
-            // Then it writes the actual entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 4608.
-            // The data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 4608 : -1;
-            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task DataOffset_RegularFile_LongLink_LongPath_Async(bool canSeek)
-        {
-            await using MemoryStream ms = new();
-            await using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongName);
-                entry.LinkName = new string('b', 1234); // Forces using a GNU LongLink entry
-                await writer.WriteEntryAsync(entry);
-            }
-            ms.Position = 0;
-
-            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            await using TarReader reader = new(streamToRead);
-            TarEntry actualEntry = await reader.GetNextEntryAsync();
-            Assert.NotNull(actualEntry);
-
-            // GNU first writes the long link and long path entries, containing:
-            // * 512 bytes of the regular long link tar header
-            // * 1234 bytes for the data section containing the full long link
-            // * 302 bytes of padding
-            // * 512 bytes of the regular long path tar header
-            // * 1234 bytes for the data section containing the full long path
-            // * 302 bytes of padding
-            // Then it writes the actual entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 4608.
-            // The data section starts on the next byte.
-            long expectedDataOffset = canSeek ? 4608 : -1;
-            Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
-        }
-
-        [Fact]
-        public void DataOffset_BeforeAndAfterArchive()
-        {
-            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-            Assert.Equal(-1, entry.DataOffset);
-            entry.DataStream = new MemoryStream();
-            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
-            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
-
-            using MemoryStream ms = new();
-            using TarWriter writer = new(ms);
-            writer.WriteEntry(entry);
-            Assert.Equal(512, entry.DataOffset);
-
-            // Write it again, the offset should now point to the second written entry
-            // First entry 512 (header) + 1 (data) + 511 (padding)
-            // Second entry 512 (header)
-            // 512 + 512 + 512 = 1536
-            writer.WriteEntry(entry);
-            Assert.Equal(1536, entry.DataOffset);
-        }
-
-        [Fact]
-        public async Task DataOffset_BeforeAndAfterArchive_Async()
-        {
-            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-            Assert.Equal(-1, entry.DataOffset);
-
-            entry.DataStream = new MemoryStream();
-            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
-            entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
-
-            await using MemoryStream ms = new();
-            await using TarWriter writer = new(ms);
-            await writer.WriteEntryAsync(entry);
-            Assert.Equal(512, entry.DataOffset);
-
-            // Write it again, the offset should now point to the second written entry
-            // First entry 512 (header) + 1 (data) + 511 (padding)
-            // Second entry 512 (header)
-            // 512 + 512 + 512 = 1536
-            await writer.WriteEntryAsync(entry);
-            Assert.Equal(1536, entry.DataOffset);
-        }
-
-        [Fact]
-        public void DataOffset_UnseekableDataStream()
-        {
-            using MemoryStream ms = new();
-            using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-                Assert.Equal(-1, entry.DataOffset);
-
-                using MemoryStream dataStream = new();
-                dataStream.WriteByte(ExpectedOffsetDataSingleByte);
-                dataStream.Position = 0;
-                using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
-                entry.DataStream = wds;
-
-                writer.WriteEntry(entry);
-            }
-            ms.Position = 0;
-
-            using TarReader reader = new(ms);
-            TarEntry actualEntry = reader.GetNextEntry();
-            Assert.NotNull(actualEntry);
-            // Gnu header length is 512, data starts in the next position
-            Assert.Equal(512, actualEntry.DataOffset);
-        }
-
-        [Fact]
-        public async Task DataOffset_UnseekableDataStream_Async()
-        {
-            await using MemoryStream ms = new();
-            await using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-                Assert.Equal(-1, entry.DataOffset);
-
-                await using MemoryStream dataStream = new();
-                dataStream.WriteByte(ExpectedOffsetDataSingleByte);
-                dataStream.Position = 0;
-                await using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
-                entry.DataStream = wds;
-
-                await writer.WriteEntryAsync(entry);
-            }
-            ms.Position = 0;
-
-            await using TarReader reader = new(ms);
-            TarEntry actualEntry = await reader.GetNextEntryAsync();
-            Assert.NotNull(actualEntry);
-            // Gnu header length is 512, data starts in the next position
-            Assert.Equal(512, actualEntry.DataOffset);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void DataOffset_LongPath_LongLink_SecondEntry(bool canSeek)
-        {
-            string veryLongPathName = new string('a', 1234); // Forces using a GNU LongPath entry
-            string veryLongLinkName = new string('b', 1234); // Forces using a GNU LongLink entry
-
-            using MemoryStream ms = new();
-            using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry1 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
-                entry1.LinkName = veryLongLinkName;
-                writer.WriteEntry(entry1);
-
-                GnuTarEntry entry2 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
-                entry2.LinkName = veryLongLinkName;
-                writer.WriteEntry(entry2);
-            }
-            ms.Position = 0;
-
-            using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            using TarReader reader = new(streamToRead);
-            TarEntry firstEntry = reader.GetNextEntry();
-            Assert.NotNull(firstEntry);
-            // GNU first writes the long link and long path entries, containing:
-            // * 512 bytes of the regular long link tar header
-            // * 1234 bytes for the data section containing the full long link
-            // * 302 bytes of padding
-            // * 512 bytes of the regular long path tar header
-            // * 1234 bytes for the data section containing the full long path
-            // * 302 bytes of padding
-            // Then it writes the actual regular file entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 4608.
-            // The regular file data section starts on the next byte.
-            long firstExpectedDataOffset = canSeek ? 4608 : -1;
-            Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
-
-            TarEntry secondEntry = reader.GetNextEntry();
-            Assert.NotNull(secondEntry);
-            // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
-            // Second entry (including its long link and long path entries) data section starts one byte after 4608 + 4608 = 9216
-            long secondExpectedDataOffset = canSeek ? 9216 : -1;
-            Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task DataOffset_LongPath_LongLink_SecondEntry_Async(bool canSeek)
-        {
-            string veryLongPathName = new string('a', 1234); // Forces using a GNU LongPath entry
-            string veryLongLinkName = new string('b', 1234); // Forces using a GNU LongLink entry
-
-            await using MemoryStream ms = new();
-            await using (TarWriter writer = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry1 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
-                entry1.LinkName = veryLongLinkName;
-                await writer.WriteEntryAsync(entry1);
-
-                GnuTarEntry entry2 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
-                entry2.LinkName = veryLongLinkName;
-                await writer.WriteEntryAsync(entry2);
-            }
-            ms.Position = 0;
-
-            await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
-            await using TarReader reader = new(streamToRead);
-            TarEntry firstEntry = await reader.GetNextEntryAsync();
-            Assert.NotNull(firstEntry);
-            // GNU first writes the long link and long path entries, containing:
-            // * 512 bytes of the regular long link tar header
-            // * 1234 bytes for the data section containing the full long link
-            // * 302 bytes of padding
-            // * 512 bytes of the regular long path tar header
-            // * 1234 bytes for the data section containing the full long path
-            // * 302 bytes of padding
-            // Then it writes the actual regular file entry, containing:
-            // * 512 bytes of the regular tar header
-            // Totalling 4608.
-            // The regular file data section starts on the next byte.
-            long firstExpectedDataOffset = canSeek ? 4608 : -1;
-            Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
-
-            TarEntry secondEntry = await reader.GetNextEntryAsync();
-            Assert.NotNull(secondEntry);
-            // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
-            // Second entry (including its long link and long path entries) data section starts one byte after 4608 + 4608 = 9216
-            long secondExpectedDataOffset = canSeek ? 9216 : -1;
-            Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
-        }
-
-        [Fact]
-        public void UnusedBytesInSizeFieldShouldBeZeroChars()
-        {
-            // The GNU format sets the unused bytes in the size field to "0" characters.
-
-            using MemoryStream ms = new();
-
-            using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
-            {
-                // Start with a regular file entry without data
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-                writer.WriteEntry(entry);
-            }
-            ms.Position = 0;
-
-            using (TarReader reader = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = reader.GetNextEntry() as GnuTarEntry;
-                Assert.NotNull(entry);
-                Assert.Equal(0, entry.Length);
-            }
-            ms.Position = 0;
-            ValidateUnusedBytesInSizeField(ms, 0);
-
-            ms.SetLength(0); // Reset the stream
-            byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }; // 8 bytes of data means a size of 10 in octal
-            using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
-            {
-                // Start with a regular file entry with data
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-                entry.DataStream = new MemoryStream(data);
-                writer.WriteEntry(entry);
-            }
-
-            ms.Position = 0;
-            using (TarReader reader = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = reader.GetNextEntry() as GnuTarEntry;
-                Assert.NotNull(entry);
-                Assert.Equal(data.Length, entry.Length);
-            }
-            ms.Position = 0;
-            ValidateUnusedBytesInSizeField(ms, data.Length);
-        }
-
-        [Fact]
-        public async Task UnusedBytesInSizeFieldShouldBeZeroChars_Async()
-        {
-            // The GNU format sets the unused bytes in the size field to "0" characters.
-
-            await using MemoryStream ms = new();
-
-            await using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
-            {
-                // Start with a regular file entry without data
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-                await writer.WriteEntryAsync(entry);
-            }
-            ms.Position = 0;
-
-            await using (TarReader reader = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = await reader.GetNextEntryAsync() as GnuTarEntry;
-                Assert.NotNull(entry);
-                Assert.Equal(0, entry.Length);
-            }
-            ms.Position = 0;
-            ValidateUnusedBytesInSizeField(ms, 0);
-
-            ms.SetLength(0); // Reset the stream
-            byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }; // 8 bytes of data means a size of 10 in octal
-            await using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
-            {
-                // Start with a regular file entry with data
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
-                entry.DataStream = new MemoryStream(data);
-                await writer.WriteEntryAsync(entry);
-            }
-
-            ms.Position = 0;
-            await using (TarReader reader = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = await reader.GetNextEntryAsync() as GnuTarEntry;
-                Assert.NotNull(entry);
-                Assert.Equal(data.Length, entry.Length);
-            }
-            ms.Position = 0;
-            ValidateUnusedBytesInSizeField(ms, data.Length);
-        }
-
-        private void ValidateUnusedBytesInSizeField(MemoryStream ms, long size)
-        {
-            // internally, the unused bytes in the size field should be "0" characters,
-            // and the rest should be the octal value of the size field
-
-            // name, mode, uid, gid,
-            // size
-            int sizeStart = 100 + 8 + 8 + 8;
-            byte[] buffer = new byte[12]; // The size field is 12 bytes in length
-
-            ms.Seek(sizeStart, SeekOrigin.Begin);
-            ms.Read(buffer);
-
-            // Convert the base 10 value of size to base 8
-            string octalSize = Convert.ToString(size, 8).PadLeft(11, '0');
-            byte[] octalSizeBytes = Encoding.ASCII.GetBytes(octalSize);
-            // The last byte should be a null character
-            Assert.Equal(octalSizeBytes, buffer.Take(octalSizeBytes.Length).ToArray());
-        }
-
-        public static IEnumerable<object[]> NameAndLink_TestData()
-        {
-            // Name and link have a max length of 100. Anything longer goes into LongPath or LongLink entries in GNU.
-            yield return new object[] { InitialEntryName, InitialEntryName }; // Short name and short link
-            yield return new object[] { InitialEntryName, new string('b', 101) }; // Short name and long link
-            yield return new object[] { new string('a', 101), InitialEntryName }; // Long name and short link
-            yield return new object[] { new string('a', 101), new string('b', 101) }; // Long name and long link
-        }
-
-        private GnuTarEntry CreateEntryForLongLinkLongPathChecks(string name, string linkName)
-        {
-            // A SymbolicLink entry can test both LongLink and LongPath entries if
-            // the length of either string is longer than what fits in the header.
-            return new GnuTarEntry(TarEntryType.SymbolicLink, name)
-            {
-                LinkName = linkName,
-                ModificationTime = DateTimeOffset.UnixEpoch,
-                AccessTime = DateTimeOffset.UnixEpoch,
-                ChangeTime = DateTimeOffset.UnixEpoch,
-                Uid = 0,
-                Gid = 0,
-                UserName = TestUName,
-                GroupName = TestGName
-            };
-        }
-
-        private void ValidateEntryForRegularEntryInLongLinkAndLongPathChecks(GnuTarEntry entry, string name, string linkName)
-        {
-            Assert.NotNull(entry);
-            Assert.Equal(DateTimeOffset.UnixEpoch, entry.ModificationTime);
-            Assert.Equal(DateTimeOffset.UnixEpoch, entry.AccessTime);
-            Assert.Equal(DateTimeOffset.UnixEpoch, entry.ChangeTime);
-            Assert.Equal(name, entry.Name);
-            Assert.Equal(linkName, entry.LinkName);
-            Assert.Equal(0, entry.Uid); // Should be '0' chars in the long header
-            Assert.Equal(0, entry.Gid); // Should be '0' chars in the long header
-            Assert.Equal(TestUName, entry.UserName);
-            Assert.Equal(TestGName, entry.GroupName);
-            Assert.Equal(0, entry.Length); // No data in the main entry
-        }
-
-        [Theory]
-        [MemberData(nameof(NameAndLink_TestData))]
-        public void Check_LongLink_AndLongPath_Metadata(string name, string linkName)
-        {
-            // The GNU format sets the mtime, atime and ctime to nulls in headers when they are set to the unix epoch.
-            // Also the uid and gid should be '0' in the long entries headers.
-            // Also the uname and gname in the long entry headers should be set to those of the main entry.
-
-            using MemoryStream ms = new();
-
-            using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
-            {
-                GnuTarEntry entry = CreateEntryForLongLinkLongPathChecks(name, linkName);
-                writer.WriteEntry(entry);
-            }
-            ms.Position = 0;
-
-            using (TarReader reader = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = reader.GetNextEntry() as GnuTarEntry;
-                ValidateEntryForRegularEntryInLongLinkAndLongPathChecks(entry, name, linkName);
-            }
-
-            ValidateLongEntryBytes(ms, name, linkName);
-        }
-
-        [Theory]
-        [MemberData(nameof(NameAndLink_TestData))]
-        public async Task Check_LongLink_AndLongPath_Metadata_Async(string name, string linkName)
-        {
-            // The GNU format sets the mtime, atime and ctime to nulls in headers when they are set to the unix epoch.
-            // Also the uid and gid should be '0' in the long entries headers.
-            // Also the uname and gname in the long entry headers should be set to those of the main entry.
-
-            await using MemoryStream ms = new();
-
-            await using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
-            {
-                GnuTarEntry entry = CreateEntryForLongLinkLongPathChecks(name, linkName);
-                await writer.WriteEntryAsync(entry);
-            }
-            ms.Position = 0;
-
-            await using (TarReader reader = new(ms, leaveOpen: true))
-            {
-                GnuTarEntry entry = await reader.GetNextEntryAsync() as GnuTarEntry;
-                ValidateEntryForRegularEntryInLongLinkAndLongPathChecks(entry, name, linkName);
-            }
-
-            ValidateLongEntryBytes(ms, name, linkName);
-        }
-
-        private void ValidateLongEntryBytes(MemoryStream ms, string name, string linkName)
-        {
-            bool isLongPath = name.Length >= 100;
-            bool isLongLink = linkName.Length >= 100;
-
-            ms.Position = 0;
-
-            long nextEntryStart = 0;
-            long reportedSize;
-
-            if (isLongLink)
-            {
-                reportedSize = CheckHeaderMetadataAndGetReportedSize(ms, nextEntryStart, isLongLinkOrLongPath: true);
-                CheckDataContainsExpectedString(ms, nextEntryStart + 512, reportedSize, linkName, shouldTrim: false); // Skip to the data section
-                nextEntryStart = nextEntryStart + 512 + 512; // Skip the current header and the long link entry
-                Assert.True(linkName.Length < 512, "Do not test paths longer than a 512 byte block");
-            }
-
-            if (isLongPath)
-            {
-                reportedSize = CheckHeaderMetadataAndGetReportedSize(ms, nextEntryStart, isLongLinkOrLongPath: true);
-                CheckDataContainsExpectedString(ms, nextEntryStart + 512, reportedSize, name, shouldTrim: false); // Skip to the data section
-                nextEntryStart = 512 + 512; // Skip the current header and the long path entry
-                Assert.True(name.Length < 512, "Do not test paths longer than a 512 byte block");
-            }
-
-            CheckHeaderMetadataAndGetReportedSize(ms, nextEntryStart, isLongLinkOrLongPath: false);
-        }
-
-        private long CheckHeaderMetadataAndGetReportedSize(MemoryStream ms, long nextEntryStart, bool isLongLinkOrLongPath)
-        {
-            // internally, mtime, atime and ctime should be nulls
-            // and if the entry is a long path or long link, the entry's data length should be
-            // equal to the string plus a null character
-
-            // name mode uid gid size mtime checksum typeflag linkname magic uname gname devmajor devminor atime ctime
-            // 100  8    8   8   12   12    8        1        100      8     32    32    8        8        12    12
-            long nameStart = nextEntryStart;
-            long modeStart = nameStart + 100;
-            long uidStart = modeStart + 8;
-            long gidStart = uidStart + 8;
-            long sizeStart = gidStart + 8;
-            long mTimeStart = sizeStart + 12;
-            long checksumStart = mTimeStart + 12;
-            long typeflagStart = checksumStart + 8;
-            long linkNameStart = typeflagStart + 1;
-            long magicStart = linkNameStart + 100;
-            long uNameStart = magicStart + 8;
-            long gNameStart = uNameStart + 32;
-            long devMajorStart = gNameStart + 32;
-            long devMinorStart = devMajorStart + 8;
-            long aTimeStart = gNameStart + 8;
-            long cTimeStart = aTimeStart + 12;
-
-            byte[] buffer = new byte[12]; // size, mtime, atime, ctime all are 12 bytes in length
-
-            if (isLongLinkOrLongPath)
-            {
-                // CheckBytesAreZeros(ms, buffer.AsSpan(0, 8), uidStart);
-                // CheckBytesAreZeros(ms, buffer.AsSpan(0, 8), gidStart);
-            }
-            CheckBytesAreNulls(ms, buffer, mTimeStart);
-            CheckBytesAreNulls(ms, buffer, aTimeStart);
-            CheckBytesAreNulls(ms, buffer, cTimeStart);
-            CheckDataContainsExpectedString(ms, uNameStart, 32, TestUName, shouldTrim: true);
-            CheckDataContainsExpectedString(ms, gNameStart, 32, TestGName, shouldTrim: true);
-
-            ms.Seek(sizeStart, SeekOrigin.Begin);
-            ms.Read(buffer);
-            return ParseNumeric<long>(buffer);
-        }
-
-        private void CheckBytesAreSpecificChar(MemoryStream ms, Span<byte> buffer, long dataStart, byte charToCheck)
-        {
-            ms.Seek(dataStart, SeekOrigin.Begin);
-            ms.Read(buffer);
-            foreach (byte b in buffer)
-            {
-                Assert.Equal(charToCheck, b);
-            }
-        }
-
-        private void CheckBytesAreNulls(MemoryStream ms, Span<byte> buffer, long dataStart) => CheckBytesAreSpecificChar(ms, buffer, dataStart, 0); // null char
-
-        private void CheckBytesAreZeros(MemoryStream ms, Span<byte> buffer, long dataStart) => CheckBytesAreSpecificChar(ms, buffer, dataStart, 0x30); // '0' char
-
-        private void CheckDataContainsExpectedString(MemoryStream ms, long dataStart, long actualDataLength, string expectedString, bool shouldTrim)
-        {
-            ms.Seek(dataStart, SeekOrigin.Begin);
-            byte[] buffer = new byte[actualDataLength];
-            ms.Read(buffer);
-
-            if (shouldTrim)
-            {
-                string actualString = Encoding.ASCII.GetString(TrimEndingNullsAndSpaces(buffer));
-                Assert.Equal(expectedString, actualString);
-            }
-            else
-            {
-                string actualString = Encoding.ASCII.GetString(buffer);
-                Assert.Equal(expectedString, actualString[..^1]); // The last byte should be a null character
-            }
-        }
-
-        private static T ParseNumeric<T>(ReadOnlySpan<byte> buffer) where T : struct, INumber<T>, IBinaryInteger<T>
-        {
-            byte leadingByte = buffer[0];
-            if (leadingByte == 0xff)
-            {
-                return T.ReadBigEndian(buffer, isUnsigned: false);
-            }
-            else if (leadingByte == 0x80)
-            {
-                return T.ReadBigEndian(buffer.Slice(1), isUnsigned: true);
-            }
-            else
-            {
-                return ParseOctal<T>(buffer);
-            }
-        }
-
-        private static T ParseOctal<T>(ReadOnlySpan<byte> buffer) where T : struct, INumber<T>
-        {
-            buffer = TrimEndingNullsAndSpaces(buffer);
-            buffer = TrimLeadingNullsAndSpaces(buffer);
-
-            if (buffer.Length == 0)
-            {
-                return T.Zero;
-            }
-
-            T octalFactor = T.CreateTruncating(8u);
-            T value = T.Zero;
-            foreach (byte b in buffer)
-            {
-                uint digit = (uint)(b - '0');
-                if (digit >= 8)
+                foreach (TarEntry entry in ReadTarGZipEntries(inputFile))
                 {
-                    throw new InvalidDataException(SR.Format(SR.TarInvalidNumber));
+                    writer.WriteEntry(entry);
                 }
-
-                value = checked((value * octalFactor) + T.CreateTruncating(digit));
             }
 
-            return value;
+            streamToCompress.Flush();
+
+            streamToCompress.Position = 0;
+            using (FileStream outputStream = File.Open(outputFile, FileMode.Create, FileAccess.Write))
+            {
+                using GZipStream compressor = new(outputStream, CompressionMode.Compress);
+                streamToCompress.CopyTo(compressor);
+            }
         }
 
-        private static ReadOnlySpan<byte> TrimEndingNullsAndSpaces(ReadOnlySpan<byte> buffer)
+        private static IEnumerable<TarEntry> ReadTarGZipEntries(string path)
         {
-            int trimmedLength = buffer.Length;
-            while (trimmedLength > 0 && buffer[trimmedLength - 1] is 0 or 32)
+            using FileStream streamToDecompress = File.OpenRead(path);
+            using GZipStream decompressor = new(streamToDecompress, CompressionMode.Decompress);
+            using TarReader tarReader = new(decompressor);
+            while (tarReader.GetNextEntry() is TarEntry entry)
             {
-                trimmedLength--;
+                yield return entry;
             }
-
-            return buffer.Slice(0, trimmedLength);
-        }
-
-        private static ReadOnlySpan<byte> TrimLeadingNullsAndSpaces(ReadOnlySpan<byte> buffer)
-        {
-            int newStart = 0;
-            while (newStart < buffer.Length && buffer[newStart] is 0 or 32)
-            {
-                newStart++;
-            }
-
-            return buffer.Slice(newStart);
         }
     }
+
+    public class GnuTarEntry_Tests : TarTestsBase
+{
+    [Fact]
+    public void Constructor_InvalidEntryName()
+    {
+        Assert.Throws<ArgumentNullException>(() => new GnuTarEntry(TarEntryType.RegularFile, entryName: null));
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.RegularFile, entryName: string.Empty));
+    }
+
+    [Fact]
+    public void Constructor_UnsupportedEntryTypes()
+    {
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry((TarEntryType)byte.MaxValue, InitialEntryName));
+
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.ExtendedAttributes, InitialEntryName));
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.GlobalExtendedAttributes, InitialEntryName));
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.V7RegularFile, InitialEntryName));
+
+        // These are specific to GNU, but currently the user cannot create them manually
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.ContiguousFile, InitialEntryName));
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.DirectoryList, InitialEntryName));
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.MultiVolume, InitialEntryName));
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.RenamedOrSymlinked, InitialEntryName));
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.SparseFile, InitialEntryName));
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.TapeVolume, InitialEntryName));
+
+        // The user should not create these entries manually
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.LongLink, InitialEntryName));
+        Assert.Throws<ArgumentException>(() => new GnuTarEntry(TarEntryType.LongPath, InitialEntryName));
+    }
+
+    [Fact]
+    public void SupportedEntryType_RegularFile()
+    {
+        GnuTarEntry regularFile = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+        SetRegularFile(regularFile);
+        VerifyRegularFile(regularFile, isWritable: true);
+    }
+
+    [Fact]
+    public void SupportedEntryType_Directory()
+    {
+        GnuTarEntry directory = new GnuTarEntry(TarEntryType.Directory, InitialEntryName);
+        SetDirectory(directory);
+        VerifyDirectory(directory);
+    }
+
+    [Fact]
+    public void SupportedEntryType_HardLink()
+    {
+        GnuTarEntry hardLink = new GnuTarEntry(TarEntryType.HardLink, InitialEntryName);
+        SetHardLink(hardLink);
+        VerifyHardLink(hardLink);
+    }
+
+    [Fact]
+    public void SupportedEntryType_SymbolicLink()
+    {
+        GnuTarEntry symbolicLink = new GnuTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
+        SetSymbolicLink(symbolicLink);
+        VerifySymbolicLink(symbolicLink);
+    }
+
+    [Fact]
+    public void SupportedEntryType_BlockDevice()
+    {
+        GnuTarEntry blockDevice = new GnuTarEntry(TarEntryType.BlockDevice, InitialEntryName);
+        SetBlockDevice(blockDevice);
+        VerifyBlockDevice(blockDevice);
+    }
+
+    [Fact]
+    public void SupportedEntryType_CharacterDevice()
+    {
+        GnuTarEntry characterDevice = new GnuTarEntry(TarEntryType.CharacterDevice, InitialEntryName);
+        SetCharacterDevice(characterDevice);
+        VerifyCharacterDevice(characterDevice);
+    }
+
+    [Fact]
+    public void SupportedEntryType_Fifo()
+    {
+        GnuTarEntry fifo = new GnuTarEntry(TarEntryType.Fifo, InitialEntryName);
+        SetFifo(fifo);
+        VerifyFifo(fifo);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DataOffset_RegularFile(bool canSeek)
+    {
+        using MemoryStream ms = new();
+        using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            entry.DataStream = new MemoryStream();
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
+            entry.DataStream.Position = 0;
+            writer.WriteEntry(entry);
+        }
+        ms.Position = 0;
+
+        using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        using TarReader reader = new(streamToRead);
+        TarEntry actualEntry = reader.GetNextEntry();
+        Assert.NotNull(actualEntry);
+
+        // Then it writes the actual regular file entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 2560.
+        // The regular file data section starts on the next byte.
+        long expectedDataOffset = canSeek ? 512 : -1;
+        Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+
+        if (canSeek)
+        {
+            ms.Position = actualEntry.DataOffset;
+            byte actualData = (byte)ms.ReadByte();
+            Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DataOffset_RegularFile_Async(bool canSeek)
+    {
+        await using MemoryStream ms = new();
+        await using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            entry.DataStream = new MemoryStream();
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
+            entry.DataStream.Position = 0;
+            await writer.WriteEntryAsync(entry);
+        }
+        ms.Position = 0;
+
+        await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        await using TarReader reader = new(streamToRead);
+        TarEntry actualEntry = await reader.GetNextEntryAsync();
+        Assert.NotNull(actualEntry);
+
+        // Then it writes the actual regular file entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 2560.
+        // The regular file data section starts on the next byte.
+        long expectedDataOffset = canSeek ? 512 : -1;
+        Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+
+        if (canSeek)
+        {
+            ms.Position = actualEntry.DataOffset;
+            byte actualData = (byte)ms.ReadByte();
+            Assert.Equal(ExpectedOffsetDataSingleByte, actualData);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DataOffset_RegularFile_LongPath(bool canSeek)
+    {
+        using MemoryStream ms = new();
+        using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, veryLongName);
+            entry.DataStream = new MemoryStream();
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
+            entry.DataStream.Position = 0;
+            writer.WriteEntry(entry);
+        }
+        ms.Position = 0;
+
+        using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        using TarReader reader = new(streamToRead);
+        TarEntry actualEntry = reader.GetNextEntry();
+        Assert.NotNull(actualEntry);
+
+        // GNU first writes the long path entry, containing:
+        // * 512 bytes of the regular tar header
+        // * 1234 bytes for the data section containing the full long path
+        // * 302 bytes of padding
+        // Then it writes the actual regular file entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 2560.
+        // The regular file data section starts on the next byte.
+        long expectedDataOffset = canSeek ? 2560 : -1;
+        Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DataOffset_RegularFile_LongPath_Async(bool canSeek)
+    {
+        await using MemoryStream ms = new();
+        await using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, veryLongName);
+            entry.DataStream = new MemoryStream();
+            entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
+            entry.DataStream.Position = 0;
+            await writer.WriteEntryAsync(entry);
+        }
+        ms.Position = 0;
+
+        await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        await using TarReader reader = new(streamToRead);
+        TarEntry actualEntry = await reader.GetNextEntryAsync();
+        Assert.NotNull(actualEntry);
+
+        // GNU first writes the long path entry, containing:
+        // * 512 bytes of the regular tar header
+        // * 1234 bytes for the data section containing the full long path
+        // * 302 bytes of padding
+        // Then it writes the actual regular file entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 2560.
+        // The regular file data section starts on the next byte.
+        long expectedDataOffset = canSeek ? 2560 : -1;
+        Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DataOffset_RegularFile_LongLink(bool canSeek)
+    {
+        using MemoryStream ms = new();
+        using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
+            entry.LinkName = new string('a', 1234); // Forces using a GNU LongLink entry
+            writer.WriteEntry(entry);
+        }
+        ms.Position = 0;
+
+        using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        using TarReader reader = new(streamToRead);
+        TarEntry actualEntry = reader.GetNextEntry();
+        Assert.NotNull(actualEntry);
+
+        // GNU first writes the long link entry, containing:
+        // * 512 bytes of the regular tar header
+        // * 1234 bytes for the data section containing the full long link
+        // * 302 bytes of padding
+        // Then it writes the actual regular file entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 2560.
+        // The regular file data section starts on the next byte.
+        long expectedDataOffset = canSeek ? 2560 : -1;
+        Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+    }
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DataOffset_RegularFile_LongLink_Async(bool canSeek)
+    {
+        await using MemoryStream ms = new();
+        await using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, InitialEntryName);
+            entry.LinkName = new string('b', 1234); // Forces using a GNU LongLink entry
+            await writer.WriteEntryAsync(entry);
+        }
+        ms.Position = 0;
+
+        await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        await using TarReader reader = new(streamToRead);
+        TarEntry actualEntry = await reader.GetNextEntryAsync();
+        Assert.NotNull(actualEntry);
+
+        // GNU first writes the long link entry, containing:
+        // * 512 bytes of the regular tar header
+        // * 1234 bytes for the data section containing the full long link
+        // * 302 bytes of padding
+        // Then it writes the actual regular file entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 2560.
+        // The regular file data section starts on the next byte.
+        long expectedDataOffset = canSeek ? 2560 : -1;
+        Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DataOffset_RegularFile_LongLink_LongPath(bool canSeek)
+    {
+        using MemoryStream ms = new();
+        using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongName);
+            entry.LinkName = new string('b', 1234); // Forces using a GNU LongLink entry
+            writer.WriteEntry(entry);
+        }
+        ms.Position = 0;
+
+        using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        using TarReader reader = new(streamToRead);
+        TarEntry actualEntry = reader.GetNextEntry();
+        Assert.NotNull(actualEntry);
+
+        // GNU first writes the long link and long path entries, containing:
+        // * 512 bytes of the regular long link tar header
+        // * 1234 bytes for the data section containing the full long link
+        // * 302 bytes of padding
+        // * 512 bytes of the regular long path tar header
+        // * 1234 bytes for the data section containing the full long path
+        // * 302 bytes of padding
+        // Then it writes the actual entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 4608.
+        // The data section starts on the next byte.
+        long expectedDataOffset = canSeek ? 4608 : -1;
+        Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DataOffset_RegularFile_LongLink_LongPath_Async(bool canSeek)
+    {
+        await using MemoryStream ms = new();
+        await using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            string veryLongName = new string('a', 1234); // Forces using a GNU LongPath entry
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongName);
+            entry.LinkName = new string('b', 1234); // Forces using a GNU LongLink entry
+            await writer.WriteEntryAsync(entry);
+        }
+        ms.Position = 0;
+
+        await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        await using TarReader reader = new(streamToRead);
+        TarEntry actualEntry = await reader.GetNextEntryAsync();
+        Assert.NotNull(actualEntry);
+
+        // GNU first writes the long link and long path entries, containing:
+        // * 512 bytes of the regular long link tar header
+        // * 1234 bytes for the data section containing the full long link
+        // * 302 bytes of padding
+        // * 512 bytes of the regular long path tar header
+        // * 1234 bytes for the data section containing the full long path
+        // * 302 bytes of padding
+        // Then it writes the actual entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 4608.
+        // The data section starts on the next byte.
+        long expectedDataOffset = canSeek ? 4608 : -1;
+        Assert.Equal(expectedDataOffset, actualEntry.DataOffset);
+    }
+
+    [Fact]
+    public void DataOffset_BeforeAndAfterArchive()
+    {
+        GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+        Assert.Equal(-1, entry.DataOffset);
+        entry.DataStream = new MemoryStream();
+        entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
+        entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
+
+        using MemoryStream ms = new();
+        using TarWriter writer = new(ms);
+        writer.WriteEntry(entry);
+        Assert.Equal(512, entry.DataOffset);
+
+        // Write it again, the offset should now point to the second written entry
+        // First entry 512 (header) + 1 (data) + 511 (padding)
+        // Second entry 512 (header)
+        // 512 + 512 + 512 = 1536
+        writer.WriteEntry(entry);
+        Assert.Equal(1536, entry.DataOffset);
+    }
+
+    [Fact]
+    public async Task DataOffset_BeforeAndAfterArchive_Async()
+    {
+        GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+        Assert.Equal(-1, entry.DataOffset);
+
+        entry.DataStream = new MemoryStream();
+        entry.DataStream.WriteByte(ExpectedOffsetDataSingleByte);
+        entry.DataStream.Position = 0; // The data stream is written to the archive from the current position
+
+        await using MemoryStream ms = new();
+        await using TarWriter writer = new(ms);
+        await writer.WriteEntryAsync(entry);
+        Assert.Equal(512, entry.DataOffset);
+
+        // Write it again, the offset should now point to the second written entry
+        // First entry 512 (header) + 1 (data) + 511 (padding)
+        // Second entry 512 (header)
+        // 512 + 512 + 512 = 1536
+        await writer.WriteEntryAsync(entry);
+        Assert.Equal(1536, entry.DataOffset);
+    }
+
+    [Fact]
+    public void DataOffset_UnseekableDataStream()
+    {
+        using MemoryStream ms = new();
+        using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            Assert.Equal(-1, entry.DataOffset);
+
+            using MemoryStream dataStream = new();
+            dataStream.WriteByte(ExpectedOffsetDataSingleByte);
+            dataStream.Position = 0;
+            using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
+            entry.DataStream = wds;
+
+            writer.WriteEntry(entry);
+        }
+        ms.Position = 0;
+
+        using TarReader reader = new(ms);
+        TarEntry actualEntry = reader.GetNextEntry();
+        Assert.NotNull(actualEntry);
+        // Gnu header length is 512, data starts in the next position
+        Assert.Equal(512, actualEntry.DataOffset);
+    }
+
+    [Fact]
+    public async Task DataOffset_UnseekableDataStream_Async()
+    {
+        await using MemoryStream ms = new();
+        await using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            Assert.Equal(-1, entry.DataOffset);
+
+            await using MemoryStream dataStream = new();
+            dataStream.WriteByte(ExpectedOffsetDataSingleByte);
+            dataStream.Position = 0;
+            await using WrappedStream wds = new(dataStream, canWrite: true, canRead: true, canSeek: false);
+            entry.DataStream = wds;
+
+            await writer.WriteEntryAsync(entry);
+        }
+        ms.Position = 0;
+
+        await using TarReader reader = new(ms);
+        TarEntry actualEntry = await reader.GetNextEntryAsync();
+        Assert.NotNull(actualEntry);
+        // Gnu header length is 512, data starts in the next position
+        Assert.Equal(512, actualEntry.DataOffset);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DataOffset_LongPath_LongLink_SecondEntry(bool canSeek)
+    {
+        string veryLongPathName = new string('a', 1234); // Forces using a GNU LongPath entry
+        string veryLongLinkName = new string('b', 1234); // Forces using a GNU LongLink entry
+
+        using MemoryStream ms = new();
+        using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry1 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
+            entry1.LinkName = veryLongLinkName;
+            writer.WriteEntry(entry1);
+
+            GnuTarEntry entry2 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
+            entry2.LinkName = veryLongLinkName;
+            writer.WriteEntry(entry2);
+        }
+        ms.Position = 0;
+
+        using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        using TarReader reader = new(streamToRead);
+        TarEntry firstEntry = reader.GetNextEntry();
+        Assert.NotNull(firstEntry);
+        // GNU first writes the long link and long path entries, containing:
+        // * 512 bytes of the regular long link tar header
+        // * 1234 bytes for the data section containing the full long link
+        // * 302 bytes of padding
+        // * 512 bytes of the regular long path tar header
+        // * 1234 bytes for the data section containing the full long path
+        // * 302 bytes of padding
+        // Then it writes the actual regular file entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 4608.
+        // The regular file data section starts on the next byte.
+        long firstExpectedDataOffset = canSeek ? 4608 : -1;
+        Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
+
+        TarEntry secondEntry = reader.GetNextEntry();
+        Assert.NotNull(secondEntry);
+        // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
+        // Second entry (including its long link and long path entries) data section starts one byte after 4608 + 4608 = 9216
+        long secondExpectedDataOffset = canSeek ? 9216 : -1;
+        Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DataOffset_LongPath_LongLink_SecondEntry_Async(bool canSeek)
+    {
+        string veryLongPathName = new string('a', 1234); // Forces using a GNU LongPath entry
+        string veryLongLinkName = new string('b', 1234); // Forces using a GNU LongLink entry
+
+        await using MemoryStream ms = new();
+        await using (TarWriter writer = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry1 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
+            entry1.LinkName = veryLongLinkName;
+            await writer.WriteEntryAsync(entry1);
+
+            GnuTarEntry entry2 = new GnuTarEntry(TarEntryType.SymbolicLink, veryLongPathName);
+            entry2.LinkName = veryLongLinkName;
+            await writer.WriteEntryAsync(entry2);
+        }
+        ms.Position = 0;
+
+        await using Stream streamToRead = new WrappedStream(ms, canWrite: true, canRead: true, canSeek: canSeek);
+        await using TarReader reader = new(streamToRead);
+        TarEntry firstEntry = await reader.GetNextEntryAsync();
+        Assert.NotNull(firstEntry);
+        // GNU first writes the long link and long path entries, containing:
+        // * 512 bytes of the regular long link tar header
+        // * 1234 bytes for the data section containing the full long link
+        // * 302 bytes of padding
+        // * 512 bytes of the regular long path tar header
+        // * 1234 bytes for the data section containing the full long path
+        // * 302 bytes of padding
+        // Then it writes the actual regular file entry, containing:
+        // * 512 bytes of the regular tar header
+        // Totalling 4608.
+        // The regular file data section starts on the next byte.
+        long firstExpectedDataOffset = canSeek ? 4608 : -1;
+        Assert.Equal(firstExpectedDataOffset, firstEntry.DataOffset);
+
+        TarEntry secondEntry = await reader.GetNextEntryAsync();
+        Assert.NotNull(secondEntry);
+        // First entry (including its long link and long path entries) end at 4608 (no padding, empty, as symlink has no data)
+        // Second entry (including its long link and long path entries) data section starts one byte after 4608 + 4608 = 9216
+        long secondExpectedDataOffset = canSeek ? 9216 : -1;
+        Assert.Equal(secondExpectedDataOffset, secondEntry.DataOffset);
+    }
+
+    [Fact]
+    public void UnusedBytesInSizeFieldShouldBeZeroChars()
+    {
+        // The GNU format sets the unused bytes in the size field to "0" characters.
+
+        using MemoryStream ms = new();
+
+        using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+        {
+            // Start with a regular file entry without data
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            writer.WriteEntry(entry);
+        }
+        ms.Position = 0;
+
+        using (TarReader reader = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = reader.GetNextEntry() as GnuTarEntry;
+            Assert.NotNull(entry);
+            Assert.Equal(0, entry.Length);
+        }
+        ms.Position = 0;
+        ValidateUnusedBytesInSizeField(ms, 0);
+
+        ms.SetLength(0); // Reset the stream
+        byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }; // 8 bytes of data means a size of 10 in octal
+        using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+        {
+            // Start with a regular file entry with data
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            entry.DataStream = new MemoryStream(data);
+            writer.WriteEntry(entry);
+        }
+
+        ms.Position = 0;
+        using (TarReader reader = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = reader.GetNextEntry() as GnuTarEntry;
+            Assert.NotNull(entry);
+            Assert.Equal(data.Length, entry.Length);
+        }
+        ms.Position = 0;
+        ValidateUnusedBytesInSizeField(ms, data.Length);
+    }
+
+    [Fact]
+    public async Task UnusedBytesInSizeFieldShouldBeZeroChars_Async()
+    {
+        // The GNU format sets the unused bytes in the size field to "0" characters.
+
+        await using MemoryStream ms = new();
+
+        await using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+        {
+            // Start with a regular file entry without data
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            await writer.WriteEntryAsync(entry);
+        }
+        ms.Position = 0;
+
+        await using (TarReader reader = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = await reader.GetNextEntryAsync() as GnuTarEntry;
+            Assert.NotNull(entry);
+            Assert.Equal(0, entry.Length);
+        }
+        ms.Position = 0;
+        ValidateUnusedBytesInSizeField(ms, 0);
+
+        ms.SetLength(0); // Reset the stream
+        byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }; // 8 bytes of data means a size of 10 in octal
+        await using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+        {
+            // Start with a regular file entry with data
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, InitialEntryName);
+            entry.DataStream = new MemoryStream(data);
+            await writer.WriteEntryAsync(entry);
+        }
+
+        ms.Position = 0;
+        await using (TarReader reader = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = await reader.GetNextEntryAsync() as GnuTarEntry;
+            Assert.NotNull(entry);
+            Assert.Equal(data.Length, entry.Length);
+        }
+        ms.Position = 0;
+        ValidateUnusedBytesInSizeField(ms, data.Length);
+    }
+
+    private void ValidateUnusedBytesInSizeField(MemoryStream ms, long size)
+    {
+        // internally, the unused bytes in the size field should be "0" characters,
+        // and the rest should be the octal value of the size field
+
+        // name, mode, uid, gid,
+        // size
+        int sizeStart = 100 + 8 + 8 + 8;
+        byte[] buffer = new byte[12]; // The size field is 12 bytes in length
+
+        ms.Seek(sizeStart, SeekOrigin.Begin);
+        ms.Read(buffer);
+
+        // Convert the base 10 value of size to base 8
+        string octalSize = Convert.ToString(size, 8).PadLeft(11, '0');
+        byte[] octalSizeBytes = Encoding.ASCII.GetBytes(octalSize);
+        // The last byte should be a null character
+        Assert.Equal(octalSizeBytes, buffer.Take(octalSizeBytes.Length).ToArray());
+    }
+
+    public static IEnumerable<object[]> NameAndLink_TestData()
+    {
+        // Name and link have a max length of 100. Anything longer goes into LongPath or LongLink entries in GNU.
+        yield return new object[] { InitialEntryName, InitialEntryName }; // Short name and short link
+        yield return new object[] { InitialEntryName, new string('b', 101) }; // Short name and long link
+        yield return new object[] { new string('a', 101), InitialEntryName }; // Long name and short link
+        yield return new object[] { new string('a', 101), new string('b', 101) }; // Long name and long link
+    }
+
+    private GnuTarEntry CreateEntryForLongLinkLongPathChecks(string name, string linkName)
+    {
+        // A SymbolicLink entry can test both LongLink and LongPath entries if
+        // the length of either string is longer than what fits in the header.
+        return new GnuTarEntry(TarEntryType.SymbolicLink, name)
+        {
+            LinkName = linkName,
+            ModificationTime = DateTimeOffset.UnixEpoch,
+            AccessTime = DateTimeOffset.UnixEpoch,
+            ChangeTime = DateTimeOffset.UnixEpoch,
+            Uid = 0,
+            Gid = 0,
+            UserName = TestUName,
+            GroupName = TestGName
+        };
+    }
+
+    private void ValidateEntryForRegularEntryInLongLinkAndLongPathChecks(GnuTarEntry entry, string name, string linkName)
+    {
+        Assert.NotNull(entry);
+        Assert.Equal(DateTimeOffset.UnixEpoch, entry.ModificationTime);
+        Assert.Equal(DateTimeOffset.UnixEpoch, entry.AccessTime);
+        Assert.Equal(DateTimeOffset.UnixEpoch, entry.ChangeTime);
+        Assert.Equal(name, entry.Name);
+        Assert.Equal(linkName, entry.LinkName);
+        Assert.Equal(0, entry.Uid); // Should be '0' chars in the long header
+        Assert.Equal(0, entry.Gid); // Should be '0' chars in the long header
+        Assert.Equal(TestUName, entry.UserName);
+        Assert.Equal(TestGName, entry.GroupName);
+        Assert.Equal(0, entry.Length); // No data in the main entry
+    }
+
+    [Theory]
+    [MemberData(nameof(NameAndLink_TestData))]
+    public void Check_LongLink_AndLongPath_Metadata(string name, string linkName)
+    {
+        // The GNU format sets the mtime, atime and ctime to nulls in headers when they are set to the unix epoch.
+        // Also the uid and gid should be '0' in the long entries headers.
+        // Also the uname and gname in the long entry headers should be set to those of the main entry.
+
+        using MemoryStream ms = new();
+
+        using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+        {
+            GnuTarEntry entry = CreateEntryForLongLinkLongPathChecks(name, linkName);
+            writer.WriteEntry(entry);
+        }
+        ms.Position = 0;
+
+        using (TarReader reader = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = reader.GetNextEntry() as GnuTarEntry;
+            ValidateEntryForRegularEntryInLongLinkAndLongPathChecks(entry, name, linkName);
+        }
+
+        ValidateLongEntryBytes(ms, name, linkName);
+    }
+
+    [Theory]
+    [MemberData(nameof(NameAndLink_TestData))]
+    public async Task Check_LongLink_AndLongPath_Metadata_Async(string name, string linkName)
+    {
+        // The GNU format sets the mtime, atime and ctime to nulls in headers when they are set to the unix epoch.
+        // Also the uid and gid should be '0' in the long entries headers.
+        // Also the uname and gname in the long entry headers should be set to those of the main entry.
+
+        await using MemoryStream ms = new();
+
+        await using (TarWriter writer = new(ms, TarEntryFormat.Gnu, leaveOpen: true))
+        {
+            GnuTarEntry entry = CreateEntryForLongLinkLongPathChecks(name, linkName);
+            await writer.WriteEntryAsync(entry);
+        }
+        ms.Position = 0;
+
+        await using (TarReader reader = new(ms, leaveOpen: true))
+        {
+            GnuTarEntry entry = await reader.GetNextEntryAsync() as GnuTarEntry;
+            ValidateEntryForRegularEntryInLongLinkAndLongPathChecks(entry, name, linkName);
+        }
+
+        ValidateLongEntryBytes(ms, name, linkName);
+    }
+
+    private void ValidateLongEntryBytes(MemoryStream ms, string name, string linkName)
+    {
+        bool isLongPath = name.Length >= 100;
+        bool isLongLink = linkName.Length >= 100;
+
+        ms.Position = 0;
+
+        long nextEntryStart = 0;
+        long reportedSize;
+
+        if (isLongLink)
+        {
+            reportedSize = CheckHeaderMetadataAndGetReportedSize(ms, nextEntryStart, isLongLinkOrLongPath: true);
+            CheckDataContainsExpectedString(ms, nextEntryStart + 512, reportedSize, linkName, shouldTrim: false); // Skip to the data section
+            nextEntryStart = nextEntryStart + 512 + 512; // Skip the current header and the long link entry
+            Assert.True(linkName.Length < 512, "Do not test paths longer than a 512 byte block");
+        }
+
+        if (isLongPath)
+        {
+            reportedSize = CheckHeaderMetadataAndGetReportedSize(ms, nextEntryStart, isLongLinkOrLongPath: true);
+            CheckDataContainsExpectedString(ms, nextEntryStart + 512, reportedSize, name, shouldTrim: false); // Skip to the data section
+            nextEntryStart = 512 + 512; // Skip the current header and the long path entry
+            Assert.True(name.Length < 512, "Do not test paths longer than a 512 byte block");
+        }
+
+        CheckHeaderMetadataAndGetReportedSize(ms, nextEntryStart, isLongLinkOrLongPath: false);
+    }
+
+    private long CheckHeaderMetadataAndGetReportedSize(MemoryStream ms, long nextEntryStart, bool isLongLinkOrLongPath)
+    {
+        // internally, mtime, atime and ctime should be nulls
+        // and if the entry is a long path or long link, the entry's data length should be
+        // equal to the string plus a null character
+
+        // name mode uid gid size mtime checksum typeflag linkname magic uname gname devmajor devminor atime ctime
+        // 100  8    8   8   12   12    8        1        100      8     32    32    8        8        12    12
+        long nameStart = nextEntryStart;
+        long modeStart = nameStart + 100;
+        long uidStart = modeStart + 8;
+        long gidStart = uidStart + 8;
+        long sizeStart = gidStart + 8;
+        long mTimeStart = sizeStart + 12;
+        long checksumStart = mTimeStart + 12;
+        long typeflagStart = checksumStart + 8;
+        long linkNameStart = typeflagStart + 1;
+        long magicStart = linkNameStart + 100;
+        long uNameStart = magicStart + 8;
+        long gNameStart = uNameStart + 32;
+        long devMajorStart = gNameStart + 32;
+        long devMinorStart = devMajorStart + 8;
+        long aTimeStart = devMinorStart + 8;
+        long cTimeStart = aTimeStart + 12;
+
+        byte[] buffer = new byte[12]; // size, mtime, atime, ctime all are 12 bytes in length
+
+        if (isLongLinkOrLongPath)
+        {
+            CheckBytesAreZeros(ms, buffer.AsSpan(0, 8), uidStart);
+            CheckBytesAreZeros(ms, buffer.AsSpan(0, 8), gidStart);
+        }
+        CheckBytesAreZeros(ms, buffer, mTimeStart);
+        CheckBytesAreZeros(ms, buffer, aTimeStart);
+        CheckBytesAreZeros(ms, buffer, cTimeStart);
+        CheckDataContainsExpectedString(ms, uNameStart, 32, TestUName, shouldTrim: true);
+        CheckDataContainsExpectedString(ms, gNameStart, 32, TestGName, shouldTrim: true);
+
+        ms.Seek(sizeStart, SeekOrigin.Begin);
+        ms.Read(buffer);
+        return ParseNumeric<long>(buffer);
+    }
+
+    private void CheckBytesAreSpecificChar(MemoryStream ms, Span<byte> buffer, long dataStart, byte charToCheck)
+    {
+        ms.Seek(dataStart, SeekOrigin.Begin);
+        ms.Read(buffer);
+        foreach (byte b in buffer.Slice(0, buffer.Length - 1)) // The last byte should be a null character
+        {
+            Assert.Equal(charToCheck, b);
+        }
+        Assert.Equal(0, buffer[^1]); // The last byte should be a null character
+    }
+
+    private void CheckBytesAreNulls(MemoryStream ms, Span<byte> buffer, long dataStart) => CheckBytesAreSpecificChar(ms, buffer, dataStart, 0); // null char
+
+    private void CheckBytesAreZeros(MemoryStream ms, Span<byte> buffer, long dataStart) => CheckBytesAreSpecificChar(ms, buffer, dataStart, 0x30); // '0' char
+
+    private void CheckDataContainsExpectedString(MemoryStream ms, long dataStart, long actualDataLength, string expectedString, bool shouldTrim)
+    {
+        ms.Seek(dataStart, SeekOrigin.Begin);
+        byte[] buffer = new byte[actualDataLength];
+        ms.Read(buffer);
+
+        if (shouldTrim)
+        {
+            string actualString = Encoding.ASCII.GetString(TrimEndingNullsAndSpaces(buffer));
+            Assert.Equal(expectedString, actualString);
+        }
+        else
+        {
+            string actualString = Encoding.ASCII.GetString(buffer);
+            Assert.Equal(expectedString, actualString[..^1]); // The last byte should be a null character
+        }
+    }
+
+    private static T ParseNumeric<T>(ReadOnlySpan<byte> buffer) where T : struct, INumber<T>, IBinaryInteger<T>
+    {
+        byte leadingByte = buffer[0];
+        if (leadingByte == 0xff)
+        {
+            return T.ReadBigEndian(buffer, isUnsigned: false);
+        }
+        else if (leadingByte == 0x80)
+        {
+            return T.ReadBigEndian(buffer.Slice(1), isUnsigned: true);
+        }
+        else
+        {
+            return ParseOctal<T>(buffer);
+        }
+    }
+
+    private static T ParseOctal<T>(ReadOnlySpan<byte> buffer) where T : struct, INumber<T>
+    {
+        buffer = TrimEndingNullsAndSpaces(buffer);
+        buffer = TrimLeadingNullsAndSpaces(buffer);
+
+        if (buffer.Length == 0)
+        {
+            return T.Zero;
+        }
+
+        T octalFactor = T.CreateTruncating(8u);
+        T value = T.Zero;
+        foreach (byte b in buffer)
+        {
+            uint digit = (uint)(b - '0');
+            if (digit >= 8)
+            {
+                throw new InvalidDataException(SR.Format(SR.TarInvalidNumber));
+            }
+
+            value = checked((value * octalFactor) + T.CreateTruncating(digit));
+        }
+
+        return value;
+    }
+
+    private static ReadOnlySpan<byte> TrimEndingNullsAndSpaces(ReadOnlySpan<byte> buffer)
+    {
+        int trimmedLength = buffer.Length;
+        while (trimmedLength > 0 && buffer[trimmedLength - 1] is 0 or 32)
+        {
+            trimmedLength--;
+        }
+
+        return buffer.Slice(0, trimmedLength);
+    }
+
+    private static ReadOnlySpan<byte> TrimLeadingNullsAndSpaces(ReadOnlySpan<byte> buffer)
+    {
+        int newStart = 0;
+        while (newStart < buffer.Length && buffer[newStart] is 0 or 32)
+        {
+            newStart++;
+        }
+
+        return buffer.Slice(newStart);
+    }
+}
 }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Tests.cs
@@ -13,48 +13,6 @@ using Xunit;
 
 namespace System.Formats.Tar.Tests
 {
-
-    public class Carlos
-    {
-        [Fact]
-        public void Test()
-        {
-            string inputFile = @"C:\Users\calope\source\repos\test\unpack-repack\input_official_good.gz";
-            string outputFile = @"C:\Users\calope\source\repos\test\unpack-repack\NEW-OUTPUT.tar.gz";
-
-            File.Delete(outputFile);
-
-            using MemoryStream streamToCompress = new();
-            using (TarWriter writer = new (streamToCompress, leaveOpen: true))
-            {
-                foreach (TarEntry entry in ReadTarGZipEntries(inputFile))
-                {
-                    writer.WriteEntry(entry);
-                }
-            }
-
-            streamToCompress.Flush();
-
-            streamToCompress.Position = 0;
-            using (FileStream outputStream = File.Open(outputFile, FileMode.Create, FileAccess.Write))
-            {
-                using GZipStream compressor = new(outputStream, CompressionMode.Compress);
-                streamToCompress.CopyTo(compressor);
-            }
-        }
-
-        private static IEnumerable<TarEntry> ReadTarGZipEntries(string path)
-        {
-            using FileStream streamToDecompress = File.OpenRead(path);
-            using GZipStream decompressor = new(streamToDecompress, CompressionMode.Decompress);
-            using TarReader tarReader = new(decompressor);
-            while (tarReader.GetNextEntry() is TarEntry entry)
-            {
-                yield return entry;
-            }
-        }
-    }
-
     public class GnuTarEntry_Tests : TarTestsBase
 {
     [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
@@ -363,7 +363,7 @@ namespace System.Formats.Tar.Tests
             if (entryType is TarEntryType.RegularFile or TarEntryType.V7RegularFile)
             {
                 entry.DataStream = new MemoryStream();
-                byte[] buffer = new byte[] { 72, 101, 108, 108, 111 }; // values don't matter, only length (5)
+                byte[] buffer = [ 72, 101, 108, 108, 111 ]; // values don't matter, only length (5)
 
                 // '0000000005\0' = 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 53 + 0 = 533
                 entry.DataStream.Write(buffer);
@@ -377,9 +377,9 @@ namespace System.Formats.Tar.Tests
             }
 
             // If V7 regular file:            '\0' = 0
-                // If Ustar/Pax/Gnu regular file: '0'  = 48
-                // If block device:               '4'  = 52
-                expectedChecksum += (byte)entryType;
+            // If Ustar/Pax/Gnu regular file: '0'  = 48
+            // If block device:               '4'  = 52
+            expectedChecksum += (byte)entryType;
 
             // Checksum so far: 256 + 351 + 353 + 359 + 571 = decimal 1890
             // If V7RegularFile: 1890 + 533 + 0  = 2423 (octal 4567) => '004567\0'
@@ -440,7 +440,7 @@ namespace System.Formats.Tar.Tests
 
                     gnuEntry.ChangeTime = expectedTimestampToTest;
                     checksum += expectedTimestampChecksumToTest;
-                    // Total: UnixEpoch = 0, otherwise = 1142
+                    // Total: UnixEpoch = 1056, otherwise = 1142
 
                     void GetTimestampToTest(bool testEpoch, out DateTimeOffset expectedTimestampToTest, out int expectedTimestampChecksumToTest)
                     {
@@ -452,8 +452,8 @@ namespace System.Formats.Tar.Tests
                             expectedTimestampToTest = TimestampForChecksum; // ToUnixTimeSeconds() = decimal 1641095100, octal 14164217674;
                         }
 
-                        expectedTimestampChecksumToTest = 0;
-                        // '\0\0\0\0\0\0\0\0\0\0\0\0' = 0
+                        expectedTimestampChecksumToTest = 528;
+                        // '00000000000\0' = 0
                         expectedTimestampToTest = UnixEpochTimestampForChecksum; // ToUnixTimeSeconds() = decimal 0, octal 0;
                     }
                 }
@@ -466,7 +466,9 @@ namespace System.Formats.Tar.Tests
             // Gnu RegularFile: 623 + 1004 + 1142 = 2769
             // Ustar BlockDevice: 655 + 1004 + 686 = 2345
             // Pax BlockDevice: 655 + 1004 + 686 = 2345
-            // Gnu BlockDevice: 623 + 1004 + 686 + 1142 = 3455
+            // Gnu BlockDevice:
+            //    No epoch: 623 + 1004 + 686 + 1142 = 3455
+            //    Epoch: 623 + 1004 + 686 + 1056 = 3369
             return checksum;
         }
     }


### PR DESCRIPTION
The Tar entry types Longlink and Longpath, which are exclusive to the GNU format, are metadata entries used to store longer-than-expected link or name strings (respectively). They precede their actual entry, and they are not visible to the user, only the data they hold is visible.

Most of the regular header metadata in this metadata entries is not relevant, but we need to make sure it is well formed so other tools can read them properly.

There are 3 fields that were not getting their values stored as expected by other tools:

- The mtime, ctime and atime fields need to be set to the Unix Epoch so it shows up as zeros (0x30) by default. We were storing them as null (0x0) characters instead. For consistency, if a regular entry happens to get its mtime set to the Epoch, it should also be shown as zeros (0x30).
- The uid, gid, uname and gname fields were not being set. These fields aren't really important in a metadata entry, but other tools set this to the default value (uid=gid=0 and uname=gname=root). Based on the fact that 'a value' is preferred for these fields, we can set them to the same value that the real entry has (not root).
- The long text value (either link or name) should be null terminated, and this extra character should be counted in the size of the longpath. The library libdpkg, used for packagin in Debian, can handle a missing null terminator in longlink and longpath data starting with Debian 13, but we use Debian 12, and in that version, without the terminator, these entries are considered malformed.