### PR TITLE
[cDAC] Fix issues found when running full SOS test suite

### DIFF
--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -41,7 +41,7 @@ extends:
           platforms:
           - windows_x64
           jobParameters:
-            buildArgs: -s clr+libs+tools.cdac+host+packs -c $(_BuildConfig)
+            buildArgs: -s clr+libs+tools.cdac+host+packs -c Debug -rc $(_BuildConfig) -lc $(_BuildConfig)
             nameSuffix: AllSubsets_CoreCLR
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             timeoutInMinutes: 360

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -19,9 +19,26 @@ public readonly struct ModuleHandle
 [Flags]
 public enum ModuleFlags
 {
-    Tenured = 0x00000001,           // Set once we know for sure the Module will not be freed until the appdomain itself exits
-    EditAndContinue = 0x00000008,   // Edit and Continue is enabled for this module
-    ReflectionEmit = 0x00000040,    // Reflection.Emit was used to create this module
+    Tenured = 0x1,                  // Set once we know for sure the Module will not be freed until the appdomain itself exits
+    ClassFreed = 0x4,
+    EditAndContinue = 0x8,          // Edit and Continue is enabled for this module
+
+    ProfilerNotified = 0x10,
+    EtwNotified = 0x20,
+
+    ReflectionEmit = 0x40,          // Reflection.Emit was used to create this module
+    ProfilerDisableOptimizations = 0x80,
+    ProfilerDisableInlining = 0x100,
+
+    DebuggerUserOverridePriv = 0x400,
+    DebuggerAllowJitOptsPriv = 0x800,
+    DebuggerTrackJitInfoPriv = 0x1000,
+    DebuggerEnCEnabledPriv = 0x2000,
+    DebuggerPDBsCopied = 0x4000,
+    DebuggerIgnorePDbs = 0x8000,
+
+    IJWFixedUp = 0x80000,
+    BeingUnloaded = 0x100000,
 }
 
 public record struct ModuleLookupTables(

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -14,9 +14,26 @@ internal readonly struct Loader_1 : ILoader
 
     private enum ModuleFlags_1 : uint
     {
-        Tenured = 0x00000001,           // Set once we know for sure the Module will not be freed until the appdomain itself exits
-        EditAndContinue = 0x00000008,   // Edit and Continue is enabled for this module
-        ReflectionEmit = 0x00000040,    // Reflection.Emit was used to create this module
+        Tenured = 0x1,           // Set once we know for sure the Module will not be freed until the appdomain itself exits
+        ClassFreed = 0x4,
+        EditAndContinue = 0x8, // Edit and Continue is enabled for this module
+
+        ProfilerNotified = 0x10,
+        EtwNotified = 0x20,
+
+        ReflectionEmit = 0x40,    // Reflection.Emit was used to create this module
+        ProfilerDisableOptimizations = 0x80,
+        ProfilerDisableInlining = 0x100,
+
+        DebuggerUserOverridePriv = 0x400,
+        DebuggerAllowJitOptsPriv = 0x800,
+        DebuggerTrackJitInfoPriv = 0x1000,
+        DebuggerEnCEnabledPriv = 0x2000,
+        DebuggerPDBsCopied = 0x4000,
+        DebuggerIgnorePDbs = 0x8000,
+
+        IJWFixedUp = 0x80000,
+        BeingUnloaded = 0x100000,
     }
 
     private readonly Target _target;
@@ -196,10 +213,37 @@ internal readonly struct Loader_1 : ILoader
         ModuleFlags flags = default;
         if (runtimeFlags.HasFlag(ModuleFlags_1.Tenured))
             flags |= ModuleFlags.Tenured;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.ClassFreed))
+            flags |= ModuleFlags.ClassFreed;
         if (runtimeFlags.HasFlag(ModuleFlags_1.EditAndContinue))
             flags |= ModuleFlags.EditAndContinue;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.ProfilerNotified))
+            flags |= ModuleFlags.ProfilerNotified;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.EtwNotified))
+            flags |= ModuleFlags.EtwNotified;
         if (runtimeFlags.HasFlag(ModuleFlags_1.ReflectionEmit))
             flags |= ModuleFlags.ReflectionEmit;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.ProfilerDisableOptimizations))
