### PR TITLE
Update MacOS signing to use PME

### DIFF
--- a/eng/pipelines/common/macos-sign-with-entitlements.yml
+++ b/eng/pipelines/common/macos-sign-with-entitlements.yml
@@ -30,12 +30,13 @@ steps:
   - task: EsrpCodeSigning@5
     displayName: 'ESRP CodeSigning'
     inputs:
-      ConnectedServiceName: 'DotNet-Engineering-Services_KeyVault'
-      AppRegistrationClientId: '28ec6507-2167-4eaa-a294-34408cf5dd0e'
-      AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-      AuthAKVName: 'EngKeyVault'
-      AuthCertName: 'DotNetCore-ESRP-AuthCert'
-      AuthSignCertName: 'DotNetCore-ESRP-AuthSignCert'
+      ConnectedServiceName: 'DotNetBuildESRP'
+      UseMSIAuthentication: true
+      EsrpClientId: '28ec6507-2167-4eaa-a294-34408cf5dd0e'
+      AppRegistrationClientId: '0ecbcdb7-8451-4cbe-940a-4ed97b08b955'
+      AppRegistrationTenantId: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+      AuthAKVName: 'DotNetEngKeyVault'
+      AuthSignCertName: 'DotNet-ESRP-AuthSignCert'
       FolderPath: '$(Build.ArtifactStagingDirectory)/'
       Pattern: 'mac_entitled_to_sign.zip'
       UseMinimatch: true


### PR DESCRIPTION
Contributes to https://github.com/dotnet/arcade-services/issues/4611

Updates the MacOS signing to use a PME identity in accordance with a corresponding [TSG](https://eng.ms/docs/microsoft-security/identity/trust-and-security-services/tss-high-security-environments/tss-esrp-fabric-and-platform-services/esrp-documentation/tsgs/sfi/tsg501-eliminate-access-to-codesigning-from-corp-tenants)

`dotnet-runtime-official` build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2702879&view=results
Example of the identity being used for publishing: https://dev.azure.com/dnceng/internal/_build/results?buildId=2702156&view=results