### PR TITLE
stop using System.CommandLine types that won't be public anymore

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -41,7 +41,7 @@
       <Uri>https://github.com/dotnet/llvm-project</Uri>
       <Sha>da5dd054a531e6fea65643b7e754285b73eab433</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta5.25260.104">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta5.25279.2">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>85778473549347b3e4bad3ea009e9438df7b11bb</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -180,7 +180,7 @@
     <!-- Not auto-updated. -->
     <MicrosoftDiaSymReaderVersion>2.0.0</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
-    <SystemCommandLineVersion>2.0.0-beta5.25260.104</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta5.25279.2</SystemCommandLineVersion>
     <TraceEventVersion>3.1.16</TraceEventVersion>
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -440,9 +440,9 @@ namespace System.CommandLine
 
             public override int Invoke(ParseResult parseResult)
             {
-                int result = _helpAction.Invoke(parseResult);
+                int result = _helpAction(parseResult);
 
-                _customizer.Invoke(parseResult);
+                _customizer(parseResult);
 
                 return result;
             }

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -440,7 +440,7 @@ namespace System.CommandLine
 
             public override int Invoke(ParseResult parseResult)
             {
-                int result = _helpAction(parseResult);
+                int result = _helpAction.Invoke(parseResult);
 
                 _customizer(parseResult);
 

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -10,6 +10,7 @@ using System.IO.Compression;
 using System.Runtime.InteropServices;
 
 using Internal.TypeSystem;
+
 namespace System.CommandLine
 {
     internal sealed class CommandLineException : Exception

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -10,8 +10,6 @@ using System.IO.Compression;
 using System.Runtime.InteropServices;
 
 using Internal.TypeSystem;
-using ILCompiler.Reflection.ReadyToRun.x86;
-
 namespace System.CommandLine
 {
     internal sealed class CommandLineException : Exception

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -1,8 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine.Help;
 using System.Collections.Generic;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.IO;
 using System.IO.Compression;

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -329,64 +329,57 @@ namespace ILCompiler
             });
         }
 
