### PR TITLE
[Mono] Fix wait's returning false on non-runtime queued user APC's.

### DIFF
--- a/src/mono/mono/metadata/monitor.c
+++ b/src/mono/mono/metadata/monitor.c
@@ -1345,7 +1345,7 @@ mono_monitor_wait (MonoObjectHandle obj_handle, guint32 ms, MonoBoolean allow_in
 	 * is private to this thread.  Therefore even if the event was
 	 * signalled before we wait, we still succeed.
 	 */
-	ret = mono_w32handle_wait_one (event, ms, TRUE);
+	ret = mono_w32handle_wait_one (event, ms, allow_interruption);
 
 	/* Reset the thread state fairly early, so we don't have to worry
 	 * about the monitor error checking
@@ -1390,6 +1390,10 @@ mono_monitor_wait (MonoObjectHandle obj_handle, guint32 ms, MonoBoolean allow_in
 		 * wait queue
 		 */
 		mon->wait_list = g_slist_remove (mon->wait_list, event);
+
+		if (is_ok (error) && allow_interruption && ret == MONO_W32HANDLE_WAIT_RET_ALERTED)
+			mono_error_set_thread_interrupted (error);
+
 	}
 	mono_w32event_close (event);
 

--- a/src/mono/mono/utils/mono-threads.h
+++ b/src/mono/mono/utils/mono-threads.h
@@ -859,13 +859,13 @@ void mono_target_thread_schedule_synchronization_context(MonoNativeThreadId targ
 void
 mono_win32_enter_alertable_wait (THREAD_INFO_TYPE *info);
 
-void
+gboolean
 mono_win32_leave_alertable_wait (THREAD_INFO_TYPE *info);
 
 void
 mono_win32_enter_blocking_io_call (THREAD_INFO_TYPE *info, HANDLE io_handle);
 
-void
+gboolean
 mono_win32_leave_blocking_io_call (THREAD_INFO_TYPE *info, HANDLE io_handle);
 
 void

--- a/src/tests/baseservices/threading/regressions/115178/115178.cs
+++ b/src/tests/baseservices/threading/regressions/115178/115178.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+using System.Threading;
+using Xunit;
+
+/*
+ * Issue description:
+ User APCs can be queued to a thread that is waiting on a wait handle.
+ This should not cancel the wait if the APC has not been queued by Mono runtime
+ as a result of internal interrupt handling.
+*/
+
+public class Test_wait_intrerrupted_user_apc
+{
+    public static bool Run115178Test => TestLibrary.Utilities.IsMonoRuntime && TestLibrary.Utilities.IsWindows;
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr GetCurrentProcess();
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr GetCurrentThread();
+
+    [DllImport("kernel32.dll")]
+    private static extern uint QueueUserAPC(
+        IntPtr pfnAPC,
+        IntPtr hThread,
+        UIntPtr dwData);
+
+    [DllImport("kernel32.dll")]
+    private static extern bool DuplicateHandle(
+        IntPtr hSourceProcessHandle,
+        IntPtr hSourceHandle,
+        IntPtr hTargetProcessHandle,
+        out IntPtr lpTargetHandle,
+        uint dwDesiredAccess,
+        bool bInheritHandle,
+        uint dwOptions);
+
+    private delegate void ApcCallback(UIntPtr param);
+
+    private static readonly ManualResetEventSlim waitEvent = new ManualResetEventSlim(false);
+
+    private static readonly ManualResetEventSlim apcExecuted = new ManualResetEventSlim(false);
+
+    private static IntPtr threadHandle;
+
+    private static int result = 100;
+
+    private static void OnApcCallback(UIntPtr param)
+    {
+        apcExecuted.Set();
+    }
+
+    private static void RunTestUsingInfiniteWait()
+    {
+        Console.WriteLine($"Running RunTestUsingInfiniteWait test.");
+
+        var enterWait = new ManualResetEventSlim(false);
+        var leaveWait = new ManualResetEventSlim(false);
+
+        apcExecuted.Reset();
+        waitEvent.Reset();
+
+        new Thread(() =>
+        {
+            Console.WriteLine($"Starting thread waiting on event.");
+
+            IntPtr pseudoHandle = GetCurrentThread();
+            if (!DuplicateHandle(
+                    GetCurrentProcess(),
+                    GetCurrentThread(),
+                    GetCurrentProcess(),
+                    out threadHandle,
+                    0,
+                    false,
+                    2))
+            {
+                Console.WriteLine($"Error duplicating handle, error code: {Marshal.GetLastWin32Error()}");
+                result = 1;
+            }
+
+            enterWait.Set();
+
+            bool signaled = waitEvent.Wait(Timeout.Infinite);
+            if (!signaled)
+            {
+                Console.WriteLine($"Error waiting on event, unknown user APC canceled wait.");
+                result = 2;
+            }
+
+            signaled = waitEvent.Wait(0);
+            if (!signaled)
+            {
+                Console.WriteLine($"Error waiting on event, event should be signaled.");
+                result = 3;
+            }
+
+            Console.WriteLine($"Stopping thread waiting on event.");
+            leaveWait.Set();
+        }).Start();
+
+        ApcCallback callback = OnApcCallback;
+        IntPtr pfnAPC = Marshal.GetFunctionPointerForDelegate(callback);
+
+        Console.WriteLine($"Waiting for thread to enter wait...");
+        enterWait.Wait(Timeout.Infinite);
+
+        Console.WriteLine($"Queue user APC.");
+        QueueUserAPC(pfnAPC, threadHandle, UIntPtr.Zero);
+
+        Console.WriteLine($"Waiting for APC to execute...");
+        apcExecuted.Wait(Timeout.Infinite);
+
+        Console.WriteLine($"Signaling wait event.");
+        waitEvent.Set();
+
+        Console.WriteLine($"Waiting for thread to leave wait...");
+        leaveWait.Wait(Timeout.Infinite);
+
+        Console.WriteLine($"RunTestUsingInfiniteWait test executed.");
+
+        GC.KeepAlive(callback);
+    }
+
+    private static void RunTestUsingTimedWait()
+    {
+        Console.WriteLine($"Running RunTestUsingTimedWait test.");
+
+        var enterWait = new ManualResetEventSlim(false);
+        var leaveWait = new ManualResetEventSlim(false);
+
+        apcExecuted.Reset();
+        waitEvent.Reset();
+
+        new Thread(() =>
+        {
+            Console.WriteLine($"Starting thread waiting on event.");
+
+            IntPtr pseudoHandle = GetCurrentThread();
+            if (!DuplicateHandle(
+                    GetCurrentProcess(),
+                    GetCurrentThread(),
+                    GetCurrentProcess(),
+                    out threadHandle,
+                    0,
+                    false,
+                    2))
+            {
+                Console.WriteLine($"Error duplicating handle, error code: {Marshal.GetLastWin32Error()}");
+                result = 4;
+            }
+
+            enterWait.Set();
+
+            apcExecuted.Wait(Timeout.Infinite);
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            waitEvent.Wait(2000);
+
+            stopwatch.Stop();
+
+            if (stopwatch.ElapsedMilliseconds < 2000)
+            {
+                Console.WriteLine($"Error waiting on event, wait returned too early.");
+                result = 5;
+            }
+
+            Console.WriteLine($"Stopping thread waiting on event.");
+            leaveWait.Set();
+        }).Start();
+
+        ApcCallback callback = OnApcCallback;
+        IntPtr pfnAPC = Marshal.GetFunctionPointerForDelegate(callback);
+
+        Console.WriteLine($"Waiting for thread to enter wait...");
+        enterWait.Wait(Timeout.Infinite);
+
+        Console.WriteLine($"Queue user APC's.");
+
+        do
+        {
+            QueueUserAPC(pfnAPC, threadHandle, UIntPtr.Zero);
+        }
+        while (!leaveWait.Wait(100));
+
+        Console.WriteLine($"Waiting for thread to leave wait...");
+        leaveWait.Wait(Timeout.Infinite);
+
+        Console.WriteLine($"RunTestUsingTimedWait test executed.");
+
+        GC.KeepAlive(callback);
+    }
+
+    [ConditionalFact(nameof(Run115178Test))]
+    public static int TestEntryPoint()
+    {
+        RunTestUsingInfiniteWait();
+        RunTestUsingTimedWait();
+        return result;
+    }
+}

--- a/src/tests/baseservices/threading/regressions/115178/115178.cs
+++ b/src/tests/baseservices/threading/regressions/115178/115178.cs
@@ -10,7 +10,7 @@ using Xunit;
 /*
  * Issue description:
  User APCs can be queued to a thread that is waiting on a wait handle.
- This should not cancel the wait if the APC has not been queued by Mono runtime
+ This should not cancel the wait if the APC has not been queued by runtime
  as a result of internal interrupt handling.
 */
 

--- a/src/tests/baseservices/threading/regressions/115178/115178.csproj
+++ b/src/tests/baseservices/threading/regressions/115178/115178.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="115178.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Mono's internal interrupt handling uses user APC to break waits in case runtime needs to interrupt threads. If that happens, wait will return false. For API's like `ManualResetEventSlim.Wait()` with `void` return, this can cause issues if the wait is broken prematurely. If a user APC have been queued to the thread, not triggered by internal runtime interrupt handling, it would lead to unexpected side effects.

Fix makes sure runtime ignores returns from WaitForSingleObjectEx/WaitForMultipleObjectsEx due to APC completions not initialized by runtime.

Fix also adds a new runtime test to trigger this scenario for Mono runtime on Windows.

Fixes https://github.com/dotnet/runtime/issues/115178.