### PR TITLE
Convert Sync RemoteExecutors to Async on Http Tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -117,9 +117,9 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [ConditionalFact(nameof(IsSocketsHttpHandlerAndRemoteExecutorSupported))]
-        public void Proxy_UseEnvironmentVariableToSetSystemProxy_RequestGoesThruProxy()
+        public async Task Proxy_UseEnvironmentVariableToSetSystemProxy_RequestGoesThruProxy()
         {
-            RemoteExecutor.Invoke(async (useVersionString) =>
+            await RemoteExecutor.Invoke(async (useVersionString) =>
             {
                 var options = new LoopbackProxyServer.Options { AddViaRequestHeader = true };
                 using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create(options))
@@ -134,7 +134,7 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Contains(proxyServer.ViaHeader, body);
                     }
                 }
-            }, UseVersion.ToString()).Dispose();
+            }, UseVersion.ToString()).DisposeAsync();
         }
 
         const string BasicAuth = "Basic";

--- a/src/libraries/System.Net.Http/tests/EnterpriseTests/HttpClientAuthenticationTest.cs
+++ b/src/libraries/System.Net.Http/tests/EnterpriseTests/HttpClientAuthenticationTest.cs
@@ -20,9 +20,9 @@ namespace System.Net.Http.Enterprise.Tests
         [InlineData(EnterpriseTestConfiguration.DigestAuthWebServer, true)]
         [InlineData(EnterpriseTestConfiguration.DigestAuthWebServer, false)]
         [InlineData(EnterpriseTestConfiguration.NtlmAuthWebServer, true)]
-        public void HttpClient_ValidAuthentication_Success(string url, bool useDomain, bool useAltPort = false)
+        public async Task HttpClient_ValidAuthentication_Success(string url, bool useDomain, bool useAltPort = false)
         {
-            RemoteExecutor.Invoke((url, useAltPort, useDomain) =>
+            await RemoteExecutor.Invoke((url, useAltPort, useDomain) =>
             {
                 // This is safe as we have no parallel tests
 		if (!string.IsNullOrEmpty(useAltPort))
@@ -35,7 +35,7 @@ namespace System.Net.Http.Enterprise.Tests
 
                 using HttpResponseMessage response = client.GetAsync(url).GetAwaiter().GetResult();
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            }, url, useAltPort ? "true" : "" , useDomain ? "true" : "").Dispose();
+            }, url, useAltPort ? "true" : "" , useDomain ? "true" : "").DisposeAsync();
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
@@ -8,5 +8,7 @@
 
     <Compile Include="$(CommonTestPath)System\Net\EnterpriseTests\EnterpriseTestConfiguration.cs"
              Link="Common\System\Net\EnterpriseTests\EnterpriseTestConfiguration.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\RemoteExecutorExtensions.cs"
+             Link="Common\System\Net\RemoteExecutorExtensions.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -1252,9 +1252,9 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("fAlSe")]
         [InlineData("helloworld")]
         [InlineData("")]
-        public void SendAsync_SuppressedGlobalStaticPropagationEnvVar(string envVarValue)
+        public async Task SendAsync_SuppressedGlobalStaticPropagationEnvVar(string envVarValue)
         {
-            RemoteExecutor.Invoke(async (useVersion, testAsync, envVarValue) =>
+            await RemoteExecutor.Invoke(async (useVersion, testAsync, envVarValue) =>
             {
                 Environment.SetEnvironmentVariable(EnableActivityPropagationEnvironmentVariableSettingName, envVarValue);
 
@@ -1283,7 +1283,7 @@ namespace System.Net.Http.Functional.Tests
 
                     Assert.Equal(isInstrumentationEnabled, anyEventLogged);
                 }
-            }, UseVersion.ToString(), TestAsync.ToString(), envVarValue).Dispose();
+            }, UseVersion.ToString(), TestAsync.ToString(), envVarValue).DisposeAsync();
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -1405,9 +1405,9 @@ namespace System.Net.Http.Functional.Tests
         public static bool RemoteExecutorAndSocketsHttpHandlerSupported => RemoteExecutor.IsSupported && SocketsHttpHandler.IsSupported;
 
         [ConditionalFact(nameof(RemoteExecutorAndSocketsHttpHandlerSupported))]
