### PR TITLE
FeatureSwitchDefinitionAttribute docs - target property does not have to be public

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/FeatureSwitchDefinitionAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/FeatureSwitchDefinitionAttribute.cs
@@ -4,7 +4,7 @@
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>
-    /// Indicates that the specified public static boolean get-only property
+    /// Indicates that the specified static boolean get-only property
     /// corresponds to the feature switch specified by name.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
Even in the example provided, the target is `internal`.