### PR TITLE
JIT: Overwrite cache during recursive map select in VN

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3675,7 +3675,10 @@ TailCall:
                     entry.Result = sameSelResult;
                     entry.SetMemoryDependencies(m_pComp, recMemoryDependencies);
 
-                    GetMapSelectWorkCache()->Set(fstruct, entry);
+                    // If we ran out of budget we could have already cached the
+                    // result in the leaf. In that case it is ok to overwrite
+                    // it here.
+                    GetMapSelectWorkCache()->Set(fstruct, entry, MapSelectWorkCache::Overwrite);
                 }
 
                 recMemoryDependencies.ForEach([this, &memoryDependencies](ValueNum vn) {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -3678,7 +3678,9 @@ TailCall:
                     // If we ran out of budget we could have already cached the
                     // result in the leaf. In that case it is ok to overwrite
                     // it here.
-                    GetMapSelectWorkCache()->Set(fstruct, entry, MapSelectWorkCache::Overwrite);
+                    MapSelectWorkCache* cache = GetMapSelectWorkCache();
+                    assert(!cache->Lookup(fstruct) || ((*cache)[fstruct].Result == sameSelResult));
+                    cache->Set(fstruct, entry, MapSelectWorkCache::Overwrite);
                 }
 
                 recMemoryDependencies.ForEach([this, &memoryDependencies](ValueNum vn) {


### PR DESCRIPTION
If the recursive select runs out of budget it may have already cached a value. In that case allow overwriting the cached value (which should just replace it with the same value).

This handles a similar case that the other case already handles:
https://github.com/dotnet/runtime/blob/f6b93319242155a72801a7bb4bc92faac2ada1a3/src/coreclr/jit/valuenum.cpp#L3723-L3724

Fix #108850