### PR TITLE
JIT: Don't reverse copied condition in fgOptimizeBranch

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2734,42 +2734,20 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
         newStmtList->SetPrevStmt(newLastStmt);
     }
 
-    //
-    // Reverse the sense of the compare
-    //
-    gtReverseCond(condTree);
-
     // We need to update the following flags of the bJump block if they were set in the bDest block
     bJump->CopyFlags(bDest, BBF_COPY_PROPAGATE);
 
     // Update bbRefs and bbPreds
     //
-    // For now we set the likelihood of the new branch to match
-    // the likelihood of the old branch.
-    //
-    // This may or may not match the block weight adjustments we're
-    // making. All this becomes easier to reconcile once we rely on
-    // edge likelihoods more and have synthesis running.
-    //
-    // Until then we won't worry that edges and blocks are potentially
-    // out of sync.
-    //
-    FlowEdge* const destFalseEdge = bDest->GetFalseEdge();
-    FlowEdge* const destTrueEdge  = bDest->GetTrueEdge();
+    FlowEdge* const falseEdge = bDest->GetFalseEdge();
+    FlowEdge* const trueEdge  = bDest->GetTrueEdge();
 
-    // bJump now falls through into the next block.
-    // Note that we're deriving the false edge's likelihood from 'destTrueEdge',
-    // because the comparison in 'bJump' is flipped.
-    // Similarly, we will derive the true edge's likelihood from 'destFalseEdge'.
-    //
-    FlowEdge* const falseEdge = fgAddRefPred(trueTarget, bJump, destTrueEdge);
-
-    // bJump now jumps to bDest's normal jump target
-    //
     fgRedirectTargetEdge(bJump, falseTarget);
-    bJump->GetTargetEdge()->setLikelihood(destFalseEdge->getLikelihood());
+    bJump->GetTargetEdge()->setLikelihood(falseEdge->getLikelihood());
 
-    bJump->SetCond(bJump->GetTargetEdge(), falseEdge);
+    FlowEdge* const newTrueEdge = fgAddRefPred(trueTarget, bJump, trueEdge);
+
+    bJump->SetCond(newTrueEdge, bJump->GetTargetEdge());
 
     // Update profile data
     //


### PR DESCRIPTION
Now that `fgOptimizeBranch` only runs late in the frontend, removing the condition reversal is low-churn. I'm PRing this as a prerequisite to a larger rewrite I'm making to make `fgOptimizeBranch` more useful for block layout's purposes (i.e. if we can predict that block layout will probably misrotate a loop, try to clone the loop condition, ideally without needing to compute/maintain loop annotations).