### PR TITLE
Support bounded channel with bound of 0 (rendezvous)

### DIFF
--- a/src/libraries/System.Threading.Channels/src/System.Threading.Channels.csproj
+++ b/src/libraries/System.Threading.Channels/src/System.Threading.Channels.csproj
@@ -25,6 +25,7 @@ System.Threading.Channel&lt;T&gt;</PackageDescription>
     <Compile Include="System\Threading\Channels\Channel_1.cs" />
     <Compile Include="System\Threading\Channels\Channel_2.cs" />
     <Compile Include="System\Threading\Channels\IDebugEnumerator.cs" />
+    <Compile Include="System\Threading\Channels\RendezvousChannel.cs" />
     <Compile Include="System\Threading\Channels\SingleConsumerUnboundedChannel.cs" />
     <Compile Include="System\Threading\Channels\UnboundedChannel.cs" />
     <Compile Include="$(CommonPath)Internal\Padding.cs" Link="Common\Internal\Padding.cs" />

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -388,13 +388,7 @@ namespace System.Threading.Channels
                         // There are no items in the channel, which means we may have blocked/waiting readers.
 
                         // Try to get a blocked reader that we can transfer the item to.
-                        while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
-                        {
-                            if (blockedReader.TryReserveCompletionIfCancelable())
-                            {
-                                break;
-                            }
-                        }
+                        blockedReader = ChannelUtilities.TryDequeueAndReserveCompletionIfCancelable(ref parent._blockedReadersHead);
 
                         // If we weren't able to get a reader, instead queue the item and get any waiters that need to be notified.
                         if (blockedReader is null)
@@ -551,13 +545,7 @@ namespace System.Threading.Channels
                         // There are no items in the channel, which means we may have blocked/waiting readers.
 
                         // Try to get a blocked reader that we can transfer the item to.
-                        while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
-                        {
-                            if (blockedReader.TryReserveCompletionIfCancelable())
-                            {
-                                break;
-                            }
-                        }
+                        blockedReader = ChannelUtilities.TryDequeueAndReserveCompletionIfCancelable(ref parent._blockedReadersHead);
 
                         // If we weren't able to get a reader, instead queue the item and get any waiters that need to be notified.
                         if (blockedReader is null)

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/Channel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/Channel.cs
@@ -15,6 +15,7 @@ namespace System.Threading.Channels
         /// <typeparam name="T">Specifies the type of data in the channel.</typeparam>
         /// <param name="options">Options that guide the behavior of the channel.</param>
         /// <returns>The created channel.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
         public static Channel<T> CreateUnbounded<T>(UnboundedChannelOptions options)
         {
             ArgumentNullException.ThrowIfNull(options);
@@ -35,35 +36,33 @@ namespace System.Threading.Channels
         /// Channels created with this method apply the <see cref="BoundedChannelFullMode.Wait"/>
         /// behavior and prohibit continuations from running synchronously.
         /// </remarks>
-        public static Channel<T> CreateBounded<T>(int capacity)
-        {
-            if (capacity < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(capacity));
-            }
-
-            return new BoundedChannel<T>(capacity, BoundedChannelFullMode.Wait, runContinuationsAsynchronously: true, itemDropped: null);
-        }
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is negative.</exception>
+        public static Channel<T> CreateBounded<T>(int capacity) =>
+            capacity > 0 ? new BoundedChannel<T>(capacity, BoundedChannelFullMode.Wait, runContinuationsAsynchronously: true, itemDropped: null) :
+            capacity == 0 ? new RendezvousChannel<T>(BoundedChannelFullMode.Wait, runContinuationsAsynchronously: true, itemDropped: null) :
+            throw new ArgumentOutOfRangeException(nameof(capacity));
 
         /// <summary>Creates a channel subject to the provided options.</summary>
         /// <typeparam name="T">Specifies the type of data in the channel.</typeparam>
         /// <param name="options">Options that guide the behavior of the channel.</param>
         /// <returns>The created channel.</returns>
-        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options)
-        {
-            return CreateBounded<T>(options, itemDropped: null);
-        }
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options) =>
+            CreateBounded<T>(options, itemDropped: null);
 
         /// <summary>Creates a channel subject to the provided options.</summary>
         /// <typeparam name="T">Specifies the type of data in the channel.</typeparam>
         /// <param name="options">Options that guide the behavior of the channel.</param>
         /// <param name="itemDropped">Delegate that will be called when item is being dropped from channel. See <see cref="BoundedChannelFullMode"/>.</param>
         /// <returns>The created channel.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
         public static Channel<T> CreateBounded<T>(BoundedChannelOptions options, Action<T>? itemDropped)
         {
             ArgumentNullException.ThrowIfNull(options);
 
-            return new BoundedChannel<T>(options.Capacity, options.FullMode, !options.AllowSynchronousContinuations, itemDropped);
+            return
+                options.Capacity > 0 ? new BoundedChannel<T>(options.Capacity, options.FullMode, !options.AllowSynchronousContinuations, itemDropped) :
+                new RendezvousChannel<T>(options.FullMode, !options.AllowSynchronousContinuations, itemDropped);
         }
     }
 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelOptions.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelOptions.cs
@@ -49,9 +49,10 @@ namespace System.Threading.Channels
 
         /// <summary>Initializes the options.</summary>
         /// <param name="capacity">The maximum number of items the bounded channel may store.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is negative.</exception>
         public BoundedChannelOptions(int capacity)
         {
-            if (capacity < 1)
+            if (capacity < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(capacity));
             }
