### PR TITLE
Fix regression caused by overload resolution.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -137,7 +137,7 @@ namespace System
         // Non-inlinable wrapper around the QCall that avoids polluting the fast path
         // with P/Invoke prolog/epilog.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static unsafe void ZeroMemory(ref byte b, nuint byteLength)
+        internal static unsafe void ZeroMemoryInternal(ref byte b, nuint byteLength)
         {
             fixed (byte* bytePointer = &b)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -127,7 +127,7 @@ namespace System
         // Non-inlinable wrapper around the QCall that avoids polluting the fast path
         // with P/Invoke prolog/epilog.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static unsafe void Memmove(ref byte dest, ref byte src, nuint len)
+        internal static unsafe void MemmoveInternal(ref byte dest, ref byte src, nuint len)
         {
             fixed (byte* pDest = &dest)
             fixed (byte* pSrc = &src)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -239,7 +239,7 @@ namespace System
             Debug.Assert(len > 0);
             _ = Unsafe.ReadUnaligned<byte>(ref dest);
             _ = Unsafe.ReadUnaligned<byte>(ref src);
-            Buffer.Memmove(ref dest, ref src, len);
+            Buffer.MemmoveInternal(ref dest, ref src, len);
         }
 
         [Intrinsic] // Unrolled for small sizes

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -425,7 +425,7 @@ namespace System
         PInvoke:
             // Implicit nullchecks
             _ = Unsafe.ReadUnaligned<byte>(ref dest);
-            Buffer.ZeroMemory(ref dest, len);
+            Buffer.ZeroMemoryInternal(ref dest, len);
         }
 
         internal static void Fill(ref byte dest, byte value, nuint len)


### PR DESCRIPTION
Introduced by https://github.com/dotnet/runtime/pull/113715

Fixes https://github.com/dotnet/runtime/issues/114696

See https://github.com/dotnet/runtime/issues/114696#issuecomment-2839800534

Thanks @tfenise