### PR TITLE
JIT: Fix SysV first/second return register GC info mismatch when generating calls

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6293,6 +6293,18 @@ void CodeGen::genCallInstruction(GenTreeCall* call X86_ARG(target_ssize_t stackA
         {
             params.retSize       = emitTypeSize(retTypeDesc->GetReturnRegType(0));
             params.secondRetSize = emitTypeSize(retTypeDesc->GetReturnRegType(1));
+
+            if (retTypeDesc->GetABIReturnReg(1, call->GetUnmanagedCallConv()) == REG_INTRET)
+            {
+                // If the second return register is REG_INTRET, then the first
+                // return is expected to be in a SIMD register.
+                // The emitter has hardcoded belief that params.retSize corresponds to
+                // REG_INTRET and secondRetSize to REG_INTRET_1, so fix up the
+                // situation here.
+                assert(!EA_IS_GCREF_OR_BYREF(params.retSize));
+                params.retSize = params.secondRetSize;
+                params.secondRetSize = EA_UNKNOWN;
+            }
         }
         else
         {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6302,7 +6302,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call X86_ARG(target_ssize_t stackA
                 // REG_INTRET and secondRetSize to REG_INTRET_1, so fix up the
                 // situation here.
                 assert(!EA_IS_GCREF_OR_BYREF(params.retSize));
-                params.retSize = params.secondRetSize;
+                params.retSize       = params.secondRetSize;
                 params.secondRetSize = EA_UNKNOWN;
             }
         }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_115815
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        var destination = new KeyValuePair<Container, double>[1_000_000];
+
+        // loop to make this method fully interruptible + to get into OSR version
+        for (int i = 0; i < destination.Length; i++)
+        {
+            destination[i] = default;
+        }
+
+        for (int i = 0; i < 5; i++)
+        {
+            for (int j = 0; j < destination.Length; j++)
+            {
+                destination[j] = GetValue(j);
+            }
+
+            Thread.Sleep(10);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static KeyValuePair<Container, double> GetValue(int i)
+        => KeyValuePair.Create(new Container(i.ToString()), (double)i);
+
+    private struct Container
+    {
+        public string Name;
+        public Container(string name) { this.Name = name; }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
On SysV it is possible to have mixed SIMD/integer return registers for calls. This leads to a case where the first return register is a SIMD register, while the second return register is an integer register. In that particular case, the emitter would get confused and expect GC information for the second return register to refer to `rdx`, when in reality it refers to `rax`.

Fix the problem by detecting the case where the second register is `rax`, and communicating the right information back to the emitter. Also add a test case that reliably segfaults under `DOTNET_GCStress=C` without the fix.

Fix #115815