### PR TITLE
[RuntimeAsync] Moving tests from runtimelabs.

### DIFF
--- a/src/tests/async/Directory.Build.targets
+++ b/src/tests/async/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <!-- runtime async testing in main repo NYI -->
+    <DisableProjectBuild>true</DisableProjectBuild>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+</Project>

--- a/src/tests/async/asynctests.csproj
+++ b/src/tests/async/asynctests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <MergedWrapperProjectReference Include="*/**/*.??proj" />
+    <MergedWrapperProjectReference Include="*.??proj" />
+    <MergedWrapperProjectReference Remove="$(MSBuildProjectName).csproj" />
+
+    <!-- Remove manual benchmarks from the test wrapper -->
+    <MergedWrapperProjectReference Remove="eh-microbench.csproj" />
+    <MergedWrapperProjectReference Remove="gc-roots-scan.csproj" />
+    <MergedWrapperProjectReference Remove="mincallcost-microbench.csproj" />
+
+    <MergedWrapperProjectReference Remove="syncfibonacci-with-yields.csproj" />
+    <MergedWrapperProjectReference Remove="syncfibonacci-without-yields.csproj" />
+    <MergedWrapperProjectReference Remove="taskbased-asyncfibonacci-with-yields.csproj" />
+    <MergedWrapperProjectReference Remove="taskbased-asyncfibonacci-without-yields.csproj" />
+    <MergedWrapperProjectReference Remove="valuetaskbased-asyncfibonacci-without-yields.csproj" />
+    <MergedWrapperProjectReference Remove="valuetaskbased-asynfibonacci-with-yields.csproj" />
+  </ItemGroup>
+
+  <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
+</Project>

--- a/src/tests/async/awaitingnotasync.cs
+++ b/src/tests/async/awaitingnotasync.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class AwaitNotAsync
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        AsyncEntryPoint().Wait();
+    }
+
+    private static async Task<T> GetTask<T>(T arg)
+    {
+        await Task.Yield();
+        return arg;
+    }
+
+    // TODO: switch every other scenario to use ValueTask
+    private static async ValueTask<T> GetValueTask<T>(T arg)
+    {
+        await Task.Yield();
+        return arg;
+    }
+
+    private static Task<int> sField;
+
+    private static Task<int> sProp => GetTask(6);
+
+    private static T sIdentity<T>(T arg) => arg;
+
+    private static async2 Task AsyncEntryPoint()
+    {
+        // static field
+        sField = GetTask(5);
+        Assert.Equal(5, await sField);
+
+        // property 
+        Assert.Equal(6, await sProp);
+
+        // generic identity
+        Assert.Equal(6, await sIdentity(sProp));
+
+        // await(await ...))
+        Assert.Equal(7, await await await GetTask(GetTask(GetTask(7))));
+
+    }
+}

