### PR TITLE
Align SlhDsa API with MLKem

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
@@ -93,13 +93,14 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Sign the specified data, writing the signature into the provided buffer.
+        ///   Signs the specified data, writing the signature into the provided buffer.
         /// </summary>
         /// <param name="data">
         ///   The data to sign.
         /// </param>
         /// <param name="destination">
-        ///   The buffer to receive the signature.
+        ///   The buffer to receive the signature. Its length must be exactly
+        ///   <see cref="SlhDsaAlgorithm.SignatureSizeInBytes"/>.
         /// </param>
         /// <param name="context">
         ///   An optional context-specific value to limit the scope of the signature.
@@ -120,10 +121,6 @@ namespace System.Security.Cryptography
         ///   <para>-or-</para>
         ///   <para>An error occurred while signing the data.</para>
         /// </exception>
-        /// <remarks>
-        ///   <paramref name="destination"/> is required to be exactly
-        ///   <see cref="SlhDsaAlgorithm.SignatureSizeInBytes"/> in length.
-        /// </remarks>
         public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default)
         {
             int signatureSizeInBytes = Algorithm.SignatureSizeInBytes;
@@ -149,14 +146,14 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Sign the specified data.
+        ///   Signs the specified data.
         /// </summary>
         /// <param name="data">
         ///   The data to sign.
         /// </param>
         /// <param name="context">
         ///   An optional context-specific value to limit the scope of the signature.
-        ///   A <see langword="null"/> context is treated as empty.
+        ///   The default value is <see langword="null" />.
         /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="data"/> is <see langword="null"/>.
@@ -172,6 +169,9 @@ namespace System.Security.Cryptography
         ///   <para>-or-</para>
         ///   <para>An error occurred while signing the data.</para>
         /// </exception>
+        /// <remarks>
+        ///   A <see langword="null" /> context is treated as empty.
+        /// </remarks>
         public byte[] SignData(byte[] data, byte[]? context = default)
         {
             ArgumentNullException.ThrowIfNull(data);
@@ -240,7 +240,7 @@ namespace System.Security.Cryptography
         /// </param>
         /// <param name="context">
         ///   The context value which was provided during signing.
-        ///   A <see langword="null"/> context is treated as empty.
+        ///   The default value is <see langword="null" />.
         /// </param>
         /// <returns>
         ///   <see langword="true"/> if the signature validates the data; otherwise, <see langword="false"/>.
@@ -259,6 +259,9 @@ namespace System.Security.Cryptography
         ///   <para>-or-</para>
         ///   <para>An error occurred while signing the data.</para>
         /// </exception>
+        /// <remarks>
+        ///   A <see langword="null" /> context is treated as empty.
+        /// </remarks>
         public bool VerifyData(byte[] data, byte[] signature, byte[]? context = default)
         {
             ArgumentNullException.ThrowIfNull(data);
@@ -831,7 +834,8 @@ namespace System.Security.Cryptography
         ///   Exports the public-key portion of the current key in the FIPS 205 public key format.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the public key.
+        ///   The buffer to receive the public key. Its length must be exactly
+        ///   <see cref="SlhDsaAlgorithm.SecretKeySizeInBytes"/>.
         /// </param>
         /// <exception cref="ArgumentException">
         ///   <paramref name="destination"/> is the incorrect length to receive the public key.
@@ -883,7 +887,8 @@ namespace System.Security.Cryptography
         ///   Exports the current key in the FIPS 205 secret key format.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the secret key.
+        ///   The buffer to receive the secret key. Its length must be exactly
+        ///   <see cref="SlhDsaAlgorithm.SecretKeySizeInBytes"/>.
         /// </param>
         /// <exception cref="ArgumentException">
         ///   <paramref name="destination"/> is the incorrect length to receive the secret key.
@@ -894,10 +899,6 @@ namespace System.Security.Cryptography
         ///   <para>An error occurred while exporting the key.</para>
         /// </exception>
         /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
-        /// <remarks>
-        ///   <paramref name="destination"/> is required to be exactly
-        ///   <see cref="SlhDsaAlgorithm.SecretKeySizeInBytes"/> in length.
-        /// </remarks>
         public void ExportSlhDsaSecretKey(Span<byte> destination)
         {
             int secretKeySizeInBytes = Algorithm.SecretKeySizeInBytes;

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
@@ -106,7 +106,7 @@ namespace System.Security.Cryptography
         ///   The default value is an empty buffer.
         /// </param>
         /// <exception cref="ArgumentException">
-        ///   The buffer in <paramref name="destination"/> is too incorrect length to receive the signature.
+        ///   The buffer in <paramref name="destination"/> is the incorrect length to receive the signature.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="context"/> has a <see cref="ReadOnlySpan{T}.Length"/> in excess of
@@ -120,6 +120,10 @@ namespace System.Security.Cryptography
         ///   <para>-or-</para>
         ///   <para>An error occurred while signing the data.</para>
         /// </exception>
+        /// <remarks>
+        ///   <paramref name="destination"/> is required to be exactly
+        ///   <see cref="SlhDsaAlgorithm.SignatureSizeInBytes"/> in length.
+        /// </remarks>
         public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default)
         {
             int signatureSizeInBytes = Algorithm.SignatureSizeInBytes;
@@ -127,7 +131,7 @@ namespace System.Security.Cryptography
             if (destination.Length != signatureSizeInBytes)
             {
                 throw new ArgumentException(
-                    SR.Format(SR.Argument_DestinationImprecise, Algorithm.SignatureSizeInBytes),
+                    SR.Format(SR.Argument_DestinationImprecise, signatureSizeInBytes),
                     nameof(destination));
             }
 
@@ -152,7 +156,7 @@ namespace System.Security.Cryptography
         /// </param>
         /// <param name="context">
         ///   An optional context-specific value to limit the scope of the signature.
-        ///   The default value is a <see langword="null"/> buffer.
+        ///   A <see langword="null"/> context is treated as empty.
         /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="data"/> is <see langword="null"/>.
@@ -236,7 +240,7 @@ namespace System.Security.Cryptography
         /// </param>
         /// <param name="context">
         ///   The context value which was provided during signing.
-        ///   The default value is a <see langword="null"/> buffer.
+        ///   A <see langword="null"/> context is treated as empty.
         /// </param>
         /// <returns>
         ///   <see langword="true"/> if the signature validates the data; otherwise, <see langword="false"/>.
@@ -836,6 +840,10 @@ namespace System.Security.Cryptography
         ///   <para>An error occurred while exporting the key.</para>
         /// </exception>
         /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        /// <remarks>
+        ///   <paramref name="destination"/> is required to be exactly
+        ///   <see cref="SlhDsaAlgorithm.PublicKeySizeInBytes"/> in length.
+        /// </remarks>
         public void ExportSlhDsaPublicKey(Span<byte> destination)
         {
             int publicKeySizeInBytes = Algorithm.PublicKeySizeInBytes;
@@ -843,7 +851,7 @@ namespace System.Security.Cryptography
             if (destination.Length != publicKeySizeInBytes)
             {
                 throw new ArgumentException(
-                    SR.Format(SR.Argument_DestinationImprecise, Algorithm.PublicKeySizeInBytes),
+                    SR.Format(SR.Argument_DestinationImprecise, publicKeySizeInBytes),
                     nameof(destination));
             }
 
@@ -886,6 +894,10 @@ namespace System.Security.Cryptography
         ///   <para>An error occurred while exporting the key.</para>
         /// </exception>
         /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        /// <remarks>
+        ///   <paramref name="destination"/> is required to be exactly
+        ///   <see cref="SlhDsaAlgorithm.SecretKeySizeInBytes"/> in length.
+        /// </remarks>
         public void ExportSlhDsaSecretKey(Span<byte> destination)
         {
             int secretKeySizeInBytes = Algorithm.SecretKeySizeInBytes;
@@ -893,7 +905,7 @@ namespace System.Security.Cryptography
             if (destination.Length != secretKeySizeInBytes)
             {
                 throw new ArgumentException(
-                    SR.Format(SR.Argument_DestinationImprecise, Algorithm.SecretKeySizeInBytes),
+                    SR.Format(SR.Argument_DestinationImprecise, secretKeySizeInBytes),
                     nameof(destination));
             }
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaContractTests.cs
@@ -31,6 +31,10 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
             PbeParameters pbeParameters = new PbeParameters(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 42);
 
+            AssertExtensions.Throws<ArgumentNullException>("data", () => slhDsa.SignData(null));
+            AssertExtensions.Throws<ArgumentNullException>("data", () => slhDsa.VerifyData(null, null));
+            AssertExtensions.Throws<ArgumentNullException>("signature", () => slhDsa.VerifyData(Array.Empty<byte>(), null));
+
             AssertExtensions.Throws<ArgumentNullException>("password", () => slhDsa.ExportEncryptedPkcs8PrivateKey((string)null, pbeParameters));
             AssertExtensions.Throws<ArgumentNullException>("password", () => slhDsa.ExportEncryptedPkcs8PrivateKeyPem((string)null, pbeParameters));
             AssertExtensions.Throws<ArgumentNullException>("password", () => slhDsa.TryExportEncryptedPkcs8PrivateKey((string)null, pbeParameters, Span<byte>.Empty, out _));
@@ -63,12 +67,17 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             }
 
             AssertExtensions.Throws<ArgumentException>("destination", () => slhDsa.ExportSlhDsaPublicKey(new byte[publicKeySize - 1]));
+            AssertExtensions.Throws<ArgumentException>("destination", () => slhDsa.ExportSlhDsaPublicKey(new byte[publicKeySize + 1]));
             AssertExtensions.Throws<ArgumentException>("destination", () => slhDsa.ExportSlhDsaSecretKey(new byte[secretKeySize - 1]));
+            AssertExtensions.Throws<ArgumentException>("destination", () => slhDsa.ExportSlhDsaSecretKey(new byte[secretKeySize + 1]));
             AssertExtensions.Throws<ArgumentException>("destination", () => slhDsa.SignData(ReadOnlySpan<byte>.Empty, new byte[signatureSize - 1], ReadOnlySpan<byte>.Empty));
+            AssertExtensions.Throws<ArgumentException>("destination", () => slhDsa.SignData(ReadOnlySpan<byte>.Empty, new byte[signatureSize + 1], ReadOnlySpan<byte>.Empty));
 
             // Context length must be less than 256
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("context", () => slhDsa.SignData(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, new byte[256]));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("context", () => slhDsa.VerifyData(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, new byte[256]));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("context", () => slhDsa.SignData(ReadOnlySpan<byte>.Empty, new byte[signatureSize], new byte[256]));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("context", () => slhDsa.SignData(Array.Empty<byte>(), new byte[signatureSize], new byte[256]));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("context", () => slhDsa.VerifyData(ReadOnlySpan<byte>.Empty, new byte[signatureSize], new byte[256]));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("context", () => slhDsa.VerifyData(Array.Empty<byte>(), new byte[signatureSize], new byte[256]));
         }
 
         [Theory]
@@ -110,72 +119,91 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         private const int PaddingSize = 10;
 
         [Theory]
-        [MemberData(nameof(ApiWithDestinationSpanTestData))]
-        public static void ExportSlhDsaPublicKey_CallsCore(SlhDsaAlgorithm algorithm, bool destinationLargerThanRequired)
+        [MemberData(nameof(SlhDsaTestData.AlgorithmsData), MemberType = typeof(SlhDsaTestData))]
+        public static void ExportSlhDsaPublicKey_CallsCore(SlhDsaAlgorithm algorithm)
         {
             using SlhDsaMockImplementation slhDsa = SlhDsaMockImplementation.Create(algorithm);
+            slhDsa.ExportSlhDsaPublicKeyCoreHook = _ => { };
+            slhDsa.AddFillDestination(1);
 
             int publicKeySize = algorithm.PublicKeySizeInBytes;
+
+            // Array overload
+            byte[] exported = slhDsa.ExportSlhDsaPublicKey();
+            Assert.Equal(1, slhDsa.ExportSlhDsaPublicKeyCoreCallCount);
+            Assert.Equal(publicKeySize, exported.Length);
+            AssertExpectedFill(exported, fillElement: 1);
+
+            // Span overload
             byte[] publicKey = CreatePaddedFilledArray(publicKeySize, 42);
 
             // Extra bytes in destination buffer should not be touched
-            int extraBytes = destinationLargerThanRequired ? PaddingSize / 2 : 0;
-            Memory<byte> destination = publicKey.AsMemory(PaddingSize, publicKeySize + extraBytes);
+            Memory<byte> destination = publicKey.AsMemory(PaddingSize, publicKeySize);
+            slhDsa.AddDestinationBufferIsSameAssertion(destination);
 
-            slhDsa.ExportSlhDsaPublicKeyCoreHook = _ => { };
-            slhDsa.AddDestinationBufferIsSameAssertion(destination[..publicKeySize]);
-            slhDsa.AddFillDestination(1);
-
-            Assert.Equal(algorithm.PublicKeySizeInBytes, slhDsa.ExportSlhDsaPublicKey(destination.Span));
-            Assert.Equal(1, slhDsa.ExportSlhDsaPublicKeyCoreCallCount);
+            slhDsa.ExportSlhDsaPublicKey(destination.Span);
+            Assert.Equal(2, slhDsa.ExportSlhDsaPublicKeyCoreCallCount);
             AssertExpectedFill(publicKey, fillElement: 1, paddingElement: 42, PaddingSize, publicKeySize);
         }
 
         [Theory]
-        [MemberData(nameof(ApiWithDestinationSpanTestData))]
-        public static void ExportSlhDsaSecretKey_CallsCore(SlhDsaAlgorithm algorithm, bool destinationLargerThanRequired)
+        [MemberData(nameof(SlhDsaTestData.AlgorithmsData), MemberType = typeof(SlhDsaTestData))]
+        public static void ExportSlhDsaSecretKey_CallsCore(SlhDsaAlgorithm algorithm)
         {
             using SlhDsaMockImplementation slhDsa = SlhDsaMockImplementation.Create(algorithm);
+            slhDsa.ExportSlhDsaSecretKeyCoreHook = _ => { };
+            slhDsa.AddFillDestination(1);
 
             int secretKeySize = algorithm.SecretKeySizeInBytes;
+
+            // Array overload
+            byte[] exported = slhDsa.ExportSlhDsaSecretKey();
+            Assert.Equal(1, slhDsa.ExportSlhDsaSecretKeyCoreCallCount);
+            Assert.Equal(secretKeySize, exported.Length);
+            AssertExpectedFill(exported, fillElement: 1);
+
+            // Span overload
             byte[] secretKey = CreatePaddedFilledArray(secretKeySize, 42);
 
             // Extra bytes in destination buffer should not be touched
-            int extraBytes = destinationLargerThanRequired ? PaddingSize / 2 : 0;
-            Memory<byte> destination = secretKey.AsMemory(PaddingSize, secretKeySize + extraBytes);
+            Memory<byte> destination = secretKey.AsMemory(PaddingSize, secretKeySize);
+            slhDsa.AddDestinationBufferIsSameAssertion(destination);
 
-            slhDsa.ExportSlhDsaSecretKeyCoreHook = _ => { };
-            slhDsa.AddDestinationBufferIsSameAssertion(destination[..secretKeySize]);
-            slhDsa.AddFillDestination(1);
-
-            Assert.Equal(algorithm.SecretKeySizeInBytes, slhDsa.ExportSlhDsaSecretKey(destination.Span));
-            Assert.Equal(1, slhDsa.ExportSlhDsaSecretKeyCoreCallCount);
+            slhDsa.ExportSlhDsaSecretKey(destination.Span);
+            Assert.Equal(2, slhDsa.ExportSlhDsaSecretKeyCoreCallCount);
             AssertExpectedFill(secretKey, fillElement: 1, paddingElement: 42, PaddingSize, secretKeySize);
         }
 
         [Theory]
-        [MemberData(nameof(ApiWithDestinationSpanTestData))]
-        public static void SignData_CallsCore(SlhDsaAlgorithm algorithm, bool destinationLargerThanRequired)
+        [MemberData(nameof(SlhDsaTestData.AlgorithmsData), MemberType = typeof(SlhDsaTestData))]
+        public static void SignData_CallsCore(SlhDsaAlgorithm algorithm)
         {
-            using SlhDsaMockImplementation slhDsa = SlhDsaMockImplementation.Create(algorithm);
-
-            int signatureSize = algorithm.SignatureSizeInBytes;
-            byte[] signature = CreatePaddedFilledArray(signatureSize, 42);
-
-            // Extra bytes in destination buffer should not be touched
-            int extraBytes = destinationLargerThanRequired ? PaddingSize / 2 : 0;
-            Memory<byte> destination = signature.AsMemory(PaddingSize, signatureSize + extraBytes);
             byte[] testData = [2];
             byte[] testContext = [3];
 
+            using SlhDsaMockImplementation slhDsa = SlhDsaMockImplementation.Create(algorithm);
             slhDsa.SignDataCoreHook = (_, _, _) => { };
             slhDsa.AddDataBufferIsSameAssertion(testData);
             slhDsa.AddContextBufferIsSameAssertion(testContext);
-            slhDsa.AddDestinationBufferIsSameAssertion(destination[..signatureSize]);
             slhDsa.AddFillDestination(1);
 
-            slhDsa.SignData(testData, signature.AsSpan(PaddingSize, signatureSize + extraBytes), testContext);
+            int signatureSize = algorithm.SignatureSizeInBytes;
+
+            // Array overload
+            byte[] exported = slhDsa.SignData(testData, testContext);
             Assert.Equal(1, slhDsa.SignDataCoreCallCount);
+            Assert.Equal(signatureSize, exported.Length);
+            AssertExpectedFill(exported, fillElement: 1);
+
+            // Span overload
+            byte[] signature = CreatePaddedFilledArray(signatureSize, 42);
+
+            // Extra bytes in destination buffer should not be touched
+            Memory<byte> destination = signature.AsMemory(PaddingSize, signatureSize);
+            slhDsa.AddDestinationBufferIsSameAssertion(destination);
+
+            slhDsa.SignData(testData, destination.Span, testContext);
+            Assert.Equal(2, slhDsa.SignDataCoreCallCount);
             AssertExpectedFill(signature, fillElement: 1, paddingElement: 42, PaddingSize, signatureSize);
         }
 
@@ -211,6 +239,41 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             // And just to prove that the Core method controls the answer...
             returnValue = false;
             AssertExtensions.FalseExpression(slhDsa.VerifyData(testData, testSignature.AsSpan(PaddingSize, signatureSize), testContext));
+            Assert.Equal(2, slhDsa.VerifyDataCoreCallCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(SlhDsaTestData.AlgorithmsData), MemberType = typeof(SlhDsaTestData))]
+        public static void VerifyData_ByteArray_CallsCore(SlhDsaAlgorithm algorithm)
+        {
+            using SlhDsaMockImplementation slhDsa = SlhDsaMockImplementation.Create(algorithm);
+
+            int signatureSize = algorithm.SignatureSizeInBytes;
+            byte[] testSignature = CreateFilledArray(signatureSize, 42);
+            byte[] testData = [2];
+            byte[] testContext = [3];
+            bool returnValue = false;
+
+            slhDsa.VerifyDataCoreHook = (_, _, _) => returnValue;
+            slhDsa.AddDataBufferIsSameAssertion(testData);
+            slhDsa.AddContextBufferIsSameAssertion(testContext);
+            slhDsa.AddSignatureBufferIsSameAssertion(testSignature);
+
+            // Since `returnValue` is true, this shows the Core method doesn't get called for the wrong sized signature.
+            returnValue = true;
+            AssertExtensions.FalseExpression(slhDsa.VerifyData(testData, new byte[signatureSize - 1], testContext));
+            Assert.Equal(0, slhDsa.VerifyDataCoreCallCount);
+
+            AssertExtensions.FalseExpression(slhDsa.VerifyData(testData, new byte[signatureSize - 1], testContext));
+            Assert.Equal(0, slhDsa.VerifyDataCoreCallCount);
+
+            // But does for the right one.
+            AssertExtensions.TrueExpression(slhDsa.VerifyData(testData, testSignature, testContext));
+            Assert.Equal(1, slhDsa.VerifyDataCoreCallCount);
+
+            // And just to prove that the Core method controls the answer...
+            returnValue = false;
+            AssertExtensions.FalseExpression(slhDsa.VerifyData(testData, testSignature, testContext));
             Assert.Equal(2, slhDsa.VerifyDataCoreCallCount);
         }
 
@@ -675,6 +738,9 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 Assert.Equal(numberOfCalls, slhDsa.TryExportPkcs8PrivateKeyCoreCallCount);
             });
         }
