### PR TITLE
Test /etc/os-release existence before grepping

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -54,7 +54,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </PropertyGroup>
 
     <!-- alpine's gcc toolchain needs alpine-linux, see https://github.com/llvm/llvm-project/issues/89146 -->
-    <Exec Command="grep -q ID=alpine &quot;$(SysRoot)/etc/os-release&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(CrossCompileArch)' != '' and '$(SysRoot)' != ''">
+    <Exec Command="test -f &quot;$(SysRoot)/etc/os-release&quot; &amp;&amp; grep -q ID=alpine &quot;$(SysRoot)/etc/os-release&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(CrossCompileArch)' != '' and '$(SysRoot)' != ''">
       <Output TaskParameter="ExitCode" PropertyName="_IsAlpineExitCode" />
     </Exec>
 


### PR DESCRIPTION
Fix `grep: /crossrootfs/arm64/etc/os-release: No such file or directory`

during the smoke tests build: https://github.com/am11/CrossRepoCITesting/actions/runs/14681685023/job/41205102419

It is not a fatal error (because of `IgnoreExitCode="true"`) but it shows up in FreeBSD crossbuild logs, where /crossrootfs/arm64/etc/os-release is a symlink to /crossrootfs/arm64/var/run/os-release, latter of which doesn't exist in rootfs environment. The added test makes sure file exists before the search op.