### PR TITLE
Teach x86 unwinder about POP ECX being optional optimization

### DIFF
--- a/src/coreclr/vm/gc_unwind_x86.inl
+++ b/src/coreclr/vm/gc_unwind_x86.inl
@@ -2443,7 +2443,7 @@ void UnwindEspFrameEpilog(
 
         // We have already popped off the frame (excluding the callee-saved registers)
 
-        if (epilogBase[0] == X86_INSTR_POP_ECX)
+        if (epilogBase[offset] == X86_INSTR_POP_ECX)
         {
             // We may use "POP ecx" for doing "ADD ESP, 4",
             // or we may not (in the case of JMP epilogs)
@@ -2560,7 +2560,7 @@ void UnwindEbpDoubleAlignFrameEpilog(
         {
             // do nothing before popping the callee-saved registers
         }
-        else if (info->rawStkSize == sizeof(void*) && epilogBase[0] == X86_INSTR_POP_ECX)
+        else if (info->rawStkSize == sizeof(void*) && epilogBase[offset] == X86_INSTR_POP_ECX)
         {
             // We may use "POP ecx" for doing "ADD ESP, 4",
             // or we may not (in the case of JMP epilogs)

--- a/src/coreclr/vm/gc_unwind_x86.inl
+++ b/src/coreclr/vm/gc_unwind_x86.inl
@@ -2560,8 +2560,11 @@ void UnwindEbpDoubleAlignFrameEpilog(
         {
             // do nothing before popping the callee-saved registers
         }
-        else if (info->rawStkSize == sizeof(void*))
+        else if (info->rawStkSize == sizeof(void*) && epilogBase[0] == X86_INSTR_POP_ECX)
         {
+            // We may use "POP ecx" for doing "ADD ESP, 4",
+            // or we may not (in the case of JMP epilogs)
+
             // "pop ecx" will make ESP point to the callee-saved registers
             if (!InstructionAlreadyExecuted(offset, info->epilogOffs))
                 ESP += sizeof(void*);


### PR DESCRIPTION
Fixes #115120

The same pattern already exists in the unwinder elsewhere:
https://github.com/dotnet/runtime/blob/2f8f6e71c8e9216840c7f80fb71c545e1cdac580/src/coreclr/vm/gc_unwind_x86.inl#L2446-L2449