+
+        private static void AssertExpectedFill(ReadOnlySpan<byte> source, byte fillElement) =>
+            AssertExpectedFill(source, fillElement, 255, 0, source.Length);
 
         private static void AssertExpectedFill(ReadOnlySpan<byte> source, byte fillElement, byte paddingElement, int startIndex, int length)
         {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaImplementationTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaImplementationTests.cs
@@ -308,8 +308,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using SlhDsa slhDsa = SlhDsa.ImportPkcs8PrivateKey(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyPkcs8);
             Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s, slhDsa.Algorithm);
 
-            byte[] secretKey = new byte[SlhDsaAlgorithm.SlhDsaSha2_128s.SecretKeySizeInBytes];
-            Assert.Equal(slhDsa.Algorithm.SecretKeySizeInBytes, slhDsa.ExportSlhDsaSecretKey(secretKey));
+            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
             AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, secretKey);
         }
 
@@ -319,8 +318,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using SlhDsa slhDsa = SlhDsa.ImportSubjectPublicKeyInfo(SlhDsaTestData.IetfSlhDsaSha2_128sPublicKeyPkcs8);
             Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s, slhDsa.Algorithm);
 
-            byte[] publicKey = new byte[SlhDsaAlgorithm.SlhDsaSha2_128s.PublicKeySizeInBytes];
-            Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s.PublicKeySizeInBytes, slhDsa.ExportSlhDsaPublicKey(publicKey));
+            byte[] publicKey = slhDsa.ExportSlhDsaPublicKey();
             AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPublicKeyValue, publicKey);
         }
 
