### PR TITLE
throw an exception instead of infinite loop in `sort_mark_list`

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -10792,6 +10792,14 @@ size_t gc_heap::sort_mark_list()
         size_t region_index = get_basic_region_index_for_address (heap_segment_mem (region));
         uint8_t* region_limit = heap_segment_allocated (region);
 
+        // Due to GC holes, x can point to something in a region that already got freed. And that region's
+        // allocated would be 0 and cause an infinite loop which is much harder to handle on production than
+        // simply throwing an exception.
+        if (region_limit == 0)
+        {
+            FATAL_GC_ERROR();
+        }
+
         uint8_t*** mark_list_piece_start_ptr = &mark_list_piece_start[region_index];
         uint8_t*** mark_list_piece_end_ptr = &mark_list_piece_end[region_index];
 #else // USE_REGIONS


### PR DESCRIPTION
we had a customer who observed an infinite loop in `sort_mark_list` due to heap corruption - the object that got marked was in a region that was already freed so `region_limit` is 0. we detect this and throw an exception which is easier for prod diag than having to deal with an infinite loop.