### PR TITLE
Update WebAssembly image to Ubuntu 24.04

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -50,7 +50,7 @@ jobs:
 
     # Browser wasm
     - ${{ if eq(parameters.platform, 'browser_wasm') }}:
-      - (Ubuntu.2204.Amd64)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-webassembly
+      - (Ubuntu.2404.Amd64)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04-helix-webassembly-amd64
 
     # iOS devices
     - ${{ if in(parameters.platform, 'ios_arm64') }}:


### PR DESCRIPTION
- Update base to Ubuntu 24.04
- Update CMake, 3.17 -> 3.31.7
- Rest of the .NET 10 build uses 3.30 (from AL3 archives)
- 3.31.7 is the latest/last 3.x build, with 4.x after that

References:

- Old: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4f5930d8206cbd9c53f49882338cdbdfed3fd53b/src/ubuntu/22.04/helix/webassembly/amd64/Dockerfile
- New: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4f5930d8206cbd9c53f49882338cdbdfed3fd53b/src/ubuntu/24.04/helix/webassembly/amd64/Dockerfile

@akoeplinger @jkoritzinsky 