### PR TITLE
Add support for string constructors to the interpreter

### DIFF
--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -281,6 +281,7 @@ OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLVIRT, "callvirt", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_NEWOBJ, "newobj", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_NEWOBJ_VT, "newobj.vt", 5, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_NEWOBJ_VAROBJSIZE, "newobj.varobjsize", 5, 1, 1, InterpOpMethodHandle)
 
 OPDEF(INTOP_CALL_HELPER_PP, "call.helper.pp", 5, 1, 0, InterpOpThreeInts)
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1220,13 +1220,9 @@ CALL_TARGET_IP:
                     callArgsOffset = ip[2];
                     methodSlot = ip[3];
 
-                    // FIXME: Duplicated code from CALL_INTERP_SLOT
                     size_t targetMethod = (size_t)pMethod->pDataItems[methodSlot];
-                    MethodDesc *pMD = nullptr;
-                    if (targetMethod & INTERP_METHOD_HANDLE_TAG)
-                    {
-                        pMD = (MethodDesc*)(targetMethod & ~INTERP_METHOD_HANDLE_TAG);
-                    }
+                    assert(targetMethod & INTERP_METHOD_HANDLE_TAG);
+                    MethodDesc *pMD = (MethodDesc*)(targetMethod & ~INTERP_METHOD_HANDLE_TAG);
 
                     // If we are constructing a type with a component size (i.e. a string) its constructor is a special
                     //  fcall that is basically a static method that returns the new instance.

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1186,13 +1186,12 @@ CALL_TARGET_IP:
                     callArgsOffset = ip[2];
                     methodSlot = ip[3];
 
-                    MethodTable *pClass = (MethodTable*)pMethod->pDataItems[ip[4]];
-                    OBJECTREF objRef = AllocateObject(pClass);
+                    OBJECTREF objRef = AllocateObject((MethodTable*)pMethod->pDataItems[ip[4]]);
 
                     // This is return value
                     LOCAL_VAR(returnOffset, OBJECTREF) = objRef;
                     // Set `this` arg for ctor call
-                    LOCAL_VAR(callArgsOffset, OBJECTREF) = objRef;
+                    LOCAL_VAR (callArgsOffset, OBJECTREF) = objRef;
                     ip += 5;
 
                     goto CALL_INTERP_SLOT;

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -413,6 +413,9 @@ public class InterpreterTest
         if (!TestBoxing())
             Environment.FailFast(null);
 
+        if (!TestStringCtor())
+            Environment.FailFast(null);
+
         if (!TestArray())
             Environment.FailFast(null);
 
@@ -706,6 +709,18 @@ public class InterpreterTest
         // `(s is int result)` generates isinst so we have to do this in steps
         int result = (int)s;
         return result == 3;
+    }
+
+    public static bool TestStringCtor()
+    {
+        string s = new string('a', 4);
+        if (s.Length != 4)
+            return false;
+        if (s[0] != 'a')
+            return false;
+        if (s != "aaaa")
+            return false;
+        return true;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]


### PR DESCRIPTION
* Updates the compiler to identify NEWOBJ opcodes that are operating on string or multidim arrays, and generates a different specialized newobj opcode for them.
* Updates the callstub generator to know how to generate the appropriate type of stub for those constructors.
* Adds a specialized newobj opcode for strings and md arrays (md arrays not actually implemented in this PR.)
* Modifies InvokeCompiledMethod to accept the code address from outside.