### PR TITLE
Fix HttpStress and SslStress missing apphost build error

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Directory.Build.props
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Directory.Build.props
@@ -15,5 +15,6 @@
         <MicrosoftNetCoreAppFrameworkName>Microsoft.NETCore.App</MicrosoftNetCoreAppFrameworkName>
         <MicrosoftNetCoreAppRefPackDir Condition="'$(MicrosoftNetCoreAppRefPackDir)' == ''" >$(RepositoryRoot)artifacts/bin/microsoft.netcore.app.ref/</MicrosoftNetCoreAppRefPackDir>
         <MicrosoftNetCoreAppRuntimePackDir Condition="'$(MicrosoftNetCoreAppRuntimePackDir)' == ''">$(RepositoryRoot)artifacts/bin/microsoft.netcore.app.runtime.$(OutputRID)/$(Configuration)/</MicrosoftNetCoreAppRuntimePackDir>
+        <UseLocalAppHostPack>false</UseLocalAppHostPack>
     </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Directory.Build.props
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Directory.Build.props
@@ -15,5 +15,6 @@
         <MicrosoftNetCoreAppFrameworkName>Microsoft.NETCore.App</MicrosoftNetCoreAppFrameworkName>
         <MicrosoftNetCoreAppRefPackDir Condition="'$(MicrosoftNetCoreAppRefPackDir)' == ''" >$(RepositoryRoot)artifacts/bin/microsoft.netcore.app.ref/</MicrosoftNetCoreAppRefPackDir>
         <MicrosoftNetCoreAppRuntimePackDir Condition="'$(MicrosoftNetCoreAppRuntimePackDir)' == ''">$(RepositoryRoot)artifacts/bin/microsoft.netcore.app.runtime.$(OutputRID)/$(Configuration)/</MicrosoftNetCoreAppRuntimePackDir>
+        <UseLocalAppHostPack>false</UseLocalAppHostPack>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes the build error described in https://github.com/dotnet/runtime/issues/42211#issuecomment-2856678820

https://github.com/dotnet/runtime/pull/114285 changes the apphost location variable, and this PR disables that for our stress builds since we get it from a locally downloaded nightly build instead.