### PR TITLE
Add `--arch` option for `--list-runtimes` and `--list-sdks` in host

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
+++ b/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.IO;
-using System.Text;
-using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.TestUtils;
 using Xunit;
 
@@ -81,52 +79,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Should().Fail()
                 .And.HaveStdErrContaining($"The application '{fileName}' does not exist")
                 .And.FindAnySdk(false);
-        }
-
-        [Fact]
-        public void DotNetInfo_NoSDK()
-        {
-            TestContext.BuiltDotNet.Exec("--info")
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdOutMatching($@"Architecture:\s*{TestContext.BuildArchitecture}")
-                .And.HaveStdOutMatching($@"RID:\s*{TestContext.BuildRID}");
-        }
-
-        [Fact]
-        public void DotNetInfo_Utf8Path()
-        {
-            string installLocation = Encoding.UTF8.GetString("utf8-龯蝌灋齅ㄥ䶱"u8);
-            DotNetCli dotnet = new DotNetBuilder(sharedTestState.BaseDirectory.Location, TestContext.BuiltDotNet.BinPath, installLocation)
-                .Build();
-
-            var result = dotnet.Exec("--info")
-                .DotNetRoot(Path.Combine(sharedTestState.BaseDirectory.Location, installLocation))
-                .CaptureStdErr()
-                .CaptureStdOut(Encoding.UTF8)
-                .Execute();
-
-            result.Should().Pass()
-                .And.HaveStdOutMatching($@"DOTNET_ROOT.*{installLocation}");
-        }
-
-        [Fact]
-        public void DotNetInfo_WithSDK()
-        {
-            DotNetCli dotnet = new DotNetBuilder(sharedTestState.BaseDirectory.Location, TestContext.BuiltDotNet.BinPath, "withSdk")
-                .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("1.0.0")
-                .AddMockSDK("1.0.0", "1.0.0")
-                .Build();
-
-            dotnet.Exec("--info")
-                .WorkingDirectory(sharedTestState.BaseDirectory.Location)
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute()
-                .Should().Pass()
-                .And.NotHaveStdOutMatching($@"RID:\s*{TestContext.BuildRID}");
         }
 
         // Return a non-existent path that contains a mix of / and \

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
@@ -139,55 +139,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(null)]
-        [InlineData(false)]
-        public void ListRuntimes(bool? multiLevelLookup)
-        {
-            // Multi-level lookup is only supported on Windows.
-            if (!OperatingSystem.IsWindows() && multiLevelLookup != false)
-                return;
-
-            string expectedOutput = string.Join(
-                string.Empty,
-                GetExpectedFrameworks(false) // MLL Is always disabled for dotnet --list-runtimes
-                    .Select(t => $"{MicrosoftNETCoreApp} {t.Version} [{Path.Combine(t.Path, "shared", MicrosoftNETCoreApp)}]{Environment.NewLine}"));
-
-            // !!IMPORTANT!!: This test verifies the exact match of the entire output of the command (not a substring!)
-            // This is important as the output of --list-runtimes is considered machine readable and thus must not change even in a minor way (unintentionally)
-            RunTest(
-                new TestSettings().WithCommandLine("--list-runtimes"),
-                multiLevelLookup,
-                testApp: null)
-                .Should().HaveStdOut(expectedOutput)
-                .And.HaveStdErrContaining("Ignoring FX version [9999.9.9] without .deps.json");
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(null)]
-        [InlineData(false)]
-        public void DotnetInfo(bool? multiLevelLookup)
-        {
-            // Multi-level lookup is only supported on Windows.
-            if (!OperatingSystem.IsWindows() && multiLevelLookup != false)
-                return;
-
-            string expectedOutput =
-                $".NET runtimes installed:{Environment.NewLine}" +
-                string.Join(string.Empty,
-                    GetExpectedFrameworks(false) // MLL is always disabled for dotnet --info
-                        .Select(t => $"  {MicrosoftNETCoreApp} {t.Version} [{Path.Combine(t.Path, "shared", MicrosoftNETCoreApp)}]{Environment.NewLine}"));
-
-            RunTest(
-                new TestSettings().WithCommandLine("--info"),
-                multiLevelLookup,
-                testApp: null)
-                .Should().HaveStdOutContaining(expectedOutput)
-                .And.HaveStdErrContaining("Ignoring FX version [9999.9.9] without .deps.json");
-        }
-
-        [Theory]
         [InlineData("net6.0", true, true)]
         [InlineData("net6.0", null, true)]
         [InlineData("net6.0", false, false)]

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
@@ -163,51 +163,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .And.HaveStdErrContaining("Ignoring FX version [9999.9.9] without .deps.json");
         }
 
