### PR TITLE
JIT: also run local assertion prop in postorder during morph

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7708,6 +7708,7 @@ public:
     BitVecTraits* apTraits;
     ASSERT_TP     apFull;
     ASSERT_TP     apLocal;
+    ASSERT_TP     apLocalPostorder;
     ASSERT_TP     apLocalIfTrue;
 
     enum optAssertionKind : uint8_t

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -808,6 +808,9 @@ RELEASE_CONFIG_INTEGER(JitEnablePhysicalPromotion, "JitEnablePhysicalPromotion",
 // Enable cross-block local assertion prop
 RELEASE_CONFIG_INTEGER(JitEnableCrossBlockLocalAssertionProp, "JitEnableCrossBlockLocalAssertionProp", 1)
 
+// Enable postorder local assertion prop
+RELEASE_CONFIG_INTEGER(JitEnablePostorderLocalAssertionProp, "JitEnablePostorderLocalAssertionProp", 1)
+
 // Enable strength reduction
 RELEASE_CONFIG_INTEGER(JitEnableStrengthReduction, "JitEnableStrengthReduction", 1)
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7747,9 +7747,14 @@ DONE_MORPHING_CHILDREN:
         qmarkOp2 = oldTree->AsOp()->gtOp2->AsOp()->gtOp2;
     }
 
-    // Give assertion prop another shot at this tree
+    // During global morph, give assertion prop another shot at this tree.
     //
-    if (optLocalAssertionProp && (optAssertionCount > 0))
+    // We need to use the "postorder" assertion set here, because apLocal
+    // may reflect results from subtrees that have since been reordered.
+    //
+    // apLocalPostorder only includes live assertions from prior statements.
+    //
+    if (fgGlobalMorph && optLocalAssertionProp && (optAssertionCount > 0))
     {
         GenTree* optimizedTree = tree;
         bool     again         = true;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13050,10 +13050,12 @@ PhaseStatus Compiler::fgMorphBlocks()
 
     if (optLocalAssertionProp)
     {
-        Metrics.LocalAssertionCount    = optAssertionCount;
-        Metrics.LocalAssertionOverflow = optAssertionOverflow;
-        Metrics.MorphTrackedLocals     = lvaTrackedCount;
-        Metrics.MorphLocals            = lvaCount;
+        Metrics.LocalAssertionCount     = optAssertionCount;
+        Metrics.LocalAssertionOverflow  = optAssertionOverflow;
+        Metrics.MorphTrackedLocals      = lvaTrackedCount;
+        Metrics.MorphLocals             = lvaCount;
+        optLocalAssertionProp           = false;
+        optCrossBlockLocalAssertionProp = false;
     }
 
     // We may have converted a tailcall into a loop, in which case the first BB

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7757,8 +7757,13 @@ DONE_MORPHING_CHILDREN:
     if (fgGlobalMorph && optLocalAssertionProp && (optAssertionCount > 0))
     {
         GenTree* optimizedTree = tree;
-        bool     again         = true;
+        bool     again         = JitConfig.JitEnablePostorderLocalAssertionProp() > 0;
         bool     didOptimize   = false;
+
+        if (!again)
+        {
+            JITDUMP("*** Postorder assertion prop disabled by config\n");
+        }
 
         while (again)
         {
@@ -12914,6 +12919,7 @@ PhaseStatus Compiler::fgMorphBlocks()
         // Local assertion prop is enabled if we are optimizing.
         //
         optAssertionInit(/* isLocalProp*/ true);
+        apLocal          = BitVecOps::MakeEmpty(apTraits);
         apLocalPostorder = BitVecOps::MakeEmpty(apTraits);
     }
     else


### PR DESCRIPTION
Morph currently applies assertions in preorder, so updates made by morph or by local assertion prop to child trees cannot be leveraged when considering parents.

For instance if we had
```
V01 = newarr
V05 = V01
if (V05 == null)
```
morph was unable to resolve the branch, despite generating both `V01 != null` and `V05 == V01`.

To address this, keep track of the assertions valid at the end of each statement (via `apLocalPostorder`), and use those assertions during morph postorder to try and optimize further. This assertion set is kept up to date with any subsequent kills, and (for simplicity) cleared out if there is a qmark.

Note morph can't use the current (`apLocal`) assertion set in postorder because morph may also reorder subtrees, so in postorder might end up using assertions generated by (formerly) later-executing subtrees to optimize now earlier-executing subtrees.