### PR TITLE
JIT: Always intersect exception sets of defs

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_112848/Runtime_112848.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_112848/Runtime_112848.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Runtime_112848;
+
+public class BaseClass { }
+
+public class TestClass : BaseClass
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Test_LDLOC(object _obj, bool flag)
+    {
+        object obj = _obj;
+        TestClass inst = null;
+        if (flag)
+        {
+            inst = (TestClass)obj;
+            return inst != null;
+        }
+        else
+        {
+            inst = (TestClass)obj;
+            return obj == null;
+        }
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        try
+        {
+            if (!Test_LDLOC(new BaseClass(), false))
+            {
+                Console.WriteLine("Failed => 103");
+                return 103;
+            }
+            
+            return 104;
+        }
+        catch (InvalidCastException)
+        {
+            Console.WriteLine("Caught InvalidCastException as expected");
+        }
+        Console.WriteLine("Done");
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_112848/Runtime_112848.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_112848/Runtime_112848.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_LCL_FLD" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_112848/Runtime_112848.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_112848/Runtime_112848.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
-    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_LCL_FLD" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_LCL_FLDS" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The existing logic would only intersect the exception sets of subsequent defs if it had also seen a use. That meant for a list of [DEF, DEF, USE] CSE candidates we would only validate that the first def's exception set was sufficient for the use.

Fix #112848