### PR TITLE
Delete redundant gcc-toolchain flag

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -562,7 +562,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TestBuildMode)' == 'nativeaot'">
-    <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(_hostOS)' != 'windows'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
     <IlcReference Include="$(TargetingPackPath)/*.dll" />
 
     <!-- Bump the generic cycle tolerance. There's at least one test with a cycle that is reachable at runtime to depth 6 -->


### PR DESCRIPTION
Fixes this warning during the smoke tests build:

> `2025-04-26T02:51:48.2072524Z clang : warning : argument unused during compilation: '--gcc-toolchain=/crossrootfs/x64/usr' [-Wunused-command-line-argument] [/runtime/src/tests/nativeaot/CustomMain/CustomMain.csproj] [/runtime/src/tests/build.proj]`

(the second occurrence of `--gcc-toolchain` is considered "unused")

It predates the consolidation work and it is now a duplicate of:
https://github.com/dotnet/runtime/blob/9df77ee4c0f640c76519b0bf5bf02f7dff965a9b/eng/toolAot.targets#L26
