### PR TITLE
[WIP] Interpreter boxing/unboxing

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1722,7 +1722,7 @@ int32_t InterpCompiler::GetDataItemIndex(void *data)
 
 int32_t InterpCompiler::GetMethodDataItemIndex(CORINFO_METHOD_HANDLE mHandle)
 {
-    size_t data = (size_t)mHandle | INTERP_METHOD_DESC_TAG;
+    size_t data = (size_t)mHandle | INTERP_METHOD_HANDLE_TAG;
     return GetDataItemIndex((void*)data);
 }
 
@@ -3692,7 +3692,7 @@ void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int3
         }
         case InterpOpMethodHandle:
         {
-            CORINFO_METHOD_HANDLE mh = (CORINFO_METHOD_HANDLE)((size_t)m_dataItems.Get(*pData) & ~INTERP_METHOD_DESC_TAG);
+            CORINFO_METHOD_HANDLE mh = (CORINFO_METHOD_HANDLE)((size_t)m_dataItems.Get(*pData) & ~INTERP_METHOD_HANDLE_TAG);
             printf(" ");
             PrintMethodName(mh);
             break;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3457,6 +3457,42 @@ retry_emit:
                 m_ip += 1;
                 break;
 
+            case CEE_BOX: {
+                CHECK_STACK(1);
+                CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
+                AddIns(INTOP_BOX);
+                m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
+                PushStackType(StackTypeO, clsHnd);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
+                m_ip += 5;
+                break;
+            }
+
+            case CEE_UNBOX: {
+                CHECK_STACK(1);
+                CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
+                AddIns(INTOP_UNBOX);
+                m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
+                PushStackType(StackTypeI, NULL);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
+                m_ip += 5;
+                break;
+            }
+
+            case CEE_UNBOX_ANY: {
+                CHECK_STACK(1);
+                CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
+                AddIns(INTOP_UNBOX_ANY);
+                m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
+                PushStackType(StackTypeVT, clsHnd);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
+                m_ip += 5;
+                break;
+            }
+
             default:
                 assert(0);
                 break;
@@ -3649,6 +3685,13 @@ void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int3
             CORINFO_METHOD_HANDLE mh = (CORINFO_METHOD_HANDLE)((size_t)m_dataItems.Get(*pData) & ~INTERP_METHOD_DESC_TAG);
             printf(" ");
             PrintMethodName(mh);
+            break;
+        }
+        case InterpOpClassHandle:
+        {
+            CORINFO_CLASS_HANDLE ch = (CORINFO_CLASS_HANDLE)((size_t)m_dataItems.Get(*pData));
+            printf(" ");
+            PrintClassName(ch);
             break;
         }
         default:

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3459,12 +3459,15 @@ retry_emit:
 
             case CEE_BOX: {
                 CHECK_STACK(1);
-                CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
+                CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1)),
+                    boxedClsHnd = m_compHnd->getTypeForBox(clsHnd);
+                CorInfoHelpFunc helpFunc = m_compHnd->getBoxHelper(clsHnd);
                 AddIns(INTOP_BOX);
                 m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
-                PushStackType(StackTypeO, clsHnd);
+                PushStackType(StackTypeO, boxedClsHnd);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
+                m_pLastNewIns->data[1] = GetDataItemIndex(m_compHnd->getHelperFtn(helpFunc));
                 m_ip += 5;
                 break;
             }
@@ -3472,11 +3475,13 @@ retry_emit:
             case CEE_UNBOX: {
                 CHECK_STACK(1);
                 CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
+                CorInfoHelpFunc helpFunc = m_compHnd->getUnBoxHelper(clsHnd);
                 AddIns(INTOP_UNBOX);
                 m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
                 PushStackType(StackTypeI, NULL);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
+                m_pLastNewIns->data[1] = GetDataItemIndex(m_compHnd->getHelperFtn(helpFunc));
                 m_ip += 5;
                 break;
             }
