### PR TITLE
JIT: Use flowgraph annotations to scale loop blocks in `optSetBlockWeights`

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -497,7 +497,6 @@ void BasicBlock::dspFlags() const
         {BBF_DONT_REMOVE, "keep"},
         {BBF_INTERNAL, "internal"},
         {BBF_HAS_SUPPRESSGC_CALL, "sup-gc"},
-        {BBF_LOOP_HEAD, "loophead"},
         {BBF_HAS_LABEL, "label"},
         {BBF_HAS_JMP, "jmp"},
         {BBF_HAS_CALL, "hascall"},

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -431,50 +431,49 @@ enum BasicBlockFlags : uint64_t
     BBF_HAS_NULLCHECK        = MAKE_BBFLAG( 9), // BB contains a null check
     BBF_HAS_SUPPRESSGC_CALL  = MAKE_BBFLAG(10), // BB contains a call to a method with SuppressGCTransitionAttribute
     BBF_RUN_RARELY           = MAKE_BBFLAG(11), // BB is rarely run (catch clauses, blocks with throws etc)
-    BBF_LOOP_HEAD            = MAKE_BBFLAG(12), // BB is the head of a loop (can reach a predecessor)
-    BBF_HAS_LABEL            = MAKE_BBFLAG(13), // BB needs a label
-    BBF_LOOP_ALIGN           = MAKE_BBFLAG(14), // Block is lexically the first block in a loop we intend to align.
-    BBF_HAS_ALIGN            = MAKE_BBFLAG(15), // BB ends with 'align' instruction
-    BBF_HAS_JMP              = MAKE_BBFLAG(16), // BB executes a JMP instruction (instead of return)
-    BBF_GC_SAFE_POINT        = MAKE_BBFLAG(17), // BB has a GC safe point (e.g. a call)
-    BBF_HAS_IDX_LEN          = MAKE_BBFLAG(18), // BB contains simple index or length expressions on an SD array local var.
-    BBF_HAS_MD_IDX_LEN       = MAKE_BBFLAG(19), // BB contains simple index, length, or lower bound expressions on an MD array local var.
-    BBF_HAS_MDARRAYREF       = MAKE_BBFLAG(20), // Block has a multi-dimensional array reference
-    BBF_HAS_NEWOBJ           = MAKE_BBFLAG(21), // BB contains 'new' of an object type.
+    BBF_HAS_LABEL            = MAKE_BBFLAG(12), // BB needs a label
+    BBF_LOOP_ALIGN           = MAKE_BBFLAG(13), // Block is lexically the first block in a loop we intend to align.
+    BBF_HAS_ALIGN            = MAKE_BBFLAG(14), // BB ends with 'align' instruction
+    BBF_HAS_JMP              = MAKE_BBFLAG(15), // BB executes a JMP instruction (instead of return)
+    BBF_GC_SAFE_POINT        = MAKE_BBFLAG(16), // BB has a GC safe point (e.g. a call)
+    BBF_HAS_IDX_LEN          = MAKE_BBFLAG(17), // BB contains simple index or length expressions on an SD array local var.
+    BBF_HAS_MD_IDX_LEN       = MAKE_BBFLAG(18), // BB contains simple index, length, or lower bound expressions on an MD array local var.
+    BBF_HAS_MDARRAYREF       = MAKE_BBFLAG(19), // Block has a multi-dimensional array reference
+    BBF_HAS_NEWOBJ           = MAKE_BBFLAG(20), // BB contains 'new' of an object type.
 
-    BBF_RETLESS_CALL                   = MAKE_BBFLAG(22), // BBJ_CALLFINALLY that will never return (and therefore, won't need a paired
+    BBF_RETLESS_CALL                   = MAKE_BBFLAG(21), // BBJ_CALLFINALLY that will never return (and therefore, won't need a paired
                                                           // BBJ_CALLFINALLYRET); see isBBCallFinallyPair().
-    BBF_COLD                           = MAKE_BBFLAG(23), // BB is cold
-    BBF_PROF_WEIGHT                    = MAKE_BBFLAG(24), // BB weight is computed from profile data
-    BBF_KEEP_BBJ_ALWAYS                = MAKE_BBFLAG(25), // A special BBJ_ALWAYS block, used by EH code generation. Keep the jump kind
+    BBF_COLD                           = MAKE_BBFLAG(22), // BB is cold
+    BBF_PROF_WEIGHT                    = MAKE_BBFLAG(23), // BB weight is computed from profile data
+    BBF_KEEP_BBJ_ALWAYS                = MAKE_BBFLAG(24), // A special BBJ_ALWAYS block, used by EH code generation. Keep the jump kind
                                                           // as BBJ_ALWAYS. Used on x86 for the final step block out of a finally.
