### PR TITLE
Add dispose of X509Chain in SignedXml

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -354,14 +354,21 @@ namespace System.Security.Cryptography.Xml
 
                 // Do the chain verification to make sure the certificate is valid.
                 X509Chain chain = new X509Chain();
-                chain.ChainPolicy.ExtraStore.AddRange(BuildBagOfCerts());
-                bool chainVerified = chain.Build(certificate);
-                SignedXmlDebugLog.LogVerifyX509Chain(this, chain, certificate);
-
-                if (!chainVerified)
+                try
                 {
-                    SignedXmlDebugLog.LogVerificationFailure(this, SR.Log_VerificationFailed_X509Chain);
-                    return false;
+                    chain.ChainPolicy.ExtraStore.AddRange(BuildBagOfCerts());
+                    bool chainVerified = chain.Build(certificate);
+                    SignedXmlDebugLog.LogVerifyX509Chain(this, chain, certificate);
+                
+                    if (!chainVerified)
+                    {
+                        SignedXmlDebugLog.LogVerificationFailure(this, SR.Log_VerificationFailed_X509Chain);
+                        return false;
+                    }
+                }
+                finally
+                {
+                    chain.Dispose();
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -353,10 +353,13 @@ namespace System.Security.Cryptography.Xml
                 }
 
                 // Do the chain verification to make sure the certificate is valid.
-                using X509Chain chain = new X509Chain();
-                chain.ChainPolicy.ExtraStore.AddRange(BuildBagOfCerts());
-                bool chainVerified = chain.Build(certificate);
-                SignedXmlDebugLog.LogVerifyX509Chain(this, chain, certificate);
+                bool chainVerified = false;
+                using (X509Chain chain = new X509Chain())
+                {
+                    chain.ChainPolicy.ExtraStore.AddRange(BuildBagOfCerts());
+                    chainVerified = chain.Build(certificate);
+                    SignedXmlDebugLog.LogVerifyX509Chain(this, chain, certificate);
+                }
 
                 if (!chainVerified)
                 {

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -353,22 +353,15 @@ namespace System.Security.Cryptography.Xml
                 }
 
                 // Do the chain verification to make sure the certificate is valid.
-                X509Chain chain = new X509Chain();
-                try
+                using X509Chain chain = new X509Chain();
+                chain.ChainPolicy.ExtraStore.AddRange(BuildBagOfCerts());
+                bool chainVerified = chain.Build(certificate);
+                SignedXmlDebugLog.LogVerifyX509Chain(this, chain, certificate);
+            
+                if (!chainVerified)
                 {
-                    chain.ChainPolicy.ExtraStore.AddRange(BuildBagOfCerts());
-                    bool chainVerified = chain.Build(certificate);
-                    SignedXmlDebugLog.LogVerifyX509Chain(this, chain, certificate);
-                
-                    if (!chainVerified)
-                    {
-                        SignedXmlDebugLog.LogVerificationFailure(this, SR.Log_VerificationFailed_X509Chain);
-                        return false;
-                    }
-                }
-                finally
-                {
-                    chain.Dispose();
+                    SignedXmlDebugLog.LogVerificationFailure(this, SR.Log_VerificationFailed_X509Chain);
+                    return false;
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -357,7 +357,7 @@ namespace System.Security.Cryptography.Xml
                 chain.ChainPolicy.ExtraStore.AddRange(BuildBagOfCerts());
                 bool chainVerified = chain.Build(certificate);
                 SignedXmlDebugLog.LogVerifyX509Chain(this, chain, certificate);
-            
+
                 if (!chainVerified)
                 {
                     SignedXmlDebugLog.LogVerificationFailure(this, SR.Log_VerificationFailed_X509Chain);


### PR DESCRIPTION
Call Dispose for X509Chain class instance
I didn't add chain.ChainElements[*].Certificate.Dispose() as mentioned [here](https://github.com/dotnet/runtime/pull/110740)
because I'm not sure that we should dispose all chained certificates. One of them is passed through the method parameters

Found by Linux Verification Center (linuxtesting.org) with SVACE.