### PR TITLE
[Mono]: Make sure interpreter gc_transitions gets reset on managed exceptions.

### DIFF
--- a/src/mono/mono/utils/mono-threads-coop.h
+++ b/src/mono/mono/utils/mono-threads-coop.h
@@ -167,4 +167,8 @@ mono_threads_is_runtime_startup_finished (void)
 void
 mono_threads_set_runtime_startup_finished (void);
 
+MONO_PROFILER_API
+void
+mono_threads_abort_gc_safe_region_internal (gpointer cookie);
+
 #endif


### PR DESCRIPTION
Interpreters `do_icall_wrapper` and `ves_pinvoke_method` uses a frame variable called `gc_transitions` that can put thread in GC SAFE mode before calling native code and switch back on return. When interpreter calls native code it also push a LMF frame with context and unwind label so in case of managed exception it will continue execution at label, but in that case it would also miss to reset the `gc_transitions` flag. That could then lead to future errors since other icalls would run under incorrect GC state due to incorrect GC switch.

This issue was observed in https://github.com/dotnet/runtime/issues/114840. In that case a custom icall could call `mono_raise_exception` that would hit this scenario, leaving the `gc_transitions` set to TRUE that would then cause issues since next icall would run in wrong GC mode causing undefined behavior.

Fix adds a mechanism to abort a GC safe region making sure thread gets back to GC unsafe mode and also make sure the cookie stack gets rebalanced on checked builds. It also makes sure `gc_transitions` gets reset to `FALSE`, if its still `TRUE` reaching the exit label.

Fix makes sure we correctly restore the interpreter GC state in case of a managed exception in native code.