### PR TITLE
[browser] OOM on monointerpreter

### DIFF
--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -443,7 +443,12 @@
 
     <!-- We need to build group #1 manually as it doesn't have a _GroupStartsWith item associated with it, see the comment in Common\dirs.proj -->
     <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="BuildManagedTestGroup" Properties="__TestGroupToBuild=1;__SkipRestorePackages=1" />
-    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="BuildManagedTestGroup" Properties="__TestGroupToBuild=%(_GroupStartsWith.GroupNumber);__SkipRestorePackages=1" />
+    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/114123 
+    The groups 2..n are disabled for browser target because they get OOM kill in CI.
+    -->
+    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="BuildManagedTestGroup" Properties="__TestGroupToBuild=%(_GroupStartsWith.GroupNumber);__SkipRestorePackages=1" 
+        Condition="'$(TargetOS)' != 'browser' or '$(ContinuousIntegrationBuild)' != 'true'"
+    />
   </Target>
 
   <Target Name="BuildManagedTestGroup"


### PR DESCRIPTION
`browser-wasm linux Release AllSubsets_Mono_RuntimeTests monointerpreter` is `exited with code 137` [OOM](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1041453&view=logs&jobId=3e93a48f-6568-53f2-76b3-1285c183c39d&j=3e93a48f-6568-53f2-76b3-1285c183c39d&t=313dc435-bc2e-554b-c5b1-106790cdfaec)


Contributes to https://github.com/dotnet/runtime/issues/113724
Contributes to https://github.com/dotnet/runtime/issues/114123