--- a/src/tests/async/awaitingnotasync.csproj
+++ b/src/tests/async/awaitingnotasync.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/collectible-alc.cs
+++ b/src/tests/async/collectible-alc.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2CollectibleAlc
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        AsyncEntryPoint().Wait();
+    }
+
+    private static async2 Task AsyncEntryPoint()
+    {
+        WeakReference wr = await CallFooAsyncAndUnload();
+
+        for (int i = 0; i < 10 && wr.IsAlive; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.False(wr.IsAlive);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task<WeakReference> CallFooAsyncAndUnload()
+    {
+        TaskCompletionSource tcs = new();
+        (Task<string> task, WeakReference wr) = CallFooAsyncInCollectibleALC(tcs.Task);
+        for (int i = 0; i < 10; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.True(wr.IsAlive);
+
+        tcs.SetResult();
+        string result = await task;
+        Assert.Equal("done", result);
+        return wr;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (Task<string>, WeakReference) CallFooAsyncInCollectibleALC(Task task)
+    {
+        CollectibleALC alc = new CollectibleALC();
+        Assembly asm = alc.LoadFromAssemblyPath(Assembly.GetExecutingAssembly().Location);
+
+        MethodInfo[] mis = asm.GetType(nameof(Async2CollectibleAlc)).GetMethods(BindingFlags.Static | BindingFlags.NonPublic);
+        MethodInfo mi = mis.Single(mi => mi.Name == "FooAsync" && mi.ReturnType == typeof(Task<string>));
+        Task<string> resultTask = (Task<string>)mi.Invoke(null, new object[] { new Task[] { task } });
+        alc.Unload();
+        return (resultTask, new WeakReference(alc, trackResurrection: true));
+    }
+
+    // Task[] to work around a compiler bug
+    private static async2 Task<string> FooAsync(Task[] t)
+    {
+        await t[0];
+        return "done";
+    }
+
+    private class CollectibleALC : AssemblyLoadContext
+    {
+        public CollectibleALC() : base(true)
+        {
+        }
+    }
+}

--- a/src/tests/async/collectible-alc.csproj
+++ b/src/tests/async/collectible-alc.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <!-- For collectible ALC -->
+    <RequiresProcessIsolation>True</RequiresProcessIsolation>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/cse-array-index-byref.cs
+++ b/src/tests/async/cse-array-index-byref.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class CseArrayIndexByref
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        int[] arr = new int[1];
+        AsyncTestEntryPoint(arr, 0).Wait();
+        Assert.Equal(199_990_000, arr[0]);
+    }
+
+    private static async Task AsyncTestEntryPoint(int[] arr, int index)
+    {
+        await HoistedByref(arr, index);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task<int> HoistedByref(int[] arr, int index)
+    {
+        for (int i = 0; i < 20000; i++)
+        {
+            arr[index] += i;
+            await Task.Yield();
+        }
+        return 0;
+    }
+}

--- a/src/tests/async/cse-array-index-byref.csproj
+++ b/src/tests/async/cse-array-index-byref.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/eh-microbench.cs
+++ b/src/tests/async/eh-microbench.cs
@@ -1,0 +1,430 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//#define ASYNC1_TASK
+//#define ASYNC1_VALUETASK
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2EHMicrobench
+{
+    public static int Main()
+    {
+        Task.Run(AsyncEntry).Wait();
+
+        Console.WriteLine("Test Passed");
+        return 100;
+    }
+
+    public static async Task AsyncEntry()
+    {
+        if (!GCSettings.IsServerGC)
+            Console.WriteLine("*** Warning: Server GC is disabled, set DOTNET_gcServer=1 ***");
+
+        string[] args = Environment.GetCommandLineArgs();
+        int depth = args.Length > 1 ? int.Parse(args[1]) : 2;
+        Console.WriteLine("Using depth = {0}", depth);
+
+        // Yield N times before throwing
+        int yieldFrequency = args.Length > 2 ? int.Parse(args[2]) : 1;
+        Console.WriteLine("Yielding {0} times before throwing", yieldFrequency);
+
+        // Inject a finally every N frames
+        int finallyRate = args.Length > 3 ? int.Parse(args[3]) : 1000;
+        Console.WriteLine("With a try/finally block every {0} frames", finallyRate);
+
+        // Throw or return
+        bool throwOrReturn = args.Length > 4 ? String.Equals(args[4], "throw", StringComparison.OrdinalIgnoreCase) : true;
+        Console.WriteLine($"Which will {(throwOrReturn ? "throw" : "return")} when finished yielding");
+
+        Benchmark warmupBm = new Benchmark(5, 5, 2, throwOrReturn);
+        warmupBm.Warmup = true;
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 40; j++)
+            {
+                await warmupBm.Run("Async2");
+                await warmupBm.Run("Async2WithContextSaveRestore");
+                await warmupBm.Run("Task");
+                await warmupBm.Run("ValueTask");
+            }
+
+            // Make sure we tier up...
+            await Task.Delay(500);
+        }
+
+        Console.WriteLine("Warmup done, running benchmark");
+        await RunBench(yieldFrequency, depth, finallyRate, throwOrReturn, "Async2");
+        await RunBench(yieldFrequency, depth, finallyRate, throwOrReturn, "Async2WithContextSaveRestore");
+        await RunBench(yieldFrequency, depth, finallyRate, throwOrReturn, "Task");
+        await RunBench(yieldFrequency, depth, finallyRate, throwOrReturn, "ValueTask");
+    }
+
+    private static async Task RunBench(int yieldCount, int depth, int finallyRate, bool throwOrReturn, string type)
+    {
+
+        Benchmark bm = new(yieldCount, depth, finallyRate, throwOrReturn);
+        Console.WriteLine($"Running benchmark on '{type}' methods");
+
+        List<long> results = new();
+        for (int i = 0; i < 16; i++)
+        {
+            long numIters = await bm.Run(type);
+//            Console.WriteLine($"iters={numIters}");
+            results.Add(numIters);
+        }
+
+        results.Sort();
+        double avg = results.Skip(3).Take(10).Average();
+        Console.WriteLine("Result = {0}", (long)avg);
+    }
+
+    private class Benchmark
+    {
+        private readonly int _yieldCount;
+        private readonly int _depth;
+        private readonly int _finallyRate;
+        private readonly bool _throwOrReturn;
+        public int Sink;
+        public bool Warmup;
+
+        public Benchmark(int yieldCount, int depth, int finallyRate, bool throwOrReturn)
+        {
+            _yieldCount = yieldCount;
+            _depth = depth;
+            _finallyRate = finallyRate;
+            _throwOrReturn = throwOrReturn;
+        }
+
+        public async2 Task<long> Run(string type)
+        {
+            if (type == "Async2")
+                return await RunAsync2(_depth);
+            if (type == "Async2WithContextSaveRestore")
+                return await RunAsync2WithContextSaveRestore(_depth);
+            if (type == "Task")
+                return await RunTask(_depth);
+            if (type == "ValueTask")
+                return await RunValueTask(_depth);
+            return 0;
+        }
+
+        public async Task<long> RunTask(int depth)
+        {
+            int liveState1 = depth * 3 + _yieldCount;
+            int liveState2 = depth;
+            double liveState3 = _yieldCount;
+
+            if (depth == 0)
+            {
+                int currentAwaitCount = 0;
+
+                while (currentAwaitCount < _yieldCount)
+                {
+                    currentAwaitCount++;
+                    await Task.Yield();
+                }
+
+                if (_throwOrReturn)
+                    throw new Exception();
+                return 8375983;
+            }
+
+            long result = 0;
+
+            if (depth == _depth)
+            {
+                int time = Warmup ? 5 : 250;
+
+                Stopwatch timer = Stopwatch.StartNew();
+
+                long numIters = 0;
+
+                while (timer.ElapsedMilliseconds < time)
+                {
+                    try
+                    {
+                        result = await RunTask(depth - 1);
+                    }
+                    catch (Exception e)
+                    {
+                    }
+                    numIters++;
+
+                }
+                return numIters;
+            }
+            else if ((depth % _finallyRate) == 0)
+            {
+                try
+                {
+                    result = await RunTask(depth - 1);
+                }
+                finally
+                {
+                    Sink = (int)liveState1 + (int)liveState2 + (int)(1 / liveState3) + depth;
+                }
+            }
+            else
+            {
+                result = await RunTask(depth - 1);
+            }
+
+            Sink = (int)liveState1 + (int)liveState2 + (int)(1 / liveState3) + depth;
+            return result;
+        }
+
+        public async ValueTask<long> RunValueTask(int depth)
+        {
+            int liveState1 = depth * 3 + _yieldCount;
+            int liveState2 = depth;
+            double liveState3 = _yieldCount;
+
+            if (depth == 0)
+            {
+                int currentAwaitCount = 0;
+
+                while (currentAwaitCount < _yieldCount)
+                {
+                    currentAwaitCount++;
+                    await Task.Yield();
+                }
+
+                if (_throwOrReturn)
+                    throw new Exception();
+                return 8375983;
+            }
+
+            long result = 0;
+
+            if (depth == _depth)
+            {
+                int time = Warmup ? 5 : 250;
+
+                Stopwatch timer = Stopwatch.StartNew();
+
+                long numIters = 0;
+
+                while (timer.ElapsedMilliseconds < time)
+                {
+                    try
+                    {
+                        result = await RunValueTask(depth - 1);
+                    }
+                    catch (Exception e)
+                    {
+
+                    }
+                    numIters++;
+
+                }
+                return numIters;
+            }
+            else if ((depth % _finallyRate) == 0)
+            {
+                try
+                {
+                    result = await RunValueTask(depth - 1);
+                }
+                finally
+                {
+                    Sink = (int)liveState1 + (int)liveState2 + (int)(1 / liveState3) + depth;
+                }
+            }
+            else
+            {
+                result = await RunValueTask(depth - 1);
+            }
+
+            Sink = (int)liveState1 + (int)liveState2 + (int)(1 / liveState3) + depth;
+            return result;
+        }
+
+        public class FakeSyncContext {}
+        public class FakeExecContext
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static void RestoreChangedContextToThread(FakeThread thread, FakeExecContext execContext, FakeExecContext newExecContext)
+            {
+            }
+        }
+        public class FakeThread
+        {
+            public FakeSyncContext _syncContext;
+            public FakeExecContext _execContext;
+        }
+        [ThreadStatic]
+        public static FakeThread CurrentThread;
+
+        // This case is used to test the impact of save/restore of the sync and execution context on performance
+        // The intent here is to measure what the performance impact of maintaining the current async semantics with
+        // the new implementation.
+        public async2 Task<long> RunAsync2WithContextSaveRestore(int depth)
+        {
+            FakeThread thread = CurrentThread;
+            if (thread == null)
+            {
+                CurrentThread = new FakeThread();
+                thread = CurrentThread;
+            }
+
+            FakeExecContext? previousExecutionCtx = thread._execContext;
+            FakeSyncContext? previousSyncCtx = thread._syncContext;
+
+            try
+            {
+                int liveState1 = depth * 3 + _yieldCount;
+                int liveState2 = depth;
+                double liveState3 = _yieldCount;
+
+                if (depth == 0)
+                {
+                    int currentAwaitCount = 0;
+
+                    while (currentAwaitCount < _yieldCount)
+                    {
+                        currentAwaitCount++;
+                        await Task.Yield();
+                    }
+
+                    if (_throwOrReturn)
+                        throw new Exception();
+                    return 8375983;
+                }
+
+                long result = 0;
+
+                if (depth == _depth)
+                {
+                    int time = Warmup ? 5 : 250;
+
+                    Stopwatch timer = Stopwatch.StartNew();
+
+                    long numIters = 0;
+
+                    while (timer.ElapsedMilliseconds < time)
+                    {
+                        try
+                        {
+                            result = await RunAsync2WithContextSaveRestore(depth - 1);
+                        }
+                        catch (Exception e)
+                        {
+
+                        }
+                        numIters++;
+
+                    }
+                    return numIters;
+                }
+                else if ((depth % _finallyRate) == 0)
+                {
+                    try
+                    {
+                        result = await RunAsync2WithContextSaveRestore(depth - 1);
+                    }
+                    finally
+                    {
+                        Sink = (int)liveState1 + (int)liveState2 + (int)(1 / liveState3) + depth;
+                    }
+                }
+                else
+                {
+                    result = await RunAsync2WithContextSaveRestore(depth - 1);
+                }
+
+                Sink = (int)liveState1 + (int)liveState2 + (int)(1 / liveState3) + depth;
+                return result;
+            }
+            finally
+            {
+                // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
+                if (previousSyncCtx != thread._syncContext)
+                {
+                    // Restore changed SynchronizationContext back to previous
+                    thread._syncContext = previousSyncCtx;
+                }
+
+                FakeExecContext? currentExecutionCtx = thread._execContext;
+                if (previousExecutionCtx != currentExecutionCtx)
+                {
+                    FakeExecContext.RestoreChangedContextToThread(thread, previousExecutionCtx, currentExecutionCtx);
+                }
+            }
+        }
+
+        public async2 Task<long> RunAsync2(int depth)
+        {
+            int liveState1 = depth * 3 + _yieldCount;
+            int liveState2 = depth;
+            double liveState3 = _yieldCount;
+
+            if (depth == 0)
+            {
+                int currentAwaitCount = 0;
+
+                while (currentAwaitCount < _yieldCount)
+                {
+                    currentAwaitCount++;
+                    await Task.Yield();
+                }
+
+                if (_throwOrReturn)
+                    throw new Exception();
+                return 8375983;
+            }
+
+            long result = 0;
+
+            if (depth == _depth)
+            {
+                int time = Warmup ? 5 : 250;
+
+                Stopwatch timer = Stopwatch.StartNew();
+
+                long numIters = 0;
+
+                while (timer.ElapsedMilliseconds < time)
+                {
+                    try
+                    {
+                        result = await RunAsync2(depth - 1);
+                    }
+                    catch (Exception e)
+                    {
+
+                    }
+                    numIters++;
+
+                }
+                return numIters;
+            }
+            else if ((depth % _finallyRate) == 0)
+            {
+                try
+                {
+                    result = await RunAsync2(depth - 1);
+                }
+                finally
+                {
+                    Sink = (int)liveState1 + (int)liveState2 + (int)(1 / liveState3) + depth;
+                }
+            }
+            else
+            {
+                result = await RunAsync2(depth - 1);
+            }
+
+            Sink = (int)liveState1 + (int)liveState2 + (int)(1 / liveState3) + depth;
+            return result;
+        }
+    }
+}

