### PR TITLE
Add dotnet to the path for copilot agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
 
+      - name: Install dependencies
+        run: ./eng/common/native/install-dependencies.sh
       - name: Restore solution
         run: ./build.sh --restore --excludecibinarylog --warnaserror false /p:BuildAllConfigurations=true /p:DotNetBuildAllRuntimePacks=true
       - name: Put dotnet on the path

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,8 +18,10 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Install dependencies
-        run: ./eng/common/native/install-dependencies.sh
+        run: sudo ./eng/common/native/install-dependencies.sh
       - name: Restore solution
         run: ./build.sh --restore --excludecibinarylog --warnaserror false /p:BuildAllConfigurations=true /p:DotNetBuildAllRuntimePacks=true
       - name: Put dotnet on the path
         run: echo "PATH=$PWD/.dotnet:$PATH" >> $GITHUB_ENV
+      - name: Run dotnet info
+        run: dotnet --info

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,3 +19,5 @@ jobs:
 
       - name: Restore solution
         run: ./build.sh --restore --excludecibinarylog --warnaserror false /p:BuildAllConfigurations=true /p:DotNetBuildAllRuntimePacks=true
+      - name: Put dotnet on the path
+        run: export PATH=$PWD/.dotnet:$PATH

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Restore solution
         run: ./build.sh --restore --excludecibinarylog --warnaserror false /p:BuildAllConfigurations=true /p:DotNetBuildAllRuntimePacks=true
       - name: Put dotnet on the path
-        run: export PATH=$PWD/.dotnet:$PATH
+        run: echo "PATH=$PWD/.dotnet:$PATH" >> $GITHUB_ENV


### PR DESCRIPTION
Putting `.dotnet` folder on the path to give copilot agent better chance at having basic commands just work.  Much of our product supports `dotnet build` on individual project thanks to @ViktorHofer's work, and these commands will always work for iterating on projects.  I chatted with @CarnaViire and she'll cover other steps in the doc.

I'm not entirely sure if this is the right way to make a persistent env variable for the copilot agent to use.  Couldn't find mention in the docs.  Figure we can try it and see!