### PR TITLE
JIT: Avoid running return value copy logic for unused return value

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1271,7 +1271,7 @@ BasicBlock* AsyncTransformation::CreateResumption(BasicBlock*               bloc
     }
 
     // Copy call return value.
-    if (layout.ReturnSize > 0)
+    if ((layout.ReturnSize > 0) && (callDefInfo.DefinitionNode != nullptr))
     {
         CopyReturnValueOnResumption(call, callDefInfo, resumeByteArrLclNum, resumeObjectArrLclNum, layout,
                                     storeResultBB);


### PR DESCRIPTION
Fix #115669

Also opened #115686 as a related optimization in the area.