@@ -331,8 +329,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using SlhDsa slhDsa = SlhDsa.ImportFromPem(pem);
             Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s, slhDsa.Algorithm);
 
-            byte[] secretKey = new byte[SlhDsaAlgorithm.SlhDsaSha2_128s.SecretKeySizeInBytes];
-            Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s.SecretKeySizeInBytes, slhDsa.ExportSlhDsaSecretKey(secretKey));
+            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
             AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, secretKey);
         }
 
@@ -343,8 +340,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using SlhDsa slhDsa = SlhDsa.ImportFromPem(pem);
             Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s, slhDsa.Algorithm);
 
-            byte[] publicKey = new byte[SlhDsaAlgorithm.SlhDsaSha2_128s.PublicKeySizeInBytes];
-            Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s.PublicKeySizeInBytes, slhDsa.ExportSlhDsaPublicKey(publicKey));
+            byte[] publicKey = slhDsa.ExportSlhDsaPublicKey();
             AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPublicKeyValue, publicKey);
         }
 
@@ -375,20 +371,17 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             // Import secret key and verify exports
             using (SlhDsa secretSlhDsa = ImportSlhDsaSecretKey(vector.Algorithm, sk))
             {
-                byte[] pubKey = new byte[vector.Algorithm.PublicKeySizeInBytes];
-                Assert.Equal(pk.Length, secretSlhDsa.ExportSlhDsaPublicKey(pubKey));
+                byte[] pubKey = secretSlhDsa.ExportSlhDsaPublicKey();
                 AssertExtensions.SequenceEqual(pk, pubKey);
 
-                byte[] secretKey = new byte[vector.Algorithm.SecretKeySizeInBytes];
-                Assert.Equal(sk.Length, secretSlhDsa.ExportSlhDsaSecretKey(secretKey));
+                byte[] secretKey = secretSlhDsa.ExportSlhDsaSecretKey();
                 AssertExtensions.SequenceEqual(sk, secretKey);
             }
 
             // Import public key and verify exports
             using (SlhDsa publicSlhDsa = ImportSlhDsaPublicKey(vector.Algorithm, pk))
             {
-                byte[] pubKey = new byte[vector.Algorithm.PublicKeySizeInBytes];
-                Assert.Equal(pk.Length, publicSlhDsa.ExportSlhDsaPublicKey(pubKey));
+                byte[] pubKey = publicSlhDsa.ExportSlhDsaPublicKey();
                 AssertExtensions.SequenceEqual(pk, pubKey);
 
                 byte[] secretKey = new byte[vector.Algorithm.SecretKeySizeInBytes];

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTestHelpers.cs
@@ -23,8 +23,10 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             byte[] tempBuffer = new byte[slhDsa.Algorithm.SignatureSizeInBytes];
             PbeParameters pbeParameters = new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 32);
 