--- a/src/tests/async/eh-microbench.csproj
+++ b/src/tests/async/eh-microbench.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/expected_failures.txt
+++ b/src/tests/async/expected_failures.txt
@@ -1,9 +1,0 @@
-DOTNET_RuntimeAsyncViaJitGeneratedStateMachines=0:
-* Loader\async\async2-returns\async2-returns.dll  (retbuffers)
-* Loader\async\simple-eh\simple-eh.dll (EH unsupported)
-* Loader\async\async2-eh-microbench\async2-eh-microbench.cmd (EH unsupported)
-* Loader\async\async2object\async2object.cmd (this one probably should be passing?)
-* Loader\async\async2sharedgeneric\async2sharedgeneric.dll (generics unsupported)
-
-DOTNET_RuntimeAsyncViaJitGeneratedStateMachines=1:
-* None

--- a/src/tests/async/expected_failures.txt
+++ b/src/tests/async/expected_failures.txt
@@ -1,0 +1,9 @@
+DOTNET_RuntimeAsyncViaJitGeneratedStateMachines=0:
+* Loader\async\async2-returns\async2-returns.dll  (retbuffers)
+* Loader\async\simple-eh\simple-eh.dll (EH unsupported)
+* Loader\async\async2-eh-microbench\async2-eh-microbench.cmd (EH unsupported)
+* Loader\async\async2object\async2object.cmd (this one probably should be passing?)
+* Loader\async\async2sharedgeneric\async2sharedgeneric.dll (generics unsupported)
+
+DOTNET_RuntimeAsyncViaJitGeneratedStateMachines=1:
+* None

--- a/src/tests/async/fibonacci-with-yields.cs
+++ b/src/tests/async/fibonacci-with-yields.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class Async2FibonacciWithYields
+{
+    const int iterations = 3;
+    const bool doYields = true;
+
+    [Fact]
+    public static void Test()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        AsyncEntry().GetAwaiter().GetResult();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+    }
+
+    public static async2 Task AsyncEntry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            int result = await Fib(25);
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
+        }
+    }
+
+    static async2 Task<int> Fib(int i)
+    {
+        if (i <= 1)
+        {
+            if (doYields)
+            {
+                await Task.Yield();
+            }
+
+            return 1;
+        }
+
+        int i1 = await Fib(i - 1);
+        int i2 = await Fib(i - 2);
+
+        return i1 + i2;
+    }
+}

--- a/src/tests/async/fibonacci-with-yields.csproj
+++ b/src/tests/async/fibonacci-with-yields.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/fibonacci-with-yields_struct_return.cs
+++ b/src/tests/async/fibonacci-with-yields_struct_return.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#define WITH_OBJECT
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class Async2FibonacceWithYields
+{
+    const int iterations = 3;
+
+    [Fact]
+    public static void Test()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        AsyncEntry().GetAwaiter().GetResult();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+    }
+
+    public struct MyInt
+    {
+        public int i;
+#if WITH_OBJECT
+        public object dummy;
+#else
+        IntPtr dummy;
+#endif
+        public MyInt(int i) => this.i = i;
+    }
+
+    public static async2 Task AsyncEntry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            MyInt result = await Fib(new MyInt(25));
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result.i}");
+        }
+    }
+
+    static async2 Task<MyInt> Fib(MyInt n)
+    {
+        int i = n.i;
+        if (i <= 1)
+        {
+            await Task.Yield();
+            return new MyInt(1);
+        }
+
+        int i1 = (await Fib(new MyInt(i - 1))).i;
+        int i2 = (await Fib(new MyInt(i - 2))).i;
+
+        return new MyInt(i1 + i2);
+    }
+}

--- a/src/tests/async/fibonacci-with-yields_struct_return.csproj
+++ b/src/tests/async/fibonacci-with-yields_struct_return.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/fibonacci-without-yields-config-await.cs
+++ b/src/tests/async/fibonacci-without-yields-config-await.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning disable SYSLIB5007 // 'System.Runtime.CompilerServices.AsyncHelpers' is for evaluation purposes only
+
+public class Async2FibonacciWithYields
+{
+    const int iterations = 3;
+    const bool doYields = false;
+
+    [Fact]
+    public static void Test()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        AsyncEntry().GetAwaiter().GetResult();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+    }
+
+    public static async2 Task AsyncEntry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            int result = AsyncHelpers.Await(Fib(30).ConfigureAwait(false));
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
+        }
+    }
+
+    static async2 Task<int> Fib(int i)
+    {
+        if (i <= 1)
+        {
+            if (doYields)
+            {
+                await Task.Yield();
+            }
+
+            return 1;
+        }
+
+        int i1 = AsyncHelpers.Await(Fib(i - 1).ConfigureAwait(true));
+        int i2 = AsyncHelpers.Await(Fib(i - 2).ConfigureAwait(false));
+
+        return i1 + i2;
+    }
+}

--- a/src/tests/async/fibonacci-without-yields-config-await.csproj
+++ b/src/tests/async/fibonacci-without-yields-config-await.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/fibonacci-without-yields.cs
+++ b/src/tests/async/fibonacci-without-yields.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class Async2FibonacciWithoutYields
+{
+    const int iterations = 3;
+    const bool doYields = false;
+
+    [Fact]
+    public static void Test()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        AsyncEntry().GetAwaiter().GetResult();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+    }
+
+    public static async2 Task AsyncEntry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            int result = await Fib(25);
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
+        }
+    }
+
+    static async2 Task<int> Fib(int i)
+    {
+        if (i <= 1)
+        {
+            if (doYields)
+            {
+                await Task.Yield();
+            }
+
+            return 1;
+        }
+
+        int i1 = await Fib(i - 1);
+        int i2 = await Fib(i - 2);
+
+        return i1 + i2;
+    }
+}