-        [Fact]
-        public void ListRuntimes_OtherArchitectures()
-        {
-            // Non-host architectures
-            string[] otherArchs = new[] { "arm64", "x64", "x86" }.Where(a => a != TestContext.BuildArchitecture).ToArray();
-            var installLocations = new (string, string)[otherArchs.Length];
-
-            using (var testArtifact = TestArtifact.Create("listOtherArchs"))
-            {
-                // Add runtimes for other architectures
-                string[] versions = ["9999.0.0", "9999.0.1", "9999.0.2"];
-                for (int i = 0; i < otherArchs.Length; i++)
-                {
-                    string arch = otherArchs[i];
-                    string installLocation = Directory.CreateDirectory(Path.Combine(testArtifact.Location, arch)).FullName;
-                    foreach (string version in versions)
-                    {
-                        DotNetBuilder.AddMicrosoftNETCoreAppFrameworkMockHostPolicy(installLocation, version);
-                    }
-
-                    installLocations[i] = (arch, installLocation);
-                }
-
-                var dotnet = new DotNetBuilder(testArtifact.Location, TestContext.BuiltDotNet.BinPath, "exe").Build();
-                using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(dotnet.GreatestVersionHostFxrFilePath))
-                {
-                    registeredInstallLocationOverride.SetInstallLocation(installLocations);
-                    foreach (var (arch, installLocation) in installLocations)
-                    {
-                        // Verifiy exact match of command output. The output of --list-runtimes is intended to be machine-readable
-                        // and must not change in a way that breaks existing parsing.
-                        string runtimePath = Path.Combine(installLocation, "shared", MicrosoftNETCoreApp);
-                        string expectedOutput = string.Join(string.Empty, versions.Select(v => $"{MicrosoftNETCoreApp} {v} [{runtimePath}]{Environment.NewLine}"));
-                        dotnet.Exec("--list-runtimes", "--arch", arch)
-                            .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
-                            .CaptureStdOut()
-                            .Execute()
-                            .Should().Pass()
-                            .And.HaveStdOut(expectedOutput);
-
-                    }
-                }
-            }
-        }
-
         [Theory]
         [InlineData(true)]
         [InlineData(null)]

--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -143,6 +143,16 @@ namespace HostActivation.Tests
         }
 
         [Fact]
+        public void ListRuntimes_UnknownArchitecture()
+        {
+            TestContext.BuiltDotNet.Exec("--list-runtimes", "--arch", "invalid")
+                .CaptureStdOut()
+                .Execute()
+                .Should().Fail()
+                .And.ExitWith(Constants.ErrorCode.InvalidArgFailure);
+        }
+
+        [Fact]
         public void ListSdks()
         {
             // Verify exact match of command output. The output of --list-sdks is intended to be machine-readable
@@ -199,6 +209,16 @@ namespace HostActivation.Tests
                     .Should().Pass()
                     .And.HaveStdOut(string.Empty);
             }
+        }
+
+        [Fact]
+        public void ListSdks_UnknownArchitecture()
+        {
+            TestContext.BuiltDotNet.Exec("--list-sdks", "--arch", "invalid")
+                .CaptureStdOut()
+                .Execute()
+                .Should().Fail()
+                .And.ExitWith(Constants.ErrorCode.InvalidArgFailure);
         }
 
         private static string GetListRuntimesOutput(string installLocation, string[] versions, string prefix = "")

--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.DotNet.Cli.Build;
-using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
 using Microsoft.DotNet.CoreSetup.Test.HostActivation;
-using Microsoft.DotNet.TestUtils;
 using Xunit;
 
 namespace HostActivation.Tests
@@ -24,14 +22,79 @@ namespace HostActivation.Tests
         }
 
         [Fact]
-        public void ListRuntimes_OtherArchitectures()
+        public void Info()
+        {
+            string expectedSdksOutput =
+                $"""
+                .NET SDKs installed:
+                {GetListSdksOutput(SharedState.DotNet.BinPath, SharedState.InstalledVersions, "  ")}
+                """;
+            string expectedRuntimesOutput =
+                $"""
+                .NET runtimes installed:
+                {GetListRuntimesOutput(SharedState.DotNet.BinPath, SharedState.InstalledVersions, "  ")}
+                """;
+            SharedState.DotNet.Exec("--info")
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining(expectedSdksOutput)
+                .And.HaveStdOutContaining(expectedRuntimesOutput)
+                .And.HaveStdOutMatching($@"Architecture:\s*{TestContext.BuildArchitecture}")
+                // If an SDK exists, we rely on it to print the RID. The host should not print it again.
+                .And.NotHaveStdOutMatching($@"RID:\s*{TestContext.BuildRID}");
+        }
+
+        [Fact]
+        public void Info_NoSDK()
+        {
+            TestContext.BuiltDotNet.Exec("--info")
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutMatching($@"Architecture:\s*{TestContext.BuildArchitecture}")
+                .And.HaveStdOutMatching($@"RID:\s*{TestContext.BuildRID}")
+                .And.HaveStdOutContaining("No SDKs were found");
+        }
+
+
+        [Fact]
+        public void Info_Utf8Path()
+        {
+            string installLocation = Encoding.UTF8.GetString("utf8-龯蝌灋齅ㄥ䶱"u8);
+            DotNetCli dotnet = new DotNetBuilder(SharedState.Artifact.Location, TestContext.BuiltDotNet.BinPath, installLocation)
+                .Build();
+
+            dotnet.Exec("--info")
+                .DotNetRoot(Path.Combine(SharedState.Artifact.Location, installLocation))
+                .CaptureStdOut(Encoding.UTF8)
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutMatching($@"DOTNET_ROOT.*{installLocation}");
+        }
+
+        [Fact]
+        public void ListRuntimes()
+        {
+            // Verify exact match of command output. The output of --list-runtimes is intended to be machine-readable
+            // and must not change in a way that breaks existing parsing.
+            string expectedOutput = GetListRuntimesOutput(SharedState.DotNet.BinPath, SharedState.InstalledVersions);
+            SharedState.DotNet.Exec("--list-runtimes")
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOut(expectedOutput);
+        }
+
+        [Fact]
+        public void ListRuntimes_OtherArchitecture()
         {
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(SharedState.DotNet.GreatestVersionHostFxrFilePath))
             {
                 registeredInstallLocationOverride.SetInstallLocation(SharedState.OtherArchInstallLocations);
                 foreach ((string arch, string installLocation) in SharedState.OtherArchInstallLocations)
                 {
-                    // Verifiy exact match of command output. The output of --list-runtimes is intended to be machine-readable
+                    // Verify exact match of command output. The output of --list-runtimes is intended to be machine-readable
                     // and must not change in a way that breaks existing parsing.
                     string expectedOutput = GetListRuntimesOutput(installLocation, SharedState.InstalledVersions);
                     SharedState.DotNet.Exec("--list-runtimes", "--arch", arch)
@@ -45,14 +108,45 @@ namespace HostActivation.Tests
         }
 
         [Fact]
-        public void ListSdks_OtherArchitectures()
+        public void ListRuntimes_OtherArchitecture_NoInstalls()
+        {
+            // Non-host architecture - arm64 if current architecture is x64, otherwise x64
+            string arch = TestContext.BuildArchitecture == "x64" ? "arm64" : "x64";
+            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(SharedState.DotNet.GreatestVersionHostFxrFilePath))
+            {
+                // Register a location that should have no runtimes installed
+                registeredInstallLocationOverride.SetInstallLocation((arch, SharedState.Artifact.Location));
+                SharedState.DotNet.Exec("--list-runtimes", "--arch", arch)
+                    .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
+                    .CaptureStdOut()
+                    .Execute()
+                    .Should().Pass()
+                    .And.HaveStdOut(string.Empty);
+            }
+        }
+
+        [Fact]
+        public void ListSdks()
+        {
+            // Verify exact match of command output. The output of --list-sdks is intended to be machine-readable
+            // and must not change in a way that breaks existing parsing.
+            string expectedOutput = GetListSdksOutput(SharedState.DotNet.BinPath, SharedState.InstalledVersions);
+            SharedState.DotNet.Exec("--list-sdks")
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOut(expectedOutput);
+        }
+
+        [Fact]
+        public void ListSdks_OtherArchitecture()
         {
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(SharedState.DotNet.GreatestVersionHostFxrFilePath))
             {
                 registeredInstallLocationOverride.SetInstallLocation(SharedState.OtherArchInstallLocations);
                 foreach ((string arch, string installLocation) in SharedState.OtherArchInstallLocations)
                 {
-                    // Verifiy exact match of command output. The output of --list-sdks is intended to be machine-readable
+                    // Verify exact match of command output. The output of --list-sdks is intended to be machine-readable
                     // and must not change in a way that breaks existing parsing.
                     string expectedOutput = GetListSdksOutput(installLocation, SharedState.InstalledVersions);
                     SharedState.DotNet.Exec("--list-sdks", "--arch", arch)
@@ -65,20 +159,39 @@ namespace HostActivation.Tests
             }
         }
 
