### PR TITLE
Fix a build message nit

### DIFF
--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -115,7 +115,7 @@
     </PropertyGroup>
 
     <!-- Use IgnoreStandardErrorWarningFormat because Arcade sets WarnAsError and we want to avoid upgrading compiler warnings to errors in release branches -->
-    <Message Text="Executing $(_CoreClrBuildPreSource)$(MSBuildThisFileDirectory)&quot;$(MSBuildThisFileDirectory)$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')" Importance="High" />
+    <Message Text="Executing $(_CoreClrBuildPreSource)$(MSBuildThisFileDirectory)&quot;$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')" Importance="High" />
     <Exec Command="$(_CoreClrBuildPreSource)$(MSBuildThisFileDirectory)&quot;$(_CoreClrBuildScript)&quot; @(_CoreClrBuildArg->'%(Identity)',' ')"
           IgnoreStandardErrorWarningFormat="true" />
   </Target>


### PR DESCRIPTION
Stop outputting an extra `$(MSBuildThisFileDirectory)`

Before:

```
Executing C:\gh\runtime\src\coreclr\"C:\gh\runtime\src\coreclr\build-runtime.cmd" ...
```

After:

```
Executing C:\gh\runtime\src\coreclr\"build-runtime.cmd" ...
```

Now it matches what the `Exec` command actually is.