--- a/src/tests/async/fibonacci-without-yields.csproj
+++ b/src/tests/async/fibonacci-without-yields.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/gc-roots-scan.cs
+++ b/src/tests/async/gc-roots-scan.cs
@@ -1,0 +1,211 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class Async2RootReporting
+{
+    private static TaskCompletionSource<int> cs;
+
+
+    static async Task<int> Recursive1(int n)
+    {
+        Task<int> cTask = cs.Task;
+
+        // make some garbage
+        object o1 = n;
+        object o2 = n;
+        object o3 = n;
+        object o4 = n;
+        object o5 = n;
+        object o6 = n;
+        object o7 = n;
+        object o8 = n;
+        object o9 = n;
+        object o10 = n;
+        object o11 = n;
+        object o12 = n;
+
+        if (n == 0)
+            return await cTask;
+
+        var result = await Recursive1(n - 1);
+
+        Assert.Equal(n, (int)o1);
+        Assert.Equal(n, (int)o2);
+        Assert.Equal(n, (int)o3);
+        Assert.Equal(n, (int)o4);
+        Assert.Equal(n, (int)o5);
+        Assert.Equal(n, (int)o6);
+        Assert.Equal(n, (int)o7);
+        Assert.Equal(n, (int)o8);
+        Assert.Equal(n, (int)o9);
+        Assert.Equal(n, (int)o10);
+        Assert.Equal(n, (int)o11);
+        Assert.Equal(n, (int)o12);
+
+        return result;
+    }
+
+    static async2 Task<int> Recursive2(int n)
+    {
+        Task<int> cTask = cs.Task;
+
+        // make some garbage
+        object o1 = n;
+
+        object o2 = n;
+        object o3 = n;
+        object o4 = n;
+        object o5 = n;
+        object o6 = n;
+        object o7 = n;
+        object o8 = n;
+        object o9 = n;
+        object o10 = n;
+        object o11 = n;
+        object o12 = n;
+
+        if (n == 0)
+            return await cTask;
+
+        var result = await Recursive2(n - 1);
+
+        Assert.Equal(n, (int)o1);
+        Assert.Equal(n, (int)o2);
+        Assert.Equal(n, (int)o3);
+        Assert.Equal(n, (int)o4);
+        Assert.Equal(n, (int)o5);
+        Assert.Equal(n, (int)o6);
+        Assert.Equal(n, (int)o7);
+        Assert.Equal(n, (int)o8);
+        Assert.Equal(n, (int)o9);
+        Assert.Equal(n, (int)o10);
+        Assert.Equal(n, (int)o11);
+        Assert.Equal(n, (int)o12);
+
+        return result;
+    }
+
+    static System.Collections.Generic.List<object> d = new System.Collections.Generic.List<object>();
+
+    public static int Main()
+    {
+        int numStacks = 10000;
+        int stackDepth = 100;
+#if DEBUG
+        int numGCs = 30;
+#else
+        int numGCs = 500;
+#endif
+
+        void Warmup()
+        {
+            for (int k = 0; k < 10000; k++)
+                d.Add(new int[k % 100]);
+
+            d = null;
+
+            for (int k = 0; k < 10; k++)
+            {
+                cs = new TaskCompletionSource<int>();
+                Task[] tasks = new Task[numStacks];
+                for (int i = 0; i < tasks.Length; i++)
+                {
+                    tasks[i] = Recursive1(stackDepth);
+                }
+
+                GC.Collect();
+                cs.SetResult(100);
+                Task.WaitAll(tasks);
+            }
+
+            {
+                cs = new TaskCompletionSource<int>();
+                Task[] tasks = new Task[numStacks];
+                for (int i = 0; i < tasks.Length; i++)
+                {
+                    tasks[i] = Recursive2(stackDepth);
+                }
+
+                GC.Collect();
+                cs.SetResult(100);
+                Task.WaitAll(tasks);
+            }
+        }
+
+        Warmup();
+
+        Console.WriteLine("async-1 ===================== ");
+        var ticks = Environment.TickCount;
+
+        // run a few iterations for 5 seconds total
+        while (Environment.TickCount - ticks < 5000)
+        {
+            cs = new TaskCompletionSource<int>();
+            Task[] tasks = new Task[numStacks];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Recursive1(stackDepth);
+            }
+
+            GC.Collect(0);
+
+            var ticksStart = Stopwatch.GetTimestamp();
+
+            for (int i = 0; i < numGCs; i++)
+            {
+                if (i % 10 == 0)
+                    Console.Write('.');
+
+                GC.Collect(0);
+            }
+
+            var info = GC.GetGCMemoryInfo();
+            Console.Write("memory Mbytes:" + info.HeapSizeBytes / 1000000 + "  ");
+            System.Console.WriteLine("Time per Gen0 GC (microseconds): " + (Stopwatch.GetTimestamp() - ticksStart) * 1000000 / numGCs / Stopwatch.Frequency);
+
+            cs.SetResult(100);
+            Task.WaitAll(tasks);
+        }
+
+        Console.WriteLine("async-2 ===================== ");
+        ticks = Environment.TickCount;
+
+        // run a few iterations for 5 seconds total
+        while (Environment.TickCount - ticks < 5000)
+        {
+            cs = new TaskCompletionSource<int>();
+            Task[] tasks = new Task[numStacks];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Recursive2(stackDepth);
+            }
+
+            GC.Collect(0);
+
+            var ticksStart = Stopwatch.GetTimestamp();
+
+            for (int i = 0; i < numGCs; i++)
+            {
+                if (i % 10 == 0)
+                    Console.Write('.');
+
+                GC.Collect(0);
+            }
+
+            var info = GC.GetGCMemoryInfo();
+            Console.Write("memory Mbytes:" + info.HeapSizeBytes / 1000000 + "  ");
+
+            System.Console.WriteLine("Time per Gen0 GC (microseconds): " + (Stopwatch.GetTimestamp() - ticksStart) * 1000000 / numGCs / Stopwatch.Frequency);
+
+            cs.SetResult(100);
+            Task.WaitAll(tasks);
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/async/gc-roots-scan.csproj
+++ b/src/tests/async/gc-roots-scan.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+   <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/implement.cs
+++ b/src/tests/async/implement.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Implement
+{
+    interface IBase1
+    {
+        public async2 Task<int> M1();
+    }
+
+    class Derived1 : IBase1
+    {
+        public async Task<int> M1()
+        {
+            await Task.Yield();
+            return 2;
+        }
+    }
+
+    class Derived1a : IBase1
+    {
+        public async2 Task<int> M1()
+        {
+            await Task.Yield();
+            return 3;
+        }
+    }
+
+    interface IBase2
+    {
+        public Task<int> M1();
+    }
+
+    class Derived2 : IBase2
+    {
+        public async2 Task<int> M1()
+        {
+            await Task.Yield();
+            return 12;
+        }
+    }
+
+    class Derived2a : IBase2
+    {
+        public async Task<int> M1()
+        {
+            await Task.Yield();
+            return 22;
+        }
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        IBase1 b1 = new Derived1();
+        Assert.Equal(2, b1.M1().Result);
+
+        b1 = new Derived1a();
+        Assert.Equal(3, b1.M1().Result);
+
+        IBase2 b2 = new Derived2();
+        Assert.Equal(12, b2.M1().Result);
+
+        b2 = new Derived2a();
+        Assert.Equal(22, b2.M1().Result);
+    }
+}

--- a/src/tests/async/implement.csproj
+++ b/src/tests/async/implement.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+   <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/mincallcost-microbench.cs
+++ b/src/tests/async/mincallcost-microbench.cs
@@ -1,0 +1,396 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//#define ASYNC1_TASK
+//#define ASYNC1_VALUETASK
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2MinCallCostMicrobench
+{
+    public static int Main()
+    {
+        Task.Run(AsyncEntry).Wait();
+
+        Console.WriteLine("Test Passed");
+        return 100;
+    }
+
+    public static async Task AsyncEntry()
+    {
+        if (!GCSettings.IsServerGC)
+            Console.WriteLine("*** Warning: Server GC is disabled, set DOTNET_gcServer=1 ***");
+
+        time = 0.5;
+
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 40; j++)
+            {
+                await RunBench("AsyncCallingAsync");
+                await RunBench("AsyncCallingValueTaskAsync");
+                await RunBench("AsyncCallingAsync2");
+                await RunBench("Async2CallingAsync");
+                await RunBench("Async2CallingValueTaskAsync");
+                await RunBench("Async2CallingAsync2");
+                await RunBench("Async2CallingAsync2NoInlining");
+                await RunBench("Async2CallingAsync2WithContextSave");
+                await RunBench("Sync2CallingSync");
+            }
+
+            // Make sure we tier up...
+            await Task.Delay(500);
+        }
+
+        Console.WriteLine("Warmup done, running benchmark");
+        printResult = true;
+        time = 1000;
+        await RunBench("AsyncCallingAsync");
+        await RunBench("AsyncCallingValueTaskAsync");
+        await RunBench("AsyncCallingAsync2");
+        await RunBench("Async2CallingAsync");
+        await RunBench("Async2CallingValueTaskAsync");
+        await RunBench("Async2CallingAsync2");
+        await RunBench("Async2CallingAsync2NoInlining");
+        await RunBench("Async2CallingAsync2WithContextSave");
+        await RunBench("Sync2CallingSync");
+    }
+
+    static double time = 10.0;
+    static bool printResult = false;
+    private static async Task RunBench(string type)
+    {
+        if (printResult)
+            Console.WriteLine($"Running benchmark on '{type}' methods");
+
+        List<long> results = new();
+        for (int i = 0; i < 16; i++)
+        {
+            long numIters = await Run(type);
+//            Console.WriteLine($"iters={numIters}");
+            results.Add(numIters);
+        }
+
+        results.Sort();
+        double avg = results.Skip(3).Take(10).Average();
+        if (printResult)
+            Console.WriteLine("Result = {0}", (long)avg);
+    }
+
+    private static async Task<long> Run(string type)
+    {
+        if (type == "AsyncCallingAsync")
+            return await AsyncCallingAsync();
+        if (type == "AsyncCallingValueTaskAsync")
+            return await AsyncCallingValueTaskAsync();
+        if (type == "AsyncCallingAsync2")
+            return await AsyncCallingAsync2();
+        if (type == "AsyncCallingYield")
+            return await AsyncCallingYield();
+        if (type == "Async2CallingAsync")
+            return await Async2CallingAsync();
+        if (type == "Async2CallingValueTaskAsync")
+            return await Async2CallingValueTaskAsync();
+        if (type == "Async2CallingAsync2")
+            return await Async2CallingAsync2();
+        if (type == "Async2CallingAsync2NoInlining")
+            return await Async2CallingAsync2NoInlining();
+        if (type == "Async2CallingYield")
+            return await Async2CallingYield();
+        if (type == "Sync2CallingSync")
+            return Sync2CallingSync();
+        if (type == "Async2CallingAsync2WithContextSave")
+            return await Async2CallingAsync2WithContextSave();
+
+        return 0;
+    }
+#pragma warning disable CS1998
+
+    private static async Task<long> AsyncCallingAsync()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await EmptyAsync();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static async Task<long> AsyncCallingValueTaskAsync()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await EmptyValueTaskAsync();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static async Task<long> AsyncCallingAsync2()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await EmptyAsync2();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static async2 Task<long> Async2CallingAsync()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await EmptyAsync();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static async2 Task<long> Async2CallingValueTaskAsync()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await EmptyValueTaskAsync();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static async2 Task<long> Async2CallingAsync2()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await EmptyAsync2();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static async2 Task<long> Async2CallingAsync2NoInlining()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await EmptyAsync2NoInlining();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static async2 Task<long> Async2CallingAsync2WithContextSave()
+    {
+        FakeThread thread = CurrentThread;
+        if (thread == null)
+        {
+            CurrentThread = new FakeThread();
+            thread = CurrentThread;
+        }
+
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await EmptyAsync2WithContextSave();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    public class FakeSyncContext {}
+    public class FakeExecContext
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void RestoreChangedContextToThread(FakeThread thread, FakeExecContext execContext, FakeExecContext newExecContext)
+        {
+        }
+    }
+    public class FakeThread
+    {
+        public FakeSyncContext _syncContext;
+        public FakeExecContext _execContext;
+    }
+    [ThreadStatic]
+    public static FakeThread CurrentThread;
+
+
+    private static async Task<long> AsyncCallingYield()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await Task.Yield();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static async2 Task<long> Async2CallingYield()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await Task.Yield();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static long Sync2CallingSync()
+    {
+        Stopwatch timer = Stopwatch.StartNew();
+
+        long numIters = 0;
+
+        while (timer.ElapsedMilliseconds < time)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                EmptyMethod();
+            }
+            numIters++;
+        }
+        return numIters * 10;
+    }
+
+    private static async Task EmptyAsync()
+    {
+        // Add some work that forces the method to be a real async method
+        if (time == 0)
+            await Task.Yield();
+        return;
+    }
+
+    private static async ValueTask EmptyValueTaskAsync()
+    {
+        // Add some work that forces the method to be a real async method
+        if (time == 0)
+            await Task.Yield();
+        return;
+    }
+
+    private static async2 Task EmptyAsync2()
+    {
+        // Add some work that forces the method to be a real async method
+        if (time == 0)
+            await Task.Yield();
+        return;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task EmptyAsync2NoInlining()
+    {
+        // Add some work that forces the method to be a real async method
+        if (time == 0)
+            await Task.Yield();
+        return;
+    }
+
+    // This simulates async2 capturing the same amount of state that existing async needs to capture to handle the current semantics around async locals and synchronizationcontext
+    private static async2 Task EmptyAsync2WithContextSave()
+    {
+        FakeThread thread = CurrentThread;
+        FakeExecContext? previousExecutionCtx = thread._execContext;
+        FakeSyncContext? previousSyncCtx = thread._syncContext;
+
+        try
+        {
+            // Add some work that forces the method to be a real async method
+            if (time == 0)
+                await Task.Yield();
+        }
+        finally
+        {
+            // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
+            if (previousSyncCtx != thread._syncContext)
+            {
+                // Restore changed SynchronizationContext back to previous
+                thread._syncContext = previousSyncCtx;
+            }
+
+            FakeExecContext? currentExecutionCtx = thread._execContext;
+            if (previousExecutionCtx != currentExecutionCtx)
+            {
+                FakeExecContext.RestoreChangedContextToThread(thread, previousExecutionCtx, currentExecutionCtx);
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void EmptyMethod()
+    {
+        return;
+    }
+}

--- a/src/tests/async/mincallcost-microbench.csproj
+++ b/src/tests/async/mincallcost-microbench.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/object.cs
+++ b/src/tests/async/object.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Object
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return (int)AsyncTestEntryPoint(100).Result;
+    }
+
+    private static async Task<object> AsyncTestEntryPoint(int arg)
+    {
+        return await ObjMethod(arg);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task<object> ObjMethod(int arg)
+    {
+        await Task.Yield();
+        return arg;
+    }
+}

--- a/src/tests/async/object.csproj
+++ b/src/tests/async/object.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/objects-captured.cs
+++ b/src/tests/async/objects-captured.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class Async2ObjectsWithYields
+{
+    internal static async2 Task<int> A(object n)
+    {
+        // use string equality so that JIT would not think of hoisting "(int)n"
+        // also to produce some amout of garbage
+        if (n.ToString() != 0.ToString())
+        {
+            return await A((int)n - 1) + (int)n;
+        }
+
+        await Task.Yield();
+        return 0;
+    }
+
+    private static async Task<int> AsyncEntry()
+    {
+        object result = 0;
+        for (int i = 0; i < 20; i++)
+        {
+            var tsk = A(i);
+            await Task.Yield();
+            GC.Collect();
+            result = await tsk;
+        }
+
+        // the result should be 20 * (20 - 1) => 190
+        return (int)result - 90;
+    }
+
+    [Fact]
+    public static int Test()
+    {
+        return (int)AsyncEntry().Result;
+    }
+}

--- a/src/tests/async/objects-captured.csproj
+++ b/src/tests/async/objects-captured.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/override.cs
+++ b/src/tests/async/override.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Override
+{
+    class Base
+    {
+        public virtual async2 Task<int> M1()
+        {
+            await Task.Yield();
+            return 1;
+        }
+    }
+
+    class Derived1 : Base
+    {
+        public override async Task<int> M1()
+        {
+            await Task.Yield();
+            return 2;
+        }
+    }
+
+    class Derived2 : Derived1
+    {
+        public override async2 Task<int> M1()
+        {
+            await Task.Yield();
+            return 3;
+        }
+    }
+
+
+    class Base1
+    {
+        public virtual async Task<int> M1()
+        {
+            await Task.Yield();
+            return 11;
+        }
+    }
+
+    class Derived11 : Base1
+    {
+        public override async2 Task<int> M1()
+        {
+            await Task.Yield();
+            return 12;
+        }
+    }
+
+    class Derived12 : Derived11
+    {
+        public override async Task<int> M1()
+        {
+            await Task.Yield();
+            return 13;
+        }
+    }
+
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Base b = new Derived1();
+        Assert.Equal(2, b.M1().Result);
+
+        b = new Derived2();
+        Assert.Equal(3, b.M1().Result);
+
+        Derived1 d = new Derived2();
+        Assert.Equal(3, d.M1().Result);
+
+
+        Base1 b1 = new Derived11();
+        Assert.Equal(12, b1.M1().Result);
+
+        b1 = new Derived12();
+        Assert.Equal(13, b1.M1().Result);
+
+        Derived11 d1 = new Derived12();
+        Assert.Equal(13, d1.M1().Result);
+
+    }
+}

--- a/src/tests/async/override.csproj
+++ b/src/tests/async/override.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/pgo.cs
+++ b/src/tests/async/pgo.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Pgo
+{
+    [Fact]
+    public static void EntryPoint()
+    {
+        AsyncEntryPoint().Wait();
+    }
+
+    internal static async2 Task<int> AsyncEntryPoint()
+    {
+        int[] arr = Enumerable.Range(0, 100_000).ToArray();
+
+        int sum = 0;
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 100; j++)
+                sum += await AggregateDelegateAsync(arr, new AggregateSum(), 0);
+
+            await Task.Delay(100);
+        }
+
+        return sum;
+    }
+
+    private class AggregateSum : I<int>
+    {
+#pragma warning disable CS1998
+        public async2 Task<int> Aggregate(int a, int b) => a + b;
+    }
+    
+    public interface I<T>
+    {
+        public Task<T> Aggregate(T seed, T val);
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async2 Task<T> AggregateDelegateAsync<T>(T[] arr, I<T> aggregate, T seed)
+    {
+        foreach (T val in arr)
+            seed = await aggregate.Aggregate(seed, val);
+            
+        return seed;
+    }
+}

