### PR TITLE
Fix HFA treatment of floating-point-based enums.

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -1080,7 +1080,9 @@ namespace Internal.TypeSystem
             if (type.Context.Target.Abi == TargetAbi.NativeAotArmel)
                 return NotHA;
 
-            MetadataType metadataType = (MetadataType)type;
+            // If type represents an enum, we want to treat it as its underlying type.
+            MetadataType metadataType = (MetadataType)type.UnderlyingType;
+
             int haElementSize = 0;
 
             switch (metadataType.Category)

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -617,13 +617,6 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- Crossgen2 arm64 specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TestBuildMode)' == 'crossgen2' or '$(TestBuildMode)' == 'crossgen') and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetArchitecture)' == 'arm64'">
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/Devirtualization/Comparer_get_Default/*">
-            <Issue>https://github.com/dotnet/runtime/issues/104927</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
     <!-- NativeAOT specific -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr'">
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/regressions/beta2/437017/**">


### PR DESCRIPTION
Treat enums of floating point types (something that's only possible in IL) as an HFA in crossgen2 like we do for CoreCLR.

Fixes failure in https://dev.azure.com/dnceng-public/public/_build/results?buildId=1041124&view=results.

Fixes https://github.com/dotnet/runtime/issues/104927