### PR TITLE
Add support for no GC regions in x86 GC info

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -68,9 +68,9 @@ class AsmOffsets
     public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x132;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
-    public const int SIZEOF__StackFrameIterator = 0x3cc;
-    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x3ba;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3c8;
+    public const int SIZEOF__StackFrameIterator = 0x3d4;
+    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x3c2;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3d0;
 #else // TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
     public const int SIZEOF__StackFrameIterator = 0xcc;
@@ -134,9 +134,9 @@ class AsmOffsets
     public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x12a;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
-    public const int SIZEOF__StackFrameIterator = 0x3c4;
-    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x3b2;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3c0;
+    public const int SIZEOF__StackFrameIterator = 0x3cc;
+    public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x3ba;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3c8;
 #else // TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
     public const int SIZEOF__StackFrameIterator = 0xc4;

--- a/src/coreclr/gcdump/i386/gcdumpx86.cpp
+++ b/src/coreclr/gcdump/i386/gcdumpx86.cpp
@@ -114,6 +114,17 @@ size_t            GCDump::DumpInfoHdr (PTR_CBYTE      gcInfoBlock,
         header->revPInvokeOffset = count;
     }
 
+    if (header->noGCRegionCnt == HAS_NOGCREGIONS)
+    {
+        hasArgTabOffset = TRUE;
+        table += decodeUnsigned(table, &count);
+        header->noGCRegionCnt = count;
+    }
+    else if (header->noGCRegionCnt > 0)
+    {
+        hasArgTabOffset = TRUE;
+    }
+
     //
     // First print out all the basic information
     //
@@ -156,6 +167,8 @@ size_t            GCDump::DumpInfoHdr (PTR_CBYTE      gcInfoBlock,
                                 gcPrintf("    Sync region = [%u,%u] ([0x%x,0x%x])\n",
                                           header->syncStartOffset, header->syncEndOffset,
                                           header->syncStartOffset, header->syncEndOffset);
+    if (header->noGCRegionCnt > 0)
+                                gcPrintf("    no GC region count = %2u \n", header->noGCRegionCnt);
 
     if  (header->epilogCount > 1 || (header->epilogCount != 0 &&
                                      header->epilogAtEnd == 0))
@@ -230,6 +243,23 @@ size_t              GCDump::DumpGCTable(PTR_CBYTE      table,
         if (header.ediSaved) calleeSavedRegs++;
         if (header.esiSaved) calleeSavedRegs++;
         if (header.ebxSaved) calleeSavedRegs++;
+    }
+
+    /* Dump the no GC region table */
+
+    if (header.noGCRegionCnt > 0)
+    {
+        count = header.noGCRegionCnt;
+        while (count-- > 0)
+        {
+            unsigned regionOffset;
+            unsigned regionSize;
+
+            table += decodeUnsigned(table, &regionOffset);
+            table += decodeUnsigned(table, &regionSize);
+
+            gcPrintf("[%04X-%04X) no GC region\n", regionOffset, regionOffset + regionSize);
+        }
     }
 
     /* Dump the untracked frame variable table */
@@ -994,6 +1024,12 @@ void                GCDump::DumpPtrsInFrame(PTR_CBYTE   gcInfoBlock,
         table += decodeUnsigned(table, &offset);
         header.revPInvokeOffset = offset;
         _ASSERTE(offset != INVALID_REV_PINVOKE_OFFSET);
+    }
+    if (header.noGCRegionCnt == HAS_NOGCREGIONS)
+    {
+        unsigned count;
+        table += decodeUnsigned(table, &count);
+        header.noGCRegionCnt = count;
     }
 
     prologSize = header.prologSize;

--- a/src/coreclr/inc/gc_unwind_x86.h
+++ b/src/coreclr/inc/gc_unwind_x86.h
@@ -367,6 +367,8 @@ struct hdrInfo
     unsigned int        syncEpilogStart; // The start of the epilog. Synchronized methods are guaranteed to have no more than one epilog.
     unsigned int        revPInvokeOffset; // INVALID_REV_PINVOKE_OFFSET if there is no Reverse PInvoke frame
 
+    unsigned int        noGCRegionCnt;
+
     enum { NOT_IN_PROLOG = -1, NOT_IN_EPILOG = -1 };
 
     int                 prologOffs;     // NOT_IN_PROLOG if not in prolog
@@ -402,5 +404,9 @@ unsigned int DecodeGCHdrInfoMethodSize(GCInfoToken gcInfoToken);
 size_t DecodeGCHdrInfo(GCInfoToken gcInfoToken,
                        unsigned    curOffset,
                        hdrInfo   * infoPtr);
+
+bool IsInNoGCRegion(hdrInfo   * infoPtr,
+                    PTR_CBYTE   table,
+                    unsigned    curOffset);
 
 #endif // _UNWIND_X86_H

--- a/src/coreclr/inc/gcdecoder.cpp
+++ b/src/coreclr/inc/gcdecoder.cpp
@@ -205,9 +205,22 @@ PTR_CBYTE FASTCALL decodeHeader(PTR_CBYTE table, UINT32 version, InfoHdr* header
                 nextByte = *table++;
                 encoding = nextByte & ADJ_ENCODING_MAX;
                 // encoding here always corresponds to codes in InfoHdrAdjust2 set
-
-                _ASSERTE(encoding < SET_RET_KIND_MAX);
-                header->returnKind = (ReturnKind)encoding;
+                if (encoding <= SET_RET_KIND_MAX)
+                {
+                    header->returnKind = (ReturnKind)encoding;
+                }
+                else if (encoding < FFFF_NOGCREGION_CNT)
+                {
+                    header->noGCRegionCnt = encoding - SET_NOGCREGIONS_CNT;
+                }
+                else if (encoding == FFFF_NOGCREGION_CNT)
+                {
+                    header->noGCRegionCnt = HAS_NOGCREGIONS;
+                }
+                else
+                {
+                    _ASSERTE(!"Unexpected encoding");
+                }
                 break;
             }
         }
