### PR TITLE
Replace ATP pattern with async/await in SmtpClient (part 1)

### DIFF
--- a/src/libraries/System.Net.Mail/src/System.Net.Mail.csproj
+++ b/src/libraries/System.Net.Mail/src/System.Net.Mail.csproj
@@ -47,6 +47,7 @@
     <Compile Include="System\Net\Mail\Attachment.cs" />
     <Compile Include="System\Net\Mail\AttachmentCollection.cs" />
     <Compile Include="System\Net\BufferedReadStream.cs" />
+    <Compile Include="System\Net\Mail\ReadWriteAdapter.cs" />
     <Compile Include="System\Net\Mail\LinkedResource.cs" />
     <Compile Include="System\Net\Mail\LinkedResourceCollection.cs" />
     <Compile Include="System\Net\Mail\DomainLiteralReader.cs" />

--- a/src/libraries/System.Net.Mail/src/System/Net/BufferBuilder.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/BufferBuilder.cs
@@ -34,6 +34,13 @@ namespace System.Net.Mail
             _buffer[_offset++] = value;
         }
 
+        internal void Append(ReadOnlyMemory<byte> value)
+        {
+            EnsureBuffer(value.Length);
+            value.Span.CopyTo(_buffer.AsSpan(_offset));
+            _offset += value.Length;
+        }
+
         internal void Append(ReadOnlySpan<byte> value)
         {
             EnsureBuffer(value.Length);

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
@@ -141,8 +141,9 @@ namespace System.Net.Mail
                     // extract the encoding from =?encoding?BorQ?blablalba?=
                     inputEncoding = MimeBasePart.DecodeEncoding(value);
                 }
-                catch (ArgumentException) { }
-                ;
+                catch (ArgumentException)
+                {
+                }
 
                 if (inputEncoding != null && value != null)
                 {
@@ -261,8 +262,8 @@ namespace System.Net.Mail
             }
             else
             {
-                using var stream = writer.GetContentStream();
                 // No content to write, just close the stream
+                writer.GetContentStream().Close();
             }
         }
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
@@ -5,6 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Mail
 {
@@ -139,7 +141,8 @@ namespace System.Net.Mail
                     // extract the encoding from =?encoding?BorQ?blablalba?=
                     inputEncoding = MimeBasePart.DecodeEncoding(value);
                 }
