### PR TITLE
[release/9.0-staging] JIT: Fix invalid removal of explicit zeroing in methods without .localsinit

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -185,7 +185,7 @@ void MorphInitBlockHelper::PrepareDst()
         m_dstVarDsc    = m_comp->lvaGetDesc(m_dstLclNum);
 
         // Kill everything about m_dstLclNum (and its field locals)
-        if (m_comp->optLocalAssertionProp)
+        if (m_comp->optLocalAssertionProp && (m_comp->optAssertionCount > 0))
         {
             m_comp->fgKillDependentAssertions(m_dstLclNum DEBUGARG(m_store));
         }
@@ -230,17 +230,14 @@ void MorphInitBlockHelper::PrepareDst()
 //    Once the init or copy tree is morphed, assertion gen can no
 //    longer recognize what it means.
 //
-//    So we generate assertions based on the original tree, provided that we
-//    will store all fields.
+//    So we generate assertions based on the original tree.
 //
 void MorphInitBlockHelper::PropagateBlockAssertions()
 {
-    if (!m_comp->optLocalAssertionProp)
+    if (m_comp->optLocalAssertionProp)
     {
-        return;
+        m_comp->fgAssertionGen(m_store);
     }
-
-    m_comp->fgAssertionGen(m_store);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -250,8 +250,6 @@ void MorphInitBlockHelper::PropagateBlockAssertions()
 //
 void MorphInitBlockHelper::PropagateExpansionAssertions()
 {
-    // Consider doing this for FieldByField as well
-    //
     if (m_comp->optLocalAssertionProp && (m_transformationDecision == BlockTransformation::OneStoreBlock))
     {
         m_comp->fgAssertionGen(m_store);
@@ -405,7 +403,7 @@ void MorphInitBlockHelper::TryInitFieldByField()
     {
         unsigned fieldLclNum = destLclVar->lvFieldLclStart + i;
 
-        if (m_comp->fgGlobalMorph && m_dstLclNode->IsLastUse(i))
+        if (!m_store->GeneratesAssertion() && m_comp->fgGlobalMorph && m_dstLclNode->IsLastUse(i))
         {
             JITDUMP("Field-by-field init skipping write to dead field V%02u\n", fieldLclNum);
             continue;
@@ -1232,7 +1230,7 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
     // So, beyond this point we cannot rely on the old values of 'm_srcVarDsc' and 'm_dstVarDsc'.
     for (unsigned i = 0; i < fieldCnt; ++i)
     {
-        if (m_dstDoFldStore && m_comp->fgGlobalMorph && m_dstLclNode->IsLastUse(i))
+        if (!m_store->GeneratesAssertion() && m_dstDoFldStore && m_comp->fgGlobalMorph && m_dstLclNode->IsLastUse(i))
         {
             INDEBUG(unsigned dstFieldLclNum = m_comp->lvaGetDesc(m_dstLclNum)->lvFieldLclStart + i);
             JITDUMP("Field-by-field copy skipping write to dead field V%02u\n", dstFieldLclNum);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_113658/Runtime_113658.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_113658/Runtime_113658.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Runtime_113658
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        FillStackWithGarbage();
+        long? nullable = FaultyDefaultNullable<long?>();
+        return (int)(100 + nullable.GetValueOrDefault());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void FillStackWithGarbage()
+    {
+        stackalloc byte[256].Fill(0xcc);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [SkipLocalsInit]
+    private static T FaultyDefaultNullable<T>()
+    {
+        // When T is a Nullable<T> (and only in that case), we support returning null
+        if (default(T) is null && typeof(T).IsValueType)
+            return default!;
+
+        throw new InvalidOperationException("Not nullable");
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_113658/Runtime_113658.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_113658/Runtime_113658.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #115556 to release/9.0-staging

## Customer Impact

- [x] Customer reported
- [ ] Found internally

The JIT may mistakenly remove explicit field zeroing for some struct fields in methods without .localsinit (e.g. by having the `SkipLocalsInit` attribute applied in C#). This can happen when the IL first zero-initializes the full struct local using e.g. `initobj`, and then later zeroes a particular field of the struct local using `stfld`. Under certain circumstances, the JIT mistakenly eliminates both explicit zeroings of the field, leaving no zero initialization present, resulting in the field containing stack garbage.

Reported by customer in #113658.

## Regression

- [x] Yes
- [ ] No

This was exposed by support for cross-block assertion prop enabled in #94689.

## Testing

Unit test added, and tested manually on user's test case.

## Risk

Low