### PR TITLE
Improve the interpreter internal diagnostic capabilities

### DIFF
--- a/src/coreclr/interpreter/CMakeLists.txt
+++ b/src/coreclr/interpreter/CMakeLists.txt
@@ -10,6 +10,8 @@ set(INTERPRETER_SOURCES
   interpconfig.cpp
   eeinterp.cpp
   stackmap.cpp
+  naming.cpp
+  methodset.cpp
   ../../native/containers/dn-simdhash.c
   ../../native/containers/dn-simdhash-ptr-ptr.c)
 

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3840,7 +3840,7 @@ void InterpCompiler::PrintMethodName(CORINFO_METHOD_HANDLE method)
     CORINFO_SIG_INFO sig;
     m_compHnd->getMethodSig(method, &sig, cls);
 
-    TArray<char> methodName = ::PrintMethodName(m_compHnd, m_classHnd, m_methodHnd, &sig,
+    TArray<char> methodName = ::PrintMethodName(m_compHnd, cls, method, &sig,
                             /* includeClassInstantiation */ true,
                             /* includeMethodInstantiation */ true,
                             /* includeSignature */ true,

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1057,8 +1057,17 @@ InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
     m_methodInfo = methodInfo;
 
 #ifdef DEBUG
-    m_methodName = compHnd->getMethodNameFromMetadata(methodInfo->ftn, nullptr, nullptr, nullptr, 0);
-    if (m_methodName && InterpConfig.InterpDump() && !strcmp(m_methodName, InterpConfig.InterpDump()))
+
+    m_classHnd   = compHnd->getMethodClass(m_methodHnd);
+
+    m_methodName = ::PrintMethodName(compHnd, m_classHnd, m_methodHnd, &m_methodInfo->args,
+                            /* includeClassInstantiation */ true,
+                            /* includeMethodInstantiation */ true,
+                            /* includeSignature */ true,
+                            /* includeReturnType */ false,
+                            /* includeThis */ false);
+
+    if (InterpConfig.InterpDump().contains(compHnd, m_methodHnd, m_classHnd, &m_methodInfo->args))
         m_verbose = true;
 #endif
 }
@@ -1066,11 +1075,9 @@ InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
 InterpMethod* InterpCompiler::CompileMethod()
 {
 #ifdef DEBUG
-    if (m_verbose)
+    if (m_verbose || InterpConfig.InterpList())
     {
-        printf("Interpreter compile method ");
-        PrintMethodName(m_methodHnd);
-        printf("\n");
+        printf("Interpreter compile method %s\n", m_methodName.GetUnderlyingArray());
     }
 #endif
 
@@ -2151,7 +2158,7 @@ int InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
     m_currentILOffset = -1;
 
 #if DEBUG
-    if (m_methodName && InterpConfig.InterpHalt() && !strcmp(m_methodName, InterpConfig.InterpHalt()))
+    if (InterpConfig.InterpHalt().contains(m_compHnd, m_methodHnd, m_classHnd, &m_methodInfo->args))
         AddIns(INTOP_BREAKPOINT);
 #endif
 
@@ -3828,13 +3835,20 @@ void InterpCompiler::PrintClassName(CORINFO_CLASS_HANDLE cls)
 
 void InterpCompiler::PrintMethodName(CORINFO_METHOD_HANDLE method)
 {
-    char methodName[100];
-
     CORINFO_CLASS_HANDLE cls = m_compHnd->getMethodClass(method);
-    PrintClassName(cls);
 
-    m_compHnd->printMethodName(method, methodName, 100);
-    printf(".%s", methodName);
+    CORINFO_SIG_INFO sig;
+    m_compHnd->getMethodSig(method, &sig, cls);
+
+    TArray<char> methodName = ::PrintMethodName(m_compHnd, m_classHnd, m_methodHnd, &sig,
+                            /* includeClassInstantiation */ true,
+                            /* includeMethodInstantiation */ true,
+                            /* includeSignature */ true,
+                            /* includeReturnType */ false,
+                            /* includeThis */ false);
+
+
+    printf(".%s", methodName.GetUnderlyingArray());
 }
 
 void InterpCompiler::PrintCode()

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -7,6 +7,16 @@
 #include "intops.h"
 #include "datastructs.h"
 
+TArray<char> PrintMethodName(COMP_HANDLE comp,
+                             CORINFO_CLASS_HANDLE  clsHnd,
+                             CORINFO_METHOD_HANDLE methHnd,
+                             CORINFO_SIG_INFO*     sig,
+                             bool                  includeClassInstantiation,
+                             bool                  includeMethodInstantiation,
+                             bool                  includeSignature,
+                             bool                  includeReturnType,
+                             bool                  includeThisSpecifier);
+
 // Types that can exist on the IL execution stack. They are used only during
 // IL import compilation stage.
 enum StackType {
@@ -257,7 +267,6 @@ struct Reloc
     }
 };
 
-typedef class ICorJitInfo* COMP_HANDLE;
 
 class InterpIAllocator;
 
@@ -272,7 +281,8 @@ private:
     COMP_HANDLE m_compHnd;
     CORINFO_METHOD_INFO* m_methodInfo;
 #ifdef DEBUG
-    const char *m_methodName;
+    CORINFO_CLASS_HANDLE m_classHnd;
+    TArray<char> m_methodName;
     bool m_verbose = false;
 #endif
 

--- a/src/coreclr/interpreter/datastructs.h
+++ b/src/coreclr/interpreter/datastructs.h
@@ -20,12 +20,56 @@ private:
 
         m_array = (T*)realloc(m_array, m_capacity * sizeof(T));
     }
