### PR TITLE
System.Formats.Tar: default to no ctime/atime.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
@@ -50,8 +50,8 @@ namespace System.Formats.Tar
         public GnuTarEntry(TarEntry other)
             : base(other, TarEntryFormat.Gnu)
         {
-            // Some tools don't accept GNU entries that have an atime/ctime.
-            // We only copy for round-tripping between GnuTarEntries.
+            // Some tools don't accept Gnu entries that have an atime/ctime.
+            // We only copy atime/ctime for round-tripping between GnuTarEntries and clear it for other formats.
             if (other is GnuTarEntry gnuOther)
             {
                 _header._aTime = gnuOther.AccessTime;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
@@ -34,10 +34,7 @@ namespace System.Formats.Tar
         /// <para><paramref name="entryType"/> is not supported in the specified format.</para></exception>
         public GnuTarEntry(TarEntryType entryType, string entryName)
             : base(entryType, entryName, TarEntryFormat.Gnu, isGea: false)
-        {
-            _header._aTime = default;
-            _header._cTime = default;
-        }
+        { }
 
         /// <summary>
         /// Initializes a new <see cref="GnuTarEntry"/> instance by converting the specified <paramref name="other"/> entry into the GNU format.
@@ -50,24 +47,7 @@ namespace System.Formats.Tar
         /// <para>The entry type of <paramref name="other"/> is not supported for conversion to the GNU format.</para></exception>
         public GnuTarEntry(TarEntry other)
             : base(other, TarEntryFormat.Gnu)
-        {
-            if (other is GnuTarEntry gnuOther)
-            {
-                _header._aTime = gnuOther.AccessTime;
-                _header._cTime = gnuOther.ChangeTime;
-                _header._gnuUnusedBytes = other._header._gnuUnusedBytes;
-            }
-            else
-            {
-                // 'other' was V7, Ustar (those formats do not have atime or ctime),
-                // or even PAX (which could contain atime and ctime in the ExtendedAttributes), but
-                // to avoid creating a GNU entry that might be incompatible with other tools,
-                // we avoid setting the atime and ctime fields. The user would have to set them manually
-                // if they are really needed.
-                _header._aTime = default;
-                _header._cTime = default;
-            }
-        }
+        { }
 
         /// <summary>
         /// A timestamp that represents the last time the file represented by this entry was accessed. Setting a value for this property is not recommended because most TAR reading tools do not support it.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace System.Formats.Tar
 {
     /// <summary>
@@ -47,7 +49,20 @@ namespace System.Formats.Tar
         /// <para>The entry type of <paramref name="other"/> is not supported for conversion to the GNU format.</para></exception>
         public GnuTarEntry(TarEntry other)
             : base(other, TarEntryFormat.Gnu)
-        { }
+        {
+            // Some tools don't accept GNU entries that have an atime/ctime.
+            // We only copy for round-tripping between GnuTarEntries.
+            if (other is GnuTarEntry gnuOther)
+            {
+                _header._aTime = gnuOther.AccessTime;
+                _header._cTime = gnuOther.ChangeTime;
+            }
+            else
+            {
+                Debug.Assert(_header._aTime == default);
+                Debug.Assert(_header._cTime == default);
+            }
+        }
 
         /// <summary>
         /// A timestamp that represents the last time the file represented by this entry was accessed. Setting a value for this property is not recommended because most TAR reading tools do not support it.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxGlobalExtendedAttributesTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxGlobalExtendedAttributesTarEntry.cs
@@ -28,7 +28,7 @@ namespace System.Formats.Tar
             : base(TarEntryType.GlobalExtendedAttributes, nameof(PaxGlobalExtendedAttributesTarEntry), TarEntryFormat.Pax, isGea: true) // Name == name of type for lack of a better temporary name until the entry is written
         {
             ArgumentNullException.ThrowIfNull(globalExtendedAttributes);
-            _header.InitializeExtendedAttributesWithExisting(globalExtendedAttributes);
+            _header.AddExtendedAttributes(globalExtendedAttributes);
         }
 
         /// <summary>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxTarEntry.cs
@@ -53,6 +53,12 @@ namespace System.Formats.Tar
         /// <item>In all platforms: <see cref="TarEntryType.Directory"/>, <see cref="TarEntryType.HardLink"/>, <see cref="TarEntryType.SymbolicLink"/>, <see cref="TarEntryType.RegularFile"/>.</item>
         /// <item>In Unix platforms only: <see cref="TarEntryType.BlockDevice"/>, <see cref="TarEntryType.CharacterDevice"/> and <see cref="TarEntryType.Fifo"/>.</item>
         /// </list>
+        /// The specified <paramref name="extendedAttributes"/> are additional attributes to be used for the entry.
+        /// <para>It may include PAX attributes like:</para>
+        /// <list type="bullet">
+        /// <item>Access time, under the name <c>atime</c>, as a <see cref="double"/> number.</item>
+        /// <item>Change time, under the name <c>ctime</c>, as a <see cref="double"/> number.</item>
+        /// </list>
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="extendedAttributes"/> or <paramref name="entryName"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><para><paramref name="entryName"/> is empty.</para>
@@ -104,7 +110,18 @@ namespace System.Formats.Tar
         /// <summary>
         /// Returns the extended attributes for this entry.
         /// </summary>
-        /// <remarks>The extended attributes are specified when constructing an entry and updated with additional attributes when the entry is written. Use <see cref="PaxTarEntry(TarEntryType, string, IEnumerable{KeyValuePair{string, string}})"/> to append custom extended attributes.</remarks>
+        /// <remarks>The extended attributes are specified when constructing an entry and updated with additional attributes when the entry is written. Use <see cref="PaxTarEntry(TarEntryType, string, IEnumerable{KeyValuePair{string, string}})"/> to append custom extended attributes.
+        /// <para>The following common PAX attributes may be included:</para>
+        /// <list type="bullet">
+        /// <item>Modification time, under the name <c>mtime</c>, as a <see cref="double"/> number.</item>
+        /// <item>Access time, under the name <c>atime</c>, as a <see cref="double"/> number.</item>
+        /// <item>Change time, under the name <c>ctime</c>, as a <see cref="double"/> number.</item>
+        /// <item>Path, under the name <c>path</c>, as a string.</item>
+        /// <item>Group name, under the name <c>gname</c>, as a string.</item>
+        /// <item>User name, under the name <c>uname</c>, as a string.</item>
+        /// <item>File length, under the name <c>size</c>, as an <see cref="int"/>.</item>
+        /// </list>
+        /// </remarks>
         public IReadOnlyDictionary<string, string> ExtendedAttributes => _readOnlyExtendedAttributes ??= _header.ExtendedAttributes.AsReadOnly();
 
         // Determines if the current instance's entry type supports setting a data stream.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxTarEntry.cs
@@ -21,7 +21,7 @@ namespace System.Formats.Tar
         }
 
         /// <summary>
-        /// Initializes a new <see cref="PaxTarEntry"/> instance with the specified entry type, entry name, and the default extended attributes.
+        /// Initializes a new <see cref="PaxTarEntry"/> instance with the specified entry type and entry name.
         /// </summary>
         /// <param name="entryType">The type of the entry.</param>
         /// <param name="entryName">A string with the path and file name of this entry.</param>
@@ -30,20 +30,7 @@ namespace System.Formats.Tar
         /// <item>In all platforms: <see cref="TarEntryType.Directory"/>, <see cref="TarEntryType.HardLink"/>, <see cref="TarEntryType.SymbolicLink"/>, <see cref="TarEntryType.RegularFile"/>.</item>
         /// <item>In Unix platforms only: <see cref="TarEntryType.BlockDevice"/>, <see cref="TarEntryType.CharacterDevice"/> and <see cref="TarEntryType.Fifo"/>.</item>
         /// </list>
-        /// <para>Use the <see cref="PaxTarEntry(TarEntryType, string, IEnumerable{KeyValuePair{string, string}})"/> constructor to include additional extended attributes when creating the entry.</para>
-        /// <para>The following entries are always found in the Extended Attributes dictionary of any PAX entry:</para>
-        /// <list type="bullet">
-        /// <item>Modification time, under the name <c>mtime</c>, as a <see cref="double"/> number.</item>
-        /// <item>Access time, under the name <c>atime</c>, as a <see cref="double"/> number.</item>
-        /// <item>Change time, under the name <c>ctime</c>, as a <see cref="double"/> number.</item>
-        /// <item>Path, under the name <c>path</c>, as a string.</item>
-        /// </list>
-        /// <para>The following entries are only found in the Extended Attributes dictionary of a PAX entry if certain conditions are met:</para>
-        /// <list type="bullet">
-        /// <item>Group name, under the name <c>gname</c>, as a string, if it is larger than 32 bytes.</item>
-        /// <item>User name, under the name <c>uname</c>, as a string, if it is larger than 32 bytes.</item>
-        /// <item>File length, under the name <c>size</c>, as an <see cref="int"/>, if the string representation of the number is larger than 12 bytes.</item>
-        /// </list>
+        /// <para>Use the <see cref="PaxTarEntry(TarEntryType, string, IEnumerable{KeyValuePair{string, string}})"/> constructor to include extended attributes when creating the entry.</para>
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="entryName"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><para><paramref name="entryName"/> is empty.</para>
@@ -53,13 +40,10 @@ namespace System.Formats.Tar
             : base(entryType, entryName, TarEntryFormat.Pax, isGea: false)
         {
             _header._prefix = string.Empty;
-
-            Debug.Assert(_header._mTime != default);
-            AddNewAccessAndChangeTimestampsIfNotExist(useMTime: true);
         }
 
         /// <summary>
-        /// Initializes a new <see cref="PaxTarEntry"/> instance with the specified entry type, entry name and Extended Attributes enumeration.
+        /// Initializes a new <see cref="PaxTarEntry"/> instance with the specified entry type, entry name and extended attributes.
         /// </summary>
         /// <param name="entryType">The type of the entry.</param>
         /// <param name="entryName">A string with the path and file name of this entry.</param>
@@ -68,20 +52,6 @@ namespace System.Formats.Tar
         /// <list type="bullet">
         /// <item>In all platforms: <see cref="TarEntryType.Directory"/>, <see cref="TarEntryType.HardLink"/>, <see cref="TarEntryType.SymbolicLink"/>, <see cref="TarEntryType.RegularFile"/>.</item>
         /// <item>In Unix platforms only: <see cref="TarEntryType.BlockDevice"/>, <see cref="TarEntryType.CharacterDevice"/> and <see cref="TarEntryType.Fifo"/>.</item>
-        /// </list>
-        /// The specified <paramref name="extendedAttributes"/> get appended to the default attributes, unless the specified enumeration overrides any of them.
-        /// <para>The following entries are always found in the Extended Attributes dictionary of any PAX entry:</para>
-        /// <list type="bullet">
-        /// <item>Modification time, under the name <c>mtime</c>, as a <see cref="double"/> number.</item>
-        /// <item>Access time, under the name <c>atime</c>, as a <see cref="double"/> number.</item>
-        /// <item>Change time, under the name <c>ctime</c>, as a <see cref="double"/> number.</item>
-        /// <item>Path, under the name <c>path</c>, as a string.</item>
-        /// </list>
-        /// <para>The following entries are only found in the Extended Attributes dictionary of a PAX entry if certain conditions are met:</para>
-        /// <list type="bullet">
-        /// <item>Group name, under the name <c>gname</c>, as a string, if it is larger than 32 bytes.</item>
-        /// <item>User name, under the name <c>uname</c>, as a string, if it is larger than 32 bytes.</item>
-        /// <item>File length, under the name <c>size</c>, as an <see cref="int"/>, if the string representation of the number is larger than 12 bytes.</item>
         /// </list>
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="extendedAttributes"/> or <paramref name="entryName"/> is <see langword="null"/>.</exception>
@@ -94,10 +64,7 @@ namespace System.Formats.Tar
             ArgumentNullException.ThrowIfNull(extendedAttributes);
 
             _header._prefix = string.Empty;
-            _header.InitializeExtendedAttributesWithExisting(extendedAttributes);
-
-            Debug.Assert(_header._mTime != default);
-            AddNewAccessAndChangeTimestampsIfNotExist(useMTime: true);
+            _header.AddExtendedAttributes(extendedAttributes);
         }
 
         /// <summary>
@@ -119,72 +86,28 @@ namespace System.Formats.Tar
 
             if (other is PaxTarEntry paxOther)
             {
-                _header.InitializeExtendedAttributesWithExisting(paxOther.ExtendedAttributes);
+                _header.AddExtendedAttributes(paxOther.ExtendedAttributes);
             }
-            else
+            else if (other is GnuTarEntry gnuOther)
             {
-                if (other is GnuTarEntry gnuOther)
+                if (gnuOther.AccessTime != default)
                 {
-                    if (gnuOther.AccessTime != default)
-                    {
-                        _header.ExtendedAttributes[TarHeader.PaxEaATime] = TarHelpers.GetTimestampStringFromDateTimeOffset(gnuOther.AccessTime);
-                    }
-                    if (gnuOther.ChangeTime != default)
-                    {
-                        _header.ExtendedAttributes[TarHeader.PaxEaCTime] = TarHelpers.GetTimestampStringFromDateTimeOffset(gnuOther.ChangeTime);
-                    }
+                    _header.ExtendedAttributes[TarHeader.PaxEaATime] = TarHelpers.GetTimestampStringFromDateTimeOffset(gnuOther.AccessTime);
+                }
+                if (gnuOther.ChangeTime != default)
+                {
+                    _header.ExtendedAttributes[TarHeader.PaxEaCTime] = TarHelpers.GetTimestampStringFromDateTimeOffset(gnuOther.ChangeTime);
                 }
             }
-
-            AddNewAccessAndChangeTimestampsIfNotExist(useMTime: false);
         }
 
         /// <summary>
         /// Returns the extended attributes for this entry.
         /// </summary>
