### PR TITLE
Optimize Vector.Max codegen using AVX512

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -24262,8 +24262,9 @@ GenTree* Compiler::gtNewSimdMaxNode(
                                                                  simdBaseJitType, simdSize);
             GenTreeVecCon* tblVecCon1 = gtNewVconNode(type);
             GenTreeVecCon* tblVecCon2 = gtNewVconNode(type);
-            tblVecCon1->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, 0x1LL);
-            tblVecCon2->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, 0x1LL);
+            const int64_t  tblValue   = 0x1;
+            tblVecCon1->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, tblValue);
+            tblVecCon2->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, tblValue);
             NamedIntrinsic fixupIntrinsic = NI_AVX512_Fixup;
             GenTree*       fixup1         = gtNewSimdHWIntrinsicNode(type, op1Dup, op2Dup, tblVecCon1, gtNewIconNode(0),
                                                                      fixupIntrinsic, simdBaseJitType, simdSize);
@@ -24538,8 +24539,9 @@ GenTree* Compiler::gtNewSimdMinNode(
                                                                  simdBaseJitType, simdSize);
             GenTreeVecCon* tblVecCon1 = gtNewVconNode(type);
             GenTreeVecCon* tblVecCon2 = gtNewVconNode(type);
-            tblVecCon1->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, 0x1LL);
-            tblVecCon2->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, 0x1LL);
+            const int64_t  tblValue   = 0x1;
+            tblVecCon1->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, tblValue);
+            tblVecCon2->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, tblValue);
             NamedIntrinsic fixupIntrinsic = NI_AVX512_Fixup;
             GenTree*       fixup1         = gtNewSimdHWIntrinsicNode(type, op1Dup, op2Dup, tblVecCon1, gtNewIconNode(0),
                                                                      fixupIntrinsic, simdBaseJitType, simdSize);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -24532,6 +24532,54 @@ GenTree* Compiler::gtNewSimdMinNode(
             return gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x04), minMaxIntrinsic, simdBaseJitType,
                                             simdSize);
         }
