### PR TITLE
Sve: Fix Gather/Scatter tests

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorFirstFaultingVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorFirstFaultingVectorBases.template
@@ -10,6 +10,7 @@
 
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -129,7 +130,16 @@ namespace JIT.HardwareIntrinsics.Arm
                 inArray2.CopyTo(inArray2Ffr, 0);
 
                 // Add the base pointer to the offsets within inArray2 to create complete pointers.
-                for (var i = 0; i < inArray2.Length; i++) { inArray2[i] += ({Op2BaseType})baseArrayPtr; }
+                for (var i = 0; i < inArray2.Length; i++)
+                {
+                    {Op2BaseType} baseAddrToValidate = (({Op2BaseType})baseArrayPtr + (sizeof({RetBaseType}) * inArray2[i]));
+
+                    // Make sure we got the correct base pointers.
+                    Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == baseArray[inArray2[i]]);
+
+                    inArray2[i] = baseAddrToValidate;
+                }
+
                 Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(inArray2Ptr), ref Unsafe.As<{Op2BaseType}, byte>(ref inArray2[0]), (uint)sizeOfinArray2);
 
                 // Add the base pointer to the offsets within inArray2Ffr to create complete pointers.
@@ -144,7 +154,12 @@ namespace JIT.HardwareIntrinsics.Arm
                     }
                     else
                     {
-                        inArray2Ffr[i] += ({Op2BaseType})baseArrayPtr;
+                        {Op2BaseType} baseAddrToValidate = (({Op2BaseType})baseArrayPtr + (sizeof({RetBaseType}) * inArray2Ffr[i]));
+
+                        // Make sure we got the correct base pointers.
+                        Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == baseArray[inArray2Ffr[i]]);
+
+                        inArray2Ffr[i] = baseAddrToValidate;
                     }
                 }
                 Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(inArray2FfrPtr), ref Unsafe.As<{Op2BaseType}, byte>(ref inArray2Ffr[0]), (uint)sizeOfinArray2);
@@ -188,7 +203,15 @@ namespace JIT.HardwareIntrinsics.Arm
                 for (var i = 0; i < Op2ElementCount; i++) { _data2[i] = {NextValueOp2} % ({Op2BaseType})BaseElementCount; }
 
                 // Add the base pointer to the offsets within inArray2 to create complete pointers.
-                for (var i = 0; i < Op2ElementCount; i++) { _data2[i] += ({Op2BaseType})_dataTable.baseArrayPtr; }
+                for (var i = 0; i < Op2ElementCount; i++)
+                {
+                    {Op2BaseType} baseAddrToValidate = (({Op2BaseType})_dataTable.baseArrayPtr + (sizeof({RetBaseType}) * _data2[i]));
+
+                    // Make sure we got the correct base pointers.
+                    Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == (({RetBaseType}*)_dataTable.baseArrayPtr)[_data2[i]]);
+
+                    _data2[i] = baseAddrToValidate;
+                }
 
                 Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op1VectorType}<{Op1BaseType}>, byte>(ref testStruct._fld1), ref Unsafe.As<{Op1BaseType}, byte>(ref _data1[0]), (uint)Unsafe.SizeOf<{Op1VectorType}<{Op1BaseType}>>());
                 Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op2VectorType}<{Op2BaseType}>, byte>(ref testStruct._fld2), ref Unsafe.As<{Op2BaseType}, byte>(ref _data2[0]), (uint)Unsafe.SizeOf<{Op2VectorType}<{Op2BaseType}>>());

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorVectorBases.template
@@ -9,6 +9,7 @@
  ******************************************************************************/
 
 using System;
+using System.Diagnostics;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -118,7 +119,16 @@ namespace JIT.HardwareIntrinsics.Arm
                 Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(baseArrayPtr), ref Unsafe.As<{RetBaseType}, byte>(ref baseArray[0]), (uint)sizeOfBaseArray);
 
                 // Add the base pointer to the offsets within inArray2 to create complete pointers.
-                for (var i = 0; i < inArray2.Length; i++) { inArray2[i] += ({Op2BaseType})baseArrayPtr; }
+                for (var i = 0; i < inArray2.Length; i++)
+                {
+                    {Op2BaseType} baseAddrToValidate = (({Op2BaseType})baseArrayPtr + (sizeof({RetBaseType}) * inArray2[i]));
+
+                    // Make sure we got the correct base pointers.
+                    Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == baseArray[inArray2[i]]);
+
+                    inArray2[i] = baseAddrToValidate;
+                }
+
                 Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(inArray2Ptr), ref Unsafe.As<{Op2BaseType}, byte>(ref inArray2[0]), (uint)sizeOfinArray2);
             }
 
@@ -158,7 +168,15 @@ namespace JIT.HardwareIntrinsics.Arm
                 for (var i = 0; i < Op2ElementCount; i++) { _data2[i] = {NextValueOp2} % ({Op2BaseType})BaseElementCount; }
 
                 // Add the base pointer to the offsets within inArray2 to create complete pointers.