+
+    void Grow(int32_t minNewCapacity)
+    {
+        if (m_capacity)
+            m_capacity *= 2;
+        else
+            m_capacity = 16;
+
+        m_capacity = (m_capacity > minNewCapacity) ? m_capacity : minNewCapacity;
+
+        m_array = (T*)realloc(m_array, m_capacity * sizeof(T));
+    }
 public:
     TArray()
     {
         m_size = 0;
         m_capacity = 0;
         m_array = NULL;
+    }
+
+    // Implicit copies are not permitted to prevent accidental allocation of large arrays.
+    TArray(const TArray<T> &other) = delete;
+    TArray<T>& operator=(const TArray<T> &other) = delete;
+
+    TArray(TArray<T> &&other)
+    {
+        m_size = other.m_size;
+        m_capacity = other.m_capacity;
+        m_array = other.m_array;
+
+        other.m_size = 0;
+        other.m_capacity = 0;
+        other.m_array = NULL;
+    }
+    TArray<T>& operator=(TArray<T> &&other)
+    {
+        if (this != &other)
+        {
+            if (m_capacity > 0)
+                free(m_array);
+
+            m_size = other.m_size;
+            m_capacity = other.m_capacity;
+            m_array = other.m_array;
+
+            other.m_size = 0;
+            other.m_capacity = 0;
+            other.m_array = NULL;
+        }
+        return *this;
     }
 
     ~TArray()
@@ -45,6 +89,39 @@ public:
             Grow();
         m_array[m_size] = element;
         return m_size++;
+    }
+
+    void Append(const T* pElements, int32_t count)
+    {
+        int32_t availableCapacity = m_capacity - m_size;
+        if (count > availableCapacity)
+        {
+            // Grow the array if there is not enough space
+            Grow(count + m_size);
+        }
+        for (int32_t i = 0; i < count; i++)
+        {
+            m_array[m_size + i] = pElements[i];
+        }
+        m_size += count;
+    }
+
+    void GrowBy(int32_t count)
+    {
+        int32_t availableCapacity = m_capacity - m_size;
+        if (count > availableCapacity)
+        {
+            // Grow the array if there is not enough space
+            Grow(count + m_size);
+        }
+        memset(&m_array[m_size], 0, count * sizeof(T)); // Initialize new elements to zero
+        m_size += count;
+    }
+
+    // Returns a pointer to the element at the specified index.
+    T* GetUnderlyingArray()
+    {
+        return m_array;
     }
 
     T Get(int32_t index)

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -64,9 +64,7 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
         // interpret everything on wasm
         doInterpret = true;
 #else
