### PR TITLE
ML-KEM: Change parameter from ReadOnlySpan to array

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -1362,7 +1362,7 @@ namespace System.Security.Cryptography
         ///   The imported key.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="password" /> is <see langword="null" />.
+        ///   <paramref name="password" /> or <paramref name="source" /> is <see langword="null" />.
         /// </exception>
         /// <exception cref="CryptographicException">
         ///   <para>
@@ -1385,9 +1385,10 @@ namespace System.Security.Cryptography
         ///   The platform does not support ML-KEM. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports ML-KEM.
         /// </exception>
-        public static MLKem ImportEncryptedPkcs8PrivateKey(string password, ReadOnlySpan<byte> source)
+        public static MLKem ImportEncryptedPkcs8PrivateKey(string password, byte[] source)
         {
             ArgumentNullException.ThrowIfNull(password);
+            ArgumentNullException.ThrowIfNull(source);
             ThrowIfTrailingData(source);
             ThrowIfNotSupported();
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemTests.cs
@@ -464,7 +464,7 @@ namespace System.Security.Cryptography.Tests
                 gJoH9z0+/Z9WzLU8ix8F7B+HWwRhib5Cd6si+AX6DsNelMq2zP1NO7Un416dkg==");
 
             Assert.Throws<CryptographicException>(() =>
-                MLKem.ImportEncryptedPkcs8PrivateKey("PLACEHOLDER", new ReadOnlySpan<byte>(ecP256Key)));
+                MLKem.ImportEncryptedPkcs8PrivateKey("PLACEHOLDER", ecP256Key));
 
             Assert.Throws<CryptographicException>(() =>
                 MLKem.ImportEncryptedPkcs8PrivateKey("PLACEHOLDER".AsSpan(), new ReadOnlySpan<byte>(ecP256Key)));
@@ -618,6 +618,16 @@ namespace System.Security.Cryptography.Tests
                 AssertExtensions.SequenceEqual(decapKey, decapsulationKey);
                 AssertExtensions.SequenceEqual(MLKemTestData.IncrementalSeed, seed);
             }
+        }
+
+        [Fact]
+        public static void ImportEncryptedPkcs8PrivateKey_NullArgs()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("source", static () =>
+                MLKem.ImportEncryptedPkcs8PrivateKey(MLKemTestData.EncryptedPrivateKeyPassword, (byte[])null));
+
+            AssertExtensions.Throws<ArgumentNullException>("password", static () =>
+                MLKem.ImportEncryptedPkcs8PrivateKey((string)null, MLKemTestData.IetfMlKem512EncryptedPrivateKeySeed));
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1909,7 +1909,7 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.MLKem ImportEncapsulationKey(System.Security.Cryptography.MLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source) { throw null; }
-        public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(string password, System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.MLKem ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<byte> passwordBytes) { throw null; }
         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<char> password) { throw null; }
         public static System.Security.Cryptography.MLKem ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }


### PR DESCRIPTION
After some backchanneling we discussed that the `ImportEncryptedPkcs8PrivateKey(string, ReadOnlySpan<byte>)` didn't have the same shape as `ImportFromEncryptedPem(string, byte[])`.

We decided that since the `string` overloads for `password` exist purely for ease-of-use for other downlevel platforms, the `ImportEncryptedPkcs8PrivateKey` one should take a byte array instead of a `ReadOnlySpan`. There is already an overload that accepts `ReadOnlySpan<char>, ReadOnlySpan<byte>`, so modern targets still have access to all the span APIs that they want.

Contributes to #113508 