### PR TITLE
Revert "[release/9.0-staging] Fix crash during Async Break when APC and CET are enabled"

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -4312,19 +4312,7 @@ bool DebuggerController::DispatchNativeException(EXCEPTION_RECORD *pException,
     }
 #endif
 
-#ifdef FEATURE_SPECIAL_USER_MODE_APC
-     if (pCurThread->m_State & Thread::TS_SSToExitApcCall)
-     {
-         if (!CheckActivationSafePoint(GetIP(pContext)))
-         {
-             return FALSE;
-         }
-         pCurThread->SetThreadState(Thread::TS_SSToExitApcCallDone);
-         pCurThread->ResetThreadState(Thread::TS_SSToExitApcCall);        
-         DebuggerController::UnapplyTraceFlag(pCurThread);
-         pCurThread->MarkForSuspensionAndWait(Thread::TS_DebugSuspendPending);
-     }
-#endif
+
 
     // Must restore the filter context. After the filter context is gone, we're
     // unprotected again and unsafe for a GC.

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -15075,14 +15075,6 @@ HRESULT Debugger::FuncEvalSetup(DebuggerIPCE_FuncEvalInfo *pEvalInfo,
         return CORDBG_E_ILLEGAL_IN_STACK_OVERFLOW;
     }
 
-#ifdef FEATURE_SPECIAL_USER_MODE_APC
-    if (pThread->m_hasPendingActivation)
-    {
-        _ASSERTE(!"Should never get here with a pending activation. (Debugger::FuncEvalSetup)");
-        return CORDBG_E_ILLEGAL_IN_NATIVE_CODE;
-    }
-#endif  
-
     bool fInException = pEvalInfo->evalDuringException;
 
     // The thread has to be at a GC safe place for now, just in case the func eval causes a collection. Processing an
@@ -16740,6 +16732,7 @@ Debugger::EnumMemoryRegionsIfFuncEvalFrame(CLRDataEnumMemoryFlags flags, Frame *
         }
     }
 }
+
 #endif // #ifdef DACCESS_COMPILE
 
 #ifndef DACCESS_COMPILE
@@ -16827,6 +16820,7 @@ void Debugger::SendSetThreadContextNeeded(CONTEXT *context, DebuggerSteppingInfo
     LOG((LF_CORDB, LL_INFO10000, "D::SSTCN SetThreadContextNeededFlare returned\n"));
     _ASSERTE(!"We failed to SetThreadContext from out of process!");
 }
+
 BOOL Debugger::IsOutOfProcessSetContextEnabled()
 {
     return m_fOutOfProcessSetContextEnabled;
@@ -16843,16 +16837,6 @@ BOOL Debugger::IsOutOfProcessSetContextEnabled()
 }
 #endif // OUT_OF_PROCESS_SETTHREADCONTEXT
 #endif // DACCESS_COMPILE
-#ifndef DACCESS_COMPILE
-#ifdef FEATURE_SPECIAL_USER_MODE_APC
-void Debugger::SingleStepToExitApcCall(Thread* pThread, CONTEXT *interruptedContext)
-{
-    pThread->SetThreadState(Thread::TS_SSToExitApcCall);
-    g_pEEInterface->SetThreadFilterContext(pThread, interruptedContext);
-    DebuggerController::EnableSingleStep(pThread);
-    g_pEEInterface->SetThreadFilterContext(pThread, NULL);
-}
-#endif //FEATURE_SPECIAL_USER_MODE_APC
-#endif // DACCESS_COMPILE
+
 #endif //DEBUGGING_SUPPORTED
 

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -3098,11 +3098,6 @@ public:
     // Used by Debugger::FirstChanceNativeException to update the context from out of process
     void SendSetThreadContextNeeded(CONTEXT *context, DebuggerSteppingInfo *pDebuggerSteppingInfo = NULL);
     BOOL IsOutOfProcessSetContextEnabled();
-#ifndef DACCESS_COMPILE
-#ifdef FEATURE_SPECIAL_USER_MODE_APC
-    void SingleStepToExitApcCall(Thread* pThread, CONTEXT *interruptedContext);
-#endif // FEATURE_SPECIAL_USER_MODE_APC
-#endif
 };
 
 

--- a/src/coreclr/vm/dbginterface.h
+++ b/src/coreclr/vm/dbginterface.h
@@ -414,9 +414,6 @@ public:
 #ifndef DACCESS_COMPILE
     virtual HRESULT DeoptimizeMethod(Module* pModule, mdMethodDef methodDef) = 0;
     virtual HRESULT IsMethodDeoptimized(Module *pModule, mdMethodDef methodDef, BOOL *pResult) = 0;
-#ifdef FEATURE_SPECIAL_USER_MODE_APC
-    virtual void SingleStepToExitApcCall(Thread* pThread, CONTEXT *interruptedContext) = 0;
-#endif // FEATURE_SPECIAL_USER_MODE_APC     
 #endif //DACCESS_COMPILE
 };
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -489,7 +489,6 @@ class Thread
     friend void STDCALL OnHijackWorker(HijackArgs * pArgs);
 #ifdef FEATURE_THREAD_ACTIVATION
     friend void HandleSuspensionForInterruptedThread(CONTEXT *interruptedContext);
-    friend void HandleSuspensionForInterruptedThread(CONTEXT *interruptedContext, bool suspendForDebugger);    
     friend BOOL CheckActivationSafePoint(SIZE_T ip);
 #endif // FEATURE_THREAD_ACTIVATION
 
