### PR TITLE
[mono][interp] Disable inlining of methods that call methods using StackCrawlMark

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Assembly.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Assembly.Mono.cs
@@ -42,9 +42,15 @@ namespace System.Reflection
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern RuntimeAssembly GetExecutingAssembly(ref StackCrawlMark stackMark);
 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [System.Security.DynamicSecurityMethod] // Methods doing stack walks has to be marked DynamicSecurityMethod
-        public static extern Assembly GetCallingAssembly();
+        public static Assembly GetCallingAssembly()
+        {
+            StackCrawlMark stackMark = StackCrawlMark.LookForMyCallersCaller;
+            return GetCallingAssembly(ref stackMark);
+        }
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern RuntimeAssembly GetCallingAssembly(ref StackCrawlMark stackMark);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern Assembly GetEntryAssemblyNative();

--- a/src/mono/mono/metadata/icall-def.h
+++ b/src/mono/mono/metadata/icall-def.h
@@ -286,7 +286,7 @@ ICALL_TYPE(OBJ, "System.Object", OBJ_3)
 HANDLES(OBJ_3, "MemberwiseClone", ves_icall_System_Object_MemberwiseClone, MonoObject, 1, (MonoObject))
 
 ICALL_TYPE(ASSEM, "System.Reflection.Assembly", ASSEM_2)
-HANDLES(ASSEM_2, "GetCallingAssembly", ves_icall_System_Reflection_Assembly_GetCallingAssembly, MonoReflectionAssembly, 0, ())
+HANDLES(ASSEM_2, "GetCallingAssembly", ves_icall_System_Reflection_Assembly_GetCallingAssembly, MonoReflectionAssembly, 1, (MonoStackCrawlMark_ptr))
 HANDLES(ASSEM_3, "GetEntryAssemblyNative", ves_icall_System_Reflection_Assembly_GetEntryAssembly, MonoReflectionAssembly, 0, ())
 HANDLES(ASSEM_4, "GetExecutingAssembly", ves_icall_System_Reflection_Assembly_GetExecutingAssembly, MonoReflectionAssembly, 1, (MonoStackCrawlMark_ptr))
 HANDLES(ASSEM_6, "InternalGetType", ves_icall_System_Reflection_Assembly_InternalGetType, MonoReflectionType, 5, (MonoReflectionAssembly, MonoReflectionModule, MonoString, MonoBoolean, MonoBoolean))

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -5145,7 +5145,7 @@ ves_icall_System_Reflection_Assembly_GetEntryAssembly (MonoError *error)
 }
 
 MonoReflectionAssemblyHandle
-ves_icall_System_Reflection_Assembly_GetCallingAssembly (MonoError *error)
+ves_icall_System_Reflection_Assembly_GetCallingAssembly (MonoStackCrawlMark *stack_mark, MonoError *error)
 {
 	MonoMethod *m;
 	MonoMethod *dest;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3854,6 +3854,8 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 		} else if (td->method->wrapper_type == MONO_WRAPPER_RUNTIME_INVOKE) {
 			// This scenario causes https://github.com/dotnet/runtime/issues/83792
 			return FALSE;
+		} else if (target_method->flags & METHOD_ATTRIBUTE_REQSECOBJ) {
+			return FALSE;
 		} else if (has_doesnotreturn_attribute(target_method)) {
 			/*
 			 * Since the method does not return, it's probably a throw helper and will not be called.


### PR DESCRIPTION
With JIT we don't inline methods doing calls. This is no longer the case on interpreter, since .NET8, after https://github.com/dotnet/runtime/pull/83548. The side effect of that change was that, because we weren't checking for the presence of the StackCrawlMark attribute, we could be inlining the callers of special methods like `Type.GetType`, `MethodBase.GetCurrentMethod`, `Assembly.GetCallingAssembly` etc. This would make them return incorrect results. Given inlining happens only once the method is tiered up, this regression wasn't detected.