### PR TITLE
[X86/Funclets] Fix uninitalized values in SoftwareExceptionFrame::UpdateContextFromTransitionBlock

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -11306,6 +11306,11 @@ void SoftwareExceptionFrame::UpdateContextFromTransitionBlock(TransitionBlock *p
 {
     LIMITED_METHOD_CONTRACT;
 
+    m_Context.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+    m_Context.SegCs = 0;
+    m_Context.SegSs = 0;
+    m_Context.EFlags = 0;
+    m_Context.Eax = 0;    
     m_Context.Ecx = pTransitionBlock->m_argumentRegisters.ECX;
     m_Context.Edx = pTransitionBlock->m_argumentRegisters.EDX;
     m_ContextPointers.Ecx = &m_Context.Ecx;


### PR DESCRIPTION
This could lead to -1 offset inadvertently not applied in `SfiInit` for control PC. As a consequence a `throw` at the very last instruction of `try` block may not be matched correctly.