### PR TITLE
Update System.Net.ServerSentEvents.Tests.csproj

### DIFF
--- a/src/libraries/System.Net.ServerSentEvents/tests/System.Net.ServerSentEvents.Tests.csproj
+++ b/src/libraries/System.Net.ServerSentEvents/tests/System.Net.ServerSentEvents.Tests.csproj
@@ -15,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\System.Net.ServerSentEvents.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Json\gen\System.Text.Json.SourceGeneration.Roslyn4.4.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <ProjectReference Include="..\src\System.Net.ServerSentEvents.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Json\src\System.Text.Json.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Unblocks the use of a newer .NET SDK that contains this runtime commit https://github.com/dotnet/runtime/commit/819bff14702a6e488a54400f0381846eb5a0f5b7

This is necessary as System.Net.ServerSentEvents got moved inbox.