### PR TITLE
Fix PipeStream leak on Windows when pipe is disposed with a pending operation

### DIFF
--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Unix.cs
@@ -139,10 +139,7 @@ namespace System.IO.Pipes
 
             if (disposing)
             {
-                if (State != PipeState.Closed)
-                {
-                    _internalTokenSource.Cancel();
-                }
+                _internalTokenSource.Cancel();
             }
         }
 

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs
@@ -62,7 +62,11 @@ namespace System.IO.Pipes
             {
                 if (Interlocked.CompareExchange(ref _reusableConnectionValueTaskSource, connectionSource, null) is not null)
                 {
-                    source._preallocatedOverlapped.Dispose();
+                    source.Dispose();
+                }
+                else if (State == PipeState.Closed)
+                {
+                    Interlocked.Exchange(ref _reusableConnectionValueTaskSource, null)?.Dispose();
                 }
             }
         }

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -144,6 +144,11 @@ namespace System.IO.Pipes
 
         protected override void Dispose(bool disposing)
         {
+            // Mark the pipe as closed before calling DisposeCore. That way, other threads that might
+            // be synchronizing on shared resources disposed of in DisposeCore will be guaranteed to
+            // see the closed state after that synchronization.
+            _state = PipeState.Closed;
+
             try
             {
                 // Nothing will be done differently based on whether we are
@@ -159,8 +164,6 @@ namespace System.IO.Pipes
             {
                 base.Dispose(disposing);
             }
-
-            _state = PipeState.Closed;
         }
 
         // ********************** Public Properties *********************** //

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
@@ -35,7 +35,11 @@ namespace Microsoft.Win32.SafeHandles
 
             if (Interlocked.CompareExchange(ref _reusableOverlappedValueTaskSource, source, null) is not null)
             {
-                source._preallocatedOverlapped.Dispose();
+                source.Dispose();
+            }
+            else if (IsClosed)
+            {
+                Interlocked.Exchange(ref _reusableOverlappedValueTaskSource, null)?.Dispose();
             }
         }
 


### PR DESCRIPTION
The same pattern occurs in a few places.

Repro:
```C#
using System.IO.Pipes;

_ = Task.Run(() =>
{
    while (true)
    {
        Thread.Sleep(1000);
        Console.WriteLine($"{Environment.WorkingSet:N0} bytes");
    }
});

var buffer = new byte[1];
for (int i = 0; ; i++)
{
    Task readTask;
    string pipeName = Guid.NewGuid().ToString("N");

    using (var server = new NamedPipeServerStream(pipeName, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
    using (var client = new NamedPipeClientStream(".", pipeName, PipeDirection.Out, PipeOptions.Asynchronous))
    {
        await Task.WhenAll(client.ConnectAsync(), server.WaitForConnectionAsync());

        readTask = server.ReadAsync(buffer, 0, buffer.Length);
    }

    if (i % 100_000 == 0)
    {
        Console.WriteLine($"Iteration {i} completed.");
        GC.Collect();
    }
}
```

Before:
```
Iteration 0 completed.
44,621,824 bytes
57,716,736 bytes
65,609,728 bytes
75,116,544 bytes
80,695,296 bytes
91,246,592 bytes
Iteration 100000 completed.
99,852,288 bytes
109,580,288 bytes
119,209,984 bytes
123,969,536 bytes
129,781,760 bytes
143,015,936 bytes
148,815,872 bytes
Iteration 200000 completed.
154,836,992 bytes
164,868,096 bytes
176,857,088 bytes
181,932,032 bytes
191,127,552 bytes
202,846,208 bytes
Iteration 300000 completed.
210,046,976 bytes
221,147,136 bytes
228,446,208 bytes
235,446,272 bytes
246,456,320 bytes
256,700,416 bytes
Iteration 400000 completed.
```

After:
```
Iteration 0 completed.
36,007,936 bytes
37,425,152 bytes
37,478,400 bytes
37,486,592 bytes
37,494,784 bytes
37,494,784 bytes
Iteration 100000 completed.
36,401,152 bytes
36,442,112 bytes
36,442,112 bytes
36,442,112 bytes
36,442,112 bytes
36,425,728 bytes
Iteration 200000 completed.
36,425,728 bytes
36,483,072 bytes
36,614,144 bytes
35,520,512 bytes
35,520,512 bytes
35,520,512 bytes
Iteration 300000 completed.
34,996,224 bytes
34,996,224 bytes
34,996,224 bytes
35,033,088 bytes
35,033,088 bytes
35,033,088 bytes
Iteration 400000 completed.
```