-        public void AllSocketsHttpHandlerCounters_Success_Recorded()
+        public async Task AllSocketsHttpHandlerCounters_Success_Recorded()
         {
-            RemoteExecutor.Invoke(static async Task () =>
+            await RemoteExecutor.Invoke(static async Task () =>
             {
                 TaskCompletionSource clientWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -1453,7 +1453,7 @@ namespace System.Net.Http.Functional.Tests
                         await connection.WaitForCloseAsync(CancellationToken.None);
                     });
                 });
-            }).Dispose();
+            }).DisposeAsync();
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -996,14 +996,14 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalTheory(nameof(SupportsRemoteExecutorAndAlpn))]
         [InlineData(false)]
         [InlineData(true)]
-        public void EventSource_Proxy_LogsIPAddress(bool useSsl)
+        public async Task EventSource_Proxy_LogsIPAddress(bool useSsl)
         {
             if (UseVersion.Major == 3)
             {
                 return;
             }
 
-            RemoteExecutor.Invoke(static async (string useVersionString, string useSslString) =>
+            await RemoteExecutor.Invoke(static async (string useVersionString, string useSslString) =>
             {
                 using var listener = new TestEventListener("System.Net.Http", EventLevel.Verbose, eventCounterInterval: 0.1d);
                 listener.AddActivityTracking();
@@ -1038,7 +1038,7 @@ namespace System.Net.Http.Functional.Tests
                         ip.Equals(IPAddress.Loopback) ||
                         ip.Equals(IPAddress.IPv6Loopback));
                 }
-            }, UseVersion.ToString(), useSsl.ToString()).Dispose();
+            }, UseVersion.ToString(), useSsl.ToString()).DisposeAsync();
         }
 
         protected static async Task WaitForEventCountersAsync(ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)> events)

--- a/src/libraries/System.Net.Http/tests/UnitTests/RuntimeSettingParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/RuntimeSettingParserTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
@@ -13,7 +14,7 @@ namespace System.Net.Http.Tests
         [ConditionalTheory(nameof(SupportsRemoteExecutor))]
         [InlineData(false)]
         [InlineData(true)]