-        private static string GetListRuntimesOutput(string installLocation, string[] versions)
+        [Fact]
+        public void ListSdks_OtherArchitecture_NoInstalls()
         {
-            string runtimePath = Path.Combine(installLocation, "shared", Constants.MicrosoftNETCoreApp);
-            return string.Join(string.Empty, versions.Select(v => $"{Constants.MicrosoftNETCoreApp} {v} [{runtimePath}]{Environment.NewLine}"));
+            // Non-host architecture - arm64 if current architecture is x64, otherwise x64
+            string arch = TestContext.BuildArchitecture == "x64" ? "arm64" : "x64";
+            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(SharedState.DotNet.GreatestVersionHostFxrFilePath))
+            {
+                // Register a location that should have no SDKs installed
+                registeredInstallLocationOverride.SetInstallLocation((arch, SharedState.Artifact.Location));
+                SharedState.DotNet.Exec("--list-sdks", "--arch", arch)
+                    .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
+                    .CaptureStdOut()
+                    .Execute()
+                    .Should().Pass()
+                    .And.HaveStdOut(string.Empty);
+            }
         }
 
-        private static string GetListSdksOutput(string installLocation, string[] versions)
+        private static string GetListRuntimesOutput(string installLocation, string[] versions, string prefix = "")
+        {
+            string runtimePath = Path.Combine(installLocation, "shared", Constants.MicrosoftNETCoreApp);
+            return string.Join(string.Empty, versions.Select(v => $"{prefix}{Constants.MicrosoftNETCoreApp} {v} [{runtimePath}]{Environment.NewLine}"));
+        }
+
+        private static string GetListSdksOutput(string installLocation, string[] versions, string prefix = "")
         {
             string sdkPath = Path.Combine(installLocation, "sdk");
-            return string.Join(string.Empty, versions.Select(v => $"{v} [{sdkPath}]{Environment.NewLine}"));
+            return string.Join(string.Empty, versions.Select(v => $"{prefix}{v} [{sdkPath}]{Environment.NewLine}"));
         }
 
         public sealed class SharedTestState : IDisposable
         {
+            public TestArtifact Artifact { get; }
             public DotNetCli DotNet { get; }
 
             // Versions are assumed to be in ascending order. We use this property to check against the
@@ -87,13 +200,11 @@ namespace HostActivation.Tests
 
             public (string, string)[] OtherArchInstallLocations { get; }
 
-            private TestArtifact _artifact;
-
             public SharedTestState()
             {
-                _artifact = TestArtifact.Create(nameof(HostCommands));
+                Artifact = TestArtifact.Create(nameof(HostCommands));
 
-                var builder = new DotNetBuilder(_artifact.Location, TestContext.BuiltDotNet.BinPath, "exe");
+                var builder = new DotNetBuilder(Artifact.Location, TestContext.BuiltDotNet.BinPath, "exe");
                 foreach (string version in InstalledVersions)
                 {
                     builder.AddMicrosoftNETCoreAppFrameworkMockHostPolicy(version);
@@ -103,12 +214,12 @@ namespace HostActivation.Tests
                 DotNet = builder.Build();
 
                 // Add runtimes and SDKs for other architectures
-                string[] otherArchs = new[] { "arm", "arm64", "x64", "x86" }.Where(a => a != TestContext.BuildArchitecture).ToArray();
+                string[] otherArchs = new[] { "arm64", "x64", "x86" }.Where(a => a != TestContext.BuildArchitecture).ToArray();
                 OtherArchInstallLocations = new (string, string)[otherArchs.Length];
                 for (int i = 0; i < otherArchs.Length; i++)
                 {
                     string arch = otherArchs[i];
-                    string installLocation = Directory.CreateDirectory(Path.Combine(_artifact.Location, arch)).FullName;
+                    string installLocation = Directory.CreateDirectory(Path.Combine(Artifact.Location, arch)).FullName;
                     foreach (string version in InstalledVersions)
                     {
                         DotNetBuilder.AddMicrosoftNETCoreAppFrameworkMockHostPolicy(installLocation, version);
@@ -127,7 +238,7 @@ namespace HostActivation.Tests
 
             public void Dispose()
             {
-                _artifact.Dispose();
+                Artifact.Dispose();
             }
         }
     }

--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.DotNet.CoreSetup.Test.HostActivation;
+using Microsoft.DotNet.TestUtils;
+using Xunit;
+
+namespace HostActivation.Tests
+{
+    public class HostCommands : IClassFixture<HostCommands.SharedTestState>
+    {
+        private SharedTestState SharedState { get; }
+
+        public HostCommands(SharedTestState sharedState)
+        {
+            SharedState = sharedState;
+        }
+
+        [Fact]
+        public void ListRuntimes_OtherArchitectures()
+        {
+            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(SharedState.DotNet.GreatestVersionHostFxrFilePath))
+            {
+                registeredInstallLocationOverride.SetInstallLocation(SharedState.OtherArchInstallLocations);
+                foreach ((string arch, string installLocation) in SharedState.OtherArchInstallLocations)
+                {
+                    // Verifiy exact match of command output. The output of --list-runtimes is intended to be machine-readable
+                    // and must not change in a way that breaks existing parsing.
+                    string expectedOutput = GetListRuntimesOutput(installLocation, SharedState.InstalledVersions);
+                    SharedState.DotNet.Exec("--list-runtimes", "--arch", arch)
+                        .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
+                        .CaptureStdOut()
+                        .Execute()
+                        .Should().Pass()
+                        .And.HaveStdOut(expectedOutput);
+                }
+            }
+        }
+
+        [Fact]
+        public void ListSdks_OtherArchitectures()
+        {
+            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(SharedState.DotNet.GreatestVersionHostFxrFilePath))
+            {
+                registeredInstallLocationOverride.SetInstallLocation(SharedState.OtherArchInstallLocations);
+                foreach ((string arch, string installLocation) in SharedState.OtherArchInstallLocations)
+                {
+                    // Verifiy exact match of command output. The output of --list-sdks is intended to be machine-readable
+                    // and must not change in a way that breaks existing parsing.
+                    string expectedOutput = GetListSdksOutput(installLocation, SharedState.InstalledVersions);
+                    SharedState.DotNet.Exec("--list-sdks", "--arch", arch)
+                        .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
+                        .CaptureStdOut()
+                        .Execute()
+                        .Should().Pass()
+                        .And.HaveStdOut(expectedOutput);
+                }
+            }
+        }
+
+        private static string GetListRuntimesOutput(string installLocation, string[] versions)
+        {
+            string runtimePath = Path.Combine(installLocation, "shared", Constants.MicrosoftNETCoreApp);
+            return string.Join(string.Empty, versions.Select(v => $"{Constants.MicrosoftNETCoreApp} {v} [{runtimePath}]{Environment.NewLine}"));
+        }
+
+        private static string GetListSdksOutput(string installLocation, string[] versions)
+        {
+            string sdkPath = Path.Combine(installLocation, "sdk");
+            return string.Join(string.Empty, versions.Select(v => $"{v} [{sdkPath}]{Environment.NewLine}"));
+        }
+
+        public sealed class SharedTestState : IDisposable
+        {
+            public DotNetCli DotNet { get; }
+
+            // Versions are assumed to be in ascending order. We use this property to check against the
+            // exact expected output of --list-sdks and --list-runtimes.
+            public string[] InstalledVersions { get; } = ["5.0.5", "10.0.0", "9999.0.1"];
+
+            public (string, string)[] OtherArchInstallLocations { get; }
+
+            private TestArtifact _artifact;
+
+            public SharedTestState()
+            {
+                _artifact = TestArtifact.Create(nameof(HostCommands));
+
+                var builder = new DotNetBuilder(_artifact.Location, TestContext.BuiltDotNet.BinPath, "exe");
+                foreach (string version in InstalledVersions)
+                {
+                    builder.AddMicrosoftNETCoreAppFrameworkMockHostPolicy(version);
+                    builder.AddMockSDK(version, version);
+                }
+
+                DotNet = builder.Build();
+
+                // Add runtimes and SDKs for other architectures
+                string[] otherArchs = new[] { "arm", "arm64", "x64", "x86" }.Where(a => a != TestContext.BuildArchitecture).ToArray();
+                OtherArchInstallLocations = new (string, string)[otherArchs.Length];
+                for (int i = 0; i < otherArchs.Length; i++)
+                {
+                    string arch = otherArchs[i];
+                    string installLocation = Directory.CreateDirectory(Path.Combine(_artifact.Location, arch)).FullName;
+                    foreach (string version in InstalledVersions)
+                    {
+                        DotNetBuilder.AddMicrosoftNETCoreAppFrameworkMockHostPolicy(installLocation, version);
+                        DotNetBuilder.AddMockSDK(installLocation, version, version);
+                    }
+
+                    OtherArchInstallLocations[i] = (arch, installLocation);
+                }
+
+
+                // Enable test-only behavior for the copied .NET. We don't bother disabling the behaviour later,
+                // as we just delete the entire copy after the tests run.
+                _ = TestOnlyProductBehavior.Enable(DotNet.GreatestVersionHostFxrFilePath);
+
+            }
+
+            public void Dispose()
+            {
+                _artifact.Dispose();
+            }
+        }
+    }
+}

--- a/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
@@ -462,26 +462,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [InlineData(true)]
         [InlineData(null)]
         [InlineData(false)]
-        public void ListSdks(bool? multiLevelLookup)
-        {
-            // Multi-level lookup is only supported on Windows.
-            if (!OperatingSystem.IsWindows() && multiLevelLookup != false)
-                return;
-
-            var expectedList = AddSdkVersionsAndGetExpectedList();
-            string expectedOutput = string.Join(string.Empty, expectedList.Select(t => $"{t.version} [{t.rootPath}]{Environment.NewLine}"));
-
-            // !!IMPORTANT!!: This test verifies the exact match of the entire output of the command (not a substring!)
-            // This is important as the output of --list-sdks is considered machine readable and thus must not change even in a minor way (unintentionally)
-            RunTest("--list-sdks", multiLevelLookup)
-                .Should().Pass()
-                .And.HaveStdOut(expectedOutput);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(null)]
-        [InlineData(false)]
         public void SdkResolutionError(bool? multiLevelLookup)
         {
             // Multi-level lookup is only supported on Windows.
@@ -499,26 +479,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             RunTest("help", multiLevelLookup)
                 .Should().Fail()
                 .And.NotFindCompatibleSdk(globalJsonPath, requestedVersion)
-                .And.HaveStdOutContaining(expectedOutput);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(null)]
-        [InlineData(false)]
-        public void DotnetInfo(bool? multiLevelLookup)
-        {
-            // Multi-level lookup is only supported on Windows.
-            if (!OperatingSystem.IsWindows() && multiLevelLookup != false)
-                return;
-
-            var expectedList = AddSdkVersionsAndGetExpectedList();
-            string expectedOutput =
-                $".NET SDKs installed:{Environment.NewLine}" +
-                string.Join(string.Empty, expectedList.Select(t => $"  {t.version} [{t.rootPath}]{Environment.NewLine}"));
-
-            RunTest("--info", multiLevelLookup)
-                .Should().Pass()
                 .And.HaveStdOutContaining(expectedOutput);
         }
 

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -603,51 +603,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdErrContaining(sdk.ErrorMessage);
         }
 
