### PR TITLE
Run outerloop pipeline only for release branches, not staging/preview

### DIFF
--- a/eng/pipelines/libraries/outerloop-mono.yml
+++ b/eng/pipelines/libraries/outerloop-mono.yml
@@ -6,6 +6,7 @@ schedules:
   branches:
     include:
     - main
+  always: false # run only if there were changes since the last successful scheduled run.
 
 variables:
   - template: variables.yml

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -6,7 +6,8 @@ schedules:
   branches:
     include:
     - main
-    - release/*.*
+    - release/*.0
+  always: false # run only if there were changes since the last successful scheduled run.
 
 variables:
   - template: variables.yml


### PR DESCRIPTION
I noticed we were sending 30k workitems each day to various Helix queues at the same time, causing a heavy load on the system. This is due to the outerloop pipeline having a schedule trigger which matches old preview branches or the staging branches.

This fixes that and also sets it so that the trigger only applies if there are actual source changes.