### PR TITLE
Improve Math.BigMul to fix Decimal compare perf regression

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -182,7 +182,7 @@ namespace System
         {
             if (Bmi2.X64.IsSupported)
             {
-                // Ideally, we should do a single multiply for low and high. Doing this efficiently would mean making BigMul an instrinct (would work on all x64 targets) or fixing https://github.com/dotnet/runtime/issues/11782
+                // Ideally, we should do a single multiply for low and high. Doing this efficiently would mean making BigMul an intrinsic (would work on all x64 targets) or fixing https://github.com/dotnet/runtime/issues/11782
                 low = a * b;
                 return Bmi2.X64.MultiplyNoFlags(a, b);
             }
@@ -211,7 +211,7 @@ namespace System
         {
             if (Bmi2.X64.IsSupported)
             {
-                // Ideally, we should do a single multiply for low and high. Doing this efficiently would mean making BigMul an instrinct (would work on all x64 targets) or fixing https://github.com/dotnet/runtime/issues/11782
+                // Ideally, we should do a single multiply for low and high. Doing this efficiently would mean making BigMul an intrinsic (would work on all x64 targets) or fixing https://github.com/dotnet/runtime/issues/11782
                 low = a * b;
                 return Bmi2.X64.MultiplyNoFlags(a, b);
             }


### PR DESCRIPTION
Improve the worst case performance of Math.BigMul which will hopefully resolve #112432 (regression i Decimal comparision)
This also allows Math.BigMul to do partial constant propagation (of the low part) 
 
The regression seems to be caused by extra stack spilling caused by usage of MultiplyNoFlags


This PR applies the workaround suggested by @tevador in https://github.com/dotnet/runtime/issues/11782#issuecomment-2174501863 (se link for benchmarks) to Math.BigMul, which removes the extra push/pop which will hopefully restore performance.

See [sharplab.io](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgCUBXAOwwEt8YLAMIR8AB14AbGFADKMgG68wMXAG4a9Jq049+ggJI8ovLrmW4WAQSj4NtRs3bc+AlkYwmzFlgA0AHEj2mgDMDGLYUHzYkgy4nhxgGAwAIjBg/DGkNADeNACQAPSFDLK8AOZcDPh4ANYMAGbQDBgAFjCNktjluI28MJIAJiwMVgwKMRwdEA0MAF4yEAymLa28vcC8yaaDytgYqgzYBcXhEOZ8Ch1pGTWxE5JTaEdcg0fjk9OzEFwdK23rBibbavPYHXrHahFEq/cr7XhXVLpTL3T4sE6FDEMAAyEAg9X2DAA8tIrBwMAByXopACiQgMAFkrNiAPoAORpAHEGJAzBhsDwWkswO0wPUmlAGLD4YiHlNcFiVlwZR1IINBAUxCYJgceT94stBWVKgy6gwALwMbgi9K1GCDAAUDtMGAAlHQEP46N6fXRXcEoadZGAYh0arhxc02h0Gl0en0BsMGAAVNYbACeuv+7U63V6DX6Qz1PGwpgVgZK0bOAHcZAwZgxyIwMEtdkp1atrsi7h9Hh1gOmRqmOrgQ9IgZmwxx4ljefyVthe1MgTAMLWYFVGAK3qR/IawI9zFd0VCtQj9qr9SDksHQ6aIxaGB7vQAxF++gPQhhsjj4YB1htgV6UdQ2WYC1gaA43gHE98jPHVLz5Q0bzHGBZAg5JLXIIIaE1bUL2LA0XVSOkWVkIRmRpFkmV8R9d0/eCCN5A0OGI5MN2TCAAAUIFrKA2VMDosN9ET7Dg/DdWY5IOEkH5yhTDjuN4mQaQqVoDg3R8mxEnSdM/U5h2qbAEH4X8awA2Ym1WQlFxCUggS2ZCYHKOsQyqeJoBgPDz0kq9kIYU0EA8Ozb3HS0AE4xIMnMahM/AzLEZTJQbKy2hshhUAc69nNcgU4hbWBvIQwjrwC4yPFQUKhMbSLcIrFMc1k558F4QZnjWZ5t1zeMC0TXo51LKoq1gLVVA3fk+B+etZirBg5vmhaGFOF88GSbAwBUXB82aJsAD0qmrdpYClMCnzgcKioI5gkAYNgYGwQYiS4SR01kCIuAAHlYngAD4GAAVWC0geL43ArPNH6CgAbQKfJyDQWH8jhugEahJHkZRxGMcxtGke071UfR7GCax/GfUJ9GyfJ0ndJxomqd9AoAF0opKG4USXQQGo6JrqlazrXgYNYEyGfqfnnIac3CpA4GBJyXKgLEIiiabOyRW4YhGAAhLZejoOByAAVgYB0q1kviGGraBBldVWq1jPMRbeSIvPq7hp3tF43nig1/3mRY1Cy3psLgUgwgGlYfeSCOqkXOV+1XdcuCxLdBd3Z4djBUx5KrRKLZS5tWwRVqOiraXZccl0cslZWMCxAchXCKAIEGRJS5zdme3jwOgIYUgUDgEIt2O93cE9rqo5Xf3m9Zr2+mVSQXqyhgQnIQ1dhDcE1fMSo7Y77sYk555GAEAVs6V84tgRDourX0+uGzqVnJVWDiixNkiWTGkQFSJYuAgaOrQBQuTVtbOsXUMDpjEIcBs0Yx5O0sNzBgXR0wQHJELPAQosQ1AwCKBgAB1UwdkSL0iZNiFoUCNSngkh0WAD0fhL2IiyB2PQxKMV1HQwYDD0xWiYWsOybCaEME4dwq0skuDyRZLJVA+kSi4mrMgmAVxYjrU2rgaAvQPbQR4YuG4QgYhgDnhKHBfAJEFCrlABevDBQAAk1IWj+iyfhpAxIWKsd9ZI8iHEmw8a6KREAZHmJ4DIdxxEGStW8Q6XxDp/GZR+n9Oy/o6r5DcYfGSckcS8UyhDBgsSUCyJKB9XAv4ahQHTJDCsbMD6xBEOIF2VoxCDAvG8FsTAADsnNgL8CkJERuBhanKxgJxDEhTCjFPwKU8pBRiBhGuv5AAapEPR4hnRVE7lkBggx4aGnViieygxSCugKHkNGvBZhOgOSweRmVCCbNICwOx5RWi23NJaP0sMTnozOSbB0WyrlZJQAwW5fzHnPItG8o5uN8jEA6XQMSSMYUmz+cwuMvR4kr3ILbW55B4UAF9YbfIuawa5gLgWsFBS8iFiNEVwAufclFjt0WryxY2JJ1ACWCh3lUS0vzWAMvjEyzFDA4BIvpSwtFCTMXwsJVyhgABCKluNEVcvhYixZUBlliFkBwYAqzNnbJWActl+R8XsqhDM7QN1iLqs1dq3VKx1mSH2QatZ1T9mHOORy5I4rHyXP5eoL1cQKjcpNj6wVLKcWBpAmFbqvQRXIvFZ+fI6SJHIIBb64lAL4UeKFvYy0IK1JJpTfJA5JLfX3JJdm4iBzQXloeYW5JKTznRo6Aqp8kKkafKRi2hg8TLRVXQmcjASavxVUaOtAqEJjr/2SDAAAjhwTWowtq/nbulLoUAFZxFQuOpIzQHT4E8ps6p4QuibVtoCSQvA7RL1affayyQuC/n/JKQEBAYjSCgLBJGQZ+QqwbuUeU5hU1pWSMNNSyQIDQKgF1IBvQzaRC3T2hoE7oDfqbSbHtH122Iy7T+konIgOe2Q6hyU1Zm4SJGLIas2AxD1mg9uSwWMe2WjgC2+F3bg2PjY8GkdybxE53ENktN1ZAlQvNsJ0tWasZSdE4Cy0GAhP5MbUjHNim6OWjWE8jj+QtOtHLaCnTNa80tHEBx01iNThbMtlIWIvxPatL9vFSQfAxBXs9g3PaPb1HLGSNWWzGDERVlwNgAQ27QKYMuZZkooVH6ySg88DgdHWl7XCkcNaLR9Doa4bhrGOa851ktD2n6lpApAzHQAfgUlwTiIMZACV+AwH+gMeB2Tq1AMGdAoYtpZnlgTpmNMMB1uUBkMlSAOgk+gcyUBnhoOSJN416N1MMAANSlf2K0Fgw3RuSAdHp54BWoCLfwwwAwM0cwtrePHDBvRD3HTSlUaWQbKhnL2IKXu0YqhbCpAwcodCDiSge3crGhLlt/Q8SwQKiy+wdqJsq3jWM9OPiiS6V06nzOWzWOOJ0Pa4DraCq10gVVbZ/T9HixtOawDiFrZp+x8bSCGYJecqnYha1tveWjPDpwbRikaM0CAVwoCxl4ojQlLPa1/T07Dzju9WMqupR0+XaMLNo2LTycQZbLSTeFXcytTOTYs814q9Gsq3nwu56KSMyVBfC+rLDAY8Cxca/TX9BbiNTfCqVwixXCOoQq+hkIbE5FRBud4AKDADoUOSDHq6Jm0MGSrlaC3Aw4hdsJ7aMn1PRIxCTTMNYcof3VBHhgEYK9D8JGx+mdhK0ZhsANA6Gr7bMkon9ewIl/rwBZvoLV+bDtXbCVaxavc3wqB3C4G1WIRKUR7Sw7w2r9HiM1dI8tIP3gw/R87dcy9NkEAXyoodG3oEzwABk6njvm0fAvpVHS9Pk7Rg712HzEYX8tIuAAVECDjiKbD4C1ngQQP+G+MkW+6YoKB+zwwAi2pqJqySUMgeweqeYePAkeMQMeceUIUM6eSegwKebmDoWBmebm2euelgVgBesAW018pepg2cle5q1e3AIW9eYiGSTeTqKOgoh+aune9Y3e/WvenqaMiKbB42Leckroh+nec2ImxqKu+QcBQeAyV64eKB0eMAdB8hBBOBqe+BiehBkgxBvA+o+ehelBVw1B5e5QGhcyjBdeDe/WIhYhqaXBxEPB0hPevEsOOSjhneh+0hven4ChCBoeKhUeaB8eeh2heBWhuBBhOeRheeZBphxeFhtB6B0KDBtezBjeFQO242auXBHeXe0k/BnhghSMA+Q+fgo+Bg4+SWU+UEs+z+vEj47+n+CuQ2VRI+KAkOwBvAbm6YO+e+eY4BQIUB9uahT+uML+7wH+wAX+HSP+f+Y81gtgQBLm/RL0YBkh4xfuNAuKQAA) for codegen (Change BigMul2 to BigMul for code in main)



New 
![image](https://github.com/user-attachments/assets/24dbb3b7-5dbb-4737-8c2c-2dd911245ba0)

Main
![image](https://github.com/user-attachments/assets/187af7d5-d4d3-4b7a-961b-c50a1f8cee38)


### Benchmark

1. Se  in https://github.com/dotnet/runtime/issues/11782#issuecomment-2174501863 

2. Benchmark for orderby with and without this pr (main is commit where decimal code was merged)
```
BenchmarkDotNet v0.14.1-nightly.20250107.205, Windows 11 (10.0.26100.3915)
AMD Ryzen 7 5800X 3.80GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 10.0.100-alpha.1.25077.2
  [Host]     : .NET 10.0.0 (10.0.25.7313), X64 RyuJIT AVX2
  Job-NQDAQW : .NET 10.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-CICNHA : .NET 10.0.0 (42.42.42.42424), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250ms  MaxIterationCount=20  
MinIterationCount=15  WarmupCount=1  

```
| Method             | Job        | Toolchain                                                                         | Mean     | Error    | StdDev   | Median   | Min      | Max      | Ratio | RatioSD | Gen0      | Allocated | Alloc Ratio |
|------------------- |----------- |---------------------------------------------------------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|--------:|----------:|----------:|------------:|
| Order00LinqQueryX  | Job-NQDAQW | \main\10.0.0\corerun.exe | 39.28 ms | 1.002 ms | 1.153 ms | 39.75 ms | 36.01 ms | 40.28 ms |  1.06 |    0.04 | 3500.0000 |  56.65 MB |        1.00 |
| Order00LinqQueryX  | Job-CICNHA | \pr\10.0.0\corerun.exe  | 37.25 ms | 0.798 ms | 0.919 ms | 37.56 ms | 34.65 ms | 38.16 ms |  1.00 |    0.04 | 3428.5714 |  56.65 MB |        1.00 |
|                    |            |                                                                                   |          |          |          |          |          |          |       |         |           |           |             |
| Order00LinqMethodX | Job-NQDAQW | \main\10.0.0\corerun.exe | 39.09 ms | 0.766 ms | 0.882 ms | 39.30 ms | 36.25 ms | 39.95 ms |  1.06 |    0.04 | 3428.5714 |  56.65 MB |        1.00 |
| Order00LinqMethodX | Job-CICNHA | \pr\10.0.0\corerun.exe  | 36.96 ms | 1.012 ms | 1.082 ms | 37.31 ms | 33.85 ms | 38.07 ms |  1.00 |    0.04 | 3428.5714 |  56.65 MB |        1.00 |
|                    |            |                                                                                   |          |          |          |          |          |          |       |         |           |           |             |
| Order00ManualX     | Job-NQDAQW | \main\10.0.0\corerun.exe | 77.68 ms | 0.331 ms | 0.309 ms | 77.69 ms | 77.21 ms | 78.11 ms |  1.01 |    0.01 |  750.0000 |  15.26 MB |        1.00 |
| Order00ManualX     | Job-CICNHA | \pr\10.0.0\corerun.exe  | 76.65 ms | 0.344 ms | 0.305 ms | 76.68 ms | 75.90 ms | 77.09 ms |  1.00 |    0.01 |  750.0000 |  15.26 MB |        1.00 |

</details>

<details>
<summary>builting x86 multiply approach (x86_multiply branch)</summary>

I've updated the code forther to make Math.BigMul a single **mul** instruction on all x64 platforms (not just those with BMI2) and the code 

### Benchmarks

currently rerunning after rebase ...

### Exampels of new code

```csharp

[MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
static void TestBigMul2(ref ulong x, ref ulong y)
{
    x = Math.BigMul(x, y, out y);
}

[MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
static void TestBigMul1(ref long x, ref long y)
{
    x = Math.BigMul(x, y, out y);
}

```

Produces the following  (code from just before rebase)
```asm
; Method Program:<<Main>$>g__TestBigMul2|0_1(byref,byref) (FullOpts)
G_M19919_IG01:  ;; offset=0x0000
						;; size=0 bbWeight=1 PerfScore 0.00

G_M19919_IG02:  ;; offset=0x0000
       mov      rax, qword ptr [rcx]
       mov      bword ptr [rsp+0x10], rdx
       mul      rdx:rax, qword ptr [rdx]
       mov      r8, bword ptr [rsp+0x10]
       mov      qword ptr [r8], rax
       mov      qword ptr [rcx], rdx
						;; size=22 bbWeight=1 PerfScore 12.00

G_M19919_IG03:  ;; offset=0x0016
       ret      
						;; size=1 bbWeight=1 PerfScore 1.00
; Total bytes of code: 23


; Method Program:<<Main>$>g__TestBigMul1|0_2(byref,byref) (FullOpts)
G_M20175_IG01:  ;; offset=0x0000
						;; size=0 bbWeight=1 PerfScore 0.00

G_M20175_IG02:  ;; offset=0x0000
       mov      rax, qword ptr [rcx]
       mov      bword ptr [rsp+0x10], rdx
       imul     rdx:rax, qword ptr [rdx]
       mov      r8, bword ptr [rsp+0x10]
       mov      qword ptr [r8], rax
       mov      qword ptr [rcx], rdx
						;; size=22 bbWeight=1 PerfScore 12.00

G_M20175_IG03:  ;; offset=0x0016
       ret      
						;; size=1 bbWeight=1 PerfScore 1.00
; Total bytes of code: 23
```
Current code according to goodbolt [goodbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:csharp,selection:(endColumn:1,endLineNumber:22,positionColumn:1,positionLineNumber:22,selectionStartColumn:1,selectionStartLineNumber:22,startColumn:1,startLineNumber:22),source:'using+System%3B%0Ausing+System.Runtime.Intrinsics%3B%0Ausing+System.Runtime.Intrinsics.X86%3B%0A%0A%23pragma+warning+disable+SYSLIB5004%0A%0Aclass+Program%0A%7B%0A++%0A%0A//%5BMethodImpl(MethodImplOptions.NoInlining+%7C+MethodImplOptions.AggressiveOptimization)%5D%0Astatic+void+TestBigMul2(ref+ulong+x,+ref+ulong+y)%0A%7B%0A++++x+%3D+Math.BigMul(x,+y,+out+y)%3B%0A%7D%0A%0A//%5BMethodImpl(MethodImplOptions.NoInlining+%7C+MethodImplOptions.AggressiveOptimization)%5D%0Astatic+void+TestBigMul1(ref+long+x,+ref+long+y)%0A%7B%0A++++x+%3D+Math.BigMul(x,+y,+out+y)%3B%0A%7D%0A%0A%7D%0A'),l:'5',n:'0',o:'C%23+source+%231',t:'0')),k:49.467003478677796,l:'4',m:100,n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:dotnet90csharpcoreclr,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'1',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:3,lang:csharp,libs:!(),options:'',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+.NET+9.0+CoreCLR+(Editor+%231)',t:'0')),k:50.53299652132221,l:'4',m:100,n:'0',o:'',s:0,t:'0')),l:'2',m:100,n:'0',o:'',t:'0')),version:4)


<details>
<summary>Further code samples with array access</summary>

```csharp
static long TestBigMulArr2(long[] x, ref long y)
{
    return Math.BigMul(y, x[1], out y);
}

				
static void TestBigMulArr12(long[] x, ref long y)
{
    x[1] = Math.BigMul(y, x[1], out y);
}
		
```

```asm
; Method Program:<<Main>$>g__TestBigMulArr2|0_5(long[],byref):long (FullOpts)
G_M60604_IG01:  ;; offset=0x0000
       sub      rsp, 40
						;; size=4 bbWeight=1 PerfScore 0.25

G_M60604_IG02:  ;; offset=0x0004
       mov      bword ptr [rsp+0x38], rdx
       mov      rax, qword ptr [rdx]
       cmp      dword ptr [rcx+0x08], 1
       jbe      SHORT G_M60604_IG04
       imul     rdx:rax, qword ptr [rcx+0x18]
       mov      rcx, bword ptr [rsp+0x38]
       mov      qword ptr [rcx], rax
       mov      rax, rdx
						;; size=29 bbWeight=1 PerfScore 15.25

G_M60604_IG03:  ;; offset=0x0021
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25
											
						; Method Program:<<Main>$>g__TestBigMulArr12|0_6(long[],byref) (FullOpts)
G_M53374_IG01:  ;; offset=0x0000
       sub      rsp, 40
						;; size=4 bbWeight=1 PerfScore 0.25

G_M53374_IG02:  ;; offset=0x0004
       mov      bword ptr [rsp+0x38], rdx
       mov      rax, qword ptr [rdx]
       mov      r8d, dword ptr [rcx+0x08]
       cmp      r8d, 1
       jbe      SHORT G_M53374_IG04
       imul     rdx:rax, qword ptr [rcx+0x18]
       mov      r8, bword ptr [rsp+0x38]
       mov      qword ptr [r8], rax
       mov      qword ptr [rcx+0x18], rdx
						;; size=34 bbWeight=1 PerfScore 15.25

G_M53374_IG03:  ;; offset=0x0026
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25

G_M53374_IG04:  ;; offset=0x002B
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
						;; size=6 bbWeight=0 PerfScore 0.00
; Total bytes of code: 49
```
</details>

</details>