### PR TITLE
[release/8.0-staging] Fix generation of minidump (#115562)

### DIFF
--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3789,10 +3789,14 @@ MethodDesc::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(dac_cast<PTR_MethodDesc>(this));
     if (!ilVersion.IsNull())
     {
-        ilVersion.GetActiveNativeCodeVersion(dac_cast<PTR_MethodDesc>(this));
-        ilVersion.GetVersionId();
-        ilVersion.GetRejitState();
-        ilVersion.GetIL();
+        EX_TRY
+        {
+            ilVersion.GetActiveNativeCodeVersion(dac_cast<PTR_MethodDesc>(this));
+            ilVersion.GetVersionId();
+            ilVersion.GetRejitState();
+            ilVersion.GetIL();
+        }
+        EX_CATCH_RETHROW_ONLY_COR_E_OPERATIONCANCELLED
     }
 #endif
 


### PR DESCRIPTION
Ports #115562

## Customer Impact

- [X] Customer reported
- [ ] Found internally

Addresses a customer reported issue in minidump generation.  The DAC implements `ICLRDataEnumMemoryRegions::EnumMemoryRegions` which is used by `dbghelp!MiniDumpWriteDump` to mark pages in the process that must be saved for actionable dumps.   As some memory enumeration API's might fail at dump collection time, we implement try/catch blocks around the logic that collects memory pages so that the entire process is not aborted.  We have a customer report on an issue resulting in corrupted mini-dumps, missing memory needed for stackwalking.  The issue was narrowed down to a call to `GetIL` on an `InlinedCallFrame` causes an exception to be thrown during memory enumeration, resulting in skipping over other memory collection API's that would have succeeded and in turn creating a minidump missing memory needed for stackwalking.  The fix addresses the issue by wrapping the IL version method calls at a lower-level with a nested try-catch block to ensure that an exception in `GetIL` doesn’t prevent dumping a full callstack.

## Regression
- [X] Yes (Works well on .NET Framework)
- [ ] No

## Testing
Manually tested, the customer verified 

## Risk
Low risk, we are adding a more granular try/catch around dump generation code