### PR TITLE
[RuntimeAsync] Do not fail EnC on ordinary Task-returning methods when async feature is turned on.

### DIFF
--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -344,13 +344,6 @@ HRESULT EditAndContinueModule::UpdateMethod(MethodDesc *pMethod)
     }
     CONTRACTL_END;
 
-    if (pMethod->HasAsyncMethodData())
-    {
-        // TODO: (async) revisit and examine if this can be supported
-        LOG((LF_ENC, LL_INFO100, "**Error** EnC for Async methods is NYI"));
-        return E_FAIL;
-    }
-
     // Notify the debugger of the update
     if (CORDebuggerAttached())
     {

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3222,10 +3222,10 @@ void MethodDesc::ResetCodeEntryPointForEnC()
 
     // Updates are expressed via metadata diff and a methoddef of a runtime async method
     // would be resolved to the thunk.
-    // If we see athink here, fetch the other variant that owns the IL and reset that.
+    // If we see a thunk here, fetch the other variant that owns the IL and reset that.
     if (IsAsyncThunkMethod())
     {
-        MethodDesc *otherVariant =  GetAsyncOtherVariantNoCreate();
+        MethodDesc *otherVariant = GetAsyncOtherVariantNoCreate();
         _ASSERTE(otherVariant != NULL);
         otherVariant->ResetCodeEntryPointForEnC();
         return;

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3235,6 +3235,19 @@ void MethodDesc::ResetCodeEntryPointForEnC()
             ppCode, pCode));
         *ppCode = (PCODE)NULL;
     }
+
+    // update of a Task-returning method effectively updates both variants,
+    // so reset the entry for the other variant as well.
+    if (IsTaskReturningMethod())
+    {
+        // TODO: (async) revisit and examine if the following is sufficient for actual runtime async methods when EnC is supported.
+        //       for now we only expect to see ordinary Task-returning methods here (not thunks).
+        _ASSERTE(!IsAsyncThunkMethod());
+
+        MethodDesc *otherVariant =  GetAsyncOtherVariantNoCreate();
+        _ASSERTE(otherVariant != NULL);
+        otherVariant->ResetCodeEntryPointForEnC();
+    }
 }
 
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1658,7 +1658,7 @@ public:
     }
 
     // same as above, but with allowCreate = FALSE
-    // for rare cases where we cannot allow GC, but we know that the other varaint is already created.
+    // for rare cases where we cannot allow GC, but we know that the other variant is already created.
     MethodDesc* GetAsyncOtherVariantNoCreate(BOOL allowInstParam = TRUE)
     {
         return FindOrCreateAssociatedMethodDesc(this, GetMethodTable(), FALSE, GetMethodInstantiation(), allowInstParam, FALSE, FALSE, AsyncVariantLookup::AsyncOtherVariant);

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1657,6 +1657,13 @@ public:
         return FindOrCreateAssociatedMethodDesc(this, GetMethodTable(), FALSE, GetMethodInstantiation(), allowInstParam, FALSE, TRUE, AsyncVariantLookup::AsyncOtherVariant);
     }
 
+    // same as above, but with allowCreate = FALSE
+    // for rare cases where we cannot allow GC, but we know that the other varaint is already created.
+    MethodDesc* GetAsyncOtherVariantNoCreate(BOOL allowInstParam = TRUE)
+    {
+        return FindOrCreateAssociatedMethodDesc(this, GetMethodTable(), FALSE, GetMethodInstantiation(), allowInstParam, FALSE, FALSE, AsyncVariantLookup::AsyncOtherVariant);
+    }
+
     // True if a MD is an funny BoxedEntryPointStub (not from the method table) or
     // an MD for a generic instantiation...In other words the MethodDescs and the
     // MethodTable are guaranteed to be "tightly-knit", i.e. if one is present in


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/115536

We currently reject EnC updates on anything async-aware if async feature is enabled, including ordinary Task-returning methods. That is a regression and the last remaining failure in existing libraries tests if the feature is turned on. 

Note that this fix not supposed to enable support for EnC in the presence of actual runtime async methods (although it may be sufficient). We are not yet looking into that. For the near future it would make sense to just disable EnC when async IL is emitted.

This is just to fix the case when an _existing_ scenario with ordinary task-returning methods is affected if the feature is enabled in the runtime.

NOTE: in this PR the async feature is not enabled. 
We can see that the change actually fixes the failure with the feature turned on in https://github.com/dotnet/runtime/pull/115947 