### PR TITLE
Do not rethrow from SocketsTestServerAPM.OnAccept

### DIFF
--- a/src/libraries/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
@@ -74,7 +74,7 @@ namespace System.Net.Sockets.Tests
             {
                 _socket.BeginAccept(OnAccept, null);
             }
-            catch (SocketException e)
+            catch (SocketException)
             {
             }
             catch (ObjectDisposedException)

--- a/src/libraries/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
@@ -51,7 +51,7 @@ namespace System.Net.Sockets.Tests
             {
                 client = _socket.EndAccept(result);
             }
-            catch (SocketException e)
+            catch (SocketException)
             {
                 return;
             }

--- a/src/libraries/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/SocketTestServerAPM.cs
@@ -53,14 +53,7 @@ namespace System.Net.Sockets.Tests
             }
             catch (SocketException e)
             {
-                if (_disposed ||
-                    e.SocketErrorCode == SocketError.OperationAborted ||
-                    e.SocketErrorCode == SocketError.Interrupted)
-                {
-                    return;
-                }
-
-                throw;
+                return;
             }
             catch (ObjectDisposedException)
             {
@@ -83,14 +76,6 @@ namespace System.Net.Sockets.Tests
             }
             catch (SocketException e)
             {
-                if (_disposed ||
-                    e.SocketErrorCode == SocketError.OperationAborted ||
-                    e.SocketErrorCode == SocketError.Interrupted)
-                {
-                    return;
-                }
-
-                throw;
             }
             catch (ObjectDisposedException)
             {


### PR DESCRIPTION
Fixes #85666.

The test class spawns a recursive OnAccept method which uses Begin/End pattern to continue accepting connections until the server is disposed. There is a condition which allows SocketException with SocketError.InvalidArgument to be thrown out of the function which leads to test process crash.

Since any sort of exception would crash the process, this PR simplifies the logic by removing any rethrows.