-        [Fact]
-        public void ListSdks_OtherArchitectures()
-        {
-            // Non-host architectures
-            var otherArchs = new[] { "arm64", "x64", "x86" }.Where(a => a != TestContext.BuildArchitecture).ToArray();
-            var installLocations = new (string, string)[otherArchs.Length];
-
-            using (var testArtifact = TestArtifact.Create("listOtherArchs"))
-            {
-                // Add SDKs for other architectures
-                string[] versions = ["9999.0.0", "9999.0.1", "9999.0.2"];
-                for (int i = 0; i < otherArchs.Length; i++)
-                {
-                    string arch = otherArchs[i];
-                    string installLocation = Directory.CreateDirectory(Path.Combine(testArtifact.Location, arch)).FullName;
-                    foreach (string version in versions)
-                    {
-                        DotNetBuilder.AddMockSDK(installLocation, version, version);
-                    }
-
-                    installLocations[i] = (arch, installLocation);
-                }
-
-                var dotnet = new DotNetBuilder(testArtifact.Location, TestContext.BuiltDotNet.BinPath, "exe").Build();
-                using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(dotnet.GreatestVersionHostFxrFilePath))
-                {
-                    registeredInstallLocationOverride.SetInstallLocation(installLocations);
-                    foreach (var (arch, installLocation) in installLocations)
-                    {
-                        // Verifiy exact match of command output. The output of --list-sdks is intended to be machine-readable
-                        // and must not change in a way that breaks existing parsing.
-                        string sdkPath = Path.Combine(installLocation, "sdk");
-                        string expectedOutput = string.Join(string.Empty, versions.Select(v => $"{v} [{sdkPath}]{Environment.NewLine}"));
-                        dotnet.Exec("--list-sdks", "--arch", arch)
-                            .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
-                            .CaptureStdOut()
-                            .EnableTracingAndCaptureOutputs()
-                            .Execute()
-                            .Should().Pass()
-                            .And.HaveStdOut(expectedOutput);
-                    }
-                }
-            }
-        }
-
         public static IEnumerable<object[]> InvalidGlobalJsonData
         {
             get

--- a/src/native/corehost/corehost.cpp
+++ b/src/native/corehost/corehost.cpp
@@ -187,17 +187,17 @@ int exe_start(const int argc, const pal::char_t* argv[])
     if (argc <= 1)
     {
         trace::println();
-        trace::println(_X("Usage: dotnet [options]"));
         trace::println(_X("Usage: dotnet [path-to-application]"));
-        trace::println();
-        trace::println(_X("Options:"));
-        trace::println(_X("  -h|--help         Display help."));
-        trace::println(_X("  --info            Display .NET information."));
-        trace::println(_X("  --list-sdks       Display the installed SDKs."));
-        trace::println(_X("  --list-runtimes   Display the installed runtimes."));
+        trace::println(_X("Usage: dotnet [commands]"));
         trace::println();
         trace::println(_X("path-to-application:"));
         trace::println(_X("  The path to an application .dll file to execute."));
+        trace::println();
+        trace::println(_X("commands:"));
+        trace::println(_X("  -h|--help                         Display help."));
+        trace::println(_X("  --info                            Display .NET information."));
+        trace::println(_X("  --list-runtimes [--arch <arch>]   Display the installed runtimes matching the host or specified architecture. Example architectures: arm64, x64, x86."));
+        trace::println(_X("  --list-sdks [--arch <arch>]       Display the installed SDKs matching the host or specified architecture. Example architectures: arm64, x64, x86."));
         return StatusCode::InvalidArgFailure;
     }
 

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -343,6 +343,7 @@ void command_line::print_muxer_usage(bool is_sdk_present)
     {
         trace::println();
         trace::println(_X("Usage: dotnet [host-options] [path-to-application]"));
+        trace::println(_X("Usage: dotnet [host-commands]"));
         trace::println();
         trace::println(_X("path-to-application:"));
         trace::println(_X("  The path to an application .dll file to execute."));
@@ -355,14 +356,15 @@ void command_line::print_muxer_usage(bool is_sdk_present)
         const host_option &arg = get_host_option(opt);
         trace::println(_X("  %s %-*s  %s"), arg.option, 30 - (int)pal::strlen(arg.option), arg.argument, arg.description);
     }
-    trace::println(_X("  --list-runtimes [--arch <arch>]  Display the installed runtimes."));
-    trace::println(_X("  --list-sdks [--arch <arch>]      Display the installed SDKs."));
 
+    trace::println();
+    trace::println(_X("host-commands:"));
     if (!is_sdk_present)
     {
-        trace::println();
-        trace::println(_X("Common Options:"));
         trace::println(_X("  -h|--help                        Displays this help."));
         trace::println(_X("  --info                           Display .NET information."));
     }
+
+    trace::println(_X("  --list-runtimes [--arch <arch>]  Display the installed runtimes matching the host or specified architecture. Example architectures: arm64, x64, x86."));
+    trace::println(_X("  --list-sdks [--arch <arch>]      Display the installed SDKs matching the host or specified architecture. Example architectures: arm64, x64, x86."));
 }

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -353,16 +353,16 @@ void command_line::print_muxer_usage(bool is_sdk_present)
     for (const auto& opt : known_opts)
     {
         const host_option &arg = get_host_option(opt);
-        trace::println(_X("  %s %-*s  %s"), arg.option, 29 - (int)pal::strlen(arg.option), arg.argument, arg.description);
+        trace::println(_X("  %s %-*s  %s"), arg.option, 30 - (int)pal::strlen(arg.option), arg.argument, arg.description);
     }
