### PR TITLE
Exclude --gcc-toolchain from cross arg

### DIFF
--- a/eng/toolAot.targets
+++ b/eng/toolAot.targets
@@ -22,10 +22,6 @@
     <PackageReference Include="runtime.$(NETCoreSdkRuntimeIdentifier).Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
-    <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(_hostOS)' != 'windows'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
-  </ItemGroup>
-
   <Target Name="LocateNativeCompiler"
           Condition="'$(UseNativeAotForComponents)' == 'true' and '$(HostOS)' != 'windows'"
           BeforeTargets="SetupOSSpecificProps">

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/NativeExports.csproj
@@ -87,7 +87,7 @@
     </XmlPeek>
 
     <PropertyGroup>
-      <CommonToolchainArgs>--target=$(TargetTriple) --gcc-toolchain=$(ROOTFS_DIR)/usr --sysroot=$(ROOTFS_DIR)</CommonToolchainArgs>
+      <CommonToolchainArgs>--target=$(TargetTriple) --sysroot=$(ROOTFS_DIR)</CommonToolchainArgs>
       <DnneLinkerUserFlags>$(CommonToolchainArgs) $(DnneLinkerCommand) $(DnneLinkerUserFlags.Replace(';',' '))</DnneLinkerUserFlags>
       <DnneCompilerUserFlags>$(CommonToolchainArgs) $(DnneCompilerUserFlags.Replace(';',' '))</DnneCompilerUserFlags>
     </PropertyGroup>


### PR DESCRIPTION
This is to fix error seen in https://github.com/dotnet/runtime/pull/114285

> clang-20(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) argument unused during compilation: '--gcc-toolchain=/crossrootfs/x64/usr' [-Wunused-command-line-argument]
