### PR TITLE
Sve/Scatter test: Add Debug.Assert for array length

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorFirstFaultingVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorFirstFaultingVectorBases.template
@@ -135,6 +135,10 @@ namespace JIT.HardwareIntrinsics.Arm
                     {Op2BaseType} baseAddrToValidate = (({Op2BaseType})baseArrayPtr + (sizeof({RetBaseType}) * inArray2[i]));
 
                     // Make sure we got the correct base pointers.
+                    if ((int)inArray2[i] >= (int)baseArray.Length)
+                    {
+                        Debug.Assert(false, $"Index {inArray2[i]} exceeds array length {baseArray.Length}");
+                    }
                     Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == baseArray[inArray2[i]]);
 
                     inArray2[i] = baseAddrToValidate;
@@ -157,6 +161,10 @@ namespace JIT.HardwareIntrinsics.Arm
                         {Op2BaseType} baseAddrToValidate = (({Op2BaseType})baseArrayPtr + (sizeof({RetBaseType}) * inArray2Ffr[i]));
 
                         // Make sure we got the correct base pointers.
+                        if ((int)inArray2Ffr[i] >= (int)baseArray.Length)
+                        {
+                            Debug.Assert(false, $"Index {inArray2Ffr[i]} exceeds array length {baseArray.Length}");
+                        }                                                
                         Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == baseArray[inArray2Ffr[i]]);
 
                         inArray2Ffr[i] = baseAddrToValidate;
@@ -207,7 +215,7 @@ namespace JIT.HardwareIntrinsics.Arm
                 {
                     {Op2BaseType} baseAddrToValidate = (({Op2BaseType})_dataTable.baseArrayPtr + (sizeof({RetBaseType}) * _data2[i]));
 
-                    // Make sure we got the correct base pointers.
+                    // Make sure we got the correct base pointers.     
                     Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == (({RetBaseType}*)_dataTable.baseArrayPtr)[_data2[i]]);
 
                     _data2[i] = baseAddrToValidate;

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorFirstFaultingVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorFirstFaultingVectorBases.template
@@ -135,10 +135,7 @@ namespace JIT.HardwareIntrinsics.Arm
                     {Op2BaseType} baseAddrToValidate = (({Op2BaseType})baseArrayPtr + (sizeof({RetBaseType}) * inArray2[i]));
 
                     // Make sure we got the correct base pointers.
-                    if ((int)inArray2[i] >= (int)baseArray.Length)
-                    {
-                        Debug.Assert(false, $"Index {inArray2[i]} exceeds array length {baseArray.Length}");
-                    }
+                    Debug.Assert((int)inArray2[i] < (int)baseArray.Length, $"Index {inArray2[i]} exceeds array length {baseArray.Length}");
                     Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == baseArray[inArray2[i]]);
 
                     inArray2[i] = baseAddrToValidate;
@@ -161,10 +158,7 @@ namespace JIT.HardwareIntrinsics.Arm
                         {Op2BaseType} baseAddrToValidate = (({Op2BaseType})baseArrayPtr + (sizeof({RetBaseType}) * inArray2Ffr[i]));
 
                         // Make sure we got the correct base pointers.
-                        if ((int)inArray2Ffr[i] >= (int)baseArray.Length)
-                        {
-                            Debug.Assert(false, $"Index {inArray2Ffr[i]} exceeds array length {baseArray.Length}");
-                        }                                                
+                        Debug.Assert((int)inArray2Ffr[i] < (int)baseArray.Length, $"Index {inArray2Ffr[i]} exceeds array length {baseArray.Length}");
                         Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == baseArray[inArray2Ffr[i]]);
 
                         inArray2Ffr[i] = baseAddrToValidate;

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorVectorBases.template
@@ -124,6 +124,10 @@ namespace JIT.HardwareIntrinsics.Arm
                     {Op2BaseType} baseAddrToValidate = (({Op2BaseType})baseArrayPtr + (sizeof({RetBaseType}) * inArray2[i]));
 
                     // Make sure we got the correct base pointers.