-            Assert.Throws<ObjectDisposedException>(() => slhDsa.SignData([], tempBuffer, []));
-            Assert.Throws<ObjectDisposedException>(() => slhDsa.VerifyData([], tempBuffer, []));
+            Assert.Throws<ObjectDisposedException>(() => slhDsa.SignData(ReadOnlySpan<byte>.Empty, tempBuffer.AsSpan(), ReadOnlySpan<byte>.Empty));
+            Assert.Throws<ObjectDisposedException>(() => slhDsa.SignData(Array.Empty<byte>(), Array.Empty<byte>()));
+            Assert.Throws<ObjectDisposedException>(() => slhDsa.VerifyData(ReadOnlySpan<byte>.Empty, tempBuffer.AsSpan(), ReadOnlySpan<byte>.Empty));
+            Assert.Throws<ObjectDisposedException>(() => slhDsa.VerifyData(Array.Empty<byte>(), tempBuffer, Array.Empty<byte>()));
 
             Assert.Throws<ObjectDisposedException>(() => slhDsa.ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte>.Empty, pbeParameters));
             Assert.Throws<ObjectDisposedException>(() => slhDsa.ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char>.Empty, pbeParameters));
@@ -200,7 +202,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             callback(slhDsa =>
             {
                 byte[] buffer = new byte[slhDsa.Algorithm.PublicKeySizeInBytes];
-                Assert.Equal(slhDsa.Algorithm.PublicKeySizeInBytes, slhDsa.ExportSlhDsaPublicKey(buffer.AsSpan()));
+                slhDsa.ExportSlhDsaPublicKey(buffer.AsSpan());
                 return buffer;
             });
 
