### PR TITLE
[WIP] Interpreter unsafe accessor tests

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1209,6 +1209,7 @@ InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
 
     if (InterpConfig.InterpDump().contains(compHnd, m_methodHnd, m_classHnd, &m_methodInfo->args))
         m_verbose = true;
+    // m_verbose = true;
 #endif
 }
 
@@ -1223,7 +1224,14 @@ InterpMethod* InterpCompiler::CompileMethod()
 
     CreateILVars();
 
-    GenerateCode(m_methodInfo);
+    int res = GenerateCode(m_methodInfo);
+    if (res != CORJIT_OK)
+    {
+        printf("Interpreter method compilation failed for ");
+        PrintMethodName(m_methodHnd);
+        printf("\n");
+        return nullptr;
+    }
 
 #ifdef DEBUG
     if (m_verbose)

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -79,6 +79,11 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
     InterpCompiler compiler(compHnd, methodInfo);
     InterpMethod *pMethod = compiler.CompileMethod();
 
+    if (!pMethod)
+    {
+        return CORJIT_BADCODE;
+    }
+
     int32_t IRCodeSize;
     int32_t *pIRCode = compiler.GetCode(&IRCodeSize);
 

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -20,6 +20,18 @@ InterleavedLoaderHeapConfig s_stubPrecodeHeapConfig;
 InterleavedLoaderHeapConfig s_fixupStubPrecodeHeapConfig;
 #endif
 
+void AssertThisIsNotInterpreterCode(PCODE code)
+{
+#ifdef FEATURE_INTERPRETER
+#ifndef DACCESS_COMPILE
+    EECodeInfo codeInfo(code);
+    if (!codeInfo.IsValid())
+        return;
+    _ASSERTE(codeInfo.GetCodeManager() != ExecutionManager::GetInterpreterCodeManager());
+#endif
+#endif
+}
+
 //==========================================================================================
 // class Precode
 //==========================================================================================

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -90,6 +90,8 @@ struct StubPrecodeData
                 // match the Type field.  This is a defense-in-depth measure (and only matters for access from the debugger)
 };
 
+void AssertThisIsNotInterpreterCode(PCODE code);
+
 typedef DPTR(StubPrecodeData) PTR_StubPrecodeData;
 
 #if !(defined(TARGET_ARM64) && defined(TARGET_UNIX))
@@ -208,6 +210,7 @@ struct StubPrecode
         CONTRACTL_END;
 
         StubPrecodeData *pData = GetData();
+        AssertThisIsNotInterpreterCode(target);
         return InterlockedCompareExchangeT<PCODE>(&pData->Target, (PCODE)target, (PCODE)expected) == expected;
     }
 
@@ -222,6 +225,7 @@ struct StubPrecode
         CONTRACTL_END;
 
         StubPrecodeData *pData = GetData();
+        AssertThisIsNotInterpreterCode(target);
         pData->Target = (PCODE)target;
     }
 
@@ -314,6 +318,7 @@ struct ThisPtrRetBufPrecode : StubPrecode
         CONTRACTL_END;
 
         ThisPtrRetBufPrecodeData *pData = GetData();
+        AssertThisIsNotInterpreterCode(target);
         return InterlockedCompareExchangeT<PCODE>(&pData->Target, (PCODE)target, (PCODE)expected) == expected;
     }
 
@@ -493,6 +498,7 @@ struct FixupPrecode
         }
 
         _ASSERTE(IS_ALIGNED(&GetData()->Target, sizeof(SIZE_T)));
+        AssertThisIsNotInterpreterCode(target);
         return InterlockedCompareExchangeT<PCODE>(&GetData()->Target, (PCODE)target, (PCODE)oldTarget) == (PCODE)oldTarget;
     }
 #endif


### PR DESCRIPTION
This PR attempts to add tests for unsafe accessor support in the interpreter. They appear to already work in certain scenarios, but not others, so I'm putting up this draft to make it easier for other people to see what's going on.

Changes in this PR:
* Add tests for unsafe field and method accessors.
* When method compilation fails, flow that out as `CORJIT_BADCODE` instead of `CORJIT_OK`.
* Assert when setting a precode target that it is not interpreted code. (Setting interpreted code as a precode target will just crash us later, it's never correct and indicates a bug elsewhere.)