### PR TITLE
Fix conditions mismatch for gc-sections with lld

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -386,7 +386,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </PropertyGroup>
 
     <!-- write linker script for lld (13+) to retain the __modules section -->
-    <WriteLinesToFile File="$(NativeIntermediateOutputPath)sections.ld" Lines="OVERWRITE_SECTIONS { __modules : { KEEP(*(__modules)) } }" Overwrite="true" Condition="'$(LinkerFlavor)' == 'lld' and '$(_LinkerVersion)' &gt; '12'" />
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)sections.ld" Lines="OVERWRITE_SECTIONS { __modules : { KEEP(*(__modules)) } }" Overwrite="true" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(LinkerFlavor)' == 'lld' and '$(_LinkerVersion)' &gt; '12'" />
 
     <Exec Command="&quot;$(CppLinker)&quot; @(CustomLinkerArg, ' ')"
       Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' != 'Static'"


### PR DESCRIPTION


Judging by the changes made in 410aa0a7cb47d66d82634c62633ba26e8a1a002d, gc-sections optimization should be enabled:
- for Unix targets
- when using `lld` newer than 12

Both conditions are checked when adding linker arguments, but only the latter condition is checked when writing the linker script. This PR adds the missing conditions.

<p>
<details open>
<summary>

### Relevant code

</summary>

https://github.com/dotnet/runtime/blob/410aa0a7cb47d66d82634c62633ba26e8a1a002d/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets#L319-L323
https://github.com/dotnet/runtime/blob/410aa0a7cb47d66d82634c62633ba26e8a1a002d/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets#L338-L341

</details>
</p>

<p>
<details open>
<summary>

### Reproduction steps

</summary>

This discrepancy is not observable in standard use cases. However, overriding the relevant properties will result in a vague error message unrelated to the actual issue.

```console
> dotnet publish -r win-x64 -p:PublishAot=true -p:LinkerFlavor=lld project.csproj

...\Microsoft.NETCore.Native.targets(364,156): error MSB4086: 
A numeric comparison was attempted on "$(_LinkerVersion)" that evaluates to "" instead of a number,
in condition "'$(LinkerFlavor)' == 'lld' and '$(_LinkerVersion)' > '12'".
```

Predictably, setting the `_LinkerVersion` property next will cause `sections.ld` file to be written but left unused:

```console
> dotnet publish -r win-x64 -p:PublishAot=true -p:LinkerFlavor=lld -p:_LinkerVersion=13 project.csproj

Build succeeded (...)

> cat obj\Release\net8.0\win-x64\native\sections.ld

OVERWRITE_SECTIONS { __modules : { KEEP(*(__modules)) } }

```

</details>
</p>