-        public static IEnumerable<Func<HelpContext, bool>> GetExtendedHelp(HelpContext _)
+        public static void GetExtendedHelp(ParseResult _)
         {
-            foreach (Func<HelpContext, bool> sectionDelegate in HelpBuilder.Default.GetLayout())
-                yield return sectionDelegate;
+            Console.WriteLine("Options may be passed on the command line, or via response file. On the command line switch values may be specified by passing " +
+                "the option followed by a space followed by the value of the option, or by specifying a : between option and switch value. A response file " +
+                "is specified by passing the @ symbol before the response file name. In a response file all options must be specified on their own lines, and " +
+                "only the : syntax for switches is supported.\n");
 
-            yield return _ =>
+            Console.WriteLine("Use the '--' option to disambiguate between input files that have begin with -- and options. After a '--' option, all arguments are " +
+                "considered to be input files. If no input files begin with '--' then this option is not necessary.\n");
+
+            string[] ValidArchitectures = new string[] { "arm", "arm64", "x86", "x64", "riscv64", "loongarch64" };
+            string[] ValidOS = new string[] { "windows", "linux", "freebsd", "osx", "maccatalyst", "ios", "iossimulator", "tvos", "tvossimulator" };
+
+            Console.WriteLine("Valid switches for {0} are: '{1}'. The default value is '{2}'\n", "--targetos", string.Join("', '", ValidOS), Helpers.GetTargetOS(null).ToString().ToLowerInvariant());
+
+            Console.WriteLine(string.Format("Valid switches for {0} are: '{1}'. The default value is '{2}'\n", "--targetarch", string.Join("', '", ValidArchitectures), Helpers.GetTargetArchitecture(null).ToString().ToLowerInvariant()));
+
+            Console.WriteLine("The allowable values for the --instruction-set option are described in the table below. Each architecture has a different set of valid " +
+                "instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. For example 'avx2,bmi,lzcnt'");
+
+            foreach (string arch in ValidArchitectures)
             {
-                Console.WriteLine("Options may be passed on the command line, or via response file. On the command line switch values may be specified by passing " +
-                    "the option followed by a space followed by the value of the option, or by specifying a : between option and switch value. A response file " +
-                    "is specified by passing the @ symbol before the response file name. In a response file all options must be specified on their own lines, and " +
-                    "only the : syntax for switches is supported.\n");
-
-                Console.WriteLine("Use the '--' option to disambiguate between input files that have begin with -- and options. After a '--' option, all arguments are " +
-                    "considered to be input files. If no input files begin with '--' then this option is not necessary.\n");
-
-                string[] ValidArchitectures = new string[] { "arm", "arm64", "x86", "x64", "riscv64", "loongarch64" };
-                string[] ValidOS = new string[] { "windows", "linux", "freebsd", "osx", "maccatalyst", "ios", "iossimulator", "tvos", "tvossimulator" };
-
-                Console.WriteLine("Valid switches for {0} are: '{1}'. The default value is '{2}'\n", "--targetos", string.Join("', '", ValidOS), Helpers.GetTargetOS(null).ToString().ToLowerInvariant());
-
-                Console.WriteLine(string.Format("Valid switches for {0} are: '{1}'. The default value is '{2}'\n", "--targetarch", string.Join("', '", ValidArchitectures), Helpers.GetTargetArchitecture(null).ToString().ToLowerInvariant()));
-
-                Console.WriteLine("The allowable values for the --instruction-set option are described in the table below. Each architecture has a different set of valid " +
-                    "instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. For example 'avx2,bmi,lzcnt'");
-
-                foreach (string arch in ValidArchitectures)
+                TargetArchitecture targetArch = Helpers.GetTargetArchitecture(arch);
+                bool first = true;
+                foreach (var instructionSet in Internal.JitInterface.InstructionSetFlags.ArchitectureToValidInstructionSets(targetArch))
                 {
-                    TargetArchitecture targetArch = Helpers.GetTargetArchitecture(arch);
-                    bool first = true;
-                    foreach (var instructionSet in Internal.JitInterface.InstructionSetFlags.ArchitectureToValidInstructionSets(targetArch))
+                    // Only instruction sets with are specifiable should be printed to the help text
+                    if (instructionSet.Specifiable)
                     {
-                        // Only instruction sets with are specifiable should be printed to the help text
-                        if (instructionSet.Specifiable)
+                        if (first)
                         {
-                            if (first)
-                            {
-                                Console.Write(arch);
-                                Console.Write(": ");
-                                first = false;
-                            }
-                            else
-                            {
-                                Console.Write(", ");
-                            }
-                            Console.Write(instructionSet.Name);
+                            Console.Write(arch);
+                            Console.Write(": ");
+                            first = false;
                         }
+                        else
+                        {
+                            Console.Write(", ");
+                        }
+                        Console.Write(instructionSet.Name);
                     }
-
-                    if (first) continue; // no instruction-set found for this architecture
-
-                    Console.WriteLine();
                 }
 
+                if (first) continue; // no instruction-set found for this architecture
+
                 Console.WriteLine();
-                Console.WriteLine("The following CPU names are predefined groups of instruction sets and can be used in --instruction-set too:");
-                Console.WriteLine(string.Join(", ", Internal.JitInterface.InstructionSetFlags.AllCpuNames));
-                return true;
-            };
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("The following CPU names are predefined groups of instruction sets and can be used in --instruction-set too:");
+            Console.WriteLine(string.Join(", ", Internal.JitInterface.InstructionSetFlags.AllCpuNames));
         }
 
         private static TargetArchitecture MakeTargetArchitecture(ArgumentResult result)

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -329,7 +329,7 @@ namespace ILCompiler
             });
         }
 
-        public static void GetExtendedHelp(ParseResult _)
+        public static void PrintExtendedHelp(ParseResult _)
         {
             Console.WriteLine("Options may be passed on the command line, or via response file. On the command line switch values may be specified by passing " +
                 "the option followed by a space followed by the value of the option, or by specifying a : between option and switch value. A response file " +

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -789,7 +789,7 @@ namespace ILCompiler
         private static int Main(string[] args) =>
             new CommandLineConfiguration(new ILCompilerRootCommand(args)
                 .UseVersion()
-                .UseExtendedHelp(ILCompilerRootCommand.GetExtendedHelp))
+                .UseExtendedHelp(ILCompilerRootCommand.PrintExtendedHelp))
             {
                 ResponseFileTokenReplacer = Helpers.TryReadResponseFile,
                 EnableDefaultExceptionHandler = false,

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -285,7 +285,7 @@ namespace ILCompiler
             });
         }
 
