### PR TITLE
[release/10.0-preview4] [browser] Ensure compression targets run after preloading

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -107,6 +107,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ResolveWasmOutputs;
       _GenerateBuildWasmBootJson;
       _AddWasmStaticWebAssets;
+      _AddWasmPreloadBuildProperties;
     </ResolveCompressedFilesDependsOn>
     <ResolveCompressedFilesForPublishDependsOn Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
       $(ResolveCompressedFilesForPublishDependsOn);
@@ -114,6 +115,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ComputeWasmExtensions;
       GeneratePublishWasmBootJson;
       _AddPublishWasmBootJsonToStaticWebAssets;
+      _AddWasmPreloadPublishProperties;
     </ResolveCompressedFilesForPublishDependsOn>
     <CompressFilesForPublishDependsOn Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
       $(CompressFilesForPublishDependsOn);


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/114953

Backport of #114940 to release/10.0-preview4

## Customer Impact

- [ ] Customer reported
- [x] Found internally

Customers using WebAssembly preloading (on by default) loses the ability to use pre-compressed asset endpoint for preloaded asset in Blazor Web scenario.

## Regression

- [x] Yes
- [ ] No

Preloading is a new feature, but it is on by default.

## Risk

Low. Manually tested on failing cases in SDK repository.
