### PR TITLE
Pin build container SHAs

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -17,113 +17,113 @@ extends:
 
     containers:
       linux_arm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm@sha256:6c30f23aa0d2a014ee9a00cc5a4e7e2ca2551c434612b2c9524c65b6763bb2aa
         env:
           ROOTFS_DIR: /crossrootfs/arm
 
       linux_arm64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm64@sha256:55b7ce3d2c14841c574b1792d0b565b6455162dd58af6e316dedb82c09c034c7
         env:
           ROOTFS_DIR: /crossrootfs/arm64
 
       linux_musl_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64-musl
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64-musl@sha256:e0d02e782121dfa31a07aa3236f580f8b0e00dcd11e63c209c197d0d8165eebb
         env:
           ROOTFS_DIR: /crossrootfs/x64
 
       linux_musl_arm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm-musl
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm-musl@sha256:cab9c1389ca47dc6f00e7e23f513c198757cd3bd4165427fc27ebe8386a993a3
         env:
           ROOTFS_DIR: /crossrootfs/arm
 
       linux_musl_arm64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm64-musl
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm64-musl@sha256:63b5841373dde875cb053e95a34ccb8a88f4e7ed9b8575ad00be4cab92ce3c1e
         env:
           ROOTFS_DIR: /crossrootfs/arm64
 
       # This container contains all required toolsets to build for Android and for Linux with bionic libc.
       android:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-android-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-android-amd64@sha256:fc759de4bbf85a3b79240ce69f4280e3a27ba59517d2198c2655a6fa7e4f01ea
 
       # This container contains all required toolsets to build for Android and for Linux with bionic libc and a special layout of OpenSSL.
       linux_bionic:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-android-openssl-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-android-openssl-amd64@sha256:be1dddb3e8ce753298cf8bc5c448ec045b10b63595b3abf90c5473151cd3efd3
 
       # This container contains all required toolsets to build for Android as well as tooling to build docker images.
       android_docker:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-android-docker-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-android-docker-amd64@sha256:82949009c89586cfbe724db1e30274af2e19cca125bd59259be217d73b1ac79d
 
       linux_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64@sha256:1761b974f5d708f96c505b73769659ca1392a1d632faa953015789cc1dddd991
         env:
           ROOTFS_DIR: /crossrootfs/x64
 
       linux_x86:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-x86
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-x86@sha256:67b5809029440b6dbccd68d0e5c777ff8b71383e51736b1da84c8779245e7a21
         env:
           ROOTFS_DIR: /crossrootfs/x86
 
       linux_x64_dev_innerloop:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04@sha256:d775eb3208cd9f676afb20e0ad566fa9deabf066b7a4e91920a24e2493fa0f6c
 
       linux_musl_x64_dev_innerloop:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.21-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.21-amd64@sha256:9784e22e5d262b57dfd24557510856e1cdf1a47b24fba34d9e382ea6bcb0531e
 
       linux_x64_sanitizer:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64-sanitizer
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64-sanitizer@sha256:98264aab1c7adb8af66580f5c18f09be94409f518cbee7157a52e76a17e695cc
         env:
           ROOTFS_DIR: /crossrootfs/x64
 
       # Used to test RHEL compatibility: CentOS Stream is upstream of RHEL
       SourceBuild_centos_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64@sha256:fb7f6d70dc8818b9cdf5d4de034c5a15b1ad0c3b2012318539fbe833fbaeb613
 
       # Used to test RHEL compatibility: Alma Linux is downstream of RHEL
       SourceBuild_linux_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-source-build-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-9-source-build-amd64@sha256:af0a4a6212ebe43548db99ec43763c08ee71822f71cc5b597f628122e0fa154d
 
       linux_s390x:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-s390x
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-s390x@sha256:69d4e36e82f1cf3e167348067f33ec5aec98a10817ca55c602aa1b52421c32fc
         env:
           ROOTFS_DIR: /crossrootfs/s390x
 
       linux_ppc64le:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-ppc64le
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-ppc64le@sha256:c6f4a858e4809156a7c45b70472834ac8e99d385bb820c032afd60c423560d5a
         env:
           ROOTFS_DIR: /crossrootfs/ppc64le
 
       linux_riscv64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-riscv64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-riscv64@sha256:4b5c0b16f3656bde2c5e8caf672645be31150545ea81382d8d20aae8dd786bf2
         env:
           ROOTFS_DIR: /crossrootfs/riscv64
 
       linux_loongarch64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-loongarch64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-loongarch64@sha256:092bf9d35c4e46fe3c854664392fa47e0157b1f2a1eaefcbb8835ec78aeacc10
         env:
           ROOTFS_DIR: /crossrootfs/loongarch64
 
       debian-12-gcc15-amd64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-gcc15-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-gcc15-amd64@sha256:8b3ca233d45f77584aaf16b3c70b6095ea5ccd3740805ad988a8c66685ccc53b
 
       linux_x64_llvmaot:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64@sha256:fb7f6d70dc8818b9cdf5d4de034c5a15b1ad0c3b2012318539fbe833fbaeb613
 
       browser_wasm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-webassembly-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-webassembly-amd64@sha256:648e2be848f415b66ee07218311d6138654719e10d7878a688550ca76a032e16
         env:
           ROOTFS_DIR: /crossrootfs/x64
 
       wasi_wasm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-webassembly-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-webassembly-amd64@sha256:648e2be848f415b66ee07218311d6138654719e10d7878a688550ca76a032e16
         env:
           ROOTFS_DIR: /crossrootfs/x64
 
       freebsd_x64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-freebsd-14-amd64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-freebsd-14-amd64@sha256:1375c5004be12ee83be556e027207b0e7c47c70021550a1a01080f04ab805e28
         env:
           ROOTFS_DIR: /crossrootfs/x64
 
       tizen_armel:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-armel-tizen
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-armel-tizen@sha256:aed2adea0f973c0353de7201ec10cade8e517f4ecf75fa5c32b585ab591f74a4
         env:
           ROOTFS_DIR: /crossrootfs/armel


### PR DESCRIPTION
Temporary measure for https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1439

Made some emergency changes to my Shaken tool. Need to clean those up. Got GitHub Copilot Agent Mode to generate the POCO records and the STJ source generator code for me (using the JSON as input).

- SHA source: https://raw.githubusercontent.com/dotnet/versions/b1db25dee248711bc5355d0ca603e88b975684e6/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
- Scratch branch: https://github.com/richlander/shaken/tree/scratch

@jkoritzinsky @mthalman 