### PR TITLE
Fix implementation of IFindReferenceTargetsCallback::FoundTrackerTarget

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -4440,7 +4440,7 @@ HRESULT ClrDataAccess::DACTryGetComWrappersObjectFromCCW(CLRDATA_ADDRESS ccwPtr,
 
     holder = (MOWHOLDERREF)ObjectFromHandle(handle);
 
-    *objRef = holder->WrappedObject;
+    *objRef = holder->_wrappedObject;
 
     return S_OK;
 
@@ -5076,7 +5076,7 @@ namespace
 TADDR ClrDataAccess::GetIdentityForManagedObjectWrapper(TADDR mow)
 {
     PTR_ManagedObjectWrapper pMOW = dac_cast<PTR_ManagedObjectWrapper>(mow);
-    // Replicate the logic for ManagedObjectWrapper.As(IID_IUnknown)
+    // Replicate the logic for _wrapper.As(IID_IUnknown)
     if ((pMOW->GetFlags() & InteropLib::Com::CreateComInterfaceFlagsEx::CallerDefinedIUnknown) == InteropLib::Com::CreateComInterfaceFlagsEx::None)
     {
         // We have the standard IUnknown implementation, so grab it from its known location.
@@ -5173,7 +5173,7 @@ HRESULT ClrDataAccess::GetObjectComWrappersData(CLRDATA_ADDRESS objAddr, CLRDATA
                 for (unsigned int i = 0; i < count; i++)
                 {
                     MOWHOLDERREF pMOWRef = (MOWHOLDERREF)pListItems->GetAt(i);
-                    PTR_ManagedObjectWrapper pMOW = PTR_ManagedObjectWrapper(dac_cast<TADDR>(pMOWRef->ManagedObjectWrapper));
+                    PTR_ManagedObjectWrapper pMOW = PTR_ManagedObjectWrapper(dac_cast<TADDR>(pMOWRef->_wrapper));
 
                     // Now that we have the managed object wrapper, we need to figure out the COM identity of it.
                     TADDR pComIdentity = GetIdentityForManagedObjectWrapper(dac_cast<TADDR>(pMOW));

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -4440,7 +4440,7 @@ HRESULT ClrDataAccess::DACTryGetComWrappersObjectFromCCW(CLRDATA_ADDRESS ccwPtr,
 
     holder = (MOWHOLDERREF)ObjectFromHandle(handle);
 
-    *objRef = holder->_wrappedObject;
+    *objRef = holder->WrappedObject;
 
     return S_OK;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -235,7 +235,7 @@ namespace System.Runtime.InteropServices
                 return HResults.S_FALSE;
             }
 
-            object sourceObject = s_currentRootObjectHandle.Target;
+            object sourceObject = s_currentRootObjectHandle.Target!;
 
             if (sourceObject == targetObject)
             {
@@ -243,7 +243,7 @@ namespace System.Runtime.InteropServices
             }
 
             // Notify the runtime a reference path was found.
-            return TrackerObjectManager.AddReferencePath(sourceObject, foundObject) ? HResults.S_OK : HResults.S_FALSE;
+            return TrackerObjectManager.AddReferencePath(sourceObject, targetObject) ? HResults.S_OK : HResults.S_FALSE;
         }
 
         internal struct ReferenceTargetsVftbl

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -230,13 +230,20 @@ namespace System.Runtime.InteropServices
                 return HResults.E_INVALIDARG;
             }
 
-            if (TryGetObject(referenceTrackerTarget, out object? foundObject))
+            if (!TryGetObject(referenceTrackerTarget, out object? targetObject))
             {
-                // Notify the runtime a reference path was found.
-                return TrackerObjectManager.AddReferencePath(s_currentRootObjectHandle.Target, foundObject) ? HResults.S_OK : HResults.S_FALSE;
+                return HResults.S_FALSE;
             }
 
-            return HResults.S_OK;
+            object sourceObject = s_currentRootObjectHandle.Target;
+
+            if (sourceObject == targetObject)
+            {
+                return HResults.S_FALSE;
+            }
+
+            // Notify the runtime a reference path was found.
+            return TrackerObjectManager.AddReferencePath(sourceObject, foundObject) ? HResults.S_OK : HResults.S_FALSE;
         }
 
         internal struct ReferenceTargetsVftbl

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -230,12 +230,15 @@ namespace System.Runtime.InteropServices
                 return HResults.E_INVALIDARG;
             }
 
-            if (!TryGetObject(referenceTrackerTarget, out object? targetObject))
+            if (s_currentRootObjectHandle.Target is not object sourceObject)
             {
                 return HResults.S_FALSE;
             }
 
-            object sourceObject = s_currentRootObjectHandle.Target!;
+            if (!TryGetObject(referenceTrackerTarget, out object? targetObject))
+            {
+                return HResults.S_FALSE;
+            }
 
             if (sourceObject == targetObject)
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -164,13 +164,13 @@ namespace System.Runtime.InteropServices
                     nativeObjectWrapper.TrackerObject != IntPtr.Zero)
                 {
                     FindReferenceTargetsCallback.s_currentRootObjectHandle = nativeObjectWrapper.ProxyHandle;
-                    if (IReferenceTracker.FindTrackerTargets(nativeObjectWrapper.TrackerObject, (IntPtr)Unsafe.AsPointer(in s_findReferencesTargetCallback)) != HResults.S_OK)
+                    int hr = IReferenceTracker.FindTrackerTargets(nativeObjectWrapper.TrackerObject, (IntPtr)Unsafe.AsPointer(in s_findReferencesTargetCallback));
+                    FindReferenceTargetsCallback.s_currentRootObjectHandle = default;
+                    if (hr < 0)
                     {
                         walkFailed = true;
-                        FindReferenceTargetsCallback.s_currentRootObjectHandle = default;
                         break;
                     }
-                    FindReferenceTargetsCallback.s_currentRootObjectHandle = default;
                 }
             }
 
