### PR TITLE
Use a custom ReadOnlySpan marshaller to prevent null pointers when marshaling

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenerateSymmetricKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenerateSymmetricKey.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
@@ -10,22 +11,22 @@ internal static partial class Interop
     internal static partial class BCrypt
     {
         [LibraryImport(Libraries.BCrypt)]
-        internal static unsafe partial NTSTATUS BCryptGenerateSymmetricKey(
+        internal static partial NTSTATUS BCryptGenerateSymmetricKey(
             SafeBCryptAlgorithmHandle hAlgorithm,
             out SafeBCryptKeyHandle phKey,
             IntPtr pbKeyObject,
             int cbKeyObject,
-            byte* pbSecret,
+            [MarshalUsing(typeof(NotNullReadOnlySpanMarshaller<,>))] ReadOnlySpan<byte> pbSecret,
             int cbSecret,
             uint dwFlags);
 
         [LibraryImport(Libraries.BCrypt)]
-        internal static unsafe partial NTSTATUS BCryptGenerateSymmetricKey(
+        internal static partial NTSTATUS BCryptGenerateSymmetricKey(
             nuint hAlgorithm,
             out SafeBCryptKeyHandle phKey,
             IntPtr pbKeyObject,
             int cbKeyObject,
-            byte* pbSecret,
+            [MarshalUsing(typeof(NotNullReadOnlySpanMarshaller<,>))] ReadOnlySpan<byte> pbSecret,
             int cbSecret,
             uint dwFlags);
     }

--- a/src/libraries/Common/src/System/Runtime/InteropServices/NotNullReadOnlySpanMarshaller.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/NotNullReadOnlySpanMarshaller.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Runtime.InteropServices.Marshalling
+{
+    [CustomMarshaller(typeof(ReadOnlySpan<>), MarshalMode.ManagedToUnmanagedIn, typeof(NotNullReadOnlySpanMarshaller<,>.ManagedToUnmanagedIn))]
+    [CustomMarshaller(typeof(ReadOnlySpan<>), MarshalMode.ManagedToUnmanagedOut, typeof(NotNullReadOnlySpanMarshaller<,>.ManagedToUnmanagedOut))]
+    [ContiguousCollectionMarshaller]
+    internal static unsafe class NotNullReadOnlySpanMarshaller<T, TUnmanagedElement>
+        where TUnmanagedElement : unmanaged
+    {
+        public ref struct ManagedToUnmanagedIn
+        {
+            /// <summary>
+            /// Gets the size of the caller-allocated buffer to allocate.
+            /// </summary>
+            // We'll keep the buffer size at a maximum of 512 bytes to avoid overflowing the stack.
+            public static int BufferSize => 0x200 / sizeof(TUnmanagedElement);
+
+            private ReadOnlySpan<T> _managedArray;
+            private TUnmanagedElement* _allocatedMemory;
+            private Span<TUnmanagedElement> _span;
+
+            public void FromManaged(ReadOnlySpan<T> managed, Span<TUnmanagedElement> buffer)
+            {
+                _managedArray = managed;
+
+                if (managed.Length <= buffer.Length)
+                {
+                    _span = buffer[0..managed.Length];
+                }
+                else
+                {
+                    int bufferSize = checked(managed.Length * sizeof(TUnmanagedElement));
+                    _allocatedMemory = (TUnmanagedElement*)NativeMemory.Alloc((nuint)bufferSize);
+                    _span = new Span<TUnmanagedElement>(_allocatedMemory, managed.Length);
+                }
+            }
+
+            public ReadOnlySpan<T> GetManagedValuesSource() => _managedArray;
+
+            public Span<TUnmanagedElement> GetUnmanagedValuesDestination() => _span;
+
+            public ref TUnmanagedElement GetPinnableReference() => ref MemoryMarshal.GetReference(_span);
+
+            public TUnmanagedElement* ToUnmanaged()
+            {
+                // Unsafe.AsPointer is safe since buffer must be pinned
+                return (TUnmanagedElement*)Unsafe.AsPointer(ref GetPinnableReference());
+            }
+
+            public void Free()
+            {
+                NativeMemory.Free(_allocatedMemory);
+            }
+
+            public static ref T GetPinnableReference(ReadOnlySpan<T> managed)
+            {
+                if (Unsafe.IsNullRef(ref MemoryMarshal.GetReference(managed)) && managed.IsEmpty)
+                {
+                    T[] notNull = new T[1];
+                    return ref MemoryMarshal.GetArrayDataReference(notNull);
+                }
+                else
+                {
+                    return ref MemoryMarshal.GetReference(managed);
+                }
+            }
+        }
+
+        public struct ManagedToUnmanagedOut
+        {
+            private TUnmanagedElement* _unmanagedArray;
+            private T[]? _managedValues;
+
+            public void FromUnmanaged(TUnmanagedElement* unmanaged)
+            {
+                _unmanagedArray = unmanaged;
+            }
+
+            public ReadOnlySpan<T> ToManaged()
+            {
+                return new ReadOnlySpan<T>(_managedValues!);
+            }
+
+            public ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements)
+            {
+                return new ReadOnlySpan<TUnmanagedElement>(_unmanagedArray, numElements);
+            }
+
+            public Span<T> GetManagedValuesDestination(int numElements)
+            {
+                _managedValues = new T[numElements];
+                return _managedValues;
+            }
+
+            public void Free()
+            {
+                Marshal.FreeCoTaskMem((IntPtr)_unmanagedArray);
+            }
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Runtime/InteropServices/NotNullReadOnlySpanMarshaller.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/NotNullReadOnlySpanMarshaller.cs
@@ -63,8 +63,7 @@ namespace System.Runtime.InteropServices.Marshalling
             {
                 if (Unsafe.IsNullRef(ref MemoryMarshal.GetReference(managed)) && managed.IsEmpty)
                 {
-                    T[] notNull = new T[1];
-                    return ref MemoryMarshal.GetArrayDataReference(notNull);
+                    return ref MemoryMarshal.GetArrayDataReference(Array.Empty<T>());
                 }
                 else
                 {

--- a/src/libraries/Common/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
@@ -128,7 +128,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        private static unsafe SafeBCryptKeyHandle CreateSymmetricKey(byte* symmetricKey, int symmetricKeyLength)
+        private static SafeBCryptKeyHandle CreateSymmetricKey(ReadOnlySpan<byte> symmetricKey)
         {
             NTSTATUS generateKeyStatus;
             SafeBCryptKeyHandle keyHandle;
@@ -141,7 +141,7 @@ namespace System.Security.Cryptography
                     pbKeyObject: IntPtr.Zero,
                     cbKeyObject: 0,
                     symmetricKey,
-                    symmetricKeyLength,
+                    symmetricKey.Length,
                     dwFlags: 0);
             }
             else
@@ -152,7 +152,7 @@ namespace System.Security.Cryptography
                     pbKeyObject: IntPtr.Zero,
                     cbKeyObject: 0,
                     symmetricKey,
-                    symmetricKeyLength,
+                    symmetricKey.Length,
                     dwFlags: 0);
             }
 

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
@@ -27,6 +27,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CommonPath)System\Runtime\InteropServices\NotNullReadOnlySpanMarshaller.cs"
+             Link="Common\System\Runtime\InteropServices\NotNullReadOnlySpanMarshaller.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs"
              Link="Microsoft\Win32\SafeHandles\SafeBCryptAlgorithmHandle.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBCryptHandle.cs"

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
@@ -13,7 +13,6 @@ namespace System.Security.Cryptography
 
             scoped ReadOnlySpan<byte> symmetricKeyMaterial;
             scoped Span<byte> clearSpan = default;
-            int symmetricKeyMaterialLength;
             int hashAlgorithmBlockSize = GetHashBlockSize(hashAlgorithm.Name);
 
             if (key.Length > hashAlgorithmBlockSize)
@@ -28,26 +27,15 @@ namespace System.Security.Cryptography
                 }
 
                 symmetricKeyMaterial = clearSpan;
-                symmetricKeyMaterialLength = symmetricKeyMaterial.Length;
-            }
-            else if (!key.IsEmpty)
-            {
-                symmetricKeyMaterial = key;
-                symmetricKeyMaterialLength = key.Length;
             }
             else
             {
-                // CNG requires a non-null pointer even when the length is zero.
-                symmetricKeyMaterial = [0];
-                symmetricKeyMaterialLength = 0;
+                symmetricKeyMaterial = key;
             }
 
             try
             {
-                fixed (byte* pSymmetricKeyMaterial = symmetricKeyMaterial)
-                {
-                    _keyHandle = CreateSymmetricKey(pSymmetricKeyMaterial, symmetricKeyMaterialLength);
-                }
+                _keyHandle = CreateSymmetricKey(symmetricKeyMaterial);
             }
             finally
             {
@@ -65,33 +53,21 @@ namespace System.Security.Cryptography
 
             scoped ReadOnlySpan<byte> symmetricKeyMaterial;
             scoped Span<byte> clearSpan = default;
-            int symmetricKeyMaterialLength;
             int hashAlgorithmBlockSize = GetHashBlockSize(hashAlgorithm.Name);
 
             if (key.Length > hashAlgorithmBlockSize)
             {
                 clearSpan = HashOneShot(hashAlgorithm, key);
                 symmetricKeyMaterial = clearSpan;
-                symmetricKeyMaterialLength = symmetricKeyMaterial.Length;
-            }
-            else if (key.Length > 0)
-            {
-                symmetricKeyMaterial = key;
-                symmetricKeyMaterialLength = key.Length;
             }
             else
             {
-                // CNG requires a non-null pointer even when the length is zero.
-                symmetricKeyMaterial = [0];
-                symmetricKeyMaterialLength = 0;
+                symmetricKeyMaterial = key;
             }
 
             try
             {
-                fixed (byte* pSymmetricKeyMaterial = symmetricKeyMaterial)
-                {
-                    _keyHandle = CreateSymmetricKey(pSymmetricKeyMaterial, symmetricKeyMaterialLength);
-                }
+                _keyHandle = CreateSymmetricKey(symmetricKeyMaterial);
             }
             finally
             {

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -1514,6 +1514,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+    <Compile Include="$(CommonPath)System\Runtime\InteropServices\NotNullReadOnlySpanMarshaller.cs"
+             Link="Common\System\Runtime\InteropServices\NotNullReadOnlySpanMarshaller.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptAcquireContext.cs"
              Link="Common\Interop\Windows\Advapi32\Interop.CryptAcquireContext.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CryptAcquireContext_IntPtr.cs"

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
@@ -7,40 +7,29 @@ namespace System.Security.Cryptography
 {
     internal sealed partial class SP800108HmacCounterKdfImplementationCng
     {
-        internal unsafe SP800108HmacCounterKdfImplementationCng(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm)
+        internal SP800108HmacCounterKdfImplementationCng(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm)
         {
             Debug.Assert(hashAlgorithm.Name is not null);
 
             scoped ReadOnlySpan<byte> symmetricKeyMaterial;
             scoped Span<byte> clearSpan = default;
-            int symmetricKeyMaterialLength;
             int hashAlgorithmBlockSize = GetHashBlockSize(hashAlgorithm.Name);
 
             if (key.Length > hashAlgorithmBlockSize)
             {
                 Span<byte> buffer = stackalloc byte[512 / 8]; // Largest supported digest is SHA512.
-                symmetricKeyMaterialLength = HashOneShot(hashAlgorithm, key, buffer);
+                int symmetricKeyMaterialLength = HashOneShot(hashAlgorithm, key, buffer);
                 clearSpan = buffer.Slice(0, symmetricKeyMaterialLength);
                 symmetricKeyMaterial = clearSpan;
             }
-            else if (!key.IsEmpty)
-            {
-                symmetricKeyMaterial = key;
-                symmetricKeyMaterialLength = key.Length;
-            }
             else
             {
-                // CNG requires a non-null pointer even when the length is zero.
-                symmetricKeyMaterial = [0];
-                symmetricKeyMaterialLength = 0;
+                symmetricKeyMaterial = key;
             }
 
             try
             {
-                fixed (byte* pSymmetricKeyMaterial = symmetricKeyMaterial)
-                {
-                    _keyHandle = CreateSymmetricKey(pSymmetricKeyMaterial, symmetricKeyMaterialLength);
-                }
+                _keyHandle = CreateSymmetricKey(symmetricKeyMaterial);
             }
             finally
             {

--- a/src/libraries/System.Security.Cryptography/tests/Rfc2898OneShotTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/Rfc2898OneShotTests.cs
@@ -208,6 +208,23 @@ namespace System.Security.Cryptography
             Assert.Equal(expected, output.ToArray());
         }
 
+        [Fact]
+        public static void Pbkdf2_Password_EmptySpans()
+        {
+            ReadOnlySpan<byte> expected =
+            [
+                0xF7, 0xCE, 0x0B, 0x65, 0x3D, 0x2D, 0x72, 0xA4, 0x10, 0x8C, 0xF5, 0xAB, 0xE9, 0x12, 0xFF, 0xDD
+            ];
+            Span<byte> output = stackalloc byte[16];
+            Rfc2898DeriveBytes.Pbkdf2(
+                ReadOnlySpan<byte>.Empty,
+                ReadOnlySpan<byte>.Empty,
+                output,
+                iterations: 1,
+                HashAlgorithmName.SHA256);
+            AssertExtensions.SequenceEqual(expected, output);
+        }
+
         [Theory]
         [MemberData(nameof(Pbkdf2_PasswordBytes_Compare_Data))]
         public static void Pbkdf2_PasswordBytes_Compare(


### PR DESCRIPTION
### Background

A common problem we have in System.Security.Cryptography is p/invoking native methods that accept data to work with, and sometimes that data can be an empty span.

Empty spans may be backed by a null `ref`, which when marshaled are done so as a `nullptr` / `NULL`.

Even though using a empty value may be legal and intended, some Win32 APIs, particularly in CNG, do not accept nullptrs - even if the corresponding buffer length is zero.

We have used a variety of tricks to try to address this.

1. Sometimes we allocate a buffer on the stack and pass the length as zero
2. We have a `Helpers.GetNonNullPinnableReference` that passes in a bogus value if the span is a null ref and the length is zero.

### Proposal 

This is a proposal to try doing a third, and hopefully better way: use a custom marshaller at the p/invoke declaration that takes care of it for us.

This pull request is an attempt at doing that, and for now is limited in scope to just `BCryptGenerateSymmetricKey`.

The hope is that if the idea is accepted, we can use `ReadOnlySpan<T>` are p/invoke declarations more and let the marshaller worry about null refs.

### Help

The biggest problem is I am not well informed at writing a customer marshaller. This is largely pattern matching off the existing `ReadOnlySpanMarshaller` and reading some of the initial design documentation for the v2 marshaller.

/cc @bartonjs @jkoritzinsky 