@@ -3484,11 +3489,13 @@ retry_emit:
             case CEE_UNBOX_ANY: {
                 CHECK_STACK(1);
                 CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
+                CorInfoHelpFunc helpFunc = m_compHnd->getUnBoxHelper(clsHnd);
                 AddIns(INTOP_UNBOX_ANY);
                 m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
                 PushStackType(StackTypeVT, clsHnd);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
+                m_pLastNewIns->data[1] = GetDataItemIndex(m_compHnd->getHelperFtn(helpFunc));
                 m_ip += 5;
                 break;
             }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3484,29 +3484,18 @@ retry_emit:
                 break;
             }
 
-            case CEE_UNBOX: {
-                CHECK_STACK(1);
-                m_pStackPointer -= 1;
-                CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
-                CorInfoHelpFunc helpFunc = m_compHnd->getUnBoxHelper(clsHnd);
-                AddIns(INTOP_UNBOX);
-                m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
-                PushStackType(StackTypeI, NULL);
-                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
-                m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
-                m_pLastNewIns->data[1] = GetDataItemIndexForHelperFtn(helpFunc);
-                m_ip += 5;
-                break;
-            }
-
+            case CEE_UNBOX:
             case CEE_UNBOX_ANY: {
                 CHECK_STACK(1);
                 m_pStackPointer -= 1;
                 CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
                 CorInfoHelpFunc helpFunc = m_compHnd->getUnBoxHelper(clsHnd);
-                AddIns(INTOP_UNBOX_ANY);
+                AddIns(opcode == CEE_UNBOX ? INTOP_UNBOX : INTOP_UNBOX_ANY);
                 m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
-                PushInterpType(GetInterpType(m_compHnd->asCorInfoType(clsHnd)), clsHnd);
+                if (opcode == CEE_UNBOX)
+                    PushStackType(StackTypeI, NULL);
+                else
+                    PushInterpType(GetInterpType(m_compHnd->asCorInfoType(clsHnd)), clsHnd);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
                 m_pLastNewIns->data[1] = GetDataItemIndexForHelperFtn(helpFunc);

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1060,7 +1060,6 @@ InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
     m_methodName = compHnd->getMethodNameFromMetadata(methodInfo->ftn, nullptr, nullptr, nullptr, 0);
     if (m_methodName && InterpConfig.InterpDump() && !strcmp(m_methodName, InterpConfig.InterpDump()))
         m_verbose = true;
-    m_verbose = true;
 #endif
 }
 

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3690,7 +3690,7 @@ void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int3
             printf(")");
             break;
         }
-        case InterpOpMethodToken:
+        case InterpOpMethodHandle:
         {
             CORINFO_METHOD_HANDLE mh = (CORINFO_METHOD_HANDLE)((size_t)m_dataItems.Get(*pData) & ~INTERP_METHOD_DESC_TAG);
             printf(" ");

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1725,6 +1725,16 @@ int32_t InterpCompiler::GetMethodDataItemIndex(CORINFO_METHOD_HANDLE mHandle)
     return GetDataItemIndex((void*)data);
 }
 
+int32_t InterpCompiler::GetDataItemIndexForHelperFtn(CorInfoHelpFunc ftn)
+{
+    void *indirect;
+    void *direct = m_compHnd->getHelperFtn(ftn, &indirect);
+    size_t data = !direct
+        ? (size_t)indirect | INTERP_INDIRECT_HELPER_TAG
+        : (size_t)direct;
+    return GetDataItemIndex((void*)data);
+}
+
 bool InterpCompiler::EmitCallIntrinsics(CORINFO_METHOD_HANDLE method, CORINFO_SIG_INFO sig)
 {
     const char *className = NULL;
@@ -3467,7 +3477,7 @@ retry_emit:
                 PushStackType(StackTypeO, boxedClsHnd);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
-                m_pLastNewIns->data[1] = GetDataItemIndex(m_compHnd->getHelperFtn(helpFunc));
+                m_pLastNewIns->data[1] = GetDataItemIndexForHelperFtn(helpFunc);
                 m_ip += 5;
                 break;
             }