-    trace::println(_X("  --list-runtimes                 Display the installed runtimes"));
-    trace::println(_X("  --list-sdks                     Display the installed SDKs"));
+    trace::println(_X("  --list-runtimes [--arch <arch>]  Display the installed runtimes."));
+    trace::println(_X("  --list-sdks [--arch <arch>]      Display the installed SDKs."));
 
     if (!is_sdk_present)
     {
         trace::println();
         trace::println(_X("Common Options:"));
-        trace::println(_X("  -h|--help                       Displays this help."));
-        trace::println(_X("  --info                          Display .NET information."));
+        trace::println(_X("  -h|--help                        Displays this help."));
+        trace::println(_X("  --info                           Display .NET information."));
     }
 }

--- a/src/native/corehost/fxr/framework_info.cpp
+++ b/src/native/corehost/fxr/framework_info.cpp
@@ -33,13 +33,13 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
 }
 
 /*static*/ void framework_info::get_all_framework_infos(
-    const pal::string_t& own_dir,
+    const pal::string_t& dotnet_dir,
     const pal::char_t* fx_name,
     bool disable_multilevel_lookup,
     std::vector<framework_info>* framework_infos)
 {
     std::vector<pal::string_t> hive_dir;
-    get_framework_locations(own_dir, disable_multilevel_lookup, &hive_dir);
+    get_framework_locations(dotnet_dir, disable_multilevel_lookup, &hive_dir);
 
     int32_t hive_depth = 0;
 
@@ -105,13 +105,13 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
     std::sort(framework_infos->begin(), framework_infos->end(), compare_by_name_and_version);
 }
 
