### PR TITLE
Add support for more libicu versions

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-debian.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-debian.proj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <LinuxPackageDependency Include="libc6;libgcc1;libgssapi-krb5-2;libstdc++6"/>
     <LinuxPackageDependency Include="libssl3" />
-    <KnownLibIcuVersion Include="72" />
+    <KnownLibIcuVersion Include="78;77;76;72" />
     <LinuxPackageDependency Include="@(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />
  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/115274

Debian Trixie package repository was updated to include just `libicu76`. We require `libicu72`.

Besides version 76, this PR also adds versions 77 and 78, to limit the need to change this file often.

Will also prepare fixes for 9.0 and 8.0.