@@ -3481,7 +3491,7 @@ retry_emit:
                 PushStackType(StackTypeI, NULL);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
-                m_pLastNewIns->data[1] = GetDataItemIndex(m_compHnd->getHelperFtn(helpFunc));
+                m_pLastNewIns->data[1] = GetDataItemIndexForHelperFtn(helpFunc);
                 m_ip += 5;
                 break;
             }
@@ -3495,7 +3505,7 @@ retry_emit:
                 PushStackType(StackTypeVT, clsHnd);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
-                m_pLastNewIns->data[1] = GetDataItemIndex(m_compHnd->getHelperFtn(helpFunc));
+                m_pLastNewIns->data[1] = GetDataItemIndexForHelperFtn(helpFunc);
                 m_ip += 5;
                 break;
             }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3467,11 +3467,12 @@ retry_emit:
                 m_ip += 1;
                 break;
 
-            case CEE_BOX: {
+            case CEE_BOX:
+            {
                 CHECK_STACK(1);
                 m_pStackPointer -= 1;
-                CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1)),
-                    boxedClsHnd = m_compHnd->getTypeForBox(clsHnd);
+                CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
+                CORINFO_CLASS_HANDLE boxedClsHnd = m_compHnd->getTypeForBox(clsHnd);
                 CorInfoHelpFunc helpFunc = m_compHnd->getBoxHelper(clsHnd);
                 AddIns(INTOP_BOX);
                 m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
@@ -3484,7 +3485,8 @@ retry_emit:
             }
 
             case CEE_UNBOX:
-            case CEE_UNBOX_ANY: {
+            case CEE_UNBOX_ANY:
+            {
                 CHECK_STACK(1);
                 m_pStackPointer -= 1;
                 CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1189,7 +1189,7 @@ static InterpType GetInterpType(CorInfoType corInfoType)
         case CORINFO_TYPE_VOID:
             return InterpTypeVoid;
         default:
-            assert(0);
+            assert(!"Unimplemented CorInfoType");
             break;
     }
     return InterpTypeVoid;
@@ -3470,11 +3470,12 @@ retry_emit:
 
             case CEE_BOX: {
                 CHECK_STACK(1);
+                m_pStackPointer -= 1;
                 CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1)),
                     boxedClsHnd = m_compHnd->getTypeForBox(clsHnd);
                 CorInfoHelpFunc helpFunc = m_compHnd->getBoxHelper(clsHnd);
                 AddIns(INTOP_BOX);
-                m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
+                m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
                 PushStackType(StackTypeO, boxedClsHnd);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
