### PR TITLE
[cDAC] Fix method table slot lookup

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -843,7 +843,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             TargetPointer auxDataPtr = mt.AuxiliaryData;
             Data.MethodTableAuxiliaryData auxData = _target.ProcessedData.GetOrAdd<Data.MethodTableAuxiliaryData>(auxDataPtr);
             TargetPointer nonVirtualSlotsArray = auxDataPtr + (ulong)auxData.OffsetToNonVirtualSlots;
-            return nonVirtualSlotsArray - (1 + (slotNum - mt.NumVirtuals));
+            return nonVirtualSlotsArray - ((1 + (slotNum - mt.NumVirtuals)) * (ulong)_target.PointerSize);
         }
     }
 


### PR DESCRIPTION
Found this bug while testing `EnumMethodInstancesByAddress`. 

MethodTable slots are pointer sized. Finding the correct one is done using pointer arithmetic on the native code but has to be done explicitly on the cDAC.