### PR TITLE
JIT: fix issue in redundant zero init opt

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5907,8 +5907,10 @@ void Compiler::optRemoveRedundantZeroInits()
                                 defsInBlock.Set(lclNum, 1);
                             }
                         }
-                        else if (varTypeIsStruct(lclDsc) && ((tree->gtFlags & GTF_VAR_USEASG) == 0) &&
-                                 lvaGetPromotionType(lclDsc) != PROMOTION_TYPE_NONE)
+                        // Here we treat both "full" and "partial" tracked field defs as defs
+                        // (that is, we ignore the state of GTF_VAR_USEASG).
+                        //
+                        else if (varTypeIsStruct(lclDsc) && lvaGetPromotionType(lclDsc) != PROMOTION_TYPE_NONE)
                         {
                             for (unsigned i = lclDsc->lvFieldLclStart; i < lclDsc->lvFieldLclStart + lclDsc->lvFieldCnt;
                                  ++i)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_115123/Runtime_115123.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_115123/Runtime_115123.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Simplified from an Antigen test case
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public struct S1_D1_F2
+{
+    public bool bool_1;
+    public bool bool_2;
+}
+
+public class Runtime_115123
+{
+    [Fact]
+    public static void Test()
+    {
+        Problem(1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Problem(int a)
+    {
+        unchecked
+        {
+            bool b = false;
+            S1_D1_F2 s1_s1_d1_f2_1983 = new S1_D1_F2();
+            try
+            {
+                if (s1_s1_d1_f2_1983.bool_1 = (b = (s1_s1_d1_f2_1983.bool_1 = false) || (a == 0)))
+                {
+                    SideEffect();
+                }
+            }
+            finally
+            {
+                switch (a)
+                {
+                    case 0: SideEffect(); break;
+                    case 1: SideEffect(); break;
+                    case 2: SideEffect(); break;
+                    case 3: SideEffect(); break;
+                    case 4: SideEffect(); break;
+                    default: SideEffect(); break;
+                }
+            }
+
+            Log("s1_s1_d1_f", s1_s1_d1_f2_1983);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Log(string varName, object varValue) {}
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void SideEffect() {}
+}
+

--- a/src/tests/JIT/Regression/JitBlue/Runtime_115123/Runtime_115123.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_115123/Runtime_115123.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If there is a redundant field zero def followed by a nonzero USEASG def in a block with EH flow, redundant zero init will improperly mark the field as not def in the block, leading to an SSA assert when it processes the USEASG def and can't find a PHI in the handler.

Treat USEASG defs as full defs. If analysis has reached this point then all fields are zero and so if the second def value is zero, a full and partial def have the same effect. If the second def value is not zero then accounting for the def (which will remain) prevents the optimization from removing any of the fields from the block def set.

Fixes #115123.