### PR TITLE
[NO MERGE] Test run for SymCrypt 1.8.1

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -45,7 +45,7 @@ jobs:
     - ${{ if and(eq(parameters.platform, 'linux_musl_arm64'), or(eq(parameters.jobParameters.isExtraPlatformsBuild, true), eq(parameters.jobParameters.includeAllPlatforms, true))) }}:
       - (Alpine.321.Arm64.Open)ubuntu.2204.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.21-helix-arm64v8
 
-    # Linux x64
+    # Linux x64 -- testing for SymCrypt-OpenSSL 1.8.1-1.azl3
     - ${{ if eq(parameters.platform, 'linux_x64') }}:
       - ${{ if and(eq(parameters.jobParameters.interpreter, ''), ne(parameters.jobParameters.isSingleFile, true)) }}:
         - ${{ if and(eq(parameters.jobParameters.testScope, 'outerloop'), eq(parameters.jobParameters.runtimeFlavor, 'mono')) }}:


### PR DESCRIPTION
A significant fix was made to SymCrypt. Kicking off a test run to double-check.

https://github.com/microsoft/azurelinux/pull/13803

I valdiated that the library is in the image we use for testing:

```bash
$ docker run --rm mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-helix-amd64 tdnf list SymCrypt-OpenSSL | grep System
SymCrypt-OpenSSL.x86_64                      1.8.1-1.azl3              @System
```