### PR TITLE
Improve unmapped error exception to include the mapping function name and the error code

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -747,6 +747,9 @@
   <data name="Cryptography_Unmapped_System_Typed_Error" xml:space="preserve">
     <value>The system cryptographic library returned error '{0}' of type '{1}'</value>
   </data>
+  <data name="Cryptography_UnmappedOpenSslCode" xml:space="preserve">
+    <value>OpenSSL mapping function {0} reported unhandled error code '{1}'.</value>
+  </data>
   <data name="Cryptography_UnsupportedPaddingMode" xml:space="preserve">
     <value>The specified PaddingMode is not supported.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
@@ -1168,7 +1168,7 @@ namespace System.Security.Cryptography.X509Certificates
                     return X509ChainStatusFlags.InvalidBasicConstraints;
                 default:
                     Debug.Fail("Unrecognized X509VerifyStatusCode:" + code.Code30);
-                    throw new CryptographicException();
+                    throw GetUnmappedCodeException(nameof(MapOpenSsl30Code), (int)code.Code30);
             }
         }
 
@@ -1180,7 +1180,7 @@ namespace System.Security.Cryptography.X509Certificates
                     return X509ChainStatusFlags.InvalidBasicConstraints;
                 default:
                     Debug.Fail("Unrecognized X509VerifyStatusCode:" + code.Code102);
-                    throw new CryptographicException();
+                    throw GetUnmappedCodeException(nameof(MapOpenSsl102Code), (int)code.Code102);
             }
         }
 
@@ -1192,7 +1192,7 @@ namespace System.Security.Cryptography.X509Certificates
                     return X509ChainStatusFlags.InvalidBasicConstraints;
                 default:
                     Debug.Fail("Unrecognized X509VerifyStatusCode:" + code.Code111);
-                    throw new CryptographicException();
+                    throw GetUnmappedCodeException(nameof(MapOpenSsl111Code), (int)code.Code111);
             }
         }
 
@@ -1418,6 +1418,11 @@ namespace System.Security.Cryptography.X509Certificates
             }
 
             return MapOpenSsl102Code;
+        }
+
+        private static CryptographicException GetUnmappedCodeException(string functionName, int code)
+        {
+            return new CryptographicException(SR.Format(SR.Cryptography_UnmappedOpenSslCode, functionName, code));
         }
 
         private unsafe struct ErrorCollection


### PR DESCRIPTION
When we encounter an unmapped OpenSSL error, retail builds do not include any information about what the error was. This adds some exception text to help diagnose.

Contributes to #114129.