### PR TITLE
Added exfat enum entry

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.UnixFileSystemTypes.cs
@@ -51,6 +51,7 @@ internal static partial class Interop
             devpts = 0x1CD1,
             ecryptfs = 0xF15F,
             efs = 0x00414A53,
+            exfat = 0x2011BAB0,
             exofs = 0x5DF5,
             ext = 0x137D,
             ext2_old = 0xEF51,


### PR DESCRIPTION
Quick fix for https://github.com/dotnet/runtime/issues/115962 adds the missing enum entry for exfat, using the magic number from the coreutils change.