### PR TITLE
JIT: enhance dead stores for locals where all uses are useasg

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6709,8 +6709,9 @@ private:
 
     //----------------------- Liveness analysis -------------------------------
 
-    VARSET_TP fgCurUseSet; // vars used     by block (before a def)
-    VARSET_TP fgCurDefSet; // vars assigned by block (before a use)
+    VARSET_TP fgCurUseSet;   // vars used     by block (before a def)
+    VARSET_TP fgCurDefSet;   // vars assigned by block (before a use)
+    VARSET_TP fgTrueUseSet;  // vars with non-useasg uses 
 
     MemoryKindSet fgCurMemoryUse;   // True iff the current basic block uses memory.
     MemoryKindSet fgCurMemoryDef;   // True iff the current basic block modifies memory.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2527,6 +2527,7 @@ class Compiler
     friend class Promotion;
     friend class ReplaceVisitor;
     friend class FlowGraphNaturalLoop;
+    friend class LiveVarAnalysis;
 
 #ifdef FEATURE_HW_INTRINSICS
     friend struct GenTreeHWIntrinsic;

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -116,6 +116,12 @@ void Compiler::fgMarkUseDef(GenTreeLclVarCommon* tree)
                     {
                         VarSetOps::AddElemD(this, fgCurDefSet, varIndex);
                     }
+
+                    if (isUse && !isDef)
+                    {
+                        // Variable is actually used
+                        VarSetOps::AddElemD(this, fgTrueUseSet, varIndex);
+                    }
                 }
             }
         }

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -602,6 +602,7 @@ class LiveVarAnalysis
                 if (varDsc->lvTracked)
                 {
                     VarSetOps::AddElemD(m_compiler, m_liveOut, varDsc->lvVarIndex);
+                    VarSetOps::AddElemD(m_compiler, m_compiler->fgTrueUseSet, varDsc->lvVarIndex);
                 }
             }
         }


### PR DESCRIPTION
A local marked `GTF_VAR_USEASG` is not a true use, but a partial def. So if a tracked local has no true uses, then stores to that local are dead.

In particular for local structs that are only stored to, those stores are dead.