@@ -470,7 +483,8 @@ bool InfoHdrSmall::isHeaderMatch(const InfoHdr& target) const
                 target.varPtrTableSize != HAS_VARPTR &&
                 target.gsCookieOffset != HAS_GS_COOKIE_OFFSET &&
                 target.syncStartOffset != HAS_SYNC_OFFSET &&
-                target.revPInvokeOffset != HAS_REV_PINVOKE_FRAME_OFFSET);
+                target.revPInvokeOffset != HAS_REV_PINVOKE_FRAME_OFFSET &&
+                target.noGCRegionCnt != HAS_NOGCREGIONS);
 #endif
 
     // compare two InfoHdr's up to but not including the untrackCnt field
@@ -495,7 +509,10 @@ bool InfoHdrSmall::isHeaderMatch(const InfoHdr& target) const
     if (target.syncStartOffset != INVALID_SYNC_OFFSET)
         return false;
 
-    if (target.revPInvokeOffset!= INVALID_REV_PINVOKE_OFFSET)
+    if (target.revPInvokeOffset != INVALID_REV_PINVOKE_OFFSET)
+        return false;
+
+    if (target.noGCRegionCnt > 0)
         return false;
 
     return true;

--- a/src/coreclr/inc/gcinfotypes.h
+++ b/src/coreclr/inc/gcinfotypes.h
@@ -320,7 +320,8 @@ enum infoHdrAdjustConstants {
     SET_EPILOGSIZE_MAX = 10,  // Change to 6
     SET_EPILOGCNT_MAX = 4,
     SET_UNTRACKED_MAX = 3,
-    SET_RET_KIND_MAX = 4,   // 2 bits for ReturnKind
+    SET_RET_KIND_MAX = 3,   // 2 bits for ReturnKind
+    SET_NOGCREGIONS_MAX = 4,
     ADJ_ENCODING_MAX = 0x7f, // Maximum valid encoding in a byte
                              // Also used to mask off next bit from each encoding byte.
     MORE_BYTES_TO_FOLLOW = 0x80 // If the High-bit of a header or adjustment byte
@@ -372,10 +373,13 @@ enum infoHdrAdjust {
 // Second set of opcodes, when first code is 0x4F
 enum infoHdrAdjust2 {
     SET_RETURNKIND = 0,  // 0x00-SET_RET_KIND_MAX Set ReturnKind to value
+    SET_NOGCREGIONS_CNT = SET_RETURNKIND + SET_RET_KIND_MAX + 1,        // 0x04
+    FFFF_NOGCREGION_CNT = SET_NOGCREGIONS_CNT + SET_NOGCREGIONS_MAX + 1 // 0x09 There is a count (>SET_NOGCREGIONS_MAX) after the header encoding
 };
 
 #define HAS_UNTRACKED               ((unsigned int) -1)
 #define HAS_VARPTR                  ((unsigned int) -1)
+#define HAS_NOGCREGIONS             ((unsigned int) -1)
 
 // 0 is a valid offset for the Reverse P/Invoke block
 // So use -1 as the sentinel for invalid and -2 as the sentinel for present.
@@ -424,7 +428,7 @@ struct InfoHdrSmall {
     unsigned short argCount;          // 5,6        in bytes
     unsigned int   frameSize;         // 7,8,9,10   in bytes
     unsigned int   untrackedCnt;      // 11,12,13,14
-    unsigned int   varPtrTableSize;   // 15.16,17,18
+    unsigned int   varPtrTableSize;   // 15,16,17,18
 
                                       // Checks whether "this" is compatible with "target".
                                       // It is not an exact bit match as "this" could have some
@@ -442,7 +446,8 @@ struct InfoHdr : public InfoHdrSmall {
     unsigned int   syncStartOffset;   // 23,24,25,26
     unsigned int   syncEndOffset;     // 27,28,29,30
     unsigned int   revPInvokeOffset;  // 31,32,33,34 Available GcInfo v2 onwards, previously undefined
-                                      // 35 bytes total
+    unsigned int   noGCRegionCnt;     // 35,36,37,38
+                                      // 39 bytes total
 
                                       // Checks whether "this" is compatible with "target".
                                       // It is not an exact bit match as "this" could have some
@@ -457,7 +462,8 @@ struct InfoHdr : public InfoHdrSmall {
             target.varPtrTableSize != HAS_VARPTR &&
             target.gsCookieOffset != HAS_GS_COOKIE_OFFSET &&
             target.syncStartOffset != HAS_SYNC_OFFSET &&
-            target.revPInvokeOffset != HAS_REV_PINVOKE_FRAME_OFFSET);
+            target.revPInvokeOffset != HAS_REV_PINVOKE_FRAME_OFFSET &&
+            target.noGCRegionCnt != HAS_NOGCREGIONS);
 #endif
 
         // compare two InfoHdr's up to but not including the untrackCnt field
@@ -487,6 +493,13 @@ struct InfoHdr : public InfoHdrSmall {
         if ((revPInvokeOffset == INVALID_REV_PINVOKE_OFFSET) !=
             (target.revPInvokeOffset == INVALID_REV_PINVOKE_OFFSET))
             return false;
+
+        if (noGCRegionCnt != target.noGCRegionCnt) {
+            if (target.noGCRegionCnt <= SET_NOGCREGIONS_MAX)
+                return false;
+            else if (noGCRegionCnt != HAS_UNTRACKED)
+                return false;
+        }
 
         return true;
     }
@@ -518,6 +531,7 @@ inline void GetInfoHdr(int index, InfoHdr * header)
     header->syncStartOffset = INVALID_SYNC_OFFSET;
     header->syncEndOffset = INVALID_SYNC_OFFSET;
     header->revPInvokeOffset = INVALID_REV_PINVOKE_OFFSET;
+    header->noGCRegionCnt = 0;
 }
 
 PTR_CBYTE FASTCALL decodeHeader(PTR_CBYTE table, UINT32 version, InfoHdr* header);

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -37,11 +37,11 @@
 
 #include <minipal/guid.h>
 
-constexpr GUID JITEEVersionIdentifier = { /* 9625a8cb-38e1-40d6-ad49-2f041c70b5ec */
-    0x9625a8cb,
-    0x38e1,
-    0x40d6,
-    {0xad, 0x49, 0x2f, 0x04, 0x1c, 0x70, 0xb5, 0xec}
+constexpr GUID JITEEVersionIdentifier = { /* 26d0dde8-bc9d-4543-9b9a-57ad8b1acdc0 */
+    0x26d0dde8,
+    0xbc9d,
+    0x4543,
+    {0x9b, 0x9a, 0x57, 0xad, 0x8b, 0x1a, 0xcd, 0xc0}
   };
 
 #endif // JIT_EE_VERSIONING_GUID_H

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -37,11 +37,11 @@
 
 #include <minipal/guid.h>
 
-constexpr GUID JITEEVersionIdentifier = { /* 26d0dde8-bc9d-4543-9b9a-57ad8b1acdc0 */
-    0x26d0dde8,
-    0xbc9d,
-    0x4543,
-    {0x9b, 0x9a, 0x57, 0xad, 0x8b, 0x1a, 0xcd, 0xc0}
+constexpr GUID JITEEVersionIdentifier = { /* 9625a8cb-38e1-40d6-ad49-2f041c70b5ec */
+    0x9625a8cb,
+    0x38e1,
+    0x40d6,
+    {0xad, 0x49, 0x2f, 0x04, 0x1c, 0x70, 0xb5, 0xec}
   };
 
 #endif // JIT_EE_VERSIONING_GUID_H

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -202,14 +202,10 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         }
         else
         {
-// TODO-Linux-x86: Do we need to handle the GC information for this NOP or JMP specially, as is done for other
-// architectures?
-#ifndef JIT32_GCENCODER
             // Because of the way the flowgraph is connected, the liveness info for this one instruction
             // after the call is not (can not be) correct in cases where a variable has a last use in the
             // handler.  So turn off GC reporting once we execute the call and reenable after the jmp/nop
             GetEmitter()->emitDisableGC();
-#endif // JIT32_GCENCODER
 
             GetEmitter()->emitIns_J(INS_call, block->GetTarget());
 
@@ -229,9 +225,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
                 inst_JMP(EJ_jmp, finallyContinuation);
             }
 
-#ifndef JIT32_GCENCODER
             GetEmitter()->emitEnableGC();
-#endif // JIT32_GCENCODER
         }
     }
 #if defined(FEATURE_EH_WINDOWS_X86)
@@ -1879,11 +1873,9 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
     switch (treeNode->gtOper)
     {
-#ifndef JIT32_GCENCODER
         case GT_START_NONGC:
             GetEmitter()->emitDisableGC();
             break;
-#endif // !defined(JIT32_GCENCODER)
 
         case GT_START_PREEMPTGC:
             // Kill callee saves GC registers, and create a label
@@ -3160,9 +3152,7 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* storeBlkNode)
     {
         case GenTreeBlk::BlkOpKindCpObjRepInstr:
         case GenTreeBlk::BlkOpKindCpObjUnroll:
-#ifndef JIT32_GCENCODER
             assert(!storeBlkNode->gtBlkOpGcUnsafe);
-#endif
             genCodeForCpObj(storeBlkNode->AsBlk());
             break;
 
@@ -3172,9 +3162,7 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* storeBlkNode)
             break;
 
         case GenTreeBlk::BlkOpKindRepInstr:
-#ifndef JIT32_GCENCODER
             assert(!storeBlkNode->gtBlkOpGcUnsafe);
-#endif
             if (isCopyBlk)
             {
                 genCodeForCpBlkRepMovs(storeBlkNode);
@@ -3188,12 +3176,10 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* storeBlkNode)
         case GenTreeBlk::BlkOpKindUnroll:
             if (isCopyBlk)
             {
-#ifndef JIT32_GCENCODER
                 if (storeBlkNode->gtBlkOpGcUnsafe)
                 {
                     GetEmitter()->emitDisableGC();
                 }
-#endif
                 if (storeBlkNode->gtBlkOpKind == GenTreeBlk::BlkOpKindUnroll)
                 {
                     genCodeForCpBlkUnroll(storeBlkNode);
@@ -3203,18 +3189,14 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* storeBlkNode)
                     assert(storeBlkNode->gtBlkOpKind == GenTreeBlk::BlkOpKindUnrollMemmove);
                     genCodeForMemmove(storeBlkNode);
                 }
-#ifndef JIT32_GCENCODER
                 if (storeBlkNode->gtBlkOpGcUnsafe)
                 {
                     GetEmitter()->emitEnableGC();
                 }
-#endif
             }
             else
             {
-#ifndef JIT32_GCENCODER
                 assert(!storeBlkNode->gtBlkOpGcUnsafe);
-#endif
                 genCodeForInitBlkUnroll(storeBlkNode);
             }
             break;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10597,7 +10597,6 @@ regMaskTP emitter::emitGetGCRegsKilledByNoGCCall(CorInfoHelpFunc helper)
     return result;
 }
 
