### PR TITLE
[RuntimeAsync] Disable building async tests on configurations that are not yet supported.

### DIFF
--- a/src/tests/async/Directory.Build.targets
+++ b/src/tests/async/Directory.Build.targets
@@ -1,5 +1,10 @@
 <Project>
   <PropertyGroup>
+    <!-- disable building for configurations that do not yet support runtime async. -->
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono' or '$(TestBuildMode)' == 'nativeaot' or '$(TargetArchitecture)' == 'wasm'">true</DisableProjectBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- runtime async testing in main repo NYI -->
     <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>


### PR DESCRIPTION

Test-only change to disable building async tests on configurations that are not yet supported.

