### PR TITLE
Add PQC support for SslStreamCertificateContext and fix test

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -1016,6 +1016,9 @@ SingleResponse ::= SEQUENCE {
             internal static KeyFactory MLDsa { get; } =
                 new(() => Cryptography.MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa65));
 
+            internal static KeyFactory SlhDsa { get; } =
+                new(() => Cryptography.SlhDsa.GenerateKey(SlhDsaAlgorithm.SlhDsaSha2_128f));
+
             private Func<IDisposable> _factory;
 
             private KeyFactory(Func<IDisposable> factory)
@@ -1035,7 +1038,7 @@ SingleResponse ::= SEQUENCE {
 
             internal static KeyFactory[] BuildVariantFactories()
             {
-                return [RSA, ECDsa];
+                return [RSA, ECDsa, MLDsa, SlhDsa];
             }
         }
 
@@ -1056,6 +1059,7 @@ SingleResponse ::= SEQUENCE {
                     cert.GetRSAPrivateKey() ??
                     cert.GetECDsaPrivateKey() ??
                     cert.GetMLDsaPrivateKey() ??
+                    cert.GetSlhDsaPrivateKey() ??
                     (IDisposable)cert.GetDSAPrivateKey() ??
                     throw new NotSupportedException();
             }
@@ -1077,6 +1081,7 @@ SingleResponse ::= SEQUENCE {
                     RSA rsa => new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
                     ECDsa ecdsa => new CertificateRequest(subject, ecdsa, HashAlgorithmName.SHA256),
                     MLDsa mldsa => new CertificateRequest(subject, mldsa),
+                    SlhDsa slhDsa => new CertificateRequest(subject, slhDsa),
                     _ => throw new NotSupportedException(),
                 };
             }
@@ -1088,6 +1093,7 @@ SingleResponse ::= SEQUENCE {
                     RSA rsa => X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1),
                     ECDsa ecdsa => X509SignatureGenerator.CreateForECDsa(ecdsa),
                     MLDsa mldsa => X509SignatureGenerator.CreateForMLDsa(mldsa),
+                    SlhDsa slhDsa => X509SignatureGenerator.CreateForSlhDsa(slhDsa),
                     _ => throw new NotSupportedException(),
                 };
             }

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -1038,7 +1038,19 @@ SingleResponse ::= SEQUENCE {
 
             internal static KeyFactory[] BuildVariantFactories()
             {
-                return [RSA, ECDsa, MLDsa, SlhDsa];
+                List<KeyFactory> factories = [RSA, ECDsa];
+
+                if (Cryptography.MLDsa.IsSupported)
+                {
+                    factories.Add(MLDsa);
+                }
+
+                if (Cryptography.SlhDsa.IsSupported)
+                {
+                    factories.Add(SlhDsa);
+                }
+
+                return factories.ToArray();
             }
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -80,11 +80,10 @@ namespace System.Net.Security
                 }
             }
 
-            if (KeyHandle == null)
-            {
 #pragma warning disable SYSLIB5006 // Post-Quantum Cryptography (PQC) types are experimental
+            if (KeyHandle == null && MLDsa.IsSupported)
+            {
                 using (MLDsaOpenSsl? mlDsa = (MLDsaOpenSsl?)target.GetMLDsaPrivateKey())
-#pragma warning restore SYSLIB5006
                 {
                     if (mlDsa != null)
                     {
@@ -93,11 +92,9 @@ namespace System.Net.Security
                 }
             }
 
-            if (KeyHandle == null)
+            if (KeyHandle == null && SlhDsa.IsSupported)
             {
-#pragma warning disable SYSLIB5006 // Post-Quantum Cryptography (PQC) types are experimental
                 using (SlhDsaOpenSsl? slhDsa = (SlhDsaOpenSsl?)target.GetSlhDsaPrivateKey())
-#pragma warning restore SYSLIB5006
                 {
                     if (slhDsa != null)
                     {
@@ -105,6 +102,7 @@ namespace System.Net.Security
                     }
                 }
             }
+#pragma warning restore SYSLIB5006
 
             if (KeyHandle == null)
             {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -78,11 +78,37 @@ namespace System.Net.Security
                         KeyHandle = ecdsa.DuplicateKeyHandle();
                     }
                 }
+            }
 
-                if (KeyHandle == null)
+            if (KeyHandle == null)
+            {
+#pragma warning disable SYSLIB5006 // Post-Quantum Cryptography (PQC) types are experimental
+                using (MLDsaOpenSsl? mlDsa = (MLDsaOpenSsl?)target.GetMLDsaPrivateKey())
+#pragma warning restore SYSLIB5006
                 {
-                    throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
+                    if (mlDsa != null)
+                    {
+                        KeyHandle = mlDsa.DuplicateKeyHandle();
+                    }
                 }
+            }
+
+            if (KeyHandle == null)
+            {
+#pragma warning disable SYSLIB5006 // Post-Quantum Cryptography (PQC) types are experimental
+                using (SlhDsaOpenSsl? slhDsa = (SlhDsaOpenSsl?)target.GetSlhDsaPrivateKey())
+#pragma warning restore SYSLIB5006
+                {
+                    if (slhDsa != null)
+                    {
+                        KeyHandle = slhDsa.DuplicateKeyHandle();
+                    }
+                }
+            }
+
+            if (KeyHandle == null)
+            {
+                throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
             }
 
             CertificateHandle = Interop.Crypto.X509UpRef(target.Handle);


### PR DESCRIPTION
Add ML-DSA and SLH-DSA to the list of tested algorithms for revocation.

Tests now exercise SslStreamCertificateContext with PQC certs so this PR also updates it to know about them.