### PR TITLE
[browser] runtimeConfig via boot config 

### DIFF
--- a/eng/testing/scenarios/BuildWasmAppsJobsList.txt
+++ b/eng/testing/scenarios/BuildWasmAppsJobsList.txt
@@ -47,3 +47,5 @@ Wasm.Build.Tests.WorkloadTests
 Wasm.Build.Tests.MT.Blazor.SimpleMultiThreadedTests
 Wasm.Build.Tests.DebugLevelTests
 Wasm.Build.Tests.PreloadingTests
+Wasm.Build.Tests.EnvVariablesTests
+Wasm.Build.Tests.HttpTests

--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -335,7 +335,6 @@
     "PropertiesThatTriggerRelinking": [
       { "identity": "InvariantTimezone",            "defaultValueInRuntimePack": "$(InvariantTimezone)" },
       { "identity": "InvariantGlobalization",       "defaultValueInRuntimePack": "$(InvariantGlobalization)" },
-      { "identity": "WasmEnableStreamingResponse",  "defaultValueInRuntimePack": "$(WasmEnableStreamingResponse)" },
       { "identity": "WasmNativeStrip",              "defaultValueInRuntimePack": "$(WasmNativeStrip)" },
       { "identity": "WasmSingleFileBundle",         "defaultValueInRuntimePack": "$(WasmSingleFileBundle)" },
       { "identity": "WasmEnableSIMD",               "defaultValueInRuntimePack": "$(WasmEnableSIMD)" },

--- a/src/mono/browser/build/BrowserWasmApp.targets
+++ b/src/mono/browser/build/BrowserWasmApp.targets
@@ -25,6 +25,7 @@
 
     <WasmGenerateAppBundleDependsOn>
       $(WasmGenerateAppBundleDependsOn);
+      GenerateBuildRuntimeConfigurationFiles;
       _GetWasmGenerateAppBundleDependencies;
       _WasmGenerateAppBundle;
       _WasmGenerateRunV8Script;

--- a/src/mono/browser/build/BrowserWasmApp.targets
+++ b/src/mono/browser/build/BrowserWasmApp.targets
@@ -181,7 +181,7 @@
       WasmIcuDataFileName="$(WasmIcuDataFileName)"
       RuntimeAssetsLocation="$(WasmRuntimeAssetsLocation)"
       CacheBootResources="$(BlazorCacheBootResources)"
-      RuntimeConfigJsonPath="$(_WasmRuntimeConfigFilePath)"
+      RuntimeConfigJsonPath="$(ProjectRuntimeConfigFilePath)"
       IsAot="$(RunAOTCompilation)"
       IsMultiThreaded="$(WasmEnableThreads)"
       >

--- a/src/mono/browser/build/WasmApp.InTree.targets
+++ b/src/mono/browser/build/WasmApp.InTree.targets
@@ -2,7 +2,6 @@
   <!-- This depends on the root Directory.Build.targets imported this file -->
   <UsingTask TaskName="MonoAOTCompiler" AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="ILStrip" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" TaskFactory="TaskHostFactory" />
-  <UsingTask TaskName="RuntimeConfigParserTask" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" TaskFactory="TaskHostFactory" />
 
   <!-- TODO: this breaks runtime tests on Helix due to the file not being there for some reason. Once this is fixed we can remove the UpdateRuntimePack target here -->
   <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(TargetingpacksTargetsImported)' != 'true' and '$(ImportTargetingPacksTargetsInWasmAppTargets)' == 'true'"/>

--- a/src/mono/browser/runtime/cwraps.ts
+++ b/src/mono/browser/runtime/cwraps.ts
@@ -46,7 +46,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_wasm_load_icu_data", "number", ["number"]],
     [false, "mono_wasm_add_assembly", "number", ["string", "number", "number"]],
     [true, "mono_wasm_add_satellite_assembly", "void", ["string", "string", "number", "number"]],
-    [false, "mono_wasm_load_runtime", null, ["number"]],
+    [false, "mono_wasm_load_runtime", null, ["number", "number", "number", "number"]],
     [true, "mono_wasm_change_debugger_log_level", "void", ["number"]],
 
     [true, "mono_wasm_assembly_load", "number", ["string"]],
@@ -173,7 +173,7 @@ export interface t_Cwraps {
     mono_wasm_load_icu_data(offset: VoidPtr): number;
     mono_wasm_add_assembly(name: string, data: VoidPtr, size: number): number;
     mono_wasm_add_satellite_assembly(name: string, culture: string, data: VoidPtr, size: number): void;
-    mono_wasm_load_runtime(debugLevel: number): void;
+    mono_wasm_load_runtime(debugLevel: number, propertyCount:number, propertyKeys:CharPtrPtr, propertyValues:CharPtrPtr): void;
     mono_wasm_change_debugger_log_level(value: number): void;
 
     mono_wasm_assembly_load(name: string): MonoAssembly;

--- a/src/mono/browser/runtime/dotnet.d.ts
+++ b/src/mono/browser/runtime/dotnet.d.ts
@@ -193,6 +193,16 @@ type MonoConfig = {
         [i: string]: string;
     };
     /**
+     * Subset of runtimeconfig.json
+     */
+    runtimeConfig?: {
+        runtimeOptions?: {
+            configProperties?: {
+                [i: string]: string | number | boolean;
+            };
+        };
+    };
+    /**
      * initial number of workers to add to the emscripten pthread pool
      */
     pthreadPoolInitialSize?: number;

--- a/src/mono/browser/runtime/startup.ts
+++ b/src/mono/browser/runtime/startup.ts
@@ -13,10 +13,10 @@ import { mono_wasm_init_aot_profiler, mono_wasm_init_devtools_profiler, mono_was
 import { initialize_marshalers_to_cs } from "./marshal-to-cs";
 import { initialize_marshalers_to_js } from "./marshal-to-js";
 import { init_polyfills_async } from "./polyfills";
-import { strings_init, utf8ToString } from "./strings";
+import { strings_init, stringToUTF8Ptr, utf8ToString } from "./strings";
 import { init_managed_exports } from "./managed-exports";
 import { cwraps_internal } from "./exports-internal";
-import { CharPtr, EmscriptenModule, InstantiateWasmCallBack, InstantiateWasmSuccessCallback } from "./types/emscripten";
+import { CharPtr, CharPtrPtr, EmscriptenModule, InstantiateWasmCallBack, InstantiateWasmSuccessCallback, VoidPtr } from "./types/emscripten";
 import { wait_for_all_assets } from "./assets";
 import { replace_linker_placeholders } from "./exports-binding";
 import { endMeasure, MeasuredBlock, startMeasure } from "./profiler";
@@ -28,7 +28,7 @@ import { populateEmscriptenPool, mono_wasm_init_threads } from "./pthreads";
 import { currentWorkerThreadEvents, dotnetPthreadCreated, initWorkerThreadEvents, monoThreadInfo } from "./pthreads";
 import { mono_wasm_pthread_ptr, update_thread_info } from "./pthreads";
 import { jiterpreter_allocate_tables } from "./jiterpreter-support";
-import { localHeapViewU8, malloc } from "./memory";
+import { localHeapViewU8, malloc, setU32 } from "./memory";
 import { assertNoProxies } from "./gc-handles";
 import { runtimeList } from "./exports";
 import { nativeAbort, nativeExit } from "./run";
@@ -617,7 +617,41 @@ export function mono_wasm_load_runtime (): void {
         if (!loaderHelpers.isDebuggingSupported() || !runtimeHelpers.config.resources!.pdb) {
             debugLevel = 0;
         }
-        cwraps.mono_wasm_load_runtime(debugLevel);
+
+        const runtimeConfigProperties = new Map<string, string>();
+        if (runtimeHelpers.config.runtimeConfig?.runtimeOptions?.configProperties) {
+            for (const [key, value] of Object.entries(runtimeHelpers.config.runtimeConfig?.runtimeOptions?.configProperties)) {
+                runtimeConfigProperties.set(key, "" + value);
+            }
+        }
+        runtimeConfigProperties.set("APP_CONTEXT_BASE_DIRECTORY", "/");
+        runtimeConfigProperties.set("RUNTIME_IDENTIFIER", "browser-wasm");
+        const propertyCount = runtimeConfigProperties.size;
+
+        const buffers:VoidPtr[] = [];
+        const appctx_keys = malloc(4 * runtimeConfigProperties.size) as any as CharPtrPtr;
+        const appctx_values = malloc(4 * runtimeConfigProperties.size) as any as CharPtrPtr;
+        buffers.push(appctx_keys as any);
+        buffers.push(appctx_values as any);
+
+        let position = 0;
+        for (const [key, value] of runtimeConfigProperties.entries()) {
+            const keyPtr = stringToUTF8Ptr(key);
+            const valuePtr = stringToUTF8Ptr(value);
+            setU32((appctx_keys as any) + (position * 4), keyPtr);
+            setU32((appctx_values as any) + (position * 4), valuePtr);
+            position++;
+            buffers.push(keyPtr as any);
+            buffers.push(valuePtr as any);
+        }
+
+        cwraps.mono_wasm_load_runtime(debugLevel, propertyCount, appctx_keys, appctx_values);
+
+        // free the buffers
+        for (const buffer of buffers) {
+            Module._free(buffer);
+        }
+
         endMeasure(mark, MeasuredBlock.loadRuntime);
 
     } catch (err: any) {

--- a/src/mono/browser/runtime/types/index.ts
+++ b/src/mono/browser/runtime/types/index.ts
@@ -145,6 +145,16 @@ export type MonoConfig = {
         [i: string]: string;
     },
     /**
+     * Subset of runtimeconfig.json
+     */
+    runtimeConfig?: {
+        runtimeOptions?: {
+            configProperties?: {
+                [i: string]: string | number | boolean;
+            }
+        }
+    },
+    /**
      * initial number of workers to add to the emscripten pthread pool
      */
     pthreadPoolInitialSize?: number,

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -130,6 +130,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </AddWasmStaticWebAssetsDependsOn>
     <GenerateBuildWasmBootJsonDependsOn>
       $(GenerateBuildWasmBootJsonDependsOn);
+      GenerateBuildRuntimeConfigurationFiles;
       ResolveWasmOutputs;
     </GenerateBuildWasmBootJsonDependsOn>
   </PropertyGroup>
@@ -403,6 +404,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       Extensions="@(WasmBootConfigExtension)"
       EnvVariables="@(WasmEnvironmentVariable)"
       Profilers="$(_WasmProfilers)"
+      RuntimeConfigJsonPath="$(ProjectRuntimeConfigFilePath)"
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       ModuleAfterConfigLoaded="@(WasmModuleAfterConfigLoaded)"
       ModuleAfterRuntimeReady="@(WasmModuleAfterRuntimeReady)"
@@ -810,6 +812,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       RuntimeOptions="$(_BlazorWebAssemblyRuntimeOptions)"
       EnvVariables="@(WasmEnvironmentVariable)"
       Profilers="$(_WasmProfilers)"
+      RuntimeConfigJsonPath="$(ProjectRuntimeConfigFilePath)"
       Extensions="@(WasmBootConfigExtension)"
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       ModuleAfterConfigLoaded="@(WasmModuleAfterConfigLoaded)"

--- a/src/mono/wasi/build/WasiApp.props
+++ b/src/mono/wasi/build/WasiApp.props
@@ -10,4 +10,12 @@
   </PropertyGroup>
 
   <Import Project="$(WasmCommonTargetsPath)WasmApp.Common.props" />
+
+  <PropertyGroup>
+    <WasmNestedPublishAppDependsOn>
+      _PrepareForNestedPublish;
+      $(WasmNestedPublishAppDependsOn);
+    </WasmNestedPublishAppDependsOn>
+  </PropertyGroup>
+
 </Project>

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -4,6 +4,11 @@
   <UsingTask TaskName="Microsoft.WebAssembly.Build.Tasks.WasiAppBuilder" AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
 
   <PropertyGroup>
+    <PrepareInputsForWasmBuildDependsOn>
+      $(PrepareInputsForWasmBuildDependsOn);
+      _WasmGetRuntimeConfigPath;
+    </PrepareInputsForWasmBuildDependsOn>
+
     <PrepareForWasmBuildNativeDependsOn>
       _CheckToolchainIsExpectedVersion;
       _PrepareForWasiBuildNative;
@@ -11,11 +16,13 @@
     </PrepareForWasmBuildNativeDependsOn>
 
     <WasmLinkDotNetDependsOn>
+      _WasmGenerateRuntimeConfig;
       $(WasmLinkDotNetDependsOn);
       _WasiLinkDotNet;
     </WasmLinkDotNetDependsOn>
 
     <WasmGenerateAppBundleDependsOn>
+      _WasmGenerateRuntimeConfig;
       $(WasmGenerateAppBundleDependsOn);
       _GetWasiGenerateAppBundleDependencies;
       _WasiGenerateAppBundle;
@@ -45,6 +52,44 @@
     <!-- FIXME: rename to WasmHost?? -->
     <!--<WasiRunner Condition="'$(WasiRunner)' == ''">wasmtime</WasiRunner>-->
   </PropertyGroup>
+
+  <Target Name="_WasmGenerateRuntimeConfig"
+          Inputs="$(_WasmRuntimeConfigFilePath)"
+          Outputs="$(_ParsedRuntimeConfigFilePath)"
+          Condition="Exists('$(_WasmRuntimeConfigFilePath)')">
+    <ItemGroup>
+      <_RuntimeConfigReservedProperties Include="RUNTIME_IDENTIFIER"/>
+      <_RuntimeConfigReservedProperties Include="APP_CONTEXT_BASE_DIRECTORY"/>
+    </ItemGroup>
+
+    <RuntimeConfigParserTask
+        RuntimeConfigFile="$(_WasmRuntimeConfigFilePath)"
+        OutputFile="$(_ParsedRuntimeConfigFilePath)"
+        RuntimeConfigReservedProperties="@(_RuntimeConfigReservedProperties)">
+    </RuntimeConfigParserTask>
+
+    <ItemGroup>
+      <WasmFilesToIncludeInFileSystem Condition="'$(WasmSingleFileBundle)' != 'true'" Include="$(_ParsedRuntimeConfigFilePath)" LoadingStage="Core" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_WasmGetRuntimeConfigPath">
+    <PropertyGroup>
+      <_MainAssemblyPath Condition="'%(WasmAssembliesToBundle.FileName)' == '$(AssemblyName)' and '%(WasmAssembliesToBundle.Extension)' == '.dll' and $(WasmGenerateAppBundle) == 'true'">%(WasmAssembliesToBundle.Identity)</_MainAssemblyPath>
+      <_WasmRuntimeConfigFilePath Condition="'$(_WasmRuntimeConfigFilePath)' == '' and $(_MainAssemblyPath) != ''">$([System.IO.Path]::ChangeExtension($(_MainAssemblyPath), '.runtimeconfig.json'))</_WasmRuntimeConfigFilePath>
+      <_ParsedRuntimeConfigFilePath Condition="'$(_WasmRuntimeConfigFilePath)' != ''">$([System.IO.Path]::GetDirectoryName($(_WasmRuntimeConfigFilePath)))\runtimeconfig.bin</_ParsedRuntimeConfigFilePath>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_PrepareForNestedPublish" DependsOnTargets="_GetDefaultWasmAssembliesToBundle" Condition="'$(WasmBuildingForNestedPublish)' == 'true'">
+    <PropertyGroup>
+      <_WasmRuntimeConfigFilePath Condition="$([System.String]::new(%(PublishItemsOutputGroupOutputs.Identity)).EndsWith('$(AssemblyName).runtimeconfig.json'))">@(PublishItemsOutputGroupOutputs)</_WasmRuntimeConfigFilePath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_WasmRuntimeConfigFilePath)' == ''">
+      <_WasmRuntimeConfigFilePath Condition="$([System.String]::new(%(PublishItemsOutputGroupOutputs.Identity)).EndsWith('$(AssemblyName).runtimeconfig.json'))">@(PublishItemsOutputGroupOutputs)</_WasmRuntimeConfigFilePath>
+    </PropertyGroup>
+  </Target>
 
   <Target Name="_GetWasiGenerateAppBundleDependencies">
     <ItemGroup Condition="'$(InvariantGlobalization)' == 'true' or '$(WasmSingleFileBundle)' == 'true'">

--- a/src/mono/wasm/Wasm.Build.Tests/EnvVariablesTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/EnvVariablesTests.cs
@@ -29,7 +29,7 @@ public class EnvVariablesTests : WasmTemplateTestsBase
         BuildProject(info, config, new BuildOptions(AssertAppBundle: false), isNativeBuild: false);
 
         var result = await RunForBuildWithDotnetRun(new BrowserRunOptions(Configuration: config, TestScenario: "EnvVariablesTest"));
-        Assert.Contains("foo=bar", result.TestOutput);
-        Assert.Contains("baz=boo", result.TestOutput);
+        Assert.Contains(result.TestOutput, m => m.Contains("foo=bar"));
+        Assert.Contains(result.TestOutput, m => m.Contains("baz=boo"));
     }
 }

--- a/src/mono/wasm/Wasm.Build.Tests/HttpTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/HttpTests.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using Xunit.Abstractions;
+using Xunit;
+
+#nullable enable
+
+namespace Wasm.Build.Tests;
+
+public class HttpTests : WasmTemplateTestsBase
+{
+    public HttpTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext)
+        : base(output, buildContext)
+    {
+    }
+
+    [Fact]
+    // testing that WasmEnableStreamingResponse=false MSbuild prop is passed to the app and HTTP behaves as expected
+    public async Task HttpNoStreamingTest()
+    {
+        Configuration config = Configuration.Release;
+        ProjectInfo info = CopyTestAsset(config, false, TestAsset.WasmBasicTestApp, "HttpTest");
+
+        BuildProject(info, config, new BuildOptions(ExtraMSBuildArgs: "-p:WasmEnableStreamingResponse=false",AssertAppBundle: false), isNativeBuild: false);
+
+        var result = await RunForBuildWithDotnetRun(new BrowserRunOptions(Configuration: config, TestScenario: "HttpNoStreamingTest"));
+
+        Assert.Contains(result.TestOutput, m => m.Contains("AppContext FeatureEnableStreamingResponse=False"));
+        Assert.Contains(result.TestOutput, m => m.Contains("response.Content is System.Net.Http.BrowserHttpContent"));
+    }
+}