@@ -60,12 +61,13 @@ namespace System.Threading.Channels
         }
 
         /// <summary>Gets or sets the maximum number of items the bounded channel may store.</summary>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is negative.</exception>
         public int Capacity
         {
             get => _capacity;
             set
             {
-                if (value < 1)
+                if (value < 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
@@ -74,6 +76,7 @@ namespace System.Threading.Channels
         }
 
         /// <summary>Gets or sets the behavior incurred by write operations when the channel is full.</summary>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is an invalid enum value.</exception>
         public BoundedChannelFullMode FullMode
         {
             get => _mode;

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
@@ -66,6 +66,23 @@ namespace System.Threading.Channels
             return new ValueTask<T>(t);
         }
 
+        /// <summary>Dequeues from <paramref name="head"/> until an element is dequeued that can have completion reserved.</summary>
+        /// <param name="head">The head of the list, with items dequeued up through the returned element, or entirely if <see langword="null"/> is returned.</param>
+        /// <returns>The operation on which completion has been reserved, or null if none can be found.</returns>
+        internal static TAsyncOp? TryDequeueAndReserveCompletionIfCancelable<TAsyncOp>(ref TAsyncOp? head)
+            where TAsyncOp : AsyncOperation<TAsyncOp>
+        {
+            while (ChannelUtilities.TryDequeue(ref head, out var op))
+            {
+                if (op.TryReserveCompletionIfCancelable())
+                {
+                    return op;
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>Dequeues an operation from the circular doubly-linked list referenced by <paramref name="head"/>.</summary>
         /// <param name="head">The head of the list.</param>
         /// <param name="op">The dequeued operation.</param>

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelUtilities.cs
@@ -317,6 +317,29 @@ namespace System.Threading.Channels
             }
         }
 
+        /// <summary>Counts the number of operations in the list.</summary>
+        /// <param name="head">The head of the queue of operations to count.</param>
+        internal static long CountOperations<TAsyncOp>(TAsyncOp? head)
+            where TAsyncOp : AsyncOperation<TAsyncOp>
+        {
+            TAsyncOp? current = head;
+            long count = 0;
+
+            if (current is not null)
+            {
+                do
+                {
+                    count++;
+
+                    Debug.Assert(current is not null);
+                    current = current.Next;
+                }
+                while (current != head);
+            }
+
+            return count;
+        }
+
         /// <summary>Creates and returns an exception object to indicate that a channel has been closed.</summary>
         internal static Exception CreateInvalidCompletionException(Exception? inner = null) =>
             inner is OperationCanceledException ? inner :

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/RendezvousChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/RendezvousChannel.cs
@@ -1,0 +1,537 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace System.Threading.Channels
+{
+    /// <summary>Provides an unbuffered channel where readers and writers must directly hand off to each other.</summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class RendezvousChannel<T> : Channel<T>
+    {
+        /// <summary>Whether to suceed writes immediately even when there's no rendezvousing reader.</summary>
+        private readonly bool _dropWrites;
+
+        /// <summary>The delegate that will be invoked when the channel hits its bound and an item is dropped from the channel.</summary>
+        private readonly Action<T>? _itemDropped;
+
+        /// <summary>Task signaled when the channel has completed.</summary>
+        private readonly TaskCompletionSource _completion;
+
+        /// <summary>Head of linked list of blocked ReadAsync calls.</summary>
+        private BlockedReadAsyncOperation<T>? _blockedReadersHead;
+
+        /// <summary>Head of linked list of blocked WriteAsync calls.</summary>
+        private BlockedWriteAsyncOperation<T>? _blockedWritersHead;
+
+        /// <summary>Head of linked list of waiting WaitToReadAsync calls.</summary>
+        private WaitingReadAsyncOperation? _waitingReadersHead;
+
+        /// <summary>Head of linked list of waiting WaitToWriteAsync calls.</summary>
+        private WaitingWriteAsyncOperation? _waitingWritersHead;
+
+        /// <summary>Whether to force continuations to be executed asynchronously from producer writes.</summary>
+        private readonly bool _runContinuationsAsynchronously;
+
+        /// <summary>Set to non-null once Complete has been called.</summary>
+        private Exception? _doneWriting;
+
+        /// <summary>Initializes the <see cref="RendezvousChannel{T}"/>.</summary>
+        /// <param name="mode">The mode used when writing to a full channel.</param>
+        /// <param name="runContinuationsAsynchronously">Whether to force continuations to be executed asynchronously.</param>
+        /// <param name="itemDropped">Delegate that will be invoked when an item is dropped from the channel. See <see cref="BoundedChannelFullMode"/>.</param>
+        internal RendezvousChannel(BoundedChannelFullMode mode, bool runContinuationsAsynchronously, Action<T>? itemDropped)
+        {
+            _dropWrites = mode is not BoundedChannelFullMode.Wait;
+
+            _runContinuationsAsynchronously = runContinuationsAsynchronously;
+            _itemDropped = itemDropped;
+            _completion = new TaskCompletionSource(runContinuationsAsynchronously ? TaskCreationOptions.RunContinuationsAsynchronously : TaskCreationOptions.None);
+
+            Reader = new RendezvousChannelReader(this);
+            Writer = new RendezvousChannelWriter(this);
+        }
+
+        [DebuggerDisplay("{DebuggerDisplay,nq}")]
+        private sealed class RendezvousChannelReader : ChannelReader<T>
+        {
+            internal readonly RendezvousChannel<T> _parent;
+            private readonly BlockedReadAsyncOperation<T> _readerSingleton;
+            private readonly WaitingReadAsyncOperation _waiterSingleton;
+
+            internal RendezvousChannelReader(RendezvousChannel<T> parent)
+            {
+                _parent = parent;
+                _readerSingleton = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, pooled: true);
+                _waiterSingleton = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, pooled: true);
+            }
+
+            public override Task Completion => _parent._completion.Task;
+
+            public override bool CanCount => true;
+
+            public override bool CanPeek => true;
+
+            public override int Count => 0;
+
+            public override bool TryRead([MaybeNullWhen(false)] out T item)
+            {
+                RendezvousChannel<T> parent = _parent;
+
+                // Reserve a blocked writer if one is available.
+                BlockedWriteAsyncOperation<T>? blockedWriter = null;
+                lock (parent.SyncObj)
+                {
+                    parent.AssertInvariants();
+
+                    if (parent._doneWriting is null)
+                    {
+                        while (ChannelUtilities.TryDequeue(ref parent._blockedWritersHead, out blockedWriter))
+                        {
+                            if (blockedWriter.TryReserveCompletionIfCancelable())
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // If we got one, transfer its item to the read and complete successfully.
+                if (blockedWriter is not null)
+                {
+                    item = blockedWriter.Item!;
+                    blockedWriter.DangerousSetResult(default);
+                    return true;
+                }
+
+                item = default;
+                return false;
+            }
+
+            public override bool TryPeek([MaybeNullWhen(false)] out T item)
+            {
+                RendezvousChannel<T> parent = _parent;
+
+                // Peek at a blocked writer if one is available.
+                lock (parent.SyncObj)
+                {
+                    parent.AssertInvariants();
+
+                    if (parent._doneWriting is null &&
+                        parent._blockedWritersHead is { } blockedWriter)
+                    {
+                        item = blockedWriter.Item!;
+                        return true;
+                    }
+                }
+
+                item = default;
+                return false;
+            }
+
+            public override ValueTask<T> ReadAsync(CancellationToken cancellationToken)
+            {
+                RendezvousChannel<T> parent = _parent;
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return new ValueTask<T>(Task.FromCanceled<T>(cancellationToken));
+                }
+
+                BlockedReadAsyncOperation<T>? reader = null;
+                WaitingWriteAsyncOperation? waitingWriters = null;
+                BlockedWriteAsyncOperation<T>? blockedWriter = null;
+                lock (parent.SyncObj)
+                {
+                    parent.AssertInvariants();
+
+                    // If we're done writing so that there will never be more items, fail.
+                    if (parent._doneWriting is not null)
+                    {
+                        return ChannelUtilities.GetInvalidCompletionValueTask<T>(parent._doneWriting);
+                    }
+
+                    // Reserve a blocked writer if one is available.
+                    while (ChannelUtilities.TryDequeue(ref parent._blockedWritersHead, out blockedWriter))
+                    {
+                        if (blockedWriter.TryReserveCompletionIfCancelable())
+                        {
+                            break;
+                        }
+                    }
+
+                    // If we couldn't get one, create a waiting reader, and reserve any waiting writers to alert.
+                    if (blockedWriter is null)
+                    {
+                        reader =
+                            !cancellationToken.CanBeCanceled && _readerSingleton.TryOwnAndReset() ? _readerSingleton :
+                            new(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                        ChannelUtilities.Enqueue(ref parent._blockedReadersHead, reader);
+
+                        waitingWriters = ChannelUtilities.TryReserveCompletionIfCancelable(ref parent._waitingWritersHead);
+                    }
+                }
+
+                // Either complete the reserved blocked writer, transferring its item to the read,
+                // or return the waiting reader task, also alerting any waiting writers.
+                ValueTask<T> result;
+                if (blockedWriter is not null)
+                {
+                    Debug.Assert(reader is null);
+                    Debug.Assert(waitingWriters is null);
+                    result = new(blockedWriter.Item!);
+                    blockedWriter.DangerousSetResult(default);
+                }
+                else
+                {
+                    Debug.Assert(reader is not null);
+                    ChannelUtilities.DangerousSetOperations(waitingWriters, result: true);
+                    result = reader.ValueTaskOfT;
+                }
+
+                return result;
+            }
+
+            public override ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return new ValueTask<bool>(Task.FromCanceled<bool>(cancellationToken));
+                }
+
+                RendezvousChannel<T> parent = _parent;
+                lock (parent.SyncObj)
+                {
+                    parent.AssertInvariants();
+
+                    // If we're done writing, a read will never be possible.
+                    if (parent._doneWriting is not null)
+                    {
+                        return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
+                            new ValueTask<bool>(Task.FromException<bool>(parent._doneWriting)) :
+                            default;
+                    }
+
+                    // If there are any writers waiting, a read is possible.
+                    if (parent._blockedWritersHead is not null)
+                    {
+                        return new ValueTask<bool>(true);
+                    }
+
+                    // Register a waiting reader task.
+                    WaitingReadAsyncOperation waiter =
+                        !cancellationToken.CanBeCanceled && _waiterSingleton.TryOwnAndReset() ? _waiterSingleton :
+                        new(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    ChannelUtilities.Enqueue(ref parent._waitingReadersHead, waiter);
+                    return waiter.ValueTaskOfT;
+                }
+            }
+
+            internal string DebuggerDisplay
+            {
+                get
+                {
+                    long blockedReaderCount, waitingReaderCount;
+                    lock (_parent.SyncObj)
+                    {
+                        blockedReaderCount = ChannelUtilities.CountOperations(_parent._blockedReadersHead);
+                        waitingReaderCount = ChannelUtilities.CountOperations(_parent._waitingReadersHead);
+                    }
+
+                    return $"ReadAsync={blockedReaderCount}, WaitToReadAsync={waitingReaderCount}";
+                }
+            }
+        }
+
+        [DebuggerDisplay("{DebuggerDisplay,nq}")]
+        private sealed class RendezvousChannelWriter : ChannelWriter<T>
+        {
+            internal readonly RendezvousChannel<T> _parent;
+            private readonly BlockedWriteAsyncOperation<T> _writerSingleton;
+            private readonly WaitingWriteAsyncOperation _waiterSingleton;
+
+            internal RendezvousChannelWriter(RendezvousChannel<T> parent)
+            {
+                _parent = parent;
+                _writerSingleton = new BlockedWriteAsyncOperation<T>(runContinuationsAsynchronously: true, pooled: true);
+                _waiterSingleton = new WaitingWriteAsyncOperation(runContinuationsAsynchronously: true, pooled: true);
+            }
+
+            public override bool TryComplete(Exception? error)
+            {
+                RendezvousChannel<T> parent = _parent;
+
+                BlockedReadAsyncOperation<T>? blockedReadersHead;
+                BlockedWriteAsyncOperation<T>? blockedWritersHead;
+                WaitingReadAsyncOperation? waitingReadersHead;
+                WaitingWriteAsyncOperation? waitingWritersHead;
+                lock (parent.SyncObj)
+                {
+                    parent.AssertInvariants();
+
+                    // If we've already marked the channel as completed, bail.
+                    if (parent._doneWriting is not null)
+                    {
+                        return false;
+                    }
+
+                    // Mark that we're done writing.
+                    parent._doneWriting = error ?? ChannelUtilities.s_doneWritingSentinel;
+
+                    // Snag the queues while holding the lock, so that we don't need to worry
+                    // about concurrent mutation, such as from cancellation of pending operations.
+                    blockedReadersHead = parent._blockedReadersHead;
+                    blockedWritersHead = parent._blockedWritersHead;
+                    waitingReadersHead = parent._waitingReadersHead;
+                    waitingWritersHead = parent._waitingWritersHead;
+                    parent._blockedReadersHead = null;
+                    parent._blockedWritersHead = null;
+                    parent._waitingReadersHead = null;
+                    parent._waitingWritersHead = null;
+                }
+
+                // Complete the channel's task, as no more data can possibly arrive at this point.  We do this outside
+                // of the lock in case we'll be running synchronous completions, and we
+                // do it before completing blocked/waiting readers, so that when they
+                // wake up they'll see the task as being completed.
+                ChannelUtilities.Complete(parent._completion, error);
+
+                // Complete all pending operations. We don't need to worry about concurrent mutation here:
+                // No other writers or readers will be able to register operations, and any cancellation callbacks
+                // will see the queues as being null and exit immediately.
+                ChannelUtilities.FailOperations(blockedReadersHead, ChannelUtilities.CreateInvalidCompletionException(error));
+                ChannelUtilities.FailOperations(blockedWritersHead, ChannelUtilities.CreateInvalidCompletionException(error));
+                ChannelUtilities.SetOrFailOperations(waitingReadersHead, result: false, error: error);
+                ChannelUtilities.SetOrFailOperations(waitingWritersHead, result: false, error: error);
+
+                // Successfully transitioned to completed.
+                return true;
+            }
+
+            public override bool TryWrite(T item)
+            {
+                RendezvousChannel<T> parent = _parent;
+
+                // Reserve a blocked reader if one is available.
+                BlockedReadAsyncOperation<T>? blockedReader = null;
+                lock (parent.SyncObj)
+                {
+                    parent.AssertInvariants();
+
+                    if (parent._doneWriting is null)
+                    {
+                        while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
+                        {
+                            if (blockedReader.TryReserveCompletionIfCancelable())
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // If we got one, transfer its item to the read and complete successfully.
+                if (blockedReader is not null)
+                {
+                    blockedReader.DangerousSetResult(item);
+                    return true;
+                }
+
+                // There's no concurrent reader, but if we're configured to drop writes, we can succeed immediately.
+                if (parent._dropWrites)
+                {
+                    parent._itemDropped?.Invoke(item);
+                    return true;
+                }
+
+                return false;
+            }
+
+            public override ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return new ValueTask<bool>(Task.FromCanceled<bool>(cancellationToken));
+                }
+
+                RendezvousChannel<T> parent = _parent;
+                lock (parent.SyncObj)
+                {
+                    parent.AssertInvariants();
+
+                    // If we're done writing, a read will never be possible.
+                    if (parent._doneWriting is not null)
+                    {
+                        return parent._doneWriting != ChannelUtilities.s_doneWritingSentinel ?
+                            new ValueTask<bool>(Task.FromException<bool>(parent._doneWriting)) :
+                            default;
+                    }
+
+                    // If there are any readers waiting, a write is possible.
+                    if (parent._blockedReadersHead is not null || parent._dropWrites)
+                    {
+                        return new ValueTask<bool>(true);
+                    }
+
+                    // There were no readers available, but there could be in the future, so ensure
+                    // there's a waiting writer task and return it.
+                    WaitingWriteAsyncOperation waiter =
+                        !cancellationToken.CanBeCanceled && _waiterSingleton.TryOwnAndReset() ? _waiterSingleton :
+                        new(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    ChannelUtilities.Enqueue(ref parent._waitingWritersHead, waiter);
+                    return waiter.ValueTaskOfT;
+                }
+            }
+
+            public override ValueTask WriteAsync(T item, CancellationToken cancellationToken)
+            {
+                RendezvousChannel<T> parent = _parent;
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return new ValueTask(Task.FromCanceled<T>(cancellationToken));
+                }
+
+                BlockedWriteAsyncOperation<T>? writer = null;
+                WaitingReadAsyncOperation? waitingReaders = null;
+                BlockedReadAsyncOperation<T>? blockedReader = null;
+                lock (parent.SyncObj)
+                {
+                    parent.AssertInvariants();
+
+                    // If we've already been marked as done for writing, we shouldn't be writing.
+                    if (parent._doneWriting is not null)
+                    {
+                        return new ValueTask(Task.FromException(ChannelUtilities.CreateInvalidCompletionException(parent._doneWriting)));
+                    }
+
+                    // Reserve a blocked reader if one is available.
+                    while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
+                    {
+                        if (blockedReader.TryReserveCompletionIfCancelable())
+                        {
+                            break;
+                        }
+                    }
+
+                    // If we couldn't get one, create a blocked writer, and reserve any waiting readers to alert.
+                    if (blockedReader is null && !parent._dropWrites)
+                    {
+                        writer =
+                            !cancellationToken.CanBeCanceled && _writerSingleton.TryOwnAndReset() ? _writerSingleton :
+                            new(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                        writer.Item = item;
+                        ChannelUtilities.Enqueue(ref parent._blockedWritersHead, writer);
+
+                        waitingReaders = ChannelUtilities.TryReserveCompletionIfCancelable(ref parent._waitingReadersHead);
+                    }
+                }
+
+                if (writer is not null)
+                {
+                    Debug.Assert(blockedReader is null);
+                    ChannelUtilities.DangerousSetOperations(waitingReaders, result: true);
+                    return writer.ValueTask;
+                }
+
+                if (blockedReader is not null)
+                {
+                    blockedReader.DangerousSetResult(item);
+                }
+                else
+                {
+                    Debug.Assert(parent._dropWrites);
+                    parent._itemDropped?.Invoke(item);
+                }
+
+                return default;
+            }
+
+            internal string DebuggerDisplay
+            {
+                get
+                {
+                    long blockedWriterCount, waitingWriterCount;
+                    lock (_parent.SyncObj)
+                    {
+                        blockedWriterCount = ChannelUtilities.CountOperations(_parent._blockedWritersHead);
+                        waitingWriterCount = ChannelUtilities.CountOperations(_parent._waitingWritersHead);
+                    }
+
+                    return $"WriteAsync={blockedWriterCount}, WaitToWriteAsync={waitingWriterCount}";
+                }
+            }
+        }
+
+        /// <summary>Gets an object used to synchronize all state on the instance.</summary>
+        private object SyncObj => _completion;
+
+        private Action<object?, CancellationToken> CancellationCallbackDelegate =>
+            field ??= (state, cancellationToken) =>
+            {
+                AsyncOperation op = (AsyncOperation)state!;
+                if (op.TrySetCanceled(cancellationToken))
+                {
+                    ChannelUtilities.UnsafeQueueUserWorkItem(static state => // escape cancellation callback
+                    {
+                        lock (state.Key.SyncObj)
+                        {
+                            switch (state.Value)
+                            {
+                                case BlockedReadAsyncOperation<T> blockedReader:
+                                    ChannelUtilities.Remove(ref state.Key._blockedReadersHead, blockedReader);
+                                    break;
+
+                                case BlockedWriteAsyncOperation<T> blockedWriter:
+                                    ChannelUtilities.Remove(ref state.Key._blockedWritersHead, blockedWriter);
+                                    break;
+
+                                case WaitingReadAsyncOperation waitingReader:
+                                    ChannelUtilities.Remove(ref state.Key._waitingReadersHead, waitingReader);
+                                    break;
+
+                                case WaitingWriteAsyncOperation waitingWriter:
+                                    ChannelUtilities.Remove(ref state.Key._waitingWritersHead, waitingWriter);
+                                    break;
+
+                                default:
+                                    Debug.Fail($"Unexpected operation: {state.Value}");
+                                    break;
+                            }
+                        }
+                    }, new KeyValuePair<RendezvousChannel<T>, AsyncOperation>(this, op));
+                }
+            };
+
+        private string DebuggerDisplay =>
+            $"{((RendezvousChannelReader)Reader).DebuggerDisplay}, {((RendezvousChannelWriter)Writer).DebuggerDisplay}";
+
+        [Conditional("DEBUG")]
+        private void AssertInvariants()
+        {
+            Debug.Assert(SyncObj is not null, "The sync obj must not be null.");
+            Debug.Assert(Monitor.IsEntered(SyncObj), "Invariants can only be validated while holding the lock.");
+
+            if (_blockedReadersHead is not null)
+            {
+                Debug.Assert(_blockedWritersHead is null, "There shouldn't be any blocked writer if there's a blocked reader.");
+                Debug.Assert(_waitingWritersHead is null, "There shouldn't be any waiting writers if there's a blocked reader.");
+            }
+
+            if (_blockedWritersHead is not null)
+            {
+                Debug.Assert(_blockedReadersHead is null, "There shouldn't be any blocked readers if there's a blocked writer.");
+                Debug.Assert(_waitingReadersHead is null, "There shouldn't be any waiting readers if there's a blocked writer.");
+            }
+
+            if (_completion.Task.IsCompleted)
+            {
+                Debug.Assert(_doneWriting is not null, "We can only complete if we're done writing.");
+            }
+        }
+    }
+}

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/RendezvousChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/RendezvousChannel.cs
@@ -90,13 +90,7 @@ namespace System.Threading.Channels
 
                     if (parent._doneWriting is null)
                     {
-                        while (ChannelUtilities.TryDequeue(ref parent._blockedWritersHead, out blockedWriter))
-                        {
-                            if (blockedWriter.TryReserveCompletionIfCancelable())
-                            {
-                                break;
-                            }
-                        }
+                        blockedWriter = ChannelUtilities.TryDequeueAndReserveCompletionIfCancelable(ref parent._blockedWritersHead);
                     }
                 }
 
@@ -156,13 +150,7 @@ namespace System.Threading.Channels
                     }
 
                     // Reserve a blocked writer if one is available.
-                    while (ChannelUtilities.TryDequeue(ref parent._blockedWritersHead, out blockedWriter))
-                    {
-                        if (blockedWriter.TryReserveCompletionIfCancelable())
-                        {
-                            break;
-                        }
-                    }
+                    blockedWriter = ChannelUtilities.TryDequeueAndReserveCompletionIfCancelable(ref parent._blockedWritersHead);
 
                     // If we couldn't get one, create a waiting reader, and reserve any waiting writers to alert.
                     if (blockedWriter is null)
@@ -324,13 +312,7 @@ namespace System.Threading.Channels
 
                     if (parent._doneWriting is null)
                     {
-                        while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
-                        {
-                            if (blockedReader.TryReserveCompletionIfCancelable())
-                            {
-                                break;
-                            }
-                        }
+                        blockedReader = ChannelUtilities.TryDequeueAndReserveCompletionIfCancelable(ref parent._blockedReadersHead);
                     }
                 }
 
@@ -410,13 +392,7 @@ namespace System.Threading.Channels
                     }
 
                     // Reserve a blocked reader if one is available.
-                    while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
-                    {
-                        if (blockedReader.TryReserveCompletionIfCancelable())
-                        {
-                            break;
-                        }
-                    }
+                    blockedReader = ChannelUtilities.TryDequeueAndReserveCompletionIfCancelable(ref parent._blockedReadersHead);
 
                     // If we couldn't get one, create a blocked writer, and reserve any waiting readers to alert.
                     if (blockedReader is null && !parent._dropWrites)

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/SingleConsumerUnboundedChannel.cs
@@ -251,8 +251,6 @@ namespace System.Threading.Channels
                     ChannelUtilities.Complete(parent._completion, error);
                 }
 
