### PR TITLE
Fix ReadContentAsDateTime method to keep DateTimeKind

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlSerializableReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlSerializableReader.cs
@@ -115,7 +115,7 @@ namespace System.Runtime.Serialization
 
         public override object ReadContentAsObject() { return InnerReader.ReadContentAsObject(); }
         public override bool ReadContentAsBoolean() { return InnerReader.ReadContentAsBoolean(); }
-        public override DateTime ReadContentAsDateTime() { return InnerReader.ReadContentAsDateTimeOffset().DateTime; }
+        public override DateTime ReadContentAsDateTime() { return InnerReader.ReadContentAsDateTime(); }
         public override double ReadContentAsDouble() { return InnerReader.ReadContentAsDouble(); }
         public override int ReadContentAsInt() { return InnerReader.ReadContentAsInt(); }
         public override long ReadContentAsLong() { return InnerReader.ReadContentAsLong(); }


### PR DESCRIPTION
potential fix for #114813

roundtripping through DateTimeOffset.DateTime loses the DateTimeKind, which in some code paths causes incorrect interpretation in DateTimeOffsetAdapter

this is also what the code looks like in framework: https://github.com/microsoft/referencesource/blob/master/System.Runtime.Serialization/System/Runtime/Serialization/XmlSerializableReader.cs#L117