### PR TITLE
Remove a couple unnecessary 'lock(this)' statements

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
@@ -73,12 +73,7 @@ namespace System.Diagnostics
                 if (value.Length == 0)
                     throw new ArgumentException(SR.Format(SR.InvalidProperty, nameof(CategoryName), value), nameof(value));
 
-                // the lock prevents a race between setting CategoryName and MachineName, since this permission
-                // checks depend on both pieces of info.
-                lock (this)
-                {
-                    _categoryName = value;
-                }
+                _categoryName = value;
             }
         }
 
@@ -136,12 +131,7 @@ namespace System.Diagnostics
                 if (!SyntaxCheck.CheckMachineName(value))
                     throw new ArgumentException(SR.Format(SR.InvalidProperty, nameof(MachineName), value), nameof(value));
 
-                // the lock prevents a race between setting CategoryName and MachineName, since this permission
-                // checks depend on both pieces of info.
-                lock (this)
-                {
-                    _machineName = value;
-                }
+                _machineName = value;
             }
         }
 


### PR DESCRIPTION
These locks were ported [from .NET Framework](https://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/PerformanceCounterCategory.cs%2c147) which did a security check within each lock, but those checks weren't ported over so the lock doesn't do anything special anymore.

Found by CodeQL.
