### PR TITLE
Introduce RegexRunnerPool to reuse multiple RegexRunner instances at once under contention

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -52,6 +52,7 @@
     <Compile Include="System\Text\RegularExpressions\RegexRunner.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexRunnerFactory.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexRunnerMode.cs" />
+    <Compile Include="System\Text\RegularExpressions\RegexRunnerPool.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexTree.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexTreeAnalyzer.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexWriter.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunnerPool.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunnerPool.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace System.Text.RegularExpressions
+{
+    internal sealed class RegexRunnerPool
+    {
+        private static readonly int s_maxCapacity = Math.Max(4, Environment.ProcessorCount);
+
+        private ConcurrentStack<RegexRunner> _storage = new();
+        private int _storedCount;
+
+        public bool TryGet([NotNullWhen(true)] out RegexRunner? runner)
+        {
+            if (_storage.TryPop(out runner))
+            {
+                Interlocked.Decrement(ref _storedCount);
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Return(RegexRunner runner)
+        {
+            if (Interlocked.Increment(ref _storedCount) <= s_maxCapacity)
+            {
+                _storage.Push(runner);
+            }
+            else
+            {
+                Interlocked.Decrement(ref _storedCount);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Just a proof of concept for now, will update description if it pans out.