### PR TITLE
Normalize the paths to ensure install works on newer versions of cmake

### DIFF
--- a/src/native/corehost/test/ijw/CMakeLists.txt
+++ b/src/native/corehost/test/ijw/CMakeLists.txt
@@ -13,12 +13,14 @@ install_with_stripped_symbols(ijw TARGETS corehost_test)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   # Copy over the debug CRT so that it is available for test runs
+  file(TO_CMAKE_PATH "$ENV{VCToolsRedistDir}" CMAKE_VS_VCTOOLSREDISTDIR)
+  file(TO_CMAKE_PATH "$ENV{ExtensionSdkDir}" CMAKE_VS_EXTENSIONSDKDIR)
   file(
     GLOB_RECURSE
     DEBUG_CRT_FILES
-    $ENV{VCToolsRedistDir}/onecore/debug_nonredist/${ARCH_TARGET_NAME}/Microsoft.VC*.DebugCRT/vcruntime*d.dll
-    $ENV{VCToolsRedistDir}/onecore/debug_nonredist/${ARCH_TARGET_NAME}/Microsoft.VC*.DebugCRT/msvcp*d.dll
-    $ENV{ExtensionSdkDir}/Microsoft.UniversalCRT.Debug/$ENV{UCRTVersion}/Redist/Debug/${ARCH_TARGET_NAME}/ucrtbased.dll
+    ${CMAKE_VS_VCTOOLSREDISTDIR}/onecore/debug_nonredist/${ARCH_TARGET_NAME}/Microsoft.VC*.DebugCRT/vcruntime*d.dll
+    ${CMAKE_VS_VCTOOLSREDISTDIR}/onecore/debug_nonredist/${ARCH_TARGET_NAME}/Microsoft.VC*.DebugCRT/msvcp*d.dll
+    ${CMAKE_VS_EXTENSIONSDKDIR}/Microsoft.UniversalCRT.Debug/$ENV{UCRTVersion}/Redist/Debug/${ARCH_TARGET_NAME}/ucrtbased.dll
   )
   install(FILES ${DEBUG_CRT_FILES} DESTINATION corehost_test/ijw-deps)
 endif ()


### PR DESCRIPTION
This was broken yesterday in https://github.com/dotnet/runtime/pull/114187

On some versions of CMake (potentially just v4.0.0 and later) the install will fail as `C:\Program Files` is interpreted as containing an escape character `\P` which is unrecognized.