### PR TITLE
Mark some Tensor extension methods as scoped

### DIFF
--- a/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.netcore.cs
@@ -469,8 +469,8 @@ namespace System.Numerics.Tensors
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> RadiansToDegrees<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, in System.Numerics.Tensors.TensorSpan<T> destination) where T : System.Numerics.ITrigonometricFunctions<T> { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Reciprocal<T>(in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x) where T : System.Numerics.IFloatingPoint<T> { throw null; }
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> Reciprocal<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, in System.Numerics.Tensors.TensorSpan<T> destination) where T : System.Numerics.IFloatingPoint<T> { throw null; }
-        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Reshape<T>(this in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
-        public static System.Numerics.Tensors.TensorSpan<T> Reshape<T>(this in System.Numerics.Tensors.TensorSpan<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
+        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Reshape<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
+        public static System.Numerics.Tensors.TensorSpan<T> Reshape<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Reshape<T>(this System.Numerics.Tensors.Tensor<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
         public static void ResizeTo<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { }
         public static void ResizeTo<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { }
@@ -511,11 +511,11 @@ namespace System.Numerics.Tensors
         public static System.Numerics.Tensors.Tensor<T>[] Split<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int splitCount, nint dimension) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Sqrt<T>(in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x) where T : System.Numerics.IRootFunctions<T> { throw null; }
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> Sqrt<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, in System.Numerics.Tensors.TensorSpan<T> destination) where T : System.Numerics.IRootFunctions<T> { throw null; }
-        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> SqueezeDimension<T>(this in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int dimension) { throw null; }
-        public static System.Numerics.Tensors.TensorSpan<T> SqueezeDimension<T>(this in System.Numerics.Tensors.TensorSpan<T> tensor, int dimension) { throw null; }
+        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> SqueezeDimension<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int dimension) { throw null; }
+        public static System.Numerics.Tensors.TensorSpan<T> SqueezeDimension<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor, int dimension) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> SqueezeDimension<T>(this System.Numerics.Tensors.Tensor<T> tensor, int dimension) { throw null; }
-        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Squeeze<T>(this in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor) { throw null; }
-        public static System.Numerics.Tensors.TensorSpan<T> Squeeze<T>(this in System.Numerics.Tensors.TensorSpan<T> tensor) { throw null; }
+        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Squeeze<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor) { throw null; }
+        public static System.Numerics.Tensors.TensorSpan<T> Squeeze<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Squeeze<T>(this System.Numerics.Tensors.Tensor<T> tensor) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> StackAlongDimension<T>(int dimension, params scoped System.ReadOnlySpan<System.Numerics.Tensors.Tensor<T>> tensors) { throw null; }
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> StackAlongDimension<T>(scoped System.ReadOnlySpan<System.Numerics.Tensors.Tensor<T>> tensors, in System.Numerics.Tensors.TensorSpan<T> destination, int dimension) { throw null; }
@@ -546,8 +546,8 @@ namespace System.Numerics.Tensors
         public static bool TryBroadcastTo<T>(this in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { throw null; }
         public static bool TryBroadcastTo<T>(this in System.Numerics.Tensors.TensorSpan<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { throw null; }
         public static bool TryBroadcastTo<T>(this System.Numerics.Tensors.Tensor<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { throw null; }
-        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Unsqueeze<T>(this in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int dimension) { throw null; }
-        public static System.Numerics.Tensors.TensorSpan<T> Unsqueeze<T>(this in System.Numerics.Tensors.TensorSpan<T> tensor, int dimension) { throw null; }
+        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Unsqueeze<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int dimension) { throw null; }
+        public static System.Numerics.Tensors.TensorSpan<T> Unsqueeze<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor, int dimension) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Unsqueeze<T>(this System.Numerics.Tensors.Tensor<T> tensor, int dimension) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Xor<T>(in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, in System.Numerics.Tensors.ReadOnlyTensorSpan<T> y) where T : System.Numerics.IBitwiseOperators<T, T, T> { throw null; }
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> Xor<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> y, in System.Numerics.Tensors.TensorSpan<T> destination) where T : System.Numerics.IBitwiseOperators<T, T, T> { throw null; }

