### PR TITLE
Fix Creating Undermined Culture

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -817,6 +817,7 @@ namespace System.Globalization
 #if TARGET_BROWSER
             culture.JSInitLocaleInfo();
 #endif
+
             // We need _sWindowsName to be initialized to know if we're using overrides.
             culture.InitUserOverride(useUserOverride);
             return culture;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -668,7 +668,7 @@ namespace System.Globalization
         internal static CultureData? GetCultureData(string? cultureName, bool useUserOverride)
         {
             // First do a shortcut for Invariant
-            if (string.IsNullOrEmpty(cultureName))
+            if (string.IsNullOrEmpty(cultureName) || cultureName.Equals("und", StringComparison.OrdinalIgnoreCase))
             {
                 return Invariant;
             }
@@ -817,13 +817,6 @@ namespace System.Globalization
 #if TARGET_BROWSER
             culture.JSInitLocaleInfo();
 #endif
-            if (string.IsNullOrEmpty(culture._sWindowsName))
-            {
-                // ICU can normalize some culture names into empty string.
-                // "und" is the name for the undetermined culture which gets normalized to empty string
-                return Invariant;
-            }
-
             // We need _sWindowsName to be initialized to know if we're using overrides.
             culture.InitUserOverride(useUserOverride);
             return culture;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -817,6 +817,12 @@ namespace System.Globalization
 #if TARGET_BROWSER
             culture.JSInitLocaleInfo();
 #endif
+            if (string.IsNullOrEmpty(culture._sWindowsName))
+            {
+                // ICU can normalize some culture names into empty string.
+                // "und" is the name for the undermined culture which get normalized to empty string
+                return Invariant;
+            }
 
             // We need _sWindowsName to be initialized to know if we're using overrides.
             culture.InitUserOverride(useUserOverride);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -820,7 +820,7 @@ namespace System.Globalization
             if (string.IsNullOrEmpty(culture._sWindowsName))
             {
                 // ICU can normalize some culture names into empty string.
-                // "und" is the name for the undermined culture which get normalized to empty string
+                // "und" is the name for the undetermined culture which gets normalized to empty string
                 return Invariant;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -667,8 +667,11 @@ namespace System.Globalization
 
         internal static CultureData? GetCultureData(string? cultureName, bool useUserOverride)
         {
+            // The undetermined culture name "und" is not a real culture, but it resolves to the invariant culture because ICU typically normalizes it to an empty string.
+            const string UndeterminedCultureName = "und";
+
             // First do a shortcut for Invariant
-            if (string.IsNullOrEmpty(cultureName) || cultureName.Equals("und", StringComparison.OrdinalIgnoreCase))
+            if (string.IsNullOrEmpty(cultureName) || cultureName.Equals(UndeterminedCultureName, StringComparison.OrdinalIgnoreCase))
             {
                 return Invariant;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -1052,7 +1052,8 @@ namespace System.Globalization
 
             lock (nameTable)
             {
-                nameTable[name] = result;
+                // add only if it wasn't already added
+                nameTable.TryAdd(name, result);
             }
 
             return result;

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCtor.cs
@@ -417,6 +417,18 @@ namespace System.Globalization.Tests
             Assert.Equal(expectedSortName, culture.CompareInfo.Name);
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
+        public void UndeterminedCultureTest()
+        {
+            CultureInfo invariant1 = CultureInfo.GetCultureInfo("");
+
+            CultureInfo undetermined1 = CultureInfo.GetCultureInfo("und");
+            Assert.Equal("", undetermined1.Name);
+
+            CultureInfo invariant2 = CultureInfo.GetCultureInfo("");
+            Assert.True(object.ReferenceEquals(invariant1, invariant2), "CultureInfo.GetCultureInfo(\"\") is not returning the previously cached instance");
+        }
+
         [Theory]
         [MemberData(nameof(Ctor_String_TestData))]
         public void Ctor_String(string name, string[] expectedNames)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/115913

The culture name `und` (undetermined) is a special case recognized by ICU. It typically gets normalized to an empty string, which maps to the invariant culture. The fix here ensures that `und` is handled consistently with the invariant culture and prevents overwriting the cached invariant culture entry when creating a culture for `und`.