### PR TITLE
Fix some static analysis errors

### DIFF
--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/CompositionException.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/CompositionException.cs
@@ -197,8 +197,7 @@ namespace System.ComponentModel.Composition
                 // The composition produced a single composition error. The root cause is provided below.
                 writer.AppendFormat(
                      CultureInfo.CurrentCulture,
-                     SR.CompositionException_SingleErrorWithSinglePath,
-                     pathCount);
+                     SR.CompositionException_SingleErrorWithSinglePath);
             }
 
             writer.Append(' ');

--- a/src/libraries/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/OnImportsSatisfiedFeature.cs
+++ b/src/libraries/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/OnImportsSatisfiedFeature.cs
@@ -40,7 +40,7 @@ namespace System.Composition.TypedParts.ActivationFeatures
 
             foreach (var m in importsSatisfiedMethods)
             {
-                if (!(m.IsPublic || m.IsAssembly) | m.IsStatic || m.ReturnType != typeof(void) ||
+                if (!(m.IsPublic || m.IsAssembly) || m.IsStatic || m.ReturnType != typeof(void) ||
                     m.IsGenericMethodDefinition || m.GetParameters().Length != 0)
                 {
                     string message = SR.Format(SR.OnImportsSatisfiedFeature_AttributeError, partType, m.Name);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
@@ -360,10 +360,10 @@ namespace System.DirectoryServices.ActiveDirectory
                         }
                         catch (COMException e)
                         {
-                            if (e.ErrorCode == unchecked((int)0x80072020) |          // dir_error on server side
+                            if (e.ErrorCode == unchecked((int)0x80072020) ||          // dir_error on server side
                                    e.ErrorCode == unchecked((int)0x80072030))           // object not exists
                                 throw new ArgumentException(SR.DSNoObject, "objectPath");
-                            else if (e.ErrorCode == unchecked((int)0x80005000) |          // bad path name
+                            else if (e.ErrorCode == unchecked((int)0x80005000) ||          // bad path name
                                    e.ErrorCode == unchecked((int)0x80072032)) // ERROR_DS_INVALID_DN_SYNTAX
                                 throw new ArgumentException(SR.DSInvalidPath, "objectPath");
                         }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -178,7 +178,7 @@ namespace System.Threading.Channels
                     // cancellation callback could end up running arbitrary code, including code that called back into the reader or
                     // writer and tried to take the same lock held by the thread running UnregisterCancellation... deadlock.  As such,
                     // we only allow synchronous continuations here if both a) the caller requested it and the token isn't cancelable.
-                    var reader = new AsyncOperation<T>(parent._runContinuationsAsynchronously | cancellationToken.CanBeCanceled, cancellationToken);
+                    var reader = new AsyncOperation<T>(parent._runContinuationsAsynchronously || cancellationToken.CanBeCanceled, cancellationToken);
                     parent._blockedReaders.EnqueueTail(reader);
                     return reader.ValueTaskOfT;
                 }
@@ -232,7 +232,7 @@ namespace System.Threading.Channels
                     // cancellation callback could end up running arbitrary code, including code that called back into the reader or
                     // writer and tried to take the same lock held by the thread running UnregisterCancellation... deadlock.  As such,
                     // we only allow synchronous continuations here if both a) the caller requested it and the token isn't cancelable.
-                    var waiter = new AsyncOperation<bool>(parent._runContinuationsAsynchronously | cancellationToken.CanBeCanceled, cancellationToken);
+                    var waiter = new AsyncOperation<bool>(parent._runContinuationsAsynchronously || cancellationToken.CanBeCanceled, cancellationToken);
                     ChannelUtilities.QueueWaiter(ref _parent._waitingReadersTail, waiter);
                     return waiter.ValueTaskOfT;
                 }


### PR DESCRIPTION
These were all flagged by internal compliance tooling.  None of these seem to create functional issues, but it's easier to clean them up then suppress the compliance tool diagnostics.