### PR TITLE
Adjust Test_wait_interrupted_user_apc test timeout to handle deviation due to lowres timers.

### DIFF
--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -3309,12 +3309,12 @@ DWORD Thread::DoAppropriateWaitWorker(int countHandles, HANDLE *handles, BOOL wa
     }
 
     ULONGLONG dwStart = 0, dwEnd;
-retry:
     if (millis != INFINITE)
     {
         dwStart = minipal_lowres_ticks();
     }
 
+retry:
     if (tryNonblockingWaitFirst)
     {
         // We have a final wait result from the nonblocking wait above
@@ -3344,10 +3344,9 @@ retry:
                 ret = WAIT_TIMEOUT;
                 goto WaitCompleted;
             }
-            else
-            {
-                millis -= (DWORD)(dwEnd - dwStart);
-            }
+
+            millis -= (DWORD)(dwEnd - dwStart);
+            dwStart = dwEnd;
         }
         goto retry;
     }
@@ -3421,18 +3420,17 @@ retry:
 
             // Compute the new timeout value by assume that the timeout
             // is not large enough for more than one wrap
-            dwEnd = minipal_lowres_ticks();
             if (millis != INFINITE)
             {
+                dwEnd = minipal_lowres_ticks();
                 if (dwEnd - dwStart >= millis)
                 {
                     ret = WAIT_TIMEOUT;
                     goto WaitCompleted;
                 }
-                else
-                {
-                    millis -= (DWORD)(dwEnd - dwStart);
-                }
+
+                millis -= (DWORD)(dwEnd - dwStart);
+                dwStart = dwEnd;
             }
             goto retry;
         }
@@ -3574,11 +3572,9 @@ retry:
                 ret = WAIT_TIMEOUT;
                 goto WaitCompleted;
             }
-            else
-            {
-                millis -= (DWORD)(dwEnd - dwStart);
-            }
-            dwStart = minipal_lowres_ticks();
+
+            millis -= (DWORD)(dwEnd - dwStart);
+            dwStart = dwEnd;
         }
         //Retry case we don't want to signal again so only do the wait...
         ret = WaitForSingleObjectEx(pHandles[1],millis,TRUE);

--- a/src/tests/baseservices/threading/regressions/115178/115178.cs
+++ b/src/tests/baseservices/threading/regressions/115178/115178.cs
@@ -166,9 +166,9 @@ public class Test_wait_interrupted_user_apc
             stopwatch.Stop();
 
             long elapsedMilliseconds = stopwatch.ElapsedMilliseconds;
-            if (elapsedMilliseconds < 2000)
+            if (elapsedMilliseconds < 1500)
             {
-                Console.WriteLine($"Error waiting on event, wait returned too early. Waited {elapsedMilliseconds} ms, expected at least 2000 ms.");
+                Console.WriteLine($"Error waiting on event, wait returned too early. Waited {elapsedMilliseconds} ms, expected at least 1500 ms.");
                 result = 5;
             }
 

--- a/src/tests/baseservices/threading/regressions/115178/115178.cs
+++ b/src/tests/baseservices/threading/regressions/115178/115178.cs
@@ -165,9 +165,10 @@ public class Test_wait_interrupted_user_apc
 
             stopwatch.Stop();
 
-            if (stopwatch.ElapsedMilliseconds < 2000)
+            long elapsedMilliseconds = stopwatch.ElapsedMilliseconds;
+            if (elapsedMilliseconds < 2000)
             {
-                Console.WriteLine($"Error waiting on event, wait returned too early.");
+                Console.WriteLine($"Error waiting on event, wait returned too early. Waited {elapsedMilliseconds} ms, expected at least 2000 ms.");
                 result = 5;
             }
 

--- a/src/tests/baseservices/threading/regressions/115178/115178.cs
+++ b/src/tests/baseservices/threading/regressions/115178/115178.cs
@@ -166,9 +166,10 @@ public class Test_wait_interrupted_user_apc
             stopwatch.Stop();
 
             long elapsedMilliseconds = stopwatch.ElapsedMilliseconds;
-            if (elapsedMilliseconds < 1500)
+            if (elapsedMilliseconds < 1980)
             {
-                Console.WriteLine($"Error waiting on event, wait returned too early. Waited {elapsedMilliseconds} ms, expected at least 1500 ms.");
+                // Wait uses low resolution timer, test includes a margin of 20ms to account for timer resolution differences.
+                Console.WriteLine($"Error waiting on event, wait returned too early. Waited {elapsedMilliseconds} ms, expected at least 1980 ms.");
                 result = 5;
             }
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -30,9 +30,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/regressions/2164/foreground-shutdown/*">
             <Issue>https://github.com/dotnet/runtime/issues/83658</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/regressions/115178/115178/*">
-            <Issue>https://github.com/dotnet/runtime/issues/116060</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/Coverage/271010/**">
             <Issue>https://github.com/dotnet/runtime/issues/5933</Issue>
         </ExcludeList>


### PR DESCRIPTION
Looks like outer loop x64 and arm64 Windows lanes hit issues with one of the tests added in https://github.com/dotnet/runtime/pull/116001.

Test validates that waits are not broken too early by queued APC's by measuring time it spends waiting compared to requested timeout. Test uses higres timer to measure, but it appears that CoreCLR uses lowres timers calculating the wait timeout. Test probably need to include some error margin to handle timer resolution differences.

PR adds logging to the amount of time waited in case of error and increased the acceptance deviations to 500 ms, should be enough to trigger multiple APC's triggering retry of the internal wait with recalculated timeout.

Fixes https://github.com/dotnet/runtime/issues/116060