### PR TITLE
PipeWriter.UnflushedBytes long property wraps to negative numbers after int.MaxValue

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -20,7 +20,7 @@ namespace System.IO.Pipelines
         private BufferSegment? _tail;
         private Memory<byte> _tailMemory;
         private int _tailBytesBuffered;
-        private int _bytesBuffered;
+        private long _bytesBuffered;
 
         private readonly MemoryPool<byte>? _pool;
         private readonly int _maxPooledBufferSize;
@@ -75,8 +75,12 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.bytes);
             }
 
-            _tailBytesBuffered += bytes;
-            _bytesBuffered += bytes;
+            checked
+            {
+                _tailBytesBuffered += bytes;
+                _bytesBuffered += bytes;
+            }
+
             _tailMemory = _tailMemory.Slice(bytes);
         }
 

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -75,9 +75,9 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.bytes);
             }
 
+            _tailBytesBuffered += bytes;
             checked
             {
-                _tailBytesBuffered += bytes;
                 _bytesBuffered += bytes;
             }
 

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -77,7 +77,6 @@ namespace System.IO.Pipelines
 
             _tailBytesBuffered += bytes;
             _bytesBuffered += bytes;
-
             _tailMemory = _tailMemory.Slice(bytes);
         }
 

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -76,10 +76,7 @@ namespace System.IO.Pipelines
             }
 
             _tailBytesBuffered += bytes;
-            checked
-            {
-                _bytesBuffered += bytes;
-            }
+            _bytesBuffered += bytes;
 
             _tailMemory = _tailMemory.Slice(bytes);
         }

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -365,22 +365,15 @@ namespace System.IO.Pipelines.Tests
         public void UnflushedBytesShouldOverflowInt()
         {
             PipeWriter writer = PipeWriter.Create(Stream.Null);
+            int bufferSize = 10000;
+
             while (writer.UnflushedBytes >= 0 && writer.UnflushedBytes <= int.MaxValue)
             {
-                Memory<byte> buffer = writer.GetMemory();
-                if (buffer.Length < 47)
-                {
-                    writer.Advance(21);
-                    buffer = writer.GetMemory(47);
-                    writer.Advance(14);
-                }
-                else
-                {
-                    writer.Advance(35);
-                }
+                writer.GetMemory(bufferSize);
+                writer.Advance(bufferSize);
             }
 
-            Assert.True(writer.UnflushedBytes > int.MaxValue);
+            Assert.Equal(2147490000, writer.UnflushedBytes);
         }
     }
 }

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -362,7 +362,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.Is64BitProcess))]
-        public void UnflushedBytesShouldOverflowInt()
+        public void UnflushedBytes_HandlesLargeValues()
         {
             PipeWriter writer = PipeWriter.Create(Stream.Null);
             int bufferSize = 10000;

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -360,5 +360,27 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(0, pool.CurrentlyRentedBlocks);
             Assert.Equal(0, Pipe.Writer.UnflushedBytes);
         }
+
+        [Fact]
+        public void UnflushedBytesShouldOverflowInt()
+        {
+            PipeWriter writer = PipeWriter.Create(Stream.Null);
+            while (writer.UnflushedBytes >= 0 && writer.UnflushedBytes <= int.MaxValue)
+            {
+                Memory<byte> buffer = writer.GetMemory();
+                if (buffer.Length < 47)
+                {
+                    writer.Advance(21);
+                    buffer = writer.GetMemory(47);
+                    writer.Advance(14);
+                }
+                else
+                {
+                    writer.Advance(35);
+                }
+            }
+
+            Assert.True(writer.UnflushedBytes > int.MaxValue);
+        }
     }
 }

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -361,7 +361,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(0, Pipe.Writer.UnflushedBytes);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.Is64BitProcess))]
         public void UnflushedBytesShouldOverflowInt()
         {
             PipeWriter writer = PipeWriter.Create(Stream.Null);


### PR DESCRIPTION
Fixes #109513