-        /// <remarks>The extended attributes are specified when constructing an entry. Use <see cref="PaxTarEntry(TarEntryType, string, IEnumerable{KeyValuePair{string, string}})"/> to append your own enumeration of extended attributes to the current entry on top of the default ones. Use <see cref="PaxTarEntry(TarEntryType, string)"/> to only use the default extended attributes.
-        /// <para>The following entries are always found in the Extended Attributes dictionary of any PAX entry:</para>
-        /// <list type="bullet">
-        /// <item>Modification time, under the name <c>mtime</c>, as a <see cref="double"/> number.</item>
-        /// <item>Access time, under the name <c>atime</c>, as a <see cref="double"/> number.</item>
-        /// <item>Change time, under the name <c>ctime</c>, as a <see cref="double"/> number.</item>
-        /// <item>Path, under the name <c>path</c>, as a string.</item>
-        /// </list>
-        /// <para>The following entries are only found in the Extended Attributes dictionary of a PAX entry if certain conditions are met:</para>
-        /// <list type="bullet">
-        /// <item>Group name, under the name <c>gname</c>, as a string, if it is larger than 32 bytes.</item>
-        /// <item>User name, under the name <c>uname</c>, as a string, if it is larger than 32 bytes.</item>
-        /// <item>File length, under the name <c>size</c>, as an <see cref="int"/>, if the string representation of the number is larger than 12 bytes.</item>
-        /// </list>
-        /// </remarks>
+        /// <remarks>The extended attributes are specified when constructing an entry and updated with additional attributes when the entry is written. Use <see cref="PaxTarEntry(TarEntryType, string, IEnumerable{KeyValuePair{string, string}})"/> to append custom extended attributes.</remarks>
         public IReadOnlyDictionary<string, string> ExtendedAttributes => _readOnlyExtendedAttributes ??= _header.ExtendedAttributes.AsReadOnly();
 
         // Determines if the current instance's entry type supports setting a data stream.
         internal override bool IsDataStreamSetterSupported() => EntryType == TarEntryType.RegularFile;