-                Debug.Assert(blockedReader is null || waitingReader is null, "There should only ever be at most one reader.");
-
                 // Complete a blocked reader if necessary
                 if (blockedReader is not null)
                 {

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
@@ -97,19 +97,10 @@ namespace System.Threading.Channels
                         return ChannelUtilities.GetInvalidCompletionValueTask<T>(parent._doneWriting);
                     }
 
-                    // If we're able to use the singleton reader, do so.
-                    if (!cancellationToken.CanBeCanceled)
-                    {
-                        BlockedReadAsyncOperation<T> singleton = _readerSingleton;
-                        if (singleton.TryOwnAndReset())
-                        {
-                            ChannelUtilities.Enqueue(ref parent._blockedReadersHead, singleton);
-                            return singleton.ValueTaskOfT;
-                        }
-                    }
-
-                    // Otherwise, create and queue a reader.
-                    var reader = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    // If we're able to use the singleton reader, do so. Otherwise, create a new reader.
+                    BlockedReadAsyncOperation<T> reader =
+                        !cancellationToken.CanBeCanceled && _readerSingleton.TryOwnAndReset() ? _readerSingleton :
+                        new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
                     ChannelUtilities.Enqueue(ref parent._blockedReadersHead, reader);
                     return reader.ValueTaskOfT;
                 }
