### PR TITLE
Fix SmtpClientTest zero timeout hang

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -19,6 +19,7 @@ namespace System.Net.Mail
         private SmtpConnection? _connection;
         private readonly SmtpClient _client;
         private ICredentialsByHost? _credentials;
+        private bool _shouldAbort;
 
         private bool _enableSsl;
         private X509CertificateCollection? _clientCertificates;
@@ -90,6 +91,11 @@ namespace System.Net.Mail
             lock (this)
             {
                 _connection = new SmtpConnection(this, _client, _credentials, _authenticationModules);
+                if (_shouldAbort)
+                {
+                    _connection.Abort();
+                }
+                _shouldAbort = false;
             }
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _connection);
@@ -146,7 +152,14 @@ namespace System.Net.Mail
         {
             lock (this)
             {
-                _connection?.Abort();
+                if (_connection != null)
+                {
+                    _connection.Abort();
+                }
+                else
+                {
+                    _shouldAbort = true;
+                }
             }
         }
     }


### PR DESCRIPTION
This reverts part of the SmtpTransport changes from https://github.com/dotnet/runtime/pull/115722 which caused timeouts and test suite crashes of System.Net.Mail.Tests.SmtpClientTest.TestZeroTimeout test.

Zero timeout values are weird, but for now the easier step is to preserve the old behavior than consider making breaking changes.