### PR TITLE
[Mono] Fix c11 ARM64 atomics to issue full memory barrier.

### DIFF
--- a/src/mono/mono/utils/atomic.h
+++ b/src/mono/mono/utils/atomic.h
@@ -95,11 +95,18 @@ Apple targets have historically being problematic, xcode 4.6 would miscompile th
 
 #include <stdatomic.h>
 
+#if defined(HOST_ARM64)
+#define C11_MEMORY_ORDER_SEQ_CST() atomic_thread_fence (memory_order_seq_cst)
+#else
+#define C11_MEMORY_ORDER_SEQ_CST()
+#endif
+
 static inline guint8
 mono_atomic_cas_u8 (volatile guint8 *dest, guint8 exch, guint8 comp)
 {
 	g_static_assert (sizeof (atomic_char) == sizeof (*dest) && ATOMIC_CHAR_LOCK_FREE == 2);
 	(void)atomic_compare_exchange_strong ((volatile atomic_char *)dest, (char*)&comp, exch);
+	C11_MEMORY_ORDER_SEQ_CST ();
 	return comp;
 }
 
@@ -108,6 +115,7 @@ mono_atomic_cas_u16 (volatile guint16 *dest, guint16 exch, guint16 comp)
 {
 	g_static_assert (sizeof (atomic_short) == sizeof (*dest) && ATOMIC_SHORT_LOCK_FREE == 2);
 	(void)atomic_compare_exchange_strong ((volatile atomic_short *)dest, (short*)&comp, exch);
+	C11_MEMORY_ORDER_SEQ_CST ();
 	return comp;
 }
 
@@ -116,6 +124,7 @@ mono_atomic_cas_i32 (volatile gint32 *dest, gint32 exch, gint32 comp)
 {
 	g_static_assert (sizeof (atomic_int) == sizeof (*dest) && ATOMIC_INT_LOCK_FREE == 2);
 	(void)atomic_compare_exchange_strong ((volatile atomic_int *)dest, &comp, exch);
+	C11_MEMORY_ORDER_SEQ_CST ();
 	return comp;
 }
 
@@ -125,14 +134,14 @@ mono_atomic_cas_i64 (volatile gint64 *dest, gint64 exch, gint64 comp)
 #if SIZEOF_LONG == 8
 	g_static_assert (sizeof (atomic_long) == sizeof (*dest) && ATOMIC_LONG_LOCK_FREE == 2);
 	(void)atomic_compare_exchange_strong ((volatile atomic_long *)dest, (long*)&comp, exch);
-	return comp;
 #elif SIZEOF_LONG_LONG == 8
 	g_static_assert (sizeof (atomic_llong) == sizeof (*dest) && ATOMIC_LLONG_LOCK_FREE == 2);
 	(void)atomic_compare_exchange_strong ((volatile atomic_llong *)dest, (long long*)&comp, exch);
-	return comp;
 #else
 #error "gint64 not same size atomic_llong or atomic_long, don't define MONO_USE_STDATOMIC"
 #endif
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return comp;
 }
 
 static inline gpointer
@@ -140,6 +149,7 @@ mono_atomic_cas_ptr (volatile gpointer *dest, gpointer exch, gpointer comp)
 {
 	g_static_assert(ATOMIC_POINTER_LOCK_FREE == 2);
 	(void)atomic_compare_exchange_strong ((volatile _Atomic(gpointer) *)dest, &comp, exch);
+	C11_MEMORY_ORDER_SEQ_CST ();
 	return comp;
 }
 
