### PR TITLE
[LoongArch64] Fix the pointer load in asmhelper.S:`ThisPtrRetBufPrecodeWorker` with PR#112548.

### DIFF
--- a/src/coreclr/vm/loongarch64/asmhelpers.S
+++ b/src/coreclr/vm/loongarch64/asmhelpers.S
@@ -1149,7 +1149,7 @@ LEAF_END JIT_PollGC, _TEXT
 //a0 -This pointer
 //a1 -ReturnBuffer
 LEAF_ENTRY ThisPtrRetBufPrecodeWorker, _TEXT
-    ld.w  $METHODDESC_REGISTER, $METHODDESC_REGISTER, ThisPtrRetBufPrecodeData__Target
+    ld.d  $METHODDESC_REGISTER, $METHODDESC_REGISTER, ThisPtrRetBufPrecodeData__Target
     move  $t0, $a0     // Move first arg pointer to temp register
     move  $a0, $a1     // Move ret buf arg pointer from location in ABI for return buffer for instance method to location in ABI for return buffer for static method
     move  $a1, $t0     // Move temp register to first arg register for static method with return buffer


### PR DESCRIPTION
[LoongArch64] Fix the pointer load in asmhelper.S:`ThisPtrRetBufPrecodeWorker` with  https://github.com/dotnet/runtime/pull/112548 .