### PR TITLE
Fix typo in RecognizerBase: invalid variable in condition

### DIFF
--- a/src/libraries/System.Speech/src/Recognition/RecognizerBase.cs
+++ b/src/libraries/System.Speech/src/Recognition/RecognizerBase.cs
@@ -2101,7 +2101,7 @@ ISpGrammarResourceLoader
             lock (_thisObjectLock)
             {
                 SpeechEvent speechEvent = eventData as SpeechEvent;
-                if (!_disposed && eventData != null)
+                if (!_disposed && speechEvent != null)
                 {
                     switch (speechEvent.EventId)
                     {


### PR DESCRIPTION
Found by Linux Verification Center (linuxtesting.org) with SVACE.