### PR TITLE
Update DotNetBuild.props

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -92,6 +92,6 @@
 
       <InnerBuildArgs Condition="'$(EnableDefaultRidSpecificArtifacts)' != ''">$(InnerBuildArgs) /p:EnableDefaultRidSpecificArtifacts=$(EnableDefaultRidSpecificArtifacts)</InnerBuildArgs>
     </PropertyGroup>
-  </Target
+  </Target>
 
 </Project>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -92,40 +92,6 @@
 
       <InnerBuildArgs Condition="'$(EnableDefaultRidSpecificArtifacts)' != ''">$(InnerBuildArgs) /p:EnableDefaultRidSpecificArtifacts=$(EnableDefaultRidSpecificArtifacts)</InnerBuildArgs>
     </PropertyGroup>
-  </Target>
-
-  <Target Name="CategorizeRuntimeSupplementalArtifacts"
-          BeforeTargets="GetCategorizedIntermediateNupkgContents">
-    <PropertyGroup>
-      <!-- Symbols archive is too big for main intermediate package, add it to a different one. -->
-      <SymbolsIntermediateNupkgCategory>runtime</SymbolsIntermediateNupkgCategory>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <!--
-        Runtime artifacts are too large to fit into a single package (Azure DevOps feeds 500 mb constraint).
-        Split large components into separate packages.
-      -->
-      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\dotnet-runtime-*$(ArchiveExtension)" Category="runtime" />
-      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\*Microsoft.DotNet.ILCompiler.*.nupkg" Category="ILCompiler" />
-
-      <IntermediateNupkgArtifactFile
-        Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\Microsoft.NETCore.App.Crossgen2.*.nupkg"
-        Category="Crossgen2Pack" />
-
-        <IntermediateNupkgArtifactFile
-        Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\dotnet-crossgen2-*$(ArchiveExtension)"
-        Category="Crossgen2Archive" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(DotNetBuildOrchestrator)' == 'true'">
-      <!-- Include installers when in product VMR builds. These are not necessary when building the repo-only build as we don't
-           need them in downstream source-only PR legs. We could include them, but it may bump us over the package size limit. -->
-      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\*.msi" />
-      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\*.deb" />
-      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\*.rpm" />
-      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\*.pkg" />
-    </ItemGroup>
-  </Target>
+  </Target
 
 </Project>


### PR DESCRIPTION
The `CategorizeRuntimeSupplementalArtifacts` target isn't necessary anymore as SB doesn't produce an intermediate package anymore.