### PR TITLE
Report error if dotnet-pgo trace contains multiple processes

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -1050,7 +1050,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             {
                 bool hasPid = IsSet(_command.Pid);
                 string processName = Get(_command.ProcessName);
-                if (hasPid && processName == null && traceLog.Processes.Count != 1)
+                if (!hasPid && processName == null && traceLog.Processes.Count != 1)
                 {
                     PrintError("Trace file contains multiple processes to distinguish between");
                     PrintOutput("Either a pid or process name from the following list must be specified");


### PR DESCRIPTION
Fixes a logic error. When the trace file has multiple processes and no PID or process name was specified, we're supposed to instruct the user to provide it. Instead, we instruct user to provide it only if `--pid` is actually specified.