-        // TODO: replace this by something like the JIT does to support multiple methods being specified
-        const char *methodToInterpret = InterpConfig.Interpreter();
-        doInterpret = (methodName != NULL && strcmp(methodName, methodToInterpret) == 0);
+        doInterpret = (InterpConfig.Interpreter().contains(compHnd, methodInfo->ftn, compHnd->getMethodClass(methodInfo->ftn), &methodInfo->args));
 #endif
 
         if (doInterpret)

--- a/src/coreclr/interpreter/interpconfig.cpp
+++ b/src/coreclr/interpreter/interpconfig.cpp
@@ -10,7 +10,8 @@ void InterpConfigValues::Initialize(ICorJitHost* host)
     assert(!m_isInitialized);
 
 #define RELEASE_CONFIG_STRING(name, key)    m_##name = host->getStringConfigValue(key);
-
+#define RELEASE_CONFIG_METHODSET(name, key)    do { const char *pConfigValue = host->getStringConfigValue(key); m_##name.initialize(pConfigValue); host->freeStringConfigValue(pConfigValue); } while (0);
+#define RELEASE_CONFIG_INTEGER(name, key, defaultValue)   m_##name = host->getIntConfigValue(key, defaultValue);
 #include "interpconfigvalues.h"
 
     m_isInitialized = true;
@@ -22,7 +23,8 @@ void InterpConfigValues::Destroy(ICorJitHost* host)
         return;
 
 #define RELEASE_CONFIG_STRING(name, key)    host->freeStringConfigValue(m_##name);
-
+#define RELEASE_CONFIG_METHODSET(name, key) m_##name.destroy();
+#define RELEASE_CONFIG_INTEGER(name, key, defaultValue)
 #include "interpconfigvalues.h"
 
     m_isInitialized = false;

--- a/src/coreclr/interpreter/interpconfig.h
+++ b/src/coreclr/interpreter/interpconfig.h
@@ -12,7 +12,8 @@ private:
     bool m_isInitialized;
 
 #define RELEASE_CONFIG_STRING(name, key)    const char* m_##name;
-
+#define RELEASE_CONFIG_INTEGER(name, key, defaultValue) int m_##name;
+#define RELEASE_CONFIG_METHODSET(name, key) MethodSet m_##name;
 #include "interpconfigvalues.h"
 
 public:
@@ -21,6 +22,18 @@ public:
     inline const char* name() const         \
     {                                       \
         return m_##name;                    \
+    }
+
+#define RELEASE_CONFIG_INTEGER(name, key, defaultValue)  \
+    inline int name() const                              \
+    {                                                    \
+        return m_##name;                                 \
+    }
+
+#define RELEASE_CONFIG_METHODSET(name, key)  \
+    inline const MethodSet& name() const     \
+    {                                        \
+        return m_##name;                     \
     }
 
 #include "interpconfigvalues.h"

--- a/src/coreclr/interpreter/interpconfigvalues.h
+++ b/src/coreclr/interpreter/interpconfigvalues.h
@@ -7,9 +7,24 @@
 #define CONFIG_STRING(name, key)
 #endif
 
-RELEASE_CONFIG_STRING(Interpreter, "Interpreter")
-CONFIG_STRING(InterpHalt, "InterpHalt");
-CONFIG_STRING(InterpDump, "InterpDump");
+#ifdef DEBUG
+#define CONFIG_METHODSET(name, key)             RELEASE_CONFIG_METHODSET(name, key)
+#else
+#define CONFIG_METHODSET(name, key)
+#endif
+
+#ifdef DEBUG
+#define CONFIG_INTEGER(name, key, defaultValue) RELEASE_CONFIG_INTEGER(name, key, defaultValue)
+#else
+#define CONFIG_INTEGER(name, key, defaultValue)
+#endif
+
+RELEASE_CONFIG_METHODSET(Interpreter, "Interpreter")
+CONFIG_METHODSET(InterpHalt, "InterpHalt");
+CONFIG_METHODSET(InterpDump, "InterpDump");
+CONFIG_INTEGER(InterpList, "InterpList", 0); // List the methods which are compiled by the interpreter JIT
 
 #undef CONFIG_STRING
 #undef RELEASE_CONFIG_STRING
