### PR TITLE
[NativeAOT] Fix: Prevent EETypeKindMask invalidation from uint16_t cast

### DIFF
--- a/src/coreclr/nativeaot/Runtime/MethodTable.cpp
+++ b/src/coreclr/nativeaot/Runtime/MethodTable.cpp
@@ -95,7 +95,7 @@ bool MethodTable::Validate(bool assertOnFail /* default: true */)
 //-----------------------------------------------------------------------------------------------------------
 MethodTable::Kinds MethodTable::GetKind()
 {
-	return (Kinds)(m_uFlags & (uint16_t)EETypeKindMask);
+	return (Kinds)(m_uFlags & (uint32_t)EETypeKindMask);
 }
 
 //-----------------------------------------------------------------------------------------------------------

--- a/src/coreclr/nativeaot/Runtime/MethodTable.cpp
+++ b/src/coreclr/nativeaot/Runtime/MethodTable.cpp
@@ -95,7 +95,7 @@ bool MethodTable::Validate(bool assertOnFail /* default: true */)
 //-----------------------------------------------------------------------------------------------------------
 MethodTable::Kinds MethodTable::GetKind()
 {
-	return (Kinds)(m_uFlags & (uint32_t)EETypeKindMask);
+	return (Kinds)(m_uFlags & EETypeKindMask);
 }
 
 //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
EETypeKindMask = 0x00030000, so it need uint32_t. 
@MichalStrehovsky 