### PR TITLE
JIT: Unprotect handler entry after finally removal

### DIFF
--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -751,8 +751,10 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
         assert(firstHandlerBlock->bbRefs >= 2);
         firstHandlerBlock->bbRefs -= 1;
 
-        // (8) The old try entry no longer needs special protection.
+        // (8) The old try/handler entries no longer need special protection.
         firstTryBlock->RemoveFlags(BBF_DONT_REMOVE);
+        assert(!bbIsHandlerBeg(firstHandlerBlock));
+        firstHandlerBlock->RemoveFlags(BBF_DONT_REMOVE);
 
         // Another one bites the dust...
         emptyCount++;
@@ -1476,9 +1478,6 @@ PhaseStatus Compiler::fgCloneFinally()
             {
                 // Mark the block as the start of the cloned finally.
                 newBlock->SetFlags(BBF_CLONED_FINALLY_BEGIN);
-
-                // Cloned finally entry block does not need any special protection.
-                newBlock->RemoveFlags(BBF_DONT_REMOVE);
             }
 
             if (block == lastBlock)
@@ -1487,6 +1486,7 @@ PhaseStatus Compiler::fgCloneFinally()
                 newBlock->SetFlags(BBF_CLONED_FINALLY_END);
             }
 
+            // Cloned finally block does not need any special protection.
             newBlock->RemoveFlags(BBF_DONT_REMOVE);
 
             // Make sure clone block state hasn't munged the try region.


### PR DESCRIPTION
Found while working on #115850. Suppose we have the following flowgraph:
```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight   [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                             1    [000..00D)-> BB02(1)                 (always)                   i
BB02 [0001]  1  0    BB01                  1    [00D..00F)-> BB03(1)                 (callf ) T0    try {       i keep
BB07 [0006]  1  0    BB05                  1    [???..???)-> BB08(1)                 (callfr) T0    }           i internal
BB08 [0007]  1       BB07                  1    [???..???)-> BB06(1)                 (ALWAYS)                   i internal KEEP
BB03 [0002]  2     0 BB02                  1    [00F..012)-> BB05(0.5),BB04(0.5)     ( cond )    H0 finally {   i keep
BB04 [0003]  1     0 BB03                  1    [012..018)-> BB05(1)                 (always)    H0             i
BB05 [0004]  2     0 BB03,BB04             1    [018..019)-> BB07(1)                 (finret)    H0 }           i
BB06 [0005]  1       BB08                  1    [019..01A)                           (return)                   i
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

`fgRemoveEmptyTry` will remove the `BBF_DONT_REMOVE` guard from the try entry if it decides to remove the region, but it won't do so for the corresponding finally entry:
```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight   [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                             1    [000..00D)-> BB02(1)                 (always)                   i
BB02 [0001]  1       BB01                  1    [00D..00F)-> BB03(1)                 (always)                   i
BB08 [0007]  1       BB05                  1    [???..???)-> BB06(1)                 (always)                   i internal
BB03 [0002]  1       BB02                  1    [00F..012)-> BB05(0.5),BB04(0.5)     ( cond )                   i keep
BB04 [0003]  1       BB03                  1    [012..018)-> BB05(1)                 (always)                   i
BB05 [0004]  2       BB03,BB04             1    [018..019)-> BB08(1)                 (always)                   i
BB06 [0005]  1       BB08                  1    [019..01A)                           (return)                   i
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

If we remove the guard for the finally entry in this case, loop inversion will make it unreachable, and flow opts will remove it entirely, rather than converting it into an unnecessary `BBJ_THROW`. This change enables that.