### PR TITLE
make copilot setup run on 8 cores not 2

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,7 +7,7 @@ jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   # See https://docs.github.com/en/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
   copilot-setup-steps:
-    runs-on: ubuntu-latest
+    runs-on: 8-core-ubuntu-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
I created this runner group at the org level locked down to main (and test branch) in this repo. (You have to lock to ref(s))

I verified the test runner is found and used when I kick the action manually against this PR branch:
https://github.com/dotnet/runtime/actions/workflows/copilot-setup-steps.yml
It cuts down the setup time from 26 min to 17 min. (We could add more cores too)

Now putting it in main, the question is, will copilot use it, as it creates its own PR branch which it builds (not main). I guess if we merge this, we will find out.