### PR TITLE
Attempt to fix the rare stack overflow tests issue

### DIFF
--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -558,8 +558,13 @@ extern "C" void signal_handler_worker(int code, siginfo_t *siginfo, void *contex
     // fault. We must disassemble the instruction at record.ExceptionAddress
     // to correctly fill in this value.
 
-    // Unmask the activation signal now that we are running on the original stack of the thread
-    UnmaskActivationSignal();
+    if (code != (SIGSEGV | StackOverflowFlag))
+    {
+        // Unmask the activation signal now that we are running on the original stack of the thread
+        // except for the stack overflow case when we are actually running on a special stack overflow
+        // stack.
+        UnmaskActivationSignal();
+    }
 
     returnPoint->returnFromHandler = common_signal_handler(code, siginfo, context, 2, (size_t)0, (size_t)siginfo->si_addr);
 


### PR DESCRIPTION
Our CI hits a strange issue in the stack overflow tests about once a day. We are hitting another stack overflow on the thread that handles the stack overflow. One theory I have is that an activation signal kicks in and somehow results in overflowing the stack overflow handling helper stack. This change disables activation signals for the current thread once stack overflow is hit.
We'll see if that fixes the problem.