### PR TITLE
Move FLS init before EventPipeAdapter::FinishInitialize and the first SetupThread()

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -839,7 +839,7 @@ void EEStartupHelper()
 
 #ifdef PROFILING_SUPPORTED
         // Initialize the profiling services.
-        // THis must happen before the finalizer thread is stopped on its first wait.
+        // This must happen before Thread::HasStarted() that fires profiler notifications is called on the finalizer thread.
         hr = ProfilingAPIUtility::InitializeProfiling();
 
         _ASSERTE(SUCCEEDED(hr));

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -894,6 +894,7 @@ void EEStartupHelper()
 #endif
 
         // throws on error
+        _ASSERTE(GetThreadNULLOk() == NULL);
         SetupThread();
 
 #ifdef DEBUGGING_SUPPORTED

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -837,6 +837,15 @@ void EEStartupHelper()
         InitializeDebugger(); // throws on error
 #endif // DEBUGGING_SUPPORTED
 
+#ifdef PROFILING_SUPPORTED
+        // Initialize the profiling services.
+        // THis must happen before the finalizer thread is stopped on its first wait.
+        hr = ProfilingAPIUtility::InitializeProfiling();
+
+        _ASSERTE(SUCCEEDED(hr));
+        IfFailGo(hr);
+#endif // PROFILING_SUPPORTED
+
         // This isn't done as part of InitializeGarbageCollector() above because
         // debugger must be initialized before creating EE thread objects
         FinalizerThread::FinalizerThreadCreate();
@@ -866,14 +875,6 @@ void EEStartupHelper()
         }
 
         IfFailGo(hr);
-
-#ifdef PROFILING_SUPPORTED
-        // Initialize the profiling services.
-        hr = ProfilingAPIUtility::InitializeProfiling();
-
-        _ASSERTE(SUCCEEDED(hr));
-        IfFailGo(hr);
-#endif // PROFILING_SUPPORTED
 
         InitializeExceptionHandling();
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -916,7 +916,7 @@ void EEStartupHelper()
         // debugger must be initialized before creating EE thread objects
         FinalizerThread::FinalizerThreadCreate();
 #else
-        // On windows the finalizer thread is already partially created created and is waiting
+        // On windows the finalizer thread is already partially created and is waiting
         // right before doing HasStarted(). We will release it now.
         FinalizerThread::EnableFinalization();
 #endif

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -392,6 +392,7 @@ DWORD WINAPI FinalizerThread::FinalizerThreadStart(void *args)
 
     // handshake with EE initialization, as now we can attach Thread objects to native threads.
     hEventFinalizerDone->Set();
+    WaitForFinalizerEvent (hEventFinalizer);
 #endif
 
     s_FinalizerThreadOK = GetFinalizerThread()->HasStarted();

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -593,13 +593,6 @@ void SyncBlockCache::CleanupSyncBlocks()
 
 // create the sync block cache
 /* static */
-void SyncBlockCache::Attach()
-{
-    LIMITED_METHOD_CONTRACT;
-}
-
-// create the sync block cache
-/* static */
 void SyncBlockCache::Start()
 {
     CONTRACTL


### PR DESCRIPTION
Fixes: #114506


In the previous fix we tried to call `FinalizerThread::WaitForFinalizerThreadStart();` as late as possible in `EEStartupHelper()` - to make sure finalizer has enough time to do its part in initializing COM and FLS slot.  

But if calls that happen before `FinalizerThread::WaitForFinalizerThreadStart();` can result in `Thread` objects created and registered for OS destruction, then those threads will see `g_flsIndex != FLS_OUT_OF_INDEXES`, that includes the call to `SetupThread()`, which `EEStartupHelper()` itself does.

The change moves `FinalizerThread::WaitForFinalizerThreadStart();` earlier, before any `Threads` could be created and registered for OS destruction. 
We still have GC heap initialization happening before that, which will typically result in finalizer thread completing its part before the EE init thread needs to check for the completion.