-                catch (ArgumentException) { };
+                catch (ArgumentException) { }
+                ;
 
                 if (inputEncoding != null && value != null)
                 {
@@ -240,94 +243,8 @@ namespace System.Net.Mail
 
         #region Sending
 
-        internal void EmptySendCallback(IAsyncResult result)
-        {
-            Exception? e = null;
-
-            if (result.CompletedSynchronously)
-            {
-                return;
-            }
-
-            EmptySendContext context = (EmptySendContext)result.AsyncState!;
-            try
-            {
-                BaseWriter.EndGetContentStream(result).Close();
-            }
-            catch (Exception ex)
-            {
-                e = ex;
-            }
-            context._result.InvokeCallback(e);
-        }
-
-        internal sealed class EmptySendContext
-        {
-            internal EmptySendContext(BaseWriter writer, LazyAsyncResult result)
-            {
-                _writer = writer;
-                _result = result;
-            }
-
-            internal LazyAsyncResult _result;
-            internal BaseWriter _writer;
-        }
-
-        internal IAsyncResult BeginSend(BaseWriter writer, bool allowUnicode,
-            AsyncCallback? callback, object? state)
-        {
-            PrepareHeaders(allowUnicode);
-            writer.WriteHeaders(Headers, allowUnicode);
-
-            if (Content != null)
-            {
-                return Content.BeginSend(writer, callback, allowUnicode, state);
-            }
-            else
-            {
-                LazyAsyncResult result = new LazyAsyncResult(this, state, callback);
-                IAsyncResult newResult = writer.BeginGetContentStream(EmptySendCallback, new EmptySendContext(writer, result));
-                if (newResult.CompletedSynchronously)
-                {
-                    BaseWriter.EndGetContentStream(newResult).Close();
-                    result.InvokeCallback();
-                }
-                return result;
-            }
-        }
-
-        internal void EndSend(IAsyncResult asyncResult)
-        {
-            ArgumentNullException.ThrowIfNull(asyncResult);
-
-            if (Content != null)
-            {
-                Content.EndSend(asyncResult);
-            }
-            else
-            {
-                LazyAsyncResult? castedAsyncResult = asyncResult as LazyAsyncResult;
-
-                if (castedAsyncResult == null || castedAsyncResult.AsyncObject != this)
-                {
-                    throw new ArgumentException(SR.net_io_invalidasyncresult);
-                }
-
-                if (castedAsyncResult.EndCalled)
-                {
-                    throw new InvalidOperationException(SR.Format(SR.net_io_invalidendcall, nameof(EndSend)));
-                }
-
-                castedAsyncResult.InternalWaitForCompletion();
-                castedAsyncResult.EndCalled = true;
-                if (castedAsyncResult.Result is Exception e)
-                {
-                    ExceptionDispatchInfo.Throw(e);
-                }
-            }
-        }
-
-        internal void Send(BaseWriter writer, bool sendEnvelope, bool allowUnicode)
+        internal async Task SendAsync<TIOAdapter>(BaseWriter writer, bool sendEnvelope, bool allowUnicode, CancellationToken cancellationToken = default)
+            where TIOAdapter : IReadWriteAdapter
         {
             if (sendEnvelope)
             {
@@ -340,11 +257,12 @@ namespace System.Net.Mail
 
             if (Content != null)
             {
-                Content.Send(writer, allowUnicode);
+                await Content.SendAsync<TIOAdapter>(writer, allowUnicode, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                writer.GetContentStream().Close();
+                using var stream = writer.GetContentStream();
+                // No content to write, just close the stream
             }
         }
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailWriter.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailWriter.cs
@@ -40,7 +40,7 @@ namespace System.Net.Mail
         internal override void Close()
         {
             _bufferBuilder.Append("\r\n"u8);
-            Flush(null);
+            Flush();
             _stream.Close();
         }
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/ReadWriteAdapter.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/ReadWriteAdapter.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Mail
+{
+    internal interface IReadWriteAdapter
+    {
+        static abstract ValueTask<int> ReadAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken);
+        static abstract ValueTask<int> ReadAtLeastAsync(Stream stream, Memory<byte> buffer, int minimumBytes, bool throwOnEndOfStream, CancellationToken cancellationToken);
+        static abstract ValueTask WriteAsync(Stream stream, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken);
+        static abstract Task FlushAsync(Stream stream, CancellationToken cancellationToken);
+        static abstract Task WaitAsync(TaskCompletionSource<bool> waiter);
+    }
+
+    internal readonly struct AsyncReadWriteAdapter : IReadWriteAdapter
+    {
+        public static ValueTask<int> ReadAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken) =>
+            stream.ReadAsync(buffer, cancellationToken);
+
+        public static ValueTask<int> ReadAtLeastAsync(Stream stream, Memory<byte> buffer, int minimumBytes, bool throwOnEndOfStream, CancellationToken cancellationToken) =>
+            stream.ReadAtLeastAsync(buffer, minimumBytes, throwOnEndOfStream, cancellationToken);
+
+        public static ValueTask WriteAsync(Stream stream, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) =>
+            stream.WriteAsync(buffer, cancellationToken);
+
+        public static Task FlushAsync(Stream stream, CancellationToken cancellationToken) => stream.FlushAsync(cancellationToken);
+
+        public static Task WaitAsync(TaskCompletionSource<bool> waiter) => waiter.Task;
+    }
+
+    internal readonly struct SyncReadWriteAdapter : IReadWriteAdapter
+    {
+        public static ValueTask<int> ReadAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken) =>
+            new ValueTask<int>(stream.Read(buffer.Span));
+
+        public static ValueTask<int> ReadAtLeastAsync(Stream stream, Memory<byte> buffer, int minimumBytes, bool throwOnEndOfStream, CancellationToken cancellationToken) =>
+            new ValueTask<int>(stream.ReadAtLeast(buffer.Span, minimumBytes, throwOnEndOfStream));
+
+        public static ValueTask WriteAsync(Stream stream, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        {
+            stream.Write(buffer.Span);
+            return default;
+        }
+
+        public static Task FlushAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            stream.Flush();
+            return Task.CompletedTask;
+        }
+
+        public static Task WaitAsync(TaskCompletionSource<bool> waiter)
+        {
+            waiter.Task.GetAwaiter().GetResult();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -892,7 +892,7 @@ namespace System.Net.Mail
         {
             try
             {
-                _message!.EndSend(result);
+                MailMessage.EndSend(result);
                 // If some recipients failed but not others, throw AFTER sending the message.
                 Complete(_failedRecipientException, result.AsyncState!);
             }
@@ -929,8 +929,7 @@ namespace System.Net.Mail
                 }
                 else
                 {
-                    _message!.BeginSend(_writer,
-                        IsUnicodeSupported(), new AsyncCallback(SendMessageCallback), result.AsyncState!);
+                    _message!.BeginSend(_writer, DeliveryMethod != SmtpDeliveryMethod.Network, IsUnicodeSupported(), new AsyncCallback(SendMessageCallback), result.AsyncState!);
                 }
             }
             catch (Exception e)

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpCommands.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpCommands.cs
@@ -23,16 +23,6 @@ namespace System.Net.Mail
             return task.GetAwaiter().GetResult();
         }
 
-        internal static IAsyncResult BeginSend(SmtpConnection conn, AsyncCallback callback, object? state)
-        {
-            return TaskToAsyncResult.Begin(SendAsync<AsyncReadWriteAdapter>(conn), callback, state);
-        }
-
-        internal static LineInfo EndSend(IAsyncResult asyncResult)
-        {
-            return TaskToAsyncResult.End<LineInfo>(asyncResult);
-        }
-
         internal static async Task<LineInfo> SendAsync<TIOAdapter>(SmtpConnection conn, CancellationToken cancellationToken = default)
             where TIOAdapter : IReadWriteAdapter
         {

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReader.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReader.cs
@@ -2,13 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Mail
 {
     //streams are read only; return of 0 means end of server's reply
-    internal sealed class SmtpReplyReader
+    internal sealed class SmtpReplyReader : IDisposable
     {
+        public void Dispose()
+        {
+            Close();
+        }
+
         private readonly SmtpReplyReaderFactory _reader;
 
         internal SmtpReplyReader(SmtpReplyReaderFactory reader)
@@ -16,39 +24,65 @@ namespace System.Net.Mail
             _reader = reader;
         }
 
-        internal IAsyncResult BeginReadLines(AsyncCallback? callback, object? state)
-        {
-            return _reader.BeginReadLines(this, callback, state);
-        }
-
-        internal IAsyncResult BeginReadLine(AsyncCallback? callback, object? state)
-        {
-            return _reader.BeginReadLine(this, callback, state);
-        }
-
         public void Close()
         {
             _reader.Close(this);
         }
 
-        internal static LineInfo[] EndReadLines(IAsyncResult result)
-        {
-            return SmtpReplyReaderFactory.EndReadLines(result);
-        }
-
-        internal static LineInfo EndReadLine(IAsyncResult result)
-        {
-            return SmtpReplyReaderFactory.EndReadLine(result);
-        }
-
         internal LineInfo[] ReadLines()
         {
-            return _reader.ReadLines(this);
+            Task<LineInfo[]> task = ReadLinesAsync<SyncReadWriteAdapter>();
+
+            Debug.Assert(task.IsCompleted, "ReadLinesAsync should be completed synchronously.");
+            return task.GetAwaiter().GetResult();
+        }
+
+        internal IAsyncResult BeginReadLines(AsyncCallback callback, object? state)
+        {
+            return TaskToAsyncResult.Begin(ReadLinesAsync<AsyncReadWriteAdapter>(), callback, state);
+        }
+
+        internal static LineInfo[] EndReadLines(IAsyncResult asyncResult)
+        {
+            return TaskToAsyncResult.End<LineInfo[]>(asyncResult);
         }
 
         internal LineInfo ReadLine()
         {
-            return _reader.ReadLine(this);
+            Task<LineInfo> task = ReadLineAsync<SyncReadWriteAdapter>();
+
+            Debug.Assert(task.IsCompleted, "ReadLineAsync should be completed synchronously.");
+            return task.GetAwaiter().GetResult();
+        }
+
+        internal IAsyncResult BeginReadLine(AsyncCallback callback, object? state)
+        {
+            return TaskToAsyncResult.Begin(ReadLineAsync<AsyncReadWriteAdapter>(), callback, state);
+        }
+
+        internal static LineInfo EndReadLine(IAsyncResult asyncResult)
+        {
+            return TaskToAsyncResult.End<LineInfo>(asyncResult);
+        }
+
+        internal Task<LineInfo[]> ReadLinesAsync()
+        {
+            return ReadLinesAsync<AsyncReadWriteAdapter>();
+        }
+
+        internal Task<LineInfo> ReadLineAsync()
+        {
+            return ReadLineAsync<AsyncReadWriteAdapter>();
+        }
+
+        internal Task<LineInfo[]> ReadLinesAsync<TIOAdapter>(CancellationToken cancellationToken = default) where TIOAdapter : IReadWriteAdapter
+        {
+            return _reader.ReadLinesAsync<TIOAdapter>(this, false, cancellationToken);
+        }
+
+        internal Task<LineInfo> ReadLineAsync<TIOAdapter>(CancellationToken cancellationToken = default) where TIOAdapter : IReadWriteAdapter
+        {
+            return _reader.ReadLineAsync<TIOAdapter>(this, cancellationToken);
         }
     }
 }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReaderFactory.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReaderFactory.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Mail
 {
@@ -53,20 +56,6 @@ namespace System.Net.Mail
             }
         }
 