@@ -191,21 +201,27 @@ static inline guint8
 mono_atomic_xchg_u8 (volatile guint8 *dest, guint8 exch)
 {
 	g_static_assert (sizeof (atomic_char) == sizeof (*dest) && ATOMIC_CHAR_LOCK_FREE == 2);
-	return atomic_exchange ((volatile atomic_char *)dest, exch);
+	guint8 old = atomic_exchange ((volatile atomic_char *)dest, exch);
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return old;
 }
 
 static inline guint16
 mono_atomic_xchg_u16 (volatile guint16 *dest, guint16 exch)
 {
 	g_static_assert (sizeof (atomic_short) == sizeof (*dest) && ATOMIC_SHORT_LOCK_FREE == 2);
-	return atomic_exchange ((volatile atomic_short *)dest, exch);
+	guint16 old = atomic_exchange ((volatile atomic_short *)dest, exch);
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return old;
 }
 
 static inline gint32
 mono_atomic_xchg_i32 (volatile gint32 *dest, gint32 exch)
 {
 	g_static_assert (sizeof (atomic_int) == sizeof (*dest) && ATOMIC_INT_LOCK_FREE == 2);
-	return atomic_exchange ((volatile atomic_int *)dest, exch);
+	gint32 old = atomic_exchange ((volatile atomic_int *)dest, exch);
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return old;
 }
 
 static inline gint64
@@ -213,27 +229,33 @@ mono_atomic_xchg_i64 (volatile gint64 *dest, gint64 exch)
 {
 #if SIZEOF_LONG == 8
 	g_static_assert (sizeof (atomic_long) == sizeof (*dest) && ATOMIC_LONG_LOCK_FREE == 2);
-	return atomic_exchange ((volatile atomic_long *)dest, exch);
+	gint64 old = atomic_exchange ((volatile atomic_long *)dest, exch);
 #elif SIZEOF_LONG_LONG == 8
 	g_static_assert (sizeof (atomic_llong) == sizeof (*dest) && ATOMIC_LLONG_LOCK_FREE == 2);
-	return atomic_exchange ((volatile atomic_llong *)dest, exch);
+	gint64 old = atomic_exchange ((volatile atomic_llong *)dest, exch);
 #else
 #error "gint64 not same size atomic_llong or atomic_long, don't define MONO_USE_STDATOMIC"
 #endif
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return old;
 }
 
 static inline gpointer
 mono_atomic_xchg_ptr (volatile gpointer *dest, gpointer exch)
 {
 	g_static_assert (ATOMIC_POINTER_LOCK_FREE == 2);
-	return atomic_exchange ((volatile _Atomic(gpointer) *)dest, exch);
+	gpointer old = atomic_exchange ((volatile _Atomic(gpointer) *)dest, exch);
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return old;
 }
 
 static inline gint32
 mono_atomic_fetch_add_i32 (volatile gint32 *dest, gint32 add)
 {
 	g_static_assert (sizeof (atomic_int) == sizeof (*dest) && ATOMIC_INT_LOCK_FREE == 2);
-	return atomic_fetch_add ((volatile atomic_int *)dest, add);
+	gint32 old = atomic_fetch_add ((volatile atomic_int *)dest, add);
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return old;
 }
 
 static inline gint64
@@ -241,33 +263,41 @@ mono_atomic_fetch_add_i64 (volatile gint64 *dest, gint64 add)
 {
 #if SIZEOF_LONG == 8
 	g_static_assert (sizeof (atomic_long) == sizeof (*dest) && ATOMIC_LONG_LOCK_FREE == 2);
-	return atomic_fetch_add ((volatile atomic_long *)dest, add);
+	gint64 old = atomic_fetch_add ((volatile atomic_long *)dest, add);
 #elif SIZEOF_LONG_LONG == 8
 	g_static_assert (sizeof (atomic_llong) == sizeof (*dest) && ATOMIC_LLONG_LOCK_FREE == 2);
-	return atomic_fetch_add ((volatile atomic_llong *)dest, add);
+	gint64 old = atomic_fetch_add ((volatile atomic_llong *)dest, add);
 #else
 #error "gint64 not same size atomic_llong or atomic_long, don't define MONO_USE_STDATOMIC"
 #endif
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return old;
 }
 
 static inline gint8
 mono_atomic_load_i8 (volatile gint8 *src)
 {
 	g_static_assert (sizeof (atomic_char) == sizeof (*src) && ATOMIC_CHAR_LOCK_FREE == 2);
-	return atomic_load ((volatile atomic_char *)src);
+	gint8 val = atomic_load ((volatile atomic_char *)src);
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return val;
 }
 
 static inline gint16
 mono_atomic_load_i16 (volatile gint16 *src)
 {
 	g_static_assert (sizeof (atomic_short) == sizeof (*src) && ATOMIC_SHORT_LOCK_FREE == 2);
-	return atomic_load ((volatile atomic_short *)src);
+	gint16 val = atomic_load ((volatile atomic_short *)src);
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return val;
 }
 
 static inline gint32 mono_atomic_load_i32 (volatile gint32 *src)
 {
 	g_static_assert (sizeof (atomic_int) == sizeof (*src) && ATOMIC_INT_LOCK_FREE == 2);
-	return atomic_load ((volatile atomic_int *)src);
+	gint32 val = atomic_load ((volatile atomic_int *)src);
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return val;
 }
 
 static inline gint64
