### PR TITLE
Don't  allow mutating the ScopeId on static readonly IPAddress fields

### DIFF
--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -28,11 +28,11 @@ namespace System.Net
 
         internal const uint LoopbackMaskHostOrder = 0xFF000000;
 
-        public static readonly IPAddress IPv6Any = new IPAddress((ReadOnlySpan<byte>)[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 0);
-        public static readonly IPAddress IPv6Loopback = new IPAddress((ReadOnlySpan<byte>)[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], 0);
+        public static readonly IPAddress IPv6Any = new ReadOnlyIPAddress([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 0);
+        public static readonly IPAddress IPv6Loopback = new ReadOnlyIPAddress([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], 0);
         public static readonly IPAddress IPv6None = IPv6Any;
 
-        private static readonly IPAddress s_loopbackMappedToIPv6 = new IPAddress((ReadOnlySpan<byte>)[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1], 0);
+        private static readonly IPAddress s_loopbackMappedToIPv6 = new ReadOnlyIPAddress([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 127, 0, 0, 1], 0);
 
         /// <summary>
         /// For IPv4 addresses, this field stores the Address.
@@ -438,6 +438,11 @@ namespace System.Net
                     ThrowSocketOperationNotSupported();
                 }
 
+                if (this is ReadOnlyIPAddress)
+                {
+                    ThrowSocketOperationNotSupported();
+                }
+
                 // Consider: Since scope is only valid for link-local and site-local
                 //           addresses we could implement some more robust checking here
                 ArgumentOutOfRangeException.ThrowIfNegative(value);
@@ -771,6 +776,9 @@ namespace System.Net
         private sealed class ReadOnlyIPAddress : IPAddress
         {
             public ReadOnlyIPAddress(ReadOnlySpan<byte> newAddress) : base(newAddress)
+            { }
+
+            public ReadOnlyIPAddress(ReadOnlySpan<byte> address, long scopeid) : base(address, scopeid)
             { }
         }
     }

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -346,6 +346,10 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Throws<SocketException>(() => IPAddress.Broadcast.Address = MaxAddress - 1);
             Assert.Throws<SocketException>(() => IPAddress.Loopback.Address = MaxAddress - 1);
             Assert.Throws<SocketException>(() => IPAddress.None.Address = MaxAddress - 1);
+
+            Assert.Throws<SocketException>(() => IPAddress.IPv6Any.ScopeId = 1);
+            Assert.Throws<SocketException>(() => IPAddress.IPv6Loopback.ScopeId = 1);
+            Assert.Throws<SocketException>(() => IPAddress.IPv6None.ScopeId = 1);
         }
 #pragma warning restore 618
     }


### PR DESCRIPTION
The `IPAddress` class has some `static readonly` instances of `IPAddress` declared on it. The `Address` field of these instances was made readonly in dotnet/corefx#33531. Somehow `ScopeId`, the only other mutable property, was missed. I did not see discussion of this in that PR or the related issue.

An example program that illustrates the problem:

```csharp
Console.WriteLine(IPAddress.IPv6Loopback);
IPAddress.IPv6Loopback.ScopeId = 1;
Console.WriteLine(IPAddress.IPv6Loopback);
```

When run, this program prints the following, showing that the `static readonly` instance has been mutated:

```txt
::1
::1%1
```

I think the right behavior is to throw when setting the `ScopeId` (this pr).

Contributes to #27870