### PR TITLE
Remove bounds check for arr1[arr2.Length] pattern

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1486,7 +1486,7 @@ bool RangeCheck::ComputeDoesOverflow(BasicBlock* block, GenTree* expr, const Ran
     {
         overflows = false;
     }
-    else if (expr->OperIs(GT_IND))
+    else if (expr->OperIs(GT_IND, GT_ARR_LENGTH))
     {
         overflows = false;
     }
@@ -1643,6 +1643,11 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreas
     {
         // TODO: consider computing range for CastOp and intersect it with this.
         range = GetRangeFromType(expr->AsCast()->CastToType());
+    }
+    else if (expr->OperIs(GT_ARR_LENGTH))
+    {
+        // Better than keUnknown
+        range = Range(Limit(Limit::keConstant, 0), Limit(Limit::keConstant, CORINFO_Array_MaxLength));
     }
     else
     {


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/115793

```cs
static bool Repro(string prefix, string path)
{
    if (prefix.Length < path.Length)
        return (path[prefix.Length] == '/');

    return false;
}
```

```diff
 ; Method Program:Repro(System.String,System.String):ubyte (FullOpts)
-      sub      rsp, 40
       mov      ecx, dword ptr [rcx+0x08]
-      mov      r8d, dword ptr [rdx+0x08]
-      cmp      ecx, r8d
+      mov      eax, dword ptr [rdx+0x08]
+      cmp      ecx, eax
       jl       SHORT G_M15110_IG05
       xor      eax, eax
-      add      rsp, 40
       ret      
 G_M15110_IG05:
-      cmp      ecx, r8d
-      jae      SHORT G_M15110_IG07
       mov      eax, ecx
       cmp      word  ptr [rdx+2*rax+0x0C], 47
       sete     al
       movzx    rax, al
-      add      rsp, 40
       ret      
-G_M15110_IG07:
-      call     CORINFO_HELP_RNGCHKFAIL
-      int3     
-; Total bytes of code: 53
+; Total bytes of code: 28
```

A few [diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1050763&view=ms.vss-build-web.run-extensions-tab)