### PR TITLE
Add support of System.Uri to UrlAttribute

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UrlAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UrlAttribute.cs
@@ -19,6 +19,12 @@ namespace System.ComponentModel.DataAnnotations
         {
             switch (value)
             {
+                case Uri valueAsUri:
+                {
+                    return valueAsUri.Scheme == Uri.UriSchemeHttp
+                        || valueAsUri.Scheme == Uri.UriSchemeHttps
+                        || valueAsUri.Scheme == Uri.UriSchemeFtp;
+                }
                 case string valueAsString:
                 {
                     return valueAsString.StartsWith("http://", StringComparison.OrdinalIgnoreCase)

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UrlAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UrlAttribute.cs
@@ -17,15 +17,23 @@ namespace System.ComponentModel.DataAnnotations
 
         public override bool IsValid(object? value)
         {
-            if (value == null)
+            switch (value)
             {
-                return true;
+                case string valueAsString:
+                {
+                    return valueAsString.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                        || valueAsString.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+                        || valueAsString.StartsWith("ftp://", StringComparison.OrdinalIgnoreCase);
+                }
+                case null:
+                {
+                    return true;
+                }
+                default:
+                {
+                    return false;
+                }
             }
-
-            return value is string valueAsString &&
-                (valueAsString.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-                || valueAsString.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
-                || valueAsString.StartsWith("ftp://", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/UrlAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/UrlAttributeTests.cs
@@ -14,6 +14,9 @@ namespace System.ComponentModel.DataAnnotations.Tests
             yield return new TestCase(new UrlAttribute(), "http://foo.bar");
             yield return new TestCase(new UrlAttribute(), "https://foo.bar");
             yield return new TestCase(new UrlAttribute(), "ftp://foo.bar");
+            yield return new TestCase(new UrlAttribute(), new Uri("http://foo.bar"));
+            yield return new TestCase(new UrlAttribute(), new Uri("https://foo.bar"));
+            yield return new TestCase(new UrlAttribute(), new Uri("ftp://foo.bar"));
         }
 
         protected override IEnumerable<TestCase> InvalidValues()
@@ -21,6 +24,8 @@ namespace System.ComponentModel.DataAnnotations.Tests
             yield return new TestCase(new UrlAttribute(), "file:///foo.bar");
             yield return new TestCase(new UrlAttribute(), "foo.png");
             yield return new TestCase(new UrlAttribute(), new object());
+            yield return new TestCase(new UrlAttribute(), new Uri("file:///foo.bar"));
+            yield return new TestCase(new UrlAttribute(), new Uri("//foo.png"));
         }
 
         [Fact]


### PR DESCRIPTION
Current PR implements https://github.com/dotnet/runtime/issues/71008 .
Please, pay attention, that it does not cover [ftps schema](https://learn.microsoft.com/en-us/dotnet/api/system.uri.urischemeftps?view=net-9.0)