--- a/src/mono/wasm/build/WasmApp.Common.props
+++ b/src/mono/wasm/build/WasmApp.Common.props
@@ -18,7 +18,6 @@
     </_WasmBuildAppCoreDependsOn>
 
     <WasmNestedPublishAppDependsOn>
-      _PrepareForNestedPublish;
       _WasmBuildAppCore;
     </WasmNestedPublishAppDependsOn>
   </PropertyGroup>

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -125,12 +125,10 @@
       _ReadWasmProps;
       _SetWasmBuildNativeDefaults;
       _GetDefaultWasmAssembliesToBundle;
-      _WasmGetRuntimeConfigPath;
     </PrepareInputsForWasmBuildDependsOn>
 
     <WasmGenerateAppBundleDependsOn>
       $(WasmGenerateAppBundleDependsOn);
-      _WasmGenerateRuntimeConfig;
     </WasmGenerateAppBundleDependsOn>
 
     <!-- FIXME: TMP: added _PrepareForWasmBuildNative as it used by emsdk cache as beforeTargets -->
@@ -152,7 +150,6 @@
       _WasmSelectRuntimeComponentsForLinking;
       _WasmCompileAssemblyBitCodeFilesForAOT;
       _WasmCalculateInitialHeapSizeFromBitcodeFiles;
