### PR TITLE
Fix last issue with GC bridge comparison and enable all tests

### DIFF
--- a/src/mono/mono/metadata/sgen-new-bridge.c
+++ b/src/mono/mono/metadata/sgen-new-bridge.c
@@ -654,6 +654,7 @@ static void
 reset_data (void)
 {
 	dyn_array_ptr_empty (&registered_bridges);
+	free_data ();
 }
 
 static void

--- a/src/mono/mono/metadata/sgen-new-bridge.c
+++ b/src/mono/mono/metadata/sgen-new-bridge.c
@@ -654,7 +654,6 @@ static void
 reset_data (void)
 {
 	dyn_array_ptr_empty (&registered_bridges);
-	free_data ();
 }
 
 static void
@@ -676,6 +675,15 @@ processing_stw_step (void)
 
 	dyn_array_ptr_init (&dfs_stack);
 	dyn_array_int_init (&merge_array);
+
+	/*
+	Overflow collections can call processing_stw_step twice. If that happens we have to reset
+	the hash table to the initial state. The previously processed data are no longer valid and
+	we get a new set of of registered bridges.
+	*/
+	if (sgen_hash_table_num_entries(&hash_table) != 0) {
+		free_data();
+	}
 
 	current_time = 0;
 	/*

--- a/src/tests/GC/Features/Bridge/Bridge.cs
+++ b/src/tests/GC/Features/Bridge/Bridge.cs
@@ -405,7 +405,7 @@ public class BridgeTest
 
     public static int Main(string[] args)
     {
-        TestLinkedList(); // Crashes, but only in this multithreaded variant, also only on osx for me
+        TestLinkedList();
         RunGraphTest(SetupFragmentation<Bridge14, NonBridge14>);
         RunGraphTest(SetupFragmentation<Bridge, NonBridge>);
         RunGraphTest(SetupLinks);

--- a/src/tests/GC/Features/Bridge/Bridge.cs
+++ b/src/tests/GC/Features/Bridge/Bridge.cs
@@ -405,9 +405,9 @@ public class BridgeTest
 
     public static int Main(string[] args)
     {
-//        TestLinkedList(); // Crashes, but only in this multithreaded variant, also only on osx for me
-        RunGraphTest(SetupFragmentation<Bridge14, NonBridge14>); // This passes but the following crashes ??
-//        RunGraphTest(SetupFragmentation<Bridge, NonBridge>);
+        TestLinkedList(); // Crashes, but only in this multithreaded variant, also only on osx for me
+        RunGraphTest(SetupFragmentation<Bridge14, NonBridge14>);
+        RunGraphTest(SetupFragmentation<Bridge, NonBridge>);
         RunGraphTest(SetupLinks);
         RunGraphTest(SetupLinkedFan);
         RunGraphTest(SetupInverseFan);
@@ -416,7 +416,7 @@ public class BridgeTest
         RunGraphTest(SetupSelfLinks);
         RunGraphTest(NestedCycles);
         RunGraphTest(FauxHeavyNodeWithCycles);
-//        RunGraphTest(Spider); // Crashes
+        RunGraphTest(Spider);
         return 100;
     }
 }


### PR DESCRIPTION
Fixes an issue in the "new" GC bridge when overflow collections happen in GC. This can happen when a concurrent GC is triggered and the user code calls `GC.Collect`. In this case the bridge work is restarted and `processing_stw_step` gets called twice. The state between these two calls was not cleared properly which resulted in accessing dead objects.

Additionally, fixing this issue unblocked all the remaining GC bridge tests which were previously crashing or producing different results than the (default) Tarjan bridge.