### PR TITLE
Add support for hot/cold code split based on instrumentation

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/FileLayoutOptimizer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/FileLayoutOptimizer.cs
@@ -29,6 +29,7 @@ namespace ILCompiler
         DefaultSort,
         ExclusiveWeight,
         HotCold,
+        InstrumentedHotCold,
         HotWarmCold,
 #if READYTORUN
         CallFrequency,
@@ -151,6 +152,10 @@ namespace ILCompiler
                     {
                         return MethodWithGCInfoToWeight(method) > 0 ? 0 : 1;
                     }
+                    break;
+
+                case MethodLayoutAlgorithm.InstrumentedHotCold:
+                    methods.MergeSortAllowDuplicates((MethodWithGCInfo left, MethodWithGCInfo right) => (_profileData[left.Method] != null).CompareTo(_profileData[right.Method] != null));
                     break;
 
                 case MethodLayoutAlgorithm.HotWarmCold:

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -427,6 +427,7 @@ namespace ILCompiler
                 "defaultsort" => MethodLayoutAlgorithm.DefaultSort,
                 "exclusiveweight" => MethodLayoutAlgorithm.ExclusiveWeight,
                 "hotcold" => MethodLayoutAlgorithm.HotCold,
+                "instrumentedhotcold" => MethodLayoutAlgorithm.InstrumentedHotCold,
                 "hotwarmcold" => MethodLayoutAlgorithm.HotWarmCold,
                 "pettishansen" => MethodLayoutAlgorithm.PettisHansen,
                 "random" => MethodLayoutAlgorithm.Random,

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -388,6 +388,7 @@ namespace ILCompiler
                 "defaultsort" => MethodLayoutAlgorithm.DefaultSort,
                 "exclusiveweight" => MethodLayoutAlgorithm.ExclusiveWeight,
                 "hotcold" => MethodLayoutAlgorithm.HotCold,
+                "instrumentedhotcold" => MethodLayoutAlgorithm.InstrumentedHotCold,
                 "hotwarmcold" => MethodLayoutAlgorithm.HotWarmCold,
                 "callfrequency" => MethodLayoutAlgorithm.CallFrequency,
                 "pettishansen" => MethodLayoutAlgorithm.PettisHansen,


### PR DESCRIPTION
The existing `MethodLayoutAlgorithm.HotCold` uses sampling data to do the split. Introduce a hot/cold split that is based on _any_ profile data for the method.