### PR TITLE
Add packaging information to windowsdesktop transport package

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -35,6 +35,15 @@
     <!-- During NoBuild pack invocations, skip project reference build. Necessary for the IncludeProjectReferencesWithPackAttributeInPackage target. -->
     <BuildProjectReferences Condition="'$(NoBuild)' == 'true'">false</BuildProjectReferences>
   </PropertyGroup>
+  
+  <!-- Flow these properties to consuming projects. Used by i.e. Microsoft.Internal.Runtime.WindowsDesktop.Transport. -->
+  <ItemDefinitionGroup>
+    <TargetPathWithTargetPlatformMoniker>
+      <IsPackable>true</IsPackable>
+      <PackageId>$(PackageId)</PackageId>
+      <PackageVersion>$(PackageVersion)</PackageVersion>
+    </TargetPathWithTargetPlatformMoniker>
+  </ItemDefinitionGroup>
 
   <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == 'servicing'">
     <!-- In servicing, the live package is compared against the GA version in strict mode. -->

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -45,7 +45,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <TransportPropsTemplateProperty Include="RuntimeWindowsDesktopPackageLibrary=$(RuntimeWindowsDesktopPackageLibraryContent)" />
+      <TransportPropsTemplateProperty Include="RuntimeWindowsDesktopPackageLibraries=$(RuntimeWindowsDesktopPackageLibraryContent)" />
     </ItemGroup>
 
     <GenerateFileFromTemplate

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets">
+
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)-windows</TargetFramework>
     <IsShipping>false</IsShipping>
@@ -10,6 +11,11 @@
     <PackageDescription>Internal transport package to provide windowsdesktop with the assemblies from dotnet/runtime that make up the Microsoft.WindowsDesktop.App shared framework.</PackageDescription>
     <!-- Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684. -->
     <NoWarn>$(NoWarn);NU5131;NU5128</NoWarn>
+
+    <!-- Generate the transport props file -->
+    <BeforePack>$(BeforePack);GenerateTransportPropsFile</BeforePack>
+    <TransportPropsFileInputPath>$(MSBuildThisFileDirectory)build\$(MSBuildProjectName).props</TransportPropsFileInputPath>
+    <TransportPropsFileOutputPath>$(IntermediateOutputPath)$(MSBuildProjectName).props</TransportPropsFileOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,5 +27,35 @@
                       Pack="true"
                       Private="true"
                       IncludeReferenceAssemblyInPackage="true" />
+
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
   </ItemGroup>