-    BBF_HAS_CALL                       = MAKE_BBFLAG(26), // BB contains a call
-    BBF_DOMINATED_BY_EXCEPTIONAL_ENTRY = MAKE_BBFLAG(27), // Block is dominated by exceptional entry.
-    BBF_BACKWARD_JUMP                  = MAKE_BBFLAG(28), // BB is surrounded by a backward jump/switch arc
-    BBF_BACKWARD_JUMP_SOURCE           = MAKE_BBFLAG(29), // Block is a source of a backward jump
-    BBF_BACKWARD_JUMP_TARGET           = MAKE_BBFLAG(30), // Block is a target of a backward jump
-    BBF_PATCHPOINT                     = MAKE_BBFLAG(31), // Block is a patchpoint
-    BBF_PARTIAL_COMPILATION_PATCHPOINT = MAKE_BBFLAG(32), // Block is a partial compilation patchpoint
-    BBF_HAS_HISTOGRAM_PROFILE          = MAKE_BBFLAG(33), // BB contains a call needing a histogram profile
-    BBF_TAILCALL_SUCCESSOR             = MAKE_BBFLAG(34), // BB has pred that has potential tail call
-    BBF_RECURSIVE_TAILCALL             = MAKE_BBFLAG(35), // Block has recursive tailcall that may turn into a loop
-    BBF_NO_CSE_IN                      = MAKE_BBFLAG(36), // Block should kill off any incoming CSE
-    BBF_CAN_ADD_PRED                   = MAKE_BBFLAG(37), // Ok to add pred edge to this block, even when "safe" edge creation disabled
-    BBF_HAS_VALUE_PROFILE              = MAKE_BBFLAG(38), // Block has a node that needs a value probing
-    BBF_HAS_NEWARR                     = MAKE_BBFLAG(39), // BB contains 'new' of an array type.
-    BBF_MAY_HAVE_BOUNDS_CHECKS         = MAKE_BBFLAG(40), // BB *likely* has a bounds check (after rangecheck phase).
-    BBF_ASYNC_RESUMPTION               = MAKE_BBFLAG(41), // Block is a resumption block in an async method
+    BBF_HAS_CALL                       = MAKE_BBFLAG(25), // BB contains a call
+    BBF_DOMINATED_BY_EXCEPTIONAL_ENTRY = MAKE_BBFLAG(26), // Block is dominated by exceptional entry.
+    BBF_BACKWARD_JUMP                  = MAKE_BBFLAG(27), // BB is surrounded by a backward jump/switch arc
+    BBF_BACKWARD_JUMP_SOURCE           = MAKE_BBFLAG(28), // Block is a source of a backward jump
+    BBF_BACKWARD_JUMP_TARGET           = MAKE_BBFLAG(29), // Block is a target of a backward jump
+    BBF_PATCHPOINT                     = MAKE_BBFLAG(30), // Block is a patchpoint
+    BBF_PARTIAL_COMPILATION_PATCHPOINT = MAKE_BBFLAG(31), // Block is a partial compilation patchpoint
+    BBF_HAS_HISTOGRAM_PROFILE          = MAKE_BBFLAG(32), // BB contains a call needing a histogram profile
+    BBF_TAILCALL_SUCCESSOR             = MAKE_BBFLAG(33), // BB has pred that has potential tail call
+    BBF_RECURSIVE_TAILCALL             = MAKE_BBFLAG(34), // Block has recursive tailcall that may turn into a loop
+    BBF_NO_CSE_IN                      = MAKE_BBFLAG(35), // Block should kill off any incoming CSE
+    BBF_CAN_ADD_PRED                   = MAKE_BBFLAG(36), // Ok to add pred edge to this block, even when "safe" edge creation disabled
+    BBF_HAS_VALUE_PROFILE              = MAKE_BBFLAG(37), // Block has a node that needs a value probing
+    BBF_HAS_NEWARR                     = MAKE_BBFLAG(38), // BB contains 'new' of an array type.
+    BBF_MAY_HAVE_BOUNDS_CHECKS         = MAKE_BBFLAG(39), // BB *likely* has a bounds check (after rangecheck phase).
+    BBF_ASYNC_RESUMPTION               = MAKE_BBFLAG(40), // Block is a resumption block in an async method
 
     // The following are sets of flags.
 
     // Flags to update when two blocks are compacted
 
     BBF_COMPACT_UPD = BBF_GC_SAFE_POINT | BBF_NEEDS_GCPOLL | BBF_HAS_JMP | BBF_HAS_IDX_LEN | BBF_HAS_MD_IDX_LEN | BBF_BACKWARD_JUMP | \
