### PR TITLE
Do not shortcut `CompilerComparer`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AddressTakenMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AddressTakenMethodNode.cs
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
-            return _methodNode.CompareToImpl(((AddressTakenMethodNode)other)._methodNode, comparer);
+            return comparer.Compare(_methodNode, ((AddressTakenMethodNode)other)._methodNode);
         }
 
         public ISymbolNode NodeForLinkage(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TentativeMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TentativeMethodNode.cs
@@ -65,7 +65,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
-            return _methodNode.CompareToImpl(((TentativeMethodNode)other)._methodNode, comparer);
+            return comparer.Compare(_methodNode, ((TentativeMethodNode)other)._methodNode);
         }
 
         public ISymbolNode NodeForLinkage(NodeFactory factory)


### PR DESCRIPTION
In rt-sz (https://github.com/MichalStrehovsky/rt-sz/actions/runs/15128663241/job/42525897839) I ran into following exception:

```
  System.AggregateException: One or more errors occurred. (Specified cast is not valid.)
   ---> System.InvalidCastException: Specified cast is not valid.
     at ILCompiler.DependencyAnalysis.RuntimeImportMethodNode.CompareToImpl(ISortableNode, CompilerComparer) + 0x3c
```

I am not actually able to repro this locally, but this seems to be the only way how this could happen (we're trying to compare two nodes that are not of the same type - `CompilerComparer` will handle that case; `CompareToImpl` will not).