-
-        // Checks if the extended attributes dictionary contains 'atime' and 'ctime'.
-        // If any of them is not found, it is added with the value of either the current entry's 'mtime',
-        // or 'DateTimeOffset.UtcNow', depending on the value of 'useMTime'.
-        private void AddNewAccessAndChangeTimestampsIfNotExist(bool useMTime)
-        {
-            Debug.Assert(!useMTime || (useMTime && _header._mTime != default));
-            bool containsATime = _header.ExtendedAttributes.ContainsKey(TarHeader.PaxEaATime);
-            bool containsCTime = _header.ExtendedAttributes.ContainsKey(TarHeader.PaxEaCTime);
-
-            if (!containsATime || !containsCTime)
-            {
-                string secondsFromEpochString = TarHelpers.GetTimestampStringFromDateTimeOffset(useMTime ? _header._mTime : DateTimeOffset.UtcNow);
-
-                if (!containsATime)
-                {
-                    _header.ExtendedAttributes[TarHeader.PaxEaATime] = secondsFromEpochString;
-                }
-
-                if (!containsCTime)
-                {
-                    _header.ExtendedAttributes[TarHeader.PaxEaCTime] = secondsFromEpochString;
-                }
-            }
-        }
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -790,19 +790,8 @@ namespace System.Formats.Tar
 
             if (_typeFlag is not TarEntryType.LongLink and not TarEntryType.LongPath)
             {
-                if (_aTime != default)
-                {
-                    checksum += WriteAsTimestamp(_aTime, buffer.Slice(FieldLocations.ATime, FieldLengths.ATime));
-                }
-                if (_cTime != default)
-                {
-                    checksum += WriteAsTimestamp(_cTime, buffer.Slice(FieldLocations.CTime, FieldLengths.CTime));
-                }
-            }
-
-            if (_gnuUnusedBytes != null)
-            {
-                checksum += WriteLeftAlignedBytesAndGetChecksum(_gnuUnusedBytes, buffer.Slice(FieldLocations.GnuUnused, FieldLengths.AllGnuUnused));
+                checksum += WriteAsTimestamp(_aTime, buffer.Slice(FieldLocations.ATime, FieldLengths.ATime));
+                checksum += WriteAsTimestamp(_cTime, buffer.Slice(FieldLocations.CTime, FieldLengths.CTime));
             }
 
             return checksum;