-                for (var i = 0; i < Op2ElementCount; i++) { _data2[i] += ({Op2BaseType})_dataTable.baseArrayPtr; }
+                for (var i = 0; i < Op2ElementCount; i++)
+                {
+                    {Op2BaseType} baseAddrToValidate = (({Op2BaseType})_dataTable.baseArrayPtr + (sizeof({RetBaseType}) * _data2[i]));
+
+                    // Make sure we got the correct base pointers.
+                    Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == (({RetBaseType}*)_dataTable.baseArrayPtr)[_data2[i]]);
+
+                    _data2[i] = baseAddrToValidate;
+                }
 
                 Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op1VectorType}<{Op1BaseType}>, byte>(ref testStruct._fld1), ref Unsafe.As<{Op1BaseType}, byte>(ref _data1[0]), (uint)Unsafe.SizeOf<{Op1VectorType}<{Op1BaseType}>>());
                 Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op2VectorType}<{Op2BaseType}>, byte>(ref testStruct._fld2), ref Unsafe.As<{Op2BaseType}, byte>(ref _data2[0]), (uint)Unsafe.SizeOf<{Op2VectorType}<{Op2BaseType}>>());

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -114,7 +115,16 @@ namespace JIT.HardwareIntrinsics.Arm._Sve
                 Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(outArrayPtr), ref Unsafe.As<{Op1BaseType}, byte>(ref outArray[0]), (uint)sizeOfOutArray);
 
                 // Add the base pointer to the offsets within outArray to create complete pointers.
-                for (var i = 0; i < inAddress.Length; i++) { inAddress[i] += ({Op2BaseType})outArrayPtr; }
+                for (var i = 0; i < inAddress.Length; i++)
+                {
+                    {Op2BaseType} baseAddrToValidate = (({Op2BaseType})outArrayPtr + (sizeof({Op2BaseType}) * inAddress[i]));
+
+                    // Make sure we got the correct base pointers.
+                    Debug.Assert(*(({Op1BaseType}*)baseAddrToValidate) == outArray[inAddress[i]]);
+
+                    inAddress[i] = baseAddrToValidate;
+                }
+
                 Unsafe.CopyBlockUnaligned(ref Unsafe.AsRef<byte>(inAddressArrayPtr), ref Unsafe.As<{Op2BaseType}, byte>(ref inAddress[0]), (uint)sizeOfInOffset);
             }
 
@@ -175,11 +185,19 @@ namespace JIT.HardwareIntrinsics.Arm._Sve
                 _dataTable.ResetOutArray();
 
                 // Fill full of offsets into the data buffer.
-                for (var i = 0; i < AddressElementCount; i++) { _addressArr[i] = ({NextValueOp2} % ({Op2BaseType})OutElementCount ) * sizeof({Op2BaseType}); }
+                for (var i = 0; i < AddressElementCount; i++) { _addressArr[i] = ({NextValueOp2} % ({Op2BaseType})OutElementCount ); }
                 MakeDistinct(_addressArr);
 
-                // Add the base pointer to the offsets within outArray to create complete pointers.
-                for (var i = 0; i < AddressElementCount; i++) { _addressArr[i] += ({Op2BaseType})_dataTable.outArrayPtr; }
+                // Add the base pointer to the offsets within inArray2 to create complete pointers.
+                for (var i = 0; i < AddressElementCount; i++)
+                {
+                    {Op2BaseType} baseAddrToValidate = (({Op2BaseType})_dataTable.outArrayPtr + (sizeof({Op2BaseType}) * _addressArr[i]));
+
+                    // Make sure we got the correct base pointers.
+                    Debug.Assert(*(({Op1BaseType}*)baseAddrToValidate) == (({Op1BaseType}*)_dataTable.outArrayPtr)[_addressArr[i]]);
+
+                    _addressArr[i] = baseAddrToValidate;
+                }
 
                 Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op1VectorType}<{Op1BaseType}>, byte>(ref testStruct._mask), ref Unsafe.As<{Op1BaseType}, byte>(ref _maskArr[0]), (uint)Unsafe.SizeOf<{Op1VectorType}<{Op1BaseType}>>());
                 Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op1VectorType}<{Op1BaseType}>, byte>(ref testStruct._data), ref Unsafe.As<{Op1BaseType}, byte>(ref _dataArr[0]), (uint)Unsafe.SizeOf<{Op1VectorType}<{Op1BaseType}>>());
@@ -224,7 +242,7 @@ namespace JIT.HardwareIntrinsics.Arm._Sve
             for (var i = 0; i < DataElementCount; i++) { _dataArr[i] = {NextValueOp3}; }
 
             // Fill full of offsets into the data buffer. They wil be expanded to full pointers inside the DataTable constructor.
-            for (var i = 0; i < AddressElementCount; i++) { _addressArr[i] = ({NextValueOp2} % ({Op2BaseType})OutElementCount) * sizeof({Op2BaseType}); }
+            for (var i = 0; i < AddressElementCount; i++) { _addressArr[i] = ({NextValueOp2} % ({Op2BaseType})OutElementCount); }
             MakeDistinct(_addressArr);
 
             for (var i = 0; i < DataElementCount; i++) { _falseData[i] = {NextValueOp3}; }


### PR DESCRIPTION
SVE Gather/Scatter tests populates a data array and then get the addresses of some of the elements of data array. These addresses are then passed to SVE APIs to see if the API correctly loads the required elements and validates the result. The step where we were populating the individual element address has a bug in pointer arithmetic and was returning incorrect address of pointers. When the underlying data is `double`, returning invalid aligned data element address would treat the underlying data as `NaN` or other times, might not match the expected return result from these APIs. I have fixed the pointer arithmetic to correctly calculate the address of the individual element and now the tests are passing as expected. I have also added `Debug.Assert()` while setting up the addresses to make sure we are doing it correctly.

I also noticed similar problem for Scatter test cases and fixed them too.

Fixes: https://github.com/dotnet/runtime/issues/114646
Fixes: https://github.com/dotnet/runtime/issues/112264