### PR TITLE
Optimize IsLeapYear based on an article by Falk Hüffner

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1155,6 +1155,12 @@ Algorithms
 Aspects of Date/Time processing based on algorithm described in "Euclidean Affine Functions and Applications to Calendar
 Algorithms", Cassio Neri and Lorenz Schneider. https://arxiv.org/pdf/2102.06959.pdf
 
+Notice for faster "Is leap year" algorithm
+-------------------------------
+
+Based on algorithm described in "A leap year check in three instructions", Falk Hüffner, 15 May 2025. 
+https://hueffner.de/falk/blog/a-leap-year-check-in-three-instructions.html
+
 License notice for amd/aocl-libm-ose
 -------------------------------
 

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1568,7 +1568,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRange_Year();
             }
 
-            // Based on "A leap year check in three instructions" by Falk Hüffner 
+            // Based on "A leap year check in three instructions" by Falk Hüffner
             // https://hueffner.de/falk/blog/a-leap-year-check-in-three-instructions.html
             return ((year * 1073750999) & 3221352463) <= 126976;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1570,7 +1570,7 @@ namespace System
 
             // Based on "A leap year check in three instructions" by Falk Hüffner 
             // https://hueffner.de/falk/blog/a-leap-year-check-in-three-instructions.html
-            return ((y * 1073750999) & 3221352463) <= 126976;
+            return ((year * 1073750999) & 3221352463) <= 126976;
         }
 
         // Constructs a DateTime from a string. The string must specify a

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1567,9 +1567,10 @@ namespace System
             {
                 ThrowHelper.ThrowArgumentOutOfRange_Year();
             }
-            if ((year & 3) != 0) return false;
-            if ((year & 15) == 0) return true;
-            return (uint)year % 25 != 0;
+
+            // Based on "A leap year check in three instructions" by Falk Hüffner 
+            // https://hueffner.de/falk/blog/a-leap-year-check-in-three-instructions.html
+            return ((y * 1073750999) & 3221352463) <= 126976;
         }
 
         // Constructs a DateTime from a string. The string must specify a


### PR DESCRIPTION
Optimize DateTime.IsLeapYear based on https://hueffner.de/falk/blog/a-leap-year-check-in-three-instructions.html article. The author doesn't mind our use of it in .NET. It is not something we can optimize in JIT (unless directly recognizing this code pattern under specific if-conditions).

```cs
static bool IsLeapYear_old(int year)
{
    if ((year & 3) != 0) return false;
    if ((year & 15) == 0) return true;
    return (uint)year % 25 != 0;
}


static bool IsLeapYear_new(uint y)
{
    return ((y * 1073750999) & 3221352463) <= 126976;
}
```
Codegen:
```asm
; Assembly listing for method IsLeapYear_old(int):ubyte (FullOpts)
       test     cl, 3
       jne      SHORT G_M000_IG07
       test     cl, 15
       je       SHORT G_M000_IG05
       mov      eax, ecx
       imul     rax, rax, 0x51EB851F
       shr      rax, 35
       imul     eax, eax, 25
       sub      ecx, eax
       setne    al
       movzx    rax, al
       ret      
G_M000_IG05:
       mov      eax, 1
       ret      
G_M000_IG07:
       xor      eax, eax
       ret      
; Total bytes of code 44


; Assembly listing for method IsLeapYear_new(uint):ubyte (FullOpts)
       imul     eax, ecx, 0x400023D7
       and      eax, 0xFFFFFFFFC001F00F
       cmp      eax, 0x1F000
       setbe    al
       movzx    rax, al
       ret      
; Total bytes of code 23
```

We don't need a formal proof, since it passes a simple exhaustive test perfectly (IsLeapYear's input is guarded to be within [1..9999] range).
```cs
for (int i = 1; i <= 9999; i++)
{
    if (IsLeapYear_old(i) != IsLeapYear_new((uint)i))
        Console.WriteLine($"Mismatch for year {i}");
}

bool IsLeapYear_old(int year)
{
    if ((year & 3) != 0) return false;
    if ((year & 15) == 0) return true;
    return (uint)year % 25 != 0;
}

bool IsLeapYear_new(uint y) => ((y * 1073750999) & 3221352463) <= 126976;
```

PS: will run a few benchmarks shortly..