-      _WasmGenerateRuntimeConfig;
       _WasmWriteRspForCompilingNativeSourceFiles;
       _WasmCompileNativeSourceFiles;
       _GenerateObjectFilesForSingleFileBundle;
@@ -350,14 +347,6 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="_WasmGetRuntimeConfigPath">
-    <PropertyGroup>
-      <_MainAssemblyPath Condition="'%(WasmAssembliesToBundle.FileName)' == '$(AssemblyName)' and '%(WasmAssembliesToBundle.Extension)' == '.dll' and $(WasmGenerateAppBundle) == 'true'">%(WasmAssembliesToBundle.Identity)</_MainAssemblyPath>
-      <_WasmRuntimeConfigFilePath Condition="'$(_WasmRuntimeConfigFilePath)' == '' and $(_MainAssemblyPath) != ''">$([System.IO.Path]::ChangeExtension($(_MainAssemblyPath), '.runtimeconfig.json'))</_WasmRuntimeConfigFilePath>
-      <_ParsedRuntimeConfigFilePath Condition="'$(_WasmRuntimeConfigFilePath)' != ''">$([System.IO.Path]::GetDirectoryName($(_WasmRuntimeConfigFilePath)))\runtimeconfig.bin</_ParsedRuntimeConfigFilePath>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="_WasmResolveReferences" Condition="'$(WasmResolveAssembliesBeforeBuild)' == 'true'" Returns="@(_WasmAssembliesInternal)">
     <WasmLoadAssembliesAndReferences
       Assemblies="@(_WasmAssembliesInternal)"