--- a/src/tests/async/pgo.csproj
+++ b/src/tests/async/pgo.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/pinvoke.cs
+++ b/src/tests/async/pinvoke.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2PInvoke
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        AsyncEntryPoint().Wait();
+    }
+
+    private static async2 Task AsyncEntryPoint()
+    {
+        unsafe
+        {
+            Assert.Equal(5, GetFPtr()());
+        }
+
+        await Task.Yield();
+
+        unsafe
+        {
+            Assert.Equal(5, GetFPtr()());
+        }
+
+        await Task.Yield();
+
+        unsafe
+        {
+            Assert.Equal(5, GetFPtr()());
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static unsafe delegate* unmanaged<int> GetFPtr() => &GetValue;
+
+    [UnmanagedCallersOnly]
+    private static int GetValue() => 5;
+}

--- a/src/tests/async/pinvoke.csproj
+++ b/src/tests/async/pinvoke.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/returns.cs
+++ b/src/tests/async/returns.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Returns
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Returns(new C()).Wait();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task Returns(C c)
+    {
+        for (int i = 0; i < 20000; i++)
+        {
+            S<long> val = await ReturnsStruct();
+
+            AssertEqual(42, val.A);
+            AssertEqual(4242, val.B);
+            AssertEqual(424242, val.C);
+            AssertEqual(42424242, val.D);
+
+            c.Val = default;
+            c.Val = await ReturnsStruct();
+
+            AssertEqual(42, c.Val.A);
+            AssertEqual(4242, c.Val.B);
+            AssertEqual(424242, c.Val.C);
+            AssertEqual(42424242, c.Val.D);
+
+            S<string> strings = await ReturnsStructGC();
+            AssertEqual("A", strings.A);
+            AssertEqual("B", strings.B);
+            AssertEqual("C", strings.C);
+            AssertEqual("D", strings.D);
+
+            S<byte> bytes = await ReturnsBytes();
+            AssertEqual(4, bytes.A);
+            AssertEqual(40, bytes.B);
+            AssertEqual(42, bytes.C);
+            AssertEqual(45, bytes.D);
+
+            string str = await ReturnsString();
+            AssertEqual("a string!", str);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AssertEqual<T>(T expected, T actual)
+    {
+        Assert.Equal(expected, actual);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task<S<long>> ReturnsStruct()
+    {
+        await Task.Yield();
+        return new S<long> { A = 42, B = 4242, C = 424242, D = 42424242 };
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task<S<string>> ReturnsStructGC()
+    {
+        await Task.Yield();
+        return new S<string> { A = "A", B = "B", C = "C", D = "D" };
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task<S<byte>> ReturnsBytes()
+    {
+        await Task.Yield();
+        return new S<byte> { A = 4, B = 40, C = 42, D = 45 };
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task<string> ReturnsString()
+    {
+        await Task.Yield();
+        return "a string!";
+    }
+
+    private struct S<T> { public T A, B, C, D; }
+
+    private class C { public S<long> Val; }
+}

--- a/src/tests/async/returns.csproj
+++ b/src/tests/async/returns.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/shared-generic.cs
+++ b/src/tests/async/shared-generic.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+public class Async2SharedGeneric
+{
+    public struct S0
+    {
+        public object _o;
+        public S0(object o) => _o = o;
+    }
+
+    public struct S1<T>
+    {
+        public T t;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        // simple cases
+        Async1EntryPoint<int>(typeof(int), 42).Wait();
+        Async1EntryPoint<string>(typeof(string), "abc").Wait();
+        Async1EntryPoint<object>(typeof(object), "def").Wait();
+
+        // struct with an obj and its nullable
+        Async1EntryPoint<S0>(typeof(S0), new S0(42)).Wait();
+        Async1EntryPoint<S0?>(typeof(S0?), new S0(42)).Wait();
+        Async1EntryPoint<S0?>(typeof(S0?), null).Wait();
+
+        // generic struct with an obj and its nullable
+        Async1EntryPoint<S1<string>>(typeof(S1<string>), new S1<string> { t = "ghj" }).Wait();
+        Async1EntryPoint<S1<string>?>(typeof(S1<string>?), new S1<string> { t = "qwe" }).Wait();
+        Async1EntryPoint<S1<string>?>(typeof(S1<string>?), null).Wait();
+
+        // simple cases
+        Async2EntryPoint<int>(typeof(int), 142).Wait();
+        Async2EntryPoint<string>(typeof(string), "ghi").Wait();
+        Async2EntryPoint<object>(typeof(object), "jkl").Wait();
+
+        // struct with an obj and its nullable
+        Async2EntryPoint<S0>(typeof(S0), new S0(4242)).Wait();
+        Async2EntryPoint<S0?>(typeof(S0?), new S0(424242)).Wait();
+        Async2EntryPoint<S0?>(typeof(S0?), null).Wait();
+
+        // generic struct with an obj and its nullable
+        Async2EntryPoint<S1<string>>(typeof(S1<string>), new S1<string> { t = "kl" }).Wait();
+        Async2EntryPoint<S1<string>?>(typeof(S1<string>?), new S1<string> { t = "zx" }).Wait();
+        Async2EntryPoint<S1<string>?>(typeof(S1<string>?), null).Wait();
+    }
+
+    private static async Task Async1EntryPoint<T>(Type t, T value)
+    {
+        await new GenericClass<T>().InstanceMethod(t);
+        await GenericClass<T>.StaticMethod(t);
+        await GenericClass<T>.StaticMethod<T>(t, t);
+        await GenericClass<T>.StaticMethodAsync1(t);
+        await GenericClass<T>.StaticMethodAsync1<T>(t, t);
+        Assert.Equal(value, value); // make sure we can compare value
+        Assert.Equal(value, await GenericClass<T>.StaticReturnClassType(value));
+        Assert.Equal(value, await GenericClass<T>.StaticReturnMethodType<T>(value));
+        Assert.Equal(value, await GenericClass<T>.StaticReturnClassTypeAsync1(value));
+        Assert.Equal(value, await GenericClass<T>.StaticReturnMethodTypeAsync1<T>(value));
+    }
+
+    private static async2 Task Async2EntryPoint<T>(Type t, T value)
+    {
+        await new GenericClass<T>().InstanceMethod(t);
+        await GenericClass<T>.StaticMethod(t);
+        await GenericClass<T>.StaticMethod<T>(t, t);
+        await GenericClass<T>.StaticMethodAsync1(t);
+        await GenericClass<T>.StaticMethodAsync1<T>(t, t);
+        Assert.Equal(value, value); // make sure we can compare value
+        Assert.Equal(value, await GenericClass<T>.StaticReturnClassType(value));
+        Assert.Equal(value, await GenericClass<T>.StaticReturnMethodType<T>(value));
+        Assert.Equal(value, await GenericClass<T>.StaticReturnClassTypeAsync1(value));
+        Assert.Equal(value, await GenericClass<T>.StaticReturnMethodTypeAsync1<T>(value));
+    }
+}
+
+public class GenericClass<T>
+{
+    // 'this' is context
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public async2 Task InstanceMethod(Type t)
+    {
+        Assert.Equal(typeof(T), t);
+        await Task.Yield();
+        Assert.Equal(typeof(T), t);
+    }
+
+    // Class context
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async2 Task StaticMethod(Type t)
+    {
+        Assert.Equal(typeof(T), t);
+        await Task.Yield();
+        Assert.Equal(typeof(T), t);
+    }
+
+    // Method context
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async2 Task StaticMethod<TM>(Type t, Type tm)
+    {
+        Assert.Equal(typeof(T), t);
+        Assert.Equal(typeof(TM), tm);
+        await Task.Yield();
+        Assert.Equal(typeof(T), t);
+        Assert.Equal(typeof(TM), tm);
+    }
+
+    // Class context
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task StaticMethodAsync1(Type t)
+    {
+        Assert.Equal(typeof(T), t);
+        await Task.Yield();
+        Assert.Equal(typeof(T), t);
+    }
+
+    // Method context
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task StaticMethodAsync1<TM>(Type t, Type tm)
+    {
+        Assert.Equal(typeof(T), t);
+        Assert.Equal(typeof(TM), tm);
+        await Task.Yield();
+        Assert.Equal(typeof(T), t);
+        Assert.Equal(typeof(TM), tm);
+    }
+
+    public static async2 Task<T> StaticReturnClassType(T value)
+    {
+        await Task.Yield();
+        return value;
+    }
+
+    public static async2 Task<TM> StaticReturnMethodType<TM>(TM value)
+    {
+        await Task.Yield();
+        return value;
+    }
+
+    public static async Task<T> StaticReturnClassTypeAsync1(T value)
+    {
+        await Task.Yield();
+        return value;
+    }
+
+    public static async Task<TM> StaticReturnMethodTypeAsync1<TM>(TM value)
+    {
+        await Task.Yield();
+        return value;
+    }
+}

--- a/src/tests/async/shared-generic.csproj
+++ b/src/tests/async/shared-generic.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/simple-eh.cs
+++ b/src/tests/async/simple-eh.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2SimpleEH
+{
+    [Fact]
+    public static void Test()
+    {
+        Task.Run(AsyncEntry).Wait();
+    }
+
+    public static async Task AsyncEntry()
+    {
+        int result = await Handler();
+        Assert.Equal(42, result);
+    }
+
+    public static async2 Task<int> Handler()
+    {
+        try
+        {
+            return await Throw(42);
+        }
+        catch (IntegerException ex)
+        {
+            return ex.Value;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async2 Task<int> Throw(int value)
+    {
+        await Task.Yield();
+        throw new IntegerException(value);
+    }
+
+    public class IntegerException : Exception
+    {
+        public int Value;
+        public IntegerException(int value) => Value = value;
+    }
+}

--- a/src/tests/async/simple-eh.csproj
+++ b/src/tests/async/simple-eh.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/small.cs
+++ b/src/tests/async/small.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Small
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        SmallType(123).Wait();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task SmallType(byte arg)
+    {
+        await Task.Yield();
+        Assert.Equal(123, arg);
+    }
+}

--- a/src/tests/async/small.csproj
+++ b/src/tests/async/small.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/struct.cs
+++ b/src/tests/async/struct.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable 1998
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Struct
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Async().Wait();
+        Async2().Wait();
+    }
+
+    private static async Task Async()
+    {
+        S s = new S(100);
+        await s.Test();
+        AssertEqual(100, s.Value);
+    }
+
+    private static async2 Task Async2()
+    {
+        S s = new S(100);
+        await s.Test();
+        AssertEqual(100, s.Value);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AssertEqual(int expected, int val)
+    {
+        Assert.Equal(expected, val);
+    }
+
+    private struct S
+    {
+        public int Value;
+
+        public S(int value) => Value = value;
+
+        public async2 Task Test()
+        {
+            // TODO: C# compiler is expected to do this, but not in the prototype.
+            S @this = this;
+
+            AssertEqual(100, @this.Value);
+            @this.Value++;
+            await @this.InstanceCall();
+            AssertEqual(101, @this.Value);
+
+            await @this.TaskButNotAsync();
+            AssertEqual(102, @this.Value);
+        }
+
+        private async2 Task InstanceCall()
+        {
+            // TODO: C# compiler is expected to do this, but not in the prototype.
+            S @this = this;
+
+            AssertEqual(101, @this.Value);
+            @this.Value++;
+            AssertEqual(102, @this.Value);
+            await Task.Yield();
+            AssertEqual(102, @this.Value);
+        }
+
+        private Task TaskButNotAsync()
+        {
+            AssertEqual(101, Value);
+            Value++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/tests/async/struct.csproj
+++ b/src/tests/async/struct.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/syncfibonacci-without-yields.cs
+++ b/src/tests/async/syncfibonacci-without-yields.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class SyncFibonacci
+{
+    const int iterations = 3;
+    const bool doYields = false;
+
+    public static int Main()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        Entry();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+
+        return 100;
+    }
+
+    public static void Entry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            int result = Fib(25);
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
+        }
+    }
+
+    static int Fib(int i)
+    {
+        if (i <= 1)
+        {
+            return 1;
+        }
+
+        int i1 = Fib(i - 1);
+        int i2 = Fib(i - 2);
+
+        return i1 + i2;
+    }
+}

--- a/src/tests/async/syncfibonacci-without-yields.csproj
+++ b/src/tests/async/syncfibonacci-without-yields.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/taskbased-asyncfibonacci-with-yields.cs
+++ b/src/tests/async/taskbased-asyncfibonacci-with-yields.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class TaskBasedAsyncFibonacciWithYields
+{
+    const int iterations = 3;
+    const bool doYields = true;
+
+    public static int Main()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        AsyncEntry().GetAwaiter().GetResult();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+
+        return 100;
+    }
+
+    public static async Task AsyncEntry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            int result = await Fib(25);
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
+        }
+    }
+
+    static async Task<int> Fib(int i)
+    {
+        if (i <= 1)
+        {
+            if (doYields)
+            {
+                await Task.Yield();
+            }
+
+            return 1;
+        }
+
+        int i1 = await Fib(i - 1);
+        int i2 = await Fib(i - 2);
+
+        return i1 + i2;
+    }
+}

--- a/src/tests/async/taskbased-asyncfibonacci-with-yields.csproj
+++ b/src/tests/async/taskbased-asyncfibonacci-with-yields.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/taskbased-asyncfibonacci-without-yields.cs
+++ b/src/tests/async/taskbased-asyncfibonacci-without-yields.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class TaskBasedAsyncFibonacciWithoutYields
+{
+    const int iterations = 3;
+    const bool doYields = false;
+
+    public static int Main()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        AsyncEntry().GetAwaiter().GetResult();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+
+        return 100;
+    }
+
+    public static async Task AsyncEntry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            int result = await Fib(25);
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
+        }
+    }
+
+    static async Task<int> Fib(int i)
+    {
+        if (i <= 1)
+        {
+            if (doYields)
+            {
+                await Task.Yield();
+            }
+
+            return 1;
+        }
+
+        int i1 = await Fib(i - 1);
+        int i2 = await Fib(i - 2);
+
+        return i1 + i2;
+    }
+}

