### PR TITLE
[release/8.0-staging] Handle OSSL 3.4 change to SAN:othername formatting

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -57,9 +57,10 @@ namespace System
             throw new PlatformNotSupportedException();
 
         private static readonly Version s_openssl3Version = new Version(3, 0, 0);
-        public static bool IsOpenSsl3 => !IsOSXLike && !IsWindows && !IsAndroid && !IsBrowser ?
-            GetOpenSslVersion() >= s_openssl3Version :
-            false;
+        private static readonly Version s_openssl3_4Version = new Version(3, 4, 0);
+
+        public static bool IsOpenSsl3 => IsOpenSslVersionAtLeast(s_openssl3Version);
+        public static bool IsOpenSsl3_4 => IsOpenSslVersionAtLeast(s_openssl3_4Version);
 
         /// <summary>
         /// If gnulibc is available, returns the release, such as "stable".
@@ -144,6 +145,18 @@ namespace System
             }
 
             return s_opensslVersion;
+        }
+
+        // The "IsOpenSsl" properties answer false on Apple, even if OpenSSL is present for lightup,
+        // as they are answering the question "is OpenSSL the primary crypto provider".
+        private static bool IsOpenSslVersionAtLeast(Version minVersion)
+        {
+            if (IsOSXLike || IsWindows || IsAndroid || IsBrowser)
+            {
+                return false;
+            }
+
+            return GetOpenSslVersion() >= minVersion;
         }
 
         private static Version ToVersion(string versionString)

--- a/src/libraries/System.Security.Cryptography/tests/AsnEncodedDataTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/AsnEncodedDataTests.cs
@@ -112,11 +112,13 @@ namespace System.Security.Cryptography.Tests
 
             string s = asnData.Format(false);
             bool isOpenSsl3 = PlatformDetection.IsOpenSsl3;
+            bool isOpenSsl3_4 = PlatformDetection.IsOpenSsl3_4;
 
             string expected = string.Join(
                 ", ",
                 // Choice[0]: OtherName
-                isOpenSsl3 ? "othername: UPN::subjectupn1@example.org" : "othername:<unsupported>",
+                isOpenSsl3_4 ? "othername: UPN:subjectupn1@example.org" :
+                    isOpenSsl3 ? "othername: UPN::subjectupn1@example.org" : "othername:<unsupported>",
                 // Choice[1]: Rfc822Name (EmailAddress)
                 "email:sanemail1@example.org",
                 // Choice[2]: DnsName


### PR DESCRIPTION
Backport of #111820 to release/8.0-staging

/cc @vcsjones @bartonjs

## Customer Impact

- [ ] Customer reported
- [X] Found internally

This is a test-only change to react to a change in OpenSSL 3.4 that is starting to appear in our CI pipelines. OpenSSL 3.4 formats a UPN in an otherName SAN differently.

## Regression

- [ ] Yes
- [ ] No
- [X] Upstream Change

Reacting to an upstream change in OpenSSL 3.4 that was introduced here https://github.com/openssl/openssl/commit/de8861a7e3100053542ec020aadd3f4fc88b7a02

## Testing

Existing tests caught the change. Tests pass after conditionally handling the OpenSSL 3.4 change, so that tests will continue to pass on older OpenSSL versions, too.

## Risk

Low. Test only change.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.