@@ -215,7 +217,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             callback(slhDsa =>
             {
                 byte[] buffer = new byte[slhDsa.Algorithm.SecretKeySizeInBytes];
-                Assert.Equal(slhDsa.Algorithm.SecretKeySizeInBytes, slhDsa.ExportSlhDsaSecretKey(buffer.AsSpan()));
+                slhDsa.ExportSlhDsaSecretKey(buffer.AsSpan());
                 return buffer;
             });
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTests.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             ExerciseSuccessfulVerify(slhDsa, data, signature, []);
 
             signature.AsSpan().Clear();
-            signature = slhDsa.SignData(data, Array.Empty<byte>());
+            slhDsa.SignData(data, signature, Array.Empty<byte>());
             ExerciseSuccessfulVerify(slhDsa, data, signature, Array.Empty<byte>());
         }
 
@@ -90,7 +90,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             ExerciseSuccessfulVerify(slhDsa, [], signature, []);
 
             signature.AsSpan().Clear();
-            signature = slhDsa.SignData(Array.Empty<byte>(), Array.Empty<byte>());
+            slhDsa.SignData(Array.Empty<byte>(), signature, Array.Empty<byte>());
             ExerciseSuccessfulVerify(slhDsa, [], signature, []);
         }
 
@@ -104,7 +104,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             ExerciseSuccessfulVerify(slhDsa, [], signature, context);
 
             signature.AsSpan().Clear();
