### PR TITLE
Remove canceled AsyncOperations from channel queues

### DIFF
--- a/src/libraries/Common/src/System/Collections/Concurrent/SingleProducerSingleConsumerQueue.cs
+++ b/src/libraries/Common/src/System/Collections/Concurrent/SingleProducerSingleConsumerQueue.cs
@@ -99,7 +99,7 @@ namespace System.Collections.Concurrent
         /// <param name="segment">The segment in which to first attempt to store the item.</param>
         private void EnqueueSlow(T item, ref Segment segment)
         {
-            Debug.Assert(segment != null, "Expected a non-null segment.");
+            Debug.Assert(segment is not null, "Expected a non-null segment.");
 
             if (segment._state._firstCopy != segment._state._first)
             {
@@ -176,8 +176,8 @@ namespace System.Collections.Concurrent
         /// <returns>true if an item could be dequeued; otherwise, false.</returns>
         private bool TryDequeueSlow(Segment segment, T[] array, bool peek, [MaybeNullWhen(false)] out T result)
         {
-            Debug.Assert(segment != null, "Expected a non-null segment.");
-            Debug.Assert(array != null, "Expected a non-null item array.");
+            Debug.Assert(segment is not null, "Expected a non-null segment.");
+            Debug.Assert(array is not null, "Expected a non-null item array.");
 
             if (segment._state._last != segment._state._lastCopy)
             {
@@ -187,7 +187,7 @@ namespace System.Collections.Concurrent
                     TryDequeue(out result); // will only recur once for this operation
             }
 
-            if (segment._next != null && segment._state._first == segment._state._last)
+            if (segment._next is not null && segment._state._first == segment._state._last)
             {
                 segment = segment._next;
                 array = segment._array;
@@ -227,7 +227,7 @@ namespace System.Collections.Concurrent
             if (first != segment._state._lastCopy)
             {
                 result = array[first];
-                if (predicate == null || predicate(result))
+                if (predicate is null || predicate(result))
                 {
                     array[first] = default!; // Clear the slot to release the element
                     segment._state._first = (first + 1) & (array.Length - 1);
@@ -250,8 +250,8 @@ namespace System.Collections.Concurrent
         /// <returns>true if an item could be dequeued; otherwise, false.</returns>
         private bool TryDequeueIfSlow(Predicate<T>? predicate, Segment segment, T[] array, [MaybeNullWhen(false)] out T result)
         {
-            Debug.Assert(segment != null, "Expected a non-null segment.");
-            Debug.Assert(array != null, "Expected a non-null item array.");
+            Debug.Assert(segment is not null, "Expected a non-null segment.");
+            Debug.Assert(array is not null, "Expected a non-null item array.");
 
             if (segment._state._last != segment._state._lastCopy)
             {
@@ -259,7 +259,7 @@ namespace System.Collections.Concurrent
                 return TryDequeueIf(predicate, out result); // will only recur once for this dequeue operation
             }
 
-            if (segment._next != null && segment._state._first == segment._state._last)
+            if (segment._next is not null && segment._state._first == segment._state._last)
             {
                 segment = segment._next;
                 array = segment._array;
@@ -275,7 +275,7 @@ namespace System.Collections.Concurrent
             }
 
             result = array[first];
-            if (predicate == null || predicate(result))
+            if (predicate is null || predicate(result))
             {
                 array[first] = default!; // Clear the slot to release the element
                 segment._state._first = (first + 1) & (segment._array.Length - 1);
@@ -312,7 +312,7 @@ namespace System.Collections.Concurrent
                     return false;
                 }
 
-                return head._next == null;
+                return head._next is null;
             }
         }
 
@@ -320,7 +320,7 @@ namespace System.Collections.Concurrent
         /// <remarks>This method is not safe to use concurrently with any other members that may mutate the collection.</remarks>
         public IEnumerator<T> GetEnumerator()
         {
-            for (Segment? segment = _head; segment != null; segment = segment._next)
+            for (Segment? segment = _head; segment is not null; segment = segment._next)
             {
                 for (int pt = segment._state._first;
                     pt != segment._state._last;
@@ -341,7 +341,7 @@ namespace System.Collections.Concurrent
             get
             {
                 int count = 0;
-                for (Segment? segment = _head; segment != null; segment = segment._next)
+                for (Segment? segment = _head; segment is not null; segment = segment._next)
                 {
                     int arraySize = segment._array.Length;
                     int first, last;
@@ -365,7 +365,7 @@ namespace System.Collections.Concurrent
         /// <remarks>The Count is not thread safe, so we need to acquire the lock.</remarks>
         int IProducerConsumerQueue<T>.GetCountSafe(object syncObj)
         {
-            Debug.Assert(syncObj != null, "The syncObj parameter is null.");
+            Debug.Assert(syncObj is not null, "The syncObj parameter is null.");
             lock (syncObj)
             {
                 return Count;
@@ -426,7 +426,7 @@ namespace System.Collections.Concurrent
             /// <param name="queue">The queue being debugged.</param>
             public SingleProducerSingleConsumerQueue_DebugView(SingleProducerSingleConsumerQueue<T> queue)
             {
-                Debug.Assert(queue != null, "Expected a non-null queue.");
+                Debug.Assert(queue is not null, "Expected a non-null queue.");
                 _queue = queue;
             }
 

--- a/src/libraries/Common/src/System/Collections/Generic/Deque.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/Deque.cs
@@ -10,7 +10,7 @@ namespace System.Collections.Generic
     [DebuggerDisplay("Count = {_size}")]
     internal sealed class Deque<T>
     {
-        private T[] _array = Array.Empty<T>();
+        private T[] _array = [];
         private int _head; // First valid element in the queue
         private int _tail; // First open slot in the dequeue, unless the dequeue is full
         private int _size; // Number of elements.
@@ -72,7 +72,7 @@ namespace System.Collections.Generic
         public T PeekTail()
         {
             Debug.Assert(!IsEmpty); // caller's responsibility to make sure there are elements remaining
-            var index = _tail - 1;
+            int index = _tail - 1;
             if (index == -1)
             {
                 index = _array.Length - 1;

--- a/src/libraries/System.Threading.Channels/src/System.Threading.Channels.csproj
+++ b/src/libraries/System.Threading.Channels/src/System.Threading.Channels.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.1;netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
@@ -37,6 +37,7 @@ System.Threading.Channel&lt;T&gt;</PackageDescription>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <Compile Include="System\Threading\Channels\AsyncOperation.netstandard.cs" />
+    <Compile Include="System\Threading\Channels\ChannelUtilities.netstandard.cs" />
     <Compile Include="System\Threading\Channels\TaskCompletionSource.cs" />
   </ItemGroup>
 
@@ -44,6 +45,7 @@ System.Threading.Channel&lt;T&gt;</PackageDescription>
     <Compile Include="System\Threading\Channels\AsyncOperation.netcoreapp.cs" />
     <Compile Include="System\Threading\Channels\Channel.netcoreapp.cs" />
     <Compile Include="System\Threading\Channels\ChannelOptions.netcoreapp.cs" />
+    <Compile Include="System\Threading\Channels\ChannelUtilities.netcoreapp.cs" />
     <Compile Include="System\Threading\Channels\UnboundedPriorityChannel.cs" />
   </ItemGroup>
 

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
@@ -3,22 +3,22 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
 
 namespace System.Threading.Channels
 {
-    internal abstract class AsyncOperation
+    /// <summary>Represents an asynchronous operation on a channel.</summary>
+    internal abstract partial class AsyncOperation
     {
         /// <summary>Sentinel object used in a field to indicate the operation is available for use.</summary>
         protected static readonly Action<object?> s_availableSentinel = AvailableSentinel; // named method to help with debugging
-        private static void AvailableSentinel(object? s) => Debug.Fail($"{nameof(AsyncOperation)}.{nameof(AvailableSentinel)} invoked with {s}");
+        private static void AvailableSentinel(object? s) => Debug.Fail($"{nameof(AsyncOperation<>)}.{nameof(AvailableSentinel)} invoked with {s}");
 
         /// <summary>Sentinel object used in a field to indicate the operation has completed</summary>
         protected static readonly Action<object?> s_completedSentinel = CompletedSentinel; // named method to help with debugging
-        private static void CompletedSentinel(object? s) => Debug.Fail($"{nameof(AsyncOperation)}.{nameof(CompletedSentinel)} invoked with {s}");
+        private static void CompletedSentinel(object? s) => Debug.Fail($"{nameof(AsyncOperation<>)}.{nameof(CompletedSentinel)} invoked with {s}");
 
         /// <summary>Throws an exception indicating that the operation's result was accessed before the operation completed.</summary>
         protected static void ThrowIncompleteOperationException() =>
@@ -31,30 +31,39 @@ namespace System.Threading.Channels
         /// <summary>Throws an exception indicating that the operation was used after it was supposed to be used.</summary>
         protected static void ThrowIncorrectCurrentIdException() =>
             throw new InvalidOperationException(SR.InvalidOperation_IncorrectToken);
-    }
 
-    /// <summary>The representation of an asynchronous operation that has a result value.</summary>
-    /// <typeparam name="TResult">Specifies the type of the result.  May be <see cref="VoidResult"/>.</typeparam>
-    internal partial class AsyncOperation<TResult> : AsyncOperation, IValueTaskSource, IValueTaskSource<TResult>
-    {
         /// <summary>Registration with a provided cancellation token.</summary>
-        private readonly CancellationTokenRegistration _registration;
+        private readonly CancellationTokenRegistration _cancellationRegistration;
+
+#if !NET
+        /// <summary>Callback invoked when cancellation is requested.</summary>
+        /// <remarks>
+        /// This is not needed on .NET, where the CancellationToken.UnsafeRegister method accepts this signature directly.
+        /// On .NET Framework / .NET Standard we need to proxy this via the overload that takes only the object instance.
+        /// </remarks>
+        private readonly Action<object?, CancellationToken> _cancellationCallback;
+#endif
+
         /// <summary>true if this object is pooled and reused; otherwise, false.</summary>
         /// <remarks>
         /// If the operation is cancelable, then it can't be pooled.  And if it's poolable, there must never be race conditions to complete it,
         /// which is the main reason poolable objects can't be cancelable, as then cancellation could fire, the object could get reused,
         /// and then we may end up trying to complete an object that's used by someone else.
         /// </remarks>
-        private readonly bool _pooled;
-        /// <summary>Whether continuations should be forced to run asynchronously.</summary>
-        private readonly bool _runContinuationsAsynchronously;
+        private protected readonly bool _pooled;
 
         /// <summary>Only relevant to cancelable operations; 0 if the operation hasn't had completion reserved, 1 if it has.</summary>
-        private volatile int _completionReserved;
-        /// <summary>The result of the operation.</summary>
-        private TResult? _result;
+        private volatile
+#if NET9_0_OR_GREATER
+            bool
+#else
+            int
+#endif
+            _completionReserved;
+
         /// <summary>Any error that occurred during the operation.</summary>
-        private ExceptionDispatchInfo? _error;
+        private protected ExceptionDispatchInfo? _error;
+
         /// <summary>The continuation callback.</summary>
         /// <remarks>
         /// This may be the completion sentinel if the operation has already completed.
@@ -62,286 +71,81 @@ namespace System.Threading.Channels
         /// This may be null if the operation is pending.
         /// This may be another callback if the operation has had a callback hooked up with OnCompleted.
         /// </remarks>
-        private Action<object?>? _continuation;
+        private protected Action<object?>? _continuation;
+
         /// <summary>State object to be passed to <see cref="_continuation"/>.</summary>
-        private object? _continuationState;
-        /// <summary>Scheduling context (a <see cref="SynchronizationContext"/> or <see cref="TaskScheduler"/>) to which to queue the continuation. May be null.</summary>
-        private object? _schedulingContext;
-        /// <summary>Execution context to use when invoking <see cref="_continuation"/>. May be null.</summary>
-        private ExecutionContext? _executionContext;
+        private protected object? _continuationState;
+
+        /// <summary>
+        /// Null if no special context was found.
+        /// ExecutionContext if one was captured due to needing to be flowed.
+        /// A scheduler (TaskScheduler or SynchronizationContext) if one was captured and needs to be used for callback scheduling.
+        /// Or a CapturedSchedulerAndExecutionContext if there's both an ExecutionContext and a scheduler.
+        /// The most common and the fast path case to optimize for is null.
+        /// </summary>
+        private protected object? _capturedContext;
+
         /// <summary>The token value associated with the current operation.</summary>
         /// <remarks>
         /// IValueTaskSource operations on this instance are only valid if the provided token matches this value,
         /// which is incremented once GetResult is called to avoid multiple awaits on the same instance.
         /// </remarks>
-        private short _currentId;
+        private protected short _currentId;
 
         /// <summary>Initializes the interactor.</summary>
         /// <param name="runContinuationsAsynchronously">true if continuations should be forced to run asynchronously; otherwise, false.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel the operation.</param>
         /// <param name="pooled">Whether this instance is pooled and reused.</param>
-        public AsyncOperation(bool runContinuationsAsynchronously, CancellationToken cancellationToken = default, bool pooled = false)
+        /// <param name="cancellationCallback">Callback to invoke if cancellation is requested.</param>
+        protected AsyncOperation(
+            bool runContinuationsAsynchronously,
+            CancellationToken cancellationToken,
+            bool pooled,
+            Action<object?, CancellationToken>? cancellationCallback)
         {
+            Debug.Assert(!pooled || !cancellationToken.CanBeCanceled);
+
             _continuation = pooled ? s_availableSentinel : null;
             _pooled = pooled;
-            _runContinuationsAsynchronously = runContinuationsAsynchronously;
+            RunContinuationsAsynchronously = runContinuationsAsynchronously;
+
             if (cancellationToken.CanBeCanceled)
             {
+                Debug.Assert(cancellationCallback is not null, "Expected a non-null cancellation callback when the token is cancelable");
                 Debug.Assert(!_pooled, "Cancelable operations can't be pooled");
+#if NET
+                _cancellationRegistration = cancellationToken.UnsafeRegister(cancellationCallback, this);
+#else
+                _cancellationCallback = cancellationCallback;
                 CancellationToken = cancellationToken;
-                _registration = UnsafeRegister(cancellationToken, static s =>
+                _cancellationRegistration = cancellationToken.Register(static s =>
                 {
-                    var thisRef = (AsyncOperation<TResult>)s!;
-                    thisRef.TrySetCanceled(thisRef.CancellationToken);
+                    var thisRef = (AsyncOperation)s!;
+                    thisRef._cancellationCallback(thisRef, thisRef.CancellationToken);
                 }, this);
+#endif
             }
         }
 
-        /// <summary>Gets or sets the next operation in the linked list of operations.</summary>
-        public AsyncOperation<TResult>? Next { get; set; }
+        /// <summary>Gets whether continuations should be forced to run asynchronously.</summary>
+        public bool RunContinuationsAsynchronously { get; }
+
         /// <summary>Gets the cancellation token associated with this operation.</summary>
-        public CancellationToken CancellationToken { get; }
-        /// <summary>Gets a <see cref="ValueTask"/> backed by this instance and its current token.</summary>
-        public ValueTask ValueTask => new ValueTask(this, _currentId);
-        /// <summary>Gets a <see cref="ValueTask{TResult}"/> backed by this instance and its current token.</summary>
-        public ValueTask<TResult> ValueTaskOfT => new ValueTask<TResult>(this, _currentId);
-
-        /// <summary>Gets the current status of the operation.</summary>
-        /// <param name="token">The token that must match <see cref="_currentId"/>.</param>
-        public ValueTaskSourceStatus GetStatus(short token)
-        {
-            if (_currentId != token)
-            {
-                ThrowIncorrectCurrentIdException();
-            }
-
-            return
-                !IsCompleted ? ValueTaskSourceStatus.Pending :
-                _error == null ? ValueTaskSourceStatus.Succeeded :
-                _error.SourceException is OperationCanceledException ? ValueTaskSourceStatus.Canceled :
-                ValueTaskSourceStatus.Faulted;
-        }
+        private CancellationToken CancellationToken
+#if NET
+            => _cancellationRegistration.Token;
+#else
+            { get; }
+#endif
 
         /// <summary>Gets whether the operation has completed.</summary>
         internal bool IsCompleted => ReferenceEquals(_continuation, s_completedSentinel);
-
-        /// <summary>Gets the result of the operation.</summary>
-        /// <param name="token">The token that must match <see cref="_currentId"/>.</param>
-        public TResult GetResult(short token)
-        {
-            if (_currentId != token)
-            {
-                ThrowIncorrectCurrentIdException();
-            }
-
-            if (!IsCompleted)
-            {
-                ThrowIncompleteOperationException();
-            }
-
-            ExceptionDispatchInfo? error = _error;
-            TResult? result = _result;
-            _currentId++;
-
-            if (_pooled)
-            {
-                Volatile.Write(ref _continuation, s_availableSentinel); // only after fetching all needed data
-            }
-
-            error?.Throw();
-            return result!;
-        }
-
-        /// <summary>Gets the result of the operation.</summary>
-        /// <param name="token">The token that must match <see cref="_currentId"/>.</param>
-        void IValueTaskSource.GetResult(short token)
-        {
-            if (_currentId != token)
-            {
-                ThrowIncorrectCurrentIdException();
-            }
-
-            if (!IsCompleted)
-            {
-                ThrowIncompleteOperationException();
-            }
-
-            ExceptionDispatchInfo? error = _error;
-            _currentId++;
-
-            if (_pooled)
-            {
-                Volatile.Write(ref _continuation, s_availableSentinel); // only after fetching all needed data
-            }
-
-            error?.Throw();
-        }
-
-        /// <summary>Attempts to take ownership of the pooled instance.</summary>
-        /// <returns>true if the instance is now owned by the caller, in which case its state has been reset; otherwise, false.</returns>
-        public bool TryOwnAndReset()
-        {
-            Debug.Assert(_pooled, "Should only be used for pooled objects");
-            if (ReferenceEquals(Interlocked.CompareExchange(ref _continuation, null, s_availableSentinel), s_availableSentinel))
-            {
-                _continuationState = null;
-                _result = default;
-                _error = null;
-                _schedulingContext = null;
-                _executionContext = null;
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>Hooks up a continuation callback for when the operation has completed.</summary>
-        /// <param name="continuation">The callback.</param>
-        /// <param name="state">The state to pass to the callback.</param>
-        /// <param name="token">The current token that must match <see cref="_currentId"/>.</param>
-        /// <param name="flags">Flags that influence the behavior of the callback.</param>
-        public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
-        {
-            if (_currentId != token)
-            {
-                ThrowIncorrectCurrentIdException();
-            }
-
-            // We need to store the state before the CompareExchange, so that if it completes immediately
-            // after the CompareExchange, it'll find the state already stored.  If someone misuses this
-            // and schedules multiple continuations erroneously, we could end up using the wrong state.
-            // Make a best-effort attempt to catch such misuse.
-            if (_continuationState != null)
-            {
-                ThrowMultipleContinuations();
-            }
-            _continuationState = state;
-
-            // Capture the execution context if necessary.
-            Debug.Assert(_executionContext == null);
-            if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) != 0)
-            {
-                _executionContext = ExecutionContext.Capture();
-            }
-
-            // Capture the scheduling context if necessary.
-            Debug.Assert(_schedulingContext == null);
-            SynchronizationContext? sc = null;
-            TaskScheduler? ts = null;
-            if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) != 0)
-            {
-                sc = SynchronizationContext.Current;
-                if (sc != null && sc.GetType() != typeof(SynchronizationContext))
-                {
-                    _schedulingContext = sc;
-                }
-                else
-                {
-                    sc = null;
-                    ts = TaskScheduler.Current;
-                    if (ts != TaskScheduler.Default)
-                    {
-                        _schedulingContext = ts;
-                    }
-                }
-            }
-
-            // Try to set the provided continuation into _continuation.  If this succeeds, that means the operation
-            // has not yet completed, and the completer will be responsible for invoking the callback.  If this fails,
-            // that means the operation has already completed, and we must invoke the callback, but because we're still
-            // inside the awaiter's OnCompleted method and we want to avoid possible stack dives, we must invoke
-            // the continuation asynchronously rather than synchronously.
-            Action<object?>? prevContinuation = Interlocked.CompareExchange(ref _continuation, continuation, null);
-            if (prevContinuation != null)
-            {
-                // If the set failed because there's already a delegate in _continuation, but that delegate is
-                // something other than s_completedSentinel, something went wrong, which should only happen if
-                // the instance was erroneously used, likely to hook up multiple continuations.
-                Debug.Assert(IsCompleted, $"Expected IsCompleted");
-                if (!ReferenceEquals(prevContinuation, s_completedSentinel))
-                {
-                    Debug.Assert(prevContinuation != s_availableSentinel, "Continuation was the available sentinel.");
-                    ThrowMultipleContinuations();
-                }
-
-                // Queue the continuation.  We always queue here, even if !RunContinuationsAsynchronously, in order
-                // to avoid stack diving; this path happens in the rare race when we're setting up to await and the
-                // object is completed after the awaiter.IsCompleted but before the awaiter.OnCompleted.
-                if (_schedulingContext == null)
-                {
-                    if (_executionContext == null)
-                    {
-                        UnsafeQueueUserWorkItem(continuation, state);
-                    }
-                    else
-                    {
-                        QueueUserWorkItem(continuation, state);
-                    }
-                }
-                else if (sc != null)
-                {
-                    sc.Post(static s =>
-                    {
-                        var t = (KeyValuePair<Action<object?>, object?>)s!;
-                        t.Key(t.Value);
-                    }, new KeyValuePair<Action<object?>, object?>(continuation, state));
-                }
-                else
-                {
-                    Debug.Assert(ts != null);
-                    Task.Factory.StartNew(continuation, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
-                }
-            }
-        }
-
-        /// <summary>Unregisters from cancellation and returns whether cancellation already started.</summary>
-        /// <returns>
-        /// true if either the instance wasn't cancelable or cancellation successfully unregistered without cancellation having started.
-        /// false if cancellation successfully unregistered after cancellation was initiated.
-        /// </returns>
-        /// <remarks>
-        /// This is important for two reasons:
-        /// 1. To avoid leaking a registration into a token, so it must be done prior to completing the operation.
-        /// 2. To avoid having to worry about concurrent completion; once invoked, the caller can be guaranteed
-        /// that no one else will try to complete the operation (assuming the caller is properly constructed
-        /// and themselves guarantees only a single completer other than through cancellation).
-        /// </remarks>
-        public bool UnregisterCancellation()
-        {
-            if (CancellationToken.CanBeCanceled)
-            {
-                _registration.Dispose(); // Dispose rather than Unregister is important to know work has quiesced
-                return _completionReserved == 0;
-            }
-
-            Debug.Assert(_registration == default);
-            return true;
-        }
-
-        /// <summary>Completes the operation with a success state and the specified result.</summary>
-        /// <param name="item">The result value.</param>
-        /// <returns>true if the operation could be successfully transitioned to a completed state; false if it was already completed.</returns>
-        public bool TrySetResult(TResult item)
-        {
-            UnregisterCancellation();
-
-            if (TryReserveCompletionIfCancelable())
-            {
-                _result = item;
-                SignalCompletion();
-                return true;
-            }
-
-            return false;
-        }
 
         /// <summary>Completes the operation with a failed state and the specified error.</summary>
         /// <param name="exception">The error.</param>
         /// <returns>true if the operation could be successfully transitioned to a completed state; false if it was already completed.</returns>
         public bool TrySetException(Exception exception)
         {
-            UnregisterCancellation();
-
             if (TryReserveCompletionIfCancelable())
             {
                 _error = ExceptionDispatchInfo.Capture(exception);
@@ -371,53 +175,82 @@ namespace System.Threading.Channels
         /// <remarks>
         /// This will always return true for non-cancelable objects, as they only ever have a single owner
         /// responsible for completion.  For cancelable operations, this will attempt to atomically transition
-        /// from Initialized to CompletionReserved.
+        /// to a reserved completion state.
         /// </remarks>
-        private bool TryReserveCompletionIfCancelable() =>
+        public bool TryReserveCompletionIfCancelable() =>
             !CancellationToken.CanBeCanceled ||
-            Interlocked.CompareExchange(ref _completionReserved, 1, 0) == 0;
+            Interlocked.Exchange(ref _completionReserved,
+#if NET9_0_OR_GREATER
+                true) == false;
+#else
+                1) == 0;
+#endif
 
         /// <summary>Signals to a registered continuation that the operation has now completed.</summary>
-        private void SignalCompletion()
+        private protected void SignalCompletion()
         {
-            if (_continuation != null || Interlocked.CompareExchange(ref _continuation, s_completedSentinel, null) != null)
+            Debug.Assert(
+                !CancellationToken.CanBeCanceled ||
+#if NET9_0_OR_GREATER
+                _completionReserved);
+#else
+                _completionReserved == 1);
+#endif
+
+            // Unregister cancellation. It's fine to use CTR.Unregister rather than CTR.Dispose and not wait for any pending
+            // callback, because if we're here completion has already been reserved. If this is being called as part of the
+            // cancellation callback, then Dispose wouldn't wait, anyway. And if this is being called as part of TrySetResult/Exception,
+            // then they've already reserved completion, so the cancellation callback (which starts with a TrySetCanceled) will
+            // be a nop, as its TrySetCanceled will return false and the callback will exit without doing further work.
+            Unregister(_cancellationRegistration);
+
+            if (_continuation is not null || Interlocked.CompareExchange(ref _continuation, s_completedSentinel, null) is not null)
             {
                 Debug.Assert(_continuation != s_completedSentinel, $"The continuation was the completion sentinel.");
                 Debug.Assert(_continuation != s_availableSentinel, $"The continuation was the available sentinel.");
 
-                if (_schedulingContext == null)
+                object? ctx = _capturedContext;
+                if (ctx is null or ExecutionContext)
                 {
                     // There's no captured scheduling context.  If we're forced to run continuations asynchronously, queue it.
                     // Otherwise fall through to invoke it synchronously.
-                    if (_runContinuationsAsynchronously)
+                    if (RunContinuationsAsynchronously)
                     {
                         UnsafeQueueSetCompletionAndInvokeContinuation();
                         return;
                     }
                 }
-                else if (_schedulingContext is SynchronizationContext sc)
-                {
-                    // There's a captured synchronization context.  If we're forced to run continuations asynchronously,
-                    // or if there's a current synchronization context that's not the one we're targeting, queue it.
-                    // Otherwise fall through to invoke it synchronously.
-                    if (_runContinuationsAsynchronously || sc != SynchronizationContext.Current)
-                    {
-                        sc.Post(static s => ((AsyncOperation<TResult>)s!).SetCompletionAndInvokeContinuation(), this);
-                        return;
-                    }
-                }
                 else
                 {
-                    // There's a captured TaskScheduler.  If we're forced to run continuations asynchronously,
-                    // or if there's a current scheduler that's not the one we're targeting, queue it.
-                    // Otherwise fall through to invoke it synchronously.
-                    TaskScheduler ts = (TaskScheduler)_schedulingContext;
-                    Debug.Assert(ts != null, "Expected a TaskScheduler");
-                    if (_runContinuationsAsynchronously || ts != TaskScheduler.Current)
+                    SynchronizationContext? sc =
+                        ctx as SynchronizationContext ??
+                        (ctx as CapturedSchedulerAndExecutionContext)?._scheduler as SynchronizationContext;
+                    if (sc is not null)
                     {
-                        Task.Factory.StartNew(static s => ((AsyncOperation<TResult>)s!).SetCompletionAndInvokeContinuation(), this,
-                            CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
-                        return;
+                        // There's a captured synchronization context.  If we're forced to run continuations asynchronously,
+                        // or if there's a current synchronization context that's not the one we're targeting, queue it.
+                        // Otherwise fall through to invoke it synchronously.
+                        if (RunContinuationsAsynchronously || sc != SynchronizationContext.Current)
+                        {
+                            sc.Post(static s => ((AsyncOperation)s!).SetCompletionAndInvokeContinuation(), this);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        // There's a captured TaskScheduler.  If we're forced to run continuations asynchronously,
+                        // or if there's a current scheduler that's not the one we're targeting, queue it.
+                        // Otherwise fall through to invoke it synchronously.
+                        TaskScheduler? ts =
+                            ctx as TaskScheduler ??
+                            (ctx as CapturedSchedulerAndExecutionContext)?._scheduler as TaskScheduler;
+                        Debug.Assert(ts is not null, "Expected a TaskScheduler");
+                        if (RunContinuationsAsynchronously || ts != TaskScheduler.Current)
+                        {
+                            Task.Factory.StartNew(static s => ((AsyncOperation)s!).SetCompletionAndInvokeContinuation(), this,
+                                CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
+                            return;
+                        }
                     }
                 }
 
@@ -428,7 +261,13 @@ namespace System.Threading.Channels
 
         private void SetCompletionAndInvokeContinuation()
         {
-            if (_executionContext == null)
+            object? ctx = _capturedContext;
+            ExecutionContext? ec =
+                ctx is null ? null :
+                ctx as ExecutionContext ??
+                (ctx as CapturedSchedulerAndExecutionContext)?._executionContext;
+
+            if (ec is null)
             {
                 Action<object?> c = _continuation!;
                 _continuation = s_completedSentinel;
@@ -436,31 +275,326 @@ namespace System.Threading.Channels
             }
             else
             {
-                ExecutionContext.Run(_executionContext, static s =>
+                ExecutionContext.Run(ec, static s =>
                 {
-                    var thisRef = (AsyncOperation<TResult>)s!;
+                    var thisRef = (AsyncOperation)s!;
                     Action<object?> c = thisRef._continuation!;
                     thisRef._continuation = s_completedSentinel;
                     c(thisRef._continuationState);
                 }, this);
             }
         }
+
+        /// <summary>Hooks up a continuation callback for when the operation has completed.</summary>
+        /// <param name="continuation">The callback.</param>
+        /// <param name="state">The state to pass to the callback.</param>
+        /// <param name="token">The current token that must match <see cref="_currentId"/>.</param>
+        /// <param name="flags">Flags that influence the behavior of the callback.</param>
+        public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        {
+            if (_currentId != token)
+            {
+                ThrowIncorrectCurrentIdException();
+            }
+
+            // We need to store the state before the CompareExchange, so that if it completes immediately
+            // after the CompareExchange, it'll find the state already stored.  If someone misuses this
+            // and schedules multiple continuations erroneously, we could end up using the wrong state.
+            // Make a best-effort attempt to catch such misuse.
+            if (_continuationState is not null)
+            {
+                ThrowMultipleContinuations();
+            }
+            _continuationState = state;
+
+            // Capture the execution context if necessary.
+            Debug.Assert(_capturedContext is null);
+            if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) != 0)
+            {
+                _capturedContext = ExecutionContext.Capture();
+            }
+
+            // Capture the scheduling context if necessary.
+            SynchronizationContext? sc = null;
+            TaskScheduler? ts = null;
+            if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) != 0)
+            {
+                sc = SynchronizationContext.Current;
+                if (sc is not null && sc.GetType() != typeof(SynchronizationContext))
+                {
+                    _capturedContext = _capturedContext is null ?
+                        sc :
+                        new CapturedSchedulerAndExecutionContext(sc, (ExecutionContext)_capturedContext);
+                }
+                else
+                {
+                    sc = null;
+                    ts = TaskScheduler.Current;
+                    if (ts != TaskScheduler.Default)
+                    {
+                        _capturedContext = _capturedContext is null ?
+                            ts :
+                            new CapturedSchedulerAndExecutionContext(ts, (ExecutionContext)_capturedContext);
+                    }
+                    else
+                    {
+                        ts = null;
+                    }
+                }
+            }
+
+            // Try to set the provided continuation into _continuation.  If this succeeds, that means the operation
+            // has not yet completed, and the completer will be responsible for invoking the callback.  If this fails,
+            // that means the operation has already completed, and we must invoke the callback, but because we're still
+            // inside the awaiter's OnCompleted method and we want to avoid possible stack dives, we must invoke
+            // the continuation asynchronously rather than synchronously.
+            Action<object?>? prevContinuation = Interlocked.CompareExchange(ref _continuation, continuation, null);
+            if (prevContinuation is not null)
+            {
+                // If the set failed because there's already a delegate in _continuation, but that delegate is
+                // something other than s_completedSentinel, something went wrong, which should only happen if
+                // the instance was erroneously used, likely to hook up multiple continuations.
+                Debug.Assert(IsCompleted, $"Expected IsCompleted");
+                if (!ReferenceEquals(prevContinuation, s_completedSentinel))
+                {
+                    Debug.Assert(prevContinuation != s_availableSentinel, "Continuation was the available sentinel.");
+                    ThrowMultipleContinuations();
+                }
+
+                // Queue the continuation.  We always queue here, even if !RunContinuationsAsynchronously, in order
+                // to avoid stack diving; this path happens in the rare race when we're setting up to await and the
+                // object is completed after the awaiter.IsCompleted but before the awaiter.OnCompleted.
+                if (_capturedContext is null)
+                {
+                    ChannelUtilities.UnsafeQueueUserWorkItem(continuation, state);
+                }
+                else if (sc is not null)
+                {
+                    sc.Post(static s =>
+                    {
+                        var t = (KeyValuePair<Action<object?>, object?>)s!;
+                        t.Key(t.Value);
+                    }, new KeyValuePair<Action<object?>, object?>(continuation, state));
+                }
+                else if (ts is not null)
+                {
+                    Debug.Assert(ts is not null);
+                    Task.Factory.StartNew(continuation, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
+                }
+                else
+                {
+                    Debug.Assert(_capturedContext is ExecutionContext);
+                    ChannelUtilities.QueueUserWorkItem(continuation, state);
+                }
+            }
+        }
+
+        /// <summary>A tuple of both a non-null scheduler and a non-null ExecutionContext.</summary>
+        private protected sealed class CapturedSchedulerAndExecutionContext
+        {
+            internal readonly object _scheduler;
+            internal readonly ExecutionContext _executionContext;
+
+            public CapturedSchedulerAndExecutionContext(object scheduler, ExecutionContext executionContext)
+            {
+                Debug.Assert(scheduler is SynchronizationContext or TaskScheduler, $"{nameof(scheduler)} is {scheduler}");
+                Debug.Assert(executionContext is not null, $"{nameof(executionContext)} is null");
+
+                _scheduler = scheduler;
+                _executionContext = executionContext;
+            }
+        }
     }
 
-    /// <summary>The representation of an asynchronous operation that has a result value and carries additional data with it.</summary>
-    /// <typeparam name="TData">Specifies the type of data being written.</typeparam>
-    internal sealed class VoidAsyncOperationWithData<TData> : AsyncOperation<VoidResult>
+    /// <summary>Represents an asynchronous operation on a channel.</summary>
+    /// <typeparam name="TSelf">The type of this instance, ala the Curiously Recurring Template Pattern.</typeparam>
+    internal abstract class AsyncOperation<TSelf> : AsyncOperation, IValueTaskSource
     {
-        /// <summary>Initializes the interactor.</summary>
-        /// <param name="runContinuationsAsynchronously">true if continuations should be forced to run asynchronously; otherwise, false.</param>
-        /// <param name="cancellationToken">The cancellation token used to cancel the operation.</param>
-        /// <param name="pooled">Whether this instance is pooled and reused.</param>
-        public VoidAsyncOperationWithData(bool runContinuationsAsynchronously, CancellationToken cancellationToken = default, bool pooled = false) :
-            base(runContinuationsAsynchronously, cancellationToken, pooled)
+        /// <inheritdoc />
+        protected AsyncOperation(bool runContinuationsAsynchronously, CancellationToken cancellationToken = default, bool pooled = false, Action<object?, CancellationToken>? cancellationCallback = null) :
+            base(runContinuationsAsynchronously, cancellationToken, pooled, cancellationCallback)
         {
         }
 
-        /// <summary>The item being written.</summary>
-        public TData? Item { get; set; }
+        /// <summary>Gets or sets the next operation in the linked list of operations.</summary>
+        public TSelf? Next { get; set; }
+
+        /// <summary>Gets or sets the previous operation in the linked list of operations.</summary>
+        public TSelf? Previous { get; set; }
+
+        /// <summary>Gets a <see cref="ValueTask"/> backed by this instance and its current token.</summary>
+        public ValueTask ValueTask => new ValueTask(this, _currentId);
+
+        /// <summary>Gets the current status of the operation.</summary>
+        /// <param name="token">The token that must match <see cref="AsyncOperation._currentId"/>.</param>
+        public ValueTaskSourceStatus GetStatus(short token)
+        {
+            if (_currentId != token)
+            {
+                ThrowIncorrectCurrentIdException();
+            }
+
+            return
+                !IsCompleted ? ValueTaskSourceStatus.Pending :
+                _error is null ? ValueTaskSourceStatus.Succeeded :
+                _error.SourceException is OperationCanceledException ? ValueTaskSourceStatus.Canceled :
+                ValueTaskSourceStatus.Faulted;
+        }
+
+        /// <summary>Gets the result of the operation.</summary>
+        /// <param name="token">The token that must match <see cref="AsyncOperation._currentId"/>.</param>
+        void IValueTaskSource.GetResult(short token)
+        {
+            if (_currentId != token)
+            {
+                ThrowIncorrectCurrentIdException();
+            }
+
+            if (!IsCompleted)
+            {
+                ThrowIncompleteOperationException();
+            }
+
+            ExceptionDispatchInfo? error = _error;
+            _currentId++;
+
+            if (_pooled)
+            {
+                Volatile.Write(ref _continuation, s_availableSentinel); // only after fetching all needed data
+            }
+
+            error?.Throw();
+        }
+    }
+
+    /// <summary>Represents an asynchronous operation with a result on a channel.</summary>
+    /// <typeparam name="TSelf">The type of this instance, ala the Curiously Recurring Template Pattern.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    internal abstract class AsyncOperation<TSelf, TResult> : AsyncOperation<TSelf>, IValueTaskSource<TResult>
+        where TSelf : AsyncOperation<TSelf, TResult>
+    {
+        /// <summary>The result of the operation.</summary>
+        private TResult? _result;
+
+        /// <inheritdoc />
+        public AsyncOperation(bool runContinuationsAsynchronously, CancellationToken cancellationToken = default, bool pooled = false, Action<object?, CancellationToken>? cancellationCallback = null) :
+            base(runContinuationsAsynchronously, cancellationToken, pooled, cancellationCallback)
+        {
+        }
+
+        /// <summary>Gets a <see cref="ValueTask{TResult}"/> backed by this instance and its current token.</summary>
+        public ValueTask<TResult> ValueTaskOfT => new ValueTask<TResult>(this, _currentId);
+
+        /// <summary>Gets the result of the operation.</summary>
+        /// <param name="token">The token that must match <see cref="AsyncOperation._currentId"/>.</param>
+        public TResult GetResult(short token)
+        {
+            if (_currentId != token)
+            {
+                ThrowIncorrectCurrentIdException();
+            }
+
+            if (!IsCompleted)
+            {
+                ThrowIncompleteOperationException();
+            }
+
+            ExceptionDispatchInfo? error = _error;
+            TResult? result = _result;
+            _currentId++;
+
+            if (_pooled)
+            {
+                Volatile.Write(ref _continuation, s_availableSentinel); // only after fetching all needed data
+            }
+
+            error?.Throw();
+            return result!;
+        }
+
+        /// <summary>Attempts to take ownership of the pooled instance.</summary>
+        /// <returns>true if the instance is now owned by the caller, in which case its state has been reset; otherwise, false.</returns>
+        public bool TryOwnAndReset()
+        {
+            Debug.Assert(_pooled, "Should only be used for pooled objects");
+            if (ReferenceEquals(Interlocked.CompareExchange(ref _continuation, null, s_availableSentinel), s_availableSentinel))
+            {
+                _continuationState = null;
+                _result = default;
+                _error = null;
+                _capturedContext = null;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>Completes the operation with a success state and the specified result.</summary>
+        /// <param name="result">The result value.</param>
+        /// <returns>true if the operation could be successfully transitioned to a completed state; false if it was already completed.</returns>
+        public bool TrySetResult(TResult result)
+        {
+            if (TryReserveCompletionIfCancelable())
+            {
+                DangerousSetResult(result);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>Completes the operation with a success state and the specified result.</summary>
+        /// <param name="result">The result value.</param>
+        /// <remarks>This must only be called if the caller owns the right to complete this instance.</remarks>
+        public void DangerousSetResult(TResult result)
+        {
+            _result = result;
+            SignalCompletion();
+        }
+    }
+
+    /// <summary>Represents a blocked reader from <see cref="ChannelReader{T}.ReadAsync"/>.</summary>
+    /// <typeparam name="TResult">The type of the data read.</typeparam>
+    internal sealed class BlockedReadAsyncOperation<TResult> : AsyncOperation<BlockedReadAsyncOperation<TResult>, TResult>
+    {
+        /// <inheritdoc />
+        public BlockedReadAsyncOperation(bool runContinuationsAsynchronously, CancellationToken cancellationToken = default, bool pooled = false, Action<object?, CancellationToken>? cancellationCallback = null) :
+            base(runContinuationsAsynchronously, cancellationToken, pooled, cancellationCallback)
+        {
+        }
+    }
+
+    /// <summary>Represents a blocked writer from <see cref="ChannelWriter{T}.WriteAsync"/>.</summary>
+    /// <typeparam name="T">The type of the data written.</typeparam>
+    internal sealed class BlockedWriteAsyncOperation<T> : AsyncOperation<BlockedWriteAsyncOperation<T>, VoidResult>
+    {
+        /// <inheritdoc />
+        public BlockedWriteAsyncOperation(bool runContinuationsAsynchronously, CancellationToken cancellationToken = default, bool pooled = false, Action<object?, CancellationToken>? cancellationCallback = null) :
+            base(runContinuationsAsynchronously, cancellationToken, pooled, cancellationCallback)
+        {
+        }
+
+        /// <summary>Gets or sets the item being written.</summary>
+        public T? Item { get; set; }
+    }
+
+    /// <summary>Represents a waiting reader from <see cref="ChannelReader{T}.WaitToReadAsync"/>.</summary>
+    internal sealed class WaitingReadAsyncOperation : AsyncOperation<WaitingReadAsyncOperation, bool>
+    {
+        /// <inheritdoc />
+        public WaitingReadAsyncOperation(bool runContinuationsAsynchronously, CancellationToken cancellationToken = default, bool pooled = false, Action<object?, CancellationToken>? cancellationCallback = null) :
+            base(runContinuationsAsynchronously, cancellationToken, pooled, cancellationCallback)
+        {
+        }
+    }
+
+    /// <summary>Represents a waiting writer from <see cref="ChannelWriter{T}.WaitToWriteAsync"/>.</summary>
+    internal sealed class WaitingWriteAsyncOperation : AsyncOperation<WaitingWriteAsyncOperation, bool>
+    {
+        /// <inheritdoc />
+        public WaitingWriteAsyncOperation(bool runContinuationsAsynchronously, CancellationToken cancellationToken = default, bool pooled = false, Action<object?, CancellationToken>? cancellationCallback = null) :
+            base(runContinuationsAsynchronously, cancellationToken, pooled, cancellationCallback)
+        {
+        }
     }
 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.netcoreapp.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.netcoreapp.cs
@@ -3,20 +3,14 @@
 
 namespace System.Threading.Channels
 {
-    internal partial class AsyncOperation<TResult> : IThreadPoolWorkItem
+    internal partial class AsyncOperation : IThreadPoolWorkItem
     {
         void IThreadPoolWorkItem.Execute() => SetCompletionAndInvokeContinuation();
 
         private void UnsafeQueueSetCompletionAndInvokeContinuation() =>
             ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
 
-        private static void UnsafeQueueUserWorkItem(Action<object?> action, object? state) =>
-            ThreadPool.UnsafeQueueUserWorkItem(action, state, preferLocal: false);
-
-        private static void QueueUserWorkItem(Action<object?> action, object? state) =>
-            ThreadPool.QueueUserWorkItem(action, state, preferLocal: false);
-
-        private static CancellationTokenRegistration UnsafeRegister(CancellationToken cancellationToken, Action<object?> action, object? state) =>
-            cancellationToken.UnsafeRegister(action, state);
+        private static void Unregister(CancellationTokenRegistration registration) =>
+            registration.Unregister();
     }
 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.netstandard.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.netstandard.cs
@@ -1,23 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading.Tasks;
-
 namespace System.Threading.Channels
 {
-    internal partial class AsyncOperation<TResult>
+    internal partial class AsyncOperation
     {
         private void UnsafeQueueSetCompletionAndInvokeContinuation() =>
-            ThreadPool.UnsafeQueueUserWorkItem(static s => ((AsyncOperation<TResult>)s).SetCompletionAndInvokeContinuation(), this);
+            ThreadPool.UnsafeQueueUserWorkItem(static s => ((AsyncOperation)s).SetCompletionAndInvokeContinuation(), this);
 
-        private static void UnsafeQueueUserWorkItem(Action<object?> action, object? state) =>
-            QueueUserWorkItem(action, state);
-
-        private static void QueueUserWorkItem(Action<object?> action, object? state) =>
-            Task.Factory.StartNew(action, state,
-                CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
-
-        private static CancellationTokenRegistration UnsafeRegister(CancellationToken cancellationToken, Action<object?> action, object? state) =>
-            cancellationToken.Register(action, state);
+        private static void Unregister(CancellationTokenRegistration registration) =>
+            registration.Dispose();
     }
 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -15,28 +15,36 @@ namespace System.Threading.Channels
     {
         /// <summary>The mode used when the channel hits its bound.</summary>
         private readonly BoundedChannelFullMode _mode;
+
         /// <summary>The delegate that will be invoked when the channel hits its bound and an item is dropped from the channel.</summary>
         private readonly Action<T>? _itemDropped;
+
         /// <summary>Task signaled when the channel has completed.</summary>
         private readonly TaskCompletionSource _completion;
+
         /// <summary>The maximum capacity of the channel.</summary>
         private readonly int _bufferedCapacity;
+
         /// <summary>Items currently stored in the channel waiting to be read.</summary>
         private readonly Deque<T> _items = new Deque<T>();
-        /// <summary>Readers waiting to read from the channel.</summary>
-        private readonly Deque<AsyncOperation<T>> _blockedReaders = new Deque<AsyncOperation<T>>();
-        /// <summary>Writers waiting to write to the channel.</summary>
-        private readonly Deque<VoidAsyncOperationWithData<T>> _blockedWriters = new Deque<VoidAsyncOperationWithData<T>>();
-        /// <summary>Linked list of WaitToReadAsync waiters.</summary>
-        private AsyncOperation<bool>? _waitingReadersTail;
-        /// <summary>Linked list of WaitToWriteAsync waiters.</summary>
-        private AsyncOperation<bool>? _waitingWritersTail;
+
+        /// <summary>Head of linked list of blocked ReadAsync calls.</summary>
+        private BlockedReadAsyncOperation<T>? _blockedReadersHead;
+
+        /// <summary>Head of linked list of blocked WriteAsync calls.</summary>
+        private BlockedWriteAsyncOperation<T>? _blockedWritersHead;
+
+        /// <summary>Head of linked list of waiting WaitToReadAsync calls.</summary>
+        private WaitingReadAsyncOperation? _waitingReadersHead;
+
+        /// <summary>Head of linked list of waiting WaitToWriteAsync calls.</summary>
+        private WaitingWriteAsyncOperation? _waitingWritersHead;
+
         /// <summary>Whether to force continuations to be executed asynchronously from producer writes.</summary>
         private readonly bool _runContinuationsAsynchronously;
+
         /// <summary>Set to non-null once Complete has been called.</summary>
         private Exception? _doneWriting;
-        /// <summary>Gets an object used to synchronize all state on the instance.</summary>
-        private object SyncObj => _items;
 
         /// <summary>Initializes the <see cref="BoundedChannel{T}"/>.</summary>
         /// <param name="bufferedCapacity">The positive bounded capacity for the channel.</param>
@@ -46,11 +54,13 @@ namespace System.Threading.Channels
         internal BoundedChannel(int bufferedCapacity, BoundedChannelFullMode mode, bool runContinuationsAsynchronously, Action<T>? itemDropped)
         {
             Debug.Assert(bufferedCapacity > 0);
+
             _bufferedCapacity = bufferedCapacity;
             _mode = mode;
             _runContinuationsAsynchronously = runContinuationsAsynchronously;
             _itemDropped = itemDropped;
             _completion = new TaskCompletionSource(runContinuationsAsynchronously ? TaskCreationOptions.RunContinuationsAsynchronously : TaskCreationOptions.None);
+
             Reader = new BoundedChannelReader(this);
             Writer = new BoundedChannelWriter(this);
         }
@@ -60,14 +70,14 @@ namespace System.Threading.Channels
         private sealed class BoundedChannelReader : ChannelReader<T>, IDebugEnumerable<T>
         {
             internal readonly BoundedChannel<T> _parent;
-            private readonly AsyncOperation<T> _readerSingleton;
-            private readonly AsyncOperation<bool> _waiterSingleton;
+            private readonly BlockedReadAsyncOperation<T> _readerSingleton;
+            private readonly WaitingReadAsyncOperation _waiterSingleton;
 
             internal BoundedChannelReader(BoundedChannel<T> parent)
             {
                 _parent = parent;
-                _readerSingleton = new AsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
-                _waiterSingleton = new AsyncOperation<bool>(parent._runContinuationsAsynchronously, pooled: true);
+                _readerSingleton = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
+                _waiterSingleton = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, pooled: true);
             }
 
             public override Task Completion => _parent._completion.Task;
@@ -154,7 +164,7 @@ namespace System.Threading.Channels
 
                     // There weren't any items.  If we're done writing so that there
                     // will never be more items, fail.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return ChannelUtilities.GetInvalidCompletionValueTask<T>(parent._doneWriting);
                     }
@@ -162,24 +172,17 @@ namespace System.Threading.Channels
                     // If we're able to use the singleton reader, do so.
                     if (!cancellationToken.CanBeCanceled)
                     {
-                        AsyncOperation<T> singleton = _readerSingleton;
+                        BlockedReadAsyncOperation<T> singleton = _readerSingleton;
                         if (singleton.TryOwnAndReset())
                         {
-                            parent._blockedReaders.EnqueueTail(singleton);
+                            ChannelUtilities.Enqueue(ref parent._blockedReadersHead, singleton);
                             return singleton.ValueTaskOfT;
                         }
                     }
 
-                    // Otherwise, queue a reader.  Note that in addition to checking whether synchronous continuations were requested,
-                    // we also check whether the supplied cancellation token can be canceled.  The writer calls UnregisterCancellation
-                    // while holding the lock, and if a callback needs to be unregistered and is currently running, it needs to wait
-                    // for that callback to complete so that the subsequent code knows it won't be contending with another thread
-                    // trying to complete the operation.  However, if we allowed a synchronous continuation from this operation, that
-                    // cancellation callback could end up running arbitrary code, including code that called back into the reader or
-                    // writer and tried to take the same lock held by the thread running UnregisterCancellation... deadlock.  As such,
-                    // we only allow synchronous continuations here if both a) the caller requested it and the token isn't cancelable.
-                    var reader = new AsyncOperation<T>(parent._runContinuationsAsynchronously || cancellationToken.CanBeCanceled, cancellationToken);
-                    parent._blockedReaders.EnqueueTail(reader);
+                    // Otherwise, queue a reader.
+                    var reader = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    ChannelUtilities.Enqueue(ref parent._blockedReadersHead, reader);
                     return reader.ValueTaskOfT;
                 }
             }
@@ -203,7 +206,7 @@ namespace System.Threading.Channels
                     }
 
                     // There were no items available, so if we're done writing, a read will never be possible.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
                             new ValueTask<bool>(Task.FromException<bool>(parent._doneWriting)) :
@@ -216,24 +219,17 @@ namespace System.Threading.Channels
                     // If we're able to use the singleton waiter, do so.
                     if (!cancellationToken.CanBeCanceled)
                     {
-                        AsyncOperation<bool> singleton = _waiterSingleton;
+                        WaitingReadAsyncOperation singleton = _waiterSingleton;
                         if (singleton.TryOwnAndReset())
                         {
-                            ChannelUtilities.QueueWaiter(ref parent._waitingReadersTail, singleton);
+                            ChannelUtilities.Enqueue(ref parent._waitingReadersHead, singleton);
                             return singleton.ValueTaskOfT;
                         }
                     }
 
-                    // Otherwise, queue a reader.  Note that in addition to checking whether synchronous continuations were requested,
-                    // we also check whether the supplied cancellation token can be canceled.  The writer calls UnregisterCancellation
-                    // while holding the lock, and if a callback needs to be unregistered and is currently running, it needs to wait
-                    // for that callback to complete so that the subsequent code knows it won't be contending with another thread
-                    // trying to complete the operation.  However, if we allowed a synchronous continuation from this operation, that
-                    // cancellation callback could end up running arbitrary code, including code that called back into the reader or
-                    // writer and tried to take the same lock held by the thread running UnregisterCancellation... deadlock.  As such,
-                    // we only allow synchronous continuations here if both a) the caller requested it and the token isn't cancelable.
-                    var waiter = new AsyncOperation<bool>(parent._runContinuationsAsynchronously || cancellationToken.CanBeCanceled, cancellationToken);
-                    ChannelUtilities.QueueWaiter(ref _parent._waitingReadersTail, waiter);
+                    // Otherwise, queue a reader.
+                    var waiter = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    ChannelUtilities.Enqueue(ref parent._waitingReadersHead, waiter);
                     return waiter.ValueTaskOfT;
                 }
             }
@@ -248,7 +244,7 @@ namespace System.Threading.Channels
                 // Dequeue an item.
                 T item = parent._items.DequeueHead();
 
-                if (parent._doneWriting != null)
+                if (parent._doneWriting is not null)
                 {
                     // We're done writing, so if we're now empty, complete the channel.
                     if (parent._items.IsEmpty)
@@ -262,17 +258,15 @@ namespace System.Threading.Channels
                     // to be promoted to have its item moved into the items queue.  We need
                     // to loop while trying to complete the writer in order to find one that
                     // hasn't yet been canceled (canceled writers transition to canceled but
-                    // remain in the physical queue).
+                    // may temporarily remain in the physical queue).
                     //
                     // (It's possible for _doneWriting to be non-null due to Complete
                     // having been called but for there to still be blocked/waiting writers.
                     // This is a temporary condition, after which Complete has set _doneWriting
                     // and then exited the lock; at that point it'll proceed to clean this up,
                     // so we just ignore them.)
-
-                    while (!parent._blockedWriters.IsEmpty)
+                    while (ChannelUtilities.TryDequeue(ref parent._blockedWritersHead, out BlockedWriteAsyncOperation<T>? w))
                     {
-                        VoidAsyncOperationWithData<T> w = parent._blockedWriters.DequeueHead();
                         if (w.TrySetResult(default))
                         {
                             parent._items.EnqueueTail(w.Item!);
@@ -280,9 +274,9 @@ namespace System.Threading.Channels
                         }
                     }
 
-                    // There was no blocked writer, so see if there's a WaitToWriteAsync
-                    // we should wake up.
-                    ChannelUtilities.WakeUpWaiters(ref parent._waitingWritersTail, result: true);
+                    // There was no blocked writer; alert any WaitToWriteAsync waiters that they may be able to write now.
+                    ChannelUtilities.AssertAll(parent._waitingWritersHead, static writer => writer.RunContinuationsAsynchronously, "All WaitToWriteAsync waiters should have been asynchronous.");
+                    ChannelUtilities.SetOperations(ref parent._waitingWritersHead, result: true);
                 }
 
                 // Return the item
@@ -298,26 +292,32 @@ namespace System.Threading.Channels
         private sealed class BoundedChannelWriter : ChannelWriter<T>, IDebugEnumerable<T>
         {
             internal readonly BoundedChannel<T> _parent;
-            private readonly VoidAsyncOperationWithData<T> _writerSingleton;
-            private readonly AsyncOperation<bool> _waiterSingleton;
+            private readonly BlockedWriteAsyncOperation<T> _writerSingleton;
+            private readonly WaitingWriteAsyncOperation _waiterSingleton;
 
             internal BoundedChannelWriter(BoundedChannel<T> parent)
             {
                 _parent = parent;
-                _writerSingleton = new VoidAsyncOperationWithData<T>(runContinuationsAsynchronously: true, pooled: true);
-                _waiterSingleton = new AsyncOperation<bool>(runContinuationsAsynchronously: true, pooled: true);
+                _writerSingleton = new BlockedWriteAsyncOperation<T>(runContinuationsAsynchronously: true, pooled: true);
+                _waiterSingleton = new WaitingWriteAsyncOperation(runContinuationsAsynchronously: true, pooled: true);
             }
 
             public override bool TryComplete(Exception? error)
             {
                 BoundedChannel<T> parent = _parent;
+
+                BlockedReadAsyncOperation<T>? blockedReadersHead;
+                BlockedWriteAsyncOperation<T>? blockedWritersHead;
+                WaitingReadAsyncOperation? waitingReadersHead;
+                WaitingWriteAsyncOperation? waitingWritersHead;
+
                 bool completeTask;
                 lock (parent.SyncObj)
                 {
                     parent.AssertInvariants();
 
                     // If we've already marked the channel as completed, bail.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return false;
                     }
@@ -325,6 +325,17 @@ namespace System.Threading.Channels
                     // Mark that we're done writing.
                     parent._doneWriting = error ?? ChannelUtilities.s_doneWritingSentinel;
                     completeTask = parent._items.IsEmpty;
+
+                    // Snag the queues while holding the lock, so that we don't need to worry
+                    // about concurrent mutation, such as from cancellation of pending operations.
+                    blockedReadersHead = parent._blockedReadersHead;
+                    blockedWritersHead = parent._blockedWritersHead;
+                    waitingReadersHead = parent._waitingReadersHead;
+                    waitingWritersHead = parent._waitingWritersHead;
+                    parent._blockedReadersHead = null;
+                    parent._blockedWritersHead = null;
+                    parent._waitingReadersHead = null;
+                    parent._waitingWritersHead = null;
                 }
 
                 // If there are no items in the queue, complete the channel's task,
@@ -337,15 +348,13 @@ namespace System.Threading.Channels
                     ChannelUtilities.Complete(parent._completion, error);
                 }
 
-                // At this point, _blockedReaders/Writers and _waitingReaders/Writers will not be mutated:
-                // they're only mutated by readers/writers while holding the lock, and only if _doneWriting is null.
-                // We also know that only one thread (this one) will ever get here, as only that thread
-                // will be the one to transition from _doneWriting false to true.  As such, we can
-                // freely manipulate them without any concurrency concerns.
-                ChannelUtilities.FailOperations<AsyncOperation<T>, T>(parent._blockedReaders, ChannelUtilities.CreateInvalidCompletionException(error));
-                ChannelUtilities.FailOperations<VoidAsyncOperationWithData<T>, VoidResult>(parent._blockedWriters, ChannelUtilities.CreateInvalidCompletionException(error));
-                ChannelUtilities.WakeUpWaiters(ref parent._waitingReadersTail, result: false, error: error);
-                ChannelUtilities.WakeUpWaiters(ref parent._waitingWritersTail, result: false, error: error);
+                // Complete all pending operations. We don't need to worry about concurrent mutation here:
+                // No other writers or readers will be able to register operations, and any cancellation callbacks
+                // will see the queues as being null and exit immediately.
+                ChannelUtilities.FailOperations(blockedReadersHead, ChannelUtilities.CreateInvalidCompletionException(error));
+                ChannelUtilities.FailOperations(blockedWritersHead, ChannelUtilities.CreateInvalidCompletionException(error));
+                ChannelUtilities.SetOrFailOperations(waitingReadersHead, result: false, error: error);
+                ChannelUtilities.SetOrFailOperations(waitingWritersHead, result: false, error: error);
 
                 // Successfully transitioned to completed.
                 return true;
@@ -353,8 +362,8 @@ namespace System.Threading.Channels
 
             public override bool TryWrite(T item)
             {
-                AsyncOperation<T>? blockedReader = null;
-                AsyncOperation<bool>? waitingReadersTail = null;
+                BlockedReadAsyncOperation<T>? blockedReader = null;
+                WaitingReadAsyncOperation? waitingReadersHead = null;
 
                 BoundedChannel<T> parent = _parent;
 
@@ -366,7 +375,7 @@ namespace System.Threading.Channels
                     parent.AssertInvariants();
 
                     // If we're done writing, nothing more to do.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return false;
                     }
@@ -378,30 +387,24 @@ namespace System.Threading.Channels
                     {
                         // There are no items in the channel, which means we may have blocked/waiting readers.
 
-                        // If there are any blocked readers, find one that's not canceled
-                        // and store it to complete outside of the lock, in case it has
-                        // continuations that'll run synchronously
-                        while (!parent._blockedReaders.IsEmpty)
+                        // Try to get a blocked reader that we can transfer the item to.
+                        while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
                         {
-                            AsyncOperation<T> r = parent._blockedReaders.DequeueHead();
-                            if (r.UnregisterCancellation()) // ensure that once we grab it, we own its completion
+                            if (blockedReader.TryReserveCompletionIfCancelable())
                             {
-                                blockedReader = r;
                                 break;
                             }
                         }
 
-                        if (blockedReader == null)
+                        // If we weren't able to get a reader, instead queue the item and get any waiters that need to be notified.
+                        if (blockedReader is null)
                         {
-                            // If there wasn't a blocked reader, then store the item. If no one's waiting
-                            // to be notified about a 0-to-1 transition, we're done.
                             parent._items.EnqueueTail(item);
-                            waitingReadersTail = parent._waitingReadersTail;
-                            if (waitingReadersTail == null)
+                            waitingReadersHead = ChannelUtilities.TryReserveCompletionIfCancelable(ref parent._waitingReadersHead);
+                            if (waitingReadersHead is null)
                             {
                                 return true;
                             }
-                            parent._waitingReadersTail = null;
                         }
                     }
                     else if (count < parent._bufferedCapacity)
@@ -452,22 +455,16 @@ namespace System.Threading.Channels
                     }
                 }
 
-                // We either wrote the item already, or we're transferring it to the blocked reader we grabbed.
-                if (blockedReader != null)
+                // Now that we're outside of the lock, if we successfully got any tasks to complete and reserved their completion, do so.
+                if (blockedReader is not null)
                 {
-                    Debug.Assert(waitingReadersTail == null, "Shouldn't have any waiters to wake up");
-
-                    // Transfer the written item to the blocked reader.
-                    bool success = blockedReader.TrySetResult(item);
-                    Debug.Assert(success, "We should always be able to complete the reader.");
+                    Debug.Assert(waitingReadersHead is null);
+                    blockedReader.DangerousSetResult(item);
                 }
                 else
                 {
-                    // We stored an item bringing the count up from 0 to 1.  Alert
-                    // any waiting readers that there may be something for them to consume.
-                    // Since we're no longer holding the lock, it's possible we'll end up
-                    // waking readers that have since come in.
-                    ChannelUtilities.WakeUpWaiters(ref waitingReadersTail, result: true);
+                    Debug.Assert(waitingReadersHead is not null);
+                    ChannelUtilities.DangerousSetOperations(waitingReadersHead, result: true);
                 }
 
                 return true;
@@ -486,7 +483,7 @@ namespace System.Threading.Channels
                     parent.AssertInvariants();
 
                     // If we're done writing, no writes will ever succeed.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
                             new ValueTask<bool>(Task.FromException<bool>(parent._doneWriting)) :
@@ -506,17 +503,17 @@ namespace System.Threading.Channels
                     // If we're able to use the singleton waiter, do so.
                     if (!cancellationToken.CanBeCanceled)
                     {
-                        AsyncOperation<bool> singleton = _waiterSingleton;
+                        WaitingWriteAsyncOperation singleton = _waiterSingleton;
                         if (singleton.TryOwnAndReset())
                         {
-                            ChannelUtilities.QueueWaiter(ref parent._waitingWritersTail, singleton);
+                            ChannelUtilities.Enqueue(ref parent._waitingWritersHead, singleton);
                             return singleton.ValueTaskOfT;
                         }
                     }
 
                     // Otherwise, queue a waiter.
-                    var waiter = new AsyncOperation<bool>(runContinuationsAsynchronously: true, cancellationToken);
-                    ChannelUtilities.QueueWaiter(ref parent._waitingWritersTail, waiter);
+                    var waiter = new WaitingWriteAsyncOperation(runContinuationsAsynchronously: true, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    ChannelUtilities.Enqueue(ref parent._waitingWritersHead, waiter);
                     return waiter.ValueTaskOfT;
                 }
             }
@@ -528,8 +525,8 @@ namespace System.Threading.Channels
                     return new ValueTask(Task.FromCanceled(cancellationToken));
                 }
 
-                AsyncOperation<T>? blockedReader = null;
-                AsyncOperation<bool>? waitingReadersTail = null;
+                BlockedReadAsyncOperation<T>? blockedReader = null;
+                WaitingReadAsyncOperation? waitingReadersHead = null;
 
                 BoundedChannel<T> parent = _parent;
 
@@ -541,7 +538,7 @@ namespace System.Threading.Channels
                     parent.AssertInvariants();
 
                     // If we're done writing, trying to write is an error.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return new ValueTask(Task.FromException(ChannelUtilities.CreateInvalidCompletionException(parent._doneWriting)));
                     }
@@ -553,30 +550,24 @@ namespace System.Threading.Channels
                     {
                         // There are no items in the channel, which means we may have blocked/waiting readers.
 
-                        // If there are any blocked readers, find one that's not canceled
-                        // and store it to complete outside of the lock, in case it has
-                        // continuations that'll run synchronously
-                        while (!parent._blockedReaders.IsEmpty)
+                        // Try to get a blocked reader that we can transfer the item to.
+                        while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
                         {
-                            AsyncOperation<T> r = parent._blockedReaders.DequeueHead();
-                            if (r.UnregisterCancellation()) // ensure that once we grab it, we own its completion
+                            if (blockedReader.TryReserveCompletionIfCancelable())
                             {
-                                blockedReader = r;
                                 break;
                             }
                         }
 
-                        if (blockedReader == null)
+                        // If we weren't able to get a reader, instead queue the item and get any waiters that need to be notified.
+                        if (blockedReader is null)
                         {
-                            // If there wasn't a blocked reader, then store the item. If no one's waiting
-                            // to be notified about a 0-to-1 transition, we're done.
                             parent._items.EnqueueTail(item);
-                            waitingReadersTail = parent._waitingReadersTail;
-                            if (waitingReadersTail == null)
+                            waitingReadersHead = ChannelUtilities.TryReserveCompletionIfCancelable(ref parent._waitingReadersHead);
+                            if (waitingReadersHead is null)
                             {
                                 return default;
                             }
-                            parent._waitingReadersTail = null;
                         }
                     }
                     else if (count < parent._bufferedCapacity)
@@ -594,19 +585,21 @@ namespace System.Threading.Channels
                         // If we're able to use the singleton writer, do so.
                         if (!cancellationToken.CanBeCanceled)
                         {
-                            VoidAsyncOperationWithData<T> singleton = _writerSingleton;
+                            BlockedWriteAsyncOperation<T> singleton = _writerSingleton;
                             if (singleton.TryOwnAndReset())
                             {
                                 singleton.Item = item;
-                                parent._blockedWriters.EnqueueTail(singleton);
+                                ChannelUtilities.Enqueue(ref parent._blockedWritersHead, singleton);
                                 return singleton.ValueTask;
                             }
                         }
 
                         // Otherwise, queue a new writer.
-                        var writer = new VoidAsyncOperationWithData<T>(runContinuationsAsynchronously: true, cancellationToken);
-                        writer.Item = item;
-                        parent._blockedWriters.EnqueueTail(writer);
+                        var writer = new BlockedWriteAsyncOperation<T>(runContinuationsAsynchronously: true, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate)
+                        {
+                            Item = item
+                        };
+                        ChannelUtilities.Enqueue(ref parent._blockedWritersHead, writer);
                         return writer.ValueTask;
                     }
                     else if (parent._mode == BoundedChannelFullMode.DropWrite)
@@ -643,20 +636,16 @@ namespace System.Threading.Channels
                     }
                 }
 
-                // We either wrote the item already, or we're transfering it to the blocked reader we grabbed.
-                if (blockedReader != null)
+                // Now that we're outside of the lock, if we successfully got any tasks to complete and reserved their completion, do so.
+                if (blockedReader is not null)
                 {
-                    // Transfer the written item to the blocked reader.
-                    bool success = blockedReader.TrySetResult(item);
-                    Debug.Assert(success, "We should always be able to complete the reader.");
+                    Debug.Assert(waitingReadersHead is null);
+                    blockedReader.DangerousSetResult(item);
                 }
                 else
                 {
-                    // We stored an item bringing the count up from 0 to 1.  Alert
-                    // any waiting readers that there may be something for them to consume.
-                    // Since we're no longer holding the lock, it's possible we'll end up
-                    // waking readers that have since come in.
-                    ChannelUtilities.WakeUpWaiters(ref waitingReadersTail, result: true);
+                    Debug.Assert(waitingReadersHead is not null);
+                    ChannelUtilities.DangerousSetOperations(waitingReadersHead, result: true);
                 }
 
                 return default;
@@ -672,35 +661,79 @@ namespace System.Threading.Channels
             IEnumerator<T> IDebugEnumerable<T>.GetEnumerator() => _parent._items.GetEnumerator();
         }
 
+        /// <summary>Gets an object used to synchronize all state on the instance.</summary>
+        private object SyncObj => _items;
+
+        private Action<object?, CancellationToken> CancellationCallbackDelegate =>
+            field ??= (state, cancellationToken) =>
+            {
+                AsyncOperation op = (AsyncOperation)state!;
+                if (op.TrySetCanceled(cancellationToken))
+                {
+                    ChannelUtilities.UnsafeQueueUserWorkItem(static state => // escape cancellation callback
+                    {
+                        lock (state.Key.SyncObj)
+                        {
+                            switch (state.Value)
+                            {
+                                case BlockedReadAsyncOperation<T> blockedReader:
+                                    ChannelUtilities.Remove(ref state.Key._blockedReadersHead, blockedReader);
+                                    break;
+
+                                case BlockedWriteAsyncOperation<T> blockedWriter:
+                                    ChannelUtilities.Remove(ref state.Key._blockedWritersHead, blockedWriter);
+                                    break;
+
+                                case WaitingReadAsyncOperation waitingReader:
+                                    ChannelUtilities.Remove(ref state.Key._waitingReadersHead, waitingReader);
+                                    break;
+
+                                case WaitingWriteAsyncOperation waitingWriter:
+                                    ChannelUtilities.Remove(ref state.Key._waitingWritersHead, waitingWriter);
+                                    break;
+
+                                default:
+                                    Debug.Fail($"Unexpected operation: {state.Value}");
+                                    break;
+                            }
+                        }
+                    }, new KeyValuePair<BoundedChannel<T>, AsyncOperation>(this, op));
+                }
+            };
+
         [Conditional("DEBUG")]
         private void AssertInvariants()
         {
-            Debug.Assert(SyncObj != null, "The sync obj must not be null.");
+            Debug.Assert(SyncObj is not null, "The sync obj must not be null.");
             Debug.Assert(Monitor.IsEntered(SyncObj), "Invariants can only be validated while holding the lock.");
 
             if (!_items.IsEmpty)
             {
-                Debug.Assert(_blockedReaders.IsEmpty, "There are items available, so there shouldn't be any blocked readers.");
-                Debug.Assert(_waitingReadersTail == null, "There are items available, so there shouldn't be any waiting readers.");
+                Debug.Assert(_blockedReadersHead is null, "There are items available, so there shouldn't be any blocked readers.");
+                Debug.Assert(_waitingReadersHead is null, "There are items available, so there shouldn't be any waiting readers.");
             }
+
             if (_items.Count < _bufferedCapacity)
             {
-                Debug.Assert(_blockedWriters.IsEmpty, "There's space available, so there shouldn't be any blocked writers.");
-                Debug.Assert(_waitingWritersTail == null, "There's space available, so there shouldn't be any waiting writers.");
+                Debug.Assert(_blockedWritersHead is null, "There's space available, so there shouldn't be any blocked writers.");
+                Debug.Assert(_waitingWritersHead is null, "There's space available, so there shouldn't be any waiting writers.");
             }
-            if (!_blockedReaders.IsEmpty)
+
+            if (_blockedReadersHead is not null)
             {
                 Debug.Assert(_items.IsEmpty, "There shouldn't be queued items if there's a blocked reader.");
-                Debug.Assert(_blockedWriters.IsEmpty, "There shouldn't be any blocked writer if there's a blocked reader.");
+                Debug.Assert(_blockedWritersHead is null, "There shouldn't be any blocked writer if there's a blocked reader.");
             }
-            if (!_blockedWriters.IsEmpty)
+
+            if (_blockedWritersHead is not null)
             {
                 Debug.Assert(_items.Count == _bufferedCapacity, "We should have a full buffer if there's a blocked writer.");
-                Debug.Assert(_blockedReaders.IsEmpty, "There shouldn't be any blocked readers if there's a blocked writer.");
+                Debug.Assert(_blockedReadersHead is null, "There shouldn't be any blocked readers if there's a blocked writer.");
             }
+
             if (_completion.Task.IsCompleted)
             {
-                Debug.Assert(_doneWriting != null, "We can only complete if we're done writing.");
+                Debug.Assert(_doneWriting is not null, "We can only complete if we're done writing.");
             }
         }
 
@@ -708,7 +741,7 @@ namespace System.Threading.Channels
         private int ItemsCountForDebugger => _items.Count;
 
         /// <summary>Report if the channel is closed or not. This should only be used by the debugger.</summary>
-        private bool ChannelIsClosedForDebugger => _doneWriting != null;
+        private bool ChannelIsClosedForDebugger => _doneWriting is not null;
 
         /// <summary>Gets an enumerator the debugger can use to show the contents of the channel.</summary>
         IEnumerator<T> IDebugEnumerable<T>.GetEnumerator() => _items.GetEnumerator();

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelClosedException.netcoreapp.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelClosedException.netcoreapp.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NET8_0_OR_GREATER
 using System.ComponentModel;
+#endif
 using System.Runtime.Serialization;
 
 namespace System.Threading.Channels

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.cs
@@ -69,7 +69,7 @@ namespace System.Threading.Channels
                     return new ValueTask<T>(fastItem);
                 }
             }
-            catch (Exception exc) when (!(exc is ChannelClosedException || exc is OperationCanceledException))
+            catch (Exception exc) when (exc is not (ChannelClosedException or OperationCanceledException))
             {
                 return new ValueTask<T>(Task.FromException<T>(exc));
             }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
@@ -1,14 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace System.Threading.Channels
 {
     /// <summary>Provides internal helper methods for implementing channels.</summary>
-    internal static class ChannelUtilities
+    internal static partial class ChannelUtilities
     {
         /// <summary>Sentinel object used to indicate being done writing.</summary>
         internal static readonly Exception s_doneWritingSentinel = new Exception(nameof(s_doneWritingSentinel));
@@ -33,7 +33,7 @@ namespace System.Threading.Channels
             {
                 tcs.TrySetCanceled(oce.CancellationToken);
             }
-            else if (error != null && error != s_doneWritingSentinel)
+            else if (error is not null && error != s_doneWritingSentinel)
             {
                 if (tcs.TrySetException(error))
                 {
@@ -56,7 +56,7 @@ namespace System.Threading.Channels
         /// <returns>The failed task.</returns>
         internal static ValueTask<T> GetInvalidCompletionValueTask<T>(Exception error)
         {
-            Debug.Assert(error != null);
+            Debug.Assert(error is not null);
 
             Task<T> t =
                 error == s_doneWritingSentinel ? Task.FromException<T>(CreateInvalidCompletionException()) :
@@ -66,60 +66,261 @@ namespace System.Threading.Channels
             return new ValueTask<T>(t);
         }
 
-        internal static void QueueWaiter(ref AsyncOperation<bool>? tail, AsyncOperation<bool> waiter)
+        /// <summary>Dequeues an operation from the circular doubly-linked list referenced by <paramref name="head"/>.</summary>
+        /// <param name="head">The head of the list.</param>
+        /// <param name="op">The dequeued operation.</param>
+        /// <returns>true if an operation could be dequeued; otherwise, false.</returns>
+        internal static bool TryDequeue<TAsyncOp>(ref TAsyncOp? head, [NotNullWhen(true)] out TAsyncOp? op)
+            where TAsyncOp : AsyncOperation<TAsyncOp>
         {
-            AsyncOperation<bool>? c = tail;
-            if (c == null)
+            op = head;
+
+            if (head is null)
             {
-                waiter.Next = waiter;
+                return false;
+            }
+
+            Debug.Assert(head.Previous is not null);
+            Debug.Assert(head.Next is not null);
+
+            if (head.Next == head)
+            {
+                head = null;
             }
             else
             {
-                waiter.Next = c.Next;
-                c.Next = waiter;
+                TAsyncOp last = head.Previous;
+
+                head = head.Next;
+                head.Previous = last;
+                last.Next = head;
             }
-            tail = waiter;
+
+            Debug.Assert(op is not null);
+            op.Next = op.Previous = null;
+            return true;
         }
 
-        internal static void WakeUpWaiters(ref AsyncOperation<bool>? listTail, bool result, Exception? error = null)
+        /// <summary>Enqueues an operation onto the circular doubly-linked list referenced by <paramref name="head"/>.</summary>
+        /// <param name="head">The head of the list.</param>
+        /// <param name="op">The operation to enqueue.</param>
+        internal static void Enqueue<TAsyncOp>(ref TAsyncOp? head, TAsyncOp op)
+            where TAsyncOp : AsyncOperation<TAsyncOp>
         {
-            AsyncOperation<bool>? tail = listTail;
-            if (tail != null)
-            {
-                listTail = null;
+            Debug.Assert(op.Next is null && op.Previous is null);
 
-                AsyncOperation<bool> head = tail.Next!;
-                AsyncOperation<bool> c = head;
+            if (head is null)
+            {
+                head = op.Next = op.Previous = op;
+            }
+            else
+            {
+                TAsyncOp last = head.Previous!;
+                Debug.Assert(last is not null);
+
+                op.Next = head;
+                op.Previous = last;
+                last.Next = op;
+                head.Previous = op;
+            }
+        }
+
+        /// <summary>Removes the specified operation from the circular doubly-linked list referenced by <paramref name="head"/>.</summary>
+        /// <param name="head">The head of the list.</param>
+        /// <param name="op">The operation to remove.</param>
+        internal static void Remove<TAsyncOp>(ref TAsyncOp? head, TAsyncOp op)
+            where TAsyncOp : AsyncOperation<TAsyncOp>
+        {
+            Debug.Assert(op is not null);
+            Debug.Assert(op.Next is null == op.Previous is null);
+
+            // If the operation is known to not be in the list referenced by head, avoid further manipulating the instance.
+            if (head is null || op.Next is null)
+            {
+                return;
+            }
+
+            Debug.Assert(op.Previous is not null);
+
+            if (op.Next == op)
+            {
+                Debug.Assert(op.Previous == op);
+                Debug.Assert(head == op);
+                head = null;
+            }
+            else
+            {
+                op.Previous.Next = op.Next;
+                op.Next.Previous = op.Previous;
+
+                if (head == op)
+                {
+                    head = op.Next;
+                }
+            }
+
+            op.Next = op.Previous = null;
+        }
+
+        /// <summary>Iterates through the linked list, successfully completing or failing each operation based on whether <paramref name="error"/> is <see langword="null"/>.</summary>
+        /// <param name="head">The head of the queue of operations to complete.</param>
+        /// <param name="result">The result with which to complete each operations.</param>
+        /// <param name="error">The error with which to complete each operations.</param>
+        internal static void SetOrFailOperations<TAsyncOp, T>(TAsyncOp? head, T result, Exception? error = null)
+            where TAsyncOp : AsyncOperation<TAsyncOp, T>
+        {
+            if (error is not null)
+            {
+                FailOperations(head, error);
+            }
+            else
+            {
+                SetOperations(ref head, result);
+            }
+        }
+
+        /// <summary>Iterates through the linked list, successfully completing each operation.</summary>
+        /// <param name="head">The head of the queue of operations to complete.</param>
+        /// <param name="result">The result with which to complete each operations.</param>
+        internal static void SetOperations<TAsyncOp, TResult>(ref TAsyncOp? head, TResult result)
+            where TAsyncOp : AsyncOperation<TAsyncOp, TResult>
+        {
+            TAsyncOp? current = head;
+            if (current is not null)
+            {
                 do
                 {
-                    AsyncOperation<bool> next = c.Next!;
-                    c.Next = null;
+                    Debug.Assert(current is not null);
 
-                    bool completed = error != null ? c.TrySetException(error) : c.TrySetResult(result);
-                    Debug.Assert(completed || c.CancellationToken.CanBeCanceled);
+                    TAsyncOp? next = current.Next;
+                    Debug.Assert(next is not null);
 
-                    c = next;
+                    current.Next = current.Previous = null;
+
+                    current.TrySetResult(result);
+
+                    current = next;
                 }
-                while (c != head);
+                while (current != head);
+
+                head = null;
             }
         }
 
-        /// <summary>Removes all operations from the queue, failing each.</summary>
-        /// <param name="operations">The queue of operations to complete.</param>
-        /// <param name="error">The error with which to complete each operations.</param>
-        internal static void FailOperations<T, TInner>(Deque<T> operations, Exception error) where T : AsyncOperation<TInner>
+        /// <summary>Iterates through the linked list, successfully completing each operation that should have already had completion reserved.</summary>
+        /// <param name="head">The head of the queue of operations to complete.</param>
+        /// <param name="result">The result with which to complete each operations.</param>
+        internal static void DangerousSetOperations<TAsyncOp, TResult>(TAsyncOp? head, TResult result)
+            where TAsyncOp : AsyncOperation<TAsyncOp, TResult>
         {
-            Debug.Assert(error != null);
-            while (!operations.IsEmpty)
+            TAsyncOp? current = head;
+            if (current is not null)
             {
-                operations.DequeueHead().TrySetException(error);
+                do
+                {
+                    Debug.Assert(current is not null);
+
+                    TAsyncOp? next = current.Next;
+                    Debug.Assert(next is not null);
+
+                    current.Next = current.Previous = null;
+
+                    current.DangerousSetResult(result);
+
+                    current = next;
+                }
+                while (current != head);
+            }
+        }
+
+        /// <summary>Iterates through the linked list, reserving completion for every element.</summary>
+        /// <param name="head">The head of the queue of operations to complete.</param>
+        /// <returns>A linked list of all successfully reserved operations. All other operations are ignored and dropped.</returns>
+        internal static TAsyncOp? TryReserveCompletionIfCancelable<TAsyncOp>(ref TAsyncOp? head)
+            where TAsyncOp : AsyncOperation<TAsyncOp>
+        {
+            TAsyncOp? reserved = null;
+
+            TAsyncOp? current = head;
+            if (current is not null)
+            {
+                do
+                {
+                    Debug.Assert(current is not null);
+
+                    TAsyncOp? next = current.Next;
+                    Debug.Assert(next is not null);
+
+                    current.Next = current.Previous = null;
+
+                    if (current.TryReserveCompletionIfCancelable())
+                    {
+                        Enqueue(ref reserved, current);
+                    }
+
+                    current = next;
+                }
+                while (current != head);
+
+                head = null;
+            }
+
+            return reserved;
+        }
+
+        /// <summary>Iterates through the linked list, failing each operation.</summary>
+        /// <param name="head">The head of the queue of operations to complete.</param>
+        /// <param name="error">The error with which to complete each operations.</param>
+        internal static void FailOperations<TAsyncOp>(TAsyncOp? head, Exception error)
+            where TAsyncOp : AsyncOperation<TAsyncOp>
+        {
+            Debug.Assert(error is not null);
+
+            TAsyncOp? current = head;
+            if (current is not null)
+            {
+                do
+                {
+                    Debug.Assert(current is not null);
+
+                    TAsyncOp? next = current.Next;
+                    Debug.Assert(next is not null);
+
+                    current.Next = current.Previous = null;
+
+                    current.TrySetException(error);
+
+                    current = next;
+                }
+                while (current != head);
+            }
+        }
+
+        /// <summary>Asserts that all operations in the list pass the specified condition.</summary>
+        /// <param name="head">The head of the queue of operations to analyze.</param>
+        /// <param name="condition">The condition with which to evaluate each operation.</param>
+        /// <param name="message">The assert message to use in the case of failure.</param>
+        [Conditional("DEBUG")]
+        internal static void AssertAll<TAsyncOp>(TAsyncOp? head, Func<TAsyncOp, bool> condition, string message)
+            where TAsyncOp : AsyncOperation<TAsyncOp>
+        {
+            TAsyncOp? current = head;
+            if (current is not null)
+            {
+                do
+                {
+                    Debug.Assert(current is not null);
+                    Debug.Assert(condition(current), message);
+                    current = current.Next;
+                }
+                while (current != head);
             }
         }
 
         /// <summary>Creates and returns an exception object to indicate that a channel has been closed.</summary>
         internal static Exception CreateInvalidCompletionException(Exception? inner = null) =>
             inner is OperationCanceledException ? inner :
-            inner != null && inner != s_doneWritingSentinel ? new ChannelClosedException(inner) :
+            inner is not null && inner != s_doneWritingSentinel ? new ChannelClosedException(inner) :
             new ChannelClosedException();
     }
 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.netcoreapp.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.netcoreapp.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Threading.Channels
+{
+    internal static partial class ChannelUtilities
+    {
+        internal static void UnsafeQueueUserWorkItem<TState>(Action<TState> action, TState state) =>
+            ThreadPool.UnsafeQueueUserWorkItem(action, state, preferLocal: false);
+
+        internal static void QueueUserWorkItem(Action<object?> action, object? state) =>
+            ThreadPool.QueueUserWorkItem(action, state, preferLocal: false);
+    }
+}

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.netstandard.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.netstandard.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+
+namespace System.Threading.Channels
+{
+    internal static partial class ChannelUtilities
+    {
+        internal static void UnsafeQueueUserWorkItem(Action<object?> action, object? state) =>
+            // No overload of {Unsafe}QueueUserWorkItem accepts an Action, only a WaitCallback.
+            // To avoid allocating an extra object, use QueueUserWorkItem, which uses Task,
+            // which does support Action<object>.
+            QueueUserWorkItem(action, state);
+
+        internal static void UnsafeQueueUserWorkItem<TState>(Action<TState> action, TState state)
+        {
+            ThreadPool.UnsafeQueueUserWorkItem(static tuple =>
+            {
+                var args = (Tuple<Action<TState>, TState>)tuple;
+                args.Item1(args.Item2);
+            }, Tuple.Create(action, state));
+        }
+
+        internal static void QueueUserWorkItem(Action<object?> action, object? state) =>
+            Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+    }
+}

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/IDebugEnumerator.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/IDebugEnumerator.cs
@@ -11,19 +11,9 @@ namespace System.Threading.Channels
         IEnumerator<T> GetEnumerator();
     }
 
-    internal sealed class DebugEnumeratorDebugView<T>
+    internal sealed class DebugEnumeratorDebugView<T>(IDebugEnumerable<T> enumerable)
     {
-        public DebugEnumeratorDebugView(IDebugEnumerable<T> enumerable)
-        {
-            var list = new List<T>();
-            foreach (T item in enumerable)
-            {
-                list.Add(item);
-            }
-            Items = list.ToArray();
-        }
-
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public T[] Items { get; }
+        public T[] Items { get; } = [.. enumerable];
     }
 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
@@ -32,10 +32,10 @@ namespace System.Threading.Channels
         private volatile Exception? _doneWriting;
 
         /// <summary>An <see cref="AsyncOperation{T}"/> if there's a blocked reader.</summary>
-        private AsyncOperation<T>? _blockedReader;
+        private BlockedReadAsyncOperation<T>? _blockedReader;
 
         /// <summary>A waiting reader (e.g. WaitForReadAsync) if there is one.</summary>
-        private AsyncOperation<bool>? _waitingReader;
+        private WaitingReadAsyncOperation? _waitingReader;
 
         /// <summary>Initialize the channel.</summary>
         /// <param name="runContinuationsAsynchronously">Whether to force continuations to be executed asynchronously.</param>
@@ -53,14 +53,14 @@ namespace System.Threading.Channels
         private sealed class UnboundedChannelReader : ChannelReader<T>, IDebugEnumerable<T>
         {
             internal readonly SingleConsumerUnboundedChannel<T> _parent;
-            private readonly AsyncOperation<T> _readerSingleton;
-            private readonly AsyncOperation<bool> _waiterSingleton;
+            private readonly BlockedReadAsyncOperation<T> _readerSingleton;
+            private readonly WaitingReadAsyncOperation _waiterSingleton;
 
             internal UnboundedChannelReader(SingleConsumerUnboundedChannel<T> parent)
             {
                 _parent = parent;
-                _readerSingleton = new AsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
-                _waiterSingleton = new AsyncOperation<bool>(parent._runContinuationsAsynchronously, pooled: true);
+                _readerSingleton = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
+                _waiterSingleton = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, pooled: true);
             }
 
             public override Task Completion => _parent._completion.Task;
@@ -81,7 +81,7 @@ namespace System.Threading.Channels
 
                 SingleConsumerUnboundedChannel<T> parent = _parent;
 
-                AsyncOperation<T>? oldBlockedReader, newBlockedReader;
+                BlockedReadAsyncOperation<T>? oldBlockedReader, newBlockedReader;
                 lock (parent.SyncObj)
                 {
                     // Now that we hold the lock, try reading again.
@@ -91,7 +91,7 @@ namespace System.Threading.Channels
                     }
 
                     // If no more items will be written, fail the read.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return ChannelUtilities.GetInvalidCompletionValueTask<T>(parent._doneWriting);
                     }
@@ -111,7 +111,7 @@ namespace System.Threading.Channels
                     }
                     else
                     {
-                        newBlockedReader = new AsyncOperation<T>(_parent._runContinuationsAsynchronously, cancellationToken);
+                        newBlockedReader = new BlockedReadAsyncOperation<T>(_parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
                     }
                     parent._blockedReader = newBlockedReader;
                 }
@@ -125,7 +125,7 @@ namespace System.Threading.Channels
                 SingleConsumerUnboundedChannel<T> parent = _parent;
                 if (parent._items.TryDequeue(out item))
                 {
-                    if (parent._doneWriting != null && parent._items.IsEmpty)
+                    if (parent._doneWriting is not null && parent._items.IsEmpty)
                     {
                         ChannelUtilities.Complete(parent._completion, parent._doneWriting);
                     }
@@ -151,7 +151,7 @@ namespace System.Threading.Channels
                 }
 
                 SingleConsumerUnboundedChannel<T> parent = _parent;
-                AsyncOperation<bool>? oldWaitingReader = null, newWaitingReader;
+                WaitingReadAsyncOperation? oldWaitingReader = null, newWaitingReader;
                 lock (parent.SyncObj)
                 {
                     // Again while holding the lock, check to see if there are any items available.
@@ -161,7 +161,7 @@ namespace System.Threading.Channels
                     }
 
                     // There aren't any items; if we're done writing, there never will be more items.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
                             new ValueTask<bool>(Task.FromException<bool>(parent._doneWriting)) :
@@ -183,7 +183,7 @@ namespace System.Threading.Channels
                     }
                     else
                     {
-                        newWaitingReader = new AsyncOperation<bool>(_parent._runContinuationsAsynchronously, cancellationToken);
+                        newWaitingReader = new WaitingReadAsyncOperation(_parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
                     }
                     parent._waitingReader = newWaitingReader;
                 }
@@ -208,15 +208,15 @@ namespace System.Threading.Channels
 
             public override bool TryComplete(Exception? error)
             {
-                AsyncOperation<T>? blockedReader = null;
-                AsyncOperation<bool>? waitingReader = null;
+                BlockedReadAsyncOperation<T>? blockedReader = null;
+                WaitingReadAsyncOperation? waitingReader = null;
                 bool completeTask = false;
 
                 SingleConsumerUnboundedChannel<T> parent = _parent;
                 lock (parent.SyncObj)
                 {
                     // If we're already marked as complete, there's nothing more to do.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return false;
                     }
@@ -231,13 +231,13 @@ namespace System.Threading.Channels
                     {
                         completeTask = true;
 
-                        if (parent._blockedReader != null)
+                        if (parent._blockedReader is not null)
                         {
                             blockedReader = parent._blockedReader;
                             parent._blockedReader = null;
                         }
 
-                        if (parent._waitingReader != null)
+                        if (parent._waitingReader is not null)
                         {
                             waitingReader = parent._waitingReader;
                             parent._waitingReader = null;
@@ -251,10 +251,10 @@ namespace System.Threading.Channels
                     ChannelUtilities.Complete(parent._completion, error);
                 }
 
-                Debug.Assert(blockedReader == null || waitingReader == null, "There should only ever be at most one reader.");
+                Debug.Assert(blockedReader is null || waitingReader is null, "There should only ever be at most one reader.");
 
                 // Complete a blocked reader if necessary
-                if (blockedReader != null)
+                if (blockedReader is not null)
                 {
                     error = ChannelUtilities.CreateInvalidCompletionException(error);
                     blockedReader.TrySetException(error);
@@ -262,15 +262,15 @@ namespace System.Threading.Channels
 
                 // Complete a waiting reader if necessary.  (We really shouldn't have both a blockedReader
                 // and a waitingReader, but it's more expensive to prevent it than to just tolerate it.)
-                if (waitingReader != null)
+                if (waitingReader is not null)
                 {
-                    if (error != null)
+                    if (error is not null)
                     {
                         waitingReader.TrySetException(error);
                     }
                     else
                     {
-                        waitingReader.TrySetResult(item: false);
+                        waitingReader.TrySetResult(result: false);
                     }
                 }
 
@@ -283,13 +283,13 @@ namespace System.Threading.Channels
                 SingleConsumerUnboundedChannel<T> parent = _parent;
                 while (true) // in case a reader was canceled and we need to try again
                 {
-                    AsyncOperation<T>? blockedReader = null;
-                    AsyncOperation<bool>? waitingReader = null;
+                    BlockedReadAsyncOperation<T>? blockedReader = null;
+                    WaitingReadAsyncOperation? waitingReader = null;
 
                     lock (parent.SyncObj)
                     {
                         // If writing is completed, exit out without writing.
-                        if (parent._doneWriting != null)
+                        if (parent._doneWriting is not null)
                         {
                             return false;
                         }
@@ -297,7 +297,7 @@ namespace System.Threading.Channels
                         // If there's a blocked reader, store it into a local for completion outside of the lock.
                         // If there isn't a blocked reader, queue the item being written; then if there's a waiting
                         blockedReader = parent._blockedReader;
-                        if (blockedReader != null)
+                        if (blockedReader is not null)
                         {
                             parent._blockedReader = null;
                         }
@@ -306,7 +306,7 @@ namespace System.Threading.Channels
                             parent._items.Enqueue(item);
 
                             waitingReader = parent._waitingReader;
-                            if (waitingReader == null)
+                            if (waitingReader is null)
                             {
                                 return true;
                             }
@@ -315,13 +315,13 @@ namespace System.Threading.Channels
                     }
 
                     // If we get here, we grabbed a blocked or a waiting reader.
-                    Debug.Assert((blockedReader != null) ^ (waitingReader != null), "Expected either a blocked or waiting reader, but not both");
+                    Debug.Assert((blockedReader is not null) ^ (waitingReader is not null), "Expected either a blocked or waiting reader, but not both");
 
                     // If we have a waiting reader, notify it that an item was written and exit.
-                    if (waitingReader != null)
+                    if (waitingReader is not null)
                     {
                         // If we get here, we grabbed a waiting reader.
-                        waitingReader.TrySetResult(item: true);
+                        waitingReader.TrySetResult(result: true);
                         return true;
                     }
 
@@ -329,7 +329,7 @@ namespace System.Threading.Channels
                     // In the case of a ReadAsync(CancellationToken), it's possible the reader could
                     // have been completed due to cancellation by the time we get here.  In that case,
                     // we'll loop around to try again so as not to lose the item being written.
-                    Debug.Assert(blockedReader != null);
+                    Debug.Assert(blockedReader is not null);
                     if (blockedReader.TrySetResult(item))
                     {
                         return true;
@@ -342,7 +342,7 @@ namespace System.Threading.Channels
                 Exception? doneWriting = _parent._doneWriting;
                 return
                     cancellationToken.IsCancellationRequested ? new ValueTask<bool>(Task.FromCanceled<bool>(cancellationToken)) :
-                    doneWriting == null ? new ValueTask<bool>(true) :
+                    doneWriting is null ? new ValueTask<bool>(true) :
                     doneWriting != ChannelUtilities.s_doneWritingSentinel ? new ValueTask<bool>(Task.FromException<bool>(doneWriting)) :
                     default;
             }
@@ -363,11 +363,33 @@ namespace System.Threading.Channels
 
         private object SyncObj => _items;
 
+        private Action<object?, CancellationToken> CancellationCallbackDelegate =>
+            field ??= (state, cancellationToken) =>
+            {
+                if (((AsyncOperation)state!).TrySetCanceled(cancellationToken))
+                {
+                    switch (state)
+                    {
+                        case BlockedReadAsyncOperation<T> blockedReader:
+                            Interlocked.CompareExchange(ref _blockedReader, null, blockedReader);
+                            break;
+
+                        case WaitingReadAsyncOperation waitingReader:
+                            Interlocked.CompareExchange(ref _waitingReader, null, waitingReader);
+                            break;
+
+                        default:
+                            Debug.Fail($"Unexpected operation: {state}");
+                            break;
+                    }
+                }
+            };
+
         /// <summary>Gets the number of items in the channel.  This should only be used by the debugger.</summary>
         private int ItemsCountForDebugger => _items.Count;
 
         /// <summary>Report if the channel is closed or not. This should only be used by the debugger.</summary>
-        private bool ChannelIsClosedForDebugger => _doneWriting != null;
+        private bool ChannelIsClosedForDebugger => _doneWriting is not null;
 
         /// <summary>Gets an enumerator the debugger can use to show the contents of the channel.</summary>
         IEnumerator<T> IDebugEnumerable<T>.GetEnumerator() => _items.GetEnumerator();

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
@@ -16,15 +16,19 @@ namespace System.Threading.Channels
     {
         /// <summary>Task that indicates the channel has completed.</summary>
         private readonly TaskCompletionSource _completion;
+
         /// <summary>The items in the channel.</summary>
         private readonly ConcurrentQueue<T> _items = new ConcurrentQueue<T>();
-        /// <summary>Readers blocked reading from the channel.</summary>
-        private readonly Deque<AsyncOperation<T>> _blockedReaders = new Deque<AsyncOperation<T>>();
+
         /// <summary>Whether to force continuations to be executed asynchronously from producer writes.</summary>
         private readonly bool _runContinuationsAsynchronously;
 
+        /// <summary>Readers blocked reading from the channel.</summary>
+        private BlockedReadAsyncOperation<T>? _blockedReadersHead;
+
         /// <summary>Readers waiting for a notification that data is available.</summary>
-        private AsyncOperation<bool>? _waitingReadersTail;
+        private WaitingReadAsyncOperation? _waitingReadersHead;
+
         /// <summary>Set to non-null once Complete has been called.</summary>
         private Exception? _doneWriting;
 
@@ -33,6 +37,7 @@ namespace System.Threading.Channels
         {
             _runContinuationsAsynchronously = runContinuationsAsynchronously;
             _completion = new TaskCompletionSource(runContinuationsAsynchronously ? TaskCreationOptions.RunContinuationsAsynchronously : TaskCreationOptions.None);
+
             Reader = new UnboundedChannelReader(this);
             Writer = new UnboundedChannelWriter(this);
         }
@@ -42,14 +47,14 @@ namespace System.Threading.Channels
         private sealed class UnboundedChannelReader : ChannelReader<T>, IDebugEnumerable<T>
         {
             internal readonly UnboundedChannel<T> _parent;
-            private readonly AsyncOperation<T> _readerSingleton;
-            private readonly AsyncOperation<bool> _waiterSingleton;
+            private readonly BlockedReadAsyncOperation<T> _readerSingleton;
+            private readonly WaitingReadAsyncOperation _waiterSingleton;
 
             internal UnboundedChannelReader(UnboundedChannel<T> parent)
             {
                 _parent = parent;
-                _readerSingleton = new AsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
-                _waiterSingleton = new AsyncOperation<bool>(parent._runContinuationsAsynchronously, pooled: true);
+                _readerSingleton = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
+                _waiterSingleton = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, pooled: true);
             }
 
             public override Task Completion => _parent._completion.Task;
@@ -87,7 +92,7 @@ namespace System.Threading.Channels
                     }
 
                     // There are no items, so if we're done writing, fail.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return ChannelUtilities.GetInvalidCompletionValueTask<T>(parent._doneWriting);
                     }
@@ -95,17 +100,17 @@ namespace System.Threading.Channels
                     // If we're able to use the singleton reader, do so.
                     if (!cancellationToken.CanBeCanceled)
                     {
-                        AsyncOperation<T> singleton = _readerSingleton;
+                        BlockedReadAsyncOperation<T> singleton = _readerSingleton;
                         if (singleton.TryOwnAndReset())
                         {
-                            parent._blockedReaders.EnqueueTail(singleton);
+                            ChannelUtilities.Enqueue(ref parent._blockedReadersHead, singleton);
                             return singleton.ValueTaskOfT;
                         }
                     }
 
                     // Otherwise, create and queue a reader.
-                    var reader = new AsyncOperation<T>(parent._runContinuationsAsynchronously, cancellationToken);
-                    parent._blockedReaders.EnqueueTail(reader);
+                    var reader = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    ChannelUtilities.Enqueue(ref parent._blockedReadersHead, reader);
                     return reader.ValueTaskOfT;
                 }
             }
@@ -130,7 +135,7 @@ namespace System.Threading.Channels
 
             private static void CompleteIfDone(UnboundedChannel<T> parent)
             {
-                if (parent._doneWriting != null && parent._items.IsEmpty)
+                if (parent._doneWriting is not null && parent._items.IsEmpty)
                 {
                     // If we've now emptied the items queue and we're not getting any more, complete.
                     ChannelUtilities.Complete(parent._completion, parent._doneWriting);
@@ -162,7 +167,7 @@ namespace System.Threading.Channels
                     }
 
                     // There are no items, so if we're done writing, there's never going to be data available.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
                             new ValueTask<bool>(Task.FromException<bool>(parent._doneWriting)) :
@@ -172,17 +177,17 @@ namespace System.Threading.Channels
                     // If we're able to use the singleton waiter, do so.
                     if (!cancellationToken.CanBeCanceled)
                     {
-                        AsyncOperation<bool> singleton = _waiterSingleton;
+                        WaitingReadAsyncOperation singleton = _waiterSingleton;
                         if (singleton.TryOwnAndReset())
                         {
-                            ChannelUtilities.QueueWaiter(ref parent._waitingReadersTail, singleton);
+                            ChannelUtilities.Enqueue(ref parent._waitingReadersHead, singleton);
                             return singleton.ValueTaskOfT;
                         }
                     }
 
                     // Otherwise, create and queue a waiter.
-                    var waiter = new AsyncOperation<bool>(parent._runContinuationsAsynchronously, cancellationToken);
-                    ChannelUtilities.QueueWaiter(ref parent._waitingReadersTail, waiter);
+                    var waiter = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    ChannelUtilities.Enqueue(ref parent._waitingReadersHead, waiter);
                     return waiter.ValueTaskOfT;
                 }
             }
@@ -201,14 +206,17 @@ namespace System.Threading.Channels
             public override bool TryComplete(Exception? error)
             {
                 UnboundedChannel<T> parent = _parent;
-                bool completeTask;
 
+                BlockedReadAsyncOperation<T>? blockedReadersHead;
+                WaitingReadAsyncOperation? waitingReadersHead;
+
+                bool completeTask;
                 lock (parent.SyncObj)
                 {
                     parent.AssertInvariants();
 
                     // If we've already marked the channel as completed, bail.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return false;
                     }
@@ -216,6 +224,13 @@ namespace System.Threading.Channels
                     // Mark that we're done writing.
                     parent._doneWriting = error ?? ChannelUtilities.s_doneWritingSentinel;
                     completeTask = parent._items.IsEmpty;
+
+                    // Snag the queues while holding the lock, so that we don't need to worry
+                    // about concurrent mutation, such as from cancellation of pending operations.
+                    blockedReadersHead = parent._blockedReadersHead;
+                    waitingReadersHead = parent._waitingReadersHead;
+                    parent._blockedReadersHead = null;
+                    parent._waitingReadersHead = null;
                 }
 
                 // If there are no items in the queue, complete the channel's task,
@@ -228,11 +243,11 @@ namespace System.Threading.Channels
                     ChannelUtilities.Complete(parent._completion, error);
                 }
 
-                // At this point, _blockedReaders and _waitingReaders will not be mutated:
-                // they're only mutated by readers while holding the lock, and only if _doneWriting is null.
-                // freely manipulate _blockedReaders and _waitingReaders without any concurrency concerns.
-                ChannelUtilities.FailOperations<AsyncOperation<T>, T>(parent._blockedReaders, ChannelUtilities.CreateInvalidCompletionException(error));
-                ChannelUtilities.WakeUpWaiters(ref parent._waitingReadersTail, result: false, error: error);
+                // Complete all pending operations. We don't need to worry about concurrent mutation here:
+                // No other writers or readers will be able to register operations, and any cancellation callbacks
+                // will see the queues as being null and exit immediately.
+                ChannelUtilities.FailOperations(blockedReadersHead, ChannelUtilities.CreateInvalidCompletionException(error));
+                ChannelUtilities.SetOrFailOperations(waitingReadersHead, result: false, error: error);
 
                 // Successfully transitioned to completed.
                 return true;
@@ -241,61 +256,46 @@ namespace System.Threading.Channels
             public override bool TryWrite(T item)
             {
                 UnboundedChannel<T> parent = _parent;
-                while (true)
+
+                BlockedReadAsyncOperation<T>? blockedReader = null;
+                WaitingReadAsyncOperation? waitingReadersHead = null;
+                lock (parent.SyncObj)
                 {
-                    AsyncOperation<T>? blockedReader = null;
-                    AsyncOperation<bool>? waitingReadersTail = null;
-                    lock (parent.SyncObj)
+                    // If writing has already been marked as done, fail the write.
+                    parent.AssertInvariants();
+                    if (parent._doneWriting is not null)
                     {
-                        // If writing has already been marked as done, fail the write.
-                        parent.AssertInvariants();
-                        if (parent._doneWriting != null)
-                        {
-                            return false;
-                        }
+                        return false;
+                    }
 
-                        // If there aren't any blocked readers, just add the data to the queue,
-                        // and let any waiting readers know that they should try to read it.
-                        // We can only complete such waiters here under the lock if they run
-                        // continuations asynchronously (otherwise the synchronous continuations
-                        // could be invoked under the lock).  If we don't complete them here, we
-                        // need to do so outside of the lock.
-                        if (parent._blockedReaders.IsEmpty)
+                    // Try to get a blocked reader that we can transfer the item to.
+                    while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
+                    {
+                        if (blockedReader.TryReserveCompletionIfCancelable())
                         {
-                            parent._items.Enqueue(item);
-                            waitingReadersTail = parent._waitingReadersTail;
-                            if (waitingReadersTail == null)
-                            {
-                                return true;
-                            }
-                            parent._waitingReadersTail = null;
-                        }
-                        else
-                        {
-                            // There were blocked readers.  Grab one, and then complete it outside of the lock.
-                            blockedReader = parent._blockedReaders.DequeueHead();
+                            break;
                         }
                     }
 
-                    if (blockedReader != null)
+                    // If we weren't able to get a reader, instead queue the item and get any waiters that need to be notified.
+                    if (blockedReader is null)
                     {
-                        // Complete the reader.  It's possible the reader was canceled, in which
-                        // case we loop around to try everything again.
-                        if (blockedReader.TrySetResult(item))
-                        {
-                            return true;
-                        }
-                    }
-                    else
-                    {
-                        // Wake up all of the waiters.  Since we've released the lock, it's possible
-                        // we could cause some spurious wake-ups here, if we tell a waiter there's
-                        // something available but all data has already been removed.  It's a benign
-                        // race condition, though, as consumers already need to account for such things.
-                        ChannelUtilities.WakeUpWaiters(ref waitingReadersTail, result: true);
-                        return true;
+                        parent._items.Enqueue(item);
+                        waitingReadersHead = ChannelUtilities.TryReserveCompletionIfCancelable(ref parent._waitingReadersHead);
                     }
                 }
+
+                // Now that we're outside of the lock, if we successfully got any tasks to complete and reserved their completion, do so.
+                if (blockedReader is not null)
+                {
+                    blockedReader.DangerousSetResult(item);
+                }
+                else if (waitingReadersHead is not null)
+                {
+                    ChannelUtilities.DangerousSetOperations(waitingReadersHead, result: true);
+                }
+
+                return true;
             }
 
             public override ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken)
@@ -303,7 +303,7 @@ namespace System.Threading.Channels
                 Exception? doneWriting = _parent._doneWriting;
                 return
                     cancellationToken.IsCancellationRequested ? new ValueTask<bool>(Task.FromCanceled<bool>(cancellationToken)) :
-                    doneWriting == null ? new ValueTask<bool>(true) : // unbounded writing can always be done if we haven't completed
+                    doneWriting is null ? new ValueTask<bool>(true) : // unbounded writing can always be done if we haven't completed
                     doneWriting != ChannelUtilities.s_doneWritingSentinel ? new ValueTask<bool>(Task.FromException<bool>(doneWriting)) :
                     default;
             }
@@ -323,28 +323,59 @@ namespace System.Threading.Channels
         /// <summary>Gets the object used to synchronize access to all state on this instance.</summary>
         private object SyncObj => _items;
 
+        private Action<object?, CancellationToken> CancellationCallbackDelegate =>
+            field ??= (state, cancellationToken) =>
+            {
+                AsyncOperation op = (AsyncOperation)state!;
+                if (op.TrySetCanceled(cancellationToken))
+                {
+                    ChannelUtilities.UnsafeQueueUserWorkItem(static state => // escape cancellation callback
+                    {
+                        lock (state.Key.SyncObj)
+                        {
+                            switch (state.Value)
+                            {
+                                case BlockedReadAsyncOperation<T> blockedReader:
+                                    ChannelUtilities.Remove(ref state.Key._blockedReadersHead, blockedReader);
+                                    break;
+
+                                case WaitingReadAsyncOperation waitingReader:
+                                    ChannelUtilities.Remove(ref state.Key._waitingReadersHead, waitingReader);
+                                    break;
+
+                                default:
+                                    Debug.Fail($"Unexpected operation: {state.Value}");
+                                    break;
+                            }
+                        }
+                    }, new KeyValuePair<UnboundedChannel<T>, AsyncOperation>(this, op));
+                }
+            };
+
         [Conditional("DEBUG")]
         private void AssertInvariants()
         {
-            Debug.Assert(SyncObj != null, "The sync obj must not be null.");
+            Debug.Assert(SyncObj is not null, "The sync obj must not be null.");
             Debug.Assert(Monitor.IsEntered(SyncObj), "Invariants can only be validated while holding the lock.");
 
             if (!_items.IsEmpty)
             {
                 if (_runContinuationsAsynchronously)
                 {
-                    Debug.Assert(_blockedReaders.IsEmpty, "There's data available, so there shouldn't be any blocked readers.");
-                    Debug.Assert(_waitingReadersTail == null, "There's data available, so there shouldn't be any waiting readers.");
+                    Debug.Assert(_blockedReadersHead is null, "There's data available, so there shouldn't be any blocked readers.");
+                    Debug.Assert(_waitingReadersHead is null, "There's data available, so there shouldn't be any waiting readers.");
                 }
                 Debug.Assert(!_completion.Task.IsCompleted, "We still have data available, so shouldn't be completed.");
             }
-            if ((!_blockedReaders.IsEmpty || _waitingReadersTail != null) && _runContinuationsAsynchronously)
+
+            if ((_blockedReadersHead is not null || _waitingReadersHead is not null) && _runContinuationsAsynchronously)
             {
                 Debug.Assert(_items.IsEmpty, "There are blocked/waiting readers, so there shouldn't be any data available.");
             }
+
             if (_completion.Task.IsCompleted)
             {
-                Debug.Assert(_doneWriting != null, "We're completed, so we must be done writing.");
+                Debug.Assert(_doneWriting is not null, "We're completed, so we must be done writing.");
             }
         }
 
@@ -352,7 +383,7 @@ namespace System.Threading.Channels
         private int ItemsCountForDebugger => _items.Count;
 
         /// <summary>Report if the channel is closed or not. This should only be used by the debugger.</summary>
-        private bool ChannelIsClosedForDebugger => _doneWriting != null;
+        private bool ChannelIsClosedForDebugger => _doneWriting is not null;
 
         /// <summary>Gets an enumerator the debugger can use to show the contents of the channel.</summary>
         IEnumerator<T> IDebugEnumerable<T>.GetEnumerator() => _items.GetEnumerator();

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedPriorityChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedPriorityChannel.cs
@@ -20,16 +20,20 @@ namespace System.Threading.Channels
     {
         /// <summary>Task that indicates the channel has completed.</summary>
         private readonly TaskCompletionSource _completion;
+
         /// <summary>The items in the channel.</summary>
         /// <remarks>To avoid double storing of a potentially large struct T, the priority doubles as the element and the element is ignored.</remarks>
         private readonly PriorityQueue<bool, T> _items;
-        /// <summary>Readers blocked reading from the channel.</summary>
-        private readonly Deque<AsyncOperation<T>> _blockedReaders = new Deque<AsyncOperation<T>>();
+
         /// <summary>Whether to force continuations to be executed asynchronously from producer writes.</summary>
         private readonly bool _runContinuationsAsynchronously;
 
+        /// <summary>Readers blocked reading from the channel.</summary>
+        private BlockedReadAsyncOperation<T>? _blockedReadersHead;
+
         /// <summary>Readers waiting for a notification that data is available.</summary>
-        private AsyncOperation<bool>? _waitingReadersTail;
+        private WaitingReadAsyncOperation? _waitingReadersHead;
+
         /// <summary>Set to non-null once Complete has been called.</summary>
         private Exception? _doneWriting;
 
@@ -38,9 +42,11 @@ namespace System.Threading.Channels
         {
             _runContinuationsAsynchronously = runContinuationsAsynchronously;
             _completion = new TaskCompletionSource(runContinuationsAsynchronously ? TaskCreationOptions.RunContinuationsAsynchronously : TaskCreationOptions.None);
+
+            _items = new PriorityQueue<bool, T>(comparer);
+
             Reader = new UnboundedPrioritizedChannelReader(this);
             Writer = new UnboundedPrioritizedChannelWriter(this);
-            _items = new PriorityQueue<bool, T>(comparer);
         }
 
         [DebuggerDisplay("Items = {Count}")]
@@ -48,14 +54,14 @@ namespace System.Threading.Channels
         private sealed class UnboundedPrioritizedChannelReader : ChannelReader<T>, IDebugEnumerable<T>
         {
             internal readonly UnboundedPrioritizedChannel<T> _parent;
-            private readonly AsyncOperation<T> _readerSingleton;
-            private readonly AsyncOperation<bool> _waiterSingleton;
+            private readonly BlockedReadAsyncOperation<T> _readerSingleton;
+            private readonly WaitingReadAsyncOperation _waiterSingleton;
 
             internal UnboundedPrioritizedChannelReader(UnboundedPrioritizedChannel<T> parent)
             {
                 _parent = parent;
-                _readerSingleton = new AsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
-                _waiterSingleton = new AsyncOperation<bool>(parent._runContinuationsAsynchronously, pooled: true);
+                _readerSingleton = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
+                _waiterSingleton = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, pooled: true);
             }
 
             public override Task Completion => _parent._completion.Task;
@@ -87,7 +93,7 @@ namespace System.Threading.Channels
                     }
 
                     // There are no items, so if we're done writing, fail.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return ChannelUtilities.GetInvalidCompletionValueTask<T>(parent._doneWriting);
                     }
@@ -95,17 +101,17 @@ namespace System.Threading.Channels
                     // If we're able to use the singleton reader, do so.
                     if (!cancellationToken.CanBeCanceled)
                     {
-                        AsyncOperation<T> singleton = _readerSingleton;
+                        BlockedReadAsyncOperation<T> singleton = _readerSingleton;
                         if (singleton.TryOwnAndReset())
                         {
-                            parent._blockedReaders.EnqueueTail(singleton);
+                            ChannelUtilities.Enqueue(ref parent._blockedReadersHead, singleton);
                             return singleton.ValueTaskOfT;
                         }
                     }
 
                     // Otherwise, create and queue a reader.
-                    var reader = new AsyncOperation<T>(parent._runContinuationsAsynchronously, cancellationToken);
-                    parent._blockedReaders.EnqueueTail(reader);
+                    var reader = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    ChannelUtilities.Enqueue(ref parent._blockedReadersHead, reader);
                     return reader.ValueTaskOfT;
                 }
             }
@@ -140,7 +146,7 @@ namespace System.Threading.Channels
             {
                 Debug.Assert(Monitor.IsEntered(parent.SyncObj));
 
-                if (parent._doneWriting != null && parent._items.Count == 0)
+                if (parent._doneWriting is not null && parent._items.Count == 0)
                 {
                     // If we've now emptied the items queue and we're not getting any more, complete.
                     ChannelUtilities.Complete(parent._completion, parent._doneWriting);
@@ -166,7 +172,7 @@ namespace System.Threading.Channels
                     }
 
                     // There are no items, so if we're done writing, there's never going to be data available.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
                             ValueTask.FromException<bool>(parent._doneWriting) :
@@ -176,17 +182,17 @@ namespace System.Threading.Channels
                     // If we're able to use the singleton waiter, do so.
                     if (!cancellationToken.CanBeCanceled)
                     {
-                        AsyncOperation<bool> singleton = _waiterSingleton;
+                        WaitingReadAsyncOperation singleton = _waiterSingleton;
                         if (singleton.TryOwnAndReset())
                         {
-                            ChannelUtilities.QueueWaiter(ref parent._waitingReadersTail, singleton);
+                            ChannelUtilities.Enqueue(ref parent._waitingReadersHead, singleton);
                             return singleton.ValueTaskOfT;
                         }
                     }
 
                     // Otherwise, create and queue a waiter.
-                    var waiter = new AsyncOperation<bool>(parent._runContinuationsAsynchronously, cancellationToken);
-                    ChannelUtilities.QueueWaiter(ref parent._waitingReadersTail, waiter);
+                    var waiter = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    ChannelUtilities.Enqueue(ref parent._waitingReadersHead, waiter);
                     return waiter.ValueTaskOfT;
                 }
             }
@@ -206,14 +212,17 @@ namespace System.Threading.Channels
             public override bool TryComplete(Exception? error)
             {
                 UnboundedPrioritizedChannel<T> parent = _parent;
-                bool completeTask;
 
+                BlockedReadAsyncOperation<T>? blockedReadersHead;
+                WaitingReadAsyncOperation? waitingReadersHead;
+
+                bool completeTask;
                 lock (parent.SyncObj)
                 {
                     parent.AssertInvariants();
 
                     // If we've already marked the channel as completed, bail.
-                    if (parent._doneWriting != null)
+                    if (parent._doneWriting is not null)
                     {
                         return false;
                     }
@@ -221,6 +230,13 @@ namespace System.Threading.Channels
                     // Mark that we're done writing.
                     parent._doneWriting = error ?? ChannelUtilities.s_doneWritingSentinel;
                     completeTask = parent._items.Count == 0;
+
+                    // Snag the queues while holding the lock, so that we don't need to worry
+                    // about concurrent mutation, such as from cancellation of pending operations.
+                    blockedReadersHead = parent._blockedReadersHead;
+                    waitingReadersHead = parent._waitingReadersHead;
+                    parent._blockedReadersHead = null;
+                    parent._waitingReadersHead = null;
                 }
 
                 // If there are no items in the queue, complete the channel's task,
@@ -233,11 +249,11 @@ namespace System.Threading.Channels
                     ChannelUtilities.Complete(parent._completion, error);
                 }
 
-                // At this point, _blockedReaders and _waitingReaders will not be mutated:
-                // they're only mutated by readers while holding the lock, and only if _doneWriting is null.
-                // freely manipulate _blockedReaders and _waitingReaders without any concurrency concerns.
-                ChannelUtilities.FailOperations<AsyncOperation<T>, T>(parent._blockedReaders, ChannelUtilities.CreateInvalidCompletionException(error));
-                ChannelUtilities.WakeUpWaiters(ref parent._waitingReadersTail, result: false, error: error);
+                // Complete all pending operations. We don't need to worry about concurrent mutation here:
+                // No other writers or readers will be able to register operations, and any cancellation callbacks
+                // will see the queues as being null and exit immediately.
+                ChannelUtilities.FailOperations(blockedReadersHead, ChannelUtilities.CreateInvalidCompletionException(error));
+                ChannelUtilities.SetOrFailOperations(waitingReadersHead, result: false, error: error);
 
                 // Successfully transitioned to completed.
                 return true;
@@ -246,61 +262,46 @@ namespace System.Threading.Channels
             public override bool TryWrite(T item)
             {
                 UnboundedPrioritizedChannel<T> parent = _parent;
-                while (true)
+
+                BlockedReadAsyncOperation<T>? blockedReader = null;
+                WaitingReadAsyncOperation? waitingReadersHead = null;
+                lock (parent.SyncObj)
                 {
-                    AsyncOperation<T>? blockedReader = null;
-                    AsyncOperation<bool>? waitingReadersTail = null;
-                    lock (parent.SyncObj)
+                    // If writing has already been marked as done, fail the write.
+                    parent.AssertInvariants();
+                    if (parent._doneWriting is not null)
                     {
-                        // If writing has already been marked as done, fail the write.
-                        parent.AssertInvariants();
-                        if (parent._doneWriting != null)
-                        {
-                            return false;
-                        }
+                        return false;
+                    }
 
-                        // If there aren't any blocked readers, just add the data to the queue,
-                        // and let any waiting readers know that they should try to read it.
-                        // We can only complete such waiters here under the lock if they run
-                        // continuations asynchronously (otherwise the synchronous continuations
-                        // could be invoked under the lock).  If we don't complete them here, we
-                        // need to do so outside of the lock.
-                        if (parent._blockedReaders.IsEmpty)
+                    // Try to get a blocked reader that we can transfer the item to.
+                    while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
+                    {
+                        if (blockedReader.TryReserveCompletionIfCancelable())
                         {
-                            parent._items.Enqueue(true, item);
-                            waitingReadersTail = parent._waitingReadersTail;
-                            if (waitingReadersTail == null)
-                            {
-                                return true;
-                            }
-                            parent._waitingReadersTail = null;
-                        }
-                        else
-                        {
-                            // There were blocked readers.  Grab one, and then complete it outside of the lock.
-                            blockedReader = parent._blockedReaders.DequeueHead();
+                            break;
                         }
                     }
 
-                    if (blockedReader != null)
+                    // If we weren't able to get a reader, instead queue the item and get any waiters that need to be notified.
+                    if (blockedReader is null)
                     {
-                        // Complete the reader.  It's possible the reader was canceled, in which
-                        // case we loop around to try everything again.
-                        if (blockedReader.TrySetResult(item))
-                        {
-                            return true;
-                        }
-                    }
-                    else
-                    {
-                        // Wake up all of the waiters.  Since we've released the lock, it's possible
-                        // we could cause some spurious wake-ups here, if we tell a waiter there's
-                        // something available but all data has already been removed.  It's a benign
-                        // race condition, though, as consumers already need to account for such things.
-                        ChannelUtilities.WakeUpWaiters(ref waitingReadersTail, result: true);
-                        return true;
+                        parent._items.Enqueue(true, item);
+                        waitingReadersHead = ChannelUtilities.TryReserveCompletionIfCancelable(ref parent._waitingReadersHead);
                     }
                 }
+
+                // Now that we're outside of the lock, if we successfully got any tasks to complete and reserved their completion, do so.
+                if (blockedReader is not null)
+                {
+                    blockedReader.DangerousSetResult(item);
+                }
+                else if (waitingReadersHead is not null)
+                {
+                    ChannelUtilities.DangerousSetOperations(waitingReadersHead, result: true);
+                }
+
+                return true;
             }
 
             public override ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken)
@@ -308,7 +309,7 @@ namespace System.Threading.Channels
                 Exception? doneWriting = _parent._doneWriting;
                 return
                     cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<bool>(cancellationToken) :
-                    doneWriting == null ? new ValueTask<bool>(true) : // unbounded writing can always be done if we haven't completed
+                    doneWriting is null ? new ValueTask<bool>(true) : // unbounded writing can always be done if we haven't completed
                     doneWriting != ChannelUtilities.s_doneWritingSentinel ? ValueTask.FromException<bool>(doneWriting) :
                     default;
             }
@@ -328,28 +329,59 @@ namespace System.Threading.Channels
         /// <summary>Gets the object used to synchronize access to all state on this instance.</summary>
         private object SyncObj => _items;
 
+        private Action<object?, CancellationToken> CancellationCallbackDelegate =>
+            field ??= (state, cancellationToken) =>
+            {
+                AsyncOperation op = (AsyncOperation)state!;
+                if (op.TrySetCanceled(cancellationToken))
+                {
+                    ChannelUtilities.UnsafeQueueUserWorkItem(static state => // escape cancellation callback
+                    {
+                        lock (state.Key.SyncObj)
+                        {
+                            switch (state.Value)
+                            {
+                                case BlockedReadAsyncOperation<T> blockedReader:
+                                    ChannelUtilities.Remove(ref state.Key._blockedReadersHead, blockedReader);
+                                    break;
+
+                                case WaitingReadAsyncOperation waitingReader:
+                                    ChannelUtilities.Remove(ref state.Key._waitingReadersHead, waitingReader);
+                                    break;
+
+                                default:
+                                    Debug.Fail($"Unexpected operation: {state.Value}");
+                                    break;
+                            }
+                        }
+                    }, new KeyValuePair<UnboundedPrioritizedChannel<T>, AsyncOperation>(this, op));
+                }
+            };
+
         [Conditional("DEBUG")]
         private void AssertInvariants()
         {
-            Debug.Assert(SyncObj != null, "The sync obj must not be null.");
+            Debug.Assert(SyncObj is not null, "The sync obj must not be null.");
             Debug.Assert(Monitor.IsEntered(SyncObj), "Invariants can only be validated while holding the lock.");
 
             if (_items.Count != 0)
             {
                 if (_runContinuationsAsynchronously)
                 {
-                    Debug.Assert(_blockedReaders.IsEmpty, "There's data available, so there shouldn't be any blocked readers.");
-                    Debug.Assert(_waitingReadersTail == null, "There's data available, so there shouldn't be any waiting readers.");
+                    Debug.Assert(_blockedReadersHead is null, "There's data available, so there shouldn't be any blocked readers.");
+                    Debug.Assert(_waitingReadersHead is null, "There's data available, so there shouldn't be any waiting readers.");
                 }
                 Debug.Assert(!_completion.Task.IsCompleted, "We still have data available, so shouldn't be completed.");
             }
-            if ((!_blockedReaders.IsEmpty || _waitingReadersTail != null) && _runContinuationsAsynchronously)
+
+            if ((_blockedReadersHead is not null || _waitingReadersHead is not null) && _runContinuationsAsynchronously)
             {
                 Debug.Assert(_items.Count == 0, "There are blocked/waiting readers, so there shouldn't be any data available.");
             }
+
             if (_completion.Task.IsCompleted)
             {
-                Debug.Assert(_doneWriting != null, "We're completed, so we must be done writing.");
+                Debug.Assert(_doneWriting is not null, "We're completed, so we must be done writing.");
             }
         }
 
@@ -357,7 +389,7 @@ namespace System.Threading.Channels
         private int ItemsCountForDebugger => _items.Count;
 
         /// <summary>Report if the channel is closed or not. This should only be used by the debugger.</summary>
-        private bool ChannelIsClosedForDebugger => _doneWriting != null;
+        private bool ChannelIsClosedForDebugger => _doneWriting is not null;
 
         /// <summary>Gets an enumerator the debugger can use to show the contents of the channel.</summary>
         public IEnumerator<T> GetEnumerator()

--- a/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
@@ -624,7 +624,7 @@ namespace System.Threading.Channels.Tests
             Task t = waitToReadAsync ? (Task)c.Reader.WaitToReadAsync(ct).AsTask() : c.Reader.ReadAsync(ct).AsTask();
             Task r = t.ContinueWith(_ =>
             {
-                Assert.Equal(allowSynchronousContinuations && !cancelable, expectedId == Environment.CurrentManagedThreadId);
+                Assert.Equal(allowSynchronousContinuations, expectedId == Environment.CurrentManagedThreadId);
             }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
 
             Assert.True(c.Writer.WriteAsync(42).IsCompletedSuccessfully);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/761

Canceled {WaitTo}Read/WriteAsync operations currently become nops but still sit in their queue until they're dequeued by a corresponding write or read that's trying to fulfill one of the waiters. This was done intentionally, as it left the code simpler and it was deemed unlikely to be an issue to have these objects sitting around for a bit. But it has since proven disruptive for some applications, which experience a temporary but meaningful "leak". To address that, this PR switches the queues from being array-based to being doubly-linked lists, with cancellation not only marking the operation as canceled but also removing it from the corresponding list.

Doing so required adding a few fields to the operation instance, so compensating changes were also made to try to reduce the size of the instance. This includes propagating a change that had been made to ManualResetValueTaskSourceCore to also apply here: rather than having a field for ExecutionContext and a separate field for a SynchronizationContext/TaskScheduler, use just a single object field and allocate a tuple when both are needed. Needing to store an ExecutionContext is rare, so this is almost always a win. I also utilize some more .NET Core APIs, in particular an overload of CancellationToken.Register that passes in the relevant cancellation token in order to avoid needing to store that same token on the instance. The net result is, at least on .NET Core, with this change the AsyncOperation instance actually gets a bit smaller than it was previously.

As new null checks were being added, I also switched the whole project over to using is / is not rather than == / !=.

As part of this change, to help flow a bit of state about the purpose of each instance, I refactored the AsyncOperation type in order to have concrete types per scenario (e.g. ReadAsync vs WriteAsync vs WaitToReadAsync vs WaitToWriteAsync) and also pushed a bunch of members from the generic down to a non-generic base, which should help a bit further with throughput but also Native AOT size.

All in all, this should address the memory issue while also cleaning up the code a bit and having a small positive impact on overall performance. Running our microbenchmarks locally shows things to be net neutral or slightly beneficial.

Example (noting that this never tries to write anything, which would clear out all of the referenced instances):
```csharp
using System.Threading.Channels;

Channel<int> c = Channel.CreateUnbounded<int>();

for (int i = 0; ; i++)
{
    CancellationTokenSource cts = new();
    var vt = c.Reader.ReadAsync(cts.Token);
    cts.Cancel();
    await ((Task)vt.AsTask()).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);

    if (i % 100_000 == 0)
    {
        Console.WriteLine($"Working set: {Environment.WorkingSet:N0}b");
    }
}
```

Before:
```
Working set: 22,728,704b
Working set: 111,177,728b
Working set: 182,833,152b
Working set: 261,984,256b
Working set: 328,019,968b
Working set: 399,495,168b
Working set: 469,082,112b
Working set: 547,909,632b
Working set: 615,636,992b
Working set: 682,627,072b
Working set: 756,797,440b
Working set: 832,098,304b
Working set: 902,123,520b
Working set: 979,820,544b
Working set: 1,046,126,592b
Working set: 1,113,554,944b
Working set: 1,180,667,904b
Working set: 1,253,609,472b
Working set: 1,319,989,248b
Working set: 1,386,434,560b
```

After:
```
Working set: 23,281,664b
Working set: 36,900,864b
Working set: 37,466,112b
Working set: 37,691,392b
Working set: 37,699,584b
Working set: 37,707,776b
Working set: 37,707,776b
Working set: 37,707,776b
Working set: 37,728,256b
Working set: 37,744,640b
Working set: 37,761,024b
Working set: 37,769,216b
Working set: 37,769,216b
Working set: 37,769,216b
Working set: 37,769,216b
Working set: 37,781,504b
Working set: 37,785,600b
Working set: 37,797,888b
Working set: 37,814,272b
Working set: 37,834,752b
```