@@ -1179,6 +1168,12 @@ namespace System.Formats.Tar
         // Writes the specified DateTimeOffset's Unix time seconds, and returns its checksum.
         private int WriteAsTimestamp(DateTimeOffset timestamp, Span<byte> destination)
         {
+            // For 'default' we leave the buffer zero-ed to indicate: "no timestamp".
+            if (timestamp == default)
+            {
+                return 0;
+            }
+
             long unixTimeSeconds = timestamp.ToUnixTimeSeconds();
             return FormatNumeric(unixTimeSeconds, destination);
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -82,10 +82,6 @@ namespace System.Formats.Tar
         internal DateTimeOffset _aTime;
         internal DateTimeOffset _cTime;
 
-        // If the archive is GNU and the offset, longnames, unused, sparse, isextended and realsize
-        // fields have data, we store it to avoid data loss, but we don't yet expose it publicly.
-        internal byte[]? _gnuUnusedBytes;
-
         // Constructor called when creating an entry with default common fields.
         internal TarHeader(TarEntryFormat format, string name = "", int mode = 0, DateTimeOffset mTime = default, TarEntryType typeFlag = TarEntryType.RegularFile)
         {
@@ -112,7 +108,7 @@ namespace System.Formats.Tar
             _dataStream = other._dataStream;
         }
 
-        internal void InitializeExtendedAttributesWithExisting(IEnumerable<KeyValuePair<string, string>> existing)
+        internal void AddExtendedAttributes(IEnumerable<KeyValuePair<string, string>> existing)
         {
             Debug.Assert(_ea == null);
             Debug.Assert(existing != null);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -106,8 +106,6 @@ namespace System.Formats.Tar
             _checksum = other._checksum;
             _linkName = other._linkName;
             _dataStream = other._dataStream;
-            _aTime = other._aTime;
-            _cTime = other._cTime;
         }
 
         internal void AddExtendedAttributes(IEnumerable<KeyValuePair<string, string>> existing)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -106,6 +106,8 @@ namespace System.Formats.Tar
             _checksum = other._checksum;
             _linkName = other._linkName;
             _dataStream = other._dataStream;
+            _aTime = other._aTime;
+            _cTime = other._cTime;
         }
 
         internal void AddExtendedAttributes(IEnumerable<KeyValuePair<string, string>> existing)

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Conversion.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/GnuTarEntry.Conversion.Tests.cs
@@ -13,6 +13,8 @@ namespace System.Formats.Tar.Tests
 {
     public class GnuTarEntry_Conversion_Tests : TarTestsConversionBase
     {
+        protected override TarEntryFormat FormatUnderTest => TarEntryFormat.Gnu;
+
         [Fact]
         public void Constructor_ConversionFromV7_RegularFile() => TestConstructionConversion(TarEntryType.RegularFile, TarEntryFormat.V7, TarEntryFormat.Gnu);
 

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Conversion.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Conversion.Tests.cs
@@ -13,6 +13,8 @@ namespace System.Formats.Tar.Tests
 {
     public class PaxTarEntry_Conversion_Tests : TarTestsConversionBase
     {
+        protected override TarEntryFormat FormatUnderTest => TarEntryFormat.Pax;
+
         [Fact]
         public void Constructor_ConversionFromV7_RegularFile() => TestConstructionConversion(TarEntryType.RegularFile, TarEntryFormat.V7, TarEntryFormat.Pax);
 

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Conversion.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Conversion.Tests.cs
@@ -92,8 +92,8 @@ namespace System.Formats.Tar.Tests
             dataStream.Position = 0;
             originalEntry.DataStream = dataStream;
 
-            DateTimeOffset expectedATime = default;
-            DateTimeOffset expectedCTime = default;
+            DateTimeOffset? expectedATime = null;
+            DateTimeOffset? expectedCTime = null;
 
             if (originalEntry is GnuTarEntry gnuEntry)
             {
@@ -108,11 +108,9 @@ namespace System.Formats.Tar.Tests
             }
             else if (originalEntry is PaxTarEntry paxEntry)
             {
-                expectedATime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaATime);
-                expectedCTime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaCTime);
+                expectedATime = TryGetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaATime);
+                expectedCTime = TryGetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaCTime);
 
-                Assert.Equal(paxEntry.ModificationTime, expectedATime);
-                Assert.Equal(paxEntry.ModificationTime, expectedCTime);
                 // Can't change them, it's a read-only dictionary
             }
 