@@ -275,20 +305,24 @@ mono_atomic_load_i64 (volatile gint64 *src)
 {
 #if SIZEOF_LONG == 8
 	g_static_assert (sizeof (atomic_long) == sizeof (*src) && ATOMIC_LONG_LOCK_FREE == 2);
-	return atomic_load ((volatile atomic_long *)src);
+	gint64 val = atomic_load ((volatile atomic_long *)src);
 #elif SIZEOF_LONG_LONG == 8
 	g_static_assert (sizeof (atomic_llong) == sizeof (*src) && ATOMIC_LLONG_LOCK_FREE == 2);
-	return atomic_load ((volatile atomic_llong *)src);
+	gint64 val = atomic_load ((volatile atomic_llong *)src);
 #else
 #error "gint64 not same size atomic_llong or atomic_long, don't define MONO_USE_STDATOMIC"
 #endif
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return val;
 }
 
 static inline gpointer
 mono_atomic_load_ptr (volatile gpointer *src)
 {
 	g_static_assert (ATOMIC_POINTER_LOCK_FREE == 2);
-	return atomic_load ((volatile _Atomic(gpointer) *)src);
+	gpointer val = atomic_load ((volatile _Atomic(gpointer) *)src);
+	C11_MEMORY_ORDER_SEQ_CST ();
+	return val;
 }
 
 static inline void
@@ -296,6 +330,7 @@ mono_atomic_store_i8 (volatile gint8 *dst, gint8 val)
 {
 	g_static_assert (sizeof (atomic_char) == sizeof (*dst) && ATOMIC_CHAR_LOCK_FREE == 2);
 	atomic_store ((volatile atomic_char *)dst, val);
+	C11_MEMORY_ORDER_SEQ_CST ();
 }
 
 static inline void
@@ -303,6 +338,7 @@ mono_atomic_store_i16 (volatile gint16 *dst, gint16 val)
 {
 	g_static_assert (sizeof (atomic_short) == sizeof (*dst) && ATOMIC_SHORT_LOCK_FREE == 2);
 	atomic_store ((volatile atomic_short *)dst, val);
+	C11_MEMORY_ORDER_SEQ_CST ();
 }
 
 static inline void
@@ -310,6 +346,7 @@ mono_atomic_store_i32 (volatile gint32 *dst, gint32 val)
 {
 	g_static_assert (sizeof (atomic_int) == sizeof (*dst) && ATOMIC_INT_LOCK_FREE == 2);
 	atomic_store ((atomic_int *)dst, val);
+	C11_MEMORY_ORDER_SEQ_CST ();
 }
 
 static inline void
@@ -324,6 +361,7 @@ mono_atomic_store_i64 (volatile gint64 *dst, gint64 val)
 #else
 #error "gint64 not same size atomic_llong or atomic_long, don't define MONO_USE_STDATOMIC"
 #endif
