### PR TITLE
[mono][interp] Fix broken code attempting to reapply superinstruction optimization

### DIFF
--- a/src/mono/mono/mini/interp/transform-opt.c
+++ b/src/mono/mono/mini/interp/transform-opt.c
@@ -3403,9 +3403,11 @@ interp_super_instructions (TransformData *td)
 		current_liveness.bb_dfs_index = bb->dfs_index;
 		current_liveness.ins_index = 0;
 		for (InterpInst *ins = bb->first_ins; ins != NULL; ins = ins->next) {
-			int opcode = ins->opcode;
+			int opcode;
 			if (bb->dfs_index >= td->bblocks_count_no_eh || bb->dfs_index == -1 || (ins->flags & INTERP_INST_FLAG_LIVENESS_MARKER))
 				current_liveness.ins_index++;
+retry_ins:
+			opcode = ins->opcode;
 			if (MINT_IS_NOP (opcode))
 				continue;
 
@@ -3804,9 +3806,7 @@ interp_super_instructions (TransformData *td)
 								g_print ("superins: ");
 								interp_dump_ins (ins, td->data_items);
 							}
-							// The newly added opcode could be part of further superinstructions. Retry
-							ins = ins->prev;
-							continue;
+							goto retry_ins;
 						}
 					}
 				}


### PR DESCRIPTION
For each instruction in a basic block we check for patterns. In a certain case, once we replaced the instruction with a new one, we were attempting to do a loop reiteration by setting `ins = ins->prev` so after the loop reincrements with `ins = ins->next` we check super instruction patterns again for the current instruction. This is broken if `ins` was the first instruction in a basic block, aka `ins->prev` is NULL. This used to be impossible before SSA optimizations, since super instruction pass was applying optimizations in a single basic block only.

Bug reported in https://github.com/xoofx/markdig/issues/873