### PR TITLE
Fix intermittent failures in PAL tests

### DIFF
--- a/src/coreclr/pal/tests/palsuite/threading/Sleep/test1/Sleep.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/Sleep/test1/Sleep.cpp
@@ -45,11 +45,11 @@ PALTEST(threading_Sleep_test1_paltest_sleep_test1, "threading/Sleep/test1/paltes
 
     for( i = 0; i < sizeof(SleepTimes) / sizeof(DWORD); i++)
     {
-        OldTimeStamp = minipal_lowres_ticks();
+        OldTimeStamp = minipal_hires_ticks();
         Sleep(SleepTimes[i]);
-        NewTimeStamp = minipal_lowres_ticks();
+        NewTimeStamp = minipal_hires_ticks();
 
-        TimeDelta = NewTimeStamp - OldTimeStamp;
+        TimeDelta = (NewTimeStamp - OldTimeStamp) / (minipal_hires_tick_frequency() / 1000);;
 
         /* For longer intervals use a 10 percent tolerance */
         if ((SleepTimes[i] * 0.1) > AcceptableTimeError)

--- a/src/coreclr/pal/tests/palsuite/threading/Sleep/test2/sleep.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/Sleep/test2/sleep.cpp
@@ -44,11 +44,11 @@ PALTEST(threading_Sleep_test2_paltest_sleep_test2, "threading/Sleep/test2/paltes
 
     for( i = 0; i < sizeof(SleepTimes) / sizeof(DWORD); i++)
     {
-        OldTimeStamp = minipal_lowres_ticks();
+        OldTimeStamp = minipal_hires_ticks();
         Sleep(SleepTimes[i]);
-        NewTimeStamp = minipal_lowres_ticks();
+        NewTimeStamp = minipal_hires_ticks();
 
-        TimeDelta = NewTimeStamp - OldTimeStamp;
+        TimeDelta = (NewTimeStamp - OldTimeStamp) / (minipal_hires_tick_frequency() / 1000);;
 
         MaxDelta = SleepTimes[i] + AcceptableTimeError;
 

--- a/src/coreclr/pal/tests/palsuite/threading/SleepEx/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SleepEx/test1/test1.cpp
@@ -52,13 +52,13 @@ PALTEST(threading_SleepEx_test1_paltest_sleepex_test1, "threading/SleepEx/test1/
 
     for (i = 0; i<sizeof(testCases) / sizeof(testCases[0]); i++)
     {
-        OldTimeStamp = minipal_lowres_ticks();
+        OldTimeStamp = minipal_hires_ticks();
 
         SleepEx(testCases[i].SleepTime, testCases[i].Alertable);
 
-        NewTimeStamp = minipal_lowres_ticks();
+        NewTimeStamp = minipal_hires_ticks();
 
-        TimeDelta = NewTimeStamp - OldTimeStamp;
+        TimeDelta = (NewTimeStamp - OldTimeStamp) / (minipal_hires_tick_frequency() / 1000);;
 
         /* For longer intervals use a 10 percent tolerance */
         if ((testCases[i].SleepTime * 0.1) > AcceptableTimeError)

--- a/src/coreclr/pal/tests/palsuite/threading/SleepEx/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SleepEx/test2/test2.cpp
@@ -162,12 +162,12 @@ DWORD PALAPI SleeperProc_SleepEx_test2(LPVOID lpParameter)
 
     Alertable = (BOOL)(SIZE_T) lpParameter;
 
-    OldTimeStamp = minipal_lowres_ticks();
+    OldTimeStamp = minipal_hires_ticks();
     s_preWaitTimestampRecorded = true;
 
     ret = SleepEx(ChildThreadSleepTime, Alertable);
     
-    NewTimeStamp = minipal_lowres_ticks();
+    NewTimeStamp = minipal_hires_ticks();
 
     if (Alertable && ret != WAIT_IO_COMPLETION)
     {
@@ -180,7 +180,7 @@ DWORD PALAPI SleeperProc_SleepEx_test2(LPVOID lpParameter)
     }
 
 
-    ThreadSleepDelta = NewTimeStamp - OldTimeStamp;
+    ThreadSleepDelta = (NewTimeStamp - OldTimeStamp) / (minipal_hires_tick_frequency() / 1000);;
 
     return 0;
 }

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.cpp
@@ -156,13 +156,13 @@ DWORD PALAPI WaiterProc_WFMO_test2(LPVOID lpParameter)
 
     Alertable = (BOOL)(SIZE_T) lpParameter;
 
-    OldTimeStamp = minipal_lowres_ticks();
+    OldTimeStamp = minipal_hires_ticks();
     s_preWaitTimestampRecorded = true;
 
     ret = WaitForMultipleObjectsEx(1, &Semaphore, FALSE, ChildThreadWaitTime,
         Alertable);
 
-    NewTimeStamp = minipal_lowres_ticks();
+    NewTimeStamp = minipal_hires_ticks();
 
 
     if (Alertable && ret != WAIT_IO_COMPLETION)
@@ -176,7 +176,7 @@ DWORD PALAPI WaiterProc_WFMO_test2(LPVOID lpParameter)
             "Expected return of WAIT_TIMEOUT, got %d.\n", ret);
     }
 
-    ThreadWaitDelta_WFMO_test2 = NewTimeStamp - OldTimeStamp;
+    ThreadWaitDelta_WFMO_test2 = (NewTimeStamp - OldTimeStamp) / (minipal_hires_tick_frequency() / 1000);;
 
     ret = CloseHandle(Semaphore);
     if (!ret)

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
@@ -184,14 +184,14 @@ DWORD PALAPI WaiterProc_WFSOExMutexTest(LPVOID lpParameter)
 
     Alertable = (BOOL)(SIZE_T) lpParameter;
 
-    OldTimeStamp = minipal_lowres_ticks();
+    OldTimeStamp = minipal_hires_ticks();
     s_preWaitTimestampRecorded = true;
 
     ret = WaitForSingleObjectEx(	hMutex_WFSOExMutexTest, 
 								ChildThreadWaitTime, 
         							Alertable);
     
-    NewTimeStamp = minipal_lowres_ticks();
+    NewTimeStamp = minipal_hires_ticks();
 
     if (Alertable && ret != WAIT_IO_COMPLETION)
     {
@@ -204,7 +204,7 @@ DWORD PALAPI WaiterProc_WFSOExMutexTest(LPVOID lpParameter)
             "Expected return of WAIT_TIMEOUT, got %d.\n", ret);
     }
 
-    ThreadWaitDelta_WFSOExMutexTest = NewTimeStamp - OldTimeStamp;
+    ThreadWaitDelta_WFSOExMutexTest = (NewTimeStamp - OldTimeStamp) / (minipal_hires_tick_frequency() / 1000);;
   
     return 0;
 }

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.cpp
@@ -149,14 +149,14 @@ DWORD PALAPI WaiterProc_WFSOExSemaphoreTest(LPVOID lpParameter)
 
     Alertable = (BOOL)(SIZE_T) lpParameter;
 
-    OldTimeStamp = minipal_lowres_ticks();
+    OldTimeStamp = minipal_hires_ticks();
     s_preWaitTimestampRecorded = true;
 
     ret = WaitForSingleObjectEx(	hSemaphore,
 								ChildThreadWaitTime,
         							Alertable);
 
-    NewTimeStamp = minipal_lowres_ticks();
+    NewTimeStamp = minipal_hires_ticks();
 
 
     if (Alertable && ret != WAIT_IO_COMPLETION)
@@ -171,7 +171,7 @@ DWORD PALAPI WaiterProc_WFSOExSemaphoreTest(LPVOID lpParameter)
     }
 
 
