### PR TITLE
Switch to ymm after zmm in genZeroInitFrameUsingBlockInit

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -11267,8 +11267,8 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
                 assert(regSize >= XMM_REGSIZE_BYTES);
 
                 // frameReg is definitely not known to be 32B/64B aligned -> switch to unaligned movs
-                instruction ins = regSize > XMM_REGSIZE_BYTES ? simdUnalignedMovIns() : simdMov;
-                const int offset  = blkSize - lenRemaining;
+                instruction ins    = regSize > XMM_REGSIZE_BYTES ? simdUnalignedMovIns() : simdMov;
+                const int   offset = blkSize - lenRemaining;
                 emit->emitIns_AR_R(ins, EA_ATTR(regSize), zeroSIMDReg, frameReg, alignedLclLo + offset);
 
                 lenRemaining -= regSize;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -11265,8 +11265,10 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
                 const int regSize = (int)compiler->roundDownSIMDSize(lenRemaining);
                 const int offset  = blkSize - lenRemaining;
 
-                emit->emitIns_AR_R(simdUnalignedMovIns(), EA_ATTR(regSize), zeroSIMDReg, frameReg,
-                                   alignedLclLo + offset);
+                // It is known to be 16-bytes aligned
+                instruction ins = regSize == XMM_REGSIZE_BYTES ? simdAlignedMovIns() : simdUnalignedMovIns();
+
+                emit->emitIns_AR_R(ins, EA_ATTR(regSize), zeroSIMDReg, frameReg, alignedLclLo + offset);
 
                 assert(lenRemaining >= regSize);
                 lenRemaining -= regSize;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -11259,7 +11259,7 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
 
             assert((blkSize % XMM_REGSIZE_BYTES) == 0);
 
-            int regSize = (int)compiler->roundDownSIMDSize(blkSize);
+            int regSize      = (int)compiler->roundDownSIMDSize(blkSize);
             int lenRemaining = blkSize;
             while (lenRemaining > 0)
             {


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/114274

```diff
 vxorps   xmm4, xmm4, xmm4
 vmovdqu32 zmmword ptr [rsp+0x20], zmm4
-vmovdqa  xmmword ptr [rsp+0x60], xmm4
-vmovdqa  xmmword ptr [rsp+0x70], xmm4
+vmovdqu  ymmword ptr [rsp+0x60], ymm4
 vmovdqu  xmmword ptr [rsp+0x80], xmm4
```