+#undef RELEASE_CONFIG_METHODSET
+#undef RELEASE_CONFIG_INTEGER

--- a/src/coreclr/interpreter/interpretershared.h
+++ b/src/coreclr/interpreter/interpretershared.h
@@ -51,4 +51,55 @@ struct InterpMethod
     }
 };
 
+typedef class ICorJitInfo* COMP_HANDLE;
+
+class MethodSet
+{
+private:
+    struct MethodName
+    {
+        MethodName* m_next;
+        const char* m_patternStart;
+        const char* m_patternEnd;
+        bool        m_containsClassName;
+        bool        m_classNameContainsInstantiation;
+        bool        m_methodNameContainsInstantiation;
+        bool        m_containsSignature;
+    };
+
+    const char* m_listFromConfig = nullptr;
+    MethodName* m_names = nullptr;
+
+    MethodSet(const MethodSet& other)            = delete;
+    MethodSet& operator=(const MethodSet& other) = delete;
+
+public:
+    MethodSet()
+    {
+    }
+
+    ~MethodSet()
+    {
+        destroy();
+    }
+
+    const char* list() const
+    {
+        return m_listFromConfig;
+    }
+
+    void initialize(const char* listFromConfig);
+    void destroy();
+
+    inline bool isEmpty() const
+    {
+        return m_names == nullptr;
+    }
+    bool contains(COMP_HANDLE comp, CORINFO_METHOD_HANDLE methodHnd, CORINFO_CLASS_HANDLE classHnd, CORINFO_SIG_INFO* sigInfo) const;
+};
+
+const CORINFO_CLASS_HANDLE  NO_CLASS_HANDLE  = nullptr;
+const CORINFO_FIELD_HANDLE  NO_FIELD_HANDLE  = nullptr;
+const CORINFO_METHOD_HANDLE NO_METHOD_HANDLE = nullptr;
+
 #endif

