### PR TITLE
JIT: revise may/must point to stack analysis

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -675,6 +675,8 @@ void Compiler::optAssertionInit(bool isLocalProp)
             {
                 optMaxAssertionCount = (AssertionIndex)min(maxTrackedLocals, ((3 * lvaTrackedCount / 128) + 1) * 64);
             }
+
+            JITDUMP("Cross-block table size %u (for %u tracked locals)\n", optMaxAssertionCount, lvaTrackedCount);
         }
         else
         {

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -133,7 +133,7 @@ unsigned ObjectAllocator::LocalToIndex(unsigned lclNum)
 {
     unsigned result = BAD_VAR_NUM;
 
-    if (lclNum < comp->lvaCount)
+    if (lclNum < m_firstPseudoLocalNum)
     {
         assert(IsTrackedLocal(lclNum));
         LclVarDsc* const varDsc = comp->lvaGetDesc(lclNum);
@@ -1136,10 +1136,10 @@ bool ObjectAllocator::MorphAllocObjNodes()
                 continue;
             }
 
-            bool         canStack     = false;
-            bool         bashCall     = false;
-            const char*  onHeapReason = nullptr;
-            unsigned int lclNum       = stmtExpr->AsLclVar()->GetLclNum();
+            bool               canStack     = false;
+            bool               bashCall     = false;
+            const char*        onHeapReason = nullptr;
+            const unsigned int lclNum       = stmtExpr->AsLclVar()->GetLclNum();
 
             // Don't attempt to do stack allocations inside basic blocks that may be in a loop.
             //
@@ -1324,6 +1324,11 @@ bool ObjectAllocator::MorphAllocObjNodes()
                     GenTree* const newData       = MorphAllocObjNodeIntoHelperCall(data->AsAllocObj());
                     stmtExpr->AsLclVar()->Data() = newData;
                     stmtExpr->AddAllEffectsFlags(newData);
+                }
+
+                if (IsTrackedLocal(lclNum))
+                {
+                    AddConnGraphEdge(lclNum, m_unknownSourceLocalNum);
                 }
             }
         }

--- a/src/tests/JIT/opt/ObjectStackAllocation/ConnectionCycles.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ConnectionCycles.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class X
+{
+    public X() { a = 15; b = 35; }
+    public int a;
+    public int b;
+}
+
+public class ConnectionCycles
+{
+   static bool b;
+
+   [Fact]
+   public static int Problem()
+   {
+       return SubProblem(false) + SubProblem(true);
+   }
+
+   [MethodImpl(MethodImplOptions.NoInlining)]
+   static int SubProblem(bool b)
+   {
+       X x1 = new X();
+       X x2 = new X();
+
+       if (b)
+       {
+           x1 = x2;
+       }
+       else
+       {
+           x2 = x1;
+       }
+
+       SideEffect();
+
+       return x1.a + x2.b;
+   }
+
+
+   [MethodImpl(MethodImplOptions.NoInlining)]
+   static void SideEffect() { }
+}

--- a/src/tests/JIT/opt/ObjectStackAllocation/ConnectionCycles.csproj
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ConnectionCycles.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Keep track of locals that may point to the heap as well as locals that may point to the stack.

The set of definitely stack-pointing locals is then the difference in these two sets. This handles the "cyclic" case where stack pointing locals are assigned to one another.

Fixes #115017