-        internal IAsyncResult BeginReadLines(SmtpReplyReader caller, AsyncCallback? callback, object? state)
-        {
-            ReadLinesAsyncResult result = new ReadLinesAsyncResult(this, callback, state);
-            result.Read(caller);
-            return result;
-        }
-
-        internal IAsyncResult BeginReadLine(SmtpReplyReader caller, AsyncCallback? callback, object? state)
-        {
-            ReadLinesAsyncResult result = new ReadLinesAsyncResult(this, callback, state, true);
-            result.Read(caller);
-            return result;
-        }
-
         internal void Close(SmtpReplyReader caller)
         {
             if (_currentReader == caller)
@@ -80,21 +69,6 @@ namespace System.Net.Mail
 
                 _currentReader = null;
             }
-        }
-
-        internal static LineInfo[] EndReadLines(IAsyncResult result)
-        {
-            return ReadLinesAsyncResult.End(result);
-        }
-
-        internal static LineInfo EndReadLine(IAsyncResult result)
-        {
-            LineInfo[] info = ReadLinesAsyncResult.End(result);
-            if (info != null && info.Length > 0)
-            {
-                return info[0];
-            }
-            return default;
         }
 
         internal SmtpReplyReader GetNextReplyReader()
@@ -299,28 +273,47 @@ namespace System.Net.Mail
 
         internal LineInfo[] ReadLines(SmtpReplyReader caller, bool oneLine)
         {
+            Task<LineInfo[]> task = ReadLinesAsync<SyncReadWriteAdapter>(caller, oneLine);
+            Debug.Assert(task.IsCompleted, "ReadLinesAsync should complete synchronously for SyncReadWriteAdapter");
+
+            return task.GetAwaiter().GetResult();
+        }
+
+        internal Task<LineInfo[]> ReadLinesAsync(SmtpReplyReader caller, bool oneLine = false, CancellationToken cancellationToken = default)
+        {
+            return ReadLinesAsync<AsyncReadWriteAdapter>(caller, oneLine, cancellationToken);
+        }
+
+        internal async Task<LineInfo[]> ReadLinesAsync<TIOAdapter>(SmtpReplyReader caller, bool oneLine = false, CancellationToken cancellationToken = default) where TIOAdapter : IReadWriteAdapter
+        {
             if (caller != _currentReader || _readState == ReadState.Done)
             {
                 return Array.Empty<LineInfo>();
             }
 
-            _byteBuffer ??= new byte[SmtpReplyReaderFactory.DefaultBufferSize];
-
+            _byteBuffer ??= new byte[DefaultBufferSize];
             System.Diagnostics.Debug.Assert(_readState == ReadState.Status0);
 
             var builder = new StringBuilder();
             var lines = new List<LineInfo>();
             int statusRead = 0;
 
-            for (int start = 0, read = 0; ;)
+            int start = 0;
+            int read = 0;
+
+            while (true)
             {
                 if (start == read)
                 {
-                    read = _bufferedStream.Read(_byteBuffer);
                     start = 0;
+                    read = await TIOAdapter.ReadAsync(_bufferedStream, _byteBuffer, cancellationToken).ConfigureAwait(false);
+                    if (read == 0)
+                    {
+                        throw new IOException(SR.Format(SR.net_io_readfailure, SR.net_io_connectionclosed));
+                    }
                 }
 
-                int actual = ProcessRead(_byteBuffer.AsSpan(start, read), true);
+                int actual = ProcessRead(_byteBuffer!.AsSpan(start, read - start), true);
 
                 if (statusRead < 4)
                 {
@@ -340,160 +333,36 @@ namespace System.Net.Mail
                 if (_readState == ReadState.Status0)
                 {
                     statusRead = 0;
-                    lines.Add(new LineInfo(_statusCode, builder.ToString(0, builder.Length - 2))); // return everything except CRLF
+                    lines.Add(new LineInfo(_statusCode, builder.ToString(0, builder.Length - 2))); // Exclude CRLF
 
                     if (oneLine)
                     {
-                        _bufferedStream.Push(_byteBuffer.AsSpan(start, read - start));
+                        _bufferedStream.Push(_byteBuffer!.AsSpan(start, read - start));
                         return lines.ToArray();
                     }
-                    builder = new StringBuilder();
+
+                    builder.Clear();
                 }
                 else if (_readState == ReadState.Done)
                 {
-                    lines.Add(new LineInfo(_statusCode, builder.ToString(0, builder.Length - 2))); // return everything except CRLF
-                    _bufferedStream.Push(_byteBuffer.AsSpan(start, read - start));
+                    lines!.Add(new LineInfo(_statusCode, builder.ToString(0, builder.Length - 2))); // return everything except CRLF
+                    _bufferedStream.Push(_byteBuffer!.AsSpan(start, read - start));
                     return lines.ToArray();
                 }
             }
+
         }
 
-        private sealed class ReadLinesAsyncResult : LazyAsyncResult
+        internal async Task<LineInfo> ReadLineAsync(SmtpReplyReader caller)
         {
-            private StringBuilder? _builder;
-            private List<LineInfo>? _lines;
-            private readonly SmtpReplyReaderFactory _parent;
-            private static readonly AsyncCallback s_readCallback = new AsyncCallback(ReadCallback);
-            private int _read;
-            private int _statusRead;
-            private readonly bool _oneLine;
+            LineInfo[] lines = await ReadLinesAsync(caller, oneLine: true).ConfigureAwait(false);
+            return lines.Length > 0 ? lines[0] : default;
+        }
 
-            internal ReadLinesAsyncResult(SmtpReplyReaderFactory parent, AsyncCallback? callback, object? state) : base(null, state, callback)
-            {
-                _parent = parent;
-            }
-
-            internal ReadLinesAsyncResult(SmtpReplyReaderFactory parent, AsyncCallback? callback, object? state, bool oneLine) : base(null, state, callback)
-            {
-                _oneLine = oneLine;
-                _parent = parent;
-            }
-
-            internal void Read(SmtpReplyReader caller)
-            {
-                // if we've already found the delimitter, then return 0 indicating
-                // end of stream.
-                if (_parent._currentReader != caller || _parent._readState == ReadState.Done)
-                {
-                    InvokeCallback();
-                    return;
-                }
-
-                _parent._byteBuffer ??= new byte[SmtpReplyReaderFactory.DefaultBufferSize];
-
-                System.Diagnostics.Debug.Assert(_parent._readState == ReadState.Status0);
-
-                _builder = new StringBuilder();
-                _lines = new List<LineInfo>();
-
-                Read();
-            }
-
-            internal static LineInfo[] End(IAsyncResult result)
-            {
-                ReadLinesAsyncResult thisPtr = (ReadLinesAsyncResult)result;
-                thisPtr.InternalWaitForCompletion();
-                return thisPtr._lines!.ToArray();
-            }
-
-            private void Read()
-            {
-                do
-                {
-                    IAsyncResult result = _parent._bufferedStream.BeginRead(_parent._byteBuffer!, 0, _parent._byteBuffer!.Length, s_readCallback, this);
-                    if (!result.CompletedSynchronously)
-                    {
-                        return;
-                    }
-                    _read = _parent._bufferedStream.EndRead(result);
-                } while (ProcessRead());
-            }
-
-            private static void ReadCallback(IAsyncResult result)
-            {
-                if (!result.CompletedSynchronously)
-                {
-                    Exception? exception = null;
-                    ReadLinesAsyncResult thisPtr = (ReadLinesAsyncResult)result.AsyncState!;
-                    try
-                    {
-                        thisPtr._read = thisPtr._parent._bufferedStream.EndRead(result);
-                        if (thisPtr.ProcessRead())
-                        {
-                            thisPtr.Read();
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        exception = e;
-                    }
-
-                    if (exception != null)
-                    {
-                        thisPtr.InvokeCallback(exception);
-                    }
-                }
-            }
-
-            private bool ProcessRead()
-            {
-                if (_read == 0)
-                {
-                    throw new IOException(SR.Format(SR.net_io_readfailure, SR.net_io_connectionclosed));
-                }
-
-                for (int start = 0; start != _read;)
-                {
-                    int actual = _parent.ProcessRead(_parent._byteBuffer!.AsSpan(start, _read - start), true);
-
-                    if (_statusRead < 4)
-                    {
-                        int left = Math.Min(4 - _statusRead, actual);
-                        _statusRead += left;
-                        start += left;
-                        actual -= left;
-                        if (actual == 0)
-                        {
-                            continue;
-                        }
-                    }
-
-                    _builder!.Append(Encoding.UTF8.GetString(_parent._byteBuffer!, start, actual));
-                    start += actual;
-
-                    if (_parent._readState == ReadState.Status0)
-                    {
-                        _lines!.Add(new LineInfo(_parent._statusCode, _builder.ToString(0, _builder.Length - 2))); // return everything except CRLF
-                        _builder = new StringBuilder();
-                        _statusRead = 0;
-
-                        if (_oneLine)
-                        {
-                            _parent._bufferedStream.Push(_parent._byteBuffer!.AsSpan(start, _read - start));
-                            InvokeCallback();
-                            return false;
-                        }
-                    }
-                    else if (_parent._readState == ReadState.Done)
-                    {
-                        _lines!.Add(new LineInfo(_parent._statusCode, _builder.ToString(0, _builder.Length - 2))); // return everything except CRLF
-                        _parent._bufferedStream.Push(_parent._byteBuffer!.AsSpan(start, _read - start));
-                        InvokeCallback();
-                        return false;
-                    }
-                }
-                return true;
-            }
+        internal async Task<LineInfo> ReadLineAsync<TIOAdapter>(SmtpReplyReader caller, CancellationToken cancellationToken) where TIOAdapter : IReadWriteAdapter
+        {
+            LineInfo[] lines = await ReadLinesAsync<TIOAdapter>(caller, oneLine: true, cancellationToken).ConfigureAwait(false);
+            return lines.Length > 0 ? lines[0] : default;
         }
     }
 }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -316,7 +316,7 @@ namespace System.Net.Mail
         {
             while (_toIndex < _toCollection.Count)
             {
-                MultiAsyncResult result = (MultiAsyncResult)RecipientCommand.BeginSend(_connection,
+                IAsyncResult result = RecipientCommand.BeginSend(_connection,
                     _toCollection[_toIndex++].GetSmtpAddress(_allowUnicode) + _deliveryNotify,
                     s_sendToCollectionCompleted, this);
                 if (!result.CompletedSynchronously)

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
@@ -4,10 +4,12 @@
 using System.Collections.Specialized;
 using System.Net.Mail;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Mime
 {
-    internal class MimeBasePart
+    internal abstract class MimeBasePart
     {
         internal const string DefaultCharSet = "utf-8";
 
@@ -186,46 +188,6 @@ namespace System.Net.Mime
             }
         }
 
-        internal virtual void Send(BaseWriter writer, bool allowUnicode)
-        {
-            throw new NotImplementedException();
-        }
-
-        internal virtual IAsyncResult BeginSend(BaseWriter writer, AsyncCallback? callback,
-            bool allowUnicode, object? state)
-        {
-            throw new NotImplementedException();
-        }
-
-        internal void EndSend(IAsyncResult asyncResult)
-        {
-            ArgumentNullException.ThrowIfNull(asyncResult);
-
-            LazyAsyncResult? castedAsyncResult = asyncResult as MimePartAsyncResult;
-
-            if (castedAsyncResult == null || castedAsyncResult.AsyncObject != this)
-            {
-                throw new ArgumentException(SR.net_io_invalidasyncresult, nameof(asyncResult));
-            }
-
-            if (castedAsyncResult.EndCalled)
-            {
-                throw new InvalidOperationException(SR.Format(SR.net_io_invalidendcall, nameof(EndSend)));
-            }
-
-            castedAsyncResult.InternalWaitForCompletion();
-            castedAsyncResult.EndCalled = true;
-            if (castedAsyncResult.Result is Exception)
-            {
-                throw (Exception)castedAsyncResult.Result;
-            }
-        }
-
-        internal sealed class MimePartAsyncResult : LazyAsyncResult
-        {
-            internal MimePartAsyncResult(MimeBasePart part, object? state, AsyncCallback? callback) : base(part, state, callback)
-            {
-            }
-        }
+        internal abstract Task SendAsync<TIOAdapter>(BaseWriter writer, bool allowUnicode, CancellationToken cancellationToken) where TIOAdapter : IReadWriteAdapter;
     }
 }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeMultiPart.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeMultiPart.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Mime
 {
@@ -14,8 +15,6 @@ namespace System.Net.Mime
     {
         private Collection<MimeBasePart>? _parts;
         private static int s_boundary;
-        private AsyncCallback? _mimePartSentCallback;
-        private bool _allowUnicode;
 
         internal MimeMultiPart(MimeMultiPartType type)
         {
@@ -42,182 +41,7 @@ namespace System.Net.Mime
 
         internal Collection<MimeBasePart> Parts => _parts ??= new Collection<MimeBasePart>();
 
-        internal static void Complete(IAsyncResult result, Exception? e)
-        {
-            //if we already completed and we got called again,
-            //it mean's that there was an exception in the callback and we
-            //should just rethrow it.
-
-            MimePartContext context = (MimePartContext)result.AsyncState!;
-
-            if (context._completed)
-            {
-                ExceptionDispatchInfo.Throw(e!);
-            }
-
-            try
-            {
-                context._outputStream!.Close();
-            }
-            catch (Exception ex)
-            {
-                e ??= ex;
-            }
-            context._completed = true;
-            context._result.InvokeCallback(e);
-        }
-
-        internal void MimeWriterCloseCallback(IAsyncResult result)
-        {
-            if (result.CompletedSynchronously)
-            {
-                return;
-            }
-
-            ((MimePartContext)result.AsyncState!)._completedSynchronously = false;
-
-            try
-            {
-                MimeWriterCloseCallbackHandler(result);
-            }
-            catch (Exception e)
-            {
-                Complete(result, e);
-            }
-        }
-
-        private static void MimeWriterCloseCallbackHandler(IAsyncResult result)
-        {
-            MimePartContext context = (MimePartContext)result.AsyncState!;
-            ((MimeWriter)context._writer).EndClose(result);
-            Complete(result, null);
-        }
-
-        internal void MimePartSentCallback(IAsyncResult result)
-        {
-            if (result.CompletedSynchronously)
-            {
-                return;
-            }
-
-            ((MimePartContext)result.AsyncState!)._completedSynchronously = false;
-
-            try
-            {
-                MimePartSentCallbackHandler(result);
-            }
-            catch (Exception e)
-            {
-                Complete(result, e);
-            }
-        }
-
-        private void MimePartSentCallbackHandler(IAsyncResult result)
-        {
-            MimePartContext context = (MimePartContext)result.AsyncState!;
-            MimeBasePart part = (MimeBasePart)context._partsEnumerator.Current;
-            part.EndSend(result);
-
-            if (context._partsEnumerator.MoveNext())
-            {
-                part = (MimeBasePart)context._partsEnumerator.Current;
-                IAsyncResult sendResult = part.BeginSend(context._writer, _mimePartSentCallback!, _allowUnicode, context);
-                if (sendResult.CompletedSynchronously)
-                {
-                    MimePartSentCallbackHandler(sendResult);
-                }
-                return;
-            }
-            else
-            {
-                IAsyncResult closeResult = ((MimeWriter)context._writer).BeginClose(new AsyncCallback(MimeWriterCloseCallback), context);
-                if (closeResult.CompletedSynchronously)
-                {
-                    MimeWriterCloseCallbackHandler(closeResult);
-                }
-            }
-        }
-
-        internal void ContentStreamCallback(IAsyncResult result)
-        {
-            if (result.CompletedSynchronously)
-            {
-                return;
-            }
-
-            ((MimePartContext)result.AsyncState!)._completedSynchronously = false;
-
-            try
-            {
-                ContentStreamCallbackHandler(result);
-            }
-            catch (Exception e)
-            {
-                Complete(result, e);
-            }
-        }
-
-        private void ContentStreamCallbackHandler(IAsyncResult result)
-        {
-            MimePartContext context = (MimePartContext)result.AsyncState!;
-            context._outputStream = BaseWriter.EndGetContentStream(result);
-            context._writer = new MimeWriter(context._outputStream!, ContentType.Boundary!);
-            if (context._partsEnumerator.MoveNext())
-            {
-                MimeBasePart part = (MimeBasePart)context._partsEnumerator.Current;
-
-                _mimePartSentCallback = new AsyncCallback(MimePartSentCallback);
-                IAsyncResult sendResult = part.BeginSend(context._writer, _mimePartSentCallback, _allowUnicode, context);
-                if (sendResult.CompletedSynchronously)
-                {
-                    MimePartSentCallbackHandler(sendResult);
-                }
-                return;
-            }
-            else
-            {
-                IAsyncResult closeResult = ((MimeWriter)context._writer).BeginClose(new AsyncCallback(MimeWriterCloseCallback), context);
-                if (closeResult.CompletedSynchronously)
-                {
-                    MimeWriterCloseCallbackHandler(closeResult);
-                }
-            }
-        }
-
-        internal override IAsyncResult BeginSend(BaseWriter writer, AsyncCallback? callback, bool allowUnicode,
-            object? state)
-        {
-            _allowUnicode = allowUnicode;
-            PrepareHeaders(allowUnicode);
-            writer.WriteHeaders(Headers, allowUnicode);
-            MimePartAsyncResult result = new MimePartAsyncResult(this, state, callback);
-            MimePartContext context = new MimePartContext(writer, result, Parts.GetEnumerator());
-            IAsyncResult contentResult = writer.BeginGetContentStream(new AsyncCallback(ContentStreamCallback), context);
-            if (contentResult.CompletedSynchronously)
-            {
-                ContentStreamCallbackHandler(contentResult);
-            }
-            return result;
-        }
-
-        internal sealed class MimePartContext
-        {
-            internal MimePartContext(BaseWriter writer, LazyAsyncResult result, IEnumerator<MimeBasePart> partsEnumerator)
-            {
-                _writer = writer;
-                _result = result;
-                _partsEnumerator = partsEnumerator;
-            }
-
-            internal IEnumerator<MimeBasePart> _partsEnumerator;
-            internal Stream? _outputStream;
-            internal LazyAsyncResult _result;
-            internal BaseWriter _writer;
-            internal bool _completed;
-            internal bool _completedSynchronously = true;
-        }
-
-        internal override void Send(BaseWriter writer, bool allowUnicode)
+        internal override async Task SendAsync<TIOAdapter>(BaseWriter writer, bool allowUnicode, CancellationToken cancellationToken = default)
         {
             PrepareHeaders(allowUnicode);
             writer.WriteHeaders(Headers, allowUnicode);
@@ -226,7 +50,7 @@ namespace System.Net.Mime
 
             foreach (MimeBasePart part in Parts)
             {
-                part.Send(mimeWriter, allowUnicode);
+                await part.SendAsync<TIOAdapter>(mimeWriter, allowUnicode, cancellationToken).ConfigureAwait(false);
             }
 
             mimeWriter.Close();

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MimePart.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MimePart.cs
@@ -8,6 +8,8 @@ using System.IO;
 using System.Net.Mail;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Mime
 {
@@ -19,8 +21,6 @@ namespace System.Net.Mime
         private Stream? _stream;
         private bool _streamSet;
         private bool _streamUsedOnce;
-        private AsyncCallback? _readCallback;
-        private AsyncCallback? _writeCallback;
         private const int maxBufferSize = 0x4400;  //seems optimal for send based on perf analysis
 
         internal MimePart() { }
@@ -139,98 +139,6 @@ namespace System.Net.Mime
             SetContent(stream);
         }
 
-        internal static void Complete(IAsyncResult result, Exception? e)
-        {
-            //if we already completed and we got called again,
-            //it mean's that there was an exception in the callback and we
-            //should just rethrow it.
-
-            MimePartContext context = (MimePartContext)result.AsyncState!;
-            if (context._completed)
-            {
-                ExceptionDispatchInfo.Throw(e!);
-            }
-
-            try
-            {
-                context._outputStream?.Close();
-            }
-            catch (Exception ex)
-            {
-                e ??= ex;
-            }
-            context._completed = true;
-            context._result.InvokeCallback(e);
-        }
-
-
-        internal void ReadCallback(IAsyncResult result)
-        {
-            if (result.CompletedSynchronously)
-            {
-                return;
-            }
-
-            ((MimePartContext)result.AsyncState!)._completedSynchronously = false;
-
-            try
-            {
-                ReadCallbackHandler(result);
-            }
-            catch (Exception e)
-            {
-                Complete(result, e);
-            }
-        }
-
-        internal void ReadCallbackHandler(IAsyncResult result)
-        {
-            MimePartContext context = (MimePartContext)result.AsyncState!;
-            context._bytesLeft = Stream!.EndRead(result);
-            if (context._bytesLeft > 0)
-            {
-                IAsyncResult writeResult = context._outputStream!.BeginWrite(context._buffer, 0, context._bytesLeft, _writeCallback, context);
-                if (writeResult.CompletedSynchronously)
-                {
-                    WriteCallbackHandler(writeResult);
-                }
-            }
-            else
-            {
-                Complete(result, null);
-            }
-        }
-
-        internal void WriteCallback(IAsyncResult result)
-        {
-            if (result.CompletedSynchronously)
-            {
-                return;
-            }
-
-            ((MimePartContext)result.AsyncState!)._completedSynchronously = false;
-
-            try
-            {
-                WriteCallbackHandler(result);
-            }
-            catch (Exception e)
-            {
-                Complete(result, e);
-            }
-        }
-
-        internal void WriteCallbackHandler(IAsyncResult result)
-        {
-            MimePartContext context = (MimePartContext)result.AsyncState!;
-            context._outputStream!.EndWrite(result);
-            IAsyncResult readResult = Stream!.BeginRead(context._buffer, 0, context._buffer.Length, _readCallback, context);
-            if (readResult.CompletedSynchronously)
-            {
-                ReadCallbackHandler(readResult);
-            }
-        }
-
         internal Stream GetEncodedStream(Stream stream)
         {
             Stream outputStream = stream;
@@ -251,76 +159,7 @@ namespace System.Net.Mime
             return outputStream;
         }
 
-        internal void ContentStreamCallbackHandler(IAsyncResult result)
-        {
-            MimePartContext context = (MimePartContext)result.AsyncState!;
-            Stream outputStream = BaseWriter.EndGetContentStream(result);
-            context._outputStream = GetEncodedStream(outputStream);
-
-            _readCallback = new AsyncCallback(ReadCallback);
-            _writeCallback = new AsyncCallback(WriteCallback);
-            IAsyncResult readResult = Stream!.BeginRead(context._buffer, 0, context._buffer.Length, _readCallback, context);
-            if (readResult.CompletedSynchronously)
-            {
-                ReadCallbackHandler(readResult);
-            }
-        }
-
-        internal void ContentStreamCallback(IAsyncResult result)
-        {
-            if (result.CompletedSynchronously)
-            {
-                return;
-            }
-
-            ((MimePartContext)result.AsyncState!)._completedSynchronously = false;
-
-            try
-            {
-                ContentStreamCallbackHandler(result);
-            }
-            catch (Exception e)
-            {
-                Complete(result, e);
-            }
-        }
-
-        internal sealed class MimePartContext
-        {
-            internal MimePartContext(BaseWriter writer, LazyAsyncResult result)
-            {
-                _writer = writer;
-                _result = result;
-                _buffer = new byte[maxBufferSize];
-            }
-
-            internal Stream? _outputStream;
-            internal LazyAsyncResult _result;
-            internal int _bytesLeft;
-            internal BaseWriter _writer;
-            internal byte[] _buffer;
-            internal bool _completed;
-            internal bool _completedSynchronously = true;
-        }
-
-        internal override IAsyncResult BeginSend(BaseWriter writer, AsyncCallback? callback, bool allowUnicode, object? state)
-        {
-            PrepareHeaders(allowUnicode);
-            writer.WriteHeaders(Headers, allowUnicode);
-            MimePartAsyncResult result = new MimePartAsyncResult(this, state, callback);
-            MimePartContext context = new MimePartContext(writer, result);
-
-            ResetStream();
-            _streamUsedOnce = true;
-            IAsyncResult contentResult = writer.BeginGetContentStream(new AsyncCallback(ContentStreamCallback), context);
-            if (contentResult.CompletedSynchronously)
-            {
-                ContentStreamCallbackHandler(contentResult);
-            }
-            return result;
-        }
-
-        internal override void Send(BaseWriter writer, bool allowUnicode)
+        internal override async Task SendAsync<TIOAdapter>(BaseWriter writer, bool allowUnicode, CancellationToken cancellationToken = default)
         {
             if (Stream != null)
             {
@@ -332,15 +171,15 @@ namespace System.Net.Mime
                 Stream outputStream = writer.GetContentStream();
                 outputStream = GetEncodedStream(outputStream);
 
-                int read;
-
                 ResetStream();
                 _streamUsedOnce = true;
 
-                while ((read = Stream.Read(buffer, 0, maxBufferSize)) > 0)
+                int read;
+                while ((read = await TIOAdapter.ReadAsync(Stream, buffer.AsMemory(0, maxBufferSize), cancellationToken).ConfigureAwait(false)) > 0)
                 {
-                    outputStream.Write(buffer, 0, read);
+                    await TIOAdapter.WriteAsync(outputStream, buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
                 }
+
                 outputStream.Close();
             }
         }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeWriter.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeWriter.cs
@@ -35,37 +35,13 @@ namespace System.Net.Mime
 
         #region Cleanup
 
-        internal IAsyncResult BeginClose(AsyncCallback? callback, object? state)
-        {
-            MultiAsyncResult multiResult = new MultiAsyncResult(this, callback, state);
-
-            Close(multiResult);
-
-            multiResult.CompleteSequence();
-
-            return multiResult;
-        }
-
-        internal void EndClose(IAsyncResult result)
-        {
-            MultiAsyncResult.End(result);
-
-            _stream.Close();
-        }
-
         internal override void Close()
-        {
-            Close(null);
-
-            _stream.Close();
-        }
-
-        private void Close(MultiAsyncResult? multiResult)
         {
             _bufferBuilder.Append("\r\n--"u8);
             _bufferBuilder.Append(_boundaryBytes);
             _bufferBuilder.Append("--\r\n"u8);
-            Flush(multiResult);
+            Flush();
+            _stream.Close();
         }
 
         /// <summary>

--- a/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
@@ -36,7 +36,7 @@ namespace System.Net.Mail.Tests
                     listener.RunWithCallback(events.Enqueue, () =>
                     {
                         // Invoke a test that'll cause some events to be generated
-                        new SmtpClientTest().TestMailDelivery();
+                        new SmtpClientTest(null!).TestMailDelivery();
                     });
                     Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself
                     Assert.InRange(events.Count, 1, int.MaxValue);

--- a/src/libraries/System.Net.Mail/tests/Functional/LoopbackSmtpServer.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/LoopbackSmtpServer.cs
@@ -63,10 +63,11 @@ namespace System.Net.Mail.Tests
         {
             _output = output;
             _socketsToDispose = new ConcurrentBag<Socket>();
-            _listenSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            _listenSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             _socketsToDispose.Add(_listenSocket);
 
-            _listenSocket.Bind(new IPEndPoint(IPAddress.Any, 0));
+            // if dual socket supported, bind to Ipv6Any, otherwise Any
+            _listenSocket.Bind(new IPEndPoint(_listenSocket.AddressFamily == AddressFamily.InterNetwork ? IPAddress.Any : IPAddress.IPv6Any, 0));
             Port = ((IPEndPoint)_listenSocket.LocalEndPoint).Port;
             _listenSocket.Listen(1);
 

--- a/src/libraries/System.Net.Mail/tests/Functional/MailMessageTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/MailMessageTest.cs
@@ -261,17 +261,14 @@ blah blah
                                 culture: null,
                                 activationAttributes: null);
 
-            // var syncSendAdapterType = typeof(MailMessage).Assembly.GetTypes()
-            //     .FirstOrDefault(t => t.Name == "SyncReadWriteAdapter");
+            var syncSendAdapterType = typeof(MailMessage).Assembly.GetTypes()
+                .FirstOrDefault(t => t.Name == "SyncReadWriteAdapter");
 
             // Send the message.
-            // typeof(MailMessage)
-            //     .GetMethod("SendAsync", BindingFlags.Instance | BindingFlags.NonPublic)
-            //     .MakeGenericMethod(syncSendAdapterType)
-            //     .Invoke(mail, new object[] { mailWriter, true, true, CancellationToken.None });
             typeof(MailMessage)
-                .GetMethod("Send", BindingFlags.Instance | BindingFlags.NonPublic)
-                .Invoke(mail, new object[] { mailWriter, true, true });
+                .GetMethod("SendAsync", BindingFlags.Instance | BindingFlags.NonPublic)
+                .MakeGenericMethod(syncSendAdapterType)
+                .Invoke(mail, new object[] { mailWriter, true, true, CancellationToken.None });
 
             // Decode contents.
             string result = Encoding.UTF8.GetString(stream.ToArray());

--- a/src/libraries/System.Net.Mail/tests/Functional/MailMessageTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/MailMessageTest.cs
@@ -11,8 +11,10 @@
 
 using System.IO;
 using System.Reflection;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Xunit;
 
 namespace System.Net.Mail.Tests
@@ -259,13 +261,17 @@ blah blah
                                 culture: null,
                                 activationAttributes: null);
 
+            // var syncSendAdapterType = typeof(MailMessage).Assembly.GetTypes()
+            //     .FirstOrDefault(t => t.Name == "SyncReadWriteAdapter");
+
             // Send the message.
-            typeof(MailMessage).InvokeMember(
-                                name: "Send",
-                                invokeAttr: BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
-                                binder: null,
-                                target: mail,
-                                args: new object[] { mailWriter, true, true });
+            // typeof(MailMessage)
+            //     .GetMethod("SendAsync", BindingFlags.Instance | BindingFlags.NonPublic)
+            //     .MakeGenericMethod(syncSendAdapterType)
+            //     .Invoke(mail, new object[] { mailWriter, true, true, CancellationToken.None });
+            typeof(MailMessage)
+                .GetMethod("Send", BindingFlags.Instance | BindingFlags.NonPublic)
+                .Invoke(mail, new object[] { mailWriter, true, true });
 
             // Decode contents.
             string result = Encoding.UTF8.GetString(stream.ToArray());

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
@@ -23,6 +23,17 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        public async Task UnrecognizedReply_Throws()
+        {
+            Server.OnCommandReceived = (command, arg) =>
+            {
+                return "Go away";
+            };
+
+            await SendMail<SmtpException>(new MailMessage("mono@novell.com", "everyone@novell.com", "introduction", "hello"));
+        }
+
+        [Fact]
         public async Task EHelloNotRecognized_RestartWithHello()
         {
             bool helloReceived = false;

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
 using System.Net.Test.Common;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Mail.Tests
 {
@@ -51,6 +52,13 @@ namespace System.Net.Mail.Tests
                 _smtp.Dispose();
             }
             base.Dispose(disposing);
+        }
+
+        ITestOutputHelper _output;
+
+        public SmtpClientTest(ITestOutputHelper output)
+        {
+            _output = output;
         }
 
         [Theory]
@@ -237,7 +245,7 @@ namespace System.Net.Mail.Tests
         [Fact]
         public void TestMailDelivery()
         {
-            using var server = new LoopbackSmtpServer();
+            using var server = new LoopbackSmtpServer(_output);
             using SmtpClient client = server.CreateClient();
             client.Credentials = new NetworkCredential("foo", "bar");
             MailMessage msg = new MailMessage("foo@example.com", "bar@example.com", "hello", "howdydoo");
@@ -282,7 +290,7 @@ namespace System.Net.Mail.Tests
         [Fact]
         public void SendMailAsync_CanBeCanceled_CancellationToken_SetAlready()
         {
-            using var server = new LoopbackSmtpServer();
+            using var server = new LoopbackSmtpServer(_output);
             using SmtpClient client = server.CreateClient();
 
             CancellationTokenSource cts = new CancellationTokenSource();
@@ -299,7 +307,7 @@ namespace System.Net.Mail.Tests
         [Fact]
         public async Task SendMailAsync_CanBeCanceled_CancellationToken()
         {
-            using var server = new LoopbackSmtpServer();
+            using var server = new LoopbackSmtpServer(_output);
             using SmtpClient client = server.CreateClient();
 
             server.ReceiveMultipleConnections = true;

--- a/src/libraries/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
@@ -110,6 +110,8 @@
              Link="ProductionCode\MailHeaderInfo.cs" />
     <Compile Include="..\..\src\System\Net\BufferBuilder.cs"
              Link="ProductionCode\BufferBuilder.cs" />
+    <Compile Include="..\..\src\System\Net\Mail\ReadWriteAdapter.cs"
+             Link="ProductionCode\ReadWriteAdapter.cs" />
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs"
              Link="Common\DisableRuntimeMarshalling.cs" />
     <Compile Include="$(CommonPath)System\Net\InternalException.cs"


### PR DESCRIPTION
This PR replaces some of the ATP pattern (begin + end methods) with async/await equivalent. It also utilizes the IReadWriteAdapter trick that is used in SslStream to deduplicate sync and async code paths.

This PR focuses on the easy picks where the pattern can be clearly replaced, Following PR will focus on refactoring SmtpClient, SmtpConnection and SmtpTransport classes themselves, where the ATP pattern usage is more complicated.

Lastly, this PR improves test infrastructure by listening on dual sockets (if supported), this greatly speeds up the test suite on Windows (4s instead of 3 minutes, due to 2s timeout per test case because the test code attempted IPv6 first)