### PR TITLE
Add missing null check for SlhDsa's constructor

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
@@ -55,6 +55,7 @@ namespace System.Security.Cryptography
         /// </param>
         protected SlhDsa(SlhDsaAlgorithm algorithm)
         {
+            ArgumentNullException.ThrowIfNull(algorithm);
             Algorithm = algorithm;
         }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
@@ -53,6 +53,9 @@ namespace System.Security.Cryptography
         /// <param name="algorithm">
         ///   The specific SLH-DSA algorithm for this key.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="algorithm" /> is <see langword="null" />.
+        /// </exception>
         protected SlhDsa(SlhDsaAlgorithm algorithm)
         {
             ArgumentNullException.ThrowIfNull(algorithm);

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaContractTests.cs
@@ -50,6 +50,12 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => slhDsa.TryExportEncryptedPkcs8PrivateKey(string.Empty, null, Span<byte>.Empty, out _));
         }
 
+        [Fact]
+        public static void ArgumentValidation_Ctor_NullAlgorithm()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => new SlhDsaMockImplementation(null));
+        }
+
         [Theory]
         [MemberData(nameof(ArgumentValidationData))]
         public static void ArgumentValidation(SlhDsaAlgorithm algorithm, bool shouldDispose)
@@ -95,7 +101,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             SlhDsaTestHelpers.AssertEncryptedExportPkcs8PrivateKey(export =>
             {
                 // Unknown algorithm
-                AssertExtensions.Throws<CryptographicException>(() => 
+                AssertExtensions.Throws<CryptographicException>(() =>
                     export(slhDsa, "PLACEHOLDER", new PbeParameters(PbeEncryptionAlgorithm.Unknown, HashAlgorithmName.SHA1, 42)));
 
                 // TripleDes3KeyPkcs12 only works with SHA1


### PR DESCRIPTION
A type that is derived from `SlhDsa` could pass `null` in to the algorithm parameter. This adds a null check and a test to prevent it. This makes SlhDsa consistent with MLKem and MLDsa's constructor checks.