### PR TITLE
When cloning method descs be careful with fields that have different offsets between the source and destination. 

### DIFF
--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -7148,16 +7148,31 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
             // and should not be used.  We should go to the effort of having proper constructors
             // in the MethodDesc class. </NICE>
 
-            memcpy(pUnboxedMD, pMD, pMD->SizeOf());
+            memcpy(pUnboxedMD, pMD, pMD->GetBaseSize());
 
             // Reset the chunk index
             pUnboxedMD->SetChunkIndex(pChunk);
 
-            if (bmtGenerics->GetNumGenericArgs() == 0) {
-                pUnboxedMD->SetHasNonVtableSlot();
-
+            if (bmtGenerics->GetNumGenericArgs() == 0)
+            {
                 // By settings HasNonVTableSlot, the following chunks of data have been shifted around.
                 // This is an example of the fragility noted in the memcpy comment above
+
+                if (pUnboxedMD->HasNativeCodeSlot())
+                {
+                    *pUnboxedMD->GetAddrOfNativeCodeSlot() = 0;
+                }
+                if (pUnboxedMD->HasMethodImplSlot())
+                {
+                    *pUnboxedMD->GetMethodImpl() = {};
+                }
+                if (pUnboxedMD->HasAsyncMethodData())
+                {
+                    *pUnboxedMD->GetAddrOfAsyncMethodData() = {};
+                }
+
+                pUnboxedMD->SetHasNonVtableSlot();
+
                 if (pUnboxedMD->HasNativeCodeSlot())
                 {
                     *pUnboxedMD->GetAddrOfNativeCodeSlot() = *pMD->GetAddrOfNativeCodeSlot();

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -7148,29 +7148,12 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
             // and should not be used.  We should go to the effort of having proper constructors
             // in the MethodDesc class. </NICE>
 
-            memcpy(pUnboxedMD, pMD, pMD->GetBaseSize());
-
-            // Reset the chunk index
-            pUnboxedMD->SetChunkIndex(pChunk);
-
             if (bmtGenerics->GetNumGenericArgs() == 0)
             {
+                memcpy(pUnboxedMD, pMD, pMD->GetBaseSize());
+
                 // By settings HasNonVTableSlot, the following chunks of data have been shifted around.
                 // This is an example of the fragility noted in the memcpy comment above
-
-                if (pUnboxedMD->HasNativeCodeSlot())
-                {
-                    *pUnboxedMD->GetAddrOfNativeCodeSlot() = 0;
-                }
-                if (pUnboxedMD->HasMethodImplSlot())
-                {
-                    *pUnboxedMD->GetMethodImpl() = {};
-                }
-                if (pUnboxedMD->HasAsyncMethodData())
-                {
-                    *pUnboxedMD->GetAddrOfAsyncMethodData() = {};
-                }
-
                 pUnboxedMD->SetHasNonVtableSlot();
 
                 if (pUnboxedMD->HasNativeCodeSlot())
@@ -7186,6 +7169,13 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
                     *pUnboxedMD->GetAddrOfAsyncMethodData() = *pMD->GetAddrOfAsyncMethodData();
                 }
             }
+            else
+            {
+                memcpy(pUnboxedMD, pMD, pMD->SizeOf());
+            }
+
+            // Reset the chunk index
+            pUnboxedMD->SetChunkIndex(pChunk);
 
             //////////////////////////////////////////////////////////
             // Modify the original MethodDesc to be an unboxing stub

--- a/src/tests/Regressions/coreclr/GitHub_115667/test115667.cs
+++ b/src/tests/Regressions/coreclr/GitHub_115667/test115667.cs
@@ -19,18 +19,16 @@ public struct S1 : I0
     }
 }
 
