### PR TITLE
Fix reporting of foreign native exception not handled by runtime

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3935,13 +3935,16 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
             // Check if there are any further managed frames on the stack or a catch for all exceptions in native code (marked by
             // DebuggerU2MCatchHandlerFrame with CatchesAllExceptions() returning true).
             // If not, the exception is unhandled.
-            if ((pFrame == FRAME_TOP) ||
+            bool isNotHandledByRuntime = 
+                (pFrame == FRAME_TOP) ||
                 (IsTopmostDebuggerU2MCatchHandlerFrame(pFrame) && !((DebuggerU2MCatchHandlerFrame*)pFrame)->CatchesAllExceptions())
 #ifdef HOST_UNIX
                 // Don't allow propagating exceptions from managed to non-runtime native code
                 || isPropagatingToExternalNativeCode
 #endif
-               )
+                ;
+
+            if (IsComPlusException(pTopExInfo->m_ptrs.ExceptionRecord) && isNotHandledByRuntime)
             {
                 EH_LOG((LL_INFO100, "SfiNext (pass %d): no more managed frames on the stack, the exception is unhandled", pTopExInfo->m_passNumber));
                 if (pTopExInfo->m_passNumber == 1)

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInteropNative.cpp
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInteropNative.cpp
@@ -40,7 +40,7 @@ extern "C" DLL_EXPORT void InvokeCallbackCatchCallbackAndRethrow(PFNACTION1 call
 }
 
 #ifdef _WIN32
-extern "C" DLL_EXPORT void InvokeCallbackAndCatchNative(PFNACTION1 callback)
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE InvokeCallbackAndCatchNative(PFNACTION1 callback)
 {
     try
     {

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInteropNative.cpp
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInteropNative.cpp
@@ -3,6 +3,12 @@
 
 #include <exception>
 #include <platformdefines.h>
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable:4265 4577)
+#include <thread>
+#pragma warning(pop)
+#endif // _WIN32
 
 extern "C" DLL_EXPORT void STDMETHODCALLTYPE ThrowException()
 {
@@ -33,3 +39,22 @@ extern "C" DLL_EXPORT void InvokeCallbackCatchCallbackAndRethrow(PFNACTION1 call
     }
 }
 
+#ifdef _WIN32
+extern "C" DLL_EXPORT void InvokeCallbackAndCatchNative(PFNACTION1 callback)
+{
+    try
+    {
+        callback();
+    }
+    catch (std::exception& ex)
+    {
+        printf("Caught exception %s in native code\n", ex.what());
+    }
+}
+
+extern "C" DLL_EXPORT void InvokeCallbackOnNewThread(PFNACTION1 callback)
+{
+    std::thread t1(InvokeCallbackAndCatchNative, callback);
+    t1.join();
+}
+#endif // _WIN32

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInteropNative.cpp
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInteropNative.cpp
@@ -52,7 +52,7 @@ extern "C" DLL_EXPORT void STDMETHODCALLTYPE InvokeCallbackAndCatchNative(PFNACT
     }
 }
 
-extern "C" DLL_EXPORT void InvokeCallbackOnNewThread(PFNACTION1 callback)
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE InvokeCallbackOnNewThread(PFNACTION1 callback)
 {
     std::thread t1(InvokeCallbackAndCatchNative, callback);
     t1.join();


### PR DESCRIPTION
When a native exception occurs on a foreign thread, it is propagated through managed frames and then flows into the foreign native frames and is handled there, the runtime still reports the exception as unhandled via `AppDomain.CurrentDomain.UnhandledException` event and also prints out the unhandled exception message. Even though the process then continues running just fine.

This change fixes the behavior so that only managed exceptions thrown by the .NET runtime are reported as unhandled in such case. Foreign exceptions, like e.g. C++ exceptions, are not reported as unhandled and they are just propagated into the foreign native frames. If that exception is not handled by the native frames, then C++ reports them as unhandled.

I have also added a test that fails without this fix.

Close #115654