@@ -174,19 +165,10 @@ namespace System.Threading.Channels
                             default;
                     }
 
-                    // If we're able to use the singleton waiter, do so.
-                    if (!cancellationToken.CanBeCanceled)
-                    {
-                        WaitingReadAsyncOperation singleton = _waiterSingleton;
-                        if (singleton.TryOwnAndReset())
-                        {
-                            ChannelUtilities.Enqueue(ref parent._waitingReadersHead, singleton);
-                            return singleton.ValueTaskOfT;
-                        }
-                    }
-
-                    // Otherwise, create and queue a waiter.
-                    var waiter = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    // If we're able to use the singleton waiter, do so. Otherwise, create a new waiter.
+                    WaitingReadAsyncOperation waiter =
+                        !cancellationToken.CanBeCanceled && _waiterSingleton.TryOwnAndReset() ? _waiterSingleton :
+                        new(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
                     ChannelUtilities.Enqueue(ref parent._waitingReadersHead, waiter);
                     return waiter.ValueTaskOfT;
                 }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedChannel.cs
@@ -251,13 +251,7 @@ namespace System.Threading.Channels
                     }
 
                     // Try to get a blocked reader that we can transfer the item to.
-                    while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
-                    {
-                        if (blockedReader.TryReserveCompletionIfCancelable())
-                        {
-                            break;
-                        }
-                    }
+                    blockedReader = ChannelUtilities.TryDequeueAndReserveCompletionIfCancelable(ref parent._blockedReadersHead);
 
                     // If we weren't able to get a reader, instead queue the item and get any waiters that need to be notified.
                     if (blockedReader is null)

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedPriorityChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedPriorityChannel.cs
@@ -257,13 +257,7 @@ namespace System.Threading.Channels
                     }
 
                     // Try to get a blocked reader that we can transfer the item to.