--- a/src/tests/async/taskbased-asyncfibonacci-without-yields.csproj
+++ b/src/tests/async/taskbased-asyncfibonacci-without-yields.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/valuetask.cs
+++ b/src/tests/async/valuetask.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2valuetask
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return (int)AsyncTestEntryPoint(100).Result;
+    }
+
+    private static ValueTask<int> AsyncTestEntryPoint(int arg)
+    {
+        return M1(arg);
+    }
+
+    private static async2 ValueTask<int> M1(int arg)
+    {
+        await Task.Yield();
+        return arg;
+    }
+}

--- a/src/tests/async/valuetask.csproj
+++ b/src/tests/async/valuetask.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/valuetaskbased-asyncfibonacci-with-yields.cs
+++ b/src/tests/async/valuetaskbased-asyncfibonacci-with-yields.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class TaskBasedAsyncFibonacciWithYields
+{
+    const int iterations = 3;
+    const bool doYields = true;
+
+    public static int Main()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        AsyncEntry().GetAwaiter().GetResult();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+
+        return 100;
+    }
+
+    public static async ValueTask AsyncEntry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            int result = await Fib(25);
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
+        }
+    }
+
+    static async ValueTask<int> Fib(int i)
+    {
+        if (i <= 1)
+        {
+            if (doYields)
+            {
+                await Task.Yield();
+            }
+
+            return 1;
+        }
+
+        int i1 = await Fib(i - 1);
+        int i2 = await Fib(i - 2);
+
+        return i1 + i2;
+    }
+}