-                      BBF_HAS_NEWOBJ | BBF_HAS_NEWARR | BBF_HAS_NULLCHECK | BBF_HAS_MDARRAYREF | BBF_LOOP_HEAD | BBF_MAY_HAVE_BOUNDS_CHECKS,
+                      BBF_HAS_NEWOBJ | BBF_HAS_NEWARR | BBF_HAS_NULLCHECK | BBF_HAS_MDARRAYREF | BBF_MAY_HAVE_BOUNDS_CHECKS,
 
     // Flags a block should not have had before it is split.
 
-    BBF_SPLIT_NONEXIST = BBF_LOOP_HEAD | BBF_RETLESS_CALL | BBF_COLD,
+    BBF_SPLIT_NONEXIST = BBF_RETLESS_CALL | BBF_COLD,
 
     // Flags lost by the top block when a block is split.
     // Note, this is a conservative guess.
@@ -1149,10 +1148,6 @@ public:
     bool isRunRarely() const
     {
         return HasFlag(BBF_RUN_RARELY);
-    }
-    bool isLoopHead() const
-    {
-        return HasFlag(BBF_LOOP_HEAD);
     }
 
     bool isLoopAlign() const

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7083,12 +7083,8 @@ protected:
 #endif
 
     void optResetLoopInfo();
-    void optFindAndScaleGeneralLoopBlocks();
 
-    // Determine if there are any potential loops, and set BBF_LOOP_HEAD on potential loop heads.
-    void optMarkLoopHeads();
-
-    void optScaleLoopBlocks(BasicBlock* begBlk, BasicBlock* endBlk);
+    void optScaleLoopBlocks(FlowGraphNaturalLoop* loop);
 
     bool optIsLoopTestEvalIntoTemp(Statement* testStmt, Statement** newTestStmt);
     unsigned optIsLoopIncrTree(GenTree* incr);

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4704,8 +4704,7 @@ BasicBlock* Compiler::fgSplitBlockAtEnd(BasicBlock* curr)
     newBlock->CopyFlags(curr);
 
     // Remove flags that the new block can't have.
-    newBlock->RemoveFlags(BBF_LOOP_HEAD | BBF_KEEP_BBJ_ALWAYS | BBF_PATCHPOINT | BBF_BACKWARD_JUMP_TARGET |
-                          BBF_LOOP_ALIGN);
+    newBlock->RemoveFlags(BBF_KEEP_BBJ_ALWAYS | BBF_PATCHPOINT | BBF_BACKWARD_JUMP_TARGET | BBF_LOOP_ALIGN);
 
     // Remove the GC safe bit on the new block. It seems clear that if we split 'curr' at the end,
     // such that all the code is left in 'curr', and 'newBlock' just gets the control flow, then

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -820,8 +820,7 @@ bool Compiler::fgDumpFlowGraph(Phases phase, PhasePosition pos)
                 const bool isTryEntryBlock     = bbIsTryBeg(block);
                 const bool isFuncletEntryBlock = fgFuncletsCreated && bbIsFuncletBeg(block);
 
