### PR TITLE
USE_REGIONS for 32 bit initial commit

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -49261,7 +49261,11 @@ HRESULT GCHeap::Initialize()
 #endif
         }
         size_t virtual_mem_limit = GCToOSInterface::GetVirtualMemoryLimit();
+#ifdef HOST_64BIT
         gc_heap::regions_range = min(gc_heap::regions_range, virtual_mem_limit/2);
+#else
+        gc_heap::regions_range = min(gc_heap::regions_range, virtual_mem_limit/4);
+#endif
         gc_heap::regions_range = align_on_page(gc_heap::regions_range);
     }
     GCConfig::SetGCRegionRange(gc_heap::regions_range);

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -23549,7 +23549,16 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
     // 4GB of RAM. Once Local GC code divergence is resolved and code is flowing
     // more freely between branches, it would be good to clean this up to use
     // total_physical_mem instead of SIZE_T_MAX.
-    assert(total_allowed_soh_allocation <= SIZE_T_MAX);
+
+    // Clamp total allowed SOH allocation to SIZE_T_MAX to prevent overflow in 32-bit adress spaces.
+    // On 32-bit architectures max_soh_allocated * num_heaps can exceed 32-bit address space,
+    // while on 64-bit architectures this prevents threoretical overflow when using an large
+    // number of heaps (num_heaps > 1). This ensures all size calculations remain within the maximum
+    // representable value for the platform's address space.
+    if(total_allowed_soh_allocation > SIZE_T_MAX)
+    {
+        total_allowed_soh_allocation = SIZE_T_MAX;
+    }
     uint64_t total_allowed_loh_allocation = SIZE_T_MAX;
     uint64_t total_allowed_soh_alloc_scaled = allocation_no_gc_soh > 0 ? static_cast<uint64_t>(total_allowed_soh_allocation / scale_factor) : 0;
     uint64_t total_allowed_loh_alloc_scaled = allocation_no_gc_loh > 0 ? static_cast<uint64_t>(total_allowed_loh_allocation / scale_factor) : 0;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -49239,8 +49239,14 @@ HRESULT GCHeap::Initialize()
         }
         else
         {
+#ifdef HOST_64BIT
             // If no hard_limit is configured the reservation size is min of 1/2 GetVirtualMemoryLimit() or max of 256Gb or 2x physical limit.
             gc_heap::regions_range = max((size_t)256 * 1024 * 1024 * 1024, (size_t)(2 * gc_heap::total_physical_mem));
+#else
+            gc_heap::regions_range = (2 * gc_heap::total_physical_mem) <= SIZE_MAX ?
+                                        (size_t)(2 * gc_heap::total_physical_mem) :
+                                        (size_t) gc_heap::total_physical_mem;
+#endif
         }
         size_t virtual_mem_limit = GCToOSInterface::GetVirtualMemoryLimit();
         gc_heap::regions_range = min(gc_heap::regions_range, virtual_mem_limit/2);

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -46136,7 +46136,10 @@ void gc_heap::generation_delete_heap_segment (generation* gen,
         // For doubly linked list we go forward for SOH
         heap_segment_next (prev_seg) = next_seg;
 #else //DOUBLY_LINKED_FL
-        heap_segment_next (next_seg) = prev_seg;
+        if (next_seg)
+        {
+            heap_segment_next (next_seg) = prev_seg;
+        }
 #endif //DOUBLY_LINKED_FL
 
         dprintf (3, ("Preparing empty small segment %zx for deletion", (size_t)seg));

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -9418,7 +9418,16 @@ bool gc_heap::get_card_table_commit_layout (uint8_t* from, uint8_t* to,
         assert (required_begin <= required_end);
         commit_end = align_on_page(required_end);
 
-        commit_end = min (commit_end, align_lower_page(bookkeeping_start + card_table_element_layout[i + 1]));
+        // Account for seg_mapping_table ending on the same page as mark_array begins.
+        // If background GC is disabled in run time (i.e. empty mark_array with 0 size), no need to align down.
+        if (i != seg_mapping_table_element
+#ifdef BACKGROUND_GC
+            || card_table_element_layout[mark_array_element] != card_table_element_layout[total_bookkeeping_elements]
+#endif // BACKGROUND_GC
+           )
+        {
+            commit_end = min (commit_end, align_lower_page(bookkeeping_start + card_table_element_layout[i + 1]));
+        }
         commit_begin = min (commit_begin, commit_end);
         assert (commit_begin <= commit_end);
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -46897,7 +46897,7 @@ void gc_heap::background_sweep()
             else
             {
                 // For SOH segments we go backwards.
-                next_seg = heap_segment_prev (start_seg, seg);
+                next_seg = heap_segment_prev (gen_start_seg, seg);
             }
 #endif //DOUBLY_LINKED_FL
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -14453,6 +14453,10 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
     {
         dynamic_adaptation_mode = 0;
     }
+#if !defined(HOST_64BIT)
+    // TODO: remove this when DATAS is ready for 32 bit
+    dynamic_adaptation_mode = 0;
+#endif
 
     if ((dynamic_adaptation_mode == dynamic_adaptation_to_application_sizes) && (conserve_mem_setting == 0))
         conserve_mem_setting = 5;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -46883,7 +46883,7 @@ void gc_heap::background_sweep()
             else
             {
                 // For SOH segments we go backwards.
-                next_seg = heap_segment_prev (gen_start_seg, seg);
+                next_seg = heap_segment_prev (start_seg, seg);
             }
 #endif //DOUBLY_LINKED_FL
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -2448,9 +2448,9 @@ size_t      gc_heap::hc_change_cancelled_count_bgc = 0;
 #endif //BACKGROUND_GC
 #endif //DYNAMIC_HEAP_COUNT
 
-#if defined(HOST_64BIT)
 #define MAX_ALLOWED_MEM_LOAD 85
 
+#if defined(HOST_64BIT)
 // consider putting this in dynamic data -
 // we may want different values for workstation
 // and server GC.
@@ -25365,7 +25365,14 @@ void gc_heap::equalize_promoted_bytes(int condemned_gen_number)
 
 // check that the fields of a decommissioned heap have their expected values,
 // i.e. were not inadvertently modified
+#ifdef HOST_64BIT
 #define DECOMMISSIONED_VALUE 0xdec0dec0dec0dec0
+static const ptrdiff_t UNINITIALIZED_VALUE  = 0xbaadbaadbaadbaad;
+#else // HOST_32BIT
+#define DECOMMISSIONED_VALUE 0xdec0dec0
+static const ptrdiff_t UNINITIALIZED_VALUE  = 0xbaadbaad;
+#endif // HOST_64BIT
+
 static const size_t DECOMMISSIONED_SIZE_T = DECOMMISSIONED_VALUE;
 static const ptrdiff_t DECOMMISSIONED_PTRDIFF_T = (ptrdiff_t)DECOMMISSIONED_VALUE;
 static const ptrdiff_t DECOMMISSIONED_UINT64_T = (uint64_t)DECOMMISSIONED_VALUE;
@@ -25376,8 +25383,6 @@ static mark* const DECOMMISSIONED_MARK_P = (mark*)DECOMMISSIONED_VALUE;
 static const BOOL DECOMMISSIONED_BOOL = 0xdec0dec0;
 static const BOOL DECOMMISSIONED_INT = (int)0xdec0dec0;
 static const float DECOMMISSIONED_FLOAT = (float)DECOMMISSIONED_VALUE;
-
-static const ptrdiff_t UNINITIALIZED_VALUE  = 0xbaadbaadbaadbaad;
 
 void gc_heap::check_decommissioned_heap()
 {

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -4848,11 +4848,7 @@ public:
     // Now we set more bits should actually only clear the mark bit
     void ClearMarked()
     {
-#ifdef DOUBLY_LINKED_FL
         RawSetMethodTable ((MethodTable *)(((size_t) RawGetMethodTable()) & (~GC_MARKED)));
-#else
-        RawSetMethodTable (GetMethodTable());
-#endif //DOUBLY_LINKED_FL
     }
 
 #ifdef DOUBLY_LINKED_FL


### PR DESCRIPTION
PR includes initial fixes GC with USE_REGIONS enabled for arm32.

Tests failed cause enabling USE_REGIONS on arm32 on Checked, fixed by this PR:
```
GC/API/GC/GetGCMemoryInfo/GetGCMemoryInfo
GC/Scenarios/Boxing/simpvariant/simpvariant
```

Tests failed cause enabling USE_REGIONS on arm32 on Checked, not fixed yet by this PR:
```
GC/API/NoGCRegion/Callback_Svr/Callback_Svr
GC/Features/HeapExpansion/plug/plug
JIT/jit64/opt/cse/hugeexpr1/hugeexpr1
readytorun/coreroot_determinism/coreroot_determinism/coreroot_determinism
```

cc @gbalykov 