### PR TITLE
Specialize Dictionary<,> for string key

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -394,6 +394,7 @@ namespace System.Collections.Generic
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ref TValue FindValue(TKey key)
         {
             if (key == null)


### PR DESCRIPTION
A quick search on [grep.app](https://grep.app/search?f.lang=C%23&case=true&words=true&q=Dictionary%3C) reveals **243 574** exact, case-sensitive matches for `Dictionary<`. Of these, **172 763** (about **71%**) use String as the `TKey` type; many of the remaining dictionaries use value-types as keys.

Presumably, in most of these cases the default (ordinal) comparer is used, and per @GrabYourPitchforks dictionary rehashing when we switch to the randomized comparer is extremely rare. That suggests it would be worthwhile to specialize `Dictionary<string, TValue>` for the common ordinal-comparer scenario, a sort of hand-made PGO or generic specialization for ref types.

Under the hood, `FindValue` on a string-keyed dictionary is always a shared generic method (_Canon). The JIT is unable to devirtualize any call inside it (There was an issue logged about this, but I couldn’t locate it.)

The check I’m proposing is lightweight and should speed up lookups by roughly 50% when using the OrdinalComparer, while incurring only about a 5% slowdown for other reference-keyed dictionaries. With some extra efforts we can, in theory, limit the overhead to String keys only with help of `IsKnownConstant(typeof(TKey)) && typeof(TKey) == typeof(string)`, but my attempt to do so wasn't pretty.

@stephentoub @jkotas @kg  - is this something we think is worth doing or the regression is not acceptable?

Bonus idea: constant fold `"string literal key".GetNonRandomizedHashCode()` in JIT.