### PR TITLE
Don't include LICENSE.TXT in nuget packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -84,11 +84,6 @@
 
   <!-- Packaging -->
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <!-- The sfxproj files add the license themselves. -->
-    <None Include="$(LicenseFile)"
-          PackagePath="$([System.IO.Path]::GetFileName('$(LicenseFile)'))"
-          Pack="true"
-          Condition="'$(MSBuildProjectExtension)' != '.sfxproj' and '$(MSBuildProjectFile)' != 'msi.csproj'" />
     <None Include="$(PackageThirdPartyNoticesFile)"
           PackagePath="$([System.IO.Path]::GetFileName('$(PackageThirdPartyNoticesFile)'))"
           Pack="true" />


### PR DESCRIPTION
Runtime nuget packages already define a PackageLicenseExpression=MIT

There's no need to also bundle the LICENSE file into the packages as the nuspec points to the license url.

![image](https://github.com/user-attachments/assets/1de9858c-a841-4bcb-bbf8-eeb67f801037)

And Arcade already validates that there's either a PackageLicenseExpression or PackageLicenseFile defined: https://github.com/dotnet/arcade/blob/6b63184d8ff276115846b232816ece935a26a22c/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.targets#L65C105-L65C129