-                    while (ChannelUtilities.TryDequeue(ref parent._blockedReadersHead, out blockedReader))
-                    {
-                        if (blockedReader.TryReserveCompletionIfCancelable())
-                        {
-                            break;
-                        }
-                    }
+                    blockedReader = ChannelUtilities.TryDequeueAndReserveCompletionIfCancelable(ref parent._blockedReadersHead);
 
                     // If we weren't able to get a reader, instead queue the item and get any waiters that need to be notified.
                     if (blockedReader is null)

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedPriorityChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/UnboundedPriorityChannel.cs
@@ -98,19 +98,10 @@ namespace System.Threading.Channels
                         return ChannelUtilities.GetInvalidCompletionValueTask<T>(parent._doneWriting);
                     }
 
-                    // If we're able to use the singleton reader, do so.
-                    if (!cancellationToken.CanBeCanceled)
-                    {
-                        BlockedReadAsyncOperation<T> singleton = _readerSingleton;
-                        if (singleton.TryOwnAndReset())
-                        {
-                            ChannelUtilities.Enqueue(ref parent._blockedReadersHead, singleton);
-                            return singleton.ValueTaskOfT;
-                        }
-                    }
-
-                    // Otherwise, create and queue a reader.
-                    var reader = new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    // If we're able to use the singleton reader, do so. Otherwise, create a new reader.
+                    BlockedReadAsyncOperation<T> reader =
+                        !cancellationToken.CanBeCanceled && _readerSingleton.TryOwnAndReset() ? _readerSingleton :
+                        new BlockedReadAsyncOperation<T>(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
                     ChannelUtilities.Enqueue(ref parent._blockedReadersHead, reader);
                     return reader.ValueTaskOfT;
                 }