-            signature = slhDsa.SignData(Array.Empty<byte>(), context);
+            slhDsa.SignData(Array.Empty<byte>(), signature, context);
             ExerciseSuccessfulVerify(slhDsa, [], signature, context);
         }
 
@@ -141,7 +141,6 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using (SlhDsa slhDsa = GenerateKey(algorithm))
             {
                 signature = slhDsa.SignData(data);
-
                 secretKey = slhDsa.ExportSlhDsaSecretKey();
             }
 
@@ -150,7 +149,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 ExerciseSuccessfulVerify(slhDsa, data, signature, []);
 
                 signature.AsSpan().Clear();
-                signature = slhDsa.SignData(data);
+                slhDsa.SignData(data, signature, []);
 
                 ExerciseSuccessfulVerify(slhDsa, data, signature, []);
             }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTests.cs
@@ -61,13 +61,11 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         {
             using SlhDsa slhDsa = GenerateKey(algorithm);
             byte[] data = [1, 2, 3, 4, 5];
-            byte[] signature = new byte[slhDsa.Algorithm.SignatureSizeInBytes];
-
-            Assert.Equal(signature.Length, slhDsa.SignData(data, signature));
+            byte[] signature = slhDsa.SignData(data);
             ExerciseSuccessfulVerify(slhDsa, data, signature, []);
 
             signature.AsSpan().Clear();
-            Assert.Equal(signature.Length, slhDsa.SignData(data, signature, Array.Empty<byte>()));
+            signature = slhDsa.SignData(data, Array.Empty<byte>());
             ExerciseSuccessfulVerify(slhDsa, data, signature, Array.Empty<byte>());
         }
 
@@ -78,9 +76,8 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using SlhDsa slhDsa = GenerateKey(algorithm);
             byte[] context = [1, 1, 3, 5, 6];
             byte[] data = [1, 2, 3, 4, 5];
-            byte[] signature = new byte[slhDsa.Algorithm.SignatureSizeInBytes];
 
-            Assert.Equal(signature.Length, slhDsa.SignData(data, signature, context));
+            byte[] signature = slhDsa.SignData(data, context);
             ExerciseSuccessfulVerify(slhDsa, data, signature, context);
         }
 
@@ -89,13 +86,11 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         public void GenerateSignVerifyEmptyMessageNoContext(SlhDsaAlgorithm algorithm)
         {
             using SlhDsa slhDsa = GenerateKey(algorithm);
-            byte[] signature = new byte[slhDsa.Algorithm.SignatureSizeInBytes];
-
-            Assert.Equal(signature.Length, slhDsa.SignData([], signature));
+            byte[] signature = slhDsa.SignData([]);
             ExerciseSuccessfulVerify(slhDsa, [], signature, []);
 
             signature.AsSpan().Clear();
-            Assert.Equal(signature.Length, slhDsa.SignData(Array.Empty<byte>(), signature, Array.Empty<byte>()));
+            signature = slhDsa.SignData(Array.Empty<byte>(), Array.Empty<byte>());
             ExerciseSuccessfulVerify(slhDsa, [], signature, []);
         }
 