@@ -380,8 +369,8 @@
              Text="Could not find %24(AssemblyName)=$(AssemblyName).dll in the assemblies to be bundled."
              Importance="Low" />
 
-    <Message Condition="'$(WasmGenerateAppBundle)' == 'true' and $(_WasmRuntimeConfigFilePath) != '' and !Exists($(_WasmRuntimeConfigFilePath))"
-             Text="Could not find $(_WasmRuntimeConfigFilePath) for $(_MainAssemblyPath)."
+    <Message Condition="'$(WasmGenerateAppBundle)' == 'true' and $(ProjectRuntimeConfigFilePath) != '' and !Exists($(ProjectRuntimeConfigFilePath))"
+             Text="Could not find $(ProjectRuntimeConfigFilePath) for $(_MainAssemblyPath)."
              Importance="Low" />
 
     <ItemGroup>
@@ -427,26 +416,6 @@
 
   <Target Name="WasmGenerateAppBundle" DependsOnTargets="$(WasmGenerateAppBundleDependsOn)" Condition="'$(WasmGenerateAppBundle)' == 'true'" />
 
-  <Target Name="_WasmGenerateRuntimeConfig"
-          Inputs="$(_WasmRuntimeConfigFilePath)"
-          Outputs="$(_ParsedRuntimeConfigFilePath)"
-          Condition="Exists('$(_WasmRuntimeConfigFilePath)')">
-    <ItemGroup>
-      <_RuntimeConfigReservedProperties Include="RUNTIME_IDENTIFIER"/>
-      <_RuntimeConfigReservedProperties Include="APP_CONTEXT_BASE_DIRECTORY"/>
-    </ItemGroup>
-
-    <RuntimeConfigParserTask
-        RuntimeConfigFile="$(_WasmRuntimeConfigFilePath)"
-        OutputFile="$(_ParsedRuntimeConfigFilePath)"
-        RuntimeConfigReservedProperties="@(_RuntimeConfigReservedProperties)">
-    </RuntimeConfigParserTask>
-
-    <ItemGroup>
-      <WasmFilesToIncludeInFileSystem Condition="'$(WasmSingleFileBundle)' != 'true'" Include="$(_ParsedRuntimeConfigFilePath)" LoadingStage="Core" />
-    </ItemGroup>
-  </Target>
-
   <Target Name="WasmTriggerPublishApp"
           AfterTargets="$(WasmTriggerPublishAppAfterThisTarget)"
           Condition="('$(IsBrowserWasmProject)' == 'true' or '$(IsWasiProject)' == 'true') and '$(WasmBuildingForNestedPublish)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'">