@@ -558,7 +557,7 @@ public:
         TS_Hijacked               = 0x00000080,    // Return address has been hijacked
 #endif // FEATURE_HIJACK
 
-        TS_SSToExitApcCall        = 0x00000100,    // Enable SS and resume the thread to exit an APC Call and keep the thread in suspend state
+        // unused                 = 0x00000100,
         TS_Background             = 0x00000200,    // Thread is a background thread
         TS_Unstarted              = 0x00000400,    // Thread has never been started
         TS_Dead                   = 0x00000800,    // Thread is dead
@@ -575,7 +574,7 @@ public:
         TS_ReportDead             = 0x00010000,    // in WaitForOtherThreads()
         TS_FullyInitialized       = 0x00020000,    // Thread is fully initialized and we are ready to broadcast its existence to external clients
 
-        TS_SSToExitApcCallDone    = 0x00040000,    // The thread exited an APC Call and it is already resumed and paused on SS
+        // unused                 = 0x00040000,
 
         TS_SyncSuspended          = 0x00080000,    // Suspended via WaitSuspendEvent
         TS_DebugWillSync          = 0x00100000,    // Debugger will wait for this thread to sync
@@ -2569,9 +2568,6 @@ private:
     // Waiting & Synchronization
     //-------------------------------------------------------------
 
-friend class DebuggerController;
-protected:
-    void MarkForSuspensionAndWait(ULONG bit);
     // For suspends.  The thread waits on this event.  A client sets the event to cause
     // the thread to resume.
     void    WaitSuspendEvents();

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -4238,18 +4238,6 @@ bool Thread::SysSweepThreadsForDebug(bool forceSync)
         if ((thread->m_State & TS_DebugWillSync) == 0)
             continue;
 
-#ifdef FEATURE_SPECIAL_USER_MODE_APC
-        if (thread->m_State & Thread::TS_SSToExitApcCallDone)
-        {
-            thread->ResetThreadState(Thread::TS_SSToExitApcCallDone);
-            goto Label_MarkThreadAsSynced;
-        }
-        if (thread->m_State & Thread::TS_SSToExitApcCall)
-        {
-            continue;
-        }
- #endif
-
         if (!UseContextBasedThreadRedirection())
         {
             // On platforms that do not support safe thread suspension we either
@@ -5365,19 +5353,6 @@ BOOL Thread::HandledJITCase()
 #endif // FEATURE_HIJACK
 
 // Some simple helpers to keep track of the threads we are waiting for
-void Thread::MarkForSuspensionAndWait(ULONG bit)
-{
-    CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-    }
-    CONTRACTL_END;
-    m_DebugSuspendEvent.Reset();
-    InterlockedOr((LONG*)&m_State, bit);
-    ThreadStore::IncrementTrapReturningThreads();
-    m_DebugSuspendEvent.Wait(INFINITE,FALSE);
-}
-
 void Thread::MarkForSuspension(ULONG bit)
 {
     CONTRACTL {
@@ -5800,7 +5775,7 @@ BOOL CheckActivationSafePoint(SIZE_T ip)
 //       address to take the thread to the appropriate stub (based on the return
 //       type of the method) which will then handle preparing the thread for GC.
 //
-void HandleSuspensionForInterruptedThread(CONTEXT *interruptedContext, bool suspendForDebugger)
+void HandleSuspensionForInterruptedThread(CONTEXT *interruptedContext)
 {
     struct AutoClearPendingThreadActivation
     {
@@ -5835,18 +5810,6 @@ void HandleSuspensionForInterruptedThread(CONTEXT *interruptedContext, bool susp
     EECodeInfo codeInfo(ip);
     if (!codeInfo.IsValid())
         return;
-
-#ifdef FEATURE_SPECIAL_USER_MODE_APC
-    // It's not allowed to change the IP while paused in an APC Callback for security reasons if CET is turned on
-    // So we enable the single step in the thread that is running the APC Callback
-    // and then it will be paused using single step exception after exiting the APC callback
-    // this will allow the debugger to setIp to execute FuncEvalHijack.
-    if (suspendForDebugger)
-    {
-        g_pDebugInterface->SingleStepToExitApcCall(pThread, interruptedContext);
-        return;
-    }
- #endif    
 
     DWORD addrOffset = codeInfo.GetRelOffset();
 
@@ -5923,11 +5886,6 @@ void HandleSuspensionForInterruptedThread(CONTEXT *interruptedContext, bool susp
     }
 }
 
-void HandleSuspensionForInterruptedThread(CONTEXT *interruptedContext)
-{
-    HandleSuspensionForInterruptedThread(interruptedContext, false);
-}
-
 #ifdef FEATURE_SPECIAL_USER_MODE_APC
 void Thread::ApcActivationCallback(ULONG_PTR Parameter)
 {
@@ -5957,7 +5915,7 @@ void Thread::ApcActivationCallback(ULONG_PTR Parameter)
         case ActivationReason::SuspendForGC:
         case ActivationReason::SuspendForDebugger:
         case ActivationReason::ThreadAbort:
-            HandleSuspensionForInterruptedThread(pContext, reason == ActivationReason::SuspendForDebugger);
+            HandleSuspensionForInterruptedThread(pContext);
             break;
 
         default:


### PR DESCRIPTION
Reverts dotnet/runtime#114932