@@ -140,19 +138,11 @@ namespace System.Formats.Tar.Tests
                     Assert.Equal(contents, streamReader.ReadLine());
                 }
 
-                // atime and ctime should've been added automatically in the conversion constructor
-                // and should not be equal to the value of mtime, which was set on the original entry constructor
+                DateTimeOffset? atime = TryGetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaATime);
+                DateTimeOffset? ctime = TryGetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaCTime);
 
-                Assert.Contains(PaxEaATime, paxEntry.ExtendedAttributes);
-                Assert.Contains(PaxEaCTime, paxEntry.ExtendedAttributes);
-                DateTimeOffset atime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes[PaxEaATime]);
-                DateTimeOffset ctime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes[PaxEaCTime]);
-
-                if (originalEntryFormat is TarEntryFormat.Pax or TarEntryFormat.Gnu)
-                {
-                    Assert.Equal(expectedATime, atime);
-                    Assert.Equal(expectedCTime, ctime);
-                }
+                Assert.Equal(expectedATime, atime);
+                Assert.Equal(expectedCTime, ctime);
             }
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/TarEntry.Conversion.Tests.Base.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/TarEntry.Conversion.Tests.Base.cs
@@ -69,10 +69,8 @@ namespace System.Formats.Tar.Tests
             if (format is TarEntryFormat.Pax)
             {
                 PaxTarEntry paxEntry = firstEntry as PaxTarEntry;
-                Assert.Contains("atime", paxEntry.ExtendedAttributes);
-                Assert.Contains("ctime", paxEntry.ExtendedAttributes);
-                Assert.Equal(firstEntry.ModificationTime, GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, "atime"));
-                Assert.Equal(firstEntry.ModificationTime, GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, "ctime"));
+                Assert.DoesNotContain("atime", paxEntry.ExtendedAttributes);
+                Assert.DoesNotContain("ctime", paxEntry.ExtendedAttributes);
             }
             else if (format is TarEntryFormat.Gnu)
             {
@@ -115,98 +113,64 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(originalPosixTarEntry.DeviceMinor, convertedPosixTarEntry.DeviceMinor);
             }
 
+            // 'null' indicates the originalEntry did not include a timestamp.
+            DateTimeOffset? expectedATime = null, expectedCTime = null;
+            if (originalEntry.Format is TarEntryFormat.Pax or TarEntryFormat.Gnu)
+            {
+                GetExpectedTimestampsFromOriginalPaxOrGnu(originalEntry, formatToConvert, out expectedATime, out expectedCTime);
+            }
+
             if (formatToConvert is TarEntryFormat.Pax)
             {
                 PaxTarEntry paxEntry = convertedEntry as PaxTarEntry;
-                if (originalEntry.Format is TarEntryFormat.Gnu)
-                {
-                    GnuTarEntry gnuEntry = originalEntry as GnuTarEntry;
-
-                    DateTimeOffset expectedATime = gnuEntry.AccessTime;
-                    DateTimeOffset expectedCTime = gnuEntry.ChangeTime;
-
-                    DateTimeOffset actualAccessTime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaATime);
-                    DateTimeOffset actualChangeTime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaCTime);
-
-                    if (expectedATime == default)
-                    {
-                        AssertExtensions.GreaterThanOrEqualTo(actualAccessTime, paxEntry.ModificationTime);
-                    }
-                    else
-                    {
-                        expectedATime = expectedATime - _oneSecond;
-                        AssertExtensions.GreaterThanOrEqualTo(expectedATime, actualAccessTime);
-                    }
-
-                    if (expectedCTime == default)
-                    {
-                        AssertExtensions.GreaterThanOrEqualTo(actualChangeTime, paxEntry.ModificationTime);
-                    }
-                    else
-                    {
-                        expectedCTime = expectedCTime - _oneSecond;
-                        AssertExtensions.GreaterThanOrEqualTo(expectedCTime, actualChangeTime);
-                    }
-                }
-                else if (originalEntry.Format is TarEntryFormat.Pax)
-                {
-                    PaxTarEntry originalPaxEntry = originalEntry as PaxTarEntry;
-
-                    DateTimeOffset expectedATime = GetDateTimeOffsetFromTimestampString(originalPaxEntry.ExtendedAttributes, PaxEaATime) - _oneSecond;
-                    DateTimeOffset expectedCTime = GetDateTimeOffsetFromTimestampString(originalPaxEntry.ExtendedAttributes, PaxEaCTime) - _oneSecond;
-
-                    DateTimeOffset actualAccessTime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaATime);
-                    DateTimeOffset actualChangeTime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaCTime);
-
-                    AssertExtensions.GreaterThanOrEqualTo(actualAccessTime, expectedATime);
-                    AssertExtensions.GreaterThanOrEqualTo(actualChangeTime, expectedCTime);
-                }
-                else if (originalEntry.Format is TarEntryFormat.Ustar or TarEntryFormat.V7)
-                {
-                    DateTimeOffset actualAccessTime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaATime);
-                    DateTimeOffset actualChangeTime = GetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaCTime);
-
-                    AssertExtensions.GreaterThanOrEqualTo(actualAccessTime, initialNow);
-                    AssertExtensions.GreaterThanOrEqualTo(actualChangeTime, initialNow);
-                }
+                DateTimeOffset? actualAccessTime = TryGetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaATime);
+                DateTimeOffset? actualChangeTime = TryGetDateTimeOffsetFromTimestampString(paxEntry.ExtendedAttributes, PaxEaCTime);
+                Assert.Equal(expectedATime, actualAccessTime);
+                Assert.Equal(expectedCTime, actualChangeTime);
             }