--- a/src/tests/async/valuetaskbased-asyncfibonacci-with-yields.csproj
+++ b/src/tests/async/valuetaskbased-asyncfibonacci-with-yields.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/valuetaskbased-asyncfibonacci-without-yields.cs
+++ b/src/tests/async/valuetaskbased-asyncfibonacci-without-yields.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class TaskBasedAsyncFibonacciWithoutYields
+{
+    const int iterations = 3;
+    const bool doYields = false;
+
+    public static int Main()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        AsyncEntry().GetAwaiter().GetResult();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+
+        return 100;
+    }
+
+    public static async ValueTask AsyncEntry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            int result = await Fib(25);
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
+        }
+    }
+
+    static async ValueTask<int> Fib(int i)
+    {
+        if (i <= 1)
+        {
+            if (doYields)
+            {
+                await Task.Yield();
+            }
+
+            return 1;
+        }
+
+        int i1 = await Fib(i - 1);
+        int i2 = await Fib(i - 2);
+
+        return i1 + i2;
+    }
+}

--- a/src/tests/async/valuetaskbased-asyncfibonacci-without-yields.csproj
+++ b/src/tests/async/valuetaskbased-asyncfibonacci-without-yields.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/varying-yields-task.csproj
+++ b/src/tests/async/varying-yields-task.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DefineConstants>ASYNC1_TASK;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="varying-yields.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/varying-yields-valuetask.csproj
+++ b/src/tests/async/varying-yields-valuetask.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DefineConstants>ASYNC1_VALUETASK;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="varying-yields.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/varying-yields.cs
+++ b/src/tests/async/varying-yields.cs
@@ -1,0 +1,216 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//#define ASYNC1_TASK
+//#define ASYNC1_VALUETASK
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2VaryingYields
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Task.Run(AsyncEntry).Wait();
+    }
+
+    public static async Task AsyncEntry()
+    {
+        if (!GCSettings.IsServerGC)
+            Console.WriteLine("*** Warning: Server GC is disabled, set DOTNET_gcServer=1 ***");
+
+        string[] args = Environment.GetCommandLineArgs();
+        int depth = args.Length > 1 ? int.Parse(args[1]) : 0;
+        Console.WriteLine("Using depth = {0}", depth);
+
+        // Yield on average every X iterations.
+        int yieldFrequency = args.Length > 2 ? int.Parse(args[2]) : 1;
+        Console.WriteLine("Using yield frequency = {0}", yieldFrequency);
+
+        Benchmark warmupBm = new Benchmark(0.0001);
+        warmupBm.Warmup = true;
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 40; j++)
+            {
+                await warmupBm.Run(0);
+            }
+
+            // Make sure we tier up...
+            await Task.Delay(500);
+        }
+
+        Console.WriteLine("Warmup done, running benchmark");
+
+        Benchmark bm = new(yieldFrequency == 0 ? 0 : (1 / (double)yieldFrequency));
+
+        List<long> results = new();
+        for (int i = 0; i < 16; i++)
+        {
+            bm.NumYields = 0;
+            long numIters = await bm.Run(depth);
+            Console.WriteLine($"iters={numIters} suspensions={bm.NumYields}");
+            results.Add(numIters);
+        }
+
+        results.Sort();
+        double avg = results.Skip(3).Take(10).Average();
+        Console.WriteLine("Result = {0}", (long)avg);
+    }
+
+    private class Benchmark
+    {
+        private readonly Random _rand = new();
+        private readonly double _yieldProbability;
+        public ulong NumYields;
+        public int Sink;
+        public bool Warmup;
+
+        public Benchmark(double yieldProbability) => _yieldProbability = yieldProbability;
+
+public
+#if ASYNC1_TASK
+        async Task<long>
+#elif ASYNC1_VALUETASK
+        async ValueTask<long>
+#else
+        async2 Task<long>
+#endif
+        Run(int depth)
+        {
+            int liveState1 = depth * 3 + (int)(1 / _yieldProbability);
+            int liveState2 = depth;
+            double liveState3 = _yieldProbability;
+
+            if (depth == 0)
+                return await Loop();
+
+            long result = await Run(depth - 1);
+            Sink = (int)liveState1 + (int)liveState2 + (int)(1 / liveState3) + depth;
+            return result;
+        }
+
+private
+#if ASYNC1_TASK
+        async Task<long>
+#elif ASYNC1_VALUETASK
+        async ValueTask<long>
+#else
+        async2 Task<long>
+#endif
+        Loop()
+        {
+            int time = Warmup ? 5 : 500;
+
+            Stopwatch timer = Stopwatch.StartNew();
+
+            long numIters = 0;
+            while (timer.ElapsedMilliseconds < time)
+            {
+                for (int i = 0; i < 20; i++)
+                {
+                    numIters += await DoYields();
+                }
+            }
+
+            return numIters;
+        }
+
+private
+#if ASYNC1_TASK
+        async Task<int>
+#elif ASYNC1_VALUETASK
+        async ValueTask<int>
+#else
+        async2 Task<int>
+#endif
+        DoYields()
+        {
+            int numIters = 0;
+
+            if (_rand.NextDouble() < _yieldProbability)
+            {
+                if (s_useDirectYield)
+                    await new DirectYieldAwaitable(NumYields);
+                else
+                    await Task.Yield();
+
+                NumYields++;
+            }
+
+            numIters++;
+
+            if (_rand.NextDouble() < _yieldProbability)
+            {
+                if (s_useDirectYield)
+                    await new DirectYieldAwaitable(NumYields);
+                else
+                    await Task.Yield();
+
+                NumYields++;
+            }
+
+            numIters++;
+
+            if (_rand.NextDouble() < _yieldProbability)
+            {
+                if (s_useDirectYield)
+                    await new DirectYieldAwaitable(NumYields);
+                else
+                    await Task.Yield();
+
+                NumYields++;
+            }
+
+            numIters++;
+            return numIters;
+        }
+
+        private static readonly bool s_useDirectYield = Environment.GetCommandLineArgs().Contains("--use-direct-yield");
+
+        private struct DirectYieldAwaitable
+        {
+            private readonly ulong _numYields;
+
+            public DirectYieldAwaitable(ulong numYields) => _numYields = numYields;
+
+            public DirectYieldAwaiter GetAwaiter() => new DirectYieldAwaiter(_numYields);
+
+            public struct DirectYieldAwaiter : ICriticalNotifyCompletion
+            {
+                private readonly ulong _numYields;
+
+                public DirectYieldAwaiter(ulong numYields) => _numYields = numYields;
+
+                public bool IsCompleted => false;
+
+                public void OnCompleted(Action continuation)
+                {
+                    if (_numYields % 512 == 0)
+                        ThreadPool.UnsafeQueueUserWorkItem(static act => act(), continuation, true);
+                    else
+                        continuation();
+                }
+
+                public void UnsafeOnCompleted(Action continuation)
+                {
+                    if (_numYields % 512 == 0)
+                        ThreadPool.UnsafeQueueUserWorkItem(static act => act(), continuation, true);
+                    else
+                        continuation();
+                }
+
+                public void GetResult() { }
+            }
+        }
+
+    }
+}

