### PR TITLE
Replace readdir_r call in TimeZoneInfo.Unix

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Enumeration;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
 using Microsoft.Win32.SafeHandles;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
@@ -1,12 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.InteropServices;
+using System.IO.Enumeration;
 using System.Security;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
@@ -271,102 +270,6 @@ namespace System
             return Path.Join(currentPath.AsSpan(), direntName);
         }
 
-        /// <summary>
-        /// Enumerate files
-        /// </summary>
-        private static unsafe void EnumerateFilesRecursively(string path, Predicate<string> condition)
-        {
-            List<string>? toExplore = null; // List used as a stack
-
-            int bufferSize = Interop.Sys.GetReadDirRBufferSize();
-            byte[] dirBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
-            try
-            {
-                string currentPath = path;
-
-                fixed (byte* dirBufferPtr = dirBuffer)
-                {
-                    while (true)
-                    {
-                        IntPtr dirHandle = Interop.Sys.OpenDir(currentPath);
-                        if (dirHandle == IntPtr.Zero)
-                        {
-                            throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo(), currentPath, isDirError: true);
-                        }
-
-                        try
-                        {
-                            // Read each entry from the enumerator
-                            Interop.Sys.DirectoryEntry dirent;
-                            while (Interop.Sys.ReadDirR(dirHandle, dirBufferPtr, bufferSize, &dirent) == 0)
-                            {
-                                string? fullPath = GetDirectoryEntryFullPath(ref dirent, currentPath);
-                                if (fullPath == null)
-                                    continue;
-
-                                // Get from the dir entry whether the entry is a file or directory.
-                                // We classify everything as a file unless we know it to be a directory.
-                                bool isDir;
-                                if (dirent.InodeType == Interop.Sys.NodeType.DT_DIR)
-                                {
-                                    // We know it's a directory.
-                                    isDir = true;
-                                }
-                                else if (dirent.InodeType == Interop.Sys.NodeType.DT_LNK || dirent.InodeType == Interop.Sys.NodeType.DT_UNKNOWN)
-                                {
-                                    // It's a symlink or unknown: stat to it to see if we can resolve it to a directory.
-                                    // If we can't (e.g. symlink to a file, broken symlink, etc.), we'll just treat it as a file.
-
-                                    Interop.Sys.FileStatus fileinfo;
-                                    if (Interop.Sys.Stat(fullPath, out fileinfo) >= 0)
-                                    {
-                                        isDir = (fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
-                                    }
-                                    else
-                                    {
-                                        isDir = false;
-                                    }
-                                }
-                                else
-                                {
-                                    // Otherwise, treat it as a file.  This includes regular files, FIFOs, etc.
-                                    isDir = false;
-                                }
-
-                                // Yield the result if the user has asked for it.  In the case of directories,
-                                // always explore it by pushing it onto the stack, regardless of whether
-                                // we're returning directories.
-                                if (isDir)
-                                {
-                                    toExplore ??= new List<string>();
-                                    toExplore.Add(fullPath);
-                                }
-                                else if (condition(fullPath))
-                                {
-                                    return;
-                                }
-                            }
-                        }
-                        finally
-                        {
-                            if (dirHandle != IntPtr.Zero)
-                                Interop.Sys.CloseDir(dirHandle);
-                        }
-
-                        if (toExplore == null || toExplore.Count == 0)
-                            break;
-
-                        currentPath = toExplore[toExplore.Count - 1];
-                        toExplore.RemoveAt(toExplore.Count - 1);
-                    }
-                }
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(dirBuffer);
-            }
-        }
-
         private static bool CompareTimeZoneFile(string filePath, byte[] buffer, byte[] rawData)
         {
             try
@@ -424,7 +327,12 @@ namespace System
 
             try
             {
-                EnumerateFilesRecursively(timeZoneDirectory, (string filePath) =>
+                var timeZoneDirectoryEnumerable = new FileSystemEnumerable<string>(
+                    timeZoneDirectory,
+                    transform: (ref entry) => entry.ToSpecifiedFullPath(),
+                    new EnumerationOptions { RecurseSubdirectories = true });
+
+                foreach (string filePath in timeZoneDirectoryEnumerable)
                 {
                     // skip the localtime and posixrules file, since they won't give us the correct id
                     if (!string.Equals(filePath, localtimeFilePath, StringComparison.OrdinalIgnoreCase)
@@ -440,11 +348,11 @@ namespace System
                             {
                                 id = id.Substring(timeZoneDirectory.Length);
                             }
-                            return true;
+
+                            break;
                         }
                     }
-                    return false;
-                });
+                }
             }
             catch (IOException) { }
             catch (SecurityException) { }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
