### PR TITLE
Fix linux-armel build break in pal_evp_pkey_ml_dsa.c

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_ml_dsa.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_ml_dsa.c
@@ -44,6 +44,8 @@ int32_t CryptoNative_MLDsaGetPalId(const EVP_PKEY* pKey, int32_t* mldsaId, int32
 
     (void)pKey;
     *mldsaId = PalMLDsaId_Unknown;
+    *hasSeed = 0;
+    *hasSecretKey = 0;
     return 0;
 }
 


### PR DESCRIPTION
Build break in linux-armel legs from https://github.com/dotnet/runtime/pull/115569