### PR TITLE
Disable ctor calls on classes marked with `ComImport` when COM interop feature isn't enabled.

### DIFF
--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -350,8 +350,8 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
         return GetEEFuncEntryPoint(FCComCtor);
     }
 #else // !FEATURE_COMINTEROP
-    // This code path is taken when a class marked with ComInterop is being created.
-    // If we get here and ComInterop isn't suppported, throw.
+    // This code path is taken when a class marked with ComImport is being created.
+    // If we get here and COM interop isn't suppported, throw.
     if (pMT->IsComObjectType())
         COMPlusThrow(kPlatformNotSupportedException, IDS_EE_ERROR_COM);
 #endif // FEATURE_COMINTEROP

--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -338,9 +338,7 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
 
 #ifdef FEATURE_COMINTEROP
     // COM imported classes have special constructors
-    if (pMT->IsComObjectType()
-        && (g_pBaseCOMObject == NULL || pMT != g_pBaseCOMObject)
-    )
+    if (pMT->IsComObjectType() && pMT != g_pBaseCOMObject)
     {
         if (pfSharedOrDynamicFCallImpl)
             *pfSharedOrDynamicFCallImpl = TRUE;
@@ -351,6 +349,11 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
         // FCComCtor does not need to be in the fcall hashtable since it does not erect frame.
         return GetEEFuncEntryPoint(FCComCtor);
     }
+#else // !FEATURE_COMINTEROP
+    // This code path is taken when a class marked with ComInterop is being created.
+    // If we get here and ComInterop isn't suppported, throw.
+    if (pMT->IsComObjectType())
+        COMPlusThrow(kPlatformNotSupportedException, IDS_EE_ERROR_COM);
 #endif // FEATURE_COMINTEROP
 
     if (!pMD->GetModule()->IsSystem())

--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -336,11 +336,10 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
         return CoreLibBinder::GetMethod(METHOD__DELEGATE__CONSTRUCT_DELEGATE)->GetMultiCallableAddrOfCode();
     }
 
+#ifdef FEATURE_COMINTEROP
     // COM imported classes have special constructors
     if (pMT->IsComObjectType()
-#ifdef FEATURE_COMINTEROP
         && (g_pBaseCOMObject == NULL || pMT != g_pBaseCOMObject)
-#endif // FEATURE_COMINTEROP
     )
     {
         if (pfSharedOrDynamicFCallImpl)
@@ -352,6 +351,7 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
         // FCComCtor does not need to be in the fcall hashtable since it does not erect frame.
         return GetEEFuncEntryPoint(FCComCtor);
     }
+#endif // FEATURE_COMINTEROP
 
     if (!pMD->GetModule()->IsSystem())
         COMPlusThrow(kSecurityException, BFA_ECALLS_MUST_BE_IN_SYS_MOD);

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -149,9 +149,14 @@ namespace System.Runtime.CompilerServices.Tests
                 Assert.ThrowsAny<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(IList).GetMethod("Add").MethodHandle));
             }
 
-            if (PlatformDetection.IsNotWindows)
+            try
             {
-                Assert.Throws<PlatformNotSupportedException>(() => RuntimeHelpers.PrepareMethod(typeof(ComClass).GetMethod("Func").MethodHandle));
+                // This is expected to either succeed or throw PlatformNotSupportedException depending on the platform
+                // and runtime flavor
+                RuntimeHelpers.PrepareMethod(typeof(ComClass).GetMethod("Func").MethodHandle);
+            }
+            catch (PlatformNotSupportedException)
+            {
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -127,10 +127,17 @@ namespace System.Runtime.CompilerServices.Tests
             }
         }
 
+        [ComImport]
+        [Guid("00000000-0000-0000-0000-000000000000")]
+        interface ComInterface
+        {
+            void Func();
+        }
+
         // This class is used to test the PrepareMethod API with COM interop on non-Windows platforms.
         [ComImport]
         [Guid("00000000-0000-0000-0000-000000000000")]
-        class ComClass
+        class ComClass : ComInterface
         {
             [MethodImpl(MethodImplOptions.InternalCall)]
             public extern void Func();

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -127,6 +127,15 @@ namespace System.Runtime.CompilerServices.Tests
             }
         }
 
+        // This class is used to test the PrepareMethod API with COM interop on non-Windows platforms.
+        [ComImport]
+        [Guid("00000000-0000-0000-0000-000000000000")]
+        class ComClass
+        {
+            [MethodImpl(MethodImplOptions.InternalCall)]
+            public extern void Func();
+        }
+
         [Fact]
         public static void PrepareMethod()
         {
@@ -138,6 +147,11 @@ namespace System.Runtime.CompilerServices.Tests
             if (RuntimeFeature.IsDynamicCodeSupported)
             {
                 Assert.ThrowsAny<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(IList).GetMethod("Add").MethodHandle));
+            }
+
+            if (PlatformDetection.IsNotWindows)
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => RuntimeHelpers.PrepareMethod(typeof(ComClass).GetMethod("Func").MethodHandle));
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/114933