-        public static void GetExtendedHelp(ParseResult _)
+        public static void PrintExtendedHelp(ParseResult _)
         {
             Console.WriteLine(SR.OptionPassingHelp);
             Console.WriteLine();

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -285,69 +285,62 @@ namespace ILCompiler
             });
         }
 
-        public static IEnumerable<Func<HelpContext, bool>> GetExtendedHelp(HelpContext _)
+        public static void GetExtendedHelp(ParseResult _)
         {
-            foreach (Func<HelpContext, bool> sectionDelegate in HelpBuilder.Default.GetLayout())
-                yield return sectionDelegate;
+            Console.WriteLine(SR.OptionPassingHelp);
+            Console.WriteLine();
+            Console.WriteLine(SR.DashDashHelp);
+            Console.WriteLine();
 
-            yield return _ =>
+            string[] ValidArchitectures = new string[] {"arm", "armel", "arm64", "x86", "x64", "riscv64", "loongarch64"};
+            string[] ValidOS = new string[] {"windows", "linux", "osx", "ios", "iossimulator", "maccatalyst"};
+
+            Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--targetos", String.Join("', '", ValidOS), Helpers.GetTargetOS(null).ToString().ToLowerInvariant()));
+            Console.WriteLine();
+            Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--targetarch", String.Join("', '", ValidArchitectures), Helpers.GetTargetArchitecture(null).ToString().ToLowerInvariant()));
+            Console.WriteLine();
+            Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--type-validation", String.Join("', '", Enum.GetNames<TypeValidationRule>()), nameof(TypeValidationRule.Automatic)));
+            Console.WriteLine();
+
+            Console.WriteLine(SR.CrossModuleInliningExtraHelp);
+            Console.WriteLine();
+            Console.WriteLine(String.Format(SR.LayoutOptionExtraHelp, "--method-layout", String.Join("', '", Enum.GetNames<MethodLayoutAlgorithm>())));
+            Console.WriteLine();
+            Console.WriteLine(String.Format(SR.LayoutOptionExtraHelp, "--file-layout", String.Join("', '", Enum.GetNames<FileLayoutAlgorithm>())));
+            Console.WriteLine();
+
+            Console.WriteLine(SR.InstructionSetHelp);
+            foreach (string arch in ValidArchitectures)
             {
-                Console.WriteLine(SR.OptionPassingHelp);
-                Console.WriteLine();
-                Console.WriteLine(SR.DashDashHelp);
-                Console.WriteLine();
-
-                string[] ValidArchitectures = new string[] {"arm", "armel", "arm64", "x86", "x64", "riscv64", "loongarch64"};
-                string[] ValidOS = new string[] {"windows", "linux", "osx", "ios", "iossimulator", "maccatalyst"};
-
-                Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--targetos", String.Join("', '", ValidOS), Helpers.GetTargetOS(null).ToString().ToLowerInvariant()));
-                Console.WriteLine();
-                Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--targetarch", String.Join("', '", ValidArchitectures), Helpers.GetTargetArchitecture(null).ToString().ToLowerInvariant()));
-                Console.WriteLine();
-                Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--type-validation", String.Join("', '", Enum.GetNames<TypeValidationRule>()), nameof(TypeValidationRule.Automatic)));
-                Console.WriteLine();
-
-                Console.WriteLine(SR.CrossModuleInliningExtraHelp);
-                Console.WriteLine();
-                Console.WriteLine(String.Format(SR.LayoutOptionExtraHelp, "--method-layout", String.Join("', '", Enum.GetNames<MethodLayoutAlgorithm>())));
-                Console.WriteLine();
-                Console.WriteLine(String.Format(SR.LayoutOptionExtraHelp, "--file-layout", String.Join("', '", Enum.GetNames<FileLayoutAlgorithm>())));
-                Console.WriteLine();
-
-                Console.WriteLine(SR.InstructionSetHelp);
-                foreach (string arch in ValidArchitectures)
+                TargetArchitecture targetArch = Helpers.GetTargetArchitecture(arch);
+                bool first = true;
+                foreach (var instructionSet in Internal.JitInterface.InstructionSetFlags.ArchitectureToValidInstructionSets(targetArch))
                 {
-                    TargetArchitecture targetArch = Helpers.GetTargetArchitecture(arch);
-                    bool first = true;
-                    foreach (var instructionSet in Internal.JitInterface.InstructionSetFlags.ArchitectureToValidInstructionSets(targetArch))
+                    // Only instruction sets with are specifiable should be printed to the help text
+                    if (instructionSet.Specifiable)
                     {
-                        // Only instruction sets with are specifiable should be printed to the help text
-                        if (instructionSet.Specifiable)
+                        if (first)
                         {
-                            if (first)
-                            {
-                                Console.Write(arch);
-                                Console.Write(": ");
-                                first = false;
-                            }
-                            else
-                            {
-                                Console.Write(", ");
-                            }
-                            Console.Write(instructionSet.Name);
+                            Console.Write(arch);
+                            Console.Write(": ");
+                            first = false;
                         }
+                        else
+                        {
+                            Console.Write(", ");
+                        }
+                        Console.Write(instructionSet.Name);
                     }
-
-                    if (first) continue; // no instruction-set found for this architecture
-
-                    Console.WriteLine();
                 }
 
+                if (first) continue; // no instruction-set found for this architecture
+
                 Console.WriteLine();
-                Console.WriteLine(SR.CpuFamilies);
-                Console.WriteLine(string.Join(", ", Internal.JitInterface.InstructionSetFlags.AllCpuNames));
-                return true;
-            };
+            }
+
+            Console.WriteLine();
+            Console.WriteLine(SR.CpuFamilies);
+            Console.WriteLine(string.Join(", ", Internal.JitInterface.InstructionSetFlags.AllCpuNames));
         }
 
         private static TargetArchitecture MakeTargetArchitecture(ArgumentResult result)

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -914,7 +914,7 @@ namespace ILCompiler
         private static int Main(string[] args) =>
             new CommandLineConfiguration(new Crossgen2RootCommand(args)
                 .UseVersion()
-                .UseExtendedHelp(Crossgen2RootCommand.GetExtendedHelp))
+                .UseExtendedHelp(Crossgen2RootCommand.PrintExtendedHelp))
             {
                 ResponseFileTokenReplacer = Helpers.TryReadResponseFile,
                 EnableDefaultExceptionHandler = false,

--- a/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
+++ b/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
@@ -260,16 +260,11 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             }
         }
 