+	C11_MEMORY_ORDER_SEQ_CST ();
 }
 
 static inline void
@@ -331,6 +369,7 @@ mono_atomic_store_ptr (volatile gpointer *dst, gpointer val)
 {
 	g_static_assert (ATOMIC_POINTER_LOCK_FREE == 2);
 	atomic_store ((volatile _Atomic(gpointer) *)dst, val);
+	C11_MEMORY_ORDER_SEQ_CST ();
 }
 
 #elif defined(MONO_USE_WIN32_ATOMIC)

--- a/src/tests/FunctionalTests/iOS/Device/ParallelForEachAsync/Program.cs
+++ b/src/tests/FunctionalTests/iOS/Device/ParallelForEachAsync/Program.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Linq;
+
+public static class Program
+{
+    [DllImport("__Internal")]
+    public static extern void mono_ios_set_summary (string value);
+
+    private static async Task GitHubIssue_114262_Async()
+    {
+        var options = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = 5,
+            CancellationToken = new CancellationTokenSource().Token
+        };
+
+        var range = Enumerable.Range(1, 1000);
+
+        for (int i = 0; i < 100; i++)
+        {
+            await Parallel.ForEachAsync(range, options, async (data, token) =>
+            {
+                for (int i = 0; i < 5; i++)
+                {
+                    await Task.Yield();
+                    var buffer = new byte[10_000];
+                    await Task.Run(() => {var _ = buffer[0];} );
+                    await Task.Yield();
+                }
+            });
+        }
+    }
+    
+    public static async Task<int> Main(string[] args)
+    {
+        mono_ios_set_summary($"Starting functional test");
+
+        await GitHubIssue_114262_Async();
+
+        Console.WriteLine("Done!");
+
+        return 42;
+    }
+}

--- a/src/tests/FunctionalTests/iOS/Device/ParallelForEachAsync/iOS.Device.ParallelForEachAsync.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Device/ParallelForEachAsync/iOS.Device.ParallelForEachAsync.Test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <MonoForceInterpreter>true</MonoForceInterpreter>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <TestRuntime>true</TestRuntime>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetOS Condition="'$(TargetOS)' == ''">ios</TargetOS>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">arm64</TargetArchitecture>
+    <MainLibraryFileName>iOS.Device.ParallelForEachAsync.Test.dll</MainLibraryFileName>
+    <IncludesTestRunner>false</IncludesTestRunner>
+    <ExpectedExitCode>42</ExpectedExitCode>
+    <RuntimeFlavor>Mono</RuntimeFlavor>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/FunctionalTests/iOS/Device/ParallelForEachAsync/iOS.Device.ParallelForEachAsync.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Device/ParallelForEachAsync/iOS.Device.ParallelForEachAsync.Test.csproj
@@ -1,16 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <MonoForceInterpreter>true</MonoForceInterpreter>
-    <RunAOTCompilation>false</RunAOTCompilation>
     <TestRuntime>true</TestRuntime>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TargetOS Condition="'$(TargetOS)' == ''">ios</TargetOS>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">arm64</TargetArchitecture>
-    <MainLibraryFileName>iOS.Device.ParallelForEachAsync.Test.dll</MainLibraryFileName>
     <IncludesTestRunner>false</IncludesTestRunner>
     <ExpectedExitCode>42</ExpectedExitCode>
-    <RuntimeFlavor>Mono</RuntimeFlavor>
+    <UseConsoleUITemplate>true</UseConsoleUITemplate>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(RuntimeFlavor)' == 'Mono'">
+    <MonoForceInterpreter>true</MonoForceInterpreter>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <MainLibraryFileName>iOS.Device.ParallelForEachAsync.Test.dll</MainLibraryFileName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In .NET 9 Mono changed its internal atomic implementation in `atomic.h` to use C11 atomics on a number of platforms and CPU architectures, https://github.com/dotnet/runtime/commit/c48aa81069ef4cdb661acae7356e3cb166324486, but it was not until we implemented I4 Interlocked.Exchange intrinsics in interpreter, https://github.com/dotnet/runtime/commit/12ecfe7b127aff7e33a33587f5159c683777e3e3, that triggered issue to become more visible.