+                    if ((int)inArray2[i] >= (int)baseArray.Length)
+                    {
+                        Debug.Assert(false, $"Index {inArray2[i]} exceeds array length {baseArray.Length}");
+                    }                    
                     Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == baseArray[inArray2[i]]);
 
                     inArray2[i] = baseAddrToValidate;
@@ -172,7 +176,7 @@ namespace JIT.HardwareIntrinsics.Arm
                 {
                     {Op2BaseType} baseAddrToValidate = (({Op2BaseType})_dataTable.baseArrayPtr + (sizeof({RetBaseType}) * _data2[i]));
 
-                    // Make sure we got the correct base pointers.
+                    // Make sure we got the correct base pointers.           
                     Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == (({RetBaseType}*)_dataTable.baseArrayPtr)[_data2[i]]);
 
                     _data2[i] = baseAddrToValidate;

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveGatherVectorVectorBases.template
@@ -124,10 +124,7 @@ namespace JIT.HardwareIntrinsics.Arm
                     {Op2BaseType} baseAddrToValidate = (({Op2BaseType})baseArrayPtr + (sizeof({RetBaseType}) * inArray2[i]));
 
                     // Make sure we got the correct base pointers.
-                    if ((int)inArray2[i] >= (int)baseArray.Length)
-                    {
-                        Debug.Assert(false, $"Index {inArray2[i]} exceeds array length {baseArray.Length}");
-                    }                    
+                    Debug.Assert((int)inArray2[i] < (int)baseArray.Length, $"Index {inArray2[i]} exceeds array length {baseArray.Length}");
                     Debug.Assert(*(({RetBaseType}*)baseAddrToValidate) == baseArray[inArray2[i]]);
 
                     inArray2[i] = baseAddrToValidate;

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
@@ -120,10 +120,7 @@ namespace JIT.HardwareIntrinsics.Arm._Sve
                     {Op2BaseType} baseAddrToValidate = (({Op2BaseType})outArrayPtr + (sizeof({Op2BaseType}) * inAddress[i]));
 
                     // Make sure we got the correct base pointers.
-                    if ((int)inAddress[i] >= (int)outArray.Length)
-                    {
-                        Debug.Assert(false, $"Index {inAddress[i]} exceeds array length {outArray.Length}");
-                    }
+                    Debug.Assert((int)inAddress[i] < (int)outArray.Length, $"Index {inAddress[i]} exceeds array length {outArray.Length}");
                     Debug.Assert(*(({Op1BaseType}*)baseAddrToValidate) == outArray[inAddress[i]]);
 
                     inAddress[i] = baseAddrToValidate;

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
@@ -120,6 +120,10 @@ namespace JIT.HardwareIntrinsics.Arm._Sve
                     {Op2BaseType} baseAddrToValidate = (({Op2BaseType})outArrayPtr + (sizeof({Op2BaseType}) * inAddress[i]));
 
                     // Make sure we got the correct base pointers.
+                    if ((int)inAddress[i] >= (int)outArray.Length)
+                    {
+                        Debug.Assert(false, $"Index {inAddress[i]} exceeds array length {outArray.Length}");
+                    }
                     Debug.Assert(*(({Op1BaseType}*)baseAddrToValidate) == outArray[inAddress[i]]);
 
                     inAddress[i] = baseAddrToValidate;
@@ -193,7 +197,7 @@ namespace JIT.HardwareIntrinsics.Arm._Sve
                 {
                     {Op2BaseType} baseAddrToValidate = (({Op2BaseType})_dataTable.outArrayPtr + (sizeof({Op2BaseType}) * _addressArr[i]));
 
-                    // Make sure we got the correct base pointers.
+                    // Make sure we got the correct base pointers.                   
                     Debug.Assert(*(({Op1BaseType}*)baseAddrToValidate) == (({Op1BaseType}*)_dataTable.outArrayPtr)[_addressArr[i]]);
 
                     _addressArr[i] = baseAddrToValidate;


### PR DESCRIPTION
Add more tracking to catch reasons for getting https://github.com/dotnet/runtime/issues/115712.