### PR TITLE
Add a helper utility to clear the environment variables for tests

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/TestEnvironment.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/TestEnvironment.cs
@@ -28,7 +28,7 @@ namespace System
             var keysToRemove = new List<string>();
             foreach (var key in environment.Keys)
             {
-                if (key == "LANG" || (key.StartsWith("DOTNET_SYSTEM_GLOBALIZATION", StringComparison.OrdinalIgnoreCase)))
+                if (key == "LANG" || key.StartsWith("DOTNET_SYSTEM_GLOBALIZATION", StringComparison.OrdinalIgnoreCase))
                 {
                     keysToRemove.Add(key);
                 }

--- a/src/libraries/Common/tests/TestUtilities/System/TestEnvironment.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/TestEnvironment.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+
 namespace System
 {
     public static class TestEnvironment

--- a/src/libraries/Common/tests/TestUtilities/System/TestEnvironment.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/TestEnvironment.cs
@@ -23,13 +23,12 @@ namespace System
         /// <summary>
         /// Removes LANG and any environment variable starting with DOTNET_SYSTEM_GLOBALIZATION from the given environment dictionary.
         /// </summary>
-        public static void ClearGlobalizationEnvironmentVars(System.Collections.IDictionary environment)
+        public static void ClearGlobalizationEnvironmentVars(IDictionary<string,string?> environment)
         {
             var keysToRemove = new List<string>();
-            foreach (System.Collections.DictionaryEntry entry in environment)
+            foreach (var key in environment.Keys)
             {
-                string key = entry.Key as string;
-                if (key == "LANG" || (key != null && key.StartsWith("DOTNET_SYSTEM_GLOBALIZATION", StringComparison.OrdinalIgnoreCase)))
+                if (key == "LANG" || (key.StartsWith("DOTNET_SYSTEM_GLOBALIZATION", StringComparison.OrdinalIgnoreCase)))
                 {
                     keysToRemove.Add(key);
                 }

--- a/src/libraries/Common/tests/TestUtilities/System/TestEnvironment.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/TestEnvironment.cs
@@ -17,5 +17,25 @@ namespace System
                 return value != null && (value == "1" || value.Equals("true", StringComparison.OrdinalIgnoreCase));
             }
         }
+
+        /// <summary>
+        /// Removes LANG and any environment variable starting with DOTNET_SYSTEM_GLOBALIZATION from the given environment dictionary.
+        /// </summary>
+        public static void ClearGlobalizationEnvironmentVars(System.Collections.IDictionary environment)
+        {
+            var keysToRemove = new List<string>();
+            foreach (System.Collections.DictionaryEntry entry in environment)
+            {
+                string key = entry.Key as string;
+                if (key == "LANG" || (key != null && key.StartsWith("DOTNET_SYSTEM_GLOBALIZATION", StringComparison.OrdinalIgnoreCase)))
+                {
+                    keysToRemove.Add(key);
+                }
+            }
+            foreach (var key in keysToRemove)
+            {
+                environment.Remove(key);
+            }
+        }
     }
 }

--- a/src/libraries/System.Memory/tests/Span/StringSearchValues.cs
+++ b/src/libraries/System.Memory/tests/Span/StringSearchValues.cs
@@ -597,7 +597,7 @@ namespace System.Memory.Tests.Span
             Assert.True(CanTestInvariantCulture);
 
             var psi = new ProcessStartInfo();
-            psi.Environment.Clear();
+            TestEnvironment.ClearGlobalizationEnvironmentVars(psi.Environment);
             psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "true");
 
             RemoteExecutor.Invoke(action, new RemoteInvokeOptions { StartInfo = psi, TimeOut = 10 * 60 * 1000 }).Dispose();
@@ -608,7 +608,7 @@ namespace System.Memory.Tests.Span
             Assert.True(CanTestNls);
 
             var psi = new ProcessStartInfo();
-            psi.Environment.Clear();
+            TestEnvironment.ClearGlobalizationEnvironmentVars(psi.Environment);
             psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_USENLS", "true");
 
             RemoteExecutor.Invoke(action, new RemoteInvokeOptions { StartInfo = psi, TimeOut = 10 * 60 * 1000 }).Dispose();

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -130,9 +130,7 @@ namespace System.Globalization.Tests
         public void CurrentCulture_BasedOnLangEnvVar(string langEnvVar, string expectedCultureName)
         {
             var psi = new ProcessStartInfo();
-            psi.Environment.Clear();
-
-            CopyEssentialTestEnvironment(psi.Environment);
+            TestEnvironment.ClearGlobalizationEnvironmentVars(psi.Environment);
 
             psi.Environment["LANG"] = langEnvVar;
 
@@ -154,9 +152,7 @@ namespace System.Globalization.Tests
         public void CurrentCulture_DefaultWithNoLang(string langEnvVar)
         {
             var psi = new ProcessStartInfo();
-            psi.Environment.Clear();
-
-            CopyEssentialTestEnvironment(psi.Environment);
+            TestEnvironment.ClearGlobalizationEnvironmentVars(psi.Environment);
 
             if (langEnvVar != null)
             {
@@ -186,21 +182,6 @@ namespace System.Globalization.Tests
                     Assert.Equal("", CultureInfo.CurrentUICulture.Name);
                 }
             }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
-        }
-
-        private static void CopyEssentialTestEnvironment(IDictionary<string, string> environment)
-        {
-            string[] essentialVariables = { "HOME", "LD_LIBRARY_PATH", "ICU_DATA" };
-            string[] prefixedVariables = { "DOTNET_", "COMPlus_", "SuperPMIShim" };
-
-            foreach (DictionaryEntry de in Environment.GetEnvironmentVariables())
-            {
-                if (Array.FindIndex(essentialVariables, x => x.Equals(de.Key)) >= 0 ||
-                    Array.FindIndex(prefixedVariables, x => ((string)de.Key).StartsWith(x, StringComparison.OrdinalIgnoreCase)) >= 0)
-                {
-                    environment[(string)de.Key] = (string)de.Value;
-                }
-            }
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/GetCultureInfo.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/GetCultureInfo.cs
@@ -147,7 +147,7 @@ namespace System.Globalization.Tests
         public void PredefinedCulturesOnlyEnvVarTest(string predefinedCulturesOnlyEnvVar, string cultureName)
         {
             var psi = new ProcessStartInfo();
-            psi.Environment.Clear();
+            TestEnvironment.ClearGlobalizationEnvironmentVars(psi.Environment);
 
             psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY", predefinedCulturesOnlyEnvVar);
 
@@ -176,7 +176,7 @@ namespace System.Globalization.Tests
         public void TestAllowInvariantCultureOnly(bool enableInvariant, bool predefinedCulturesOnly, bool declarePredefinedCulturesOnly)
         {
             var psi = new ProcessStartInfo();
-            psi.Environment.Clear();
+            TestEnvironment.ClearGlobalizationEnvironmentVars(psi.Environment);
 
             if (enableInvariant)
             {


### PR DESCRIPTION
This preserves most ambient varibles other than LANG and anything prefixed with DOTNET_SYSTEM_GLOBALIZATION.

Mostly done via copilot.

Fixes #100505