### PR TITLE
Notify attached debugger of NAOT exception

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -648,17 +648,19 @@ namespace System.Runtime
         [StackTraceHidden]
         public static void RhThrowEx(object exceptionObj, ref ExInfo exInfo)
         {
+#if NATIVEAOT
+
 #if TARGET_WINDOWS
             // Alert the debugger that we threw an exception.
             InternalCalls.RhpFirstChanceExceptionNotification();
 #endif // TARGET_WINDOWS
 
-#if NATIVEAOT
             // trigger a GC (only if gcstress) to ensure we can stackwalk at this point
             GCStress.TriggerGC();
 
             InternalCalls.RhpValidateExInfoStack();
-#endif
+#endif // NATIVEAOT
+
             // Transform attempted throws of null to a throw of NullReferenceException.
             if (exceptionObj == null)
             {

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -648,6 +648,11 @@ namespace System.Runtime
         [StackTraceHidden]
         public static void RhThrowEx(object exceptionObj, ref ExInfo exInfo)
         {
+#if TARGET_WINDOWS
+            // Alert the debugger that we threw an exception.
+            InternalCalls.RhpFirstChanceException();
+#endif // TARGET_WINDOWS
+
 #if NATIVEAOT
             // trigger a GC (only if gcstress) to ensure we can stackwalk at this point
             GCStress.TriggerGC();
@@ -665,6 +670,7 @@ namespace System.Runtime
             DispatchEx(ref exInfo._frameIter, ref exInfo);
             FallbackFailFast(RhFailFastReason.InternalError, null);
         }
+
 #if !NATIVEAOT
         public static void RhUnwindAndIntercept(ref ExInfo exInfo, UIntPtr interceptStackFrameSP)
         {

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -650,7 +650,7 @@ namespace System.Runtime
         {
 #if TARGET_WINDOWS
             // Alert the debugger that we threw an exception.
-            InternalCalls.RhpFirstChanceException();
+            InternalCalls.RhpFirstChanceExceptionNotification();
 #endif // TARGET_WINDOWS
 
 #if NATIVEAOT

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -248,6 +248,12 @@ namespace System.Runtime
         internal static extern void RhpValidateExInfoStack();
 
 #if TARGET_WINDOWS
+        [RuntimeImport(Redhawk.BaseName, "RhpFirstChanceException")]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern void RhpFirstChanceException();
+#endif
+
+#if TARGET_WINDOWS
         [RuntimeImport(Redhawk.BaseName, "RhpCopyContextFromExInfo")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern unsafe void RhpCopyContextFromExInfo(void* pOSContext, int cbOSContext, EH.PAL_LIMITED_CONTEXT* pPalContext);

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -248,9 +248,9 @@ namespace System.Runtime
         internal static extern void RhpValidateExInfoStack();
 
 #if TARGET_WINDOWS
-        [RuntimeImport(Redhawk.BaseName, "RhpFirstChanceException")]
+        [RuntimeImport(Redhawk.BaseName, "RhpFirstChanceExceptionNotification")]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern void RhpFirstChanceException();
+        internal static extern void RhpFirstChanceExceptionNotification();
 #endif
 
 #if TARGET_WINDOWS

--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -88,7 +88,7 @@ FCIMPL0(void, RhpValidateExInfoStack)
 FCIMPLEND
 
 #ifdef TARGET_WINDOWS
-FCIMPL0(void, RhpFirstChanceException)
+FCIMPL0(void, RhpFirstChanceExceptionNotification)
 {
     // Throw an SEH exception and immediately catch it. This is used to notify debuggers and other tools
     // that an exception has been thrown.

--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -31,6 +31,8 @@
 #include "MethodTable.inl"
 #include "CommonMacros.inl"
 #include "NativeContext.h"
+#include <minipal/debugger.h>
+#include "corexcep.h"
 
 struct MethodRegionInfo
 {
@@ -84,6 +86,26 @@ FCIMPL0(void, RhpValidateExInfoStack)
     pThisThread->ValidateExInfoStack();
 }
 FCIMPLEND
+
+#ifdef TARGET_WINDOWS
+FCIMPL0(void, RhpFirstChanceException)
+{
+    // Thow an SEH exception and immediately catch it. This is used to notify debuggers and other tools
+    // that an exception has been thrown.
+    if (minipal_is_native_debugger_present())
+    {
+        __try
+        {
+            RaiseException(EXCEPTION_COMPLUS, 0, 0, NULL);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            // Do nothing, we just want to notify the debugger.
+        }
+    }
+}
+FCIMPLEND
+#endif // TARGET_WINDOWS
 
 FCIMPL0(void, RhpClearThreadDoNotTriggerGC)
 {

--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -90,7 +90,7 @@ FCIMPLEND
 #ifdef TARGET_WINDOWS
 FCIMPL0(void, RhpFirstChanceException)
 {
-    // Thow an SEH exception and immediately catch it. This is used to notify debuggers and other tools
+    // Throw an SEH exception and immediately catch it. This is used to notify debuggers and other tools
     // that an exception has been thrown.
     if (minipal_is_native_debugger_present())
     {

--- a/src/coreclr/nativeaot/Runtime/corexcep.h
+++ b/src/coreclr/nativeaot/Runtime/corexcep.h
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*********************************************************************
+ **                                                                 **
+ ** CorExcep.h - lists the exception codes used by the CLR.         **
+ **                                                                 **
+ *********************************************************************/
+
+
+#ifndef __COREXCEP_H__
+#define __COREXCEP_H__
+
+// All CLR exceptions are expressed as a RaiseException with this exception
+// code.  If you change this value, you must also change
+// Exception.cs's EXCEPTION_COMPLUS value.
+
+#define EXCEPTION_MSVC    0xe06d7363    // 0xe0000000 | 'msc'
+
+#define EXCEPTION_COMPLUS 0xe0434352    // 0xe0000000 | 'CCR'
+
+#define EXCEPTION_HIJACK  0xe0434f4e    // 0xe0000000 | 'COM'+1
+
+#if defined(_DEBUG)
+#define EXCEPTION_INTERNAL_ASSERT 0xe0584d4e // 0xe0000000 | 'XMN'
+                                        // An internal Assert will raise this exception when the config
+                                        // value "RaiseExceptionOnAssert" si specified. This is used in
+                                        // stress to facilitate failure triaging.
+#endif
+
+#endif // __COREXCEP_H__

--- a/src/coreclr/nativeaot/Runtime/corexcep.h
+++ b/src/coreclr/nativeaot/Runtime/corexcep.h
@@ -1,31 +1,4 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*********************************************************************
- **                                                                 **
- ** CorExcep.h - lists the exception codes used by the CLR.         **
- **                                                                 **
- *********************************************************************/
-
-
-#ifndef __COREXCEP_H__
-#define __COREXCEP_H__
-
-// All CLR exceptions are expressed as a RaiseException with this exception
-// code.  If you change this value, you must also change
-// Exception.cs's EXCEPTION_COMPLUS value.
-
-#define EXCEPTION_MSVC    0xe06d7363    // 0xe0000000 | 'msc'
-
-#define EXCEPTION_COMPLUS 0xe0434352    // 0xe0000000 | 'CCR'
-
-#define EXCEPTION_HIJACK  0xe0434f4e    // 0xe0000000 | 'COM'+1
-
-#if defined(_DEBUG)
-#define EXCEPTION_INTERNAL_ASSERT 0xe0584d4e // 0xe0000000 | 'XMN'
-                                        // An internal Assert will raise this exception when the config
-                                        // value "RaiseExceptionOnAssert" si specified. This is used in
-                                        // stress to facilitate failure triaging.
-#endif
-
-#endif // __COREXCEP_H__
+#include "../../inc/corexcep.h"

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -1558,7 +1558,7 @@ BOOL HandleHardwareException(PAL_SEHException* ex)
 void FirstChanceExceptionNotification()
 {
 #ifdef TARGET_WINDOWS
-    // Thow an SEH exception and immediately catch it. This is used to notify debuggers and other tools
+    // Throw an SEH exception and immediately catch it. This is used to notify debuggers and other tools
     // that an exception has been thrown.
     if (minipal_is_native_debugger_present())
     {

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -592,7 +592,7 @@ ProcessCLRException(IN     PEXCEPTION_RECORD   pExceptionRecord,
                 // The 3rd argument passes to PopExplicitFrame is normally the parent SP to correctly handle InlinedCallFrame embbeded
                 // in parent managed frame. But at this point there are no further managed frames are on the stack, so we can pass NULL.
                 // Also don't pop the GC frames, their destructor will pop them as the exception propagates.
-                // NOTE: this needs to be popped in the 2nd pass to ensure that crash dumps and Watson get the dump with these still 
+                // NOTE: this needs to be popped in the 2nd pass to ensure that crash dumps and Watson get the dump with these still
                 // present.
                 ExInfo *pExInfo = (ExInfo*)pThread->GetExceptionState()->GetCurrentExceptionTracker();
                 void *sp = (void*)GetRegdisplaySP(pExInfo->m_frameIter.m_crawl.GetRegisterSet());
@@ -624,7 +624,7 @@ ProcessCLRException(IN     PEXCEPTION_RECORD   pExceptionRecord,
 
 #ifdef TARGET_X86
         CallRtlUnwind((PEXCEPTION_REGISTRATION_RECORD)pEstablisherFrame, NULL, pExceptionRecord, 0);
-#else        
+#else
         ClrUnwindEx(pExceptionRecord,
                     (UINT_PTR)pThread,
                     INVALID_RESUME_ADDRESS,
@@ -1557,19 +1557,21 @@ BOOL HandleHardwareException(PAL_SEHException* ex)
 
 void FirstChanceExceptionNotification()
 {
-#ifndef TARGET_UNIX
+#ifdef TARGET_WINDOWS
+    // Thow an SEH exception and immediately catch it. This is used to notify debuggers and other tools
+    // that an exception has been thrown.
     if (minipal_is_native_debugger_present())
     {
-        PAL_TRY(VOID *, unused, NULL)
+        __try
         {
             RaiseException(EXCEPTION_COMPLUS, 0, 0, NULL);
         }
-        PAL_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        __except (EXCEPTION_EXECUTE_HANDLER)
         {
+            // Do nothing, we just want to notify the debugger.
         }
-        PAL_ENDTRY;
     }
-#endif // TARGET_UNIX
+#endif // TARGET_WINDOWS
 }
 
 VOID DECLSPEC_NORETURN DispatchManagedException(OBJECTREF throwable, CONTEXT* pExceptionContext, EXCEPTION_RECORD* pExceptionRecord)
@@ -3313,7 +3315,7 @@ extern "C" void QCALLTYPE ResumeAtInterceptionLocation(REGDISPLAY* pvRegDisplay)
     uResumePC = codeInfo.GetJitManager()->GetCodeAddressForRelOffset(codeInfo.GetMethodToken(), static_cast<DWORD>(ulRelOffset));
 
     SetIP(pvRegDisplay->pCurrentContext, uResumePC);
-    
+
     STRESS_LOG2(LF_EH, LL_INFO100, "Resuming at interception location at IP=%p, SP=%p\n", uResumePC, GetSP(pvRegDisplay->pCurrentContext));
     ClrRestoreNonvolatileContext(pvRegDisplay->pCurrentContext, targetSSP);
 }
@@ -3408,7 +3410,7 @@ extern "C" CLR_BOOL QCALLTYPE EHEnumInitFromStackFrameIterator(StackFrameIterato
     IJitManager* pJitMan = pFrameIter->m_crawl.GetJitManager();
     const METHODTOKEN& MethToken = pFrameIter->m_crawl.GetMethodToken();
     pExtendedEHEnum->EHCount = pJitMan->InitializeEHEnumeration(MethToken, pEHEnum);
-    EH_LOG((LL_INFO100, "Initialized EH enumeration, %d clauses found\n", pExtendedEHEnum->EHCount));    
+    EH_LOG((LL_INFO100, "Initialized EH enumeration, %d clauses found\n", pExtendedEHEnum->EHCount));
 
     if (pExtendedEHEnum->EHCount == 0)
     {
@@ -4037,7 +4039,7 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
 
                             // Unwind to the frame of the prevExInfo
                             ExInfo* pPrevExInfo = pThis->GetNextExInfo();
-                            EH_LOG((LL_INFO100, "SfiNext: collided with previous exception handling, skipping from IP=%p, SP=%p to IP=%p, SP=%p\n", 
+                            EH_LOG((LL_INFO100, "SfiNext: collided with previous exception handling, skipping from IP=%p, SP=%p to IP=%p, SP=%p\n",
                                     GetControlPC(&pTopExInfo->m_regDisplay), GetRegdisplaySP(&pTopExInfo->m_regDisplay),
                                     GetControlPC(&pPrevExInfo->m_regDisplay), GetRegdisplaySP(&pPrevExInfo->m_regDisplay)));
 


### PR DESCRIPTION
Native AOT does not use C++ or SEH exceptions, meaning that debuggers do not recognize the exception throw/catch sequence and cannot break on first-chance exceptions. On Windows, we can use OS functionality to throw and catch an SEH exception when a Native AOT exception is thrown and a debugger is attached, effectively acting as a notification to debuggers that an exception is in flight. The exception code used here is the same one as CoreCLR, so the WinDbg command `sxe clr` would also be sufficient to catch Native AOT exceptions.

Fixes #115514