### PR TITLE
Trust single-edge synthetic profile

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6479,6 +6479,7 @@ public:
     bool                                   fgPgoSynthesized;
     bool                                   fgPgoDynamic;
     bool                                   fgPgoConsistent;
+    bool                                   fgPgoSingleEdge = false;
 
 #ifdef DEBUG
     bool                                   fgPgoDeferredInconsistency;

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -89,6 +89,11 @@ bool Compiler::fgHaveSufficientProfileWeights()
         case ICorJitInfo::PgoSource::Blend:
             return true;
 
+        case ICorJitInfo::PgoSource::Synthesis:
+            // Single-edge methods always have sufficient profile data.
+            // Assuming we don't synthesize value and class profile data (which we don't currently).
+            return fgPgoSingleEdge;
+
         case ICorJitInfo::PgoSource::Static:
         {
             // We sometimes call this very early, eg evaluating the prejit root.
@@ -134,6 +139,12 @@ bool Compiler::fgHaveTrustedProfileWeights()
         case ICorJitInfo::PgoSource::Blend:
         case ICorJitInfo::PgoSource::Text:
             return true;
+
+        case ICorJitInfo::PgoSource::Synthesis:
+            // Single-edge methods with synthetic profile are trustful.
+            // Assuming we don't synthesize value and class profile data (which we don't currently).
+            return fgPgoSingleEdge;
+
         default:
             return false;
     }

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -152,7 +152,7 @@ void ProfileSynthesis::Run(ProfileSynthesisOption option)
     m_comp->fgPgoSingleEdge = true;
     for (BasicBlock* const block : m_comp->Blocks())
     {
-        if (!block->KindIs(BBJ_ALWAYS, BBJ_RETURN))
+        if (block->NumSucc() > 1)
         {
             m_comp->fgPgoSingleEdge = false;
             break;

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -148,6 +148,17 @@ void ProfileSynthesis::Run(ProfileSynthesisOption option)
     m_comp->fgPgoSynthesized = true;
     m_comp->fgPgoConsistent  = !m_approximate;
 
+    // A simple check whether the current method has more than one edge.
+    m_comp->fgPgoSingleEdge = true;
+    for (BasicBlock* const block : m_comp->Blocks())
+    {
+        if (!block->KindIs(BBJ_ALWAYS, BBJ_RETURN))
+        {
+            m_comp->fgPgoSingleEdge = false;
+            break;
+        }
+    }
+
     m_comp->Metrics.ProfileSynthesizedBlendedOrRepaired++;
 
     if (m_approximate)


### PR DESCRIPTION
Normally, we don't instrument single-edge methods, it means if such a method is an inline root (it happens in Micro-benchmarks as normally single-edge methods are inlined somewhere), all callees don't receive an inlining boost.