### PR TITLE
JIT: Avoid byref strength reductions in loops with suspension points

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -72,22 +72,22 @@ inline var_types genActualType(T value);
  *                  Forward declarations
  */
 
-struct InfoHdr;             // defined in GCInfo.h
-struct escapeMapping_t;     // defined in fgdiagnostic.cpp
-class emitter;              // defined in emit.h
-struct ShadowParamVarInfo;  // defined in GSChecks.cpp
-struct InitVarDscInfo;      // defined in registerargconvention.h
-class FgStack;              // defined in fgbasic.cpp
-class Instrumentor;         // defined in fgprofile.cpp
-class SpanningTreeVisitor;  // defined in fgprofile.cpp
-class CSE_DataFlow;         // defined in optcse.cpp
-struct CSEdsc;              // defined in optcse.h
-class CSE_HeuristicCommon;  // defined in optcse.h
-class OptBoolsDsc;          // defined in optimizer.cpp
-struct JumpThreadInfo;      // defined in redundantbranchopts.cpp
-class ProfileSynthesis;     // defined in profilesynthesis.h
-class LoopLocalOccurrences; // defined in inductionvariableopts.cpp
-class RangeCheck;           // defined in rangecheck.h
+struct InfoHdr;            // defined in GCInfo.h
+struct escapeMapping_t;    // defined in fgdiagnostic.cpp
+class emitter;             // defined in emit.h
+struct ShadowParamVarInfo; // defined in GSChecks.cpp
+struct InitVarDscInfo;     // defined in registerargconvention.h
+class FgStack;             // defined in fgbasic.cpp
+class Instrumentor;        // defined in fgprofile.cpp
+class SpanningTreeVisitor; // defined in fgprofile.cpp
+class CSE_DataFlow;        // defined in optcse.cpp
+struct CSEdsc;             // defined in optcse.h
+class CSE_HeuristicCommon; // defined in optcse.h
+class OptBoolsDsc;         // defined in optimizer.cpp
+struct JumpThreadInfo;     // defined in redundantbranchopts.cpp
+class ProfileSynthesis;    // defined in profilesynthesis.h
+class PerLoopInfo;         // defined in inductionvariableopts.cpp
+class RangeCheck;          // defined in rangecheck.h
 #ifdef DEBUG
 struct IndentStack;
 #endif
@@ -7654,33 +7654,30 @@ public:
     void optVisitBoundingExitingCondBlocks(FlowGraphNaturalLoop* loop, TFunctor func);
     bool optMakeLoopDownwardsCounted(ScalarEvolutionContext& scevContext,
                                      FlowGraphNaturalLoop*   loop,
-                                     LoopLocalOccurrences*   loopLocals);
+                                     PerLoopInfo*            loopLocals);
     bool optMakeExitTestDownwardsCounted(ScalarEvolutionContext& scevContext,
                                          FlowGraphNaturalLoop*   loop,
                                          BasicBlock*             exiting,
-                                         LoopLocalOccurrences*   loopLocals);
+                                         PerLoopInfo*            loopLocals);
     bool optCanAndShouldChangeExitTest(GenTree* cond, bool dump);
-    bool optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals);
+    bool optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loop, PerLoopInfo* loopLocals);
     bool optLocalIsLiveIntoBlock(unsigned lclNum, BasicBlock* block);
 
-    bool optWidenIVs(ScalarEvolutionContext& scevContext, FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals);
-    bool optWidenPrimaryIV(FlowGraphNaturalLoop* loop,
-                           unsigned              lclNum,
-                           ScevAddRec*           addRec,
-                           LoopLocalOccurrences* loopLocals);
+    bool optWidenIVs(ScalarEvolutionContext& scevContext, FlowGraphNaturalLoop* loop, PerLoopInfo* loopLocals);
+    bool optWidenPrimaryIV(FlowGraphNaturalLoop* loop, unsigned lclNum, ScevAddRec* addRec, PerLoopInfo* loopLocals);
 
     bool optCanSinkWidenedIV(unsigned lclNum, FlowGraphNaturalLoop* loop);
     bool optIsIVWideningProfitable(unsigned              lclNum,
                                    BasicBlock*           initBlock,
                                    bool                  initedToConstant,
                                    FlowGraphNaturalLoop* loop,
-                                   LoopLocalOccurrences* loopLocals);
+                                   PerLoopInfo*          loopLocals);
     void optBestEffortReplaceNarrowIVUses(
         unsigned lclNum, unsigned ssaNum, unsigned newLclNum, BasicBlock* block, Statement* firstStmt);
     void optReplaceWidenedIV(unsigned lclNum, unsigned ssaNum, unsigned newLclNum, Statement* stmt);
     void optSinkWidenedIV(unsigned lclNum, unsigned newLclNum, FlowGraphNaturalLoop* loop);
 
-    bool optRemoveUnusedIVs(FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals);
+    bool optRemoveUnusedIVs(FlowGraphNaturalLoop* loop, PerLoopInfo* loopLocals);
     bool optIsUpdateOfIVWithoutSideEffects(GenTree* tree, unsigned lclNum);
 
     // Redundant branch opts

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -50,8 +50,8 @@
 #include "jitpch.h"
 #include "scev.h"
 
