### PR TITLE
Decrease number of allocations in new test

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.cs
@@ -11,12 +11,12 @@ public class Runtime_115815
     [Fact]
     public static void TestEntryPoint()
     {
-        var destination = new KeyValuePair<Container, double>[1_000_000];
+        var destination = new KeyValuePair<Container, double>[1_000];
 
         // loop to make this method fully interruptible + to get into OSR version
-        for (int i = 0; i < destination.Length; i++)
+        for (int i = 0; i < destination.Length * 1000; i++)
         {
-            destination[i] = default;
+            destination[i / 1000] = default;
         }
 
         for (int i = 0; i < 5; i++)


### PR DESCRIPTION
Otherwise the test runs very slowly under DOTNET_GCStress=1/3, as @LuckyXu-HF points out in https://github.com/dotnet/runtime/pull/115827#issuecomment-2900821682.

This still catches the original issue under GCStress=c.