-                if (isTryEntryBlock || isFuncletEntryBlock ||
-                    block->HasAnyFlag(BBF_RUN_RARELY | BBF_LOOP_HEAD | BBF_LOOP_ALIGN))
+                if (isTryEntryBlock || isFuncletEntryBlock || block->HasAnyFlag(BBF_RUN_RARELY | BBF_LOOP_ALIGN))
                 {
                     // Display a very few, useful, block flags
                     fprintf(fgxFile, " [");
@@ -836,10 +835,6 @@ bool Compiler::fgDumpFlowGraph(Phases phase, PhasePosition pos)
                     if (block->HasFlag(BBF_RUN_RARELY))
                     {
                         fprintf(fgxFile, "R");
-                    }
-                    if (block->HasFlag(BBF_LOOP_HEAD))
-                    {
-                        fprintf(fgxFile, "L");
                     }
                     if (block->HasFlag(BBF_LOOP_ALIGN))
                     {
@@ -967,10 +962,6 @@ bool Compiler::fgDumpFlowGraph(Phases phase, PhasePosition pos)
             if (block->HasFlag(BBF_HAS_NEWARR))
             {
                 fprintf(fgxFile, "\n            callsNewArr=\"true\"");
-            }
-            if (block->HasFlag(BBF_LOOP_HEAD))
-            {
-                fprintf(fgxFile, "\n            loopHead=\"true\"");
             }
 
             const char* rootTreeOpName = "n/a";

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -277,7 +277,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
 
         // We need to keep a few flags...
         //
-        noway_assert((originalFlags & (BBF_SPLIT_NONEXIST & ~(BBF_LOOP_HEAD | BBF_RETLESS_CALL))) == 0);
+        noway_assert((originalFlags & (BBF_SPLIT_NONEXIST & ~BBF_RETLESS_CALL)) == 0);
         top->SetFlagsRaw(originalFlags & (~(BBF_SPLIT_LOST | BBF_RETLESS_CALL) | BBF_GC_SAFE_POINT));
         bottom->SetFlags(originalFlags & (BBF_SPLIT_GAINED | BBF_IMPORTED | BBF_GC_SAFE_POINT | BBF_RETLESS_CALL));
         bottom->inheritWeight(top);

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -65,8 +65,8 @@ PhaseStatus Compiler::optSetBlockWeights()
 
     for (FlowGraphNaturalLoop* const loop : m_loops->InReversePostOrder())
     {
-        madeChanges = true;
         optScaleLoopBlocks(loop);
+        madeChanges = true;
     }
 
     bool firstBBDominatesAllReturns = true;
@@ -2300,8 +2300,6 @@ PhaseStatus Compiler::optInvertLoops()
             //
             if (block->bbWeight == BB_ZERO_WEIGHT)
             {
-                // Zero weighted block can't have a LOOP_HEAD flag
-                noway_assert(block->isLoopHead() == false);
                 continue;
             }
 
@@ -2440,8 +2438,6 @@ void Compiler::optResetLoopInfo()
             block->bbWeight = BB_UNITY_WEIGHT;
             block->RemoveFlags(BBF_RUN_RARELY);
         }
-
-        block->RemoveFlags(BBF_LOOP_HEAD);
     }
 }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -181,7 +181,8 @@ void Compiler::optScaleLoopBlocks(FlowGraphNaturalLoop* loop)
 {
     loop->VisitLoopBlocks([&](BasicBlock* curBlk) -> BasicBlockVisit {
         auto reportBlockWeight = [&](const char* message) {
-            DBEXEC(verbose, printf("\n    " FMT_BB "(wt=" FMT_WT ")%s", curBlk->bbNum, curBlk->getBBWeight(this), message));
+            DBEXEC(verbose,
+                   printf("\n    " FMT_BB "(wt=" FMT_WT ")%s", curBlk->bbNum, curBlk->getBBWeight(this), message));
         };
 
         // Don't change the block weight if it came from profile data.

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -41,14 +41,14 @@ PhaseStatus Compiler::optSetBlockWeights()
 {
     noway_assert(opts.OptimizationEnabled());
     assert(m_dfsTree != nullptr);
-    const bool usingProfileWeights = fgIsUsingProfileWeights();
+
+    // Leave breadcrumb for loop alignment
+    fgHasLoops = m_dfsTree->HasCycle();
 
     // Rely on profile synthesis to propagate weights when we have PGO data.
     // TODO: Replace optSetBlockWeights with profile synthesis entirely.
-    if (usingProfileWeights)
+    if (fgIsUsingProfileWeights())
     {
-        // Leave breadcrumb for loop alignment
-        fgHasLoops = m_dfsTree->HasCycle();
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
@@ -63,11 +63,10 @@ PhaseStatus Compiler::optSetBlockWeights()
         m_reachabilitySets = BlockReachabilitySets::Build(m_dfsTree);
     }
 
-    if (m_dfsTree->HasCycle())
+    for (FlowGraphNaturalLoop* const loop : m_loops->InReversePostOrder())
     {
-        madeChanges = fgRenumberBlocks();
-        optMarkLoopHeads();
-        optFindAndScaleGeneralLoopBlocks();
+        madeChanges = true;
+        optScaleLoopBlocks(loop);
     }
 
     bool firstBBDominatesAllReturns = true;
@@ -108,7 +107,7 @@ PhaseStatus Compiler::optSetBlockWeights()
             block->bbSetRunRarely();
         }
 
-        if (!usingProfileWeights && firstBBDominatesAllReturns)
+        if (firstBBDominatesAllReturns)
         {
             // If the weight is already zero (and thus rarely run), there's no point scaling it.
             if (block->bbWeight != BB_ZERO_WEIGHT)
@@ -163,11 +162,10 @@ PhaseStatus Compiler::optSetBlockWeights()
 }
 
 //------------------------------------------------------------------------
-// optScaleLoopBlocks: Scale the weight of loop blocks from 'begBlk' to 'endBlk'.
+// optScaleLoopBlocks: Scale the weight of the blocks in 'loop'.
 //
 // Arguments:
-//      begBlk - first block of range. Must be marked as a loop head (BBF_LOOP_HEAD).
-//      endBlk - last block of range (inclusive). Must be reachable from `begBlk`.
+//      loop - the loop to scale the weight of.
 //
 // Operation:
 //      Calculate the 'loop weight'. This is the amount to scale the weight of each block in the loop.
@@ -179,124 +177,68 @@ PhaseStatus Compiler::optSetBlockWeights()
 //         64 -- double loop nesting
 //        512 -- triple loop nesting
 //
-void Compiler::optScaleLoopBlocks(BasicBlock* begBlk, BasicBlock* endBlk)
+void Compiler::optScaleLoopBlocks(FlowGraphNaturalLoop* loop)
 {
-    noway_assert(begBlk->bbNum <= endBlk->bbNum);
-    noway_assert(begBlk->isLoopHead());
-    noway_assert(m_reachabilitySets->CanReach(begBlk, endBlk));
-    noway_assert(!opts.MinOpts());
+    loop->VisitLoopBlocks([&](BasicBlock* curBlk) -> BasicBlockVisit {
+        auto reportBlockWeight = [&](const char* message) {
+            DBEXEC(verbose, printf("\n    " FMT_BB "(wt=" FMT_WT ")%s", curBlk->bbNum, curBlk->getBBWeight(this), message));
+        };
 
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("\nMarking a loop from " FMT_BB " to " FMT_BB, begBlk->bbNum, endBlk->bbNum);
-    }
-#endif
-
-    // Build list of back edges for block begBlk.
-    FlowEdge* backedgeList = nullptr;
-
-    for (BasicBlock* const predBlock : begBlk->PredBlocks())
-    {
-        // Is this a back edge?
-        if (predBlock->bbNum >= begBlk->bbNum)
-        {
-            backedgeList = new (this, CMK_FlowEdge) FlowEdge(predBlock, begBlk, backedgeList);
-
-#if MEASURE_BLOCK_SIZE
-            genFlowNodeCnt += 1;
-            genFlowNodeSize += sizeof(FlowEdge);
-#endif // MEASURE_BLOCK_SIZE
-        }
-    }
-
-    // At least one backedge must have been found (the one from endBlk).
-    noway_assert(backedgeList);
-
-    auto reportBlockWeight = [&](BasicBlock* blk, const char* message) {
-#ifdef DEBUG
-        if (verbose)
-        {
-            printf("\n    " FMT_BB "(wt=" FMT_WT ")%s", blk->bbNum, blk->getBBWeight(this), message);
-        }
-#endif // DEBUG
-    };
-
-    for (BasicBlock* const curBlk : BasicBlockRangeList(begBlk, endBlk))
-    {
         // Don't change the block weight if it came from profile data.
         if (curBlk->hasProfileWeight() && fgHaveProfileWeights())
         {
-            reportBlockWeight(curBlk, "; unchanged: has profile weight");
-            continue;
+            reportBlockWeight("; unchanged: has profile weight");
+            return BasicBlockVisit::Continue;
         }
 
         // Don't change the block weight if it's known to be rarely run.
         if (curBlk->isRunRarely())
         {
-            reportBlockWeight(curBlk, "; unchanged: run rarely");
-            continue;
+            reportBlockWeight("; unchanged: run rarely");
+            return BasicBlockVisit::Continue;
         }
 
-        // Don't change the block weight if it's unreachable.
-        if (!m_reachabilitySets->GetDfsTree()->Contains(curBlk))
+        // If `curBlk` reaches any of the back edge blocks we set `reachable`.
+        // If `curBlk` dominates any of the back edge blocks we set `dominates`.
+        bool reachable = false;
+        bool dominates = false;
+
+        for (FlowEdge* const backEdge : loop->BackEdges())
         {
-            reportBlockWeight(curBlk, "; unchanged: unreachable");
-            continue;
+            BasicBlock* backEdgeSource = backEdge->getSourceBlock();
+
+            reachable |= m_reachabilitySets->CanReach(curBlk, backEdgeSource);
+            dominates |= m_domTree->Dominates(curBlk, backEdgeSource);
+
+            if (dominates && reachable)
+            {
+                // No need to keep looking; we've already found all the info we need.
+                break;
+            }
         }
 
-        // For curBlk to be part of a loop that starts at begBlk, curBlk must be reachable from begBlk and
-        // (since this is a loop) begBlk must likewise be reachable from curBlk.
-
-        if (m_reachabilitySets->CanReach(curBlk, begBlk) && m_reachabilitySets->CanReach(begBlk, curBlk))
+        if (reachable)
         {
-            // If `curBlk` reaches any of the back edge blocks we set `reachable`.
-            // If `curBlk` dominates any of the back edge blocks we set `dominates`.
-            bool reachable = false;
-            bool dominates = false;
+            weight_t scale = BB_LOOP_WEIGHT_SCALE;
 
-            for (FlowEdge* tmp = backedgeList; tmp != nullptr; tmp = tmp->getNextPredEdge())
+            if (!dominates)
             {
-                BasicBlock* backedge = tmp->getSourceBlock();
-
-                reachable |= m_reachabilitySets->CanReach(curBlk, backedge);
-                dominates |= m_domTree->Dominates(curBlk, backedge);
-
-                if (dominates && reachable)
-                {
-                    // No need to keep looking; we've already found all the info we need.
-                    break;
-                }
+                // If `curBlk` reaches but doesn't dominate any back edge to `endBlk` then there must be at least
+                // some other path to `endBlk`, so don't give `curBlk` all the execution weight.
+                scale = scale / 2;
             }
 
-            if (reachable)
-            {
-                // If the block has BB_ZERO_WEIGHT, then it should be marked as rarely run, and skipped, above.
-                noway_assert(curBlk->bbWeight > BB_ZERO_WEIGHT);
+            curBlk->scaleBBWeight(scale);
 
-                weight_t scale = BB_LOOP_WEIGHT_SCALE;
-
-                if (!dominates)
-                {
-                    // If `curBlk` reaches but doesn't dominate any back edge to `endBlk` then there must be at least
-                    // some other path to `endBlk`, so don't give `curBlk` all the execution weight.
-                    scale = scale / 2;
-                }
-
-                curBlk->scaleBBWeight(scale);
-
-                reportBlockWeight(curBlk, "");
-            }
-            else
-            {
-                reportBlockWeight(curBlk, "; unchanged: back edge unreachable");
-            }
+            reportBlockWeight("");
         }
         else
         {
-            reportBlockWeight(curBlk, "; unchanged: block not in loop");
+            reportBlockWeight("; unchanged: back edge unreachable");
         }
-    }
+
+        return BasicBlockVisit::Continue;
+    });
 }
 
 //----------------------------------------------------------------------------------
@@ -2477,62 +2419,6 @@ PhaseStatus Compiler::optOptimizePostLayout()
     return status;
 }
 
-//------------------------------------------------------------------------
-// optMarkLoopHeads: Mark all potential loop heads as BBF_LOOP_HEAD. A potential loop head is a block
-// targeted by a lexical back edge, where the source of the back edge is reachable from the block.
-// Note that if there are no lexical back edges, there can't be any loops.
-//
-// If there are any potential loop heads, set `fgHasLoops` to `true`.
-//
-// Assumptions:
-//    The reachability sets must be computed and valid.
-//
-void Compiler::optMarkLoopHeads()
-{
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("*************** In optMarkLoopHeads()\n");
-    }
-    fgDebugCheckBBNumIncreasing();
-
-    int loopHeadsMarked = 0;
-#endif
-
-    assert((m_dfsTree != nullptr) && (m_reachabilitySets != nullptr));
-
-    bool hasLoops = false;
-
-    for (BasicBlock* const block : Blocks())
-    {
-        // Set BBF_LOOP_HEAD if we have backwards branches to this block.
-
-        for (BasicBlock* const predBlock : block->PredBlocks())
-        {
-            if (block->bbNum <= predBlock->bbNum)
-            {
-                if (predBlock->KindIs(BBJ_CALLFINALLY))
-                {
-                    // Loops never have BBJ_CALLFINALLY as the source of their "back edge".
-                    continue;
-                }
-
-                // If block can reach predBlock then we have a loop head
-                if (m_reachabilitySets->CanReach(block, predBlock))
-                {
-                    hasLoops = true;
-                    block->SetFlags(BBF_LOOP_HEAD);
-                    INDEBUG(++loopHeadsMarked);
-                    break; // No need to look at more `block` predecessors
-                }
-            }
-        }
-    }
-
-    JITDUMP("%d loop heads marked\n", loopHeadsMarked);
-    fgHasLoops = hasLoops;
-}
-
 //-----------------------------------------------------------------------------
 // optResetLoopInfo: reset all loop info in preparation for refinding the loops
 // and scaling blocks based on it.