@@ -105,13 +100,11 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         {
             using SlhDsa slhDsa = GenerateKey(algorithm);
             byte[] context = [1, 1, 3, 5, 6];
-            byte[] signature = new byte[slhDsa.Algorithm.SignatureSizeInBytes];
-
-            Assert.Equal(signature.Length, slhDsa.SignData([], signature, context));
+            byte[] signature = slhDsa.SignData([], context);
             ExerciseSuccessfulVerify(slhDsa, [], signature, context);
 
             signature.AsSpan().Clear();
-            Assert.Equal(signature.Length, slhDsa.SignData(Array.Empty<byte>(), signature, context));
+            signature = slhDsa.SignData(Array.Empty<byte>(), context);
             ExerciseSuccessfulVerify(slhDsa, [], signature, context);
         }
 
@@ -125,12 +118,10 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
             using (SlhDsa slhDsa = GenerateKey(algorithm))
             {
-                signature = new byte[algorithm.SignatureSizeInBytes];
-                Assert.Equal(signature.Length, slhDsa.SignData(data, signature));
+                signature = slhDsa.SignData(data);
                 AssertExtensions.TrueExpression(slhDsa.VerifyData(data, signature));
 
-                publicKey = new byte[algorithm.PublicKeySizeInBytes];
-                Assert.Equal(publicKey.Length, slhDsa.ExportSlhDsaPublicKey(publicKey));
+                publicKey = slhDsa.ExportSlhDsaPublicKey();
             }
 
             using (SlhDsa publicSlhDsa = ImportSlhDsaPublicKey(algorithm, publicKey))
@@ -149,11 +140,9 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
             using (SlhDsa slhDsa = GenerateKey(algorithm))
             {
-                signature = new byte[algorithm.SignatureSizeInBytes];
-                Assert.Equal(signature.Length, slhDsa.SignData(data, signature));
+                signature = slhDsa.SignData(data);
 
-                secretKey = new byte[algorithm.SecretKeySizeInBytes];
-                Assert.Equal(secretKey.Length, slhDsa.ExportSlhDsaSecretKey(secretKey));
+                secretKey = slhDsa.ExportSlhDsaSecretKey();
             }
 
             using (SlhDsa slhDsa = ImportSlhDsaSecretKey(algorithm, secretKey))
@@ -161,7 +150,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 ExerciseSuccessfulVerify(slhDsa, data, signature, []);
 
                 signature.AsSpan().Clear();
-                Assert.Equal(signature.Length, slhDsa.SignData(data, signature));
+                signature = slhDsa.SignData(data);
 
                 ExerciseSuccessfulVerify(slhDsa, data, signature, []);
             }
@@ -181,6 +170,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
         protected static void ExerciseSuccessfulVerify(SlhDsa slhDsa, byte[] data, byte[] signature, byte[] context)
         {
+            ReadOnlySpan<byte> buffer = [0, 1, 2, 3];
             AssertExtensions.TrueExpression(slhDsa.VerifyData(data, signature, context));
 
             if (data.Length > 0)
@@ -197,8 +187,8 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 AssertExtensions.TrueExpression(slhDsa.VerifyData(Array.Empty<byte>(), signature, context));
                 AssertExtensions.TrueExpression(slhDsa.VerifyData(ReadOnlySpan<byte>.Empty, signature, context));
 
-                AssertExtensions.FalseExpression(slhDsa.VerifyData([0], signature, context));
-                AssertExtensions.FalseExpression(slhDsa.VerifyData([1, 2, 3], signature, context));
+                AssertExtensions.FalseExpression(slhDsa.VerifyData(buffer.Slice(0, 1), signature, context));
+                AssertExtensions.FalseExpression(slhDsa.VerifyData(buffer.Slice(1), signature, context));
             }
 
             signature[0] ^= 1;
@@ -219,8 +209,8 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 AssertExtensions.TrueExpression(slhDsa.VerifyData(data, signature, Array.Empty<byte>()));
                 AssertExtensions.TrueExpression(slhDsa.VerifyData(data, signature, ReadOnlySpan<byte>.Empty));
 
-                AssertExtensions.FalseExpression(slhDsa.VerifyData(data, signature, [0]));
-                AssertExtensions.FalseExpression(slhDsa.VerifyData(data, signature, [1, 2, 3]));
+                AssertExtensions.FalseExpression(slhDsa.VerifyData(data, signature, buffer.Slice(0, 1)));
+                AssertExtensions.FalseExpression(slhDsa.VerifyData(data, signature, buffer.Slice(1)));
             }
 
             AssertExtensions.TrueExpression(slhDsa.VerifyData(data, signature, context));

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -2856,10 +2856,10 @@ namespace System.Security.Cryptography
         public byte[] ExportPkcs8PrivateKey() { throw null; }
         public string ExportPkcs8PrivateKeyPem() { throw null; }
         public byte[] ExportSlhDsaPublicKey() { throw null; }
-        public int ExportSlhDsaPublicKey(System.Span<byte> destination) { throw null; }
+        public void ExportSlhDsaPublicKey(System.Span<byte> destination) { }
         protected abstract void ExportSlhDsaPublicKeyCore(System.Span<byte> destination);
         public byte[] ExportSlhDsaSecretKey() { throw null; }
-        public int ExportSlhDsaSecretKey(System.Span<byte> destination) { throw null; }
+        public void ExportSlhDsaSecretKey(System.Span<byte> destination) { }
         protected abstract void ExportSlhDsaSecretKeyCore(System.Span<byte> destination);
         public byte[] ExportSubjectPublicKeyInfo() { throw null; }
         public string ExportSubjectPublicKeyInfoPem() { throw null; }
