### PR TITLE
Add NativeAOT.py for lldb visualization

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/NativeAOT.py
+++ b/src/coreclr/nativeaot/BuildIntegration/NativeAOT.py
@@ -1,0 +1,82 @@
+"""
+LLDB pretty printer for NativeAOT
+
+Add to ~/.lldbinit:
+
+command script import {path-to-ilcompiler-package}/build/NativeAOT.lldb.py
+"""
+
+import lldb
+
+
+def __lldb_init_module(debugger, dict):
+    debugger.HandleCommand(
+        'type summary add -x "^String$" -e -F NativeAOT.String_SummaryProvider'
+    )
+    debugger.HandleCommand(
+        'type summary add -x "^__Array<.+>$" -e -F NativeAOT.Array_SummaryProvider'
+    )
+    debugger.HandleCommand(
+        'type synthetic add -x "^__Array<.+>$" -l NativeAOT.Array_SyntheticProvider'
+    )
+    debugger.HandleCommand(
+        'type synthetic add -x "^Object$" -l NativeAOT.Object_SyntheticProvider'
+    )
+
+
+def String_SummaryProvider(valobj, internal_dict):
+    valobj = valobj.GetNonSyntheticValue()
+    strval = '"'
+    try:
+        length = valobj.GetChildMemberWithName("_stringLength").GetValueAsUnsigned()
+        chars = (
+            valobj.GetChildMemberWithName("_firstChar")
+            .address_of.GetPointeeData(0, length)
+            .uint16
+        )
+        for i in range(0, length):
+            strval += chr(chars[i])
+    except:
+        pass
+    strval += '"'
+    return strval
+
+
+def Array_SummaryProvider(valobj, internal_dict):
+    return "length=" + str(
+        valobj.GetNonSyntheticValue()
+        .GetChildMemberWithName("_numComponents")
+        .GetValueAsUnsigned()
+    )
+
+
+class Array_SyntheticProvider:
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+
+    def num_children(self):
+        return self.valobj.GetChildMemberWithName("_numComponents").GetValueAsUnsigned()
+
+    def get_child_index(self, name):
+        try:
+            return int(name.lstrip("[").rstrip("]"))
+        except:
+            return None
+
+    def get_child_at_index(self, index):
+        t = self.valobj.GetChildMemberWithName("m_Data").GetType().GetArrayElementType()
+        return self.valobj.GetChildMemberWithName(
+            "_numComponents"
+        ).address_of.CreateChildAtOffset(
+            f"[{index}]",
+            self.valobj.target.GetAddressByteSize() + index * t.GetByteSize(),
+            t,
+        )
+
+
+class Object_SyntheticProvider:
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+
+    def num_children(self):
+        return 0


### PR DESCRIPTION
Adding @jbevain script from https://github.com/dotnet/runtime/issues/115406#issuecomment-2864315221.

Context:
```gdb
(lldb) f 11
frame #11: 0x00000001005ff258 web04`_web04_Program___Main__(args=length=0) at Program.cs:11
   8   	  var testString = "Hello from NativeAOT!";
   9   	  var testArray = new int[] { 10, 20, 30 };
   10  	
-> 11  	  throw new InvalidOperationException($"{testString} {testArray.Length}");
   12  	}
   13  	
   14  	builder.Services.ConfigureHttpJsonOptions(options =>
```

Before:
```gdb
(lldb) frame var testArray testString
(__Array<Int32> &) testArray = 0x00000004c0036550: {
  S_P_CoreLib_System_Array = {
    Object = {
      m_pEEType = 0x000000010126eef8
    }
    _numComponents = 3
  }
  m_NumComponents = 3
  m_Data = {}
}
(String &) testString = 0x0000000101025940: {
  Object = {
    m_pEEType = 0x00000001010e58b0
  }
  _stringLength = 21
  _firstChar = U+0048 u'H'
}
```

After:

```gdb
(lldb) command script import /Users/adeel/projects/runtime/src/coreclr/nativeaot/BuildIntegration/NativeAOT.py
(lldb) frame var testArray testString
(__Array<Int32> &) testArray = 0x00000004c0036550 length=3: {
  [0] = 10
  [1] = 20
  [2] = 30
}
(String &) testString = 0x0000000101025940 "Hello from NativeAOT!": {
  Object = {}
  _stringLength = 21
  _firstChar = U+0048 u'H'
}
```