-public class Program
+public class Runtime_115667
 {
     [Fact]
-    public static int TestEntryPoint()
+    public static void TestEntryPoint()
     {
         System.Runtime.Loader.AssemblyLoadContext alc = new CollectibleALC();
         System.Reflection.Assembly asm = alc.LoadFromAssemblyPath(System.Reflection.Assembly.GetExecutingAssembly().Location);
         System.Reflection.MethodInfo mi = asm.GetType(typeof(Program).FullName).GetMethod(nameof(MainInner));
         System.Type runtimeTy = asm.GetType(typeof(Runtime).FullName);
         mi.Invoke(null, new object[] { System.Activator.CreateInstance(runtimeTy) });
-
-        return 100;
     }
 
     public static void MainInner(IRuntime rt)

--- a/src/tests/Regressions/coreclr/GitHub_115667/test115667.cs
+++ b/src/tests/Regressions/coreclr/GitHub_115667/test115667.cs
@@ -26,7 +26,7 @@ public class Runtime_115667
     {
         System.Runtime.Loader.AssemblyLoadContext alc = new CollectibleALC();
         System.Reflection.Assembly asm = alc.LoadFromAssemblyPath(System.Reflection.Assembly.GetExecutingAssembly().Location);
-        System.Reflection.MethodInfo mi = asm.GetType(typeof(Program).FullName).GetMethod(nameof(MainInner));
+        System.Reflection.MethodInfo mi = asm.GetType(typeof(Runtime_115667).FullName).GetMethod(nameof(MainInner));
         System.Type runtimeTy = asm.GetType(typeof(Runtime).FullName);
         mi.Invoke(null, new object[] { System.Activator.CreateInstance(runtimeTy) });
     }

--- a/src/tests/Regressions/coreclr/GitHub_115667/test115667.cs
+++ b/src/tests/Regressions/coreclr/GitHub_115667/test115667.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using Xunit;
+using System.Threading.Tasks;
+
+public interface I0
+{
+    Task<bool> M8();
+}
+
+public struct S1 : I0
+{
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    public async Task<bool> M8()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    {
+        return false;
+    }
+}
+
+public class Program
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        System.Runtime.Loader.AssemblyLoadContext alc = new CollectibleALC();
+        System.Reflection.Assembly asm = alc.LoadFromAssemblyPath(System.Reflection.Assembly.GetExecutingAssembly().Location);
+        System.Reflection.MethodInfo mi = asm.GetType(typeof(Program).FullName).GetMethod(nameof(MainInner));
+        System.Type runtimeTy = asm.GetType(typeof(Runtime).FullName);
+        mi.Invoke(null, new object[] { System.Activator.CreateInstance(runtimeTy) });
+
+        return 100;
+    }
+
+    public static void MainInner(IRuntime rt)
+    {
+        bool vr1 = new S1().M8().GetAwaiter().GetResult();
+    }
+}
+
+public interface IRuntime
+{
+    void WriteLine<T>(string site, T value);
+}
+
+public class Runtime : IRuntime
+{
+    public void WriteLine<T>(string site, T value) => System.Console.WriteLine(value);
+}
+
+public class CollectibleALC : System.Runtime.Loader.AssemblyLoadContext
+{
+    public CollectibleALC() : base(true)
+    {
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_115667/test115667.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_115667/test115667.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Optimize>True</Optimize>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Regressions/coreclr/GitHub_115667/test115667.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_115667/test115667.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test115667.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -952,6 +952,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_90219/Runtime_90219/**">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: Assembly.Load</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_115667/**">
+            <Issue>https://github.com/dotnet/runtimelab/issues/155: Assembly.Load</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/reflection\DefaultInterfaceMethods\Emit\*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: Reflection.Emit</Issue>
         </ExcludeList>
@@ -3063,6 +3066,9 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_90219/Runtime_90219/*">
             <Issue>Loads an assembly from file</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_115667/**">
+          <Issue>Loads an assembly from file</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
Fixes: #115667

When cloning methoddescs into destination that has a different layout, memcopy only the base portion, then copy remaining fields individually.

If we memcopy the whole thing, non-base fields would be copied to wrong locations. Even if we subsequently copy the non-base fields individually, the initial memcopy may corrupt destination fields that are not present in the source.

The issue appears to be not new, but somehow did not cause problems until now.
