### PR TITLE
[Performance] Add static linking build for CoreCLR Android

### DIFF
--- a/eng/pipelines/performance/perf.yml
+++ b/eng/pipelines/performance/perf.yml
@@ -28,7 +28,6 @@ resources:
       type: git
       name: internal/dotnet-performance
 
-
 variables:
 - template: /eng/pipelines/common/variables.yml
 

--- a/eng/pipelines/performance/perf.yml
+++ b/eng/pipelines/performance/perf.yml
@@ -27,6 +27,8 @@ resources:
     - repository: performance
       type: git
       name: internal/dotnet-performance
+      ref: refs/heads/improvement/build-time-measurements-maui
+
 
 variables:
 - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/performance/perf.yml
+++ b/eng/pipelines/performance/perf.yml
@@ -27,7 +27,6 @@ resources:
     - repository: performance
       type: git
       name: internal/dotnet-performance
-      ref: refs/heads/improvement/build-time-measurements-maui
 
 
 variables:

--- a/eng/pipelines/performance/templates/build-perf-sample-apps.yml
+++ b/eng/pipelines/performance/templates/build-perf-sample-apps.yml
@@ -78,6 +78,29 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
         displayName: clean bindir
 
+      # CoreCLR JIT static linking build
+      - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=CoreCLR STATIC_LINKING=true
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
+        displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=CoreCLR STATIC_LINKING=true
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish binlog'
+        inputs:
+          pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/Android/msbuild.binlog
+          artifactName:  AndroidCoreCLRArm64StaticLinkingBuildLog
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp/arm64/Release/android-arm64/Bundle/bin/HelloAndroid.apk
+          includeRootFolder: true
+          displayName: Android Sample App JIT CoreCLR Static Linking
+          artifactName: AndroidHelloWorldArm64CoreCLRStaticLinking
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
+      - script: rm -r -f $(Build.SourcesDirectory)/artifacts/bin/AndroidSampleApp
+        workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
+        displayName: clean bindir
+
       # CoreCLR R2R build
       - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=CoreCLR R2R=true
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android


### PR DESCRIPTION
## Description

This PR adds a static linking build configuration for the CoreCLR JIT on Android, to track its on-disk size.