### PR TITLE
[RISC-V] Read `isa` line in `/proc/cpuinfo` when `hwprobe` not available

### DIFF
--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -563,7 +563,43 @@ int minipal_getcpufeatures(void)
         }
     }
 
-#endif // HAVE_HWPROBE_H
+#else
+
+    // https://docs.kernel.org/arch/riscv/uabi.html
+    // Example:
+    // isa             : rv64imadc_zifoo_zigoo_zafoo_sbar_scar_zxmbaz_xqux_xrux
+
+    FILE*  cpuInfo = fopen("/proc/cpuinfo", "r");
+    size_t n       = 0;
+    char*  buf     = NULL;
+
+    assert(cpuInfo != NULL);
+
+    while (getline(&buf, &n, cpuInfo) != -1 && (strncmp(buf, "isa", 3) != 0))
+    {
+    };
+
+    char* savePtr = NULL;
+    char* isaLine;
+
+    if ((strtok_r(buf, ":", &savePtr) != NULL) && ((isaLine = strtok_r(NULL, ":", &savePtr)) != NULL))
+    {
+        savePtr = NULL;
+        for (char* extension = strtok_r(isaLine, "_", &savePtr); extension != NULL;
+             extension       = strtok_r(NULL, "_", &savePtr))
+        {
+            if (strcmp(extension, "zba") == 0)
+            {
+                result |= RiscV64IntrinsicConstants_Zba;
+            }
+            else if (strcmp(extension, "zbb") == 0)
+            {
+                result |= RiscV64IntrinsicConstants_Zbb;
+            }
+        }
+    }
+
+#endif
 
 #endif // HOST_UNIX
 


### PR DESCRIPTION
`hwprobe` was introduced in Linux kernel version 6.4 https://www.kernel.org/doc/html/v6.4/riscv/hwprobe.html (although on version 6.5, it only started supporting `Zba`, `Zbb`, and `Zbs` detection)

`isa` line in `/proc/cpuinfo` is available from Linux kernel version 6.3 upwards https://www.kernel.org/doc/html/v6.3/riscv/uabi.html (CMIIW)

`hwprobe` also exports less extensions than `/proc/cpuinfo` when first introduced. Should we prioritize `/proc/cpuinfo` on kernel version 6.11 and lower (on version 6.11, the extension supported in `hwprobe` looks complete https://www.kernel.org/doc/html/v6.11/arch/riscv/hwprobe.html)?

TODO:
- [ ] Study further on `hwprobe` and `/proc/cpuinfo` `isa` line support on Linux.

Part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung

