### PR TITLE
Fix several messages mistreated as format strings

### DIFF
--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -257,7 +257,7 @@ bool _DbgBreakCheck(
     if (formattedMessages)
     {
         OutputDebugStringUtf8(formatBuffer);
-        minipal_log_print_error(formatBuffer);
+        minipal_log_print_error("%s", formatBuffer);
     }
     else
     {
@@ -489,7 +489,7 @@ void DECLSPEC_NORETURN __FreeBuildAssertFail(const char *szFile, int iLine, cons
     OutputDebugStringUtf8(buffer.GetUTF8());
 
     // Write out the error to the console
-    minipal_log_print_error(buffer.GetUTF8());
+    minipal_log_print_error("%s", buffer.GetUTF8());
 
     // Log to the stress log. Note that we can't include the szExpr b/c that
     // may not be a string literal (particularly for formatt-able asserts).

--- a/src/coreclr/vm/classcompat.cpp
+++ b/src/coreclr/vm/classcompat.cpp
@@ -520,7 +520,7 @@ InteropMethodTableData *MethodTableBuilder::BuildInteropVTable(AllocMemTracker *
             message.AppendUTF8((LPCUTF8) qb.Ptr());
             message.AppendUTF8("\n");
 
-            minipal_log_print_info(message.GetUTF8());
+            minipal_log_print_info("%s", message.GetUTF8());
             message.Clear();
         }
     }

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -2264,7 +2264,7 @@ static void DumpGCRefMap(const char *name, BYTE *address)
     }
     buf.AppendUTF8("\n");
 
-    minipal_log_print_info(buf.GetUTF8());
+    minipal_log_print_info("%s", buf.GetUTF8());
 }
 #endif
 


### PR DESCRIPTION
#113916 started incorrectly treating several messages as format strings. For example, we saw failing JIT asserts like

```
assert(m_size % TARGET_POINTER_SIZE == 0);
```

printed as

```
Assert failure(PID 38272 [0x00009580], Thread: 16904 [0x4208]): Assertion failed 'm_size  0X0.0027A801C8C01P-1022RGET_POINTER_SIZE == 0'
```

This fixes that case and others introduced in that PR found by audit.

These minipal APIs seem dangerous given that there is no indication in their names that they are taking a format string.