@@ -3485,10 +3486,11 @@ retry_emit:
 
             case CEE_UNBOX: {
                 CHECK_STACK(1);
+                m_pStackPointer -= 1;
                 CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
                 CorInfoHelpFunc helpFunc = m_compHnd->getUnBoxHelper(clsHnd);
                 AddIns(INTOP_UNBOX);
-                m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
+                m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
                 PushStackType(StackTypeI, NULL);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
@@ -3499,11 +3501,12 @@ retry_emit:
 
             case CEE_UNBOX_ANY: {
                 CHECK_STACK(1);
+                m_pStackPointer -= 1;
                 CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
                 CorInfoHelpFunc helpFunc = m_compHnd->getUnBoxHelper(clsHnd);
                 AddIns(INTOP_UNBOX_ANY);
-                m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
-                PushStackType(StackTypeVT, clsHnd);
+                m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
+                PushInterpType(GetInterpType(m_compHnd->asCorInfoType(clsHnd)), clsHnd);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_pLastNewIns->data[0] = GetDataItemIndex(clsHnd);
                 m_pLastNewIns->data[1] = GetDataItemIndexForHelperFtn(helpFunc);

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1060,6 +1060,7 @@ InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
     m_methodName = compHnd->getMethodNameFromMetadata(methodInfo->ftn, nullptr, nullptr, nullptr, 0);
     if (m_methodName && InterpConfig.InterpDump() && !strcmp(m_methodName, InterpConfig.InterpDump()))
         m_verbose = true;
+    m_verbose = true;
 #endif
 }
 

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -292,6 +292,7 @@ private:
     TArray<void*> m_dataItems;
     int32_t GetDataItemIndex(void* data);
     int32_t GetMethodDataItemIndex(CORINFO_METHOD_HANDLE mHandle);
+    int32_t GetDataItemIndexForHelperFtn(CorInfoHelpFunc ftn);
 
     int GenerateCode(CORINFO_METHOD_INFO* methodInfo);
     void PatchInitLocals(CORINFO_METHOD_INFO* methodInfo);

--- a/src/coreclr/interpreter/interpretershared.h
+++ b/src/coreclr/interpreter/interpretershared.h
@@ -12,6 +12,7 @@
 #define INTERP_STACK_ALIGNMENT 16   // Alignment of interpreter stack at the start of a frame
 
 #define INTERP_METHOD_DESC_TAG 4 // Tag of a MethodDesc in the interp method dataItems
+#define INTERP_INDIRECT_HELPER_TAG 1 // When a helper ftn's address is indirect we tag it with this tag bit
 
 struct InterpMethod
 {

--- a/src/coreclr/interpreter/interpretershared.h
+++ b/src/coreclr/interpreter/interpretershared.h
@@ -11,7 +11,7 @@
 #define INTERP_STACK_SLOT_SIZE 8    // Alignment of each var offset on the interpreter stack
 #define INTERP_STACK_ALIGNMENT 16   // Alignment of interpreter stack at the start of a frame
 
-#define INTERP_METHOD_DESC_TAG 4 // Tag of a MethodDesc in the interp method dataItems
+#define INTERP_METHOD_HANDLE_TAG 4 // Tag of a MethodDesc in the interp method dataItems
 #define INTERP_INDIRECT_HELPER_TAG 1 // When a helper ftn's address is indirect we tag it with this tag bit
 
 struct InterpMethod

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -139,9 +139,9 @@ OPDEF(INTOP_CONV_R8_R4, "conv.r8.r4", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_CONV_U8_R4, "conv.u8.r4", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_CONV_U8_R8, "conv.u8.r8", 3, 1, 1, InterpOpNoArgs)
 
-OPDEF(INTOP_BOX, "box", 4, 1, 1, InterpOpClassHandle)
-OPDEF(INTOP_UNBOX, "unbox", 4, 1, 1, InterpOpClassHandle)
-OPDEF(INTOP_UNBOX_ANY, "unbox.any", 4, 1, 1, InterpOpClassHandle)
+OPDEF(INTOP_BOX, "box", 5, 1, 1, InterpOpClassHandle) // [class handle data item] [helper data item]
+OPDEF(INTOP_UNBOX, "unbox", 5, 1, 1, InterpOpClassHandle) // [class handle data item] [helper data item]
+OPDEF(INTOP_UNBOX_ANY, "unbox.any", 5, 1, 1, InterpOpClassHandle) // [class handle data item] [helper data item]
 // Unary operations end
 
 OPDEF(INTOP_ADD_I4_IMM, "add.i4.imm", 4, 1, 1, InterpOpInt)

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -255,10 +255,10 @@ OPDEF(INTOP_STIND_VT_NOREF, "stind.vt.noref", 5, 0, 2, InterpOpTwoInts)
 OPDEF(INTOP_LDFLDA, "ldflda", 4, 1, 1, InterpOpInt)
 
 // Calls
-OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodToken)
-OPDEF(INTOP_CALLVIRT, "callvirt", 4, 1, 1, InterpOpMethodToken)
-OPDEF(INTOP_NEWOBJ, "newobj", 5, 1, 1, InterpOpMethodToken)
-OPDEF(INTOP_NEWOBJ_VT, "newobj.vt", 5, 1, 1, InterpOpMethodToken)
+OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_CALLVIRT, "callvirt", 4, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_NEWOBJ, "newobj", 5, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_NEWOBJ_VT, "newobj.vt", 5, 1, 1, InterpOpMethodHandle)
 
 OPDEF(INTOP_CALL_HELPER_PP, "call.helper.pp", 5, 1, 0, InterpOpThreeInts)
 

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -138,6 +138,10 @@ OPDEF(INTOP_CONV_R8_R4, "conv.r8.r4", 3, 1, 1, InterpOpNoArgs)
 
 OPDEF(INTOP_CONV_U8_R4, "conv.u8.r4", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_CONV_U8_R8, "conv.u8.r8", 3, 1, 1, InterpOpNoArgs)