--- a/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.netcore.cs
@@ -469,8 +469,8 @@ namespace System.Numerics.Tensors
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> RadiansToDegrees<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, in System.Numerics.Tensors.TensorSpan<T> destination) where T : System.Numerics.ITrigonometricFunctions<T> { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Reciprocal<T>(in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x) where T : System.Numerics.IFloatingPoint<T> { throw null; }
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> Reciprocal<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, in System.Numerics.Tensors.TensorSpan<T> destination) where T : System.Numerics.IFloatingPoint<T> { throw null; }
-        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Reshape<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
-        public static System.Numerics.Tensors.TensorSpan<T> Reshape<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
+        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Reshape<T>(this scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
+        public static System.Numerics.Tensors.TensorSpan<T> Reshape<T>(this scoped in System.Numerics.Tensors.TensorSpan<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Reshape<T>(this System.Numerics.Tensors.Tensor<T> tensor, scoped System.ReadOnlySpan<nint> lengths) { throw null; }
         public static void ResizeTo<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { }
         public static void ResizeTo<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { }
@@ -511,11 +511,11 @@ namespace System.Numerics.Tensors
         public static System.Numerics.Tensors.Tensor<T>[] Split<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int splitCount, nint dimension) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Sqrt<T>(in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x) where T : System.Numerics.IRootFunctions<T> { throw null; }
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> Sqrt<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, in System.Numerics.Tensors.TensorSpan<T> destination) where T : System.Numerics.IRootFunctions<T> { throw null; }
-        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> SqueezeDimension<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int dimension) { throw null; }
-        public static System.Numerics.Tensors.TensorSpan<T> SqueezeDimension<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor, int dimension) { throw null; }
+        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> SqueezeDimension<T>(this scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int dimension) { throw null; }
+        public static System.Numerics.Tensors.TensorSpan<T> SqueezeDimension<T>(this scoped in System.Numerics.Tensors.TensorSpan<T> tensor, int dimension) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> SqueezeDimension<T>(this System.Numerics.Tensors.Tensor<T> tensor, int dimension) { throw null; }
-        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Squeeze<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor) { throw null; }
-        public static System.Numerics.Tensors.TensorSpan<T> Squeeze<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor) { throw null; }
+        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Squeeze<T>(this scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor) { throw null; }
+        public static System.Numerics.Tensors.TensorSpan<T> Squeeze<T>(this scoped in System.Numerics.Tensors.TensorSpan<T> tensor) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Squeeze<T>(this System.Numerics.Tensors.Tensor<T> tensor) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> StackAlongDimension<T>(int dimension, params scoped System.ReadOnlySpan<System.Numerics.Tensors.Tensor<T>> tensors) { throw null; }
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> StackAlongDimension<T>(scoped System.ReadOnlySpan<System.Numerics.Tensors.Tensor<T>> tensors, in System.Numerics.Tensors.TensorSpan<T> destination, int dimension) { throw null; }
@@ -546,8 +546,8 @@ namespace System.Numerics.Tensors
         public static bool TryBroadcastTo<T>(this in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { throw null; }
         public static bool TryBroadcastTo<T>(this in System.Numerics.Tensors.TensorSpan<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { throw null; }
         public static bool TryBroadcastTo<T>(this System.Numerics.Tensors.Tensor<T> tensor, in System.Numerics.Tensors.TensorSpan<T> destination) { throw null; }
-        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Unsqueeze<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int dimension) { throw null; }
-        public static System.Numerics.Tensors.TensorSpan<T> Unsqueeze<T>(scoped in System.Numerics.Tensors.TensorSpan<T> tensor, int dimension) { throw null; }
+        public static System.Numerics.Tensors.ReadOnlyTensorSpan<T> Unsqueeze<T>(this scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> tensor, int dimension) { throw null; }
+        public static System.Numerics.Tensors.TensorSpan<T> Unsqueeze<T>(this scoped in System.Numerics.Tensors.TensorSpan<T> tensor, int dimension) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Unsqueeze<T>(this System.Numerics.Tensors.Tensor<T> tensor, int dimension) { throw null; }
         public static System.Numerics.Tensors.Tensor<T> Xor<T>(in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, in System.Numerics.Tensors.ReadOnlyTensorSpan<T> y) where T : System.Numerics.IBitwiseOperators<T, T, T> { throw null; }
         public static ref readonly System.Numerics.Tensors.TensorSpan<T> Xor<T>(scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> x, scoped in System.Numerics.Tensors.ReadOnlyTensorSpan<T> y, in System.Numerics.Tensors.TensorSpan<T> destination) where T : System.Numerics.IBitwiseOperators<T, T, T> { throw null; }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -1508,7 +1508,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor"><see cref="TensorSpan{T}"/> you want to reshape.</param>
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
-        public static TensorSpan<T> Reshape<T>(in this TensorSpan<T> tensor, scoped ReadOnlySpan<nint> lengths)
+        public static TensorSpan<T> Reshape<T>(scoped in TensorSpan<T> tensor, scoped ReadOnlySpan<nint> lengths)
         {
             if (tensor.Lengths.SequenceEqual(lengths))
                 return tensor;
@@ -1584,7 +1584,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor"><see cref="TensorSpan{T}"/> you want to reshape.</param>
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
-        public static ReadOnlyTensorSpan<T> Reshape<T>(in this ReadOnlyTensorSpan<T> tensor, scoped ReadOnlySpan<nint> lengths)
+        public static ReadOnlyTensorSpan<T> Reshape<T>(scoped in ReadOnlyTensorSpan<T> tensor, scoped ReadOnlySpan<nint> lengths)
         {
             if (tensor.Lengths.SequenceEqual(lengths))
                 return tensor;
@@ -1983,7 +1983,7 @@ namespace System.Numerics.Tensors
         /// Removes all dimensions of length one from the <paramref name="tensor"/>.
         /// </summary>
         /// <param name="tensor">The <see cref="TensorSpan{T}"/> to remove all dimensions of length 1.</param>
-        public static TensorSpan<T> Squeeze<T>(in this TensorSpan<T> tensor)
+        public static TensorSpan<T> Squeeze<T>(scoped in TensorSpan<T> tensor)
         {
             return SqueezeDimension(tensor, -1);
         }
@@ -1994,7 +1994,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor">The <see cref="TensorSpan{T}"/> to remove dimension of length 1.</param>
         /// <param name="dimension">The dimension to remove.</param>
-        public static TensorSpan<T> SqueezeDimension<T>(in this TensorSpan<T> tensor, int dimension)
+        public static TensorSpan<T> SqueezeDimension<T>(scoped in TensorSpan<T> tensor, int dimension)
         {
             if (dimension >= tensor.Rank || dimension < -1)
                 ThrowHelper.ThrowArgument_AxisLargerThanRank();
@@ -2065,7 +2065,7 @@ namespace System.Numerics.Tensors
         /// Removes all dimensions of length one from the <paramref name="tensor"/>.
         /// </summary>
         /// <param name="tensor">The <see cref="ReadOnlyTensorSpan{T}"/> to remove all dimensions of length 1.</param>
-        public static ReadOnlyTensorSpan<T> Squeeze<T>(in this ReadOnlyTensorSpan<T> tensor)
+        public static ReadOnlyTensorSpan<T> Squeeze<T>(scoped in ReadOnlyTensorSpan<T> tensor)
         {
             return SqueezeDimension(tensor, -1);
         }
@@ -2076,7 +2076,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor">The <see cref="ReadOnlyTensorSpan{T}"/> to remove dimension of length 1.</param>
         /// <param name="dimension">The dimension to remove.</param>
-        public static ReadOnlyTensorSpan<T> SqueezeDimension<T>(in this ReadOnlyTensorSpan<T> tensor, int dimension)
+        public static ReadOnlyTensorSpan<T> SqueezeDimension<T>(scoped in ReadOnlyTensorSpan<T> tensor, int dimension)
         {
             if (dimension >= tensor.Rank || dimension < -1)
                 ThrowHelper.ThrowArgument_AxisLargerThanRank();
@@ -2467,7 +2467,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor">The <see cref="TensorSpan{T}"/> to add a dimension of length 1.</param>
         /// <param name="dimension">The index of the dimension to add.</param>
-        public static TensorSpan<T> Unsqueeze<T>(in this TensorSpan<T> tensor, int dimension)
+        public static TensorSpan<T> Unsqueeze<T>(scoped in TensorSpan<T> tensor, int dimension)
         {
             if (dimension > tensor.Lengths.Length)
                 ThrowHelper.ThrowArgument_AxisLargerThanRank();
@@ -2504,7 +2504,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor">The <see cref="ReadOnlyTensorSpan{T}"/> to add a dimension of length 1.</param>
         /// <param name="dimension">The index of the dimension to add.</param>
-        public static ReadOnlyTensorSpan<T> Unsqueeze<T>(in this ReadOnlyTensorSpan<T> tensor, int dimension)
+        public static ReadOnlyTensorSpan<T> Unsqueeze<T>(scoped in ReadOnlyTensorSpan<T> tensor, int dimension)
         {
             if (dimension > tensor.Lengths.Length)
                 ThrowHelper.ThrowArgument_AxisLargerThanRank();

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Tensor.cs
@@ -1508,7 +1508,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor"><see cref="TensorSpan{T}"/> you want to reshape.</param>
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
-        public static TensorSpan<T> Reshape<T>(scoped in TensorSpan<T> tensor, scoped ReadOnlySpan<nint> lengths)
+        public static TensorSpan<T> Reshape<T>(this scoped in TensorSpan<T> tensor, scoped ReadOnlySpan<nint> lengths)
         {
             if (tensor.Lengths.SequenceEqual(lengths))
                 return tensor;
@@ -1584,7 +1584,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor"><see cref="TensorSpan{T}"/> you want to reshape.</param>
         /// <param name="lengths"><see cref="ReadOnlySpan{T}"/> with the new dimensions.</param>
-        public static ReadOnlyTensorSpan<T> Reshape<T>(scoped in ReadOnlyTensorSpan<T> tensor, scoped ReadOnlySpan<nint> lengths)
+        public static ReadOnlyTensorSpan<T> Reshape<T>(this scoped in ReadOnlyTensorSpan<T> tensor, scoped ReadOnlySpan<nint> lengths)
         {
             if (tensor.Lengths.SequenceEqual(lengths))
                 return tensor;
@@ -1983,7 +1983,7 @@ namespace System.Numerics.Tensors
         /// Removes all dimensions of length one from the <paramref name="tensor"/>.
         /// </summary>
         /// <param name="tensor">The <see cref="TensorSpan{T}"/> to remove all dimensions of length 1.</param>
-        public static TensorSpan<T> Squeeze<T>(scoped in TensorSpan<T> tensor)
+        public static TensorSpan<T> Squeeze<T>(this scoped in TensorSpan<T> tensor)
         {
             return SqueezeDimension(tensor, -1);
         }
@@ -1994,7 +1994,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor">The <see cref="TensorSpan{T}"/> to remove dimension of length 1.</param>
         /// <param name="dimension">The dimension to remove.</param>
-        public static TensorSpan<T> SqueezeDimension<T>(scoped in TensorSpan<T> tensor, int dimension)
+        public static TensorSpan<T> SqueezeDimension<T>(this scoped in TensorSpan<T> tensor, int dimension)
         {
             if (dimension >= tensor.Rank || dimension < -1)
                 ThrowHelper.ThrowArgument_AxisLargerThanRank();
@@ -2065,7 +2065,7 @@ namespace System.Numerics.Tensors
         /// Removes all dimensions of length one from the <paramref name="tensor"/>.
         /// </summary>
         /// <param name="tensor">The <see cref="ReadOnlyTensorSpan{T}"/> to remove all dimensions of length 1.</param>
-        public static ReadOnlyTensorSpan<T> Squeeze<T>(scoped in ReadOnlyTensorSpan<T> tensor)
+        public static ReadOnlyTensorSpan<T> Squeeze<T>(this scoped in ReadOnlyTensorSpan<T> tensor)
         {
             return SqueezeDimension(tensor, -1);
         }
@@ -2076,7 +2076,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor">The <see cref="ReadOnlyTensorSpan{T}"/> to remove dimension of length 1.</param>
         /// <param name="dimension">The dimension to remove.</param>
-        public static ReadOnlyTensorSpan<T> SqueezeDimension<T>(scoped in ReadOnlyTensorSpan<T> tensor, int dimension)
+        public static ReadOnlyTensorSpan<T> SqueezeDimension<T>(this scoped in ReadOnlyTensorSpan<T> tensor, int dimension)
         {
             if (dimension >= tensor.Rank || dimension < -1)
                 ThrowHelper.ThrowArgument_AxisLargerThanRank();
@@ -2467,7 +2467,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor">The <see cref="TensorSpan{T}"/> to add a dimension of length 1.</param>
         /// <param name="dimension">The index of the dimension to add.</param>
-        public static TensorSpan<T> Unsqueeze<T>(scoped in TensorSpan<T> tensor, int dimension)
+        public static TensorSpan<T> Unsqueeze<T>(this scoped in TensorSpan<T> tensor, int dimension)
         {
             if (dimension > tensor.Lengths.Length)
                 ThrowHelper.ThrowArgument_AxisLargerThanRank();
@@ -2504,7 +2504,7 @@ namespace System.Numerics.Tensors
         /// </summary>
         /// <param name="tensor">The <see cref="ReadOnlyTensorSpan{T}"/> to add a dimension of length 1.</param>
         /// <param name="dimension">The index of the dimension to add.</param>
-        public static ReadOnlyTensorSpan<T> Unsqueeze<T>(scoped in ReadOnlyTensorSpan<T> tensor, int dimension)
+        public static ReadOnlyTensorSpan<T> Unsqueeze<T>(this scoped in ReadOnlyTensorSpan<T> tensor, int dimension)
         {
             if (dimension > tensor.Lengths.Length)
                 ThrowHelper.ThrowArgument_AxisLargerThanRank();

--- a/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
@@ -418,9 +418,9 @@ namespace System.Numerics.Tensors.Tests
             Assert.Throws<ArgumentException>(() =>
             {
                 var ab = new TensorSpan<double>(array: [0d, 1, 2, 3, 0d, 1, 2, 3]);  // [0, 1, 2, 3]
-                var b = ab.Reshape(lengths: new IntPtr[] { 2, 2, 2 });  // [[0, 1], [2, 3]]
+                var b = Tensor.Reshape(ab, lengths: new IntPtr[] { 2, 2, 2 });  // [[0, 1], [2, 3]]
                 var c = b.Slice(new NRange[] { 1.., 1..2, ..1 });  // [[0], [2]]
-                c.Reshape(lengths: new IntPtr[] { 1, 2, 1 });
+                Tensor.Reshape(c, lengths: new IntPtr[] { 1, 2, 1 });
             });
 
             // Make sure even if the Lengths are the same that the underlying memory has to be the same.

--- a/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorSpanTests.cs
@@ -418,9 +418,9 @@ namespace System.Numerics.Tensors.Tests
             Assert.Throws<ArgumentException>(() =>
             {
                 var ab = new TensorSpan<double>(array: [0d, 1, 2, 3, 0d, 1, 2, 3]);  // [0, 1, 2, 3]
-                var b = Tensor.Reshape(ab, lengths: new IntPtr[] { 2, 2, 2 });  // [[0, 1], [2, 3]]
+                var b = ab.Reshape(lengths: new IntPtr[] { 2, 2, 2 });  // [[0, 1], [2, 3]]
                 var c = b.Slice(new NRange[] { 1.., 1..2, ..1 });  // [[0], [2]]
-                Tensor.Reshape(c, lengths: new IntPtr[] { 1, 2, 1 });
+                c.Reshape(lengths: new IntPtr[] { 1, 2, 1 });
             });
 
             // Make sure even if the Lengths are the same that the underlying memory has to be the same.


### PR DESCRIPTION
This required using `this scoped in` as the `scoped in this` is currently blocked by the language