@@ -480,16 +449,6 @@
       <WasmAssembliesFinal OriginalItemName="WasmAssembliesFinal" />
       <FileWrites OriginalItemName="FileWrites" />
     </ItemGroup>
-  </Target>
-
-  <Target Name="_PrepareForNestedPublish" DependsOnTargets="_GetDefaultWasmAssembliesToBundle" Condition="'$(WasmBuildingForNestedPublish)' == 'true'">
-    <PropertyGroup>
-      <_WasmRuntimeConfigFilePath Condition="$([System.String]::new(%(PublishItemsOutputGroupOutputs.Identity)).EndsWith('$(AssemblyName).runtimeconfig.json'))">@(PublishItemsOutputGroupOutputs)</_WasmRuntimeConfigFilePath>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(_WasmRuntimeConfigFilePath)' == ''">
-      <_WasmRuntimeConfigFilePath Condition="$([System.String]::new(%(PublishItemsOutputGroupOutputs.Identity)).EndsWith('$(AssemblyName).runtimeconfig.json'))">@(PublishItemsOutputGroupOutputs)</_WasmRuntimeConfigFilePath>
-    </PropertyGroup>
   </Target>
 
   <Target Name="_EmitWasmAssembliesFinal" Returns="@(WasmAssembliesFinal)">