-
-            if (formatToConvert is TarEntryFormat.Gnu)
+            else if (formatToConvert is TarEntryFormat.Gnu)
             {
                 GnuTarEntry gnuEntry = convertedEntry as GnuTarEntry;
-                if (originalEntry.Format is TarEntryFormat.Pax or TarEntryFormat.Gnu)
-                {
-                    GetExpectedTimestampsFromOriginalPaxOrGnu(originalEntry, formatToConvert, out DateTimeOffset expectedATime, out DateTimeOffset expectedCTime);
-                    AssertExtensions.GreaterThanOrEqualTo(gnuEntry.AccessTime, expectedATime);
-                    AssertExtensions.GreaterThanOrEqualTo(gnuEntry.ChangeTime, expectedCTime);
-                }
-                else if (originalEntry.Format is TarEntryFormat.Ustar or TarEntryFormat.V7)
-                {
-                    Assert.Equal(default, gnuEntry.AccessTime);
-                    Assert.Equal(default, gnuEntry.ChangeTime);
-                }
+                Assert.Equal(expectedATime ?? default, gnuEntry.AccessTime);
+                Assert.Equal(expectedCTime ?? default, gnuEntry.ChangeTime);
             }
 
             return convertedEntry;
         }
 
-        private void GetExpectedTimestampsFromOriginalPaxOrGnu(TarEntry originalEntry, TarEntryFormat formatToConvert, out DateTimeOffset expectedATime, out DateTimeOffset expectedCTime)
+        private void GetExpectedTimestampsFromOriginalPaxOrGnu(TarEntry originalEntry, TarEntryFormat formatToConvert, out DateTimeOffset? expectedATime, out DateTimeOffset? expectedCTime)
         {
             Assert.True(originalEntry.Format is TarEntryFormat.Gnu or TarEntryFormat.Pax);
             if (originalEntry.Format is TarEntryFormat.Pax)
             {
                 PaxTarEntry originalPaxEntry = originalEntry as PaxTarEntry;
-                Assert.Contains("atime", originalPaxEntry.ExtendedAttributes); //  We are verifying that the original had an atime and ctime set
-                Assert.Contains("ctime", originalPaxEntry.ExtendedAttributes); //  and that when converting to GNU we are _not_ preserving them
-                // And that instead, we are setting them to MinValue
-                expectedATime = formatToConvert is TarEntryFormat.Gnu ? default : GetDateTimeOffsetFromTimestampString(originalPaxEntry.ExtendedAttributes, "atime");
-                expectedCTime = formatToConvert is TarEntryFormat.Gnu ? default : GetDateTimeOffsetFromTimestampString(originalPaxEntry.ExtendedAttributes, "ctime");
+
+                expectedATime = null;
+                if (originalPaxEntry.ExtendedAttributes.ContainsKey("atime"))
+                {
+                    expectedATime = GetDateTimeOffsetFromTimestampString(originalPaxEntry.ExtendedAttributes, "atime");
+                }
+
+                expectedCTime = null;
+                if (originalPaxEntry.ExtendedAttributes.ContainsKey("ctime"))
+                {
+                    expectedCTime = GetDateTimeOffsetFromTimestampString(originalPaxEntry.ExtendedAttributes, "ctime");
+                }
             }
             else
             {
                 GnuTarEntry originalGnuEntry = originalEntry as GnuTarEntry;
                 expectedATime = originalGnuEntry.AccessTime;
+                // default means: no timestamp.
+                if (expectedATime == default(DateTimeOffset))
+                {
+                    expectedATime = null;
+                }
                 expectedCTime = originalGnuEntry.ChangeTime;
+                if (expectedCTime == default(DateTimeOffset))
+                {
+                    expectedCTime = null;
+                }
             }
 
         }

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Conversion.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/UstarTarEntry.Conversion.Tests.cs
@@ -13,6 +13,8 @@ namespace System.Formats.Tar.Tests
 {
     public class UstarTarEntry_Conversion_Tests : TarTestsConversionBase
     {
+        protected override TarEntryFormat FormatUnderTest => TarEntryFormat.Ustar;
+
         [Fact]
         public void Constructor_ConversionFromV7_RegularFile() => TestConstructionConversion(TarEntryType.RegularFile, TarEntryFormat.V7, TarEntryFormat.Ustar);
 

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/V7TarEntry.Conversion.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/V7TarEntry.Conversion.Tests.cs
@@ -13,6 +13,8 @@ namespace System.Formats.Tar.Tests
 {
     public class V7TarEntry_Conversion_Tests : TarTestsConversionBase
     {
+        protected override TarEntryFormat FormatUnderTest => TarEntryFormat.V7;
+
         [Fact]
         public void Constructor_Conversion_UnsupportedEntryTypes_Ustar()
         {

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
@@ -113,7 +113,7 @@ namespace System.Formats.Tar.Tests
             using (var reader = new TarReader(stream))
             {
                 PaxTarEntry entry = Assert.IsType<PaxTarEntry>(reader.GetNextEntry());
-                Assert.Equal(5, entry.ExtendedAttributes.Count);
+                Assert.Equal(3, entry.ExtendedAttributes.Count);
                 Assert.Contains(KeyValuePair.Create(key, value), entry.ExtendedAttributes);
                 Assert.Null(reader.GetNextEntry());
             }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
@@ -87,9 +87,6 @@ namespace System.Formats.Tar.Tests
         private DateTimeOffset GetDateTimeOffsetFromSecondsSinceEpoch(decimal secondsSinceUnixEpoch) =>
             new DateTimeOffset((long)(secondsSinceUnixEpoch * TimeSpan.TicksPerSecond) + DateTime.UnixEpoch.Ticks, TimeSpan.Zero);
 
-        private decimal GetSecondsSinceEpochFromDateTimeOffset(DateTimeOffset value) =>
-            ((decimal)(value.UtcDateTime - DateTime.UnixEpoch).Ticks) / TimeSpan.TicksPerSecond;
-
         protected DateTimeOffset? TryGetDateTimeOffsetFromTimestampString(IReadOnlyDictionary<string, string> ea, string fieldName)
         {
             if (!ea.ContainsKey(fieldName))
@@ -109,12 +106,6 @@ namespace System.Formats.Tar.Tests
         {
             Assert.True(decimal.TryParse(strNumber, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal secondsSinceEpoch));
             return GetDateTimeOffsetFromSecondsSinceEpoch(secondsSinceEpoch);
-        }
-
-        protected string GetTimestampStringFromDateTimeOffset(DateTimeOffset timestamp)
-        {
-            decimal secondsSinceEpoch = GetSecondsSinceEpochFromDateTimeOffset(timestamp);
-            return secondsSinceEpoch.ToString("G", CultureInfo.InvariantCulture);
         }
 
         protected void VerifyExtendedAttributeTimestamp(PaxTarEntry paxEntry, string fieldName, DateTimeOffset minimumTime)

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
@@ -90,6 +90,15 @@ namespace System.Formats.Tar.Tests
         private decimal GetSecondsSinceEpochFromDateTimeOffset(DateTimeOffset value) =>
             ((decimal)(value.UtcDateTime - DateTime.UnixEpoch).Ticks) / TimeSpan.TicksPerSecond;
 
+        protected DateTimeOffset? TryGetDateTimeOffsetFromTimestampString(IReadOnlyDictionary<string, string> ea, string fieldName)
+        {
+            if (!ea.ContainsKey(fieldName))
+            {
+                return default;
+            }
+            return GetDateTimeOffsetFromTimestampString(ea[fieldName]);
+        }
+
         protected DateTimeOffset GetDateTimeOffsetFromTimestampString(IReadOnlyDictionary<string, string> ea, string fieldName)
         {
             Assert.Contains(fieldName, ea);
@@ -117,11 +126,9 @@ namespace System.Formats.Tar.Tests
         protected void VerifyExtendedAttributeTimestamps(PaxTarEntry pax)
         {
             Assert.NotNull(pax.ExtendedAttributes);
-            AssertExtensions.GreaterThanOrEqualTo(pax.ExtendedAttributes.Count, 3); // Expect to at least collect mtime, ctime and atime
+            AssertExtensions.GreaterThanOrEqualTo(pax.ExtendedAttributes.Count, 1); // Expect to at least collect mtime
 
             VerifyExtendedAttributeTimestamp(pax, PaxEaMTime, MinimumTime);
-            VerifyExtendedAttributeTimestamp(pax, PaxEaATime, MinimumTime);
-            VerifyExtendedAttributeTimestamp(pax, PaxEaCTime, MinimumTime);
         }
 
         public static IEnumerable<object[]> GetPaxExtendedAttributesRoundtripTestData()

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
@@ -182,12 +182,10 @@ namespace System.Formats.Tar.Tests
                 Assert.NotNull(regularFile.ExtendedAttributes);
 
                 // path, mtime, atime and ctime are always collected by default
-                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 5);
+                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 3);
 
                 Assert.Contains(PaxEaName, regularFile.ExtendedAttributes);
                 Assert.Contains(PaxEaMTime, regularFile.ExtendedAttributes);
-                Assert.Contains(PaxEaATime, regularFile.ExtendedAttributes);
-                Assert.Contains(PaxEaCTime, regularFile.ExtendedAttributes);
 
                 Assert.Contains(expectedKey, regularFile.ExtendedAttributes);
                 Assert.Equal(expectedValue, regularFile.ExtendedAttributes[expectedKey]);
@@ -210,10 +208,8 @@ namespace System.Formats.Tar.Tests
             {
                 PaxTarEntry regularFile = reader.GetNextEntry() as PaxTarEntry;
 
-                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 4);
+                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 2);
                 VerifyExtendedAttributeTimestamp(regularFile, PaxEaMTime, minimumTime);
-                VerifyExtendedAttributeTimestamp(regularFile, PaxEaATime, minimumTime);
-                VerifyExtendedAttributeTimestamp(regularFile, PaxEaCTime, minimumTime);
             }
         }
 
@@ -269,13 +265,11 @@ namespace System.Formats.Tar.Tests
 
                 Assert.NotNull(regularFile.ExtendedAttributes);
 
-                // path, mtime, atime and ctime are always collected by default
-                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 6);
+                // path, mtime are always collected by default
+                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 4);
 
                 Assert.Contains(PaxEaName, regularFile.ExtendedAttributes);
                 Assert.Contains(PaxEaMTime, regularFile.ExtendedAttributes);
