### PR TITLE
Emit an error message if the runtime fails to initialize, instead of just silently aborting

### DIFF
--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -1233,7 +1233,7 @@ void Thread::EnsureRuntimeInitialized()
     {
         if (g_RuntimeInitializationCallback() != 0)
         {
-            PalPrintFatalError("\nFatal error. Runtime failed to initialize.\n");
+            PalPrintFatalError("\nFatal error. .NET runtime failed to initialize.\n");
             RhFailFast();
         }
 

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -1232,7 +1232,10 @@ void Thread::EnsureRuntimeInitialized()
     if (g_RuntimeInitializationCallback != NULL)
     {
         if (g_RuntimeInitializationCallback() != 0)
+        {
+            PalPrintFatalError("\nFatal error. Runtime failed to initialize.\n");
             RhFailFast();
+        }
 
         g_RuntimeInitializationCallback = NULL;
     }


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/95257 and https://github.com/dotnet/runtime/issues/7740 and the various issue reports related to them.