-/*static*/ bool framework_info::print_all_frameworks(const pal::string_t& own_dir, const pal::string_t& leading_whitespace)
+/*static*/ bool framework_info::print_all_frameworks(const pal::string_t& dotnet_dir, const pal::char_t* leading_whitespace)
 {
     std::vector<framework_info> framework_infos;
-    get_all_framework_infos(own_dir, nullptr, /*disable_multilevel_lookup*/ true, &framework_infos);
+    get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, &framework_infos);
     for (framework_info info : framework_infos)
     {
-        trace::println(_X("%s%s %s [%s]"), leading_whitespace.c_str(), info.name.c_str(), info.version.as_str().c_str(), info.path.c_str());
+        trace::println(_X("%s%s %s [%s]"), leading_whitespace, info.name.c_str(), info.version.as_str().c_str(), info.path.c_str());
     }
 
     return framework_infos.size() > 0;

--- a/src/native/corehost/fxr/framework_info.cpp
+++ b/src/native/corehost/fxr/framework_info.cpp
@@ -107,6 +107,8 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
 
 /*static*/ bool framework_info::print_all_frameworks(const pal::string_t& dotnet_dir, const pal::char_t* leading_whitespace)
 {
+    assert(leading_whitespace != nullptr);
+
     std::vector<framework_info> framework_infos;
     get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, &framework_infos);
     for (framework_info info : framework_infos)