+        if (IsBaselineVector512IsaSupportedOpportunistically())
+        {
+            // If AVX512 is supported, we can use vrangeps/vrangepd to correctly handle the Vector.Min(-0.0, 0.0) = -0.0
+            // case. We still need to check for NaN as vrangeps/vrangepd does not handle NaN as specified in IEEE 754
+            // 2019.
+            //
+            // This can be represented as the following managed code:
+            //      Vector128<float> range = Avx512DQ.VL.Range(op1, op2, 0x4);
+            //      Vector128<float> fixup1 = Avx512F.VL.Fixup(op1, op2, Vector128<int>.One, 0);
+            //      Vector128<float> fixup2 = Avx512F.VL.Fixup(range, fixup1, Vector128<int>.One, 0);
+            //      return fixup2;
+            //
+            // 0x4 is the control byte for vrangeps/vrangepd:
+            //      Imm8[1:0] = 00b : Select Min value
+            //      Imm8[3:2] = 01b : Select sign(Compare_Result)
+
+            GenTree*       op1Dup     = fgMakeMultiUse(&op1);
+            GenTree*       op2Dup     = fgMakeMultiUse(&op2);
+            GenTree*       rangeOp    = gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x4),
+                                                        simdSize == 64 ? NI_AVX512DQ_Range : NI_AVX512DQ_VL_Range,
+                                                                 simdBaseJitType, simdSize);
+            GenTreeVecCon* tblVecCon1 = gtNewVconNode(type);
+            GenTreeVecCon* tblVecCon2 = gtNewVconNode(type);
+
+            if (simdBaseType == TYP_FLOAT)
+            {
+                for (unsigned i = 0; i < (simdSize / sizeof(float)); i++)
+                {
+                    tblVecCon1->gtSimdVal.i32[i] = tblVecCon2->gtSimdVal.i32[i] = 0x1;
+                }
+            }
+            else
+            {
+                assert(simdBaseType == TYP_DOUBLE);
+                for (unsigned i = 0; i < (simdSize / sizeof(double)); i++)
+                {
+                    tblVecCon1->gtSimdVal.i64[i] = tblVecCon2->gtSimdVal.i64[i] = 0x1;
+                }
+            }
+
+            NamedIntrinsic fixupIntrinsic = simdSize == 64 ? NI_AVX512F_Fixup : NI_AVX512F_VL_Fixup;
+            GenTree*       fixup1         = gtNewSimdHWIntrinsicNode(type, op1Dup, op2Dup, tblVecCon1, gtNewIconNode(0),
+                                                                     fixupIntrinsic, simdBaseJitType, simdSize);
+            GenTree*       fixup2 = gtNewSimdHWIntrinsicNode(type, rangeOp, fixup1, tblVecCon2, gtNewIconNode(0),
+                                                             fixupIntrinsic, simdBaseJitType, simdSize);
+            return fixup2;
+        }
+
         GenTree* op1Dup1 = fgMakeMultiUse(&op1);
         GenTree* op1Dup2 = gtCloneExpr(op1Dup1);
         GenTree* op1Dup3 = gtCloneExpr(op1Dup2);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -24242,24 +24242,25 @@ GenTree* Compiler::gtNewSimdMaxNode(
         }
         if (IsBaselineVector512IsaSupportedOpportunistically())
         {
-            // If AVX512 is supported, we can use vrangeps/vrangepd to correctly handle the Vector.Max(-0.0, 0.0) = 0.0 case.
-            // We still need to check for NaN as vrangeps/vrangepd does not handle NaN as specified in IEEE 754 2019.
+            // If AVX512 is supported, we can use vrangeps/vrangepd to correctly handle the Vector.Max(-0.0, 0.0) = 0.0
+            // case. We still need to check for NaN as vrangeps/vrangepd does not handle NaN as specified in IEEE 754
+            // 2019.
             //
             // This can be represented as the following managed code:
             //      Vector128<float> range = Avx512DQ.VL.Range(op1, op2, 0x5);
             //      Vector128<float> fixup1 = Avx512F.VL.Fixup(op1, op2, Vector128<int>.One, 0);
             //      Vector128<float> fixup2 = Avx512F.VL.Fixup(range, fixup1, Vector128<int>.One, 0);
-            //      return fixup2
+            //      return fixup2;
             //
             // 0x5 is the control byte for vrangeps/vrangepd:
             //      Imm8[1:0] = 01b : Select Max value
             //      Imm8[3:2] = 01b : Select sign(Compare_Result)
 
-            GenTree* op1Dup     = fgMakeMultiUse(&op1);
-            GenTree* op2Dup     = fgMakeMultiUse(&op2);
-            GenTree* rangeOp    = gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x5),
+            GenTree*       op1Dup     = fgMakeMultiUse(&op1);
+            GenTree*       op2Dup     = fgMakeMultiUse(&op2);
+            GenTree*       rangeOp    = gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x5),
                                                         simdSize == 64 ? NI_AVX512DQ_Range : NI_AVX512DQ_VL_Range,
-                                                           simdBaseJitType, simdSize);
+                                                                 simdBaseJitType, simdSize);
             GenTreeVecCon* tblVecCon1 = gtNewVconNode(type);
             GenTreeVecCon* tblVecCon2 = gtNewVconNode(type);
 
@@ -24282,11 +24283,10 @@ GenTree* Compiler::gtNewSimdMaxNode(
             NamedIntrinsic fixupIntrinsic = simdSize == 64 ? NI_AVX512F_Fixup : NI_AVX512F_VL_Fixup;
             GenTree*       fixup1         = gtNewSimdHWIntrinsicNode(type, op1Dup, op2Dup, tblVecCon1, gtNewIconNode(0),
                                                                      fixupIntrinsic, simdBaseJitType, simdSize);
-            GenTree*       fixup2         = gtNewSimdHWIntrinsicNode(type, rangeOp, fixup1, tblVecCon2, gtNewIconNode(0),
-                                                                     fixupIntrinsic, simdBaseJitType, simdSize);
+            GenTree*       fixup2 = gtNewSimdHWIntrinsicNode(type, rangeOp, fixup1, tblVecCon2, gtNewIconNode(0),
+                                                             fixupIntrinsic, simdBaseJitType, simdSize);
             return fixup2;
         }