+            flags |= ModuleFlags.ProfilerDisableOptimizations;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.ProfilerDisableInlining))
+            flags |= ModuleFlags.ProfilerDisableInlining;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerUserOverridePriv))
+            flags |= ModuleFlags.DebuggerUserOverridePriv;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerAllowJitOptsPriv))
+            flags |= ModuleFlags.DebuggerAllowJitOptsPriv;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerTrackJitInfoPriv))
+            flags |= ModuleFlags.DebuggerTrackJitInfoPriv;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerEnCEnabledPriv))
+            flags |= ModuleFlags.DebuggerEnCEnabledPriv;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerPDBsCopied))
+            flags |= ModuleFlags.DebuggerPDBsCopied;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerIgnorePDbs))
+            flags |= ModuleFlags.DebuggerIgnorePDbs;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.IJWFixedUp))
+            flags |= ModuleFlags.IJWFixedUp;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.BeingUnloaded))
+            flags |= ModuleFlags.BeingUnloaded;
+
         return flags;
     }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
@@ -33,6 +33,23 @@ internal sealed class FrameIterator
         FaultingExceptionFrame,
 
         HijackFrame,
+
+        /* Other Frame Types not handled by the iterator */
+        HelperMethodFrame,
+        HelperMethodFrame_1OBJ,
+        HelperMethodFrame_2OBJ,
+        HelperMethodFrame_3OBJ,
+        HelperMethodFrame_PROTECTOBJ,
+        UnmanagedToManagedFrame,
+        ComMethodFrame,
+        ComPrestubMethodFrame,
+        TailCallFrame,
+        ProtectByRefsFrame,
+        ProtectValueClassFrame,
+        DebuggerClassInitMarkFrame,
+        DebuggerExitFrame,
+        DebuggerU2MCatchHandlerFrame,
+        ExceptionFilterFrame,
     }
 
     private readonly Target target;

--- a/src/native/managed/cdac/mscordaccore_universal/Legacy/ClrDataModule.cs
+++ b/src/native/managed/cdac/mscordaccore_universal/Legacy/ClrDataModule.cs
@@ -183,14 +183,13 @@ internal sealed unsafe partial class ClrDataModule : ICustomQueryInterface, IXCL
             Contracts.ModuleHandle handle = contract.GetModuleHandle(_address);
 
             ModuleFlags moduleFlags = contract.GetFlags(handle);
-            if ((moduleFlags & ModuleFlags.EditAndContinue) != 0)
+            if ((moduleFlags & ModuleFlags.ReflectionEmit) != 0)
             {
                 *flags |= 0x1; // CLRDATA_MODULE_IS_DYNAMIC
             }
 
             if (contract.GetAssembly(handle) == contract.GetRootAssembly())
             {
-
                 *flags |= 0x4; // CLRDATA_MODULE_FLAGS_ROOT_ASSEMBLY
             }
         }

--- a/src/native/managed/cdac/mscordaccore_universal/Legacy/ISOSDacInterface.cs
+++ b/src/native/managed/cdac/mscordaccore_universal/Legacy/ISOSDacInterface.cs
@@ -202,7 +202,7 @@ internal unsafe partial interface ISOSDacInterface
 
     // Assemblies
     [PreserveSig]
-    int GetAssemblyList(ulong appDomain, int count, [In, Out, MarshalUsing(CountElementName = nameof(count))] ulong[] values, int* pNeeded);
+    int GetAssemblyList(ulong appDomain, int count, [In, Out, MarshalUsing(CountElementName = nameof(count))] ulong[]? values, int* pNeeded);
     [PreserveSig]
     int GetAssemblyData(ulong baseDomainPtr, ulong assembly, /*struct DacpAssemblyData*/ void* data);
     [PreserveSig]


### PR DESCRIPTION
## Pipeline Changes
* Changes `runtime-diagnostics` pipeline to build the cDAC in debug mode. This enforces the debug assertions during testing.

## Fixes
* https://github.com/dotnet/runtime/pull/114800 broke the `ISOSDacInterface::GetModuleData` because it enforced only sending flag values that were defined in the cDAC. Clients expected flag data that was not defined in the module flag enum, this PR adds all flags currently defined in the runtime.
* `ISOSDacInterface::GetFrameName` only worked on Frame names implemented in the cDAC. This PR adds the rest of the Frames used in any version of the runtime to possible return values.
* `ISOSDacInterface::GetFrameName` return value `pNeeded` returns a different number depending on if a return buffer is provided. If a return buffer is provided it returns the number of characters in the Frame name. If a return buffer is not provided it returns the number of characters in the Frame name + 1 (for a null terminator). This PR implements this behavior to match the DAC.
* `IXCLRDataModule::GetFlags` had a bug where it switched on the wrong enum value (oops).
* `ISOSDacInterface::GetAssemblyList` had a bug in its debug verification logic. The DAC implementation has a different behavior if the `values` array is null or not. This led to incorrect `count` values being returned.