--- a/src/coreclr/interpreter/methodset.cpp
+++ b/src/coreclr/interpreter/methodset.cpp
@@ -1,0 +1,181 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "interpreter.h"
+
+//----------------------------------------------------------------------
+// initialize: Initialize the method set by parsing the string
+//
+// Arguments:
+//     listFromConfig - A string containing the list. The string must have come from the host's config,
+//                      and this class takes ownership of the string.
+//     host           - Pointer to host interface
+//
+void MethodSet::initialize(const char* listFromConfig)
+{
+    assert(m_listFromConfig == nullptr);
+    assert(m_names == nullptr);
+
+    if (listFromConfig == nullptr)
+    {
+        return;
+    }
+
+    size_t configSize = strlen(listFromConfig);
+    if (configSize == 0)
+    {
+        return;
+    }
+
+    m_listFromConfig = static_cast<const char*>(malloc(configSize + 1));
+    strcpy(const_cast<char*>(m_listFromConfig), listFromConfig);
+
+    auto commitPattern = [this](const char* start, const char* end) {
+        if (end <= start)
+        {
+            return;
+        }
+
+        MethodName* name              = static_cast<MethodName*>(calloc(1, sizeof(MethodName)));
+        name->m_next                  = m_names;
+        name->m_patternStart          = start;
+        name->m_patternEnd            = end;
+        const char* colon             = static_cast<const char*>(memchr(start, ':', end - start));
+        const char* startOfMethodName = colon != nullptr ? colon + 1 : start;
+
+        const char* parens          = static_cast<const char*>(memchr(startOfMethodName, '(', end - startOfMethodName));
+        const char* endOfMethodName = parens != nullptr ? parens : end;
+        name->m_methodNameContainsInstantiation =
+            memchr(startOfMethodName, '[', endOfMethodName - startOfMethodName) != nullptr;
+
+        if (colon != nullptr)
+        {
+            name->m_containsClassName              = true;
+            name->m_classNameContainsInstantiation = memchr(start, '[', colon - start) != nullptr;
+        }
+        else
+        {
+            name->m_containsClassName              = false;
+            name->m_classNameContainsInstantiation = false;
+        }
+
+        name->m_containsSignature = parens != nullptr;
+        m_names                   = name;
+    };
+
+    const char* curPatternStart = m_listFromConfig;
+    const char* curChar;
+    for (curChar = curPatternStart; *curChar != '\0'; curChar++)
+    {
+        if (*curChar == ' ')
+        {
+            commitPattern(curPatternStart, curChar);
+            curPatternStart = curChar + 1;
+        }
+    }
+
+    commitPattern(curPatternStart, curChar);
+}
+
+//----------------------------------------------------------------------
+// destroy: Destroy the method set.
+//
+// Arguments:
+//     host - Pointer to host interface
+//
+void MethodSet::destroy()
+{
+    // Free method names, free the list string, and reset our state
+    for (MethodName *name = m_names, *next = nullptr; name != nullptr; name = next)
+    {
+        next = name->m_next;
+        free(static_cast<void*>(name));
+    }
+    if (m_listFromConfig != nullptr)
+    {
+        free((void*)m_listFromConfig);
+        m_listFromConfig = nullptr;
+    }
+    m_names = nullptr;
+}
+
+// Quadratic string matching algorithm that supports * and ? wildcards
+static bool matchGlob(const char* pattern, const char* patternEnd, const char* str)
+{
+    // Invariant: [patternStart..backtrackPattern) matches [stringStart..backtrackStr)
+    const char* backtrackPattern = nullptr;
+    const char* backtrackStr     = nullptr;
+
+    while (true)
+    {
+        if (pattern == patternEnd)
+        {
+            if (*str == '\0')
+                return true;
+        }
+        else if (*pattern == '*')
+        {
+            backtrackPattern = ++pattern;
+            backtrackStr     = str;
+            continue;
+        }
+        else if (*str == '\0')
+        {
+            // No match since pattern needs at least one char in remaining cases.
+        }
+        else if ((*pattern == '?') || (*pattern == *str))
+        {
+            pattern++;
+            str++;
+            continue;
+        }
+
+        // In this case there was no match, see if we can backtrack to a wild
+        // card and consume one more character from the string.
+        if ((backtrackPattern == nullptr) || (*backtrackStr == '\0'))
+            return false;
+
+        // Consume one more character for the wildcard.
+        pattern = backtrackPattern;
+        str     = ++backtrackStr;
+    }
+}
+
+bool MethodSet::contains(COMP_HANDLE comp,
+                         CORINFO_METHOD_HANDLE methodHnd,
+                         CORINFO_CLASS_HANDLE  classHnd,
+                         CORINFO_SIG_INFO*     sigInfo) const
+{
+    if (isEmpty())
+    {
+        return false;
+    }
+
+    TArray<char> printer;
+    MethodName*   prevPattern = nullptr;
+
+    for (MethodName* name = m_names; name != nullptr; name = name->m_next)
+    {
+        if ((prevPattern == nullptr) || (name->m_containsClassName != prevPattern->m_containsClassName) ||
+            (name->m_classNameContainsInstantiation != prevPattern->m_classNameContainsInstantiation) ||
+            (name->m_methodNameContainsInstantiation != prevPattern->m_methodNameContainsInstantiation) ||
+            (name->m_containsSignature != prevPattern->m_containsSignature))
+        {
+            printer = PrintMethodName(comp, name->m_containsClassName ? classHnd : NO_CLASS_HANDLE, methodHnd, sigInfo,
+                                    /* includeClassInstantiation */ name->m_classNameContainsInstantiation,
+                                    /* includeMethodInstantiation */ name->m_methodNameContainsInstantiation,
+                                    /* includeSignature */ name->m_containsSignature,
+                                    /* includeReturnType */ false,
+                                    /* includeThis */ false);
+
+            prevPattern = name;
+        }
+
+        if (matchGlob(name->m_patternStart, name->m_patternEnd, printer.GetUnderlyingArray()))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/coreclr/interpreter/naming.cpp
+++ b/src/coreclr/interpreter/naming.cpp
@@ -58,7 +58,7 @@ void AppendCorInfoType(TArray<char>* printer, CorInfoType corInfoType)
     };
 
     const char *corInfoTypeName = "CORINFO_TYPE_INVALID";
-    if (corInfoType >= 0 || corInfoType < CORINFO_TYPE_COUNT)
+    if (corInfoType >= 0 && corInfoType < CORINFO_TYPE_COUNT)
     {
         corInfoTypeName = preciseVarTypeMap[corInfoType];
     }

--- a/src/coreclr/interpreter/naming.cpp
+++ b/src/coreclr/interpreter/naming.cpp
@@ -1,0 +1,283 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "interpreter.h"
+
+void AppendType(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation);
+void AppendCorInfoType(TArray<char>* printer, CorInfoType corInfoType);
+void AppendTypeOrJitAlias(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation);
+
+void AppendString(TArray<char>& array, const char* str)
+{
+    if (str != nullptr)
+    {
+        size_t strLen = strlen(str);
+        array.Append(str, static_cast<int32_t>(strLen));
+    }
+}
+
+void AppendCorInfoTypeWithModModifiers(TArray<char>* printer, CorInfoTypeWithMod corInfoTypeWithMod)
+{
+    if ((corInfoTypeWithMod & CORINFO_TYPE_MOD_PINNED) == CORINFO_TYPE_MOD_PINNED)
+    {
+        printer->Append("PINNED__", 7);
+    }
+    if ((corInfoTypeWithMod & CORINFO_TYPE_MOD_COPY_WITH_HELPER) == CORINFO_TYPE_MOD_COPY_WITH_HELPER)
+    {
+        printer->Append("COPY_WITH_HELPER__", 17);
+    }
+}
+
+void AppendCorInfoType(TArray<char>* printer, CorInfoType corInfoType)
+{
+    static const char* preciseVarTypeMap[CORINFO_TYPE_COUNT] = {
+        // see the definition of enum CorInfoType in file inc/corinfo.h
+        "<UNDEF>",
+        "void",
+        "bool",
+        "char",
+        "sbyte",
+        "byte",
+        "short",
+        "ushort",
+        "int",
+        "uint",
+        "long",
+        "ulong",
+        "nint",
+        "nuint",
+        "float",
+        "double",
+        "string",
+        "ptr",
+        "byref",
+        "struct",
+        "class",
+        "typedbyref",
+        "var"
+    };
+
+    const char *corInfoTypeName = "CORINFO_TYPE_INVALID";
+    if (corInfoType >= 0 || corInfoType < CORINFO_TYPE_COUNT)
+    {
+        corInfoTypeName = preciseVarTypeMap[corInfoType];
+    }
+    
+    printer->Append(corInfoTypeName, static_cast<int32_t>(strlen(corInfoTypeName)));
+}
+
+void AppendTypeOrJitAlias(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation)
+{
+    CorInfoType typ = comp->asCorInfoType(clsHnd);
+    if ((typ == CORINFO_TYPE_CLASS) || (typ == CORINFO_TYPE_VALUECLASS))
+    {
+        AppendType(comp, printer, clsHnd, includeInstantiation);
+    }
+    else
+    {
+        AppendCorInfoType(printer, typ);
+    }
+}
+
+void AppendType(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation)
+{
+    unsigned arrayRank = comp->getArrayRank(clsHnd);
+    if (arrayRank > 0)
+    {
+        CORINFO_CLASS_HANDLE childClsHnd;
+        CorInfoType          childType = comp->getChildType(clsHnd, &childClsHnd);
+        if ((childType == CORINFO_TYPE_CLASS) || (childType == CORINFO_TYPE_VALUECLASS))
+        {
+            AppendType(comp, printer, childClsHnd, includeInstantiation);
+        }
+        else
+        {
+            AppendCorInfoType(printer, childType);
+        }
+
+        printer->Add('[');
+        for (unsigned i = 1; i < arrayRank; i++)
+        {
+            printer->Add(',');
+        }
+        printer->Add(']');
+        return;
+    }
+
+    size_t bufferSizeNeeded = 0;
+    comp->printClassName(clsHnd, NULL, 0, &bufferSizeNeeded);
+    if (bufferSizeNeeded != 0)
+    {
+        int32_t oldBufferSize = printer->GetSize();
+        printer->GrowBy(static_cast<int32_t>(bufferSizeNeeded));
+        comp->printClassName(clsHnd, (printer->GetUnderlyingArray() + oldBufferSize), bufferSizeNeeded, &bufferSizeNeeded);
+        printer->RemoveAt(printer->GetSize() - 1);
+    }
+
+    if (!includeInstantiation)
+    {
+        return;
+    }
+
+    char pref = '[';
+    for (unsigned typeArgIndex = 0;; typeArgIndex++)
+    {
+        CORINFO_CLASS_HANDLE typeArg = comp->getTypeInstantiationArgument(clsHnd, typeArgIndex);
+
+        if (typeArg == NO_CLASS_HANDLE)
+        {
+            break;
+        }
+
+        printer->Add(pref);
+        pref = ',';
+        AppendTypeOrJitAlias(comp, printer, typeArg, true);
+    }
+
+    if (pref != '[')
+    {
+        printer->Add(']');
+    }
+}
+
+void AppendMethodName(COMP_HANDLE comp,
+                            TArray<char>* printer,
+                            CORINFO_CLASS_HANDLE  clsHnd,
+                            CORINFO_METHOD_HANDLE methHnd,
+                            CORINFO_SIG_INFO*     sig,
+                            bool                  includeClassInstantiation,
+                            bool                  includeMethodInstantiation,
+                            bool                  includeSignature,
+                            bool                  includeReturnType,
+                            bool                  includeThisSpecifier)
+{
+    TArray<char> result;
+
+    if (clsHnd != NO_CLASS_HANDLE)
+    {
+        AppendType(comp, printer, clsHnd, includeClassInstantiation);
+        printer->Add(':');
+    }
+
+    size_t bufferSizeNeeded = 0;
+    comp->printMethodName(methHnd, NULL, 0, &bufferSizeNeeded);
+    if (bufferSizeNeeded != 0)
+    {
+        int32_t oldBufferSize = printer->GetSize();
+        printer->GrowBy(static_cast<int32_t>(bufferSizeNeeded));
+        comp->printMethodName(methHnd, (printer->GetUnderlyingArray() + oldBufferSize), bufferSizeNeeded, &bufferSizeNeeded);
+        printer->RemoveAt(printer->GetSize() - 1); // Remove null terminator
+    }
+
+    if (includeMethodInstantiation && (sig->sigInst.methInstCount > 0))
+    {
+        printer->Add('[');
+        for (unsigned i = 0; i < sig->sigInst.methInstCount; i++)
+        {
+            if (i > 0)
+            {
+                printer->Add(',');
+            }
+
+            AppendTypeOrJitAlias(comp, printer, sig->sigInst.methInst[i], true);
+        }
+        printer->Add(']');
+    }
+
+    if (includeSignature)
+    {
+        printer->Add('(');
+
+        CORINFO_ARG_LIST_HANDLE argLst = sig->args;
+        for (unsigned i = 0; i < sig->numArgs; i++)
+        {
+            if (i > 0)
+                printer->Add(',');
+
+            CORINFO_CLASS_HANDLE vcClsHnd;
+            CorInfoTypeWithMod withMod =  comp->getArgType(sig, argLst, &vcClsHnd);
+            AppendCorInfoTypeWithModModifiers(printer, withMod);
+            CorInfoType type = strip(withMod);
+            switch (type)
+            {
+                case CORINFO_TYPE_STRING:
+                case CORINFO_TYPE_CLASS:
+                case CORINFO_TYPE_VAR:
+                case CORINFO_TYPE_VALUECLASS:
+                case CORINFO_TYPE_REFANY:
+                {
+                    CORINFO_CLASS_HANDLE clsHnd = comp->getArgClass(sig, argLst);
+                    // For some SIMD struct types we can get a nullptr back from eeGetArgClass on Linux/X64
+                    if (clsHnd != NO_CLASS_HANDLE)
+                    {
+                        AppendType(comp, printer, clsHnd, true);
+                        break;
+                    }
+                }
+
+                    FALLTHROUGH;
+                default:
+                    AppendCorInfoType(printer, type);
+                    break;
+            }
+
+            argLst = comp->getArgNext(argLst);
+        }
+
+        printer->Add(')');
+
+        if (includeReturnType)
+        {
+            CorInfoType retType = sig->retType;
+            if (retType != CORINFO_TYPE_VOID)
+            {
+                printer->Add(':');
+                switch (retType)
+                {
+                    case CORINFO_TYPE_STRING:
+                    case CORINFO_TYPE_CLASS:
+                    case CORINFO_TYPE_VAR:
+                    case CORINFO_TYPE_VALUECLASS:
+                    case CORINFO_TYPE_REFANY:
+                    {
+                        CORINFO_CLASS_HANDLE clsHnd = sig->retTypeClass;
+                        if (clsHnd != NO_CLASS_HANDLE)
+                        {
+                            AppendType(comp, printer, clsHnd, true);
+                            break;
+                        }
+                    }
+                        FALLTHROUGH;
+                    default:
+                        AppendCorInfoType(printer, retType);
+                        break;
+                }
+            }
+        }
+
+        // Does it have a 'this' pointer? Don't count explicit this, which has
+        // the this pointer type as the first element of the arg type list
+        if (includeThisSpecifier && sig->hasThis() && !sig->hasExplicitThis())
+        {
+            printer->Append(":this", 5);
+        }
+    }
+}
+
+TArray<char> PrintMethodName(COMP_HANDLE comp,
+                            CORINFO_CLASS_HANDLE  clsHnd,
+                            CORINFO_METHOD_HANDLE methHnd,
+                            CORINFO_SIG_INFO*     sig,
+                            bool                  includeClassInstantiation,
+                            bool                  includeMethodInstantiation,
+                            bool                  includeSignature,
+                            bool                  includeReturnType,
+                            bool                  includeThisSpecifier)
+{
+    TArray<char> printer;
+    AppendMethodName(comp, &printer, clsHnd, methHnd, sig,
+                     includeClassInstantiation, includeMethodInstantiation,
+                     includeSignature, includeReturnType, includeThisSpecifier);
+    printer.Add('\0'); // Ensure null-termination
+    return printer;
+}

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8305,7 +8305,7 @@ public:
     // and do not do any SPMI handling. There are then convenience printing
     // functions exposed on top that have SPMI handling and additional buffer
     // handling. Note that the strings returned are never truncated here.
-    void eePrintJitType(class StringPrinter* printer, var_types jitType);
+    void eePrintCorInfoType(class StringPrinter* printer, CorInfoType corInfoType);
     void eePrintType(class StringPrinter* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation);
     void eePrintTypeOrJitAlias(class StringPrinter* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation);
     void eePrintMethod(class StringPrinter*  printer,


### PR DESCRIPTION
- Duplicate the concept of MethodSet's from the JIT
  -  Methods can be specified with granularity of by method name, class, instantiation, etc.
  - This works for DOTNET_Interpreter, DOTNET_InterpDump and DOTNET_InterpHalt
- Improve printing of method names. The names now match the JIT. One detail here is that the names are now derived directly from CorInfoType instead of the jittype. To avoid differences between interpreter and JIT behavior here, the naming in the jit was adjusted slightly. The most significant change is that bool, byte are now distinguishable, byte and sbyte names that instead of ubyte and byte, and we have nint/nuint instead of those cases being indistinguishable from the integral types.
- Add a new config switch DOTNET_InterpList, when enabled this will list all methods that go through the Interpreter compiler
  - Since this is an integer, add support for arbitrary integer config knobs in the interpreter compiler