Before .NET 9, Mono used GCC atomics, they are also plagued with assumption that acquire/release barriers are enough to be sequential consistent, so Mono added full barriers around these atomic calls, issuing full memory barrier before and after atomic instruction. This is even a stronger guarantee than what Mono and CoreCLR JIT compilers offers when compiling the Interlocked functions, so could be relaxed, at least on ARM64.

The default behavior of C11 atomics should be sequential consistent, but the implementation of C11 atomics on ARM64(clang/gcc), settle on half barriers, acquire/release semantics, but won't issue a full memory barrier. Mono's atomic implementation is used both within runtime as well as from `Interlocked` functions in icalls as well as interpreter implementation of `Interlocked` op codes. The callers of these functions expect a full memory barrier, meaning no load/stores can move past the atomic operation, for example C11 `atomic_exchange` on ARM64 ends up with the following assembly sequence on iOS and Android platforms when CPU doesn’t support ARMv8 with LSE instructions set:

```
ldaxr       // Load exclusive with acquire semantics.
stlxr       // Store exclusive with release sematnics
cbnz        // Retry on failure.
```

This doesn't include a full memory barrier after the exchange, breaking the assumptions of the callers that the function should be sequential consistent without any ordering of load/stores across the atomic operation.

Android includes runtime checks to switch to a different set of instructions, `swpal`/`casal`, if CPU supports ARMv8 + LSE. The memory reorder issues observed in #114262 have not been reproduced when the LSE assembly instructions are used, probably because it is less likely with one instruction instead of 2+ sequence, and load/stores can't be reordered past the full acquire/release barriers but can be reordered into the barriers. The guarantee offered by `swpal`/`casal` is still acquire/release semantics without a full barrier, so in theory it could end up with similar reorder issues. The issue has not been reproduced on iOS simulator since compiler will use ARMv8 + LSE instruction for that build. On iOS device build it will compile without LSE support, generating the more fragile assembler sequence, making it more likely to hit the issue on any iOS ARM64 device.

Mono JIT code generation already handles this scenario on ARM64, it will make sure exchange and CAS operations end up with a full memory barrier, CoreCLR does the same thing for its lowering of Interlocked functions and that is why the issue won't reproduce when using AOT compiled code, only using interpreter. Having that said, since the `mono_atomic_*` functions are used within runtime, it might still manifest itself under other configurations, probably leading to memory corruption and weird crashes.

Fix aligns code generated by C11 atomics with what's being generated by JIT compilers, ending with a full memory barrier:

```
ldaxr       // Load exclusive with acquire semantics.
stlxr       // Store exclusive with release semantics
cbnz        // Retry on failure.
dmb ish     // Full memory barrier.
```

This is inline with the code generated by both Mono and CoreCLR JIT ARM64 compilers for Interlocked functions.

Android ARM32 was also checked, and it appears that C11 atomics generate the expected full memory barrier on this architecture, meaning no additional memory barriers are needed.

PR adds two new tests (identical), one into libraries Tasks `ParallelForEachAsyncTests`, but since this issue requires iOS device + ARM64 + interpreter to reproduce, PR also adds the same test as a functional test, where we can force it to use interpreter only and only run test on Mono. It is also worth noting that before implementing this fix, running `ParallelForEachAsyncTests` on iOS device + ARM64 + interpreter was observed to cause hangs, GC crashes and other unstable runtime behaviour (due to memory reorder). With this fix, `ParallelForEachAsyncTests` pass without any observed issues.

It appears that CI doesn't run tests using iOS device + AMR64 + interpreter, so it won’t expose these issues. That is why a functional test was included as well, since we can control the exact configuration needed to reproduce the issue and prevent future regressions from happening.