-// Data structure that keeps track of local occurrences inside loops.
-class LoopLocalOccurrences
+// Data structure that keeps track of per-loop info, like occurrences and suspension-points inside loops.
+class PerLoopInfo
 {
     struct Occurrence
     {
@@ -63,19 +63,26 @@ class LoopLocalOccurrences
 
     typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, Occurrence*> LocalToOccurrenceMap;
 
+    struct LoopInfo
+    {
+        LocalToOccurrenceMap* LocalToOccurrences = nullptr;
+        bool                  HasSuspensionPoint = false;
+    };
+
     FlowGraphNaturalLoops* m_loops;
-    // For every loop, we track all occurrences exclusive to that loop.
-    // Occurrences in descendant loops are not kept in their ancestor's maps.
-    LocalToOccurrenceMap** m_maps;
+    // For every loop, we track all occurrences exclusive to that loop, and
+    // whether or not the loop has a suspension point.
+    // Occurrences/suspensions in descendant loops are not kept in their ancestor's maps.
+    LoopInfo* m_info;
     // Blocks whose IR we have visited to find local occurrences in.
     BitVec m_visitedBlocks;
 
-    LocalToOccurrenceMap* GetOrCreateMap(FlowGraphNaturalLoop* loop);
+    LoopInfo* GetOrCreateInfo(FlowGraphNaturalLoop* loop);
 
     template <typename TFunc>
-    bool VisitLoopNestMaps(FlowGraphNaturalLoop* loop, TFunc& func);
+    bool VisitLoopNestInfo(FlowGraphNaturalLoop* loop, TFunc& func);
 public:
-    LoopLocalOccurrences(FlowGraphNaturalLoops* loops);
+    PerLoopInfo(FlowGraphNaturalLoops* loops);
 
     template <typename TFunc>
     bool VisitOccurrences(FlowGraphNaturalLoop* loop, unsigned lclNum, TFunc func);
@@ -85,38 +92,40 @@ public:
     template <typename TFunc>
     bool VisitStatementsWithOccurrences(FlowGraphNaturalLoop* loop, unsigned lclNum, TFunc func);
 
+    bool HasSuspensionPoint(FlowGraphNaturalLoop* loop);
+
     void Invalidate(FlowGraphNaturalLoop* loop);
 };
 
-LoopLocalOccurrences::LoopLocalOccurrences(FlowGraphNaturalLoops* loops)
+PerLoopInfo::PerLoopInfo(FlowGraphNaturalLoops* loops)
     : m_loops(loops)
 {
-    Compiler* comp = loops->GetDfsTree()->GetCompiler();
-    m_maps = loops->NumLoops() == 0 ? nullptr : new (comp, CMK_LoopOpt) LocalToOccurrenceMap* [loops->NumLoops()] {};
+    Compiler* comp        = loops->GetDfsTree()->GetCompiler();
+    m_info                = loops->NumLoops() == 0 ? nullptr : new (comp, CMK_LoopOpt) LoopInfo[loops->NumLoops()];
     BitVecTraits poTraits = loops->GetDfsTree()->PostOrderTraits();
     m_visitedBlocks       = BitVecOps::MakeEmpty(&poTraits);
 }
 
 //------------------------------------------------------------------------------
-// LoopLocalOccurrences:GetOrCreateMap:
-//   Get or create the map of occurrences exclusive to a single loop.
+// PerLoopInfo:GetOrCreateInfo:
+//   Get or create the info exclusive to a single loop.
 //
 // Parameters:
 //   loop - The loop
 //
 // Returns:
-//   Map of occurrences.
+//   Loop information.
 //
 // Remarks:
 //   As a precondition occurrences of all descendant loops must already have
 //   been found.
 //
-LoopLocalOccurrences::LocalToOccurrenceMap* LoopLocalOccurrences::GetOrCreateMap(FlowGraphNaturalLoop* loop)
+PerLoopInfo::LoopInfo* PerLoopInfo::GetOrCreateInfo(FlowGraphNaturalLoop* loop)
 {
-    LocalToOccurrenceMap* map = m_maps[loop->GetIndex()];
-    if (map != nullptr)
+    LoopInfo& info = m_info[loop->GetIndex()];
+    if (info.LocalToOccurrences != nullptr)
     {
-        return map;
+        return &info;
     }
 
     BitVecTraits poTraits = m_loops->GetDfsTree()->PostOrderTraits();
@@ -132,11 +141,10 @@ LoopLocalOccurrences::LocalToOccurrenceMap* LoopLocalOccurrences::GetOrCreateMap
     }
 #endif
 
-    Compiler* comp           = m_loops->GetDfsTree()->GetCompiler();
-    map                      = new (comp, CMK_LoopOpt) LocalToOccurrenceMap(comp->getAllocator(CMK_LoopOpt));
-    m_maps[loop->GetIndex()] = map;
+    Compiler* comp          = m_loops->GetDfsTree()->GetCompiler();
+    info.LocalToOccurrences = new (comp, CMK_LoopOpt) LocalToOccurrenceMap(comp->getAllocator(CMK_LoopOpt));
 
-    loop->VisitLoopBlocksReversePostOrder([=, &poTraits](BasicBlock* block) {
+    loop->VisitLoopBlocksReversePostOrder([=, &poTraits, &info](BasicBlock* block) {
         if (!BitVecOps::TryAddElemD(&poTraits, m_visitedBlocks, block->bbPostorderNum))
         {
             return BasicBlockVisit::Continue;
@@ -146,13 +154,15 @@ LoopLocalOccurrences::LocalToOccurrenceMap* LoopLocalOccurrences::GetOrCreateMap
         {
             for (GenTree* node : stmt->TreeList())
             {
+                info.HasSuspensionPoint |= node->IsCall() && node->AsCall()->IsAsync();
+
                 if (!node->OperIsAnyLocal())
                 {
                     continue;
                 }
 
-                GenTreeLclVarCommon* lcl        = node->AsLclVarCommon();
-                Occurrence**         occurrence = map->LookupPointerOrAdd(lcl->GetLclNum(), nullptr);
+                GenTreeLclVarCommon* lcl = node->AsLclVarCommon();
+                Occurrence** occurrence  = info.LocalToOccurrences->LookupPointerOrAdd(lcl->GetLclNum(), nullptr);
 
                 Occurrence* newOccurrence = new (comp, CMK_LoopOpt) Occurrence;
                 newOccurrence->Block      = block;
@@ -166,15 +176,15 @@ LoopLocalOccurrences::LocalToOccurrenceMap* LoopLocalOccurrences::GetOrCreateMap
         return BasicBlockVisit::Continue;
     });
 
-    return map;
+    return &info;
 }
 
 //------------------------------------------------------------------------------
-// LoopLocalOccurrences:VisitLoopNestMaps:
-//   Visit all occurrence maps of the specified loop nest.
+// PerLoopInfo:VisitLoopNestInfo:
+//   Visit all info of the specified loop nest.
 //
 // Type parameters:
-//   TFunc - bool(LocalToOccurrenceMap*) functor that returns true to continue
+//   TFunc - bool(LoopInfo*) functor that returns true to continue
 //           the visit and false to abort.
 //
 // Parameters:
@@ -185,21 +195,21 @@ LoopLocalOccurrences::LocalToOccurrenceMap* LoopLocalOccurrences::GetOrCreateMap
 //   True if the visit completed; false if "func" returned false for any map.
 //
 template <typename TFunc>
-bool LoopLocalOccurrences::VisitLoopNestMaps(FlowGraphNaturalLoop* loop, TFunc& func)
+bool PerLoopInfo::VisitLoopNestInfo(FlowGraphNaturalLoop* loop, TFunc& func)
 {
     for (FlowGraphNaturalLoop* child = loop->GetChild(); child != nullptr; child = child->GetSibling())
     {
-        if (!VisitLoopNestMaps(child, func))
+        if (!VisitLoopNestInfo(child, func))
         {
             return false;
         }
     }
 
-    return func(GetOrCreateMap(loop));
+    return func(GetOrCreateInfo(loop));
 }
 
 //------------------------------------------------------------------------------
-// LoopLocalOccurrences:VisitOccurrences:
+// PerLoopInfo:VisitOccurrences:
 //   Visit all occurrences of the specified local inside the loop.
 //
 // Type parameters:
@@ -216,11 +226,11 @@ bool LoopLocalOccurrences::VisitLoopNestMaps(FlowGraphNaturalLoop* loop, TFunc& 
 //   returning false.
 //
 template <typename TFunc>
-bool LoopLocalOccurrences::VisitOccurrences(FlowGraphNaturalLoop* loop, unsigned lclNum, TFunc func)
+bool PerLoopInfo::VisitOccurrences(FlowGraphNaturalLoop* loop, unsigned lclNum, TFunc func)
 {
-    auto visitor = [=, &func](LocalToOccurrenceMap* map) {
+    auto visitor = [=, &func](LoopInfo* info) {
         Occurrence* occurrence;
-        if (!map->Lookup(lclNum, &occurrence))
+        if (!info->LocalToOccurrences->Lookup(lclNum, &occurrence))
         {
             return true;
         }
@@ -240,11 +250,11 @@ bool LoopLocalOccurrences::VisitOccurrences(FlowGraphNaturalLoop* loop, unsigned
         return true;
     };
 
-    return VisitLoopNestMaps(loop, visitor);
+    return VisitLoopNestInfo(loop, visitor);
 }
 
 //------------------------------------------------------------------------------
-// LoopLocalOccurrences:HasAnyOccurrences:
+// PerLoopInfo:HasAnyOccurrences:
 //   Check if this loop has any occurrences of the specified local.
 //
 // Parameters:
@@ -257,7 +267,7 @@ bool LoopLocalOccurrences::VisitOccurrences(FlowGraphNaturalLoop* loop, unsigned
 // Remarks:
 //   Does not take promotion into account.
 //
-bool LoopLocalOccurrences::HasAnyOccurrences(FlowGraphNaturalLoop* loop, unsigned lclNum)
+bool PerLoopInfo::HasAnyOccurrences(FlowGraphNaturalLoop* loop, unsigned lclNum)
 {
     if (!VisitOccurrences(loop, lclNum, [](BasicBlock* block, Statement* stmt, GenTreeLclVarCommon* tree) {
         return false;
@@ -270,7 +280,7 @@ bool LoopLocalOccurrences::HasAnyOccurrences(FlowGraphNaturalLoop* loop, unsigne
 }
 
 //------------------------------------------------------------------------------
-// LoopLocalOccurrences:VisitStatementsWithOccurrences:
+// PerLoopInfo:VisitStatementsWithOccurrences:
 //   Visit all statements with occurrences of the specified local inside
 //   the loop.
 //
@@ -292,11 +302,11 @@ bool LoopLocalOccurrences::HasAnyOccurrences(FlowGraphNaturalLoop* loop, unsigne
 //   once.
 //
 template <typename TFunc>
-bool LoopLocalOccurrences::VisitStatementsWithOccurrences(FlowGraphNaturalLoop* loop, unsigned lclNum, TFunc func)
+bool PerLoopInfo::VisitStatementsWithOccurrences(FlowGraphNaturalLoop* loop, unsigned lclNum, TFunc func)
 {
-    auto visitor = [=, &func](LocalToOccurrenceMap* map) {
+    auto visitor = [=, &func](LoopInfo* info) {
         Occurrence* occurrence;
-        if (!map->Lookup(lclNum, &occurrence))
+        if (!info->LocalToOccurrences->Lookup(lclNum, &occurrence))
         {
             return true;
         }
@@ -330,7 +340,43 @@ bool LoopLocalOccurrences::VisitStatementsWithOccurrences(FlowGraphNaturalLoop* 
         return true;
     };
 
-    return VisitLoopNestMaps(loop, visitor);
+    return VisitLoopNestInfo(loop, visitor);
+}
+
+//------------------------------------------------------------------------------
+// PerLoopInfo:HasSuspensionPoint:
+//   Check if a loop has a suspension point.
+//
+// Parameters:
+//   loop   - The loop
+//
+// Returns:
+//   True if so.
+//
+bool PerLoopInfo::HasSuspensionPoint(FlowGraphNaturalLoop* loop)
+{
+    if (!loop->GetDfsTree()->GetCompiler()->compIsAsync())
+    {
+        return false;
+    }
+
+    auto visitor = [](LoopInfo* info) {
+        if (info->HasSuspensionPoint)
+        {
+            // Abort now that we've found a suspension point
+            return false;
+        }
+
+        return true;
+    };
+
+    if (!VisitLoopNestInfo(loop, visitor))
+    {
+        // Aborted, so has a suspension point
+        return true;
+    }
+
+    return false;
 }
 
 //------------------------------------------------------------------------
@@ -340,16 +386,18 @@ bool LoopLocalOccurrences::VisitStatementsWithOccurrences(FlowGraphNaturalLoop* 
 // Parameters:
 //   loop - The loop
 //
-void LoopLocalOccurrences::Invalidate(FlowGraphNaturalLoop* loop)
+void PerLoopInfo::Invalidate(FlowGraphNaturalLoop* loop)
 {
     for (FlowGraphNaturalLoop* child = loop->GetChild(); child != nullptr; child = child->GetSibling())
     {
         Invalidate(child);
     }
 
-    if (m_maps[loop->GetIndex()] != nullptr)
+    LoopInfo& info = m_info[loop->GetIndex()];
+    if (info.LocalToOccurrences != nullptr)
     {
-        m_maps[loop->GetIndex()] = nullptr;
+        info.LocalToOccurrences = nullptr;
+        info.HasSuspensionPoint = false;
 
         BitVecTraits poTraits = m_loops->GetDfsTree()->PostOrderTraits();
         loop->VisitLoopBlocks([=, &poTraits](BasicBlock* block) {
@@ -446,7 +494,7 @@ bool Compiler::optCanSinkWidenedIV(unsigned lclNum, FlowGraphNaturalLoop* loop)
 //   initBlock        - The block in where the new IV would be initialized
 //   initedToConstant - Whether or not the new IV will be initialized to a constant
 //   loop             - The loop
-//   loopLocals       - Data structure tracking local uses inside the loop
+//   loopInfo         - Data structure tracking loop info, like local occurrences
 //
 //
 // Returns:
@@ -462,11 +510,8 @@ bool Compiler::optCanSinkWidenedIV(unsigned lclNum, FlowGraphNaturalLoop* loop)
 //     2. We need to store the wide IV back into the narrow one in each of
 //     the exits where the narrow IV is live-in.
 //
-bool Compiler::optIsIVWideningProfitable(unsigned              lclNum,
-                                         BasicBlock*           initBlock,
-                                         bool                  initedToConstant,
-                                         FlowGraphNaturalLoop* loop,
-                                         LoopLocalOccurrences* loopLocals)
+bool Compiler::optIsIVWideningProfitable(
+    unsigned lclNum, BasicBlock* initBlock, bool initedToConstant, FlowGraphNaturalLoop* loop, PerLoopInfo* loopInfo)
 {
     for (FlowGraphNaturalLoop* otherLoop : m_loops->InReversePostOrder())
     {
@@ -522,7 +567,7 @@ bool Compiler::optIsIVWideningProfitable(unsigned              lclNum,
         return true;
     };
 
-    loopLocals->VisitOccurrences(loop, lclNum, measure);
+    loopInfo->VisitOccurrences(loop, lclNum, measure);
 
     if (!initedToConstant)
     {
@@ -763,14 +808,12 @@ void Compiler::optBestEffortReplaceNarrowIVUses(
 // Parameters:
 //   scevContext - Context for scalar evolution
 //   loop        - The loop
-//   loopLocals  - Data structure for locals occurrences
+//   loopInfo    - Data structure for tracking loop info, like locals occurrences
 //
 // Returns:
 //   True if any primary IV was widened.
 //
-bool Compiler::optWidenIVs(ScalarEvolutionContext& scevContext,
-                           FlowGraphNaturalLoop*   loop,
-                           LoopLocalOccurrences*   loopLocals)
+bool Compiler::optWidenIVs(ScalarEvolutionContext& scevContext, FlowGraphNaturalLoop* loop, PerLoopInfo* loopInfo)
 {
     JITDUMP("Considering primary IVs of " FMT_LP " for widening\n", loop->GetIndex());
 
@@ -811,14 +854,14 @@ bool Compiler::optWidenIVs(ScalarEvolutionContext& scevContext,
 
         // For a struct field with occurrences of the parent local we won't
         // be able to do much.
-        if (lclDsc->lvIsStructField && loopLocals->HasAnyOccurrences(loop, lclDsc->lvParentLcl))
+        if (lclDsc->lvIsStructField && loopInfo->HasAnyOccurrences(loop, lclDsc->lvParentLcl))
         {
             JITDUMP("  V%02u is a struct field whose parent local V%02u has occurrences inside the loop\n", lclNum,
                     lclDsc->lvParentLcl);
             continue;
         }
 
-        if (optWidenPrimaryIV(loop, lclNum, addRec, loopLocals))
+        if (optWidenPrimaryIV(loop, lclNum, addRec, loopInfo))
         {
             numWidened++;
         }
@@ -835,12 +878,9 @@ bool Compiler::optWidenIVs(ScalarEvolutionContext& scevContext,
 //   loop       - The loop
 //   lclNum     - The primary IV
 //   addRec     - The add recurrence for the primary IV
-//   loopLocals - Data structure for locals occurrences
+//   loopInfo   - Data structure for tracking loop info like locals occurrences
 //
-bool Compiler::optWidenPrimaryIV(FlowGraphNaturalLoop* loop,
-                                 unsigned              lclNum,
-                                 ScevAddRec*           addRec,
-                                 LoopLocalOccurrences* loopLocals)
+bool Compiler::optWidenPrimaryIV(FlowGraphNaturalLoop* loop, unsigned lclNum, ScevAddRec* addRec, PerLoopInfo* loopInfo)
 {
     LclVarDsc* lclDsc = lvaGetDesc(lclNum);
     if (lclDsc->TypeGet() != TYP_INT)
@@ -882,7 +922,7 @@ bool Compiler::optWidenPrimaryIV(FlowGraphNaturalLoop* loop,
         initBlock = startSsaDsc->GetBlock();
     }
 
-    if (!optIsIVWideningProfitable(lclNum, initBlock, initToConstant, loop, loopLocals))
+    if (!optIsIVWideningProfitable(lclNum, initBlock, initToConstant, loop, loopInfo))
     {
         return false;
     }
@@ -977,10 +1017,10 @@ bool Compiler::optWidenPrimaryIV(FlowGraphNaturalLoop* loop,
         return true;
     };
 
-    loopLocals->VisitStatementsWithOccurrences(loop, lclNum, replace);
+    loopInfo->VisitStatementsWithOccurrences(loop, lclNum, replace);
 
     optSinkWidenedIV(lclNum, newLclNum, loop);
-    loopLocals->Invalidate(loop);
+    loopInfo->Invalidate(loop);
     return true;
 }
 
@@ -1031,21 +1071,21 @@ void Compiler::optVisitBoundingExitingCondBlocks(FlowGraphNaturalLoop* loop, TFu
 // Parameters:
 //   scevContext - Context for scalar evolution
 //   loop        - Loop to transform
-//   loopLocals  - Data structure that tracks occurrences of locals in the loop
+//   loopInfo  - Data structure that tracks occurrences of locals in the loop
 //
 // Returns:
 //   True if the loop was made downwards counted; otherwise false.
 //
 bool Compiler::optMakeLoopDownwardsCounted(ScalarEvolutionContext& scevContext,
                                            FlowGraphNaturalLoop*   loop,
-                                           LoopLocalOccurrences*   loopLocals)
+                                           PerLoopInfo*            loopInfo)
 {
     JITDUMP("Checking if we should make " FMT_LP " downwards counted\n", loop->GetIndex());
 
     bool changed = false;
     optVisitBoundingExitingCondBlocks(loop, [=, &scevContext, &changed](BasicBlock* exiting) {
         JITDUMP("  Considering exiting block " FMT_BB "\n", exiting->bbNum);
-        changed |= optMakeExitTestDownwardsCounted(scevContext, loop, exiting, loopLocals);
+        changed |= optMakeExitTestDownwardsCounted(scevContext, loop, exiting, loopInfo);
     });
 
     return changed;
@@ -1060,7 +1100,7 @@ bool Compiler::optMakeLoopDownwardsCounted(ScalarEvolutionContext& scevContext,
 //   scevContext - SCEV context
 //   loop        - The specific loop
 //   exiting     - Exiting block
-//   loopLocals  - Data structure tracking local uses
+//   loopInfo  - Data structure tracking local uses
 //
 // Returns:
 //   True if any modification was made.
@@ -1068,7 +1108,7 @@ bool Compiler::optMakeLoopDownwardsCounted(ScalarEvolutionContext& scevContext,
 bool Compiler::optMakeExitTestDownwardsCounted(ScalarEvolutionContext& scevContext,
                                                FlowGraphNaturalLoop*   loop,
                                                BasicBlock*             exiting,
-                                               LoopLocalOccurrences*   loopLocals)
+                                               PerLoopInfo*            loopInfo)
 {
     // Note: keep the heuristics here in sync with
     // `StrengthReductionContext::IsUseExpectedToBeRemoved`.
@@ -1099,7 +1139,7 @@ bool Compiler::optMakeExitTestDownwardsCounted(ScalarEvolutionContext& scevConte
 
         unsigned candidateLclNum = stmt->GetRootNode()->AsLclVarCommon()->GetLclNum();
 
-        if (optLocalHasNonLoopUses(candidateLclNum, loop, loopLocals))
+        if (optLocalHasNonLoopUses(candidateLclNum, loop, loopInfo))
         {
             continue;
         }
@@ -1122,7 +1162,7 @@ bool Compiler::optMakeExitTestDownwardsCounted(ScalarEvolutionContext& scevConte
             return false;
         };
 
-        if (!loopLocals->VisitStatementsWithOccurrences(loop, candidateLclNum, checkRemovableUse))
+        if (!loopInfo->VisitStatementsWithOccurrences(loop, candidateLclNum, checkRemovableUse))
         {
             // Aborted means we found a non-removable use
             continue;
@@ -1215,7 +1255,7 @@ bool Compiler::optMakeExitTestDownwardsCounted(ScalarEvolutionContext& scevConte
     DISPSTMT(jtrueStmt);
     JITDUMP("\n");
 
-    loopLocals->Invalidate(loop);
+    loopInfo->Invalidate(loop);
     return true;
 }
 
@@ -1270,16 +1310,16 @@ bool Compiler::optCanAndShouldChangeExitTest(GenTree* cond, bool dump)
 // Parameters:
 //   lclNum     - The local
 //   loop       - The loop
-//   loopLocals - Data structure tracking local uses
+//   loopInfo - Data structure tracking local uses
 //
 // Returns:
 //   True if the local may have non-loop uses (or if it is a field with uses of
 //   the parent struct).
 //
-bool Compiler::optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals)
+bool Compiler::optLocalHasNonLoopUses(unsigned lclNum, FlowGraphNaturalLoop* loop, PerLoopInfo* loopInfo)
 {
     LclVarDsc* varDsc = lvaGetDesc(lclNum);
-    if (varDsc->lvIsStructField && loopLocals->HasAnyOccurrences(loop, varDsc->lvParentLcl))
+    if (varDsc->lvIsStructField && loopInfo->HasAnyOccurrences(loop, varDsc->lvParentLcl))
     {
         return true;
     }
@@ -1362,7 +1402,7 @@ class StrengthReductionContext
     Compiler*               m_comp;
     ScalarEvolutionContext& m_scevContext;
     FlowGraphNaturalLoop*   m_loop;
-    LoopLocalOccurrences&   m_loopLocals;
+    PerLoopInfo&            m_loopInfo;
 
     ArrayStack<Scev*>         m_backEdgeBounds;
     SimplificationAssumptions m_simplAssumptions;
@@ -1403,11 +1443,11 @@ public:
     StrengthReductionContext(Compiler*               comp,
                              ScalarEvolutionContext& scevContext,
                              FlowGraphNaturalLoop*   loop,
-                             LoopLocalOccurrences&   loopLocals)
+                             PerLoopInfo&            loopInfo)
         : m_comp(comp)
         , m_scevContext(scevContext)
         , m_loop(loop)
-        , m_loopLocals(loopLocals)
+        , m_loopInfo(loopInfo)
         , m_backEdgeBounds(comp->getAllocator(CMK_LoopIVOpts))
         , m_cursors1(comp->getAllocator(CMK_LoopIVOpts))
         , m_cursors2(comp->getAllocator(CMK_LoopIVOpts))
@@ -1484,7 +1524,7 @@ bool StrengthReductionContext::TryStrengthReduce()
             continue;
         }
 
-        if (m_comp->optLocalHasNonLoopUses(primaryIVLcl->GetLclNum(), m_loop, &m_loopLocals))
+        if (m_comp->optLocalHasNonLoopUses(primaryIVLcl->GetLclNum(), m_loop, &m_loopInfo))
         {
             // We won't be able to remove this primary IV
             JITDUMP("  Has non-loop uses\n");
@@ -1524,12 +1564,20 @@ bool StrengthReductionContext::TryStrengthReduce()
 
             assert(nextIV != nullptr);
 
-            if (varTypeIsGC(nextIV->Type) && !StaysWithinManagedObject(nextCursors, nextIV))
+            if (varTypeIsGC(nextIV->Type))
             {
-                JITDUMP(
-                    "    Next IV computes a GC pointer that we cannot prove to be inside a managed object. Bailing.\n",
-                    varTypeName(nextIV->Type));
-                break;
+                if (m_loopInfo.HasSuspensionPoint(m_loop))
+                {
+                    JITDUMP("    Next IV computes a GC pointer in a loop with a suspension point. Bailing.\n");
+                    break;
+                }
+
+                if (!StaysWithinManagedObject(nextCursors, nextIV))
+                {
+                    JITDUMP(
+                        "    Next IV computes a GC pointer that we cannot prove to be inside a managed object. Bailing.\n");
+                    break;
+                }
             }
 
             ExpandStoredCursors(nextCursors, cursors);
@@ -1573,7 +1621,7 @@ bool StrengthReductionContext::TryStrengthReduce()
         if (TryReplaceUsesWithNewPrimaryIV(cursors, currentIV))
         {
             strengthReducedAny = true;
-            m_loopLocals.Invalidate(m_loop);
+            m_loopInfo.Invalidate(m_loop);
         }
     }
 
@@ -1686,7 +1734,7 @@ bool StrengthReductionContext::InitializeCursors(GenTreeLclVarCommon* primaryIVL
         return true;
     };
 
-    if (!m_loopLocals.VisitOccurrences(m_loop, primaryIVLcl->GetLclNum(), visitor) || (m_cursors1.Height() <= 0))
+    if (!m_loopInfo.VisitOccurrences(m_loop, primaryIVLcl->GetLclNum(), visitor) || (m_cursors1.Height() <= 0))
     {
         JITDUMP("  Could not create cursors for all loop uses of primary IV\n");
         return false;
@@ -1882,7 +1930,7 @@ void StrengthReductionContext::ExpandStoredCursors(ArrayStack<CursorInfo>* curso
                 GenTreeLclVarCommon* storedLcl = parent->AsLclVarCommon();
                 if ((storedLcl->Data() == cur) && ((cur->gtFlags & GTF_SIDE_EFFECT) == 0) &&
                     storedLcl->HasSsaIdentity() &&
-                    !m_comp->optLocalHasNonLoopUses(storedLcl->GetLclNum(), m_loop, &m_loopLocals))
+                    !m_comp->optLocalHasNonLoopUses(storedLcl->GetLclNum(), m_loop, &m_loopInfo))
                 {
                     int         numCreated  = 0;
                     ScevAddRec* cursorIV    = cursor->IV;
@@ -1922,7 +1970,7 @@ void StrengthReductionContext::ExpandStoredCursors(ArrayStack<CursorInfo>* curso
                         return true;
                     };
 
-                    if (m_loopLocals.VisitOccurrences(m_loop, storedLcl->GetLclNum(), createExtraCursor))
+                    if (m_loopInfo.VisitOccurrences(m_loop, storedLcl->GetLclNum(), createExtraCursor))
                     {
                         JITDUMP(
                             "  [%06u] was the data of store [%06u]; expanded to %d new cursors, and will replace with a store of 0\n",
@@ -2678,12 +2726,12 @@ bool StrengthReductionContext::InsertionPointPostDominatesUses(BasicBlock*      
 //
 // Parameters:
 //   loop       - The loop
-//   loopLocals - Locals of the loop
+//   loopInfo - Locals of the loop
 //
 // Returns:
 //   True if any primary IV was removed.
 //
-bool Compiler::optRemoveUnusedIVs(FlowGraphNaturalLoop* loop, LoopLocalOccurrences* loopLocals)
+bool Compiler::optRemoveUnusedIVs(FlowGraphNaturalLoop* loop, PerLoopInfo* loopInfo)
 {
     JITDUMP("  Now looking for unnecessary primary IVs\n");
 
@@ -2697,7 +2745,7 @@ bool Compiler::optRemoveUnusedIVs(FlowGraphNaturalLoop* loop, LoopLocalOccurrenc
 
         unsigned lclNum = stmt->GetRootNode()->AsLclVarCommon()->GetLclNum();
         JITDUMP("  V%02u", lclNum);
-        if (optLocalHasNonLoopUses(lclNum, loop, loopLocals))
+        if (optLocalHasNonLoopUses(lclNum, loop, loopInfo))
         {
             JITDUMP(" has non-loop uses, cannot remove\n");
             continue;
@@ -2707,7 +2755,7 @@ bool Compiler::optRemoveUnusedIVs(FlowGraphNaturalLoop* loop, LoopLocalOccurrenc
             return optIsUpdateOfIVWithoutSideEffects(stmt->GetRootNode(), lclNum);
         };
 
-        if (!loopLocals->VisitStatementsWithOccurrences(loop, lclNum, visit))
+        if (!loopInfo->VisitStatementsWithOccurrences(loop, lclNum, visit))
         {
             JITDUMP(" has essential uses, cannot remove\n");
             continue;
@@ -2720,9 +2768,9 @@ bool Compiler::optRemoveUnusedIVs(FlowGraphNaturalLoop* loop, LoopLocalOccurrenc
             return true;
         };
 
-        loopLocals->VisitStatementsWithOccurrences(loop, lclNum, remove);
+        loopInfo->VisitStatementsWithOccurrences(loop, lclNum, remove);
         numRemoved++;
-        loopLocals->Invalidate(loop);
+        loopInfo->Invalidate(loop);
     }
 
     Metrics.UnusedIVsRemoved += numRemoved;
@@ -2810,7 +2858,7 @@ PhaseStatus Compiler::optInductionVariables()
         m_loops = FlowGraphNaturalLoops::Find(m_dfsTree);
     }
 
-    LoopLocalOccurrences loopLocals(m_loops);
+    PerLoopInfo loopInfo(m_loops);
 
     ScalarEvolutionContext scevContext(this);
     JITDUMP("Optimizing induction variables:\n");
@@ -2830,14 +2878,14 @@ PhaseStatus Compiler::optInductionVariables()
             continue;
         }
 
-        StrengthReductionContext strengthReductionContext(this, scevContext, loop, loopLocals);
+        StrengthReductionContext strengthReductionContext(this, scevContext, loop, loopInfo);
         if (strengthReductionContext.TryStrengthReduce())
         {
             Metrics.LoopsStrengthReduced++;
             changed = true;
         }
 
-        if (optMakeLoopDownwardsCounted(scevContext, loop, &loopLocals))
+        if (optMakeLoopDownwardsCounted(scevContext, loop, &loopInfo))
         {
             Metrics.LoopsMadeDownwardsCounted++;
             changed = true;
@@ -2847,14 +2895,14 @@ PhaseStatus Compiler::optInductionVariables()
         // addressing modes can include the zero/sign-extension of the index
         // for free.
 #if defined(TARGET_XARCH) && defined(TARGET_64BIT)
-        if (optWidenIVs(scevContext, loop, &loopLocals))
+        if (optWidenIVs(scevContext, loop, &loopInfo))
         {
             Metrics.LoopsIVWidened++;
             changed = true;
         }
 #endif
 
-        if (optRemoveUnusedIVs(loop, &loopLocals))
+        if (optRemoveUnusedIVs(loop, &loopInfo))
         {
             changed = true;
         }

--- a/src/tests/async/strength-reduction/strength-reduction.cs
+++ b/src/tests/async/strength-reduction/strength-reduction.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class StrengthReductionTest
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return StrengthReduction(Enumerable.Range(0, 1000).ToArray()).Result - 499400;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task<int> StrengthReduction(int[] arr)
+    {
+        int sum = 0;
+        foreach (int x in arr)
+        {
+            sum += x;
+            await Task.Yield();
+        }
+        return sum;
+    }
+}

--- a/src/tests/async/strength-reduction/strength-reduction.csproj
+++ b/src/tests/async/strength-reduction/strength-reduction.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Reducing to a byref type (e.g. when iterating through an array) in a
loop with suspension points is not valid, since the new byref IV will be
live across the suspension point. In those cases instead strength reduce
to the index.

Fix #115260

<details>

<summary> Example diff in test </summary>

```diff
 ; Assembly listing for method StrengthReductionTest:StrengthReduction(int[]):int (FullOpts)
 ; Emitting BLENDED_CODE for X64 with AVX - Windows
 ; FullOpts code
 ; async
 ; optimized code
 ; rsp based frame
 ; partially interruptible
 ; No PGO data
 ; 0 inlinees with PGO data; 4 single block inlinees; 0 inlinees without PGO data
 ; Final local variable assignments
 ;
-;  V00 AsyncCont    [V00,T04] (  4,  3   )     ref  ->  rcx         single-def "Async continuation arg"
-;  V01 arg1         [V01,T05] (  3,  3   )     ref  ->  rdx         class-hnd single-def <int[]>
-;  V02 loc1         [V02,T02] (  6, 10   )     int  ->  rsi        
-;  V03 loc2         [V03,T06] (  3,  2.25)     ref  ->  rdx         class-hnd single-def <int[]>
+;  V00 AsyncCont    [V00,T05] (  5,  3   )     ref  ->  rcx         single-def "Async continuation arg"
+;  V01 arg1         [V01,T06] (  3,  3   )     ref  ->  rdx         class-hnd single-def <int[]>
+;  V02 loc1         [V02,T02] (  6, 10   )     int  ->  rbx        
+;  V03 loc2         [V03,T04] (  5,  6   )     ref  ->  rsi         class-hnd single-def <int[]>
 ;* V04 loc3         [V04    ] (  0,  0   )     int  ->  zero-ref   
 ;* V05 loc4         [V05    ] (  0,  0   )     int  ->  zero-ref   
 ;* V06 loc5         [V06    ] (  0,  0   )  struct ( 8) zero-ref    do-not-enreg[SF] ld-addr-op <System.Runtime.CompilerServices.YieldAwaitable+YieldAwaiter>
 ;* V07 loc6         [V07    ] (  0,  0   )  struct ( 8) zero-ref    ld-addr-op <System.Runtime.CompilerServices.YieldAwaitable>
 ;  V08 OutArgs      [V08    ] (  1,  1   )  struct (32) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace" <UNNAMED>
 ;* V09 tmp1         [V09    ] (  0,  0   )  struct ( 8) zero-ref    ld-addr-op "Inline ldloca(s) first use temp" <System.Runtime.CompilerServices.YieldAwaitable>
 ;* V10 tmp2         [V10    ] (  0,  0   )  struct ( 8) zero-ref    ld-addr-op "Inline ldloca(s) first use temp" <System.Runtime.CompilerServices.YieldAwaitable+YieldAwaiter>
 ;  V11 cse0         [V11,T07] (  3,  2.25)     int  ->  rdi         "CSE #01: aggressive"
-;  V12 rat0         [V12,T01] (  4, 12.25)   byref  ->  rbx         must-init "Strength reduced derived IV"
-;  V13 rat1         [V13,T00] (  6, 12.25)     int  ->  rdi         "Trip count IV"
+;  V12 rat0         [V12,T00] (  6, 12.25)    long  ->  rbp         "Strength reduced derived IV"
+;  V13 rat1         [V13,T01] (  6, 12.25)     int  ->  rdi         "Trip count IV"
 ;  V14 rat2         [V14,T03] (  3,  8   )     ref  ->  rcx         "returned continuation"
-;  V15 rat3         [V15,T08] (  5,  0   )     ref  ->  rax         "new continuation"
-;  V16 rat4         [V16,T09] (  3,  0   )     ref  ->  rcx         "byte[] for continuation"
-;  V17 rat5         [V17,T10] (  3,  0   )     ref  ->  rdx         "byte[] for continuation"
+;  V15 rat3         [V15,T08] (  6,  0   )     ref  ->  r14         "new continuation"
+;  V16 rat4         [V16,T11] (  2,  0   )     ref  ->  rcx         "object[] for continuation"
+;  V17 rat5         [V17,T09] (  4,  0   )     ref  ->  rax         "byte[] for continuation"
+;  V18 rat6         [V18,T10] (  4,  0   )     ref  ->  rdx         "byte[] for continuation"
+;  V19 rat7         [V19,T12] (  2,  0   )     ref  ->  rdx         "object[] for continuation"
 ;
 ; Lcl frame size = 32
 
 G_M17835_IG01:
+       push     r14
        push     rdi
        push     rsi
+       push     rbp
        push     rbx
        sub      rsp, 32
-       xor      ebx, ebx
-						;; size=9 bbWeight=1 PerfScore 3.50
+						;; size=10 bbWeight=1 PerfScore 5.25
 G_M17835_IG02:
        test     rcx, rcx
-       jne      SHORT G_M17835_IG10
-       xor      esi, esi
-       mov      edi, dword ptr [rdx+0x08]
+       jne      G_M17835_IG10
+       xor      ebx, ebx
+       mov      rsi, rdx
+       mov      edi, dword ptr [rsi+0x08]
        test     edi, edi
        jle      SHORT G_M17835_IG06
-						;; size=14 bbWeight=1 PerfScore 4.75
+						;; size=21 bbWeight=1 PerfScore 5.00
 G_M17835_IG03:
-       lea      rbx, bword ptr [rdx+0x10]
-						;; size=4 bbWeight=0.25 PerfScore 0.12
+       mov      ebp, 16
+						;; size=5 bbWeight=0.25 PerfScore 0.06
 G_M17835_IG04:
-       add      esi, dword ptr [rbx]
+       add      ebx, dword ptr [rsi+rbp]
        xor      edx, edx
        xor      rcx, rcx
        call     [System.Runtime.CompilerServices.AsyncHelpers:UnsafeAwaitAwaiter[System.Runtime.CompilerServices.YieldAwaitable+YieldAwaiter](System.Runtime.CompilerServices.YieldAwaitable+YieldAwaiter)]
        test     rcx, rcx
        jne      SHORT G_M17835_IG08
-						;; size=17 bbWeight=4 PerfScore 31.00
+						;; size=18 bbWeight=4 PerfScore 31.00
 G_M17835_IG05:
-       add      rbx, 4
+       add      rbp, 4
        dec      edi
        jne      SHORT G_M17835_IG04
 						;; size=8 bbWeight=4 PerfScore 6.00
 G_M17835_IG06:
-       mov      eax, esi
+       mov      eax, ebx
        xor      ecx, ecx
 						;; size=4 bbWeight=1 PerfScore 0.50
 G_M17835_IG07:
        add      rsp, 32
        pop      rbx
+       pop      rbp
        pop      rsi
        pop      rdi
+       pop      r14
        ret      
-						;; size=8 bbWeight=1 PerfScore 2.75
+						;; size=11 bbWeight=1 PerfScore 3.75
 G_M17835_IG08:
-       xor      edx, edx
-       mov      r8d, 8
+       mov      edx, 1
+       mov      r8d, 16
        call     [CORINFO_HELP_ALLOC_CONTINUATION]
+       mov      r14, rax
        mov      rcx, 0xD1FFAB1E      ; code for (dynamicClass):IL_STUB_AsyncResume_StrengthReduction_Optimized(System.Object):System.Object
-       mov      qword ptr [rax+0x20], rcx
+       mov      qword ptr [r14+0x20], rcx
        xor      ecx, ecx
-       mov      qword ptr [rax+0x28], rcx
-       mov      rcx, gword ptr [rax+0x10]
-       mov      dword ptr [rcx+0x10], esi
-       mov      dword ptr [rcx+0x14], edi
-       mov      rcx, rax
-						;; size=47 bbWeight=0 PerfScore 0.00
+       mov      qword ptr [r14+0x28], rcx
+       mov      rcx, gword ptr [r14+0x18]
+       lea      rcx, bword ptr [rcx+0x10]
+       mov      rdx, rsi
+       call     CORINFO_HELP_ASSIGN_REF
+       mov      rax, gword ptr [r14+0x10]
+       mov      qword ptr [rax+0x10], rbp
+       mov      dword ptr [rax+0x18], ebx
+       mov      dword ptr [rax+0x1C], edi
+       mov      rcx, r14
+						;; size=73 bbWeight=0 PerfScore 0.00
 G_M17835_IG09:
        add      rsp, 32
        pop      rbx
+       pop      rbp
        pop      rsi
        pop      rdi
+       pop      r14
        ret      
-						;; size=8 bbWeight=0 PerfScore 0.00
+						;; size=11 bbWeight=0 PerfScore 0.00
 G_M17835_IG10:
        mov      rdx, gword ptr [rcx+0x10]
-       mov      esi, dword ptr [rdx+0x10]
-       mov      edi, dword ptr [rdx+0x14]
-       jmp      SHORT G_M17835_IG05
-						;; size=12 bbWeight=0 PerfScore 0.00
+       mov      rbp, qword ptr [rdx+0x10]
+       mov      ebx, dword ptr [rdx+0x18]
+       mov      edi, dword ptr [rdx+0x1C]
+       mov      rdx, gword ptr [rcx+0x18]
+       mov      rsi, gword ptr [rdx+0x10]
+       jmp      G_M17835_IG05
+						;; size=27 bbWeight=0 PerfScore 0.00
 
-; Total bytes of code 131, prolog size 7, PerfScore 48.62, instruction count 48, allocated bytes for code 131 (MethodHash=4bf7ba54) for method StrengthReductionTest:StrengthReduction(int[]):int (FullOpts)
+; Total bytes of code 188, prolog size 10, PerfScore 51.56, instruction count 63, allocated bytes for code 188 (MethodHash=4bf7ba54) for method StrengthReductionTest:StrengthReduction(int[]):int (FullOpts)
 ; ============================================================
 
-System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
- ---> System.NullReferenceException: Object reference not set to an instance of an object.
-   at StrengthReductionTest.StrengthReduction(Int32[] arr) in C:\dev\dotnet\runtimelab\src\tests\async\strength-reduction.cs:line 21
-   at System.Runtime.CompilerServices.AsyncHelpers.DispatchContinuations(Continuation continuation)
-   at System.Runtime.CompilerServices.AsyncHelpers.FinalizeTaskReturningThunk[T](Continuation continuation)
-   --- End of inner exception stack trace ---
-   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
-   at StrengthReductionTest.TestEntryPoint() in C:\dev\dotnet\runtimelab\src\tests\async\strength-reduction.cs:line 15
-   at __GeneratedMainWrapper.Main() in C:\dev\dotnet\runtimelab\artifacts\tests\coreclr\obj\windows.x64.Release\Managed\async\strength-reduction\XUnitWrapperGenerator\XUnitWrapperGenerator.XUnitWrapperGenerator\SimpleRunner.g.cs:line 7

```

</details>