### PR TITLE
[RISC-V] Reverse unordered FP comparisons in branches

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3136,65 +3136,38 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 
     if (varTypeIsFloating(op1Type))
     {
-        bool      isUnordered = (tree->gtFlags & GTF_RELOP_NAN_UN) != 0;
-        regNumber regOp1      = op1->GetRegNum();
-        regNumber regOp2      = op2->GetRegNum();
+        assert(!op2->isContainedIntOrIImmed());
+        assert(op1Type == op2Type);
+        genTreeOps oper = tree->OperGet();
 
+        bool isUnordered = (tree->gtFlags & GTF_RELOP_NAN_UN) != 0;
         if (isUnordered)
         {
-            if (tree->OperIs(GT_LT))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_fle_s : INS_fle_d, cmpSize, targetReg, regOp2, regOp1);
-            }
-            else if (tree->OperIs(GT_LE))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_flt_s : INS_flt_d, cmpSize, targetReg, regOp2, regOp1);
-            }
-            else if (tree->OperIs(GT_NE))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_feq_s : INS_feq_d, cmpSize, targetReg, regOp1, regOp2);
-            }
-            else if (tree->OperIs(GT_GT))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_fle_s : INS_fle_d, cmpSize, targetReg, regOp1, regOp2);
-            }
-            else if (tree->OperIs(GT_GE))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_flt_s : INS_flt_d, cmpSize, targetReg, regOp1, regOp2);
-            }
-            else
-            {
-                unreached();
-            }
-            emit->emitIns_R_R_I(INS_xori, EA_8BYTE, targetReg, targetReg, 1);
+            oper = GenTree::ReverseRelop(oper);
         }
-        else
+        if (oper == GT_GT || oper == GT_GE)
         {
-            if (tree->OperIs(GT_LT))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_flt_s : INS_flt_d, cmpSize, targetReg, regOp1, regOp2);
-            }
-            else if (tree->OperIs(GT_LE))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_fle_s : INS_fle_d, cmpSize, targetReg, regOp1, regOp2);
-            }
-            else if (tree->OperIs(GT_EQ))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_feq_s : INS_feq_d, cmpSize, targetReg, regOp1, regOp2);
-            }
-            else if (tree->OperIs(GT_GT))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_flt_s : INS_flt_d, cmpSize, targetReg, regOp2, regOp1);
-            }
-            else if (tree->OperIs(GT_GE))
-            {
-                emit->emitIns_R_R_R(cmpSize == EA_4BYTE ? INS_fle_s : INS_fle_d, cmpSize, targetReg, regOp2, regOp1);
-            }
-            else
-            {
-                unreached();
-            }
+            oper = GenTree::SwapRelop(oper);
+            std::swap(op1, op2);
         }
+        instruction instr = INS_none;
+        switch (oper)
+        {
+            case GT_LT:
+                instr = (cmpSize == EA_4BYTE) ? INS_flt_s : INS_flt_d;
+                break;
+            case GT_LE:
+                instr = (cmpSize == EA_4BYTE) ? INS_fle_s : INS_fle_d;
+                break;
+            case GT_EQ:
+                instr = (cmpSize == EA_4BYTE) ? INS_feq_s : INS_feq_d;
+                break;
+            default:
+                unreached();
+        }
+        emit->emitIns_R_R_R(instr, cmpSize, targetReg, op1->GetRegNum(), op2->GetRegNum());
+        if (isUnordered)
+            emit->emitIns_R_R_I(INS_xori, EA_8BYTE, targetReg, targetReg, 1);
     }
     else
     {

--- a/src/coreclr/jit/lowerriscv64.cpp
+++ b/src/coreclr/jit/lowerriscv64.cpp
@@ -136,11 +136,10 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
     GenTree*     cmpOp1;
     GenTree*     cmpOp2;
 
+    assert(!op->OperIsCompare() || op->OperIsCmpCompare()); // We do not expect any other relops on RISCV64
+
     if (op->OperIsCompare() && !varTypeIsFloating(op->gtGetOp1()))
     {
-        // We do not expect any other relops on RISCV64
-        assert(op->OperIs(GT_EQ, GT_NE, GT_LT, GT_LE, GT_GE, GT_GT));
-
         cond = GenCondition::FromRelop(op);
 
         cmpOp1 = op->gtGetOp1();
@@ -151,7 +150,16 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
     }
     else
     {
-        cond = GenCondition(GenCondition::NE);
+        GenCondition::Code code = GenCondition::NE;
+        if (op->OperIsCompare() && varTypeIsFloating(op->gtGetOp1()) && (op->gtFlags & GTF_RELOP_NAN_UN) != 0)
+        {
+            // Unordered floating-point comparisons are achieved by neg'ing the ordered counterparts. Avoid that by
+            // reversing both the FP comparison and the zero-comparison fused with the branch.
+            op->ChangeOper(GenTree::ReverseRelop(op->OperGet()));
+            op->gtFlags &= ~GTF_RELOP_NAN_UN;
+            code = GenCondition::EQ;
+        }
+        cond = GenCondition(code);
 
         cmpOp1 = op;
         cmpOp2 = comp->gtNewZeroConNode(cmpOp1->TypeGet());


### PR DESCRIPTION
Unordered floating-point comparisons are achieved by neg'ing the ordered counterparts. Avoid that by reversing both the FP comparison and the zero-comparison fused with the branch.

Also, minor codegen haircut.

Part of #84834, cc @dotnet/samsung