+
+OPDEF(INTOP_BOX, "box", 4, 1, 1, InterpOpClassHandle)
+OPDEF(INTOP_UNBOX, "unbox", 4, 1, 1, InterpOpClassHandle)
+OPDEF(INTOP_UNBOX_ANY, "unbox.any", 4, 1, 1, InterpOpClassHandle)
 // Unary operations end
 
 OPDEF(INTOP_ADD_I4_IMM, "add.i4.imm", 4, 1, 1, InterpOpInt)

--- a/src/coreclr/interpreter/intops.h
+++ b/src/coreclr/interpreter/intops.h
@@ -21,6 +21,7 @@ typedef enum
     InterpOpBranch,
     InterpOpSwitch,
     InterpOpMethodToken,
+    InterpOpClassHandle,
 } InterpOpArgType;
 
 extern const uint8_t g_interpOpLen[];

--- a/src/coreclr/interpreter/intops.h
+++ b/src/coreclr/interpreter/intops.h
@@ -20,7 +20,7 @@ typedef enum
     InterpOpThreeInts,
     InterpOpBranch,
     InterpOpSwitch,
-    InterpOpMethodToken,
+    InterpOpMethodHandle,
     InterpOpClassHandle,
 } InterpOpArgType;
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1058,11 +1058,11 @@ MAIN_LOOP:
 CALL_INTERP_SLOT:
                     {
                     size_t targetMethod = (size_t)pMethod->pDataItems[methodSlot];
-                    if (targetMethod & INTERP_METHOD_DESC_TAG)
+                    if (targetMethod & INTERP_METHOD_HANDLE_TAG)
                     {
                         // First execution of this call. Ensure target method is compiled and
                         // patch the data item slot with the actual method code.
-                        MethodDesc *pMD = (MethodDesc*)(targetMethod & ~INTERP_METHOD_DESC_TAG);
+                        MethodDesc *pMD = (MethodDesc*)(targetMethod & ~INTERP_METHOD_HANDLE_TAG);
                         PCODE code = pMD->GetNativeCode();
                         if (!code) {
                             // This is an optimization to ensure that the stack walk will not have to search

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -8,6 +8,7 @@
 #include "interpexec.h"
 
 typedef void* (*HELPER_FTN_PP)(void*);
+typedef void (*HELPER_FTN_VPP)(void*, void*);
 
 InterpThreadContext::InterpThreadContext()
 {
@@ -1205,7 +1206,13 @@ CALL_TARGET_IP:
                     int dreg = ip[1];
                     int sreg = ip[2];
                     CORINFO_CLASS_HANDLE clsHnd = (CORINFO_CLASS_HANDLE)pMethod->pDataItems[ip[3]];
-                    void *helper = pMethod->pDataItems[ip[4]];
+                    size_t helperDirectOrIndirect = (size_t)pMethod->pDataItems[ip[4]];
+                    HELPER_FTN_VPP helper = nullptr;
+                    if (helperDirectOrIndirect & INTERP_INDIRECT_HELPER_TAG)
+                        helper = *(HELPER_FTN_VPP *)(helperDirectOrIndirect & ~INTERP_INDIRECT_HELPER_TAG);
+                    else
+                        helper = (HELPER_FTN_VPP)helperDirectOrIndirect;
+                    helper(LOCAL_VAR_ADDR(dreg, OBJECTREF), LOCAL_VAR_ADDR(sreg, void));
                     assert(0);
                     ip += 5;
                 }

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1200,6 +1200,15 @@ CALL_TARGET_IP:
                     UNREACHABLE();
                     break;
                 }
+                case INTOP_BOX:
+                {
+                    int dreg = ip[1];
+                    int sreg = ip[2];
+                    CORINFO_CLASS_HANDLE clsHnd = (CORINFO_CLASS_HANDLE)pMethod->pDataItems[ip[3]];
+                    void *helper = pMethod->pDataItems[ip[4]];
+                    assert(0);
+                    ip += 5;
+                }
                 case INTOP_FAILFAST:
                     assert(0);
                     break;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1202,6 +1202,8 @@ CALL_TARGET_IP:
                     break;
                 }
                 case INTOP_BOX:
+                case INTOP_UNBOX:
+                case INTOP_UNBOX_ANY:
                 {
                     int dreg = ip[1];
                     int sreg = ip[2];
@@ -1213,9 +1215,20 @@ CALL_TARGET_IP:
                     else
                         helper = (HELPER_FTN_BOX_UNBOX)helperDirectOrIndirect;
 
-                    LOCAL_VAR(dreg, Object*) = (Object*)helper(pMT, LOCAL_VAR_ADDR(sreg, void));
-                    assert(0);
+                    switch (*ip) {
+                        case INTOP_BOX:
+                            LOCAL_VAR(dreg, Object*) = (Object*)helper(pMT, LOCAL_VAR_ADDR(sreg, void));
+                            break;
+                        case INTOP_UNBOX:
+                            LOCAL_VAR(dreg, void*) = helper(pMT, LOCAL_VAR(sreg, Object*));
+                            break;
+                        case INTOP_UNBOX_ANY:
+                            void *unboxedData = helper(pMT, LOCAL_VAR(sreg, Object*));
+                            CopyValueClassUnchecked(LOCAL_VAR_ADDR(dreg, void), unboxedData, pMT);
+                            break;
+                    }
                     ip += 5;
+                    break;
                 }
                 case INTOP_FAILFAST:
                     assert(0);

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -117,6 +117,9 @@ public class InterpreterTest
         if (!TestVirtual())
             Environment.FailFast(null);
 
+        if (!TestBoxing())
+            Environment.FailFast(null);
+
         System.GC.Collect();
     }
 