@@ -2881,7 +2881,8 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.SlhDsa ImportSlhDsaSecretKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.SlhDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
         public static System.Security.Cryptography.SlhDsa ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source) { throw null; }
-        public int SignData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.ReadOnlySpan<byte> context = default(System.ReadOnlySpan<byte>)) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public void SignData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.ReadOnlySpan<byte> context = default(System.ReadOnlySpan<byte>)) { }
         protected abstract void SignDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.Span<byte> destination);
         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
@@ -2889,6 +2890,7 @@ namespace System.Security.Cryptography
         public bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected virtual bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
         public bool VerifyData(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> signature, System.ReadOnlySpan<byte> context = default(System.ReadOnlySpan<byte>)) { throw null; }
         protected abstract bool VerifyDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.ReadOnlySpan<byte> signature);
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/SlhDsaX509SignatureGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/SlhDsaX509SignatureGenerator.cs
@@ -38,6 +38,8 @@ namespace System.Security.Cryptography.X509Certificates
 
         public override byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             // Ignore the hashAlgorithm parameter.
             // This generator only supports SLH-DSA "Pure" signatures, but the overall design of
             // CertificateRequest makes it easy for a hashAlgorithm value to get here.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/SlhDsaX509SignatureGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/SlhDsaX509SignatureGenerator.cs
@@ -38,16 +38,11 @@ namespace System.Security.Cryptography.X509Certificates
 
         public override byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm)
         {
-            ArgumentNullException.ThrowIfNull(data);
-
             // Ignore the hashAlgorithm parameter.
             // This generator only supports SLH-DSA "Pure" signatures, but the overall design of
             // CertificateRequest makes it easy for a hashAlgorithm value to get here.
 
-            byte[] signature = new byte[_key.Algorithm.SignatureSizeInBytes];
-            int written = _key.SignData(data, signature);
-            Debug.Assert(written == signature.Length);
-            return signature;
+            return _key.SignData(data);
         }
 
         protected override PublicKey BuildPublicKey()

--- a/src/libraries/System.Security.Cryptography/tests/SlhDsaOpenSslTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/SlhDsaOpenSslTests.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             {
                 byte[] data = [1, 1, 2, 3, 5, 8];
                 byte[] context = [13, 21];
-                byte[] oneSignature = new byte[SlhDsaAlgorithm.SlhDsaSha2_128s.SignatureSizeInBytes];
+                byte[] oneSignature;
 
                 using (one)
                 {

--- a/src/libraries/System.Security.Cryptography/tests/SlhDsaOpenSslTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/SlhDsaOpenSslTests.cs
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
                 using (one)
                 {
-                    Assert.Equal(oneSignature.Length, one.SignData(data, oneSignature, context));
+                    oneSignature = one.SignData(data, context);
                     VerifyInstanceIsUsable(one);
                     VerifyInstanceIsUsable(two);
                 }
@@ -75,14 +75,12 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
         private static void VerifyInstanceIsUsable(SlhDsaOpenSsl slhDsa)
         {
-            byte[] secretKey = new byte[slhDsa.Algorithm.SecretKeySizeInBytes];
-            Assert.Equal(slhDsa.Algorithm.SecretKeySizeInBytes, slhDsa.ExportSlhDsaSecretKey(secretKey)); // does not throw
+            _ = slhDsa.ExportSlhDsaSecretKey(); // does not throw
 
             // usable
             byte[] data = [1, 2, 3];
             byte[] context = [4];
-            byte[] signature = new byte[SlhDsaAlgorithm.SlhDsaSha2_128s.SignatureSizeInBytes];
-            slhDsa.SignData(data, signature, context);
+            byte[] signature = slhDsa.SignData(data, context);
 
             ExerciseSuccessfulVerify(slhDsa, data, signature, context);
         }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.cs
@@ -872,9 +872,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                         byte[] data = new byte[RandomNumberGenerator.GetInt32(97)];
                         RandomNumberGenerator.Fill(data);
 
-                        byte[] signature = new byte[pub.Algorithm.SignatureSizeInBytes];
-                        int written = priv.SignData(data, signature);
-                        Assert.Equal(signature.Length, written);
+                        byte[] signature = priv.SignData(data);
                         Assert.True(pub.VerifyData(data, signature));
                     });
             }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
@@ -786,9 +786,7 @@ MII
                         AssertExtensions.SequenceEqual(sharedSecret1, sharedSecret2);
                         break;
                     case (SlhDsa slhDsa, SlhDsa slhDsaPem):
-
-                        byte[] slhDsaSignature = new byte[slhDsa.Algorithm.SignatureSizeInBytes];
-                        Assert.Equal(slhDsaSignature.Length, slhDsa.SignData(data, slhDsaSignature));
+                        byte[] slhDsaSignature = slhDsa.SignData(data);
                         Assert.True(slhDsaPem.VerifyData(data, slhDsaSignature));
                         break;
                     default:


### PR DESCRIPTION
Adds/updates the following methods for convenience and to align with ML-KEM:
- `SignData`, `ExportSlhDsaPublicKey` and `ExportSlhDsaSecretKey` don't return the size of the result and now require the caller's destination buffer length to exactly match the required size.
- `SignData` and `VerifyData` have overloads for `byte[]`.

Note that `VerifyData` will still return false instead of throwing when the signature size is not exactly equal to `Algorithm.SignatureSizeInBytes`.