### PR TITLE
JIT: fix retyping error in object stack allocation

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -2039,16 +2039,11 @@ void ObjectAllocator::UpdateAncestorTypes(GenTree*              tree,
                         // It's either null or points to inside a stack-allocated object.
                         parent->gtFlags |= GTF_IND_TGT_NOT_HEAP;
                     }
-                }
-                else
-                {
-                    assert(tree == parent->AsIndir()->Data());
-                    GenTree* const addr = parent->AsIndir()->Addr();
 
-                    // If we are storing to a GC struct field, we may need to retype the store
+                    // If we are storing to a GC struct field we may need to retype the store
                     //
-                    if (retypeFields && parent->OperIs(GT_STOREIND) && (addr->OperIs(GT_FIELD_ADDR)) &&
-                        (varTypeIsGC(parent->TypeGet())))
+                    if (retypeFields && parent->OperIs(GT_STOREIND) && tree->OperIs(GT_FIELD_ADDR) &&
+                        varTypeIsGC(parent->TypeGet()))
                     {
                         parent->ChangeType(newType);
                     }

--- a/src/tests/JIT/opt/ObjectStackAllocation/Retyping.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/Retyping.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+class C1
+{
+    public C1(int x) { a = x; b = x; }
+    public int a;
+    public int b;
+}
+
+struct S1
+{
+    public S1(C1 z) { c = z; }
+    public int a;
+    public int b;
+    public C1 c;
+}
+
+public class Runtime_111922
+{
+   [Fact]
+   public static int Problem()
+   {
+       S1 s = new S1(new C1(4));
+       return 95 + SubProblem(1, s);
+   }
+
+   [MethodImpl(MethodImplOptions.NoInlining)]
+   static int SubProblem(int x, S1 s)
+   {
+       s = new S1(new C1(5));
+
+       SideEffect();
+
+       C1 v = s.c;
+       return v.a;
+   }
+
+   [MethodImpl(MethodImplOptions.NoInlining)]
+   static void SideEffect() { }
+}

--- a/src/tests/JIT/opt/ObjectStackAllocation/Retyping.csproj
+++ b/src/tests/JIT/opt/ObjectStackAllocation/Retyping.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Retype GT_STOREIND based on the store address, not the store data, since we need to know if we are retyping fields, and only know that when propagating from the local that forms the store address.

Fixes #111922.