### PR TITLE
Mark CoreLib Internal.Console methods with NoInline

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.Android.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.Android.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Internal
 {
     public static partial class Console
     {
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static unsafe void Write(string s)
         {
             Interop.Logcat.AndroidLogPrint(Interop.Logcat.LogLevel.Debug, "DOTNET", s ?? string.Empty);
@@ -15,6 +17,7 @@ namespace Internal
 
         public static partial class Error
         {
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
             public static unsafe void Write(string s)
             {
                 Interop.Logcat.AndroidLogPrint(Interop.Logcat.LogLevel.Error, "DOTNET", s ?? string.Empty);

--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.Unix.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Internal
 {
     public static partial class Console
     {
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static unsafe void Write(string s)
         {
             byte[] bytes = Encoding.UTF8.GetBytes(s);
@@ -19,6 +21,7 @@ namespace Internal
 
         public static partial class Error
         {
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
             public static unsafe void Write(string s)
             {
                 byte[] bytes = Encoding.UTF8.GetBytes(s);

--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.Windows.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Internal
 {
     public static partial class Console
     {
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static void Write(string s)
         {
             WriteCore(Interop.Kernel32.GetStdHandle(Interop.Kernel32.HandleTypes.STD_OUTPUT_HANDLE), s);
@@ -15,6 +17,7 @@ namespace Internal
 
         public static partial class Error
         {
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
             public static void Write(string s)
             {
                 WriteCore(Interop.Kernel32.GetStdHandle(Interop.Kernel32.HandleTypes.STD_ERROR_HANDLE), s);

--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Internal
 {
@@ -12,14 +13,17 @@ namespace Internal
 
     public static partial class Console
     {
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static void WriteLine(string? s) =>
             Write(s + Environment.NewLineConst);
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static void WriteLine() =>
             Write(Environment.NewLineConst);
 
         public static partial class Error
         {
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
             public static void WriteLine() =>
                 Write(Environment.NewLineConst);
         }

--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.iOS.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Internal
 {
     public static partial class Console
     {
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static unsafe void Write(string s)
         {
             fixed (char* ptr = s)
@@ -17,6 +19,7 @@ namespace Internal
         }
         public static partial class Error
         {
+            [MethodImplAttribute(MethodImplOptions.NoInlining)]
             public static unsafe void Write(string s)
             {
                 fixed (char* ptr = s)


### PR DESCRIPTION
- Matches public System.Console
- Makes optimized code easier to understand when one uses WriteLine debugging