### PR TITLE
Fix instance size emission in ILCompiler to handle indeterminate sizes

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -732,7 +732,7 @@ namespace ILCompiler
                 statics[i] = staticsDescs[i];
             }
 
-            LayoutInt instanceSize = defType.InstanceByteCount;
+            LayoutInt instanceSize = defType.IsValueType ? defType.InstanceFieldSize : defType.InstanceByteCount;
             int instanceSizeEmit = instanceSize.IsIndeterminate ? 0xBAAD : instanceSize.AsInt;
             ClassFieldsTypeDescriptor fieldsDescriptor = new ClassFieldsTypeDescriptor
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -732,11 +732,11 @@ namespace ILCompiler
                 statics[i] = staticsDescs[i];
             }
 
-            LayoutInt elementSize = defType.GetElementSize();
-            int elementSizeEmit = elementSize.IsIndeterminate ? 0xBAAD : elementSize.AsInt;
+            LayoutInt instanceSize = defType.InstanceByteCount;
+            int instanceSizeEmit = instanceSize.IsIndeterminate ? 0xBAAD : instanceSize.AsInt;
             ClassFieldsTypeDescriptor fieldsDescriptor = new ClassFieldsTypeDescriptor
             {
-                Size = (ulong)elementSizeEmit,
+                Size = (ulong)instanceSizeEmit,
                 FieldsCount = fieldsDescs.Count,
             };
 


### PR DESCRIPTION
This PR fixes incorrect class size emission for reference types in NativeAOT PDBs, which caused IDA and other debuggers to ignore most fields.

See discussion and issue here:
https://github.com/dotnet/runtime/issues/115283#issuecomment-2849672499

Before this fix, the emitted size would always be the pointer size (e.g., 8), even if the actual instance size was known and available. This caused debuggers to parse only the base class portion of the type.

After this fix, we use `defType.InstanceByteCount` instead of `GetElementSize()` for class types when the size is determinate.