-        public void QueryRuntimeSettingSwitch_WhenNotSet_DefaultIsUsed(bool defaultValue)
+        public async Task QueryRuntimeSettingSwitch_WhenNotSet_DefaultIsUsed(bool defaultValue)
         {
             static void RunTest(string defaultValueStr)
             {
@@ -22,11 +23,11 @@ namespace System.Net.Http.Tests
                 Assert.Equal(expected, actual);
             }
 
-            RemoteExecutor.Invoke(RunTest, defaultValue.ToString()).Dispose();
+            await RemoteExecutor.Invoke(RunTest, defaultValue.ToString()).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void QueryRuntimeSettingSwitch_AppContextHasPriority()
+        public async Task QueryRuntimeSettingSwitch_AppContextHasPriority()
         {
             static void RunTest()
             {
@@ -37,11 +38,11 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "true";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void QueryRuntimeSettingSwitch_EnvironmentVariable()
+        public async Task QueryRuntimeSettingSwitch_EnvironmentVariable()
         {
             static void RunTest()
             {
@@ -51,11 +52,11 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "false";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void QueryRuntimeSettingSwitch_InvalidValue_FallbackToDefault()
+        public async Task QueryRuntimeSettingSwitch_InvalidValue_FallbackToDefault()
         {
             static void RunTest()
             {
@@ -65,13 +66,13 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "cheese";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
 
         [ConditionalTheory(nameof(SupportsRemoteExecutor))]
         [InlineData(0)]
         [InlineData(42)]
-        public void QueryRuntimeSettingInt32_WhenNotSet_DefaultIsUsed(int defaultValue)
+        public async Task QueryRuntimeSettingInt32_WhenNotSet_DefaultIsUsed(int defaultValue)
         {
             static void RunTest(string defaultValueStr)
             {
@@ -80,11 +81,11 @@ namespace System.Net.Http.Tests
                 Assert.Equal(expected, actual);
             }
 
-            RemoteExecutor.Invoke(RunTest, defaultValue.ToString()).Dispose();
+            await RemoteExecutor.Invoke(RunTest, defaultValue.ToString()).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void QueryRuntimeSettingInt32_AppContextHasPriority()
+        public async Task QueryRuntimeSettingInt32_AppContextHasPriority()
         {
             static void RunTest()
             {
@@ -95,11 +96,11 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "3";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void QueryRuntimeSettingInt32_EnvironmentVariable()
+        public async Task QueryRuntimeSettingInt32_EnvironmentVariable()
         {
             static void RunTest()
             {
@@ -109,12 +110,12 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "1";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
 
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void QueryRuntimeSettingInt32_InvalidValue_FallbackToDefault()
+        public async Task QueryRuntimeSettingInt32_InvalidValue_FallbackToDefault()
         {
             static void RunTest()
             {
@@ -124,22 +125,22 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "cheese";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void ParseInt32EnvironmentVariableValue_WhenNotSet_DefaultIsUsed()
+        public async Task ParseInt32EnvironmentVariableValue_WhenNotSet_DefaultIsUsed()
         {
             static void RunTest()
             {
                 int actual = RuntimeSettingParser.ParseInt32EnvironmentVariableValue("FOO_BAR", -42);
                 Assert.Equal(-42, actual);
             }
-            RemoteExecutor.Invoke(RunTest).Dispose();
+            await RemoteExecutor.Invoke(RunTest).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void ParseInt32EnvironmentVariableValue_ValidValue()
+        public async Task ParseInt32EnvironmentVariableValue_ValidValue()
         {
             static void RunTest()
             {
@@ -150,11 +151,11 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "84";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void ParseInt32EnvironmentVariableValue_InvalidValue_FallbackToDefault()
+        public async Task ParseInt32EnvironmentVariableValue_InvalidValue_FallbackToDefault()
         {
             static void RunTest()
             {
@@ -165,22 +166,22 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "-~4!";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void ParseDoubleEnvironmentVariableValue_WhenNotSet_DefaultIsUsed()
+        public async Task ParseDoubleEnvironmentVariableValue_WhenNotSet_DefaultIsUsed()
         {
             static void RunTest()
             {
                 double actual = RuntimeSettingParser.ParseDoubleEnvironmentVariableValue("FOO_BAR", -0.42);
                 Assert.Equal(-0.42, actual);
             }
-            RemoteExecutor.Invoke(RunTest).Dispose();
+            await RemoteExecutor.Invoke(RunTest).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void ParseDoubleEnvironmentVariableValue_ValidValue()
+        public async Task ParseDoubleEnvironmentVariableValue_ValidValue()
         {
             static void RunTest()
             {
@@ -191,11 +192,11 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "0.84";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
 
         [ConditionalFact(nameof(SupportsRemoteExecutor))]
-        public void ParseDoubleEnvironmentVariableValue_InvalidValue_FallbackToDefault()
+        public async Task ParseDoubleEnvironmentVariableValue_InvalidValue_FallbackToDefault()
         {
             static void RunTest()
             {
@@ -206,7 +207,7 @@ namespace System.Net.Http.Tests
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables["FOO_BAR"] = "-~4!";
 
-            RemoteExecutor.Invoke(RunTest, options).Dispose();
+            await RemoteExecutor.Invoke(RunTest, options).DisposeAsync();
         }
     }
 }


### PR DESCRIPTION
Applied a generic regex to convert Sync RemoteExecutors tests to Async, might fix some cases, as we observed in the past. 
See for more info: https://github.com/dotnet/runtime/pull/102699