+
+  <Target Name="GenerateTransportPropsFile"
+          DependsOnTargets="BuildOnlySettings;ResolveReferences"
+          Inputs="$(MSBuildThisFileFullPath);$(TransportPropsFileInputPath)"
+          Outputs="$(TransportPropsFileOutputPath)">
+    <ItemGroup>
+      <PackageLibrary Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('Extension', '.dll')->WithMetadataValue('Pack', 'true')->WithMetadataValue('IsPackable', 'true'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <PackageLibrariesContent>@(PackageLibrary->'&lt;PackageLibrary Include=&quot;%(Filename)%(Extension)&quot; PackageId=&quot;%(PackageId)&quot; PackageVersion=&quot;%(PackageVersion)&quot; /&gt;', '
+    ')</PackageLibrariesContent>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TransportPropsTemplateProperty Include="PackageLibraries=$(PackageLibrariesContent)" />
+    </ItemGroup>
+
+    <GenerateFileFromTemplate
+      TemplateFile="$(TransportPropsFileInputPath)"
+      Properties="@(TransportPropsTemplateProperty)"
+      OutputPath="$(TransportPropsFileOutputPath)" />
+
+    <ItemGroup>
+      <None Include="$(TransportPropsFileOutputPath)" Pack="true" PackagePath="build/" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -40,12 +40,12 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <RuntimeWindowsDesktopPackageLibraryContent>@(RuntimeWindowsDesktopPackageLibrary->'&lt;RuntimeWindowsDesktopPackageLibrary Include=&quot;%(Filename)%(Extension)&quot; PackageId=&quot;%(PackageId)&quot; PackageVersion=&quot;%(PackageVersion)&quot; /&gt;', '
-    ')</RuntimeWindowsDesktopPackageLibraryContent>
+      <RuntimeWindowsDesktopPackageLibraries>@(RuntimeWindowsDesktopPackageLibrary->'&lt;RuntimeWindowsDesktopPackageLibrary Include=&quot;%(Filename)%(Extension)&quot; PackageId=&quot;%(PackageId)&quot; PackageVersion=&quot;%(PackageVersion)&quot; /&gt;', '
+    ')</RuntimeWindowsDesktopPackageLibraries>
     </PropertyGroup>
 
     <ItemGroup>
-      <TransportPropsTemplateProperty Include="RuntimeWindowsDesktopPackageLibraries=$(RuntimeWindowsDesktopPackageLibraryContent)" />
+      <TransportPropsTemplateProperty Include="RuntimeWindowsDesktopPackageLibraries=$(RuntimeWindowsDesktopPackageLibraries)" />
     </ItemGroup>
 
     <GenerateFileFromTemplate

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -36,16 +36,16 @@
           Inputs="$(MSBuildThisFileFullPath);$(TransportPropsFileInputPath)"
           Outputs="$(TransportPropsFileOutputPath)">
     <ItemGroup>
-      <PackageLibrary Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('Extension', '.dll')->WithMetadataValue('Pack', 'true')->WithMetadataValue('IsPackable', 'true'))" />
+      <RuntimeWindowsDesktopPackageLibrary Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('Extension', '.dll')->WithMetadataValue('Pack', 'true')->WithMetadataValue('IsPackable', 'true'))" />
     </ItemGroup>
 
     <PropertyGroup>
-      <PackageLibrariesContent>@(PackageLibrary->'&lt;PackageLibrary Include=&quot;%(Filename)%(Extension)&quot; PackageId=&quot;%(PackageId)&quot; PackageVersion=&quot;%(PackageVersion)&quot; /&gt;', '
-    ')</PackageLibrariesContent>
+      <RuntimeWindowsDesktopPackageLibraryContent>@(RuntimeWindowsDesktopPackageLibrary->'&lt;RuntimeWindowsDesktopPackageLibrary Include=&quot;%(Filename)%(Extension)&quot; PackageId=&quot;%(PackageId)&quot; PackageVersion=&quot;%(PackageVersion)&quot; /&gt;', '
+    ')</RuntimeWindowsDesktopPackageLibraryContent>
     </PropertyGroup>
 
     <ItemGroup>
-      <TransportPropsTemplateProperty Include="PackageLibraries=$(PackageLibrariesContent)" />
+      <TransportPropsTemplateProperty Include="RuntimeWindowsDesktopPackageLibrary=$(RuntimeWindowsDesktopPackageLibraryContent)" />
     </ItemGroup>
 
     <GenerateFileFromTemplate

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/build/Microsoft.Internal.Runtime.WindowsDesktop.Transport.props
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/build/Microsoft.Internal.Runtime.WindowsDesktop.Transport.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <!-- The list of redistributed assemblies that via out-of-band packages.
+       Includes the assembly name, PackageId and the PacakgeVersion.
+       <PackageLibrary Include="" PackageId="" PackageVersion="" /> -->
+  <ItemGroup>
+    ${PackageLibraries}
+  </ItemGroup>
+
+</Project>

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/build/Microsoft.Internal.Runtime.WindowsDesktop.Transport.props
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/build/Microsoft.Internal.Runtime.WindowsDesktop.Transport.props
@@ -1,7 +1,7 @@
 <Project>
 
   <!-- The list of redistributed assemblies that via out-of-band packages.
-       Includes the assembly name, PackageId and the PacakgeVersion.
+       Includes the assembly name, PackageId and the PackageVersion.
        <PackageLibrary Include="" PackageId="" PackageVersion="" /> -->
   <ItemGroup>
     ${PackageLibraries}

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/build/Microsoft.Internal.Runtime.WindowsDesktop.Transport.props
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/build/Microsoft.Internal.Runtime.WindowsDesktop.Transport.props
@@ -1,7 +1,7 @@
 <Project>
 
-  <!-- The list of redistributed assemblies that via out-of-band packages.
-       Includes the assembly name, PackageId and the PackageVersion:
+  <!-- The list of redistributed assemblies that also ship via out-of-band packages.
+       Includes the AssemblyName, PackageId and the PackageVersion:
        <RuntimeWindowsDesktopPackageLibrary Include="" PackageId="" PackageVersion="" /> -->
   <ItemGroup>
     ${RuntimeWindowsDesktopPackageLibraries}

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/build/Microsoft.Internal.Runtime.WindowsDesktop.Transport.props
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/build/Microsoft.Internal.Runtime.WindowsDesktop.Transport.props
@@ -1,10 +1,10 @@
 <Project>
 
   <!-- The list of redistributed assemblies that via out-of-band packages.
-       Includes the assembly name, PackageId and the PackageVersion.
-       <PackageLibrary Include="" PackageId="" PackageVersion="" /> -->
+       Includes the assembly name, PackageId and the PackageVersion:
+       <RuntimeWindowsDesktopPackageLibrary Include="" PackageId="" PackageVersion="" /> -->
   <ItemGroup>
-    ${PackageLibraries}
+    ${RuntimeWindowsDesktopPackageLibraries}
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/windowsdesktop/issues/4998

Adds a props file that gets auto-imported when referencing the internal windowsdesktop transport package. This file defines an item `PackageLibrary` that includes all the information for the runtime assemblies that get redistributed inside the package.

This information can then be used in windowsdesktop to auto-generate parts of the PackageOverrides.txt file.

I chose the following format as it allows to add more metadata later that isn't strongly tied to packaging.

### Result

![image](https://github.com/user-attachments/assets/be50897f-6096-4c09-be69-c3455f08b1b7)


![image](https://github.com/user-attachments/assets/085a76de-f699-4cb1-b251-ebcf90f57d48)
**After taking this picture I then later renamed `PackageLibrary` to `RuntimeWindowsDesktopPackageLibrary`**
