### PR TITLE
[browser] dev tools profiler - method name resolution

### DIFF
--- a/eng/testing/scenarios/BuildWasmAppsJobsList.txt
+++ b/eng/testing/scenarios/BuildWasmAppsJobsList.txt
@@ -49,3 +49,4 @@ Wasm.Build.Tests.DebugLevelTests
 Wasm.Build.Tests.PreloadingTests
 Wasm.Build.Tests.EnvVariablesTests
 Wasm.Build.Tests.HttpTests
+Wasm.Build.Tests.DiagnosticsTests

--- a/src/mono/browser/runtime/driver.c
+++ b/src/mono/browser/runtime/driver.c
@@ -524,6 +524,7 @@ EMSCRIPTEN_KEEPALIVE char * mono_wasm_method_get_name_ex (MonoMethod *method) {
 	if (mono_method_get_flags (method, NULL) & 0x0800 /* METHOD_ATTRIBUTE_SPECIAL_NAME */ && strlen (res) < 7) {
 		res = (char *) malloc (128);
 		snprintf (res, 128,"%s.%s", mono_class_get_name (mono_method_get_class (method)), method_name);
+		res[127] = '\0';
 	} else {
 		res = strdup (method_name);
 	}

--- a/src/mono/browser/runtime/driver.c
+++ b/src/mono/browser/runtime/driver.c
@@ -521,7 +521,9 @@ EMSCRIPTEN_KEEPALIVE char * mono_wasm_method_get_name_ex (MonoMethod *method) {
 	MONO_ENTER_GC_UNSAFE;
 	const char *method_name = mono_method_get_name (method);
 	// starts with .ctor or .cctor
-	if (mono_method_get_flags (method, NULL) & 0x0800 /* METHOD_ATTRIBUTE_SPECIAL_NAME */ && strlen (res) < 7) {
+	if (!method_name) {
+		res = strdup ("<unknown>");
+	} else if (method_name && mono_method_get_flags (method, NULL) & 0x0800 /* METHOD_ATTRIBUTE_SPECIAL_NAME */ && strlen (method_name) < 7) {
 		res = (char *) malloc (128);
 		snprintf (res, 128,"%s.%s", mono_class_get_name (mono_method_get_class (method)), method_name);
 		res[127] = '\0';

--- a/src/mono/wasm/Wasm.Build.Tests/DiagnosticsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/DiagnosticsTests.cs
@@ -46,12 +46,12 @@ public class DiagnosticsTests : WasmTemplateTestsBase
     public async Task RunSimpleAppWithBrowserProfiler()
     {
         Configuration config = Configuration.Release;
-        ProjectInfo info = CopyTestAsset(config, false, TestAsset.WasmBasicTestApp, "BrowserProfilerTest");
 
-        string extraArgs = $"-p:WasmProfilers=\"browser\"";
-        BuildProject(info, config, new BuildOptions(ExtraMSBuildArgs: extraArgs, AssertAppBundle: false, WasmPerfTracing: true), isNativeBuild: true);
+        string extraProperties = "<WasmProfilers>browser:callspec=all,interval=0</WasmProfilers>";
+        ProjectInfo info = CopyTestAsset(config, false, TestAsset.WasmBasicTestApp, "BrowserProfilerTest", extraProperties: extraProperties);
 
-        var result = await RunForBuildWithDotnetRun(new BrowserRunOptions(Configuration: config, TestScenario: "BrowserProfilerTest"));
-        Assert.Contains("performance.measure: TestMeaning", result.TestOutput);
+        BuildProject(info, config, new BuildOptions(AssertAppBundle: false, WasmPerfTracing: true), isNativeBuild: true);
+
+        await RunForBuildWithDotnetRun(new BrowserRunOptions(Configuration: config, TestScenario: "BrowserProfilerTest"));
     }
 }

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/BrowserProfilerTest.cs
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/BrowserProfilerTest.cs
@@ -7,11 +7,21 @@ using System.Runtime.InteropServices.JavaScript;
 
 public partial class BrowserProfilerTest
 {
+    public class ClassWithVeryVeryLongName012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+    {
+        bool _even;
+        public ClassWithVeryVeryLongName012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789(int i)
+        {
+            _even = i % 2 == 0;
+        }
+    }
+
     [JSExport]
     public static int TestMeaning()
     {
         for(int i=0; i<100; i++){
             var r = new int[1000];
+            var bla = new ClassWithVeryVeryLongName012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789(i);
         }
  
         return 42;

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -312,10 +312,12 @@ try {
             break;
         case "BrowserProfilerTest":
             console.log("not ready yet")
-            const origMeasure = globalThis.performance.measure
+            let foundB = false;
             globalThis.performance.measure = (method, options) => {
                 console.log(`performance.measure: ${method}`);
-                origMeasure(method, options);
+                if (method === "TestMeaning") {
+                    foundB = true;
+                }
             };
             const myExportsB = await getAssemblyExports(config.mainAssemblyName);
             const testMeaningB = myExportsB.BrowserProfilerTest.TestMeaning;
@@ -325,7 +327,7 @@ try {
             document.getElementById("out").innerHTML = retB;
             console.debug(`ret: ${retB}`);
 
-            exit(retB == 42 ? 0 : 1);
+            exit(foundB && retB == 42 ? 0 : 1);
 
             break;
         case "OverrideBootConfigName":


### PR DESCRIPTION
- dereference of un-initialized buffer
- `snprintf` doesn't zero-terminate too long strings

Fixes https://github.com/dotnet/runtime/issues/115551