### PR TITLE
[release/9.0-staging] Add support for more libicu versions

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-debian.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-debian.proj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <LinuxPackageDependency Include="libc6;libgcc1;libgssapi-krb5-2;libstdc++6;zlib1g"/>
     <LinuxPackageDependency Include="libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3" />
-    <KnownLibIcuVersion Include="74;72;71;70;69;68;67;66;65;63;60;57;55;52" />
+    <KnownLibIcuVersion Include="78;77;76;74;72;71;70;69;68;67;66;65;63;60;57;55;52" />
     <LibIcuPackageDependency Include="libicu" Dependencies="libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />
     <LinuxPackageDependency
       Include="@(LibIcuPackageDependency->Metadata('Dependencies'))" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/115274

Debian Trixie package repository was updated to include just `libicu76`. We require `libicu72`.

Besides version 76, this PR also adds versions 77 and 78, to limit the need to change this file often.