-        public static IEnumerable<Func<HelpContext, bool>> GetExtendedHelp(HelpContext context)
+        public static void GetExtendedHelp(ParseResult parseResult)
         {
-            foreach (Func<HelpContext, bool> sectionDelegate in HelpBuilder.Default.GetLayout())
-                yield return sectionDelegate;
-
-            if (context.Command.Name == "create-mibc" || context.Command.Name == "create-jittrace")
+            if (parseResult.CommandResult.Command.Name is "create-mibc" or "create-jittrace")
             {
-                yield return _ =>
-                {
-                    Console.WriteLine(
+                Console.WriteLine(
 @"Example tracing commands used to generate the input to this tool:
 ""dotnet-trace collect -p 73060 --providers Microsoft-Windows-DotNETRuntime:0x1E000080018:4""
 - Capture events from process 73060 where we capture both JIT and R2R events using EventPipe tracing
@@ -280,8 +275,6 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 ""perfview collect -LogFile:logOfCollection.txt -DataFile:jittrace.etl -Zip:false -merge:false -providers:Microsoft-Windows-DotNETRuntime:0x1E000080018:4""
 - Capture Jit and R2R events via perfview of all processes running using ETW tracing
 ");
-                    return true;
-                };
             }
         }
 

--- a/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
+++ b/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             }
         }
 
-        public static void GetExtendedHelp(ParseResult parseResult)
+        public static void PrintExtendedHelp(ParseResult parseResult)
         {
             if (parseResult.CommandResult.Command.Name is "create-mibc" or "create-jittrace")
             {

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         private static int Main(string[] args) =>
             new CommandLineConfiguration(new PgoRootCommand(args)
                 .UseVersion()
-                .UseExtendedHelp(PgoRootCommand.GetExtendedHelp))
+                .UseExtendedHelp(PgoRootCommand.PrintExtendedHelp))
             {
                 ResponseFileTokenReplacer = Helpers.TryReadResponseFile,
                 EnableDefaultExceptionHandler = false,


### PR DESCRIPTION
Context: https://github.com/dotnet/command-line-api/pull/2563