@@ -328,12 +328,7 @@ namespace System
 
             try
             {
-                var timeZoneDirectoryEnumerable = new FileSystemEnumerable<string>(
-                    timeZoneDirectory,
-                    transform: (ref entry) => entry.ToSpecifiedFullPath(),
-                    new EnumerationOptions { RecurseSubdirectories = true });
-
-                foreach (string filePath in timeZoneDirectoryEnumerable)
+                foreach (string filePath in Directory.EnumerateFiles(timeZoneDirectory, "*", SearchOption.AllDirectories))
                 {
                     // skip the localtime and posixrules file, since they won't give us the correct id
                     if (!string.Equals(filePath, localtimeFilePath, StringComparison.OrdinalIgnoreCase)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.Common.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.Common.cs
@@ -42,7 +42,6 @@ namespace System.Tests
         private static string s_strFiji = s_isWindows ? "Fiji Standard Time" : "Pacific/Fiji";
 
         private static TimeZoneInfo s_myUtc = TimeZoneInfo.Utc;
-        private static TimeZoneInfo s_myLocal = TimeZoneInfo.Local;
 
         [Fact]
         public static void Kind()

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2159,7 +2159,7 @@ namespace System.Tests
             }
         }
 
-        private static byte[] timeZoneFileContents = new byte[]
+        private static byte[] s_timeZoneFileContents = new byte[]
         {
             //
             // Start of v1 Header
@@ -2274,7 +2274,7 @@ namespace System.Tests
             string zoneFilePath = Path.GetTempPath() + Path.GetRandomFileName();
             using (FileStream fs = new FileStream(zoneFilePath, FileMode.Create))
             {
-                fs.Write(timeZoneFileContents.AsSpan());
+                fs.Write(s_timeZoneFileContents.AsSpan());
 
                 // Append the POSIX rule
                 fs.WriteByte(0x0A);
@@ -2314,6 +2314,31 @@ namespace System.Tests
             {
                 try { File.Delete(zoneFilePath); } catch { } // don't fail the test if we couldn't delete the file.
             }
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public static void ArbitraryTZ_UsedAsLocal()
+        {
+            const string tzId = "America/Monterrey";
+            const string tzPath = "/usr/share/zoneinfo/" + tzId;
+
+            if (!File.Exists(tzPath))
+            {
+                throw new SkipTestException($"The file {tzPath} does not exist.");
+            }
+            
+            RemoteExecutor.Invoke(() =>
+            {
+                string tmp = Path.GetTempPath() + Path.GetRandomFileName();
+                File.WriteAllBytes(tmp, File.ReadAllBytes(tzPath));
+
+                Environment.SetEnvironmentVariable("TZ", tmp);
+                TimeZoneInfo tzi = TimeZoneInfo.GetSystemTimeZones().FirstOrDefault(t => t.Id == tzId);
+
+                Assert.NotNull(tzi);
+                Assert.Equal(tzi.Id, TimeZoneInfo.Local.Id);
+            }).Dispose();
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]


### PR DESCRIPTION
Found this while investigating something else.  It's possible System.IO was not initially used because the assembly was just folded into System.PrivateCoreLib (https://github.com/dotnet/runtime/pull/53231) when the change to TimeZoneInfo was made https://github.com/dotnet/runtime/commit/46d9b317a7829489ca89fc34f0e7c17a7bdb850b.