### PR TITLE
JIT: revised fix for fp division issue in profile synthesis

### DIFF
--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -1389,14 +1389,9 @@ void ProfileSynthesis::GaussSeidelSolver()
             // Note we are using a "point" bound here ("infinity norm") rather than say
             // computing the L2-norm of the entire residual vector.
             //
-            weight_t const smallFractionOfChange = 1e-9 * change;
-            weight_t       relDivisor            = oldWeight;
-            if (relDivisor < smallFractionOfChange)
-            {
-                relDivisor = smallFractionOfChange;
-            }
-
-            weight_t const blockRelResidual = change / relDivisor;
+            // Avoid dividing by zero if oldWeight is very small.
+            //
+            weight_t const blockRelResidual = change / max(oldWeight, 1e-12);
 
             if ((relResidualBlock == nullptr) || (blockRelResidual > relResidual))
             {


### PR DESCRIPTION
The previous fix #113396 could still leave us trying to evaluate 0.0/0.0, which causes an invalid FP operation exception.

Make sure the divisor is non-zero.