### PR TITLE
Delete obsolete comments

### DIFF
--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -125,13 +125,8 @@ void FinalizerThread::FinalizeAllObjects()
 
 void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
 {
-    // Non-host environment
-
     // We don't want kLowMemoryNotification to starve out kFinalizer
-    // (as the latter may help correct the former), and we don't want either
-    // to starve out kProfilingAPIAttach, as we want decent responsiveness
-    // to a user trying to attach a profiler.  So check in this order:
-    //     kProfilingAPIAttach alone (0 wait)
+    // (as the latter may help correct the former). So check in this order:
     //     kFinalizer alone (2s wait)
     //     all events together (infinite wait)
 
@@ -162,7 +157,6 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
         //
         //     * kLowMemoryNotification (if it's non-NULL && g_fEEStarted)
         //     * kFinalizer (always)
-        //     * kProfilingAPIAttach (if it's non-NULL)
         //
         // The enum code:MHandleType values become important here, as
         // WaitForMultipleObjects needs to wait on a contiguous set of non-NULL

--- a/src/coreclr/vm/profdetach.cpp
+++ b/src/coreclr/vm/profdetach.cpp
@@ -55,9 +55,6 @@ void ProfilerDetachInfo::Init()
 }
 
 
-// ----------------------------------------------------------------------------
-// Implementation of ProfilingAPIAttachDetach statics
-
 
 // ----------------------------------------------------------------------------
 // ProfilingAPIDetach::Initialize

--- a/src/coreclr/vm/profilinghelper.cpp
+++ b/src/coreclr/vm/profilinghelper.cpp
@@ -411,13 +411,6 @@ EXTERN_C void STDMETHODCALLTYPE ProfileTailcallNaked(UINT_PTR clientData);
 // Notes:
 //     This function (or one of its callees) will log an error to the event log
 //     if there is a failure
-//
-// Assumptions:
-//    InitializeProfiling is called during startup, AFTER the host has initialized its
-//    settings and the config variables have been read, but BEFORE the finalizer thread
-//    has entered its first wait state.  ASSERTs are placed in
-//    code:ProfilingAPIAttachDetach::Initialize (which is called by this function, and
-//    which depends on these assumptions) to verify.
 
 // static
 HRESULT ProfilingAPIUtility::InitializeProfiling()


### PR DESCRIPTION
Delete comments that refer to the old Windows-specific profiler attach implementation that was deleted by https://github.com/dotnet/coreclr/pull/24670