@@ -179,19 +170,10 @@ namespace System.Threading.Channels
                             default;
                     }
 
-                    // If we're able to use the singleton waiter, do so.
-                    if (!cancellationToken.CanBeCanceled)
-                    {
-                        WaitingReadAsyncOperation singleton = _waiterSingleton;
-                        if (singleton.TryOwnAndReset())
-                        {
-                            ChannelUtilities.Enqueue(ref parent._waitingReadersHead, singleton);
-                            return singleton.ValueTaskOfT;
-                        }
-                    }
-
-                    // Otherwise, create and queue a waiter.
-                    var waiter = new WaitingReadAsyncOperation(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
+                    // If we're able to use the singleton waiter, do so. Otherwise, create a new waiter.
+                    WaitingReadAsyncOperation waiter =
+                        !cancellationToken.CanBeCanceled && _waiterSingleton.TryOwnAndReset() ? _waiterSingleton :
+                        new(parent._runContinuationsAsynchronously, cancellationToken, cancellationCallback: _parent.CancellationCallbackDelegate);
                     ChannelUtilities.Enqueue(ref parent._waitingReadersHead, waiter);
                     return waiter.ValueTaskOfT;
                 }

--- a/src/libraries/System.Threading.Channels/tests/ChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelTests.cs
@@ -62,7 +62,7 @@ namespace System.Threading.Channels.Tests
         }
 
         [Theory]
-        [InlineData(0)]
+        [InlineData(-1)]
         [InlineData(-2)]
         public void CreateBounded_InvalidBufferSizes_ThrowArgumentExceptions(int capacity)
         {
@@ -77,7 +77,7 @@ namespace System.Threading.Channels.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => new BoundedChannelOptions(1) { FullMode = mode });
 
         [Theory]
-        [InlineData(0)]
+        [InlineData(-1)]
         [InlineData(-2)]
         public void BoundedChannelOptions_InvalidCapacity_ThrowArgumentExceptions(int capacity) =>
             AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => new BoundedChannelOptions(1) { Capacity = capacity });