@@ -2557,98 +2443,6 @@ void Compiler::optResetLoopInfo()
 
         block->RemoveFlags(BBF_LOOP_HEAD);
     }
-}
-
-//-----------------------------------------------------------------------------
-// optFindAndScaleGeneralLoopBlocks: scale block weights based on loop nesting depth.
-// Note that this uses a very general notion of "loop": any block targeted by a reachable
-// back-edge is considered a loop.
-//
-void Compiler::optFindAndScaleGeneralLoopBlocks()
-{
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("*************** In optFindAndScaleGeneralLoopBlocks()\n");
-    }
-#endif
-
-    // This code depends on block number ordering.
-    INDEBUG(fgDebugCheckBBNumIncreasing());
-
-    assert((m_dfsTree != nullptr) && (m_domTree != nullptr) && (m_reachabilitySets != nullptr));
-
-    unsigned generalLoopCount = 0;
-
-    // We will use the following terminology:
-    // top        - the first basic block in the loop (i.e. the head of the backward edge)
-    // bottom     - the last block in the loop (i.e. the block from which we jump to the top)
-    // lastBottom - used when we have multiple back edges to the same top
-
-    for (BasicBlock* const top : Blocks())
-    {
-        // Only consider `top` blocks already determined to be potential loop heads.
-        if (!top->isLoopHead())
-        {
-            continue;
-        }
-
-        BasicBlock* foundBottom = nullptr;
-
-        for (BasicBlock* const bottom : top->PredBlocks())
-        {
-            // Is this a loop candidate? - We look for "back edges"
-
-            // Is this a backward edge? (from BOTTOM to TOP)
-            if (top->bbNum > bottom->bbNum)
-            {
-                continue;
-            }
-
-            // We only consider back-edges of these kinds for loops.
-            if (!bottom->KindIs(BBJ_COND, BBJ_ALWAYS, BBJ_CALLFINALLYRET))
-            {
-                continue;
-            }
-
-            /* the top block must be able to reach the bottom block */
-            if (!m_reachabilitySets->CanReach(top, bottom))
-            {
-                continue;
-            }
-
-            /* Found a new loop, record the longest backedge in foundBottom */
-
-            if ((foundBottom == nullptr) || (bottom->bbNum > foundBottom->bbNum))
-            {
-                foundBottom = bottom;
-            }
-        }
-
-        if (foundBottom)
-        {
-            generalLoopCount++;
-
-            /* Mark all blocks between 'top' and 'bottom' */
-
-            optScaleLoopBlocks(top, foundBottom);
-        }
-
-        // We track at most 255 loops
-        if (generalLoopCount == 255)
-        {
-#if COUNT_LOOPS
-            totalUnnatLoopOverflows++;
-#endif
-            break;
-        }
-    }
-
-    JITDUMP("\nFound a total of %d general loops.\n", generalLoopCount);
-
-#if COUNT_LOOPS
-    totalUnnatLoopCount += generalLoopCount;
-#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Part of #107749. This replaces `optMarkLoopHeads` and `optFindAndScaleLoopBlocks` with the graph-based loop visitor pattern we now use elsewhere in the JIT. I tried to preserve the heuristics in `optScaleLoopBlocks`, but a side effect of this change is we no longer scale unnatural loops. However, we no longer rely on lexical loop finding, so we gain some precision as well.

Once this and graph-based loop inversion have been merged, we will no longer have any `fgRenumberBlocks` calls.