### PR TITLE
Fix culture creation with undetermined lang tag

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
@@ -388,6 +388,18 @@ namespace System.Globalization.Tests
             }
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
+        [InlineData("und-us", "und-US", "und-US")]
+        [InlineData("und-us_tradnl", "und-US", "und-US_tradnl")]
+        [InlineData("und-es-u-co-phoneb", "und-ES", "und-ES_phoneb")]
+        [InlineData("und-es-t-something", "und-ES", "und-ES")]
+        public void CtorUndeterminedLanguageTag(string cultureName, string expectedCultureName, string expectedSortName)
+        {
+            CultureInfo culture = new CultureInfo(cultureName);
+            Assert.Equal(expectedCultureName, culture.Name);
+            Assert.Equal(expectedSortName, culture.CompareInfo.Name);
+        }
+
         [Theory]
         [MemberData(nameof(Ctor_String_TestData))]
         public void Ctor_String(string name, string[] expectedNames)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/98543

This change enables support for creating `CultureInfo` objects using an undetermined language tag like `und-US`.
The root issue is that ICU's `uloc_getName` returns malformed names such as `_US` when given `und-US`. This fix ensures the removed language subtag `und` is preserved and restored in the result.
A more comprehensive alternative—switching to `uloc_toLanguageTag`—was considered, but it may introduce compatibility and performance concerns. It would also require a broader audit of how we normalize culture names around ICU usage. We can revisit that approach if more issues like this one are discovered.