-                Assert.Contains(PaxEaATime, regularFile.ExtendedAttributes);
-                Assert.Contains(PaxEaCTime, regularFile.ExtendedAttributes);
 
                 Assert.Contains(PaxEaUName, regularFile.ExtendedAttributes);
                 Assert.Equal(userName, regularFile.ExtendedAttributes[PaxEaUName]);
@@ -304,7 +298,7 @@ namespace System.Formats.Tar.Tests
             {
                 PaxTarEntry regularFile = reader.GetNextEntry() as PaxTarEntry;
 
-                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 4);
+                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 2);
                 Assert.Contains(PaxEaName, regularFile.ExtendedAttributes);
             }
         }
@@ -332,7 +326,7 @@ namespace System.Formats.Tar.Tests
             {
                 PaxTarEntry symlink = reader.GetNextEntry() as PaxTarEntry;
 
-                AssertExtensions.GreaterThanOrEqualTo(symlink.ExtendedAttributes.Count, 5);
+                AssertExtensions.GreaterThanOrEqualTo(symlink.ExtendedAttributes.Count, 3);
 
                 Assert.Contains(PaxEaName, symlink.ExtendedAttributes);
                 Assert.Equal("symlink", symlink.ExtendedAttributes[PaxEaName]);
@@ -341,7 +335,7 @@ namespace System.Formats.Tar.Tests
 
                 PaxTarEntry hardlink = reader.GetNextEntry() as PaxTarEntry;
 
-                AssertExtensions.GreaterThanOrEqualTo(hardlink.ExtendedAttributes.Count, 5);
+                AssertExtensions.GreaterThanOrEqualTo(hardlink.ExtendedAttributes.Count, 3);
 
                 Assert.Contains(PaxEaName, hardlink.ExtendedAttributes);
                 Assert.Equal("hardlink", hardlink.ExtendedAttributes[PaxEaName]);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
@@ -198,12 +198,10 @@ namespace System.Formats.Tar.Tests
                     Assert.NotNull(regularFile.ExtendedAttributes);
 
                     // path, mtime, atime and ctime are always collected by default
-                    AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 5);
+                    AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 3);
 
                     Assert.Contains(PaxEaName, regularFile.ExtendedAttributes);
                     Assert.Contains(PaxEaMTime, regularFile.ExtendedAttributes);
