### PR TITLE
Log error to host

### DIFF
--- a/src/coreclr/gc/gc.h
+++ b/src/coreclr/gc/gc.h
@@ -392,4 +392,6 @@ void GCLog (const char *fmt, ... );
 FILE* CreateLogFile(const GCConfigStringHolder& temp_logfile_name, bool is_config);
 #endif //TRACE_GC || GC_CONFIG_DRIVEN
 
+void log_init_error_to_host (const char* format, ...);
+
 #endif // __GC_H

--- a/src/coreclr/gc/gccommon.cpp
+++ b/src/coreclr/gc/gccommon.cpp
@@ -132,6 +132,12 @@ FILE* CreateLogFile(const GCConfigStringHolder& temp_logfile_name, bool is_confi
     //_snprintf_s(logfile_name, MAX_LONGPATH+1, _TRUNCATE, "%s.%d%s", temp_logfile_name.Get(), pid, suffix);
     _snprintf_s(logfile_name, MAX_LONGPATH+1, _TRUNCATE, "%s%s", temp_logfile_name.Get(), suffix);
     logFile = fopen(logfile_name, "wb");
+
+    if (logFile == NULL)
+    {
+        log_init_error_to_host ("Cannot create log file %s", logfile_name);
+    }
+
     return logFile;
 }
 #endif //TRACE_GC || GC_CONFIG_DRIVEN
@@ -159,7 +165,6 @@ HRESULT initialize_log_file()
 
         if (gc_log == NULL)
         {
-            GCToEEInterface::LogErrorToHost("Cannot create log file");
             return E_FAIL;
         }
 
@@ -168,7 +173,7 @@ HRESULT initialize_log_file()
 
         if (gc_log_file_size <= 0 || gc_log_file_size > 500)
         {
-            GCToEEInterface::LogErrorToHost("Invalid log file size (valid size needs to be larger than 0 and smaller than 500)");
+            log_init_error_to_host ("Invalid log file size %zd MiB (valid size needs to be > 0 and <= 500 MiB)", gc_log_file_size);
             fclose (gc_log);
             return E_FAIL;
         }
@@ -265,4 +270,15 @@ void GCLog (const char *fmt, ... )
 }
 #endif //TRACE_GC && SIMPLE_DPRINTF
 
+// We log initialization errors to the host to help with diagnostics. By default these will show up in stdout.
+// You can also redirect them to a file. See docs/design/features/host-tracing.md.
+void log_init_error_to_host (const char* format, ...)
+{
+    char error_buf[256];
+    va_list args;
+    va_start (args, format);
+    _vsnprintf_s (error_buf, ARRAY_SIZE (error_buf), _TRUNCATE, format, args);
+    GCToEEInterface::LogErrorToHost (error_buf);
+    va_end (args);
+}
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -104,8 +104,8 @@ public:
     INT_CONFIG   (GCHeapHardLimit,           "GCHeapHardLimit",           "System.GC.HeapHardLimit",           0,                  "Specifies a hard limit for the GC heap")                                                 \
     INT_CONFIG   (GCHeapHardLimitPercent,    "GCHeapHardLimitPercent",    "System.GC.HeapHardLimitPercent",    0,                  "Specifies the GC heap usage as a percentage of the total memory")                        \
     INT_CONFIG   (GCTotalPhysicalMemory,     "GCTotalPhysicalMemory",     NULL,                                0,                  "Specifies what the GC should consider to be total physical memory")                      \
-    INT_CONFIG   (GCRegionRange,             "GCRegionRange",             NULL,                                0,                  "Specifies the range for the GC heap")                                                    \
-    INT_CONFIG   (GCRegionSize,              "GCRegionSize",              NULL,                                0,                  "Specifies the size for a basic GC region")                                               \
+    INT_CONFIG   (GCRegionRange,             "GCRegionRange",             "System.GC.RegionRange",             0,                  "Specifies the range for the GC heap")                                                    \
+    INT_CONFIG   (GCRegionSize,              "GCRegionSize",              "System.GC.RegionSize",              0,                  "Specifies the size for a basic GC region")                                               \
     INT_CONFIG   (GCEnableSpecialRegions,    "GCEnableSpecialRegions",    NULL,                                0,                  "Specifies to enable special handling some regions like SIP")                             \
     STRING_CONFIG(LogFile,                   "GCLogFile",                 NULL,                                                    "Specifies the name of the GC log file")                                                  \
     STRING_CONFIG(ConfigLogFile,             "GCConfigLogFile",           NULL,                                                    "Specifies the name of the GC config log file")                                           \
@@ -142,7 +142,7 @@ public:
     INT_CONFIG   (GCSpinCountUnit,           "GCSpinCountUnit",           NULL,                                0,                  "Specifies the spin count unit used by the GC.")                                          \
     INT_CONFIG   (GCDynamicAdaptationMode,   "GCDynamicAdaptationMode",   "System.GC.DynamicAdaptationMode",   1,                  "Enable the GC to dynamically adapt to application sizes.")                               \
     INT_CONFIG   (GCDTargetTCP,              "GCDTargetTCP",              "System.GC.DTargetTCP",              0,                  "Specifies the target tcp for DATAS")                                                     \
-    INT_CONFIG   (GCDBGCRatio,              " GCDBGCRatio",               NULL,                                0,                  "Specifies the ratio of BGC to NGC2 for HC change")                                       \
+    INT_CONFIG   (GCDBGCRatio,               "GCDBGCRatio",               NULL,                                0,                  "Specifies the ratio of BGC to NGC2 for HC change")                                       \
     BOOL_CONFIG  (GCCacheSizeFromSysConf,    "GCCacheSizeFromSysConf",    NULL,                                false,              "Specifies using sysconf to retrieve the last level cache size for Unix.")
 
 // This class is responsible for retreiving configuration information


### PR DESCRIPTION
lately I've seen a couple of customer reports where the GC initialization failed to reserve the default 256GB of virtual memory for the regions range, to make this easier to diagnose I've added this as an error communicated to host. so you would see something like this 
```
C:\temp>dotnet GCPerfSim.dll -tc 28 -tagb 50 -tlgb 2 -lohar 0 -sohsi 50 -lohsi 0 -pohsi 0 -sohpi 100 -lohpi 0 -sohfi 0 -lohfi 0 -pohfi 0 -allocType reference -testKind time
GC: Reserving 274877906944 bytes (256 GiB) for the regions range failed, do you have a virtual memory limit set on this process?
GC heap initialization failed with error 0x8007000E
Failed to create CoreCLR, HRESULT: 0x8007000E
```

also added a few other places where we might hit and got rid of some that are only for private testing. I'm not adding this for every single case where it could fail as they are really unlikely to be hit. 

since the solution is to adjust some region configs I also exposed them to the runtimeconfig. 

and fixed a typo I had for a config for private testing.