--- a/src/libraries/System.Threading.Channels/tests/RendezvousChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/RendezvousChannelTests.cs
@@ -1,0 +1,317 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
+using Xunit;
+
+namespace System.Threading.Channels.Tests
+{
+    public class RendezvousChannelTests : ChannelTestBase
+    {
+        protected override Channel<T> CreateChannel<T>() => Channel.CreateBounded<T>(0);
+
+        protected override Channel<T> CreateFullChannel<T>() => CreateChannel<T>();
+
+        protected override bool BuffersItems => false;
+
+        protected override bool HasDebuggerTypeProxy => false;
+
+        [Fact]
+        public async Task Count_AlwaysZero()
+        {
+            Channel<int> c = CreateChannel<int>();
+
+            Assert.True(c.Reader.CanCount);
+            Assert.Equal(0, c.Reader.Count);
+
+            var write1 = c.Writer.WriteAsync(1);
+            var write2 = c.Writer.WriteAsync(2);
+
+            Assert.Equal(0, c.Reader.Count);
+            Assert.False(write1.IsCompleted);
+            Assert.False(write2.IsCompleted);
+
+            Assert.Equal(1, await c.Reader.ReadAsync());
+
+            await write1;
+            Assert.Equal(0, c.Reader.Count);
+            Assert.False(write2.IsCompleted);
+
+            Assert.Equal(2, await c.Reader.ReadAsync());
+
+            await write2;
+            Assert.Equal(0, c.Reader.Count);
+        }
+
+        [Fact]
+        public void TryWrite_TryRead_NoPairing_ReturnsFalse()
+        {
+            Channel<int> c = CreateChannel();
+
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.False(c.Writer.TryWrite(42));
+                Assert.False(c.Reader.TryRead(out int item));
+                Assert.Equal(0, item);
+            }
+        }
+
+        [Theory]
+        [InlineData(BoundedChannelFullMode.DropWrite)]
+        [InlineData(BoundedChannelFullMode.DropOldest)]
+        [InlineData(BoundedChannelFullMode.DropNewest)]
+        public async Task TryWrite_DropXx_DropsWrite(BoundedChannelFullMode mode)
+        {
+            int? dropped = null;
+            Channel<int> c = Channel.CreateBounded<int>(new BoundedChannelOptions(0) { FullMode = mode }, item => dropped = item);
+
+            for (int i = 42; i < 52; i++)
+            {
+                var waiter = c.Writer.WaitToWriteAsync();
+                AssertSynchronousSuccess(waiter);
+                Assert.True(await waiter);
+
+                Assert.True(c.Writer.TryWrite(i));
+                Assert.Equal(i, dropped);
+
+                dropped = null;
+                AssertSynchronousSuccess(c.Writer.WriteAsync(i));
+                Assert.Equal(i, dropped);
+            }
+        }
+
+        [Theory]
+        [InlineData(BoundedChannelFullMode.DropWrite)]
+        [InlineData(BoundedChannelFullMode.DropOldest)]
+        [InlineData(BoundedChannelFullMode.DropNewest)]
+        public async Task TryWrite_DropXx_ReaderTakesPriority(BoundedChannelFullMode mode)
+        {
+            int? dropped = null;
+            Channel<int> c = Channel.CreateBounded<int>(new BoundedChannelOptions(0) { FullMode = mode }, item => dropped = item);
+
+            for (int i = 42; i < 52; i++)
+            {
+                ValueTask<int> reader;
+
+                reader = c.Reader.ReadAsync();
+                Assert.True(c.Writer.TryWrite(i));
+                Assert.Null(dropped);
+                Assert.Equal(i, await reader);
+
+                reader = c.Reader.ReadAsync();
+                AssertSynchronousSuccess(c.Writer.WriteAsync(i));
+                Assert.Null(dropped);
+                Assert.Equal(i, await reader);
+            }
+        }
+
+        [Fact]
+        public async Task DroppedDelegateNotCalledOnWaitMode_SyncWrites()
+        {
+            bool dropDelegateCalled = false;
+
+            Channel<int> c = Channel.CreateBounded<int>(new BoundedChannelOptions(0) { FullMode = BoundedChannelFullMode.Wait },
+                item =>
+                {
+                    dropDelegateCalled = true;
+                });
+
+            ValueTask<int> reader;
+
+            reader = c.Reader.ReadAsync();
+            Assert.True(c.Writer.TryWrite(42));
+            Assert.Equal(42, await reader);
+
+            reader = c.Reader.ReadAsync();
+            AssertSynchronousSuccess(c.Writer.WriteAsync(43));
+            Assert.Equal(43, await reader);
+
+            _ = c.Writer.WriteAsync(44);
+
+            Assert.False(dropDelegateCalled);
+        }
+
+        [Theory]
+        [InlineData(BoundedChannelFullMode.DropWrite)]
+        [InlineData(BoundedChannelFullMode.DropOldest)]
+        [InlineData(BoundedChannelFullMode.DropNewest)]
+        public void DroppedDelegateIsNull_SyncAndAsyncWrites(BoundedChannelFullMode boundedChannelFullMode)
+        {
+            Channel<int> c = Channel.CreateBounded<int>(new BoundedChannelOptions(0) { FullMode = boundedChannelFullMode }, itemDropped: null);
+
+            Assert.True(c.Writer.TryWrite(1));
+            AssertSynchronousSuccess(c.Writer.WriteAsync(2));
+
+            Assert.False(c.Reader.TryRead(out int item));
+            Assert.Equal(0, item);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(BoundedChannelFullMode.DropWrite)]
+        [InlineData(BoundedChannelFullMode.DropOldest)]
+        [InlineData(BoundedChannelFullMode.DropNewest)]
+        public void DroppedDelegateCalledAfterLockReleased_SyncWrites(BoundedChannelFullMode boundedChannelFullMode)
+        {
+            Channel<int> c = null;
+            bool dropDelegateCalled = false;
+
+            c = Channel.CreateBounded<int>(new BoundedChannelOptions(0)
+            {
+                FullMode = boundedChannelFullMode
+            }, (droppedItem) =>
+            {
+                if (dropDelegateCalled)
+                {
+                    return;
+                }
+                dropDelegateCalled = true;
+
+                // Dropped delegate should not be called while holding the channel lock.
+                // Verify this by trying to write into the channel from different thread.
+                // If lock is held during callback, this should effectively cause deadlock.
+                ManualResetEventSlim mres = new();
+                ThreadPool.QueueUserWorkItem(delegate
+                {
+                    c.Writer.TryWrite(3);
+                    mres.Set();
+                });
+
+                mres.Wait();
+            });
+
+            Assert.True(c.Writer.TryWrite(1));
+            Assert.True(c.Writer.TryWrite(2));
+
+            Assert.True(dropDelegateCalled);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(BoundedChannelFullMode.DropWrite)]
+        [InlineData(BoundedChannelFullMode.DropOldest)]
+        [InlineData(BoundedChannelFullMode.DropNewest)]
+        public async Task DroppedDelegateCalledAfterLockReleased_AsyncWrites(BoundedChannelFullMode boundedChannelFullMode)
+        {
+            Channel<int> c = null;
+            bool dropDelegateCalled = false;
+
+            c = Channel.CreateBounded<int>(new BoundedChannelOptions(0)
+            {
+                FullMode = boundedChannelFullMode
+            }, (droppedItem) =>
+            {
+                if (dropDelegateCalled)
+                {
+                    return;
+                }
+                dropDelegateCalled = true;
+
+                // Dropped delegate should not be called while holding the channel synchronisation lock.
+                // Verify this by trying to write into the channel from different thread.
+                // If lock is held during callback, this should effectively cause deadlock.
+                var mres = new ManualResetEventSlim();
+                ThreadPool.QueueUserWorkItem(delegate
+                {
+                    c.Writer.TryWrite(11);
+                    mres.Set();
+                });
+
+                mres.Wait();
+            });
+
+            await c.Writer.WriteAsync(1);
+            await c.Writer.WriteAsync(2);
+
+            Assert.True(dropDelegateCalled);
+        }
+
+        [Fact]
+        public async Task CancelPendingWrite_Reading_DataTransferredFromCorrectWriter()
+        {
+            Channel<int> c = CreateChannel();
+
+            CancellationTokenSource cts = new();
+
+            ValueTask write1 = c.Writer.WriteAsync(42);
+            ValueTask write2 = c.Writer.WriteAsync(43, cts.Token);
+            ValueTask write3 = c.Writer.WriteAsync(44);
+
+            cts.Cancel();
+
+            Assert.Equal(42, await c.Reader.ReadAsync());
+            Assert.Equal(44, await c.Reader.ReadAsync());
+
+            await write1;
+            await AssertExtensions.CanceledAsync(cts.Token, async () => await write2);
+            await write3;
+        }
+
+        [Fact]
+        public async Task WaitToWriteAsync_AfterRead_ReturnsTrue()
+        {
+            Channel<int> c = CreateChannel();
+
+            ValueTask<bool> write1 = c.Writer.WaitToWriteAsync();
+            ValueTask<bool> write2 = c.Writer.WaitToWriteAsync();
+            Assert.False(write1.IsCompleted);
+            Assert.False(write2.IsCompleted);
+
+            _ = c.Reader.ReadAsync();
+
+            Assert.True(await write1);
+            Assert.True(await write2);
+
+            ValueTask<bool> write3 = c.Writer.WaitToWriteAsync();
+            AssertSynchronousSuccess(write3);
+            Assert.True(await write3);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [MemberData(nameof(ThreeBools))]
+        public void AllowSynchronousContinuations_Reading_ContinuationsInvokedAccordingToSetting(bool allowSynchronousContinuations, bool cancelable, bool waitToReadAsync)
+        {
+            var c = Channel.CreateBounded<int>(new BoundedChannelOptions(0) { AllowSynchronousContinuations = allowSynchronousContinuations });
+
+            CancellationToken ct = cancelable ? new CancellationTokenSource().Token : CancellationToken.None;
+
+            int expectedId = Environment.CurrentManagedThreadId;
+            Task t = waitToReadAsync ? c.Reader.WaitToReadAsync(ct).AsTask() : c.Reader.ReadAsync(ct).AsTask();
+            Task r = t.ContinueWith(_ =>
+            {
+                Assert.Equal(allowSynchronousContinuations, expectedId == Environment.CurrentManagedThreadId);
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+            ValueTask write = c.Writer.WriteAsync(42);
+            if (!waitToReadAsync)
+            {
+                AssertSynchronousSuccess(write);
+            }
+
+            ((IAsyncResult)r).AsyncWaitHandle.WaitOne(); // avoid inlining the continuation
+            r.GetAwaiter().GetResult();
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AllowSynchronousContinuations_CompletionTask_ContinuationsInvokedAccordingToSetting(bool allowSynchronousContinuations)
+        {
+            if (!allowSynchronousContinuations && !PlatformDetection.IsThreadingSupported)
+            {
+                throw new SkipTestException(nameof(PlatformDetection.IsThreadingSupported));
+            }
+
+            var c = Channel.CreateBounded<int>(new BoundedChannelOptions(0) { AllowSynchronousContinuations = allowSynchronousContinuations });
+
+            int expectedId = Environment.CurrentManagedThreadId;
+            Task r = c.Reader.Completion.ContinueWith(_ =>
+            {
+                Assert.Equal(allowSynchronousContinuations, expectedId == Environment.CurrentManagedThreadId);
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+            Assert.True(c.Writer.TryComplete());
+            ((IAsyncResult)r).AsyncWaitHandle.WaitOne(); // avoid inlining the continuation
+            r.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/libraries/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
+++ b/src/libraries/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
@@ -11,6 +11,7 @@
     <Compile Include="ChannelTestBase.cs" />
     <Compile Include="ChannelTests.cs" />
     <Compile Include="DebugAttributeTests.cs" />
+    <Compile Include="RendezvousChannelTests.cs" />
     <Compile Include="Stress.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="UnboundedChannelTests.cs" />

--- a/src/libraries/System.Threading.Channels/tests/TestBase.cs
+++ b/src/libraries/System.Threading.Channels/tests/TestBase.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -10,6 +12,12 @@ namespace System.Threading.Channels.Tests
 {
     public abstract class TestBase
     {
+        public static IEnumerable<object[]> ThreeBools =>
+            from b1 in new[] { false, true }
+            from b2 in new[] { false, true }
+            from b3 in new[] { false, true }
+            select new object[] { b1, b2, b3 };
+
         protected void AssertSynchronouslyCanceled(Task task, CancellationToken token)
         {
             Assert.Equal(TaskStatus.Canceled, task.Status);


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/94046.

This PR enables Channel.CreateBounded(0), whereas currently a bound of < 1 is exceptional. A bound is the number of items the channel can buffer, so a bound of 0 means it can't buffer anything, which makes it into a rendezvous, where the reader and writer must be at the channel at the same time in order to directly hand off from the writer to the reader. This is the same meaning as in other languages/libraries, e.g. if in go you don't specify a bound or you specify a bound of 0, you similarly get an unbuffered rendezvous channel.