--- a/src/mono/wasm/build/WasmApp.LocalBuild.targets
+++ b/src/mono/wasm/build/WasmApp.LocalBuild.targets
@@ -24,7 +24,6 @@
 
   <UsingTask TaskName="MonoAOTCompiler" AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="ILStrip" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" TaskFactory="TaskHostFactory" />
-  <UsingTask TaskName="RuntimeConfigParserTask" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" TaskFactory="TaskHostFactory" />
 
   <PropertyGroup>
     <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">true</PublishTrimmed>

--- a/src/mono/wasm/data/aot-tests/ProxyProjectForAOTOnHelix.proj
+++ b/src/mono/wasm/data/aot-tests/ProxyProjectForAOTOnHelix.proj
@@ -23,6 +23,17 @@
 
   <Target Name="BundleTestWasmApp" DependsOnTargets="WasmBuildApp" />
 
+  <!-- This is fake target, we assume that runtimeconfig.json was already generated on CI agent before during build -->
+  <Target Name="GenerateBuildRuntimeConfigurationFiles" />
+    <ItemGroup>
+      <_ProjectRuntimeConfigFilePathOriginal Include="$(OriginalPublishDir)**\*.runtimeconfig.json" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(ProjectRuntimeConfigFilePath)' == ''">
+      <ProjectRuntimeConfigFilePath Condition="$([System.String]::new(%(_ProjectRuntimeConfigFilePathOriginal.Identity)).EndsWith('$(AssemblyName).runtimeconfig.json'))">@(_ProjectRuntimeConfigFilePathOriginal)</ProjectRuntimeConfigFilePath>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="PrepareForWasmBuildApp">
     <Message Text="** Building a proxy for the original test project, to AOT on helix. In order to do that, this recreates the original inputs for the *wasm* part of the build. See $(MSBuildThisFileFullPath), and $(_PropsFile). **"
              Importance="High" />

