### PR TITLE
JIT: Remove overzealous async assert

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1538,7 +1538,6 @@ void AsyncTransformation::CopyReturnValueOnResumption(GenTreeCall*              
 
     assert(callDefInfo.DefinitionNode != nullptr);
     LclVarDsc* resultLcl = m_comp->lvaGetDesc(callDefInfo.DefinitionNode);
-    assert(varTypeIsStruct(resultLcl) == varTypeIsStruct(call->gtReturnType));
 
     // TODO-TP: We can use liveness to avoid generating a lot of this IR.
     if (call->gtReturnType == TYP_STRUCT)


### PR DESCRIPTION
The store can come from a `STORE_LCL_FLD`, so in reality there is no relation between the type of the resultLcl and the call type. The code below handles `STORE_LCL_FLD` correctly, so just remove the assert.

Fix #115839