--- a/src/native/corehost/fxr/framework_info.h
+++ b/src/native/corehost/fxr/framework_info.h
@@ -16,12 +16,12 @@ struct framework_info
         , hive_depth(hive_depth) { }
 
     static void get_all_framework_infos(
-        const pal::string_t& own_dir,
+        const pal::string_t& dotnet_dir,
         const pal::char_t* fx_name,
         bool disable_multilevel_lookup,
         std::vector<framework_info>* framework_infos);
 
-    static bool print_all_frameworks(const pal::string_t& own_dir, const pal::string_t& leading_whitespace);
+    static bool print_all_frameworks(const pal::string_t& dotnet_dir, const pal::char_t* leading_whitespace);
 
     pal::string_t name;
     pal::string_t path;

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -1023,17 +1023,12 @@ namespace
 {
     pal::architecture get_requested_architecture(int argc, const pal::char_t* argv[])
     {
-        // Default to current architecture if architecture is not specified
-        if (argc < 3 || pal::strcasecmp(_X("--arch"), argv[2]) != 0)
+        // Expected format: --arch <arch>
+        // Default to current architecture if architecture is not specified in the expected format
+        if (argc < 2 || pal::strcasecmp(_X("--arch"), argv[0]) != 0)
             return get_current_arch();
 
-        if (argc < 4)
-        {
-            trace::error(_X("Architecture should be specified when using --arch"));
-            return pal::architecture::__last;
-        }
-
-        pal::string_t arch_arg = argv[3];
+        pal::string_t arch_arg = argv[1];
         for (int i = 0; i < static_cast<int>(pal::architecture::__last); ++i)
         {
             pal::architecture arch = static_cast<pal::architecture>(i);
@@ -1052,13 +1047,17 @@ int fx_muxer_t::handle_cli(
     const pal::char_t* argv[],
     const pal::string_t& app_candidate)
 {
+    // Should have already checked for and bailed out on no args
+    assert(argc > 1);
+
     // Check for commands that don't depend on the CLI SDK to be loaded
     bool list_sdks = pal::strcasecmp(_X("--list-sdks"), argv[1]) == 0;
     bool list_runtimes = !list_sdks && pal::strcasecmp(_X("--list-runtimes"), argv[1]) == 0;
 
     if (list_sdks || list_runtimes)
     {
-        pal::architecture arch = get_requested_architecture(argc, argv);
+        // Skip over first two args: <executable> --list-sdks|--list-runtimes
+        pal::architecture arch = get_requested_architecture(argc - 2, argv + 2);
         if (arch == pal::architecture::__last)
             return StatusCode::InvalidArgFailure;
 

--- a/src/native/corehost/fxr/install_info.h
+++ b/src/native/corehost/fxr/install_info.h
@@ -12,6 +12,7 @@ namespace install_info
     bool enumerate_other_architectures(std::function<void(pal::architecture, const pal::string_t&, bool)> callback);
     bool print_environment(const pal::char_t* leading_whitespace);
     bool print_other_architectures(const pal::char_t* leading_whitespace);
+    bool try_get_install_location(pal::architecture arch, pal::string_t& out_install_location, bool* out_is_registered = nullptr);
 };
 
 #endif // __INSTALL_INFO_H__

--- a/src/native/corehost/fxr/sdk_info.cpp
+++ b/src/native/corehost/fxr/sdk_info.cpp
@@ -103,13 +103,13 @@ void sdk_info::get_all_sdk_infos(
     std::sort(sdk_infos->begin(), sdk_infos->end(), compare_by_version_ascending_then_hive_depth_descending);
 }
 
-/*static*/ bool sdk_info::print_all_sdks(const pal::string_t& dotnet_dir, const pal::string_t& leading_whitespace)
+/*static*/ bool sdk_info::print_all_sdks(const pal::string_t& dotnet_dir, const pal::char_t* leading_whitespace)
 {
     std::vector<sdk_info> sdk_infos;
     get_all_sdk_infos(dotnet_dir, &sdk_infos);
     for (sdk_info info : sdk_infos)
     {
-        trace::println(_X("%s%s [%s]"), leading_whitespace.c_str(), info.version.as_str().c_str(), info.base_path.c_str());
+        trace::println(_X("%s%s [%s]"), leading_whitespace, info.version.as_str().c_str(), info.base_path.c_str());
     }
 
     return sdk_infos.size() > 0;

--- a/src/native/corehost/fxr/sdk_info.cpp
+++ b/src/native/corehost/fxr/sdk_info.cpp
@@ -105,6 +105,8 @@ void sdk_info::get_all_sdk_infos(
 
 /*static*/ bool sdk_info::print_all_sdks(const pal::string_t& dotnet_dir, const pal::char_t* leading_whitespace)
 {
+    assert(leading_whitespace != nullptr);
+
     std::vector<sdk_info> sdk_infos;
     get_all_sdk_infos(dotnet_dir, &sdk_infos);
     for (sdk_info info : sdk_infos)

--- a/src/native/corehost/fxr/sdk_info.h
+++ b/src/native/corehost/fxr/sdk_info.h
@@ -25,7 +25,7 @@ struct sdk_info
         const pal::string_t& dotnet_dir,
         std::vector<sdk_info>* sdk_infos);
 
-    static bool print_all_sdks(const pal::string_t& dotnet_dir, const pal::string_t& leading_whitespace);
+    static bool print_all_sdks(const pal::string_t& dotnet_dir, const pal::char_t* leading_whitespace);
 
     pal::string_t base_path;
     pal::string_t full_path;

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -557,20 +557,20 @@ namespace
 
 bool pal::get_default_installation_dir(pal::string_t* recv)
 {
-    //  ***Used only for testing***
-    pal::string_t environmentOverride;
-    if (test_only_getenv(_X("_DOTNET_TEST_DEFAULT_INSTALL_PATH"), &environmentOverride))
-    {
-        recv->assign(environmentOverride);
-        return true;
-    }
-    //  ***************************
-
     return get_default_installation_dir_for_arch(get_current_arch(), recv);
 }
 
 bool pal::get_default_installation_dir_for_arch(pal::architecture arch, pal::string_t* recv)
 {
+    //  ***Used only for testing***
+    pal::string_t environment_override;
+    if (test_only_getenv(_X("_DOTNET_TEST_DEFAULT_INSTALL_PATH"), &environment_override))
+    {
+        recv->assign(environment_override);
+        return true;
+    }
+    //  ***************************
+
     bool is_current_arch = arch == get_current_arch();
 
     // Bail out early for unsupported requests for different architectures

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -383,6 +383,11 @@ namespace
 
 bool pal::get_default_installation_dir(pal::string_t* recv)
 {
+    return get_default_installation_dir_for_arch(get_current_arch(), recv);
+}
+
+bool pal::get_default_installation_dir_for_arch(pal::architecture arch, pal::string_t* recv)
+{
     //  ***Used only for testing***
     pal::string_t environmentOverride;
     if (test_only_getenv(_X("_DOTNET_TEST_DEFAULT_INSTALL_PATH"), &environmentOverride))
@@ -392,11 +397,6 @@ bool pal::get_default_installation_dir(pal::string_t* recv)
     }
     //  ***************************
 
-    return get_default_installation_dir_for_arch(get_current_arch(), recv);
-}
-
-bool pal::get_default_installation_dir_for_arch(pal::architecture arch, pal::string_t* recv)
-{
     bool is_current_arch = arch == get_current_arch();
 
     // Bail out early for unsupported requests for different architectures


### PR DESCRIPTION
Allow specifying `--arch <arch>` for `--list-runtimes` and `--list-sdks` commands in host. Must be in the order `--list-runtimes/sdks --arch <arch>`.
- If not specified, behaviour remains the same - list runtimes/SDKs for the invoked `dotnet` (for SDKs, any [paths](https://learn.microsoft.com/dotnet/core/tools/global-json#paths) specified any found global.json are respected).
- If specified and not the same as the host architecture, searches for registered or default install locations for that architecture and lists runtimes/SDKs found there.
- If specified and the same as the host architecture, behaves the same as if not specified - note that this means it will not search for registered/default installs of the host architecture and only list runtimes/SDKs relative to the invoked `dotnet`.

Example - x64 host, registered x86 install, no arm64 install
```
>C:\net10.0-windows-Release-x64\dotnet.exe --list-runtimes
Microsoft.NETCore.App 10.0.0 [C:\net10.0-windows-Release-x64\shared\Microsoft.NETCore.App]

>C:\net10.0-windows-Release-x64\dotnet.exe --list-runtimes --arch x64
Microsoft.NETCore.App 10.0.0 [C:\net10.0-windows-Release-x64\shared\Microsoft.NETCore.App]

>C:\net10.0-windows-Release-x64\dotnet.exe --list-runtimes --arch arm64

>C:\net10.0-windows-Release-x64\dotnet.exe --list-runtimes --arch x86
Microsoft.AspNetCore.App 8.0.16 [C:\Program Files (x86)\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 9.0.5 [C:\Program Files (x86)\dotnet\shared\Microsoft.AspNetCore.App]
Microsoft.NETCore.App 8.0.16 [C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App]
Microsoft.NETCore.App 9.0.5 [C:\Program Files (x86)\dotnet\shared\Microsoft.NETCore.App]
Microsoft.WindowsDesktop.App 8.0.16 [C:\Program Files (x86)\dotnet\shared\Microsoft.WindowsDesktop.App]
Microsoft.WindowsDesktop.App 9.0.5 [C:\Program Files (x86)\dotnet\shared\Microsoft.WindowsDesktop.App]

>C:\net10.0-windows-Release-x64\dotnet.exe --list-sdks
10.0.100-preview.4.25258.110 [C:\net10.0-windows-Release-x64\sdk]

>C:\net10.0-windows-Release-x64\dotnet.exe --list-sdks --arch x64
10.0.100-preview.4.25258.110 [C:\net10.0-windows-Release-x64\sdk]

>C:\net10.0-windows-Release-x64\dotnet.exe --list-sdks --arch arm64

>C:\net10.0-windows-Release-x64\dotnet.exe --list-sdks --arch x86
8.0.410 [C:\Program Files (x86)\dotnet\sdk]
9.0.300 [C:\Program Files (x86)\dotnet\sdk]
```

New tests are in a `HostCommands` test class. This also moves some existing tests for host commands into the new class (https://github.com/dotnet/runtime/commit/bdcc21a05f193cdf274d074ee0b934b2c9f1f66c).
- `Info` covers `DotnetArgValidation.DotNetInfo_WithSDK`, `MultipleHives.DotNetInfo`, `MultilevelSDKLookup.DotNetInfo`
- `Info_NoSDK` covers `DotnetArgValidation.DotNetInfo_NoSDK`
- `Info_Utf8Path` covers `DotnetArgValidation.DotNetInfo_Utf8Path`
- `ListRuntimes` covers `MultipleHives.ListRuntimes`
- `ListSdks` covers `MultilevelSDKLookup.ListSdks`
- `ListRuntimes_OtherArchitecture*` and `ListSdks_OtherArchitecture*` cover the functionality added in this PR

This does remove tests running the host commands with the multi-level lookup environment variable set, but I don't think those are interesting anymore - it has been disabled since 7.0 and should always be disabled (unlike for actually running an app, where it can be based on the tfm)

Resolves https://github.com/dotnet/runtime/issues/108503

cc @dotnet/appmodel @AaronRobinsonMSFT @nagilson 