### PR TITLE
Fix XML inheritdoc of Single/Double.SinCosPi()

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -1944,7 +1944,7 @@ namespace System
         /// <inheritdoc cref="ITrigonometricFunctions{TSelf}.SinCos(TSelf)" />
         public static (double Sin, double Cos) SinCos(double x) => Math.SinCos(x);
 
-        /// <inheritdoc cref="ITrigonometricFunctions{TSelf}.SinCos(TSelf)" />
+        /// <inheritdoc cref="ITrigonometricFunctions{TSelf}.SinCosPi(TSelf)" />
         public static (double SinPi, double CosPi) SinCosPi(double x)
         {
             // This code is based on `cospi` and `sinpi` from amd/aocl-libm-ose

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -1860,7 +1860,7 @@ namespace System
         /// <inheritdoc cref="ITrigonometricFunctions{TSelf}.SinCos(TSelf)" />
         public static (float Sin, float Cos) SinCos(float x) => MathF.SinCos(x);
 
-        /// <inheritdoc cref="ITrigonometricFunctions{TSelf}.SinCos(TSelf)" />
+        /// <inheritdoc cref="ITrigonometricFunctions{TSelf}.SinCosPi(TSelf)" />
         public static (float SinPi, float CosPi) SinCosPi(float x)
         {
             // This code is based on `cospif` and `sinpif` from amd/aocl-libm-ose


### PR DESCRIPTION
This results in incorrect documentations at e.g. https://learn.microsoft.com/en-us/dotnet/api/system.double.sincospi?view=net-9.0