-#if !defined(JIT32_GCENCODER)
 //------------------------------------------------------------------------
 // emitDisableGC: Requests that the following instruction groups are not GC-interruptible.
 //
@@ -10689,4 +10688,3 @@ void emitter::emitEnableGC()
         JITDUMP("Enable GC: still %u no-gc requests\n", emitNoGCRequestCount);
     }
 }
-#endif // !defined(JIT32_GCENCODER)

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2891,11 +2891,9 @@ private:
 
     void emitNewIG();
 
-#if !defined(JIT32_GCENCODER)
     void emitDisableGC();
     void emitEnableGC();
     bool emitGCDisabled();
-#endif // !defined(JIT32_GCENCODER)
 
 #if defined(TARGET_XARCH)
     static bool emitAlignInstHasNoCode(instrDesc* id);

--- a/src/coreclr/jit/emitinl.h
+++ b/src/coreclr/jit/emitinl.h
@@ -585,10 +585,17 @@ inline bool insIsCMOV(instruction ins)
  *  false. Returns the final result of the callback.
  */
 template <typename Callback>
-bool emitter::emitGenNoGCLst(Callback& cb)
+bool emitter::emitGenNoGCLst(Callback& cb, bool skipAllPrologsAndEpilogs /* = false */)
 {
     for (insGroup* ig = emitIGlist; ig; ig = ig->igNext)
     {
+        if (skipAllPrologsAndEpilogs)
+        {
+            if (ig == emitPrologIG)
+                continue;
+            if (ig->igFlags & (IGF_EPILOG | IGF_FUNCLET_PROLOG | IGF_FUNCLET_EPILOG))
+                continue;
+        }
         if ((ig->igFlags & IGF_NOGCINTERRUPT) && ig->igSize > 0)
         {
             emitter::instrDesc* id = emitFirstInstrDesc(ig->igData);

--- a/src/coreclr/jit/emitpub.h
+++ b/src/coreclr/jit/emitpub.h
@@ -43,7 +43,7 @@ unsigned emitEndCodeGen(Compiler*         comp,
 unsigned emitGetEpilogCnt();
 
 template <typename Callback>
-bool emitGenNoGCLst(Callback& cb);
+bool emitGenNoGCLst(Callback& cb, bool skipAllPrologsAndEpilogs = false);
 
 void     emitBegProlog();
 unsigned emitGetPrologOffsetEstimate();

--- a/src/coreclr/jit/gcinfo.cpp
+++ b/src/coreclr/jit/gcinfo.cpp
@@ -419,12 +419,33 @@ GCInfo::regPtrDsc* GCInfo::gcRegPtrAllocDsc()
 
 #ifdef JIT32_GCENCODER
 
+// Small helper class to handle the No-GC-Interrupt callbacks
+// when reporting interruptible ranges.
+struct NoGCRegionCounter
+{
+    unsigned noGCRegionCount;
+
+    NoGCRegionCounter()
+        : noGCRegionCount(0)
+    {
+    }
+
+    // This callback is called for each insGroup marked with IGF_NOGCINTERRUPT.
+    bool operator()(unsigned igFuncIdx, unsigned igOffs, unsigned igSize, unsigned firstInstrSize, bool isInProlog)
+    {
+        noGCRegionCount++;
+        return true;
+    }
+};
+
 /*****************************************************************************
  *
  *  Compute the various counts that get stored in the info block header.
  */
 
-void GCInfo::gcCountForHeader(UNALIGNED unsigned int* pUntrackedCount, UNALIGNED unsigned int* pVarPtrTableSize)
+void GCInfo::gcCountForHeader(UNALIGNED unsigned int* pUntrackedCount,
+                              UNALIGNED unsigned int* pVarPtrTableSize,
+                              UNALIGNED unsigned int* pNoGCRegionCount)
 {
     unsigned   varNum;
     LclVarDsc* varDsc;
@@ -556,6 +577,19 @@ void GCInfo::gcCountForHeader(UNALIGNED unsigned int* pUntrackedCount, UNALIGNED
 #endif
 
     *pVarPtrTableSize = varPtrTableSize;
+
+    // Count the number of no GC regions
+
+    unsigned int noGCRegionCount = 0;
+
+    if (compiler->codeGen->GetInterruptible())
+    {
+        NoGCRegionCounter counter;
+        compiler->GetEmitter()->emitGenNoGCLst(counter, /* skipAllPrologsAndEpilogs = */ true);
+        noGCRegionCount = counter.noGCRegionCount;
+    }
+
+    *pNoGCRegionCount = noGCRegionCount;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7900,9 +7900,7 @@ public:
         BlkOpKindUnrollMemmove,
     } gtBlkOpKind;
 
-#ifndef JIT32_GCENCODER
     bool gtBlkOpGcUnsafe;
-#endif
 
     bool ContainsReferences()
     {
@@ -7940,11 +7938,9 @@ public:
         assert(layout != nullptr);
         assert(layout->GetSize() != 0);
 
-        m_layout    = layout;
-        gtBlkOpKind = BlkOpKindInvalid;
-#ifndef JIT32_GCENCODER
+        m_layout        = layout;
+        gtBlkOpKind     = BlkOpKindInvalid;
         gtBlkOpGcUnsafe = false;
-#endif
     }
 
 #if DEBUGGABLE_GENTREE

--- a/src/coreclr/jit/jitgcinfo.h
+++ b/src/coreclr/jit/jitgcinfo.h
@@ -289,7 +289,9 @@ public:
     //-------------------------------------------------------------------------
 
 #ifdef JIT32_GCENCODER
-    void gcCountForHeader(UNALIGNED unsigned int* pUntrackedCount, UNALIGNED unsigned int* pVarPtrTableSize);
+    void gcCountForHeader(UNALIGNED unsigned int* pUntrackedCount,
+                          UNALIGNED unsigned int* pVarPtrTableSize,
+                          UNALIGNED unsigned int* pNoGCRegionCount);
 
     bool gcIsUntrackedLocalOrNonEnregisteredArg(unsigned varNum, bool* pThisKeptAliveIsInUntracked = nullptr);
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -479,7 +479,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         bool         canUseSimd           = !doCpObj || isNotHeap;
         unsigned     copyBlockUnrollLimit = comp->getUnrollThreshold(Compiler::UnrollKind::Memcpy, canUseSimd);
 
-#ifndef JIT32_GCENCODER
         if (doCpObj && (size <= copyBlockUnrollLimit))
         {
             // No write barriers are needed if the destination is known to be outside of the GC heap.
@@ -492,7 +491,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
                 blkNode->gtBlkOpGcUnsafe = true;
             }
         }
-#endif
 
         if (doCpObj)
         {

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -479,6 +479,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         bool         canUseSimd           = !doCpObj || isNotHeap;
         unsigned     copyBlockUnrollLimit = comp->getUnrollThreshold(Compiler::UnrollKind::Memcpy, canUseSimd);
 
+#ifndef JIT32_GCENCODER
         if (doCpObj && (size <= copyBlockUnrollLimit))
         {
             // No write barriers are needed if the destination is known to be outside of the GC heap.
@@ -491,6 +492,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
                 blkNode->gtBlkOpGcUnsafe = true;
             }
         }
+#endif
 
         if (doCpObj)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
@@ -19,7 +19,8 @@ namespace ILCompiler.Reflection.ReadyToRun
         SET_EPILOGSIZE_MAX = 10,
         SET_EPILOGCNT_MAX = 4,
         SET_UNTRACKED_MAX = 3,
-        SET_RET_KIND_MAX = 4,
+        SET_RET_KIND_MAX = 3,
+        SET_NOGCREGIONS_MAX = 4,
         ADJ_ENCODING_MAX = 0x7f,
         MORE_BYTES_TO_FOLLOW = 0x80
     };
@@ -65,6 +66,16 @@ namespace ILCompiler.Reflection.ReadyToRun
         NEXT_FOUR_ARGCOUNT = 0x60,
         NEXT_THREE_PROLOGSIZE = 0x70,
         NEXT_THREE_EPILOGSIZE = 0x78
+    };
+
+    /// <summary>
+    /// Second set of opcodes, when first code is 0x4F
+    /// </summary>
+    enum InfoHdrAdjust2
+    {
+        SET_RETURNKIND = 0,  // 0x00-SET_RET_KIND_MAX Set ReturnKind to value
+        SET_NOGCREGIONS_CNT = SET_RETURNKIND + InfoHdrAdjustConstants.SET_RET_KIND_MAX + 1,        // 0x04
+        FFFF_NOGCREGION_CNT = SET_NOGCREGIONS_CNT + InfoHdrAdjustConstants.SET_NOGCREGIONS_MAX + 1 // 0x09 There is a count (>SET_NOGCREGIONS_MAX) after the header encoding
     };
 
     /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
@@ -13,6 +13,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         const uint byref_OFFSET_FLAG = 0x1;
 
         public InfoHdrSmall Header { get; set; }
+        public NoGcRegionTable NoGCRegions { get; set; }
         public GcSlotTable SlotTable { get; set; }
 
         public GcInfo() { }
@@ -27,6 +28,8 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             CodeLength = (int)NativeReader.DecodeUnsignedGc(image, ref offset);
 
             Header = InfoHdrDecoder.DecodeHeader(image, ref offset, CodeLength);
+
+            NoGCRegions = new NoGcRegionTable(image, Header, ref offset);
 
             SlotTable = new GcSlotTable(image, Header, ref offset);
 
@@ -54,6 +57,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             sb.AppendLine($"    CodeLength: {CodeLength} bytes");
             sb.AppendLine($"    InfoHdr:");
             sb.AppendLine($"{Header}");
+            sb.AppendLine($"{NoGCRegions}");
             sb.AppendLine($"{SlotTable}");
 
             sb.AppendLine($"    Size: {Size} bytes");

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
@@ -44,6 +44,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         public uint SyncStartOffset { get; set; }
         public uint SyncEndOffset { get; set; }
         public uint RevPInvokeOffset { get; set; }
+        public uint NoGCRegionCnt { get; set; }
 
         public bool HasArgTabOffset { get; set; }
         public uint ArgTabOffset { get; set; }
@@ -82,6 +83,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             SyncStartOffset = 0;
             SyncEndOffset = 0;
             RevPInvokeOffset = 0;
+            NoGCRegionCnt = 0;
 
             HasArgTabOffset = false;
             ArgTabOffset = 0;
@@ -138,6 +140,10 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             {
                 sb.AppendLine($"        Sync region = [{SyncStartOffset},{SyncEndOffset}]");
             }
+            if (NoGCRegionCnt > 0)
+            {
+                sb.AppendLine($"        No GC region count = {NoGCRegionCnt}");
+            }
 
             sb.Append($"        Epilogs:");
             foreach (int epilog in Epilogs)
@@ -158,6 +164,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         private const uint HAS_GS_COOKIE_OFFSET = 0xFFFFFFFF;
         private const uint HAS_SYNC_OFFSET = 0xFFFFFFFF;
         private const uint HAS_REV_PINVOKE_FRAME_OFFSET = 0xFFFFFFFF;
+        private const uint HAS_NOGCREGIONS = 0xFFFFFFFF;
         private const uint YES = HAS_VARPTR;
 
         /// <summary>
@@ -278,10 +285,17 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                                 nextByte = image[offset++];
                                 encoding = (byte)(nextByte & (int)InfoHdrAdjustConstants.ADJ_ENCODING_MAX);
                                 // encoding here always corresponds to codes in InfoHdrAdjust2 set
-
-                                if (encoding < (int)InfoHdrAdjustConstants.SET_RET_KIND_MAX)
+                                if (encoding <= (int)InfoHdrAdjustConstants.SET_RET_KIND_MAX)
                                 {
                                     header.ReturnKind = (ReturnKinds)encoding;
+                                }
+                                else if (encoding < (int)InfoHdrAdjust2.FFFF_NOGCREGION_CNT)
+                                {
+                                    header.NoGCRegionCnt = (uint)encoding - (uint)InfoHdrAdjust2.SET_NOGCREGIONS_CNT;
+                                }
+                                else if (encoding == (int)InfoHdrAdjust2.FFFF_NOGCREGION_CNT)
+                                {
+                                    header.NoGCRegionCnt = HAS_NOGCREGIONS;
                                 }
                                 else
                                 {
@@ -350,6 +364,10 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             if (header.RevPInvokeOffset == HAS_REV_PINVOKE_FRAME_OFFSET)
             {
                 header.RevPInvokeOffset = NativeReader.DecodeUnsignedGc(image, ref offset);
+            }
+            if (header.NoGCRegionCnt == HAS_NOGCREGIONS)
+            {
+                header.NoGCRegionCnt = NativeReader.DecodeUnsignedGc(image, ref offset);
             }
 
             header.Epilogs = new List<int>();

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/NoGcRegionTable.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/NoGcRegionTable.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+namespace ILCompiler.Reflection.ReadyToRun.x86
+{
+    public class NoGcRegionTable
+    {
+        public class NoGcRegion
+        {
+            public uint Offset { get; set; }
+            public uint Size { get; set; }
+
+            public NoGcRegion(uint offset, uint size)
+            {
+                Offset = offset;
+                Size = size;
+            }
+
+            public override string ToString()
+            {
+                return $"            [{Offset:04X}-{Offset+Size:04X})\n";
+            }
+        }
+
+        public List<NoGcRegion> Regions { get; set; }
+
+        public NoGcRegionTable() { }
+
+        public NoGcRegionTable(byte[] image, InfoHdrSmall header, ref int offset)
+        {
+            Regions = new List<NoGcRegion>((int)header.NoGCRegionCnt);
+
+            uint count = header.NoGCRegionCnt;
+            while (count-- > 0)
+            {
+                uint regionOffset = NativeReader.DecodeUnsignedGc(image, ref offset);
+                uint regionSize = NativeReader.DecodeUnsignedGc(image, ref offset);
+                Regions.Add(new NoGcRegion(regionOffset, regionSize));
+            }
+        }
+
+        public override string ToString()
+        {
+            if (Regions.Count > 0)
+            {
+                StringBuilder sb = new StringBuilder();
+
+                sb.AppendLine($"        No GC regions:");
+                foreach (NoGcRegion region in Regions)
+                {
+                    sb.Append(region.ToString());
+                }
+
+                return sb.ToString();
+            }
+
+            return string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
Contributes to #113985

https://github.com/dotnet/runtime/issues/113985#issuecomment-2874826398 identified an issue where GC info is not correctly recorded for inline jumps to finally blocks. It shows up in GC stress testing. This issue already exists on NativeAOT on win-x86 but we didn't have sufficient coverage to identify it.

For fully interruptible methods we can now encode a table in the x86 GC info that describes the no-GC regions as pair of (offset, size) tuples. The presence of the table is indicated by a new header opcode (`SET_NOGCREGIONS_CNT + count` for `count >= 0 && count <= 4` or `FFFF_NOGCREGION_CNT` and extra count field after the header).