### PR TITLE
[DNS] Ignore ObjectDisposedException on CancellationToken Callback

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -456,8 +456,6 @@ namespace System.Net
                     }
                     catch (ObjectDisposedException)
                     {
-                        // Previously, there was a lock on this codepath, but it has been removed since .NET 7.0.
-                        // https://github.com/dotnet/runtime/pull/63904
                         // The handle was already released, so we don't need to call DangerousRelease.
                         // This can happen if the operation completed after we check for completion.
                         // We can ignore this exception.

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -456,7 +456,7 @@ namespace System.Net
                     }
                     catch (ObjectDisposedException)
                     {
-                        // There is a race between checking @this._completed and @this.DangerousAddRef and disposing form another thread.
+                        // There is a race between checking @this._completed and @this.DangerousAddRef and disposing from another thread.
                         // We lost the race. No further action needed.
                     }
                     finally

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -456,9 +456,8 @@ namespace System.Net
                     }
                     catch (ObjectDisposedException)
                     {
-                        // The handle was already released, so we don't need to call DangerousRelease.
-                        // This can happen if the operation completed after we check for completion.
-                        // We can ignore this exception.
+                        // There is a race between checking @this._completed and @this.DangerousAddRef and disposing form another thread.
+                        // We lost the race. No further action needed.
                     }
                     finally
                     {

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -454,6 +454,14 @@ namespace System.Net
                             NetEventSource.Info(@this, $"GetAddrInfoExCancel returned error {cancelResult}");
                         }
                     }
+                    catch (ObjectDisposedException)
+                    {
+                        // Previously, there was a lock on this codepath, but it has been removed since .NET 7.0.
+                        // https://github.com/dotnet/runtime/pull/63904
+                        // The handle was already released, so we don't need to call DangerousRelease.
+                        // This can happen if the operation completed after we check for completion.
+                        // We can ignore this exception.
+                    }
                     finally
                     {
                         if (needRelease)


### PR DESCRIPTION
Reported by 2 customers.

Previously, there was a lock on this codepath, but it has been removed since .NET 7.0, deleted in #63904 to handle different issue 