### PR TITLE
[Mono]: Fix generic interface non-virtual method vt_slot issue in build_imt_slots.

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -1588,7 +1588,7 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, gpointer* imt, int slot_num)
 						vt_slot ++;
 					continue;
 				}
-				if (mono_method_get_imt_slot (method) != slot_num) {
+				if (m_method_is_virtual (method) && mono_method_get_imt_slot (method) != slot_num) {
 					vt_slot ++;
 					continue;
 				}

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github113958.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github113958.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+// Github issue 113958, mainly a Mono issue having a generic
+// interface including both private and virtual default methods.
+// On Mono, private methods are not included in vtable,
+// but code building the IMT slot, incorrectly counted private
+// methods when calculating the vtable slot corresponding to a
+// IMT slot. In this case, it ends up reading outside allocated
+// memory, potentially causing a crash or an assert if read
+// memory content ends up being a null pointer.
+
+namespace GenericInterfaceDefaultVirutalMethodBug
+{
+    public class Program
+    {
+        [Fact]
+        public static void TestEntryPoint()
+        {
+            var foo = new FooInt();
+            string result = foo.Run();
+            Assert.Equal("Method3", result);
+        }
+    }
+
+    public interface IFoo<T>
+    {
+        private bool Method1() => false;
+        private bool Method2() => false;
+        string Method3() { return "Method3"; }
+    }
+
+    public class FooInt : IFoo<int>
+    {
+        public string Run()
+        {
+            return ((IFoo<int>)this).Method3();
+        }
+    }
+
+}

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github113958.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github113958.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
In case of a generic interface, `build_imt_slots` calculate the vt_slot to find the index in the vtable for the implementation. Currently implementation assumed interface methods are either static and/or virtual, but it's possible to have private/sealed methods that won't end up as virtual methods in vtable. This case was handled when building the vtable, but we didn't handle that scenario when building the IMT slots, ending up with wrong vtable slot, potentially outside of allocated memory.

In repro provided by https://github.com/dotnet/runtime/issues/113958, the created vtable will have 5 slots, 4 from implementing Object and 1 from the implemented interface. When calculating the vt_slot in `build_imt_slots` we did however include the private DIM methods when calculating vtable slot, ending up with 4 + 3, slot 7, but vtable only allocated 5, so it will read outside allocated memory, and if it this turns out to be NULL, that will trigger assert, otherwise it will use random value, but since IMT slot will be patched with compiled method, the issue wouldn't manifest, at least not in the specific repro scenario.

Fix makes sure we only count virtual methods in `build_imt_slots` vt_slot index, similar to previous fixes for static and non-virtual methods in non-generic interfaces:

https://github.com/dotnet/runtime/commit/0fb7b7dd0813fd7631d9b6ed38c8c0c2036d97a8
https://github.com/dotnet/runtime/commit/6543a048d7242ddf204f2e1ba0723d27c02bdfc7

Fixes https://github.com/dotnet/runtime/issues/113958.