### PR TITLE
Do not use StabilizePackageVersion in project infra

### DIFF
--- a/src/coreclr/.nuget/Directory.Build.targets
+++ b/src/coreclr/.nuget/Directory.Build.targets
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
-    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
+    <StableVersion Condition="'$(DotNetFinalVersionKind)' != '' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
     <StableVersion Condition="'$(IsShippingPackage)' != 'true' and '$(MSBuildProjectExtension)' == '.pkgproj'"></StableVersion>
   </PropertyGroup>
 

--- a/src/installer/tests/Assets/Projects/Directory.Build.targets
+++ b/src/installer/tests/Assets/Projects/Directory.Build.targets
@@ -17,7 +17,7 @@
       <!-- When package versions are stabilized, they do not have version suffixes. Because these are
            non-shipping tests assets, the Version property will still include suffixes (unlike for shipping
            assets), so we explicitly use the ProductVersion (without suffixes) in the stabilized case. -->
-      <_UpdatedVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</_UpdatedVersion>
+      <_UpdatedVersion Condition="'$(DotNetFinalVersionKind)' != ''">$(ProductVersion)</_UpdatedVersion>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeFramework Version="$(_UpdatedVersion)"

--- a/src/libraries/System.Private.CoreLib/gen/System.Private.CoreLib.Generators.csproj
+++ b/src/libraries/System.Private.CoreLib/gen/System.Private.CoreLib.Generators.csproj
@@ -4,7 +4,7 @@
     <NoWarn>$(NoWarn);CS3001</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants Condition="'$(StabilizePackageVersion)' == 'true'">$(DefineConstants);STABILIZE_PACKAGE_VERSION</DefineConstants>
+    <DefineConstants Condition="'$(DotNetFinalVersionKind)' != ''">$(DefineConstants);STABILIZE_PACKAGE_VERSION</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +20,7 @@
     <Compile Include="$(CoreLibSharedDir)System\Collections\Generic\ValueListBuilder.cs" Link="Production\ValueListBuilder.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Collections\Generic\ValueListBuilder.Pop.cs" Link="Production\ValueListBuilder.Pop.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" />
   </ItemGroup>

--- a/src/libraries/System.Runtime/tests/System.Runtime.InteropServices.RuntimeInformation.Tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.InteropServices.RuntimeInformation.Tests/DescriptionNameTests.cs
@@ -198,8 +198,9 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Assert.DoesNotContain("+", version); // no git hash
 
 #if STABILIZE_PACKAGE_VERSION
-            // a stabilized version looks like 8.0.0
-            Assert.DoesNotContain("-", version);
+            // a stabilized version looks like 8.0.0 or 8.0.0-preview.5.final
+            Assert.True((version.IndexOf("-", StringComparison.OrdinalIgnoreCase) == -1) ||
+                        (version.IndexOf("final", StringComparison.OrdinalIgnoreCase) != -1), version);
             Assert.True(Version.TryParse(version, out Version _));
 #else
             // a non-stabilized version looks like 8.0.0-preview.5.23280.8 or 8.0.0-dev

--- a/src/libraries/System.Runtime/tests/System.Runtime.InteropServices.RuntimeInformation.Tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.InteropServices.RuntimeInformation.Tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent)-browser</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants Condition="'$(StabilizePackageVersion)' == 'true'">$(DefineConstants);STABILIZE_PACKAGE_VERSION</DefineConstants>
+    <DefineConstants Condition="'$(DotNetFinalVersionKind)' != ''">$(DefineConstants);STABILIZE_PACKAGE_VERSION</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/src/mono/nuget/Directory.Build.targets
+++ b/src/mono/nuget/Directory.Build.targets
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <!-- Central place to set the versions of all mono pkgprojs. -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
-    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
+    <StableVersion Condition="'$(DotNetFinalVersionKind)' != '' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
     <StableVersion Condition="'$(IsShippingPackage)' != 'true' and '$(MSBuildProjectExtension)' == '.pkgproj'" />
   </PropertyGroup>
 

--- a/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
@@ -136,7 +136,7 @@
     <PropertyGroup>
       <!-- Used for workload testing -->
       <PackageVersionForWorkloadManifests>$(PackageVersion)</PackageVersionForWorkloadManifests>
-      <PackageVersionForWorkloadManifests Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</PackageVersionForWorkloadManifests>
+      <PackageVersionForWorkloadManifests Condition="'$(DotNetFinalVersionKind)' != ''">$(ProductVersion)</PackageVersionForWorkloadManifests>
     </PropertyGroup>
 
     <Error Condition="'$(PackageVersionForWorkloadManifests)' == ''"

--- a/src/mono/wasi/Wasi.Build.Tests/Wasi.Build.Tests.csproj
+++ b/src/mono/wasi/Wasi.Build.Tests/Wasi.Build.Tests.csproj
@@ -97,8 +97,8 @@
 
     <PropertyGroup>
       <!-- Wasm.Build.Tests are not a shipping project, PackageVersion will have a version suffix even for release branch, where actual runtime pack version doesn't have version suffix. Copy & paste to Wasm.Build.Tests -->
-      <_RuntimePackCurrentVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</_RuntimePackCurrentVersion>
-      <_RuntimePackCurrentVersion Condition="'$(StabilizePackageVersion)' != 'true'">$(PackageVersion)</_RuntimePackCurrentVersion>
+      <_RuntimePackCurrentVersion Condition="'$(DotNetFinalVersionKind)' != ''">$(ProductVersion)</_RuntimePackCurrentVersion>
+      <_RuntimePackCurrentVersion Condition="'$(DotNetFinalVersionKind)' == ''">$(PackageVersion)</_RuntimePackCurrentVersion>
     </PropertyGroup>
     <ItemGroup>
       <_RuntimePackVersions Include="$(_RuntimePackCurrentVersion)" EnvVarName="RUNTIME_PACK_VER10" />

--- a/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
+++ b/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
@@ -134,8 +134,8 @@
 
     <PropertyGroup>
       <!-- Wasm.Build.Tests are not a shipping project, PackageVersion will have a version suffix even for release branch, where actual runtime pack version doesn't have version suffix. Copy & paste to Wasi.Build.Tests -->
-      <_RuntimePackCurrentVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</_RuntimePackCurrentVersion>
-      <_RuntimePackCurrentVersion Condition="'$(StabilizePackageVersion)' != 'true'">$(PackageVersion)</_RuntimePackCurrentVersion>
+      <_RuntimePackCurrentVersion Condition="'$(DotNetFinalVersionKind)' != ''">$(ProductVersion)</_RuntimePackCurrentVersion>
+      <_RuntimePackCurrentVersion Condition="'$(DotNetFinalVersionKind)' == ''">$(PackageVersion)</_RuntimePackCurrentVersion>
     </PropertyGroup>
     <ItemGroup>
       <_RuntimePackVersions Include="$(_RuntimePackCurrentVersion)" EnvVarName="RUNTIME_PACK_VER10" />


### PR DESCRIPTION
This property was originally just meant to be a repo global input, which was then used to set DotNetFinalVersionKind in Versions.props. That is then used in arcade to determine the package version. Where we are using StabilizePackageVersion, use DotNetFinalVersionKind.