-
 
         GenTree* op1Dup1 = fgMakeMultiUse(&op1);
         GenTree* op1Dup2 = gtCloneExpr(op1Dup1);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -24240,7 +24240,7 @@ GenTree* Compiler::gtNewSimdMaxNode(
             return gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x05), minMaxIntrinsic, simdBaseJitType,
                                             simdSize);
         }
-        if (IsBaselineVector512IsaSupportedOpportunistically())
+        if (compOpportunisticallyDependsOn(InstructionSet_AVX512))
         {
             // If AVX512 is supported, we can use vrangeps/vrangepd to correctly handle the Vector.Max(-0.0, 0.0) = 0.0
             // case. We still need to check for NaN as vrangeps/vrangepd does not handle NaN as specified in IEEE 754
@@ -24258,29 +24258,13 @@ GenTree* Compiler::gtNewSimdMaxNode(
 
             GenTree*       op1Dup     = fgMakeMultiUse(&op1);
             GenTree*       op2Dup     = fgMakeMultiUse(&op2);
-            GenTree*       rangeOp    = gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x5),
-                                                        simdSize == 64 ? NI_AVX512DQ_Range : NI_AVX512DQ_VL_Range,
+            GenTree*       rangeOp    = gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x5), NI_AVX512_Range,
                                                                  simdBaseJitType, simdSize);
             GenTreeVecCon* tblVecCon1 = gtNewVconNode(type);
             GenTreeVecCon* tblVecCon2 = gtNewVconNode(type);
-
-            if (simdBaseType == TYP_FLOAT)
-            {
-                for (unsigned i = 0; i < (simdSize / sizeof(float)); i++)
-                {
-                    tblVecCon1->gtSimdVal.i32[i] = tblVecCon2->gtSimdVal.i32[i] = 0x1;
-                }
-            }
-            else
-            {
-                assert(simdBaseType == TYP_DOUBLE);
-                for (unsigned i = 0; i < (simdSize / sizeof(double)); i++)
-                {
-                    tblVecCon1->gtSimdVal.i64[i] = tblVecCon2->gtSimdVal.i64[i] = 0x1;
-                }
-            }
-
-            NamedIntrinsic fixupIntrinsic = simdSize == 64 ? NI_AVX512F_Fixup : NI_AVX512F_VL_Fixup;
+            tblVecCon1->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, 0x1LL);
+            tblVecCon2->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, 0x1LL);
+            NamedIntrinsic fixupIntrinsic = NI_AVX512_Fixup;
             GenTree*       fixup1         = gtNewSimdHWIntrinsicNode(type, op1Dup, op2Dup, tblVecCon1, gtNewIconNode(0),
                                                                      fixupIntrinsic, simdBaseJitType, simdSize);
             GenTree*       fixup2 = gtNewSimdHWIntrinsicNode(type, rangeOp, fixup1, tblVecCon2, gtNewIconNode(0),
@@ -24532,7 +24516,7 @@ GenTree* Compiler::gtNewSimdMinNode(
             return gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x04), minMaxIntrinsic, simdBaseJitType,
                                             simdSize);
         }
-        if (IsBaselineVector512IsaSupportedOpportunistically())
+        if (compOpportunisticallyDependsOn(InstructionSet_AVX512))
         {
             // If AVX512 is supported, we can use vrangeps/vrangepd to correctly handle the Vector.Min(-0.0, 0.0) = -0.0
             // case. We still need to check for NaN as vrangeps/vrangepd does not handle NaN as specified in IEEE 754
@@ -24550,29 +24534,13 @@ GenTree* Compiler::gtNewSimdMinNode(
 
             GenTree*       op1Dup     = fgMakeMultiUse(&op1);
             GenTree*       op2Dup     = fgMakeMultiUse(&op2);
-            GenTree*       rangeOp    = gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x4),
-                                                        simdSize == 64 ? NI_AVX512DQ_Range : NI_AVX512DQ_VL_Range,
+            GenTree*       rangeOp    = gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x4), NI_AVX512_Range,
                                                                  simdBaseJitType, simdSize);
             GenTreeVecCon* tblVecCon1 = gtNewVconNode(type);
             GenTreeVecCon* tblVecCon2 = gtNewVconNode(type);
