### PR TITLE
Fix non-portable CI builds.

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1786,11 +1786,12 @@ extends:
           parameters:
             platforms:
               - name: CentOS9
+                baseOS: linux-x64
                 targetRID: centos.9-x64
                 portableBuild: false
                 container: SourceBuild_centos_x64
               - name: NonexistentRID
-                baseOS: linux
+                baseOS: linux-x64
                 targetRID: banana.24-x64
                 portableBuild: false
                 container: SourceBuild_centos_x64

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1741,6 +1741,7 @@ extends:
       # Build and test Mono Minijit with the libraries testss
       #
       - template: /eng/pipelines/common/platform-matrix.yml
+        condition: eq(variables['isRollingBuild'], true)
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1741,7 +1741,6 @@ extends:
       # Build and test Mono Minijit with the libraries testss
       #
       - template: /eng/pipelines/common/platform-matrix.yml
-        condition: eq(variables['isRollingBuild'], true)
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
@@ -1772,6 +1771,7 @@ extends:
     - stage: SourceBuild
       displayName: Source Build Validation
       dependsOn: []
+      condition: eq(variables['isRollingBuild'], true)
       jobs:
         #
         # Sourcebuild legs

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1771,7 +1771,6 @@ extends:
     - stage: SourceBuild
       displayName: Source Build Validation
       dependsOn: []
-      condition: eq(variables['isRollingBuild'], true)
       jobs:
         #
         # Sourcebuild legs

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
@@ -11,6 +11,11 @@
     <RuntimeIdentifier>$(OutputRID)</RuntimeIdentifier>
     <!-- Set the apphost RID so we download the apphost pack if needed. -->
     <AppHostRuntimeIdentifier>$(OutputRID)</AppHostRuntimeIdentifier>
+    <!--
+      If the output RID isn't the current SDK RID and we have a "base" RID, then the output RID isn't known to the SDK.
+      In that case, we need to set the AppHostRuntimeIdentifier to the base RID so the SDK can find a runtime pack for publishing.
+    -->
+    <AppHostRuntimeIdentifier Condition="'$(OutputRID)' != '$(NETCoreSdkRuntimeIdentifier)' and '$(BaseOS)' != '' ">$(BaseOS)</AppHostRuntimeIdentifier>
     <UseLocalAppHostPack>true</UseLocalAppHostPack>
     <!-- Don't use the local apphost pack on Windows as matching linker configurations is difficult. -->
     <UseLocalAppHostPack Condition="'$(TargetOS)' == 'windows'">false</UseLocalAppHostPack>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/114842.

Changes in this PR to NativeExports.csproj will be undone in https://github.com/dotnet/runtime/pull/114285.
Until that PR gets merged, this unblocks our internal CI builds and upstream SourceBuild CI legs.

@ViktorHofer @jkoritzinsky @am11 ptal.

cc @omajid 