--- a/src/mono/wasm/data/aot-tests/ProxyProjectForAOTOnHelix.proj
+++ b/src/mono/wasm/data/aot-tests/ProxyProjectForAOTOnHelix.proj
@@ -24,7 +24,7 @@
   <Target Name="BundleTestWasmApp" DependsOnTargets="WasmBuildApp" />
 
   <!-- This is fake target, we assume that runtimeconfig.json was already generated on CI agent before during build -->
-  <Target Name="GenerateBuildRuntimeConfigurationFiles" />
+  <Target Name="GenerateBuildRuntimeConfigurationFiles" >
     <ItemGroup>
       <_ProjectRuntimeConfigFilePathOriginal Include="$(OriginalPublishDir)**\*.runtimeconfig.json" />
     </ItemGroup>

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/EnvVariablesTest.cs
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/EnvVariablesTest.cs
@@ -13,7 +13,7 @@ public partial class EnvVariablesTest
         // enumerate all environment variables
         foreach (string key in Environment.GetEnvironmentVariables().Keys)
         {
-            Console.WriteLine($"{key}={Environment.GetEnvironmentVariable(key)}");
+            Console.WriteLine($"TestOutput -> {key}={Environment.GetEnvironmentVariable(key)}");
         }
 
         return 42;

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/HttpTest.cs
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/HttpTest.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.JavaScript;
+
+public partial class HttpTest
+{
+    private static bool FeatureEnableStreamingResponse { get; } = AppContext.TryGetSwitch("System.Net.Http.WasmEnableStreamingResponse", out bool value) ? value : true;
+
+    [JSExport]
+    public static async Task<int> HttpNoStreamingTest()
+    {
+        Console.WriteLine($"TestOutput -> AppContext FeatureEnableStreamingResponse={FeatureEnableStreamingResponse}");
+        if(FeatureEnableStreamingResponse)
+        {
+            Console.WriteLine("FeatureEnableStreamingResponse is true, this test is not valid.");
+            return -1;
+        }
+
+        var uri = GetOriginUrl() + "/main.js";
+        using var client = new HttpClient();
+        using var response = await client.GetAsync(uri);
+
+        var contentType = response.Content.GetType();
+        Console.WriteLine("TestOutput -> response.Content is " + contentType.FullName);
+        if (contentType == typeof(StreamContent))
+        {
+            Console.WriteLine($"response.Content is {contentType.FullName}");
+            return -2;
+        }
+
+        return 42;
+    }
+
+    public static string GetOriginUrl()
+    {
+        using var globalThis = JSHost.GlobalThis;
+        using var document = globalThis.GetPropertyAsJSObject("document");
+        using var location = globalThis.GetPropertyAsJSObject("location");
+        return location.GetPropertyAsString("origin");
+    }
+}

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -166,6 +166,8 @@ switch (testCase) {
     case "EnvVariablesTest":
         dotnet.withEnvironmentVariable("foo", "bar");
         break;
+    case "HttpNoStreamingTest":
+        break;
     case "BrowserProfilerTest":
         break;
     case "OverrideBootConfigName":
@@ -255,6 +257,29 @@ try {
             });
             exports.MemoryTest.Run();
             exit(0);
+            break;
+        case "HttpNoStreamingTest":
+            console.log("not ready yet")
+            const myExportsHttp = await getAssemblyExports(config.mainAssemblyName);
+            const httpNoStreamingTest = myExportsHttp.HttpTest.HttpNoStreamingTest;
+            console.log("ready");
+            if (config.runtimeConfig.runtimeOptions.configProperties) {
+                const configProperties = config.runtimeConfig.runtimeOptions.configProperties;
+                console.log("configProperties: " + Object.keys(configProperties).length);
+                const wasmEnableStreamingResponse = configProperties["System.Net.Http.WasmEnableStreamingResponse"];
+                if (wasmEnableStreamingResponse === undefined) {
+                    exit(2);
+                }
+                if (wasmEnableStreamingResponse === true) {
+                    exit(3);
+                }
+            }
+
+            const retHttp = await httpNoStreamingTest();
+            document.getElementById("out").innerHTML = retHttp;
+            console.debug(`ret: ${retHttp}`);
+
+            exit(retHttp == 42 ? 0 : 1);
             break;
         case "EnvVariablesTest":
             console.log("not ready yet")

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
@@ -104,6 +104,10 @@ public class BootJsonData
     /// Gets or sets environment variables.
     /// </summary>
     public System.Collections.Generic.Dictionary<string, string> environmentVariables { get; set; }