@@ -383,6 +386,16 @@ public class InterpreterTest
         if (bc.VirtualMethod() != 0xbebe)
             return false;
         if (itest.VirtualMethod() != 0xbebe)
+            return false;
+        return true;
+    }
+
+    public static bool TestBoxing()
+    {
+        int i = 4;
+        object oI = i;
+        int j = (int)oI;
+        if (j != i)
             return false;
         return true;
     }

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -392,11 +392,15 @@ public class InterpreterTest
 
     public static bool TestBoxing()
     {
-        int i = 4;
-        object oI = i;
-        int j = (int)oI;
-        if (j != i)
-            return false;
-        return true;
+        int l = 7, r = 4;
+        object s = BoxedSubtraction(l, r);
+        // `(s is int result)` generates isinst so we have to do this in steps
+        int result = (int)s;
+        return result == 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    static object BoxedSubtraction (object lhs, object rhs) {
+        return (int)lhs - (int)rhs;
     }
 }


### PR DESCRIPTION
Adds interp opcodes for box, unbox, and unbox_any. The interpreter compiler looks up the appropriate helper ftn for the operation in question at compile time and then we invoke the helper to perform the actual box/unbox operation.

Also refactors a couple inconsistent names in the interpreter (MethodDesc/MethodToken -> MethodHandle)