### PR TITLE
Implement CEE_LDOBJ and CEE_STOBJ in the interpreter

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2427,6 +2427,25 @@ retry_emit:
                 m_ip++;
                 break;
 
+            case CEE_LDOBJ:
+            case CEE_STOBJ:
+            {
+                CHECK_STACK(*m_ip == CEE_LDOBJ ? 1 : 2);
+                CORINFO_RESOLVED_TOKEN resolvedToken;
+                ResolveToken(getU4LittleEndian(m_ip + 1), CORINFO_TOKENKIND_Class, &resolvedToken);
+                InterpType interpType = GetInterpType(m_compHnd->asCorInfoType(resolvedToken.hClass));
+                if (*m_ip == CEE_LDOBJ)
+                {
+                    EmitLdind(interpType, resolvedToken.hClass, 0);
+                }
+                else
+                {
+                    EmitStind(interpType, resolvedToken.hClass, 0, false);
+                }
+                m_ip += 5;
+                break;
+            }
+
             case CEE_RET:
             {
                 CORINFO_SIG_INFO sig = methodInfo->args;

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -416,6 +416,9 @@ public class InterpreterTest
         if (!TestArray())
             Environment.FailFast(null);
 
+        if (!TestXxObj())
+            Environment.FailFast(null);
+
         if (!TestSizeof())
             Environment.FailFast(null);
 
@@ -951,6 +954,32 @@ public class InterpreterTest
         if (values[0] != value)
             return false;
         if (values[length - 1] != value)
+            return false;
+
+        return true;
+    }
+
+    public static unsafe bool TestXxObj()
+    {
+        // FIXME: There is no way to generate cpobj opcodes with roslyn at present.
+        // The only source of cpobj I've found other than hand-written IL tests is ilmarshalers.h, so once pinvoke marshaling is
+        //  supported, we can use that to verify that cpobj works. Until then, this method only tests ldobj/stobj.
+        TestStruct4fi a = new TestStruct4fi
+        {
+            a = 1,
+            b = 2,
+            c = 3,
+            d = 4,
+        }, b = default;
+        ref TestStruct4fi c = ref a,
+            d = ref b;
+
+        if (b.a == a.a)
+            return false;
+
+        c = d;
+
+        if (b.a != a.a)
             return false;
 
         return true;


### PR DESCRIPTION
ldind and stind are actually aliases for ldobj and stobj according to ecma. We already have helper code for generating appropriate intop_xxind opcodes based on type, so I just reused those helpers to generate the appropriate interpreter opcodes to do the ldobj/stobj. This meant I didn't need to add new opcodes.

cpobj is not covered since as far as i can tell roslyn never generates it. The only way I found to generate it (other than a handwritten IL test) is to use pinvoke marshaling because the marshaling generator will use it. So once we do pinvoke marshaling we'll need cpobj and that's probably the right point in time to add it.