+    /// <summary>
+    /// Subset of runtimeconfig.json
+    /// </summary>
+    public RuntimeConfigData runtimeConfig { get; set; }
 
     /// <summary>
     /// Gets or sets diagnostic tracing.
@@ -119,6 +123,25 @@ public class BootJsonData
     /// Gets or sets pthread pool unused size.
     /// </summary>
     public int? pthreadPoolUnusedSize { get; set; }
+}
+
+/// <summary>
+/// Subset of runtimeconfig.json
+/// </summary>
+public class RuntimeConfigData
+{
+    /// <summary>
+    /// Runtime options
+    /// </summary>
+    public RuntimeOptionsData runtimeOptions { get; set; }
+}
+
+public class RuntimeOptionsData
+{
+    /// <summary>
+    /// Config properties for the runtime
+    /// </summary>
+    public Dictionary<string, object> configProperties { get; set; }
 }
 
 public class ResourcesData

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
@@ -62,6 +62,8 @@ public class GenerateWasmBootJson : Task
 
     public string[]? Profilers { get; set; }
 
+    public string? RuntimeConfigJsonPath { get; set; }
+
     public string StartupMemoryCache { get; set; }
 
     public string Jiterpreter { get; set; }
@@ -435,6 +437,14 @@ public class GenerateWasmBootJson : Task
                 result.extensions[key] = config;
             }
         }
+
+        if (RuntimeConfigJsonPath != null && File.Exists(RuntimeConfigJsonPath))
+        {
+            using var fs = File.OpenRead(RuntimeConfigJsonPath);
+            var runtimeConfig = JsonSerializer.Deserialize<RuntimeConfigData>(fs, BootJsonBuilderHelper.JsonOptions);
+            result.runtimeConfig = runtimeConfig;
+        }
+
         Profilers ??= Array.Empty<string>();
         var browserProfiler = Profilers.FirstOrDefault(p => p.StartsWith("browser:"));
         if (browserProfiler != null)

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -397,7 +397,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
                 var envs = (JsonElement)valueObject!;
                 foreach (var env in envs.EnumerateObject())
                 {
-                    bootConfig.environmentVariables[env.Name] = env.Value.GetString();
+                    bootConfig.environmentVariables[env.Name] = env.Value.GetString()!;
                 }
             }
             else if (string.Equals(name, nameof(BootJsonData.diagnosticTracing), StringComparison.OrdinalIgnoreCase))
@@ -419,6 +419,13 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
         {
             bootConfig.environmentVariables ??= new();
             bootConfig.environmentVariables["DOTNET_WasmPerfInstrumentation"] = browserProfiler.Substring("browser:".Length);
+        }
+
+        if (RuntimeConfigJsonPath != null && File.Exists(RuntimeConfigJsonPath))
+        {
+            using var fs = File.OpenRead(RuntimeConfigJsonPath);
+            var runtimeConfig = JsonSerializer.Deserialize<RuntimeConfigData>(fs, BootJsonBuilderHelper.JsonOptions);
+            bootConfig.runtimeConfig = runtimeConfig;
         }
 
         foreach (ITaskItem env in EnvVariables ?? Enumerable.Empty<ITaskItem>())


### PR DESCRIPTION
- extend `BootJsonData` with `runtimeConfig` which matches just the `runtimeOptions.configProperties` part of `*.runtimeconfig.json`
- load `RuntimeConfigJsonPath` in `GenerateWasmBootJson` and in `WasmAppBuilder`
- drop RuntimeConfigParserTask from browser and move it to WASI msbuild
- convert from json to `char**` in `startup.ts`
- library mode `initialize_runtime()` out of scope

```js
export const config = /*json-start*/{
  "mainAssemblyName": "Wasm.Browser.Sample.dll",
  "debugLevel": -1,
  "globalizationMode": "sharded",
  ...
  "runtimeConfig": {
    "runtimeOptions": {
      "configProperties": {
        "System.Net.Http.WasmEnableStreamingResponse": true,
        "Microsoft.Extensions.DependencyInjection.VerifyOpenGenericServiceTrimmability": true,
        ...
      }
    }
  }
}/*json-end*/;
```

Fixes https://github.com/dotnet/runtime/issues/97449
Fixes https://github.com/dotnet/runtime/issues/112442
Together with https://github.com/dotnet/sdk/pull/48916