### PR TITLE
Fix verbatim escaping in regex code generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
@@ -298,7 +298,8 @@ namespace System.Text.RegularExpressions.Generator
                 }
                 else if (argument.Value.ConstantValue.Value is string str && str.Contains('\\'))
                 {
-                    return SyntaxFactory.ParseExpression($"@\"{str}\"");
+                    string escapedVerbatimText = str.Replace("\"", "\"\"");
+                    return SyntaxFactory.ParseExpression($"@\"{escapedVerbatimText}\"");
                 }
                 else
                 {


### PR DESCRIPTION
When the pattern expression is folded into a constant that needs escaping, we choose to use a verbatim string literal. However, verbatim strings also need to escape one character - the double quote.

The code generated for
```cs
var isMatch = Regex.IsMatch("", "[" + @"\/:<>|" + "\"]");
```

is now:

```cs
[GeneratedRegex(@"[\/:<>|""]")]
private static partial Regex MyRegex();
```

Fixes #104371