### PR TITLE
Skip static fields in FieldLayoutIntervalCalculator

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutIntervalCalculator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutIntervalCalculator.cs
@@ -135,6 +135,9 @@ namespace Internal.TypeSystem
 
                 foreach (FieldDesc field in fieldType.GetFields())
                 {
+                    if (field.IsStatic)
+                        continue;
+
                     int fieldOffset = offset + field.Offset.AsInt;
                     AddToFieldLayout(fieldLayout, fieldOffset, field.FieldType);
                 }


### PR DESCRIPTION
It was reported on discord that:

```csharp
using System.Runtime.InteropServices;

ref struct Inner1
{
    public const string SomeStr = "AAA";
}

ref struct Inner2
{
    public Inner1 F;
}

[StructLayout(LayoutKind.Explicit, Size = 100)]
ref struct Outer
{
    [FieldOffset(0)]
    public Inner2 F;
}


class Program
{
    static void Main(string[] args)
    {
        Outer x = new Outer();
        x.F.F = new Inner1();
        Console.WriteLine(Inner1.SomeStr);
    }
}
```

Will throw a _"System.TypeLoadException: Could not load type 'Outer' from assembly 'TestProj, Version=1.0.0.0, Culture=neutral, PublicKey=null' because it contains an object field at offset '2147483647' that is incorrectly aligned or overlapped by a non-object field"_ at runtime in .NET 9.

It does not throw that on .NET 10, presumably thanks to #111584, but psychic debugging tells me we still have an issue here.