### PR TITLE
JIT: Don't allow broadcast lowering to remove cast from decomposed long

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -9815,7 +9815,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                                 {
                                     GenTreeCast* cast = op1->AsCast();
                                     if (!varTypeIsFloating(cast->CastToType()) &&
-                                        !varTypeIsFloating(cast->CastFromType()) &&
+                                        !varTypeIsFloating(cast->CastFromType()) && !cast->CastOp()->OperIsLong() &&
                                         (genTypeSize(cast->CastToType()) >= genTypeSize(simdBaseType)) &&
                                         (genTypeSize(cast->CastFromType()) >= genTypeSize(simdBaseType)))
                                     {


### PR DESCRIPTION
Fixes #115202

I was unable to create a minimal repro for this, but using the latest SPMI context from https://github.com/dotnet/runtime/issues/115202#issuecomment-2902026130, I found the cause.
 
The problematic IR starts out as:

```
N025 (???,???) [016563] -ACXG+-----                t16563 = *  CALL      long   <unknown method>
                                                            /--*  t16563 long   
N026 (???,???) [016564] -ACXG+-----                t16564 = *  CAST      int <- long
                                                            /--*  t16564 int    
N027 (???,???) [016565] -ACXG+-----                t16565 = *  HWINTRINSIC simd32 32 int Create
```

This `Vector256.Create` is lowered to `Avx2.BroadcastScalarToVector256 <- Vector256.CreateScalarUnsafe <- CAST(int <- long)`.

Then the containment check for broadcast, which looks for that specific pattern, is eating both the `CreateScalarUnsafe` and the `GT_CAST`.

Resulting in an uncontained `GT_LONG`:

```
               [038143] -----------                t38143 =    LCL_FLD   int    V1485 tmp1445    [+0]
               [038144] -----------                t38144 =    LCL_FLD   int    V1485 tmp1445    [+4]
                                                            /--*  t38143 int    
                                                            +--*  t38144 int    
               [038145] -----------                t38145 = *  LONG      long  
                                                            /--*  t38145 long   
N027 (???,???) [016565] -ACXG+-----                t16565 = *  HWINTRINSIC simd32 32 int BroadcastScalarToVector256
```

In this case, the cast should have been preserved, and it should contain the `GT_LONG`.

Correct IR after lowering:

```
               [038143] -----------                t38143 =    LCL_FLD   int    V1485 tmp1445    [+0]
               [038144] -----------                t38144 =    LCL_FLD   int    V1485 tmp1445    [+4]
                                                            /--*  t38143 int    
                                                            +--*  t38144 int    
               [038145] -c---------                t38145 = *  LONG      long  
                                                            /--*  t38145 long   
N026 (???,???) [016564] -ACXG+-----                t16564 = *  CAST      int <- long
                                                            /--*  t16564 int    
N027 (???,???) [016565] -ACXG+-----                t16565 = *  HWINTRINSIC simd32 32 int BroadcastScalarToVector256
```
