### PR TITLE
[cDAC] IXCLRDataStackWalk::GetContext returns proper HResult

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -53,7 +53,15 @@ internal readonly struct StackWalk_1 : IStackWalk
         IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
         FillContextFromThread(context, threadData);
         StackWalkState state = IsManaged(context.InstructionPointer, out _) ? StackWalkState.SW_FRAMELESS : StackWalkState.SW_FRAME;
-        StackWalkData stackWalkData = new(context, state, new(_target, threadData));
+        FrameIterator frameIterator = new(_target, threadData);
+
+        // if the next Frame is not valid and we are not in managed code, there is nothing to return
+        if (state == StackWalkState.SW_FRAME && !frameIterator.IsValid())
+        {
+            yield break;
+        }
+
+        StackWalkData stackWalkData = new(context, state, frameIterator);
 
         yield return stackWalkData.ToDataFrame();
 


### PR DESCRIPTION
`IXCLRDataStackWalk::GetContext` should return `HResult.S_FALSE` when the current Frame is invalid. Previously, this method would return the initial state with `HResult.S_OK`, triggering a Debug Assert when comparing to the DAC implementation.