-
-            if (simdBaseType == TYP_FLOAT)
-            {
-                for (unsigned i = 0; i < (simdSize / sizeof(float)); i++)
-                {
-                    tblVecCon1->gtSimdVal.i32[i] = tblVecCon2->gtSimdVal.i32[i] = 0x1;
-                }
-            }
-            else
-            {
-                assert(simdBaseType == TYP_DOUBLE);
-                for (unsigned i = 0; i < (simdSize / sizeof(double)); i++)
-                {
-                    tblVecCon1->gtSimdVal.i64[i] = tblVecCon2->gtSimdVal.i64[i] = 0x1;
-                }
-            }
-
-            NamedIntrinsic fixupIntrinsic = simdSize == 64 ? NI_AVX512F_Fixup : NI_AVX512F_VL_Fixup;
+            tblVecCon1->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, 0x1LL);
+            tblVecCon2->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG, 0x1LL);
+            NamedIntrinsic fixupIntrinsic = NI_AVX512_Fixup;
             GenTree*       fixup1         = gtNewSimdHWIntrinsicNode(type, op1Dup, op2Dup, tblVecCon1, gtNewIconNode(0),
                                                                      fixupIntrinsic, simdBaseJitType, simdSize);
             GenTree*       fixup2 = gtNewSimdHWIntrinsicNode(type, rangeOp, fixup1, tblVecCon2, gtNewIconNode(0),

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -24246,29 +24246,28 @@ GenTree* Compiler::gtNewSimdMaxNode(
             // We still need to check for NaN as vrangeps/vrangepd does not handle NaN as specified in IEEE 754 2019.
             //
             // This can be represented as the following managed code:
-            //      Vector128<float> nanMask = Vector128.IsNaN(op1) | Vector128.IsNaN(op2);
-            //      Vector128<float> rangeResult = Avx512DQ.VL.Range(op1, op2, 0x5);
-            //      return Vector128.ConditionalSelect(nanMask, Vector128.Create(float.NaN), rangeResult);
+            //      Vector128<float> range = Avx512DQ.VL.Range(op1, op2, 0x5);
+            //      Vector128<float> fixup1 = Avx512F.VL.Fixup(op1, op2, Vector128<int>.One, 0);
+            //      Vector128<float> fixup2 = Avx512F.VL.Fixup(range, fixup1, Vector128<int>.One, 0);
+            //      return fixup2
             //
-            // 0x5 is the control byte:
+            // 0x5 is the control byte for vrangeps/vrangepd:
             //      Imm8[1:0] = 01b : Select Max value
             //      Imm8[3:2] = 01b : Select sign(Compare_Result)
 
-            GenTree* op1Dup1    = fgMakeMultiUse(&op1);
-            GenTree* op2Dup1    = fgMakeMultiUse(&op2);
-            GenTree* op1NaNMask = gtNewSimdIsNaNNode(type, op1, simdBaseJitType, simdSize);
-            GenTree* op2NaNMask = gtNewSimdIsNaNNode(type, op2, simdBaseJitType, simdSize);
-            GenTree* nanMask    = gtNewSimdBinOpNode(GT_OR, type, op1NaNMask, op2NaNMask, simdBaseJitType, simdSize);
-            GenTree* rangeOp    = gtNewSimdHWIntrinsicNode(type, op1Dup1, op2Dup1, gtNewIconNode(0x5),
+            GenTree* op1Dup     = fgMakeMultiUse(&op1);
+            GenTree* op2Dup     = fgMakeMultiUse(&op2);
+            GenTree* rangeOp    = gtNewSimdHWIntrinsicNode(type, op1, op2, gtNewIconNode(0x5),
                                                         simdSize == 64 ? NI_AVX512DQ_Range : NI_AVX512DQ_VL_Range,
                                                            simdBaseJitType, simdSize);
-            GenTreeVecCon* vecCon = gtNewVconNode(type);
+            GenTreeVecCon* tblVecCon1 = gtNewVconNode(type);
+            GenTreeVecCon* tblVecCon2 = gtNewVconNode(type);
 
             if (simdBaseType == TYP_FLOAT)
             {
                 for (unsigned i = 0; i < (simdSize / sizeof(float)); i++)
                 {
-                    vecCon->gtSimdVal.f32[i] = nanf("");
+                    tblVecCon1->gtSimdVal.i32[i] = tblVecCon2->gtSimdVal.i32[i] = 0x1;
                 }
             }
             else
@@ -24276,10 +24275,16 @@ GenTree* Compiler::gtNewSimdMaxNode(
                 assert(simdBaseType == TYP_DOUBLE);
                 for (unsigned i = 0; i < (simdSize / sizeof(double)); i++)
                 {
-                    vecCon->gtSimdVal.f64[i] = nan("");
+                    tblVecCon1->gtSimdVal.i64[i] = tblVecCon2->gtSimdVal.i64[i] = 0x1;
                 }
             }
-            return gtNewSimdCndSelNode(type, nanMask, vecCon, rangeOp, simdBaseJitType, simdSize);
+
+            NamedIntrinsic fixupIntrinsic = simdSize == 64 ? NI_AVX512F_Fixup : NI_AVX512F_VL_Fixup;
+            GenTree*       fixup1         = gtNewSimdHWIntrinsicNode(type, op1Dup, op2Dup, tblVecCon1, gtNewIconNode(0),
+                                                                     fixupIntrinsic, simdBaseJitType, simdSize);
+            GenTree*       fixup2         = gtNewSimdHWIntrinsicNode(type, rangeOp, fixup1, tblVecCon2, gtNewIconNode(0),
+                                                                     fixupIntrinsic, simdBaseJitType, simdSize);
+            return fixup2;
         }
 
 


### PR DESCRIPTION
This PR optimizes the codegen for `Vector128/256/512.Max` and `Vector128/256/512.Min` when AVX512 is supported. The new codegen emitted is the same pattern as the scalar codegen for `Math.Max`/`Math.Min`.


<details>

<summary>Scalar version + codegen</summary>

```csharp
public double ScalarMax(double x, double y) {
        return Math.Max(x,y);
}

public double ScalarMin(double x, double y) {
        return Math.Min(x,y);
}
```

```
C.ScalarMax(Double, Double)
    L0000: vrangesd xmm0, xmm1, xmm2, 5
    L0007: vmovups xmm3, [0x7ffcb40e0060]
    L000f: vfixupimmsd xmm1, xmm2, xmm3, 0
    L0016: vfixupimmsd xmm0, xmm1, xmm3, 0
    L001d: ret
```

```
C.ScalarMin(Double, Double)
    L0000: vrangesd xmm0, xmm1, xmm2, 4
    L0007: vmovups xmm3, [0x7ffcb40e0060]
    L000f: vfixupimmsd xmm1, xmm2, xmm3, 0
    L0016: vfixupimmsd xmm0, xmm1, xmm3, 0
    L001d: ret
```

</details>

<details>

<summary>Vector Max version + codegen</summary>

```
public Vector128<double> VectorMax(Vector128<double> x, Vector128<double> y) {
        return Vector128.Max(x, y);
}
```

Codegen (before):
```
       vmovups   xmm0,[r8]
       vmovups   xmm1,[r9]
       vcmpeqpd  xmm2,xmm1,xmm0
       vxorps    xmm3,xmm3,xmm3
       vpcmpgtq  xmm3,xmm3,xmm1
       vcmpneqpd xmm4,xmm0,xmm0
       vpternlogq xmm4,xmm3,xmm2,0F8
       vcmpltpd  xmm2,xmm1,xmm0
       vorpd     xmm2,xmm2,xmm4
       vpternlogq xmm2,xmm1,xmm0,0AC
       vmovups   [rdx],xmm2
       mov       rax,rdx
       ret
```

Codegen (after):
```
       vmovups   xmm0,[r8]
       vmovups   xmm1,[r9]
       vrangepd  xmm2,xmm0,xmm1,5
       vmovddup  xmm3,qword ptr [7FFA5DFC3030]
       vfixupimmpd xmm0,xmm1,xmm3,0
       vfixupimmpd xmm2,xmm0,xmm3,0
       vmovups   [rdx],xmm2
       mov       rax,rdx
       ret
```

</details>

<details>

<summary>Vector Min version + codegen</summary>

```
public Vector128<double> VectorMin(Vector128<double> x, Vector128<double> y) {
        return Vector128.Min(x, y);
}
```

Codegen (before):
```
       vmovups   xmm0,[r8]
       vmovups   xmm1,[r9]
       vcmpeqpd  xmm2,xmm1,xmm0
       vxorps    xmm3,xmm3,xmm3
       vpcmpgtq  xmm3,xmm3,xmm0
       vcmpneqpd xmm4,xmm0,xmm0
       vpternlogq xmm4,xmm3,xmm2,0F8
       vcmpltpd  xmm2,xmm0,xmm1
       vorpd     xmm2,xmm2,xmm4
       vpternlogq xmm2,xmm1,xmm0,0AC
       vmovups   [rdx],xmm2
       mov       rax,rdx
       ret
```

Codegen (after):
```
       vmovups   xmm0,[r8]
       vmovups   xmm1,[r9]
       vrangepd  xmm2,xmm0,xmm1,4
       vmovddup  xmm3,qword ptr [7FFA82BD3030]
       vfixupimmpd xmm0,xmm1,xmm3,0
       vfixupimmpd xmm2,xmm0,xmm3,0
       vmovups   [rdx],xmm2
       mov       rax,rdx
       ret
```

</details>


<details>

<summary>Performance</summary>

These are the existing Max microbenchmarks for System.Numerics.Tensors:

```
| Type                                | Method     | Job        | Toolchain                              | BufferLength | Mean       | Error      | StdDev     | Median     | Min        | Max        | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------------------------ |----------- |----------- |--------------------------------------- |------------- |-----------:|-----------:|-----------:|-----------:|-----------:|-----------:|------:|--------:|----------:|------------:|
| Perf_NumberTensorPrimitives<Double> | Max_Vector | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 128          |  23.580 ns |  0.4058 ns |  0.3597 ns |  23.672 ns |  22.363 ns |  23.797 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Max_Vector | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 128          |  15.917 ns |  0.0598 ns |  0.0530 ns |  15.912 ns |  15.797 ns |  16.002 ns |  0.68 |    0.01 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Max_Vector | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 128          |  13.422 ns |  0.1850 ns |  0.1731 ns |  13.425 ns |  13.119 ns |  13.691 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Max_Vector | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 128          |   9.448 ns |  0.1728 ns |  0.1617 ns |   9.427 ns |   9.265 ns |   9.781 ns |  0.70 |    0.01 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Max_Scalar | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 128          |  17.686 ns |  0.2818 ns |  0.2498 ns |  17.797 ns |  17.083 ns |  17.856 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Max_Scalar | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 128          |  10.053 ns |  0.0393 ns |  0.0368 ns |  10.060 ns |   9.986 ns |  10.117 ns |  0.57 |    0.01 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Max_Scalar | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 128          |  10.899 ns |  0.1788 ns |  0.1493 ns |  10.944 ns |  10.412 ns |  10.995 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Max_Scalar | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 128          |   6.588 ns |  0.0550 ns |  0.0515 ns |   6.576 ns |   6.492 ns |   6.664 ns |  0.60 |    0.01 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Max        | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 128          |  39.597 ns |  0.3459 ns |  0.3236 ns |  39.617 ns |  38.713 ns |  40.068 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Max        | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 128          |  20.630 ns |  0.0695 ns |  0.0616 ns |  20.622 ns |  20.556 ns |  20.759 ns |  0.52 |    0.00 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Max        | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 128          |  23.512 ns |  0.0944 ns |  0.0883 ns |  23.520 ns |  23.288 ns |  23.653 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Max        | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 128          |  11.249 ns |  0.1301 ns |  0.1217 ns |  11.295 ns |  10.971 ns |  11.385 ns |  0.48 |    0.01 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Max_Vector | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 3079         | 549.776 ns |  3.1703 ns |  2.9655 ns | 550.484 ns | 544.151 ns | 553.314 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Max_Vector | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 3079         | 441.097 ns |  1.1802 ns |  1.1039 ns | 441.030 ns | 439.368 ns | 442.973 ns |  0.80 |    0.00 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Max_Vector | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 3079         | 335.473 ns |  4.3674 ns |  4.0853 ns | 336.539 ns | 324.981 ns | 339.704 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Max_Vector | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 3079         | 183.924 ns |  0.3314 ns |  0.2938 ns | 183.908 ns | 183.439 ns | 184.449 ns |  0.55 |    0.01 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Max_Scalar | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 3079         | 376.094 ns |  1.9991 ns |  1.8700 ns | 376.419 ns | 370.356 ns | 378.039 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Max_Scalar | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 3079         | 303.696 ns |  1.1710 ns |  1.0954 ns | 303.673 ns | 302.163 ns | 305.591 ns |  0.81 |    0.00 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Max_Scalar | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 3079         | 177.732 ns |  0.6656 ns |  0.5558 ns | 177.806 ns | 176.879 ns | 178.902 ns |  1.00 |    0.00 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Max_Scalar | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 3079         | 107.079 ns |  0.3884 ns |  0.3443 ns | 107.008 ns | 106.533 ns | 107.741 ns |  0.60 |    0.00 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Max        | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 3079         | 902.804 ns | 16.9216 ns | 16.6193 ns | 907.864 ns | 848.689 ns | 921.769 ns |  1.00 |    0.03 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Max        | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 3079         | 513.187 ns |  2.4330 ns |  2.2758 ns | 513.181 ns | 510.050 ns | 517.755 ns |  0.57 |    0.01 |         - |          NA |
|                                     |            |            |                                        |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Max        | Job-DWINXP | \core_roots\base\Core_Root\corerun.exe | 3079         | 461.626 ns |  3.2858 ns |  3.0735 ns | 462.374 ns | 453.206 ns | 465.063 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Max        | Job-OMRYDZ | \core_roots\diff\Core_Root\corerun.exe | 3079         | 253.227 ns |  1.0693 ns |  1.0003 ns | 253.197 ns | 251.372 ns | 254.555 ns |  0.55 |    0.00 |         - |          NA |
```

There were not any equivalent Min benchmarks, so I copied the existing Max microbenchmarks and modified them to use Min:

```
| Type                                | Method     | Job        | Toolchain                   | BufferLength | Mean       | Error      | StdDev     | Median     | Min        | Max        | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------------------------ |----------- |----------- |---------------------------- |------------- |-----------:|-----------:|-----------:|-----------:|-----------:|-----------:|------:|--------:|----------:|------------:|
| Perf_NumberTensorPrimitives<Double> | Min_Vector | Job-YYSURG | \base\Core_Root\corerun.exe | 128          |  23.971 ns |  0.3589 ns |  0.3357 ns |  23.974 ns |  23.420 ns |  24.539 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Min_Vector | Job-GRFSHG | \diff\Core_Root\corerun.exe | 128          |  15.898 ns |  0.0416 ns |  0.0369 ns |  15.893 ns |  15.842 ns |  15.971 ns |  0.66 |    0.01 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Min_Vector | Job-YYSURG | \base\Core_Root\corerun.exe | 128          |  13.124 ns |  0.2579 ns |  0.2760 ns |  13.154 ns |  12.374 ns |  13.467 ns |  1.00 |    0.03 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Min_Vector | Job-GRFSHG | \diff\Core_Root\corerun.exe | 128          |  10.937 ns |  0.1407 ns |  0.1098 ns |  10.954 ns |  10.745 ns |  11.098 ns |  0.83 |    0.02 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Min_Scalar | Job-YYSURG | \base\Core_Root\corerun.exe | 128          |  23.141 ns |  0.2489 ns |  0.2328 ns |  23.107 ns |  22.706 ns |  23.552 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Min_Scalar | Job-GRFSHG | \diff\Core_Root\corerun.exe | 128          |  10.044 ns |  0.0248 ns |  0.0232 ns |  10.047 ns |   9.991 ns |  10.087 ns |  0.43 |    0.00 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Min_Scalar | Job-YYSURG | \base\Core_Root\corerun.exe | 128          |  12.241 ns |  0.1603 ns |  0.1500 ns |  12.287 ns |  11.919 ns |  12.462 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Min_Scalar | Job-GRFSHG | \diff\Core_Root\corerun.exe | 128          |   8.802 ns |  0.1085 ns |  0.0962 ns |   8.790 ns |   8.689 ns |   8.994 ns |  0.72 |    0.01 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Min        | Job-YYSURG | \base\Core_Root\corerun.exe | 128          |  41.013 ns |  0.6195 ns |  0.5173 ns |  40.804 ns |  40.420 ns |  41.904 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Min        | Job-GRFSHG | \diff\Core_Root\corerun.exe | 128          |  21.078 ns |  0.0973 ns |  0.0910 ns |  21.072 ns |  20.925 ns |  21.260 ns |  0.51 |    0.01 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Min        | Job-YYSURG | \base\Core_Root\corerun.exe | 128          |  23.518 ns |  0.2475 ns |  0.2315 ns |  23.578 ns |  23.127 ns |  23.825 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Min        | Job-GRFSHG | \diff\Core_Root\corerun.exe | 128          |  11.097 ns |  0.0823 ns |  0.0770 ns |  11.095 ns |  10.989 ns |  11.230 ns |  0.47 |    0.01 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Min_Vector | Job-YYSURG | \base\Core_Root\corerun.exe | 3079         | 545.986 ns |  6.8797 ns |  6.4353 ns | 547.852 ns | 527.453 ns | 551.870 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Min_Vector | Job-GRFSHG | \diff\Core_Root\corerun.exe | 3079         | 444.900 ns |  1.2448 ns |  1.1035 ns | 444.832 ns | 443.414 ns | 447.291 ns |  0.81 |    0.01 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Min_Vector | Job-YYSURG | \base\Core_Root\corerun.exe | 3079         | 340.412 ns |  2.4956 ns |  2.2123 ns | 340.250 ns | 336.724 ns | 344.329 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Min_Vector | Job-GRFSHG | \diff\Core_Root\corerun.exe | 3079         | 186.607 ns |  1.1039 ns |  0.9218 ns | 186.543 ns | 185.290 ns | 188.812 ns |  0.55 |    0.00 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Min_Scalar | Job-YYSURG | \base\Core_Root\corerun.exe | 3079         | 456.055 ns |  3.7783 ns |  3.5343 ns | 456.857 ns | 449.796 ns | 461.236 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Min_Scalar | Job-GRFSHG | \diff\Core_Root\corerun.exe | 3079         | 304.747 ns |  1.1251 ns |  0.8784 ns | 304.872 ns | 303.667 ns | 305.891 ns |  0.67 |    0.01 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Min_Scalar | Job-YYSURG | \base\Core_Root\corerun.exe | 3079         | 221.380 ns |  1.2605 ns |  1.1791 ns | 221.479 ns | 218.182 ns | 222.767 ns |  1.00 |    0.01 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Min_Scalar | Job-GRFSHG | \diff\Core_Root\corerun.exe | 3079         | 109.071 ns |  0.3560 ns |  0.3330 ns | 109.008 ns | 108.410 ns | 109.616 ns |  0.49 |    0.00 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Double> | Min        | Job-YYSURG | \base\Core_Root\corerun.exe | 3079         | 975.787 ns | 12.1159 ns | 10.7404 ns | 980.540 ns | 948.919 ns | 985.321 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Double> | Min        | Job-GRFSHG | \diff\Core_Root\corerun.exe | 3079         | 519.316 ns |  4.3723 ns |  3.8760 ns | 520.750 ns | 511.615 ns | 524.735 ns |  0.53 |    0.01 |         - |          NA |
|                                     |            |            |                             |              |            |            |            |            |            |            |       |         |           |             |
| Perf_NumberTensorPrimitives<Single> | Min        | Job-YYSURG | \base\Core_Root\corerun.exe | 3079         | 488.570 ns |  7.7281 ns |  7.2289 ns | 484.997 ns | 475.244 ns | 499.179 ns |  1.00 |    0.02 |         - |          NA |
| Perf_NumberTensorPrimitives<Single> | Min        | Job-GRFSHG | \diff\Core_Root\corerun.exe | 3079         | 253.116 ns |  1.0311 ns |  0.9141 ns | 252.851 ns | 252.003 ns | 254.950 ns |  0.52 |    0.01 |         - |          NA |
```

</details>