-    ThreadWaitDelta_WFSOExSemaphoreTest = NewTimeStamp - OldTimeStamp;
+    ThreadWaitDelta_WFSOExSemaphoreTest = (NewTimeStamp - OldTimeStamp) / (minipal_hires_tick_frequency() / 1000);;
 
     ret = CloseHandle(hSemaphore);
     if (!ret)

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
@@ -163,14 +163,14 @@ satisfying any threads that were waiting on the object.
 
     Alertable = (BOOL)(SIZE_T) lpParameter;
 
-    OldTimeStamp = minipal_lowres_ticks();
+    OldTimeStamp = minipal_hires_ticks();
     s_preWaitTimestampRecorded = true;
 
     ret = WaitForSingleObjectEx(	hWaitThread, 
 								ChildThreadWaitTime, 
         							Alertable);
     
-    NewTimeStamp = minipal_lowres_ticks();
+    NewTimeStamp = minipal_hires_ticks();
 
 
     if (Alertable && ret != WAIT_IO_COMPLETION)
@@ -184,7 +184,7 @@ satisfying any threads that were waiting on the object.
             "Expected return of WAIT_TIMEOUT, got %d.\n", ret);
     }
 
-    ThreadWaitDelta_WFSOExThreadTest = NewTimeStamp - OldTimeStamp;
+    ThreadWaitDelta_WFSOExThreadTest = (NewTimeStamp - OldTimeStamp) / (minipal_hires_tick_frequency() / 1000);;
 
     ret = CloseHandle(hWaitThread);
     if (!ret)


### PR DESCRIPTION
Fixing regression introduced by #115877. The lowres timestamp has a rounding error that makes the test fail intermittently. Switch back to highres timestamp.