--- a/src/tests/async/varying-yields.csproj
+++ b/src/tests/async/varying-yields.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/void.cs
+++ b/src/tests/async/void.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Void
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        int[] arr = new int[1];
+        AsyncTestEntryPoint(arr, 0).Wait();
+        Assert.Equal(199_990_000, arr[0]);
+    }
+
+    private static async Task AsyncTestEntryPoint(int[] arr, int index)
+    {
+        await HoistedByref(arr, index);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task HoistedByref(int[] arr, int index)
+    {
+        for (int i = 0; i < 20000; i++)
+        {
+            arr[index] += i;
+            await Task.Yield();
+        }
+    }
+}

--- a/src/tests/async/void.csproj
+++ b/src/tests/async/void.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/with-yields.cs
+++ b/src/tests/async/with-yields.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class Async2FibonacceWithYields
+{
+    internal static async2 Task<int> B(int n)
+    {
+        int num = 1;
+        await Task.Yield();
+
+        num *= 10;
+        await Task.Yield();
+
+        num *= 10;
+        await Task.Yield();
+
+        return num;
+    }
+
+    internal static async2 Task<int> A(int n)
+    {
+        int num = n;
+        for (int num2 = 0; num2 < n; num2++)
+        {
+            num = await B(num);
+        }
+
+        return num;
+    }
+
+    private static async Task<int> AsyncEntry()
+    {
+        int result = 0;
+        for (int i = 0; i < 10; i++)
+        {
+            result = await A(100);
+        }
+
+        return result;
+    }
+
+    [Fact]
+    public static int Test()
+    {
+        return AsyncEntry().Result;
+    }
+}

--- a/src/tests/async/with-yields.csproj
+++ b/src/tests/async/with-yields.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/without-yields.cs
+++ b/src/tests/async/without-yields.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class Async2FibonacceWithoutYields
+{
+    //This async method lacks 'await'
+#pragma warning disable 1998
+
+    internal static async2 Task<int> B(int n)
+    {
+        return 100;
+    }
+
+    internal static async2 Task<int> A(int n)
+    {
+        int num = n;
+        for (int num2 = 0; num2 < n; num2++)
+        {
+            num = await B(num);
+        }
+
+        return num;
+    }
+
+    private static async Task<int> AsyncEntry()
+    {
+        int result = 0;
+        for (int i = 0; i < 10; i++)
+        {
+            result = await A(100);
+        }
+
+        return result;
+    }
+
+    [Fact]
+    public static int Test()
+    {
+        return AsyncEntry().Result;
+    }
+}

--- a/src/tests/async/without-yields.csproj
+++ b/src/tests/async/without-yields.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This is a test-only change.

- The tests are currently disabled. 
The easiest way to enable is by removing `src\tests\async\Directory.Build.targets`, but the build will need to use experimental compiler that understands `async2` syntax.
- Benchmarks are included. 
We may still need them in the near future. Will remove later. 
- The tests use the old `async2` syntax as in the experiment. 
We will have to adjust the syntax once switching to the actual Roslyn prototype compiler with runtime async support. 

(see syntax switch Draft PR for details - https://github.com/dotnet/runtimelab/pull/3062)