### PR TITLE
[wasm coreclr] Fix fields alignment

### DIFF
--- a/src/coreclr/gc/env/gcenv.object.h
+++ b/src/coreclr/gc/env/gcenv.object.h
@@ -11,7 +11,7 @@ extern bool g_oldMethodTableFlags;
 // ARM requires that 64-bit primitive types are aligned at 64-bit boundaries for interlocked-like operations.
 // Additionally the platform ABI requires these types and composite type containing them to be similarly
 // aligned when passed as arguments.
-#if defined(TARGET_ARM) || defined(TARGET_BROWSER)
+#if defined(TARGET_ARM) || defined(TARGET_WASM)
 #define FEATURE_64BIT_ALIGNMENT
 #endif
 

--- a/src/coreclr/gc/env/gcenv.object.h
+++ b/src/coreclr/gc/env/gcenv.object.h
@@ -11,7 +11,7 @@ extern bool g_oldMethodTableFlags;
 // ARM requires that 64-bit primitive types are aligned at 64-bit boundaries for interlocked-like operations.
 // Additionally the platform ABI requires these types and composite type containing them to be similarly
 // aligned when passed as arguments.
-#ifdef TARGET_ARM
+#if defined(TARGET_ARM) || defined(TARGET_BROWSER)
 #define FEATURE_64BIT_ALIGNMENT
 #endif
 

--- a/src/coreclr/gc/env/gcenv.object.h
+++ b/src/coreclr/gc/env/gcenv.object.h
@@ -8,9 +8,7 @@
 extern bool g_oldMethodTableFlags;
 #endif
 
-// ARM requires that 64-bit primitive types are aligned at 64-bit boundaries for interlocked-like operations.
-// Additionally the platform ABI requires these types and composite type containing them to be similarly
-// aligned when passed as arguments.
+// Some platform ABIs require that 64-bit primitive types and composite types containing them are aligned at 64-bit boundaries.
 #if defined(TARGET_ARM) || defined(TARGET_WASM)
 #define FEATURE_64BIT_ALIGNMENT
 #endif

--- a/src/coreclr/gc/env/gcenv.object.h
+++ b/src/coreclr/gc/env/gcenv.object.h
@@ -8,7 +8,7 @@
 extern bool g_oldMethodTableFlags;
 #endif
 
-// Some platform ABIs require that 64-bit primitive types and composite types containing them are aligned at 64-bit boundaries.
+// Some 32-bit platform ABIs require that 64-bit primitive types and composite types containing them are aligned at 64-bit boundaries.
 #if defined(TARGET_ARM) || defined(TARGET_WASM)
 #define FEATURE_64BIT_ALIGNMENT
 #endif

--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -149,7 +149,7 @@
 // ARM requires that 64-bit primitive types are aligned at 64-bit boundaries for interlocked-like operations.
 // Additionally the platform ABI requires these types and composite type containing them to be similarly
 // aligned when passed as arguments.
-#if defined(TARGET_ARM) || defined(TARGET_BROWSER)
+#if defined(TARGET_ARM) || defined(TARGET_WASM)
 #define FEATURE_64BIT_ALIGNMENT
 #endif
 

--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -149,7 +149,7 @@
 // ARM requires that 64-bit primitive types are aligned at 64-bit boundaries for interlocked-like operations.
 // Additionally the platform ABI requires these types and composite type containing them to be similarly
 // aligned when passed as arguments.
-#ifdef TARGET_ARM
+#if defined(TARGET_ARM) || defined(TARGET_BROWSER)
 #define FEATURE_64BIT_ALIGNMENT
 #endif
 

--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -146,7 +146,7 @@
 #define FEATURE_HFA
 #endif
 
-// Some platform ABIs require that 64-bit primitive types and composite types containing them are aligned at 64-bit boundaries.
+// Some 32-bit platform ABIs require that 64-bit primitive types and composite types containing them are aligned at 64-bit boundaries.
 #if defined(TARGET_ARM) || defined(TARGET_WASM)
 #define FEATURE_64BIT_ALIGNMENT
 #endif

--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -146,9 +146,7 @@
 #define FEATURE_HFA
 #endif
 
-// ARM requires that 64-bit primitive types are aligned at 64-bit boundaries for interlocked-like operations.
-// Additionally the platform ABI requires these types and composite type containing them to be similarly
-// aligned when passed as arguments.
+// Some platform ABIs require that 64-bit primitive types and composite types containing them are aligned at 64-bit boundaries.
 #if defined(TARGET_ARM) || defined(TARGET_WASM)
 #define FEATURE_64BIT_ALIGNMENT
 #endif


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/115363

The problem happened in `MethodTableBuilder::PlaceInstanceFields` where in wasm case the fields were placed at wrong offsets.

The native representation looks like this:

```
class  field                                        wasm type          offset
-----------------------------------------------------------------------------------------------
Object
       PTR_MethodTable m_pMethTab                   i32                0
AssemblyLoadContextBaseObject
       int64_t         _id                          i64                8
       OBJECTREF       _unloadLock                  i32                16
       OBJECTREF       _resolvingUnmanagedDll       i32
       OBJECTREF       _resolving                   i32
       OBJECTREF       _unloading                   i32
       OBJECTREF       _name                        i32
       INT_PTR         _nativeAssemblyLoadContext   i32
       DWORD           _state                       i32                40
       CLR_BOOL        _isCollectible               i8                 44
```

While the managed field offsets were calculated wrong, the _id was placed at offset 4 and thus all the following fields were at wrong offsets too. The size check then failed.

By enabling `FEATURE_64BIT_ALIGNMENT` the `dwOffsetBias` is set to `TARGET_POINTER_SIZE` and the fields layout is calculated properly.

The 8 bytes wide types in wasm should be aligned to 8 bytes

https://github.com/WebAssembly/tool-conventions/blob/main/BasicCABI.md#data-representation

so hopefully the rest of the changes enabled by this feature should apply as well. Before this feature was enabled only for arm 32bits.