-                    Assert.Contains(PaxEaATime, regularFile.ExtendedAttributes);
-                    Assert.Contains(PaxEaCTime, regularFile.ExtendedAttributes);
 
                     Assert.Contains(expectedKey, regularFile.ExtendedAttributes);
                     Assert.Equal(expectedValue, regularFile.ExtendedAttributes[expectedKey]);
@@ -228,10 +226,8 @@ namespace System.Formats.Tar.Tests
                 {
                     PaxTarEntry regularFile = await reader.GetNextEntryAsync() as PaxTarEntry;
 
-                    AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 4);
+                    AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 2);
                     VerifyExtendedAttributeTimestamp(regularFile, PaxEaMTime, minimumTime);
-                    VerifyExtendedAttributeTimestamp(regularFile, PaxEaATime, minimumTime);
-                    VerifyExtendedAttributeTimestamp(regularFile, PaxEaCTime, minimumTime);
                 }
             }
         }
@@ -291,12 +287,10 @@ namespace System.Formats.Tar.Tests
                 Assert.NotNull(regularFile.ExtendedAttributes);
 
                 // path, mtime, atime and ctime are always collected by default
-                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 6);
+                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 4);
 
                 Assert.Contains(PaxEaName, regularFile.ExtendedAttributes);
                 Assert.Contains(PaxEaMTime, regularFile.ExtendedAttributes);
-                Assert.Contains(PaxEaATime, regularFile.ExtendedAttributes);
-                Assert.Contains(PaxEaCTime, regularFile.ExtendedAttributes);
 
                 Assert.Contains(PaxEaUName, regularFile.ExtendedAttributes);
                 Assert.Equal(userName, regularFile.ExtendedAttributes[PaxEaUName]);
@@ -325,7 +319,7 @@ namespace System.Formats.Tar.Tests
             {
                 PaxTarEntry regularFile = await reader.GetNextEntryAsync() as PaxTarEntry;
 
-                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 4);
+                AssertExtensions.GreaterThanOrEqualTo(regularFile.ExtendedAttributes.Count, 2);
                 Assert.Contains(PaxEaName, regularFile.ExtendedAttributes);
             }
         }
@@ -353,7 +347,7 @@ namespace System.Formats.Tar.Tests
             {
                 PaxTarEntry symlink = await reader.GetNextEntryAsync() as PaxTarEntry;
 
-                AssertExtensions.GreaterThanOrEqualTo(symlink.ExtendedAttributes.Count, 5);
+                AssertExtensions.GreaterThanOrEqualTo(symlink.ExtendedAttributes.Count, 3);
 
                 Assert.Contains(PaxEaName, symlink.ExtendedAttributes);
                 Assert.Equal("symlink", symlink.ExtendedAttributes[PaxEaName]);
@@ -362,7 +356,7 @@ namespace System.Formats.Tar.Tests
 
                 PaxTarEntry hardlink = await reader.GetNextEntryAsync() as PaxTarEntry;
 
-                AssertExtensions.GreaterThanOrEqualTo(hardlink.ExtendedAttributes.Count, 5);
+                AssertExtensions.GreaterThanOrEqualTo(hardlink.ExtendedAttributes.Count, 3);
 
                 Assert.Contains(PaxEaName, hardlink.ExtendedAttributes);
                 Assert.Equal("hardlink", hardlink.ExtendedAttributes[PaxEaName]);


### PR DESCRIPTION
atime and ctime are not well supported on non-PAX formats.

Even for PAX formats, tools do not include these timestamps by default because they are of limited use.

This makes .NET to also default to not include these timestamps.

Fixes https://github.com/dotnet/runtime/issues/115434.