@@ -227,13 +227,10 @@ namespace System.Runtime.InteropServices
         {
             if (referenceTrackerTarget == IntPtr.Zero)
             {
-                return HResults.E_INVALIDARG;
+                return HResults.E_POINTER;
             }
 
-            if (s_currentRootObjectHandle.Target is not object sourceObject)
-            {
-                return HResults.S_FALSE;
-            }
+            object sourceObject = s_currentRootObjectHandle.Target!;
 
             if (!TryGetObject(referenceTrackerTarget, out object? targetObject))
             {

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -462,8 +462,8 @@ DEFINE_FIELD(COMWRAPPERS, NAITVE_OBJECT_WRAPPER_TABLE, s_nativeObjectWrapperTabl
 DEFINE_FIELD(COMWRAPPERS, ALL_MANAGED_OBJECT_WRAPPER_TABLE, s_allManagedObjectWrapperTable)
 
 DEFINE_CLASS_U(Interop, ComWrappers+ManagedObjectWrapperHolder, ManagedObjectWrapperHolderObject)
-DEFINE_FIELD_U(_wrappedObject, ManagedObjectWrapperHolderObject, WrappedObject)
-DEFINE_FIELD_U(_wrapper, ManagedObjectWrapperHolderObject, ManagedObjectWrapper)
+DEFINE_FIELD_U(_wrappedObject, ManagedObjectWrapperHolderObject, _wrappedObject)
+DEFINE_FIELD_U(_wrapper, ManagedObjectWrapperHolderObject, _wrapper)
 DEFINE_CLASS_U(Interop, ComWrappers+NativeObjectWrapper, NativeObjectWrapperObject)
 DEFINE_FIELD_U(_comWrappers, NativeObjectWrapperObject, _comWrappers)
 DEFINE_FIELD_U(_externalComObject, NativeObjectWrapperObject, _externalComObject)

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -462,6 +462,7 @@ DEFINE_FIELD(COMWRAPPERS, NAITVE_OBJECT_WRAPPER_TABLE, s_nativeObjectWrapperTabl
 DEFINE_FIELD(COMWRAPPERS, ALL_MANAGED_OBJECT_WRAPPER_TABLE, s_allManagedObjectWrapperTable)
 
 DEFINE_CLASS_U(Interop, ComWrappers+ManagedObjectWrapperHolder, ManagedObjectWrapperHolderObject)
+DEFINE_FIELD_U(_wrappedObject, ManagedObjectWrapperHolderObject, WrappedObject)
 DEFINE_FIELD_U(_wrapper, ManagedObjectWrapperHolderObject, ManagedObjectWrapper)
 DEFINE_CLASS_U(Interop, ComWrappers+NativeObjectWrapper, NativeObjectWrapperObject)
 DEFINE_FIELD_U(_comWrappers, NativeObjectWrapperObject, _comWrappers)

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -456,11 +456,6 @@ namespace InteropLibImports
         ::OBJECTHANDLE srcHandle = static_cast<::OBJECTHANDLE>(sourceHandle);
         OBJECTREF source = ObjectFromHandle(srcHandle);
 
-        if (source == NULL)
-        {
-            return S_FALSE;
-        }
-
         // Get the target of the external object's reference.
         ::OBJECTHANDLE tgtHandle = static_cast<::OBJECTHANDLE>(targetHandle);
         MOWHOLDERREF holder = (MOWHOLDERREF)ObjectFromHandle(tgtHandle);
@@ -471,7 +466,7 @@ namespace InteropLibImports
             return S_FALSE;
         }
 
-        OBJECTREF target = holder->WrappedObject;
+        OBJECTREF target = holder->_wrappedObject;
 
         // Return if these are the same object.
         if (source == target)
@@ -508,7 +503,7 @@ bool ComWrappersNative::IsManagedObjectComWrapper(_In_ OBJECTREF managedObjectWr
 
     MOWHOLDERREF holder = (MOWHOLDERREF)managedObjectWrapperHolderRef;
 
-    *pIsRooted = InteropLib::Com::IsRooted(holder->ManagedObjectWrapper);
+    *pIsRooted = InteropLib::Com::IsRooted(holder->_wrapper);
 
     return true;
 }

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -453,16 +453,23 @@ namespace InteropLibImports
         CONTRACTL_END;
 
         // Get the external object's managed wrapper
-        ::OBJECTHANDLE srcHandle = static_cast<::OBJECTHANDLE>(targetHandle);
+        ::OBJECTHANDLE srcHandle = static_cast<::OBJECTHANDLE>(sourceHandle);
         OBJECTREF source = ObjectFromHandle(srcHandle);
 
         // Get the target of the external object's reference.
         ::OBJECTHANDLE tgtHandle = static_cast<::OBJECTHANDLE>(targetHandle);
-        OBJECTREF target = ObjectFromHandle(tgtHandle );
+        MOWHOLDERREF holder = ObjectFromHandle(tgtHandle);
 
-        // Return if the target has been collected or these are the same object.
-        if (target == NULL
-            || source->PassiveGetSyncBlock() == target->PassiveGetSyncBlock())
+        // Return if the holder has been collected
+        if (holder == NULL)
+        {
+            return S_FALSE;
+        }
+
+        OBJECTREF target = holder->WrappedObject;
+
+        // Return if these are the same object.
+        if (source == target)
         {
             return S_FALSE;
         }

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -458,7 +458,7 @@ namespace InteropLibImports
 
         // Get the target of the external object's reference.
         ::OBJECTHANDLE tgtHandle = static_cast<::OBJECTHANDLE>(targetHandle);
-        MOWHOLDERREF holder = ObjectFromHandle(tgtHandle);
+        MOWHOLDERREF holder = (MOWHOLDERREF)ObjectFromHandle(tgtHandle);
 
         // Return if the holder has been collected
         if (holder == NULL)

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -456,6 +456,11 @@ namespace InteropLibImports
         ::OBJECTHANDLE srcHandle = static_cast<::OBJECTHANDLE>(sourceHandle);
         OBJECTREF source = ObjectFromHandle(srcHandle);
 
+        if (source == NULL)
+        {
+            return S_FALSE;
+        }
+
         // Get the target of the external object's reference.
         ::OBJECTHANDLE tgtHandle = static_cast<::OBJECTHANDLE>(targetHandle);
         MOWHOLDERREF holder = (MOWHOLDERREF)ObjectFromHandle(tgtHandle);

--- a/src/coreclr/vm/interoplibinterface_comwrappers.h
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.h
@@ -73,8 +73,8 @@ class ManagedObjectWrapperHolderObject : public Object
     friend class ClrDataAccess;
 private:
     OBJECTREF _releaser;
-    OBJECTREF _wrappedObject;
 public:
+    OBJECTREF WrappedObject;
     DPTR(InteropLib::ABI::ManagedObjectWrapperLayout) ManagedObjectWrapper;
 };
 

--- a/src/coreclr/vm/interoplibinterface_comwrappers.h
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.h
@@ -74,8 +74,8 @@ class ManagedObjectWrapperHolderObject : public Object
 private:
     OBJECTREF _releaser;
 public:
-    OBJECTREF WrappedObject;
-    DPTR(InteropLib::ABI::ManagedObjectWrapperLayout) ManagedObjectWrapper;
+    OBJECTREF _wrappedObject;
+    DPTR(InteropLib::ABI::ManagedObjectWrapperLayout) _wrapper;
 };
 
 class NativeObjectWrapperObject : public Object


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/115881

The implementation of `FoundTrackerTarget` from the ComWrappers refactoring incorrectly used the target as the source and compared syncblocks before creating the connection from source to target. As a result, the target object's live was not tied to the source object's lifetime and was released early even though it was still referenced.