### PR TITLE
Attempt to load X.509 keys as ECDH keys first

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -1172,17 +1172,17 @@ namespace System.Security.Cryptography.X509Certificates
                         s_DsaPublicKeyPrivateKeyLabels,
                         static keyPem => CreateAndImport(keyPem, DSA.Create),
                         certificate.CopyWithPrivateKey),
-                    Oids.EcPublicKey when IsECDsa(certificate) =>
-                        ExtractKeyFromPem<ECDsa>(
-                            keyPem,
-                            s_EcPublicKeyPrivateKeyLabels,
-                            static keyPem => CreateAndImport(keyPem, ECDsa.Create),
-                            certificate.CopyWithPrivateKey),
                     Oids.EcPublicKey when IsECDiffieHellman(certificate) =>
                         ExtractKeyFromPem<ECDiffieHellman>(
                             keyPem,
                             s_EcPublicKeyPrivateKeyLabels,
                             static keyPem => CreateAndImport(keyPem, ECDiffieHellman.Create),
+                            certificate.CopyWithPrivateKey),
+                    Oids.EcPublicKey when IsECDsa(certificate) =>
+                        ExtractKeyFromPem<ECDsa>(
+                            keyPem,
+                            s_EcPublicKeyPrivateKeyLabels,
+                            static keyPem => CreateAndImport(keyPem, ECDsa.Create),
                             certificate.CopyWithPrivateKey),
                     Oids.MlKem512 or Oids.MlKem768 or Oids.MlKem1024 =>
                         ExtractKeyFromPem<MLKem>(
@@ -1259,17 +1259,17 @@ namespace System.Security.Cryptography.X509Certificates
                             password,
                             static (keyPem, password) => CreateAndImportEncrypted(keyPem, password, DSA.Create),
                             certificate.CopyWithPrivateKey),
-                    Oids.EcPublicKey when IsECDsa(certificate) =>
-                        ExtractKeyFromEncryptedPem<ECDsa>(
-                            keyPem,
-                            password,
-                            static (keyPem, password) => CreateAndImportEncrypted(keyPem, password, ECDsa.Create),
-                            certificate.CopyWithPrivateKey),
                     Oids.EcPublicKey when IsECDiffieHellman(certificate) =>
                         ExtractKeyFromEncryptedPem<ECDiffieHellman>(
                             keyPem,
                             password,
                             static (keyPem, password) => CreateAndImportEncrypted(keyPem, password, ECDiffieHellman.Create),
+                            certificate.CopyWithPrivateKey),
+                    Oids.EcPublicKey when IsECDsa(certificate) =>
+                        ExtractKeyFromEncryptedPem<ECDsa>(
+                            keyPem,
+                            password,
+                            static (keyPem, password) => CreateAndImportEncrypted(keyPem, password, ECDsa.Create),
                             certificate.CopyWithPrivateKey),
                     Oids.MlKem512 or Oids.MlKem768 or Oids.MlKem1024 =>
                         ExtractKeyFromEncryptedPem<MLKem>(

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
@@ -280,8 +280,7 @@ MII
             key.ImportFromPem(TestData.EcDhPkcs8Key);
             CertificateRequest req = new("CN=radish", key, HashAlgorithmName.SHA256);
             using X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(1));
-            using X509Certificate2 pubOnly = X509CertificateLoader.LoadCertificate(cert.RawDataMemory.Span);
-            string pemAggregate = $"{pubOnly.ExportCertificatePem()}\n{TestData.EcDhPkcs8Key}";
+            string pemAggregate = $"{cert.ExportCertificatePem()}\n{TestData.EcDhPkcs8Key}";
             using X509Certificate2 reLoaded = X509Certificate2.CreateFromPem(pemAggregate, pemAggregate);
 
             AssertKeysMatch(TestData.EcDhPkcs8Key, reLoaded.GetECDiffieHellmanPrivateKey);
@@ -301,7 +300,6 @@ MII
             key.ImportFromPem(TestData.EcDhPkcs8Key);
             CertificateRequest req = new("CN=radish", key, HashAlgorithmName.SHA256);
             using X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(1));
-            using X509Certificate2 pubOnly = X509CertificateLoader.LoadCertificate(cert.RawDataMemory.Span);
 
             PbeParameters pbe = new(PbeEncryptionAlgorithm.Aes128Cbc, HashAlgorithmName.SHA1, 32);
             const string Password = "PLACEHOLDER";
@@ -310,7 +308,7 @@ MII
                 "ENCRYPTED PRIVATE KEY",
                 key.ExportEncryptedPkcs8PrivateKey(Password, pbe));
 
-            string pemAggregate = $"{pubOnly.ExportCertificatePem()}\n{encryptedPrivateKey}";
+            string pemAggregate = $"{cert.ExportCertificatePem()}\n{encryptedPrivateKey}";
             using X509Certificate2 reLoaded = X509Certificate2.CreateFromEncryptedPem(pemAggregate, pemAggregate, Password);
 
             AssertKeysMatch(encryptedPrivateKey, reLoaded.GetECDiffieHellmanPrivateKey, Password);


### PR DESCRIPTION
Windows CNG EC keys always have a key usage attached to them. ECDH keys can be treated as either ECDH or ECDSA. However, a CNG key with ECDSA usage can only be used as ECDSA.

When we import a PEM aggregate with an ECC private key, we should attempt to import it as ECDH first, if the certificate's key usage permits it. This will allow the imported key to act as either ECDH or ECDSA.

However, if we attempt to import as ECDSA first, it will succeed however not have the correct key usage, preventing it from being used as ECDH.

Fixes #115232