### PR TITLE
Fix missing coverage of F# resources in linker RemoveResourcesStep

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/RemoveResourcesStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/RemoveResourcesStep.cs
@@ -33,8 +33,8 @@ namespace Mono.Linker.Steps
 			}
 
 			static bool IsFSharpCompilationResource (Resource resource)
-				=> resource.Name.StartsWith ("FSharpSignatureData", StringComparison.Ordinal)
-				|| resource.Name.StartsWith ("FSharpOptimizationData", StringComparison.Ordinal);
+				=> resource.Name.StartsWith ("FSharpSignature", StringComparison.Ordinal)
+				|| resource.Name.StartsWith ("FSharpOptimization", StringComparison.Ordinal);
 		}
 	}
 }


### PR DESCRIPTION
The original solution was missing 3 further dimensions of F# resources:
- Being compressed or not
- Being part of FSharp.Core (STD lib for F#) or user code
- Being original stream or a backwards-compatible stream for newer language features, particulary nullable reference types

The full set of F#-compiler-generated prefixes currently is:
FSharpSignatureData.*
FSharpSignatureDataB.*
FSharpSignatureCompressedData.*
FSharpSignatureCompressedDataB.*

FSharpOptimizationData.*
FSharpOptimizationDataB.*
FSharpOptimizationCompressedData.*
FSharpOptimizationCompressedDataB.*

FSharpOptimizationInfo.*
FSharpSignatureInfo.*


This closes https://github.com/dotnet/linker/issues/329