### PR TITLE
Follow up on recent PAL cleanups

### DIFF
--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -79,21 +79,6 @@ typedef void *              LPOVERLAPPED;
 
 #define UNREFERENCED_PARAMETER(P)          (void)(P)
 
-typedef union _LARGE_INTEGER {
-    struct {
-#if BIGENDIAN
-        int32_t HighPart;
-        uint32_t LowPart;
-#else
-        uint32_t LowPart;
-        int32_t HighPart;
-#endif
-    } u;
-    int64_t QuadPart;
-} LARGE_INTEGER, *PLARGE_INTEGER;
-
-#define DECLARE_HANDLE(_name) typedef HANDLE _name
-
 struct FILETIME
 {
     uint32_t dwLowDateTime;
@@ -102,30 +87,12 @@ struct FILETIME
 
 typedef struct _CONTEXT CONTEXT, *PCONTEXT;
 
-#define EXCEPTION_MAXIMUM_PARAMETERS 15 // maximum number of exception parameters
-
-typedef struct _EXCEPTION_RECORD32 {
-    uint32_t      ExceptionCode;
-    uint32_t      ExceptionFlags;
-    uintptr_t  ExceptionRecord;
-    uintptr_t  ExceptionAddress;
-    uint32_t      NumberParameters;
-    uintptr_t  ExceptionInformation[EXCEPTION_MAXIMUM_PARAMETERS];
-} EXCEPTION_RECORD, *PEXCEPTION_RECORD;
+typedef struct _EXCEPTION_RECORD EXCEPTION_RECORD, *PEXCEPTION_RECORD;
 
 #define EXCEPTION_CONTINUE_EXECUTION (-1)
 #define EXCEPTION_CONTINUE_SEARCH (0)
 #define EXCEPTION_EXECUTE_HANDLER (1)
 
-typedef enum _EXCEPTION_DISPOSITION {
-    ExceptionContinueExecution,
-    ExceptionContinueSearch,
-    ExceptionNestedException,
-    ExceptionCollidedUnwind
-} EXCEPTION_DISPOSITION;
-
-#define STATUS_BREAKPOINT                              ((uint32_t   )0x80000003L)
-#define STATUS_SINGLE_STEP                             ((uint32_t   )0x80000004L)
 #define STATUS_ACCESS_VIOLATION                        ((uint32_t   )0xC0000005L)
 #define STATUS_STACK_OVERFLOW                          ((uint32_t   )0xC00000FDL)
 
@@ -161,9 +128,6 @@ typedef char TCHAR;
 #define INVALID_HANDLE_VALUE    ((HANDLE)(intptr_t)-1)
 
 #define INFINITE                0xFFFFFFFF
-
-#define DUPLICATE_CLOSE_SOURCE  0x00000001
-#define DUPLICATE_SAME_ACCESS   0x00000002
 
 #define PAGE_NOACCESS           0x01
 #define PAGE_READONLY           0x02

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -224,8 +224,6 @@ bool InitGSCookie()
 #endif // TARGET_UNIX
 
 #ifdef PROFILE_STARTUP
-#define STD_OUTPUT_HANDLE ((uint32_t)-11)
-
 static void AppendInt64(char * pBuffer, uint32_t* pLen, uint64_t value)
 {
     char localBuffer[20];

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -226,17 +226,6 @@ bool InitGSCookie()
 #ifdef PROFILE_STARTUP
 #define STD_OUTPUT_HANDLE ((uint32_t)-11)
 
-struct RegisterModuleTrace
-{
-    LARGE_INTEGER Begin;
-    LARGE_INTEGER End;
-};
-
-const int NUM_REGISTER_MODULE_TRACES = 16;
-int g_registerModuleCount = 0;
-
-RegisterModuleTrace g_registerModuleTraces[NUM_REGISTER_MODULE_TRACES] = { 0 };
-
 static void AppendInt64(char * pBuffer, uint32_t* pLen, uint64_t value)
 {
     char localBuffer[20];
@@ -269,12 +258,6 @@ static void UninitDLL()
     AppendInt64(buffer, &len, g_startupTimelineEvents[NONGC_INIT_COMPLETE]);
     AppendInt64(buffer, &len, g_startupTimelineEvents[GC_INIT_COMPLETE]);
     AppendInt64(buffer, &len, g_startupTimelineEvents[PROCESS_ATTACH_COMPLETE]);
-
-    for (int i = 0; i < g_registerModuleCount; i++)
-    {
-        AppendInt64(buffer, &len, g_registerModuleTraces[i].Begin.QuadPart);
-        AppendInt64(buffer, &len, g_registerModuleTraces[i].End.QuadPart);
-    }
 
     buffer[len++] = '\n';
 

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1154,3 +1154,8 @@ void PalGetSystemTimeAsFileTime(FILETIME *lpSystemTimeAsFileTime)
     lpSystemTimeAsFileTime->dwLowDateTime = (uint32_t)result;
     lpSystemTimeAsFileTime->dwHighDateTime = (uint32_t)(result >> 32);
 }
+
+extern "C" uint64_t PalGetCurrentOSThreadId()
+{
+    return (uint64_t)minipal_get_current_thread_id();
+}

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1154,8 +1154,3 @@ void PalGetSystemTimeAsFileTime(FILETIME *lpSystemTimeAsFileTime)
     lpSystemTimeAsFileTime->dwLowDateTime = (uint32_t)result;
     lpSystemTimeAsFileTime->dwHighDateTime = (uint32_t)(result >> 32);
 }
-
-extern "C" uint64_t PalGetCurrentOSThreadId()
-{
-    return (uint64_t)minipal_get_current_thread_id();
-}

--- a/src/coreclr/pal/src/include/pal/palinternal.h
+++ b/src/coreclr/pal/src/include/pal/palinternal.h
@@ -251,11 +251,11 @@ extern "C"
 
 typedef enum _TimeConversionConstants
 {
-    tccSecondsToMillieSeconds       = 1000,         // 10^3
+    tccSecondsToMilliSeconds        = 1000,         // 10^3
     tccSecondsToMicroSeconds        = 1000000,      // 10^6
     tccSecondsToNanoSeconds         = 1000000000,   // 10^9
-    tccMillieSecondsToMicroSeconds  = 1000,         // 10^3
-    tccMillieSecondsToNanoSeconds   = 1000000,      // 10^6
+    tccMilliSecondsToMicroSeconds   = 1000,         // 10^3
+    tccMilliSecondsToNanoSeconds    = 1000000,      // 10^6
     tccMicroSecondsToNanoSeconds    = 1000,         // 10^3
     tccSecondsTo100NanoSeconds      = 10000000,     // 10^7
     tccMicroSecondsTo100NanoSeconds = 10            // 10^1

--- a/src/coreclr/pal/src/misc/time.cpp
+++ b/src/coreclr/pal/src/misc/time.cpp
@@ -100,7 +100,7 @@ GetSystemTime(
         int old_seconds;
         int new_seconds;
 
-        lpSystemTime->wMilliseconds = (WORD)(timeval.tv_usec/tccMillieSecondsToMicroSeconds);
+        lpSystemTime->wMilliseconds = (WORD)(timeval.tv_usec/tccMilliSecondsToMicroSeconds);
 
         old_seconds = utPtr->tm_sec;
         new_seconds = timeval.tv_sec%60;

--- a/src/coreclr/pal/src/synchmgr/synchmanager.cpp
+++ b/src/coreclr/pal/src/synchmgr/synchmanager.cpp
@@ -1762,9 +1762,9 @@ namespace CorUnix
                 }
                 else
                 {
-                    tv.tv_usec = (iTimeout % tccSecondsToMillieSeconds) *
-                        tccMillieSecondsToMicroSeconds;
-                    tv.tv_sec = iTimeout / tccSecondsToMillieSeconds;
+                    tv.tv_usec = (iTimeout % tccSecondsToMilliSeconds) *
+                        tccMilliSecondsToMicroSeconds;
+                    tv.tv_sec = iTimeout / tccSecondsToMilliSeconds;
                     ptv = &tv;
                 }
 
@@ -1793,9 +1793,9 @@ namespace CorUnix
                     }
                     else
                     {
-                        ts.tv_nsec = (iTimeout % tccSecondsToMillieSeconds) *
-                            tccMillieSecondsToNanoSeconds;
-                        ts.tv_sec = iTimeout / tccSecondsToMillieSeconds;
+                        ts.tv_nsec = (iTimeout % tccSecondsToMilliSeconds) *
+                            tccMilliSecondsToNanoSeconds;
+                        ts.tv_sec = iTimeout / tccSecondsToMilliSeconds;
                         pts = &ts;
                     }
 
@@ -3578,8 +3578,8 @@ namespace CorUnix
 #endif
         if (0 == iRet)
         {
-            ptsAbsTmo->tv_sec  += dwTimeout / tccSecondsToMillieSeconds;
-            ptsAbsTmo->tv_nsec += (dwTimeout % tccSecondsToMillieSeconds) * tccMillieSecondsToNanoSeconds;
+            ptsAbsTmo->tv_sec  += dwTimeout / tccSecondsToMilliSeconds;
+            ptsAbsTmo->tv_nsec += (dwTimeout % tccSecondsToMilliSeconds) * tccMilliSecondsToNanoSeconds;
             while (ptsAbsTmo->tv_nsec >= tccSecondsToNanoSeconds)
             {
                 ptsAbsTmo->tv_sec  += 1;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.Unix.cs
@@ -5,15 +5,12 @@ namespace System.Diagnostics
 {
     public partial class Stopwatch
     {
-        private static long QueryPerformanceFrequency()
+        private static long GetFrequency()
         {
             const long SecondsToNanoSeconds = 1000000000;
             return SecondsToNanoSeconds;
         }
 
-        private static long QueryPerformanceCounter()
-        {
-            return Interop.Sys.GetTimestamp();
-        }
+        public static long GetTimestamp() => Interop.Sys.GetTimestamp();
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.Windows.cs
@@ -5,7 +5,7 @@ namespace System.Diagnostics
 {
     public partial class Stopwatch
     {
-        private static unsafe long QueryPerformanceFrequency()
+        private static unsafe long GetFrequency()
         {
             long resolution;
 
@@ -16,7 +16,7 @@ namespace System.Diagnostics
             return resolution;
         }
 
-        private static unsafe long QueryPerformanceCounter()
+        public static unsafe long GetTimestamp()
         {
             long timestamp;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics
         private long _startTimeStamp;
         private bool _isRunning;
 
-        public static readonly long Frequency = QueryPerformanceFrequency();
+        public static readonly long Frequency = GetFrequency();
         public static readonly bool IsHighResolution = true;
 
         // performance-counter frequency, in counts per ticks.
@@ -92,8 +92,6 @@ namespace System.Diagnostics
                 return timeElapsed;
             }
         }
-
-        public static long GetTimestamp() => QueryPerformanceCounter();
 
         /// <summary>Gets the elapsed time since the <paramref name="startingTimestamp"/> value retrieved using <see cref="GetTimestamp"/>.</summary>
         /// <param name="startingTimestamp">The timestamp marking the beginning of the time period.</param>

--- a/src/mono/mono/utils/mono-time.c
+++ b/src/mono/mono/utils/mono-time.c
@@ -21,18 +21,6 @@
 
 #define MTICKS_PER_SEC (10 * 1000 * 1000)
 
-typedef enum _TimeConversionConstants
-{
-	tccSecondsToMillieSeconds       = 1000,         // 10^3
-	tccSecondsToMicroSeconds        = 1000000,      // 10^6
-	tccSecondsToNanoSeconds         = 1000000000,   // 10^9
-	tccMillieSecondsToMicroSeconds  = 1000,         // 10^3
-	tccMillieSecondsToNanoSeconds   = 1000000,      // 10^6
-	tccMicroSecondsToNanoSeconds    = 1000,         // 10^3
-	tccSecondsTo100NanoSeconds      = 10000000,     // 10^7
-	tccMicroSecondsTo100NanoSeconds = 10            // 10^1
-} TimeConversionConstants;
-
 gint64
 mono_msec_ticks (void)
 {


### PR DESCRIPTION
- Avoid extra layer in System.Diagnostics.Stopwatch
- Rename Millieseconds -> MillieSecond
- Delete types from NativeAOT PAL that are not longer needed
- Delete unused g_registerModuleTrace