### PR TITLE
Remove redundant unsafe context

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/ComAwareWeakReference.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ComAwareWeakReference.CoreCLR.cs
@@ -28,7 +28,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe bool PossiblyComObject(object target)
+        internal static bool PossiblyComObject(object target)
         {
 #if FEATURE_COMINTEROP
             return target is __ComObject || PossiblyComWrappersObject(target);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.CoreCLR.cs
@@ -138,7 +138,7 @@ namespace System.Reflection
             return GetTypeHelper(typeName, requestingAssembly, throwOnError, requireAssemblyQualifiedName, unsafeAccessorMethod);
         }
 
-        internal static unsafe RuntimeType? GetTypeHelper(ReadOnlySpan<char> typeName, RuntimeAssembly? requestingAssembly,
+        internal static RuntimeType? GetTypeHelper(ReadOnlySpan<char> typeName, RuntimeAssembly? requestingAssembly,
             bool throwOnError, bool requireAssemblyQualifiedName, IntPtr unsafeAccessorMethod = 0)
         {
             // Compat: Empty name throws TypeLoadException instead of

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.CoreCLR.cs
@@ -19,7 +19,7 @@ namespace System.Runtime.InteropServices
         /// <param name="fpQueryInterface">Function pointer to QueryInterface.</param>
         /// <param name="fpAddRef">Function pointer to AddRef.</param>
         /// <param name="fpRelease">Function pointer to Release.</param>
-        public static unsafe void GetIUnknownImpl(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease)
+        public static void GetIUnknownImpl(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease)
             => GetIUnknownImplInternal(out fpQueryInterface, out fpAddRef, out fpRelease);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_GetIUnknownImpl")]

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -500,7 +500,7 @@ namespace System.Threading
         // GC Suspension is done by simply dropping into native code via p/invoke, and we reuse the p/invoke
         // mechanism for suspension. On all architectures we should have the actual stub used for the check be implemented
         // as a small assembly stub which checks the global g_TrapReturningThreads flag and tail-call to this helper
-        private static unsafe void PollGC()
+        private static void PollGC()
         {
             if (CatchAtSafePoint())
             {

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
@@ -32,7 +32,7 @@ internal static partial class Interop
             private  uint _isIPv6;                             // Non-zero if this is an IPv6 address; zero for IPv4.
             internal uint ScopeId;                             // Scope ID (IPv6 only)
 
-            public override unsafe int GetHashCode()
+            public override int GetHashCode()
             {
                 HashCode h = default;
                 h.AddBytes(MemoryMarshal.CreateReadOnlySpan(ref Address[0], IsIPv6 ? IPv6AddressBytes : IPv4AddressBytes));

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/BCryptAlgorithmCache.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/BCryptAlgorithmCache.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
             /// <summary>
             /// Returns a SafeBCryptAlgorithmHandle of the desired algorithm and flags. This is a shared handle so do not dispose it!
             /// </summary>
-            public static unsafe SafeBCryptAlgorithmHandle GetCachedBCryptAlgorithmHandle(string hashAlgorithmId, BCryptOpenAlgorithmProviderFlags flags, out int hashSizeInBytes)
+            public static SafeBCryptAlgorithmHandle GetCachedBCryptAlgorithmHandle(string hashAlgorithmId, BCryptOpenAlgorithmProviderFlags flags, out int hashSizeInBytes)
             {
                 var key = (hashAlgorithmId, flags);
 
@@ -44,7 +44,7 @@ internal static partial class Interop
                 }
             }
 
-            public static unsafe bool IsBCryptAlgorithmSupported(string hashAlgorithmId, BCryptOpenAlgorithmProviderFlags flags)
+            public static bool IsBCryptAlgorithmSupported(string hashAlgorithmId, BCryptOpenAlgorithmProviderFlags flags)
             {
                 var key = (hashAlgorithmId, flags);
 

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CERT_EXTENSION.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CERT_EXTENSION.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct CERT_EXTENSION
+        internal struct CERT_EXTENSION
         {
             internal IntPtr pszObjId;
             internal int fCritical;

--- a/src/libraries/Common/src/Interop/Windows/CryptUI/Interop.CryptUIDlgCertificate.cs
+++ b/src/libraries/Common/src/Interop/Windows/CryptUI/Interop.CryptUIDlgCertificate.cs
@@ -49,7 +49,7 @@ internal static partial class Interop
 
                 public static void Free(Native native) => native.FreeNative();
 
-                internal unsafe struct Native
+                internal struct Native
                 {
                     private uint dwSize;
                     private IntPtr hwndParent;
@@ -161,7 +161,7 @@ internal static partial class Interop
 
                 public static void Free(Native native) => native.FreeNative();
 
-                internal unsafe struct Native
+                internal struct Native
                 {
                     private uint dwSize;
                     private IntPtr hwndParent;

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetTickCount64.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetTickCount64.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal static unsafe partial class Kernel32
+    internal static partial class Kernel32
     {
         [LibraryImport(Libraries.Kernel32)]
         [SuppressGCTransition]

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveKeyMaterial.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveKeyMaterial.cs
@@ -238,7 +238,7 @@ internal static partial class Interop
             }
         }
 
-        internal static unsafe byte[] DeriveKeyMaterialTruncate(
+        internal static byte[] DeriveKeyMaterialTruncate(
             SafeNCryptSecretHandle secretAgreement,
             SecretAgreementFlags flags)
         {

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -1020,7 +1020,7 @@ namespace System.Net.Security
             get { return handle == new IntPtr(0) || handle == new IntPtr(-1); }
         }
 
-        internal unsafe void Set(IntPtr value)
+        internal void Set(IntPtr value)
         {
             this.handle = value;
         }

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -173,7 +173,7 @@ namespace System.Net
             ThrowOnFailure(err);
         }
 
-        public static unsafe void Clear(Span<byte> buffer)
+        public static void Clear(Span<byte> buffer)
         {
             AddressFamily family = GetAddressFamily(buffer);
             buffer.Clear();

--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -22,7 +22,7 @@ namespace System.Security.Cryptography
         ///     if <paramref name="parameters" /> is not a valid RSA key or if <paramref name="parameters"
         ///     /> is a full key pair and the default KSP is used.
         /// </exception>
-        public override unsafe void ImportParameters(RSAParameters parameters)
+        public override void ImportParameters(RSAParameters parameters)
         {
             ArraySegment<byte> keyBlob = parameters.ToBCryptBlob();
 

--- a/src/libraries/Common/tests/TestUtilities/TestEventListener.cs
+++ b/src/libraries/Common/tests/TestUtilities/TestEventListener.cs
@@ -162,7 +162,7 @@ public sealed class TestEventListener : EventListener
             return ((sum & 0xFFF00000) == (uintPtr[3] & 0xFFF00000));
         }
 
-        public static unsafe string ActivityPathString(Guid guid)
+        public static string ActivityPathString(Guid guid)
             => IsActivityPath(guid) ? CreateActivityPathString(guid) : guid.ToString();
 
         internal static unsafe string CreateActivityPathString(Guid guid)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListener.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace System.Net
 {
-    public sealed unsafe partial class HttpListener : IDisposable
+    public sealed partial class HttpListener : IDisposable
     {
         public delegate ExtendedProtectionPolicy ExtendedProtectionSelector(HttpListenerRequest request);
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerContext.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerContext.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace System.Net
 {
-    public sealed unsafe partial class HttpListenerContext
+    public sealed partial class HttpListenerContext
     {
         internal HttpListener? _listener;
         private HttpListenerResponse? _response;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace System.Net
 {
-    public sealed unsafe partial class HttpListenerRequest
+    public sealed partial class HttpListenerRequest
     {
         private CookieCollection? _cookies;
         private bool? _keepAlive;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace System.Net
 {
-    public sealed unsafe partial class HttpListenerResponse : IDisposable
+    public sealed partial class HttpListenerResponse : IDisposable
     {
         private BoundaryType _boundaryType = BoundaryType.None;
         private CookieCollection? _cookies;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -368,7 +368,7 @@ namespace System.Net
             }
         }
 
-        private unsafe void CreateRequestQueueHandle()
+        private void CreateRequestQueueHandle()
         {
             Debug.Assert(Monitor.IsEntered(_internalLock));
             Debug.Assert(_currentSession is null);
@@ -376,7 +376,7 @@ namespace System.Net
             _currentSession = new HttpListenerSession(this);
         }
 
-        private unsafe void CloseRequestQueueHandle()
+        private void CloseRequestQueueHandle()
         {
             Debug.Assert(Monitor.IsEntered(_internalLock));
 
@@ -590,7 +590,7 @@ namespace System.Net
             }
         }
 
-        internal static unsafe bool ValidateRequest(HttpListenerSession session, RequestContextBase requestMemory)
+        internal static bool ValidateRequest(HttpListenerSession session, RequestContextBase requestMemory)
         {
             // Block potential DOS attacks
             if (requestMemory.RequestBlob->Headers.UnknownHeaderCount > UnknownHeaderLimit)
@@ -1456,7 +1456,7 @@ namespace System.Net
             }
         }
 
-        private static unsafe int GetTokenOffsetFromBlob(IntPtr blob)
+        private static int GetTokenOffsetFromBlob(IntPtr blob)
         {
             Debug.Assert(blob != IntPtr.Zero);
             IntPtr tokenPointer = ((Interop.HttpApi.HTTP_REQUEST_CHANNEL_BIND_STATUS*)blob)->ChannelToken;
@@ -1465,7 +1465,7 @@ namespace System.Net
             return (int)((byte*)tokenPointer - (byte*)blob);
         }
 
-        private static unsafe int GetTokenSizeFromBlob(IntPtr blob)
+        private static int GetTokenSizeFromBlob(IntPtr blob)
         {
             Debug.Assert(blob != IntPtr.Zero);
             return (int)((Interop.HttpApi.HTTP_REQUEST_CHANNEL_BIND_STATUS*)blob)->ChannelTokenSize;
@@ -1595,7 +1595,7 @@ namespace System.Net
                 }
             }
 
-            internal unsafe DisconnectAsyncResult(HttpListenerSession session, ulong connectionId)
+            internal DisconnectAsyncResult(HttpListenerSession session, ulong connectionId)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"HttpListener: {session.Listener}, ConnectionId: {connectionId}");
                 _ownershipState = OwnershipState.InHandleAuthentication;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerClientCertAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerClientCertAsyncResult.Windows.cs
@@ -66,7 +66,7 @@ namespace System.Net
             _memoryBlob = (Interop.HttpApi.HTTP_SSL_CLIENT_CERT_INFO*)Marshal.UnsafeAddrOfPinnedArrayElement(_backingBuffer, 0);
         }
 
-        internal unsafe void IOCompleted(uint errorCode, uint numBytes)
+        internal void IOCompleted(uint errorCode, uint numBytes)
         {
             IOCompleted(this, errorCode, numBytes);
         }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
@@ -978,7 +978,7 @@ namespace System.Net.WebSockets
                 _count = count;
             }
 
-            private unsafe void UpdateDataChunk()
+            private void UpdateDataChunk()
             {
                 if (_dataChunks == null)
                 {

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -357,13 +357,13 @@ namespace System.Net
             return addresses;
         }
 
-        private static unsafe IPAddress CreateIPv4Address(ReadOnlySpan<byte> socketAddress)
+        private static IPAddress CreateIPv4Address(ReadOnlySpan<byte> socketAddress)
         {
             long address = (long)SocketAddressPal.GetIPv4Address(socketAddress) & 0x0FFFFFFFF;
             return new IPAddress(address);
         }
 
-        private static unsafe IPAddress CreateIPv6Address(ReadOnlySpan<byte> socketAddress)
+        private static IPAddress CreateIPv6Address(ReadOnlySpan<byte> socketAddress)
         {
             Span<byte> address = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
             SocketAddressPal.GetIPv6Address(socketAddress, address, out uint scope);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
@@ -68,7 +68,7 @@ internal unsafe partial struct QUIC_CONNECTION_EVENT
         };
 }
 
-internal unsafe partial struct QUIC_STREAM_EVENT
+internal partial struct QUIC_STREAM_EVENT
 {
     public override string ToString()
         => Type switch

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
@@ -46,7 +46,7 @@ internal static class MsQuicHelpers
         return IPEndPointExtensions.CreateIPEndPoint(addressBytes);
     }
 
-    internal static unsafe QuicAddr ToQuicAddr(this IPEndPoint ipEndPoint)
+    internal static QuicAddr ToQuicAddr(this IPEndPoint ipEndPoint)
     {
         QuicAddr result = default;
         Span<byte> rawAddress = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref result, 1));

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicSafeHandle.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicSafeHandle.cs
@@ -125,7 +125,7 @@ internal sealed class MsQuicContextSafeHandle : MsQuicSafeHandle
         }
     }
 
-    protected override unsafe bool ReleaseHandle()
+    protected override bool ReleaseHandle()
     {
         base.ReleaseHandle();
         if (_context.IsAllocated)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -349,13 +349,13 @@ public sealed partial class QuicListener : IAsyncDisposable
         return QUIC_STATUS_SUCCESS;
 
     }
-    private unsafe int HandleEventStopComplete()
+    private int HandleEventStopComplete()
     {
         _shutdownTcs.TrySetResult();
         return QUIC_STATUS_SUCCESS;
     }
 
-    private unsafe int HandleListenerEvent(ref QUIC_LISTENER_EVENT listenerEvent)
+    private int HandleListenerEvent(ref QUIC_LISTENER_EVENT listenerEvent)
         => listenerEvent.Type switch
         {
             QUIC_LISTENER_EVENT_TYPE.NEW_CONNECTION => HandleEventNewConnection(ref listenerEvent.NEW_CONNECTION),
@@ -418,10 +418,7 @@ public sealed partial class QuicListener : IAsyncDisposable
         // Check if the listener has been shut down and if not, shut it down.
         if (_shutdownTcs.TryInitialize(out ValueTask valueTask, this))
         {
-            unsafe
-            {
-                MsQuicApi.Api.ListenerStop(_handle);
-            }
+            MsQuicApi.Api.ListenerStop(_handle);
         }
 
         // Wait for STOP_COMPLETE, the last event, so that all resources can be safely released.

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -60,7 +60,7 @@ namespace System.Net.Sockets
             Debug.Assert(!_handle.LastConnectFailed);
         }
 
-        private static unsafe void LoadSocketTypeFromHandle(
+        private static void LoadSocketTypeFromHandle(
             SafeSocketHandle handle, out AddressFamily addressFamily, out SocketType socketType, out ProtocolType protocolType, out bool blocking, out bool isListening, out bool isSocket)
         {
             if (OperatingSystem.IsWasi())

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -347,7 +347,7 @@ namespace System.Net.Sockets
             void IThreadPoolWorkItem.Execute() => AssociatedContext.ProcessAsyncWriteOperation(this);
         }
 
-        private abstract unsafe class SendOperation : WriteOperation
+        private abstract class SendOperation : WriteOperation
         {
             public SocketFlags Flags;
             public int BytesTransferred;
@@ -358,7 +358,7 @@ namespace System.Net.Sockets
 
             public Action<int, Memory<byte>, SocketFlags, SocketError>? Callback { get; set; }
 
-            public override unsafe void InvokeCallback(bool allowPooling) =>
+            public override void InvokeCallback(bool allowPooling) =>
                 Callback!(BytesTransferred, SocketAddress, SocketFlags.None, ErrorCode);
         }
 
@@ -374,7 +374,7 @@ namespace System.Net.Sockets
                 return SocketPal.TryCompleteSendTo(context._socket, Buffer.Span, null, ref bufferIndex, ref Offset, ref Count, Flags, SocketAddress.Span, ref BytesTransferred, out ErrorCode);
             }
 
-            public override unsafe void InvokeCallback(bool allowPooling)
+            public override void InvokeCallback(bool allowPooling)
             {
                 var cb = Callback!;
                 int bt = BytesTransferred;
@@ -668,7 +668,7 @@ namespace System.Net.Sockets
                 return result;
             }
 
-            public override unsafe void InvokeCallback(bool allowPooling)
+            public override void InvokeCallback(bool allowPooling)
             {
                 var cb = Callback!;
                 int bt = BytesTransferred;
@@ -1601,7 +1601,7 @@ namespace System.Net.Sockets
             return ReceiveFromAsync(buffer, flags, Memory<byte>.Empty, out int _, out bytesReceived, out receivedFlags, callback, cancellationToken);
         }
 
-        public unsafe SocketError ReceiveFrom(Memory<byte> buffer, ref SocketFlags flags, Memory<byte> socketAddress, out int socketAddressLen, int timeout, out int bytesReceived)
+        public SocketError ReceiveFrom(Memory<byte> buffer, ref SocketFlags flags, Memory<byte> socketAddress, out int socketAddressLen, int timeout, out int bytesReceived)
         {
             if (!Socket.OSSupportsThreads) throw new PlatformNotSupportedException();
 
@@ -1746,7 +1746,7 @@ namespace System.Net.Sockets
             return ReceiveFromAsync(buffers, flags, Memory<byte>.Empty, out int _, out bytesReceived, out receivedFlags, callback);
         }
 
-        public unsafe SocketError ReceiveFrom(IList<ArraySegment<byte>> buffers, ref SocketFlags flags, Memory<byte> socketAddress, out int socketAddressLen, int timeout, out int bytesReceived)
+        public SocketError ReceiveFrom(IList<ArraySegment<byte>> buffers, ref SocketFlags flags, Memory<byte> socketAddress, out int socketAddressLen, int timeout, out int bytesReceived)
         {
             if (!Socket.OSSupportsThreads) throw new PlatformNotSupportedException();
 
@@ -2247,7 +2247,7 @@ namespace System.Net.Sockets
         }
 
         // Called on ThreadPool thread.
-        public unsafe void HandleEvents(Interop.Sys.SocketEvents events)
+        public void HandleEvents(Interop.Sys.SocketEvents events)
         {
             Debug.Assert((events & Interop.Sys.SocketEvents.Error) == 0);
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -43,7 +43,7 @@ namespace System.Net.Sockets
             }
         }
 
-        internal unsafe SocketError DoOperationAccept(Socket _ /*socket*/, SafeSocketHandle handle, SafeSocketHandle? acceptHandle, CancellationToken cancellationToken)
+        internal SocketError DoOperationAccept(Socket _ /*socket*/, SafeSocketHandle handle, SafeSocketHandle? acceptHandle, CancellationToken cancellationToken)
         {
             if (!_buffer.Equals(default))
             {
@@ -71,7 +71,7 @@ namespace System.Net.Sockets
             CompletionCallback(bytesTransferred, SocketFlags.None, socketError);
         }
 
-        internal unsafe SocketError DoOperationConnectEx(Socket _ /*socket*/, SafeSocketHandle handle)
+        internal SocketError DoOperationConnectEx(Socket _ /*socket*/, SafeSocketHandle handle)
         {
             SocketError socketError = handle.AsyncContext.ConnectAsync(_socketAddress!.Buffer, ConnectCompletionCallback, _buffer.Slice(_offset, _count), out int sentBytes);
             if (socketError != SocketError.IOPending)
@@ -81,7 +81,7 @@ namespace System.Net.Sockets
             return socketError;
         }
 
-        internal unsafe SocketError DoOperationConnect(SafeSocketHandle handle)
+        internal SocketError DoOperationConnect(SafeSocketHandle handle)
         {
             SocketError socketError = handle.AsyncContext.ConnectAsync(_socketAddress!.Buffer, ConnectCompletionCallback, Memory<byte>.Empty, out int _);
             if (socketError != SocketError.IOPending)
@@ -114,7 +114,7 @@ namespace System.Net.Sockets
             _receivedFlags = receivedFlags;
         }
 
-        internal unsafe SocketError DoOperationReceive(SafeSocketHandle handle, CancellationToken cancellationToken)
+        internal SocketError DoOperationReceive(SafeSocketHandle handle, CancellationToken cancellationToken)
         {
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
             _socketAddressSize = 0;
@@ -150,7 +150,7 @@ namespace System.Net.Sockets
             return errorCode;
         }
 
-        internal unsafe SocketError DoOperationReceiveFrom(SafeSocketHandle handle, CancellationToken cancellationToken)
+        internal SocketError DoOperationReceiveFrom(SafeSocketHandle handle, CancellationToken cancellationToken)
         {
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
             _socketAddressSize = 0;
@@ -193,7 +193,7 @@ namespace System.Net.Sockets
             _receiveMessageFromPacketInfo = ipPacketInformation;
         }
 
-        internal unsafe SocketError DoOperationReceiveMessageFrom(Socket socket, SafeSocketHandle handle, CancellationToken cancellationToken)
+        internal SocketError DoOperationReceiveMessageFrom(Socket socket, SafeSocketHandle handle, CancellationToken cancellationToken)
         {
             _receiveMessageFromPacketInfo = default(IPPacketInformation);
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
@@ -216,7 +216,7 @@ namespace System.Net.Sockets
             return socketError;
         }
 
-        internal unsafe SocketError DoOperationSend(SafeSocketHandle handle, CancellationToken cancellationToken)
+        internal SocketError DoOperationSend(SafeSocketHandle handle, CancellationToken cancellationToken)
         {
             _receivedFlags = System.Net.Sockets.SocketFlags.None;
             _socketAddressSize = 0;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -368,7 +368,7 @@ namespace System.Net.Sockets
             return sent;
         }
 
-        private static unsafe long SendFile(SafeSocketHandle socket, SafeFileHandle fileHandle, ref long offset, ref long count, out Interop.Error errno)
+        private static long SendFile(SafeSocketHandle socket, SafeFileHandle fileHandle, ref long offset, ref long count, out Interop.Error errno)
         {
             long bytesSent;
             errno = Interop.Sys.SendFile(socket, fileHandle, offset, count, out bytesSent);
@@ -666,7 +666,7 @@ namespace System.Net.Sockets
             return false;
         }
 
-        public static unsafe bool TryStartConnect(SafeSocketHandle socket, Memory<byte> socketAddress, out SocketError errorCode) => TryStartConnect(socket, socketAddress, out errorCode, Span<byte>.Empty, false, out int _ );
+        public static bool TryStartConnect(SafeSocketHandle socket, Memory<byte> socketAddress, out SocketError errorCode) => TryStartConnect(socket, socketAddress, out errorCode, Span<byte>.Empty, false, out int _ );
 
         public static unsafe bool TryStartConnect(SafeSocketHandle socket, Memory<byte> socketAddress, out SocketError errorCode, Span<byte> data, bool tfo, out int sent)
         {
@@ -900,7 +900,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public static unsafe bool TryCompleteReceiveMessageFrom(SafeSocketHandle socket, Span<byte> buffer, IList<ArraySegment<byte>>? buffers, SocketFlags flags, Memory<byte> socketAddress, out int receivedSocketAddressLength, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
+        public static bool TryCompleteReceiveMessageFrom(SafeSocketHandle socket, Span<byte> buffer, IList<ArraySegment<byte>>? buffers, SocketFlags flags, Memory<byte> socketAddress, out int receivedSocketAddressLength, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
         {
             try
             {
@@ -1117,7 +1117,7 @@ namespace System.Net.Sockets
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
-        public static unsafe SocketError Bind(SafeSocketHandle handle, ProtocolType socketProtocolType, ReadOnlySpan<byte> buffer)
+        public static SocketError Bind(SafeSocketHandle handle, ProtocolType socketProtocolType, ReadOnlySpan<byte> buffer)
         {
             Interop.Error err = Interop.Sys.Bind(handle, socketProtocolType, buffer);
 
@@ -1759,7 +1759,7 @@ namespace System.Net.Sockets
             return SocketError.Success;
         }
 
-        public static unsafe SocketError Poll(SafeSocketHandle handle, int microseconds, SelectMode mode, out bool status)
+        public static SocketError Poll(SafeSocketHandle handle, int microseconds, SelectMode mode, out bool status)
         {
             Interop.PollEvents inEvent = Interop.PollEvents.POLLNONE;
             switch (mode)
@@ -2164,7 +2164,7 @@ namespace System.Net.Sockets
                 SocketError.Success;
         }
 
-        internal static unsafe SafeSocketHandle CreateSocket(IntPtr fileDescriptor)
+        internal static SafeSocketHandle CreateSocket(IntPtr fileDescriptor)
         {
             var res = new SafeSocketHandle(fileDescriptor, ownsHandle: true);
 

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketInflater.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketInflater.cs
@@ -161,7 +161,7 @@ namespace System.Net.WebSockets.Compression
         /// Finishes the decoding by flushing any outstanding data to the output.
         /// </summary>
         /// <returns>true if the flush completed, false to indicate that there is more outstanding data.</returns>
-        private unsafe bool Finish(Span<byte> output, ref int written)
+        private bool Finish(Span<byte> output, ref int written)
         {
             Debug.Assert(_stream is not null && _stream.AvailIn == 0);
             Debug.Assert(_available == 0);

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -157,18 +157,8 @@ namespace System
         /// <returns>The number containing the product of the specified numbers.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ulong BigMul(uint a, uint b)
+        public static ulong BigMul(uint a, uint b)
         {
-#if false // TARGET_32BIT
-            // This generates slower code currently than the simple multiplication
-            // https://github.com/dotnet/runtime/issues/11782
-            if (Bmi2.IsSupported)
-            {
-                uint low;
-                uint high = Bmi2.MultiplyNoFlags(a, b, &low);
-                return ((ulong)high << 32) | low;
-            }
-#endif
             return ((ulong)a) * b;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1261,7 +1261,7 @@ namespace System
         /// The index in the span of the first occurrence of any value other than those in <paramref name="values"/>.
         /// If all of the values are in <paramref name="values"/>, returns -1.
         /// </returns>
-        public static unsafe int IndexOfAnyExcept<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values, IEqualityComparer<T>? comparer = null)
+        public static int IndexOfAnyExcept<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values, IEqualityComparer<T>? comparer = null)
         {
             switch (values.Length)
             {
@@ -1841,7 +1841,7 @@ namespace System
         /// The index in the span of the first occurrence of any value other than those in <paramref name="values"/>.
         /// If all of the values are in <paramref name="values"/>, returns -1.
         /// </returns>
-        public static unsafe int LastIndexOfAnyExcept<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values, IEqualityComparer<T>? comparer = null)
+        public static int LastIndexOfAnyExcept<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values, IEqualityComparer<T>? comparer = null)
         {
             switch (values.Length)
             {
@@ -3364,7 +3364,7 @@ namespace System
         /// <param name="span">The span to search.</param>
         /// <param name="values">The set of values to search for.</param>
         /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to use the default <see cref="IEqualityComparer{T}"/> for the type of an element.</param>
-        public static unsafe int LastIndexOfAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values, IEqualityComparer<T>? comparer = null)
+        public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values, IEqualityComparer<T>? comparer = null)
         {
             switch (values.Length)
             {
@@ -3527,7 +3527,7 @@ namespace System
         /// <summary>
         /// Determines the relative order of the sequences being compared by comparing the elements using IComparable{T}.CompareTo(T).
         /// </summary>
-        public static unsafe int SequenceCompareTo<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other, IComparer<T>? comparer = null)
+        public static int SequenceCompareTo<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other, IComparer<T>? comparer = null)
         {
             int minLength = Math.Min(span.Length, other.Length);
             comparer ??= Comparer<T>.Default;
@@ -3580,7 +3580,7 @@ namespace System
         /// <param name="value">The sequence to compare to the start of <paramref name="span"/>.</param>
         /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to use the default <see cref="IEqualityComparer{T}"/> for the type of an element.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool StartsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value, IEqualityComparer<T>? comparer = null) =>
+        public static bool StartsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value, IEqualityComparer<T>? comparer = null) =>
             value.Length <= span.Length &&
             SequenceEqual(span.Slice(0, value.Length), value, comparer);
 
@@ -3625,7 +3625,7 @@ namespace System
         /// <param name="value">The sequence to compare to the end of <paramref name="span"/>.</param>
         /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to use the default <see cref="IEqualityComparer{T}"/> for the type of an element.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool EndsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value, IEqualityComparer<T>? comparer = null) =>
+        public static bool EndsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value, IEqualityComparer<T>? comparer = null) =>
             value.Length <= span.Length &&
             SequenceEqual(span.Slice(span.Length - value.Length), value, comparer);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -85,7 +85,7 @@ namespace System.Runtime.InteropServices
             return Marshal.QueryInterface(wrapper.ExternalComObject, iid, out unknown) == HResults.S_OK;
         }
 
-        public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown)
+        public static bool TryGetComInstance(object obj, out IntPtr unknown)
         {
             unknown = IntPtr.Zero;
             if (obj == null
@@ -119,7 +119,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// ABI for function dispatch of a COM interface.
         /// </summary>
-        public unsafe partial struct ComInterfaceDispatch
+        public partial struct ComInterfaceDispatch
         {
             public IntPtr Vtable;
 
@@ -158,7 +158,7 @@ namespace System.Runtime.InteropServices
             public DispatchTable Vtables;
 
             [InlineArray(NumEntriesInDispatchTable)]
-            internal unsafe struct DispatchTable
+            internal struct DispatchTable
             {
                 private IntPtr _element;
             }
@@ -289,7 +289,7 @@ namespace System.Runtime.InteropServices
             }
 
 
-            public unsafe int QueryInterfaceForTracker(in Guid riid, out IntPtr ppvObject)
+            public int QueryInterfaceForTracker(in Guid riid, out IntPtr ppvObject)
             {
                 if (IsMarkedToDestroy(RefCount) || Holder is null)
                 {
@@ -300,7 +300,7 @@ namespace System.Runtime.InteropServices
                 return QueryInterface(in riid, out ppvObject);
             }
 
-            public unsafe int QueryInterface(in Guid riid, out IntPtr ppvObject)
+            public int QueryInterface(in Guid riid, out IntPtr ppvObject)
             {
                 ppvObject = AsRuntimeDefined(in riid);
                 if (ppvObject == IntPtr.Zero)
@@ -347,7 +347,7 @@ namespace System.Runtime.InteropServices
             }
 
             /// <returns>true if actually destroyed</returns>
-            public unsafe bool Destroy()
+            public bool Destroy()
             {
                 Debug.Assert(GetComCount(RefCount) == 0 || HolderHandle == IntPtr.Zero);
 
@@ -380,14 +380,14 @@ namespace System.Runtime.InteropServices
                 }
             }
 
-            private unsafe IntPtr GetDispatchPointerAtIndex(int index)
+            private IntPtr GetDispatchPointerAtIndex(int index)
             {
                 InternalComInterfaceDispatch* dispatch = &Dispatches[index / InternalComInterfaceDispatch.NumEntriesInDispatchTable];
                 IntPtr* vtables = (IntPtr*)(void*)&dispatch->Vtables;
                 return (IntPtr)(&vtables[index % InternalComInterfaceDispatch.NumEntriesInDispatchTable]);
             }
 
-            private unsafe IntPtr AsRuntimeDefined(in Guid riid)
+            private IntPtr AsRuntimeDefined(in Guid riid)
             {
                 // The order of interface lookup here is important.
                 // See CreateManagedObjectWrapper() for the expected order.
@@ -422,7 +422,7 @@ namespace System.Runtime.InteropServices
                 return IntPtr.Zero;
             }
 
-            private unsafe IntPtr AsUserDefined(in Guid riid)
+            private IntPtr AsUserDefined(in Guid riid)
             {
                 for (int i = 0; i < UserDefinedCount; ++i)
                 {
@@ -483,7 +483,7 @@ namespace System.Runtime.InteropServices
                 _wrapper->HolderHandle = AllocateRefCountedHandle(this);
             }
 
-            public unsafe IntPtr ComIp => _wrapper->As(in ComWrappers.IID_IUnknown);
+            public IntPtr ComIp => _wrapper->As(in ComWrappers.IID_IUnknown);
 
             public object WrappedObject => _wrappedObject;
 
@@ -1555,7 +1555,7 @@ namespace System.Runtime.InteropServices
             return null;
         }
 
-        private static unsafe bool PossiblyComObject(object target)
+        private static bool PossiblyComObject(object target)
         {
             // If the RCW is an aggregated RCW, then the managed object cannot be recreated from the IUnknown
             // as the outer IUnknown wraps the managed object. In this case, don't create a weak reference backed
@@ -1563,7 +1563,7 @@ namespace System.Runtime.InteropServices
             return s_nativeObjectWrapperTable.TryGetValue(target, out NativeObjectWrapper? wrapper) && !wrapper.IsAggregatedWithManagedObjectWrapper;
         }
 
-        private static unsafe IntPtr ObjectToComWeakRef(object target, out object? context)
+        private static IntPtr ObjectToComWeakRef(object target, out object? context)
         {
             context = null;
             if (TryGetComInstanceForIID(

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ReferenceTrackerHost.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ReferenceTrackerHost.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.InteropServices
 
 #pragma warning disable IDE0060, CS3016
         [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-        internal static unsafe int IReferenceTrackerHost_DisconnectUnusedReferenceSources(IntPtr pThis, uint flags)
+        internal static int IReferenceTrackerHost_DisconnectUnusedReferenceSources(IntPtr pThis, uint flags)
 #pragma warning restore IDE0060, CS3016
         {
             try
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices
 
 #pragma warning disable IDE0060, CS3016
         [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-        internal static unsafe int IReferenceTrackerHost_ReleaseDisconnectedReferenceSources(IntPtr pThis)
+        internal static int IReferenceTrackerHost_ReleaseDisconnectedReferenceSources(IntPtr pThis)
 #pragma warning restore IDE0060, CS3016
         {
             // We'd like to call GC.WaitForPendingFinalizers() here, but this could lead to deadlock
@@ -58,7 +58,7 @@ namespace System.Runtime.InteropServices
 
 #pragma warning disable IDE0060, CS3016
         [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-        internal static unsafe int IReferenceTrackerHost_NotifyEndOfReferenceTrackingOnThread(IntPtr pThis)
+        internal static int IReferenceTrackerHost_NotifyEndOfReferenceTrackingOnThread(IntPtr pThis)
 #pragma warning restore IDE0060, CS3016
         {
             try
@@ -101,7 +101,7 @@ namespace System.Runtime.InteropServices
 
 #pragma warning disable IDE0060, CS3016
         [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-        internal static unsafe int IReferenceTrackerHost_AddMemoryPressure(IntPtr pThis, long bytesAllocated)
+        internal static int IReferenceTrackerHost_AddMemoryPressure(IntPtr pThis, long bytesAllocated)
 #pragma warning restore IDE0060, CS3016
         {
             try
@@ -117,7 +117,7 @@ namespace System.Runtime.InteropServices
 
 #pragma warning disable IDE0060, CS3016
         [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-        internal static unsafe int IReferenceTrackerHost_RemoveMemoryPressure(IntPtr pThis, long bytesAllocated)
+        internal static int IReferenceTrackerHost_RemoveMemoryPressure(IntPtr pThis, long bytesAllocated)
 #pragma warning restore IDE0060, CS3016
         {
             try

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.PlatformNotSupported.cs
@@ -34,49 +34,49 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint8_t svbcax[_u8](svuint8_t op1, svuint8_t op2, svuint8_t op3)
         ///   BCAX Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<byte> BitwiseClearXor(Vector<byte> xor, Vector<byte> value, Vector<byte> mask) { throw new PlatformNotSupportedException(); }
+        public static Vector<byte> BitwiseClearXor(Vector<byte> xor, Vector<byte> value, Vector<byte> mask) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint16_t svbcax[_s16](svint16_t op1, svint16_t op2, svint16_t op3)
         ///   BCAX Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<short> BitwiseClearXor(Vector<short> xor, Vector<short> value, Vector<short> mask) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> BitwiseClearXor(Vector<short> xor, Vector<short> value, Vector<short> mask) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svbcax[_s32](svint32_t op1, svint32_t op2, svint32_t op3)
         ///   BCAX Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<int> BitwiseClearXor(Vector<int> xor, Vector<int> value, Vector<int> mask) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> BitwiseClearXor(Vector<int> xor, Vector<int> value, Vector<int> mask) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svbcax[_s64](svint64_t op1, svint64_t op2, svint64_t op3)
         ///   BCAX Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<long> BitwiseClearXor(Vector<long> xor, Vector<long> value, Vector<long> mask) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> BitwiseClearXor(Vector<long> xor, Vector<long> value, Vector<long> mask) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint8_t svbcax[_s8](svint8_t op1, svint8_t op2, svint8_t op3)
         ///   BCAX Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<sbyte> BitwiseClearXor(Vector<sbyte> xor, Vector<sbyte> value, Vector<sbyte> mask) { throw new PlatformNotSupportedException(); }
+        public static Vector<sbyte> BitwiseClearXor(Vector<sbyte> xor, Vector<sbyte> value, Vector<sbyte> mask) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint16_t svbcax[_u16](svuint16_t op1, svuint16_t op2, svuint16_t op3)
         ///   BCAX Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ushort> BitwiseClearXor(Vector<ushort> xor, Vector<ushort> value, Vector<ushort> mask) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> BitwiseClearXor(Vector<ushort> xor, Vector<ushort> value, Vector<ushort> mask) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint32_t svbcax[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   BCAX Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<uint> BitwiseClearXor(Vector<uint> xor, Vector<uint> value, Vector<uint> mask) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> BitwiseClearXor(Vector<uint> xor, Vector<uint> value, Vector<uint> mask) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svbcax[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   BCAX Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ulong> BitwiseClearXor(Vector<ulong> xor, Vector<ulong> value, Vector<ulong> mask) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> BitwiseClearXor(Vector<ulong> xor, Vector<ulong> value, Vector<ulong> mask) { throw new PlatformNotSupportedException(); }
 
 
         // Bitwise select
@@ -85,49 +85,49 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint8_t svbsl[_u8](svuint8_t op1, svuint8_t op2, svuint8_t op3)
         ///   BSL Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<byte> BitwiseSelect(Vector<byte> select, Vector<byte> left, Vector<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<byte> BitwiseSelect(Vector<byte> select, Vector<byte> left, Vector<byte> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint16_t svbsl[_s16](svint16_t op1, svint16_t op2, svint16_t op3)
         ///   BSL Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<short> BitwiseSelect(Vector<short> select, Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> BitwiseSelect(Vector<short> select, Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svbsl[_s32](svint32_t op1, svint32_t op2, svint32_t op3)
         ///   BSL Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<int> BitwiseSelect(Vector<int> select, Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> BitwiseSelect(Vector<int> select, Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svbsl[_s64](svint64_t op1, svint64_t op2, svint64_t op3)
         ///   BSL Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<long> BitwiseSelect(Vector<long> select, Vector<long> left, Vector<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> BitwiseSelect(Vector<long> select, Vector<long> left, Vector<long> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint8_t svbsl[_s8](svint8_t op1, svint8_t op2, svint8_t op3)
         ///   BSL Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<sbyte> BitwiseSelect(Vector<sbyte> select, Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<sbyte> BitwiseSelect(Vector<sbyte> select, Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint16_t svbsl[_u16](svuint16_t op1, svuint16_t op2, svuint16_t op3)
         ///   BSL Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ushort> BitwiseSelect(Vector<ushort> select, Vector<ushort> left, Vector<ushort> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> BitwiseSelect(Vector<ushort> select, Vector<ushort> left, Vector<ushort> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint32_t svbsl[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   BSL Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<uint> BitwiseSelect(Vector<uint> select, Vector<uint> left, Vector<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> BitwiseSelect(Vector<uint> select, Vector<uint> left, Vector<uint> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svbsl[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   BSL Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ulong> BitwiseSelect(Vector<ulong> select, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> BitwiseSelect(Vector<ulong> select, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
         // Bitwise select with first input inverted
@@ -136,49 +136,49 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint8_t svbsl1n[_u8](svuint8_t op1, svuint8_t op2, svuint8_t op3)
         ///   BSL1N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<byte> BitwiseSelectLeftInverted(Vector<byte> select, Vector<byte> left, Vector<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<byte> BitwiseSelectLeftInverted(Vector<byte> select, Vector<byte> left, Vector<byte> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint16_t svbsl1n[_s16](svint16_t op1, svint16_t op2, svint16_t op3)
         ///   BSL1N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<short> BitwiseSelectLeftInverted(Vector<short> select, Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> BitwiseSelectLeftInverted(Vector<short> select, Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svbsl1n[_s32](svint32_t op1, svint32_t op2, svint32_t op3)
         ///   BSL1N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<int> BitwiseSelectLeftInverted(Vector<int> select, Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> BitwiseSelectLeftInverted(Vector<int> select, Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svbsl1n[_s64](svint64_t op1, svint64_t op2, svint64_t op3)
         ///   BSL1N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<long> BitwiseSelectLeftInverted(Vector<long> select, Vector<long> left, Vector<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> BitwiseSelectLeftInverted(Vector<long> select, Vector<long> left, Vector<long> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint8_t svbsl1n[_s8](svint8_t op1, svint8_t op2, svint8_t op3)
         ///   BSL1N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<sbyte> BitwiseSelectLeftInverted(Vector<sbyte> select, Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<sbyte> BitwiseSelectLeftInverted(Vector<sbyte> select, Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint16_t svbsl1n[_u16](svuint16_t op1, svuint16_t op2, svuint16_t op3)
         ///   BSL1N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ushort> BitwiseSelectLeftInverted(Vector<ushort> select, Vector<ushort> left, Vector<ushort> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> BitwiseSelectLeftInverted(Vector<ushort> select, Vector<ushort> left, Vector<ushort> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint32_t svbsl1n[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   BSL1N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<uint> BitwiseSelectLeftInverted(Vector<uint> select, Vector<uint> left, Vector<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> BitwiseSelectLeftInverted(Vector<uint> select, Vector<uint> left, Vector<uint> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svbsl1n[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   BSL1N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ulong> BitwiseSelectLeftInverted(Vector<ulong> select, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> BitwiseSelectLeftInverted(Vector<ulong> select, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
 
         // Bitwise select with second input inverted
@@ -187,49 +187,49 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint8_t svbsl2n[_u8](svuint8_t op1, svuint8_t op2, svuint8_t op3)
         ///   BSL2N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<byte> BitwiseSelectRightInverted(Vector<byte> select, Vector<byte> left, Vector<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<byte> BitwiseSelectRightInverted(Vector<byte> select, Vector<byte> left, Vector<byte> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint16_t svbsl2n[_s16](svint16_t op1, svint16_t op2, svint16_t op3)
         ///   BSL2N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<short> BitwiseSelectRightInverted(Vector<short> select, Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> BitwiseSelectRightInverted(Vector<short> select, Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svbsl2n[_s32](svint32_t op1, svint32_t op2, svint32_t op3)
         ///   BSL2N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<int> BitwiseSelectRightInverted(Vector<int> select, Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> BitwiseSelectRightInverted(Vector<int> select, Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svbsl2n[_s64](svint64_t op1, svint64_t op2, svint64_t op3)
         ///   BSL2N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<long> BitwiseSelectRightInverted(Vector<long> select, Vector<long> left, Vector<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> BitwiseSelectRightInverted(Vector<long> select, Vector<long> left, Vector<long> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint8_t svbsl2n[_s8](svint8_t op1, svint8_t op2, svint8_t op3)
         ///   BSL2N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<sbyte> BitwiseSelectRightInverted(Vector<sbyte> select, Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<sbyte> BitwiseSelectRightInverted(Vector<sbyte> select, Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint16_t svbsl2n[_u16](svuint16_t op1, svuint16_t op2, svuint16_t op3)
         ///   BSL2N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ushort> BitwiseSelectRightInverted(Vector<ushort> select, Vector<ushort> left, Vector<ushort> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> BitwiseSelectRightInverted(Vector<ushort> select, Vector<ushort> left, Vector<ushort> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint32_t svbsl2n[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   BSL2N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<uint> BitwiseSelectRightInverted(Vector<uint> select, Vector<uint> left, Vector<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> BitwiseSelectRightInverted(Vector<uint> select, Vector<uint> left, Vector<uint> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svbsl2n[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   BSL2N Ztied1.D, Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ulong> BitwiseSelectRightInverted(Vector<ulong> select, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> BitwiseSelectRightInverted(Vector<ulong> select, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
 
         // Shift left and insert
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
@@ -22,7 +22,7 @@ namespace System.Threading
             SafeWaitHandle = handle;
         }
 
-        private unsafe void CreateEventCore(bool initialState, EventResetMode mode)
+        private void CreateEventCore(bool initialState, EventResetMode mode)
         {
             ValidateMode(mode);
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Text/BinHexEncoding.cs
@@ -21,7 +21,7 @@ namespace System.Text
             return GetMaxByteCount(count);
         }
 
-        public override unsafe int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             ArgumentNullException.ThrowIfNull(chars);
             ArgumentOutOfRangeException.ThrowIfNegative(charIndex);
@@ -60,7 +60,7 @@ namespace System.Text
             return GetMaxCharCount(count);
         }
 
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
         {
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentOutOfRangeException.ThrowIfNegative(byteIndex);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
@@ -1234,7 +1234,7 @@ namespace System.Xml
                 throw new ArgumentOutOfRangeException(nameof(count), SR.Format(SR.SizeExceedsRemainingBufferSpace, array.Length - offset));
         }
 
-        private unsafe int ReadArray(bool[] array, int offset, int count)
+        private int ReadArray(bool[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
             int actual = Math.Min(count, _arrayCount);
@@ -1257,7 +1257,7 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        private unsafe int ReadArray(short[] array, int offset, int count)
+        private int ReadArray(short[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
             int actual = Math.Min(count, _arrayCount);
@@ -1280,7 +1280,7 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        private unsafe int ReadArray(int[] array, int offset, int count)
+        private int ReadArray(int[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
             int actual = Math.Min(count, _arrayCount);
@@ -1303,7 +1303,7 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        private unsafe int ReadArray(long[] array, int offset, int count)
+        private int ReadArray(long[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
             int actual = Math.Min(count, _arrayCount);
@@ -1326,7 +1326,7 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        private unsafe int ReadArray(float[] array, int offset, int count)
+        private int ReadArray(float[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
             int actual = Math.Min(count, _arrayCount);
@@ -1349,7 +1349,7 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        private unsafe int ReadArray(double[] array, int offset, int count)
+        private int ReadArray(double[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
             int actual = Math.Min(count, _arrayCount);
@@ -1372,7 +1372,7 @@ namespace System.Xml
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
-        private unsafe int ReadArray(decimal[] array, int offset, int count)
+        private int ReadArray(decimal[] array, int offset, int count)
         {
             CheckArray(array, offset, count);
             int actual = Math.Min(count, _arrayCount);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -565,7 +565,7 @@ namespace System.Xml
             }
         }
 
-        public override unsafe void WriteText(string value)
+        public override void WriteText(string value)
             => WriteTextImpl(value);
 
         public override void WriteText(char[] chars, int offset, int count)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
@@ -707,13 +707,13 @@ namespace System.Xml
             return count + ToCharsR((int)value, chars, offset);
         }
 
-        private static unsafe bool IsNegativeZero(float value)
+        private static bool IsNegativeZero(float value)
         {
             // Simple equals function will report that -0 is equal to +0, so compare bits instead
             return BitConverter.SingleToUInt32Bits(value) == 0x8000_0000U;
         }
 
-        private static unsafe bool IsNegativeZero(double value)
+        private static bool IsNegativeZero(double value)
         {
             // Simple equals function will report that -0 is equal to +0, so compare bits instead
             return BitConverter.DoubleToUInt64Bits(value) == 0x8000_0000_0000_0000UL;

--- a/src/libraries/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -87,7 +87,7 @@ namespace System.Net
             return new string(stackSpace.Slice(0, pos));
         }
 
-        private static unsafe bool IsLoopback(ReadOnlySpan<ushort> numbers)
+        private static bool IsLoopback(ReadOnlySpan<ushort> numbers)
         {
             //
             // is the address loopback? Loopback is defined as one of:

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -585,7 +585,7 @@ namespace System
         // The assumptions:
         //  - baseUri is a valid absolute Uri
         //  - relative part is not null and not empty
-        private static unsafe void GetCombinedString(Uri baseUri, string relativeStr,
+        private static void GetCombinedString(Uri baseUri, string relativeStr,
             bool dontEscape, ref string? result)
         {
             // NB: This is not RFC2396 compliant although it is inline with w3c.org recommendations
@@ -1903,7 +1903,7 @@ namespace System
         //  This method is called first to figure out the scheme or a simple file path
         //  Is called only at the .ctor time
         //
-        private static unsafe ParsingError ParseScheme(string uriString, ref Flags flags, ref UriParser? syntax)
+        private static ParsingError ParseScheme(string uriString, ref Flags flags, ref UriParser? syntax)
         {
             Debug.Assert((flags & Flags.Debug_LeftConstructor) == 0);
 

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -10,7 +10,7 @@ namespace System
 {
     internal static class UriHelper
     {
-        public static unsafe string SpanToLowerInvariantString(ReadOnlySpan<char> span)
+        public static string SpanToLowerInvariantString(ReadOnlySpan<char> span)
         {
             return string.Create(span.Length, span, static (buffer, span) =>
             {
@@ -212,7 +212,7 @@ namespace System
             return result;
         }
 
-        internal static unsafe void EscapeString(scoped ReadOnlySpan<char> stringToEscape, ref ValueStringBuilder dest,
+        internal static void EscapeString(scoped ReadOnlySpan<char> stringToEscape, ref ValueStringBuilder dest,
             bool checkExistingEscaped, SearchValues<char> noEscape)
         {
             Debug.Assert(!noEscape.Contains('%'), "Need to treat % specially; it should be part of any escaped set");
@@ -591,7 +591,7 @@ namespace System
             char.IsBetween(ch, '\u200E', '\u202E') && !char.IsBetween(ch, '\u2010', '\u2029');
 
         // Strip Bidirectional control characters from this string
-        internal static unsafe string StripBidiControlCharacters(ReadOnlySpan<char> strToClean, string? backingString = null)
+        internal static string StripBidiControlCharacters(ReadOnlySpan<char> strToClean, string? backingString = null)
         {
             Debug.Assert(backingString is null || strToClean.Length == backingString.Length);
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
@@ -2962,7 +2962,7 @@ namespace System.Xml.Xsl
             }
         }
 
-        public static unsafe double StringToDouble(string s)
+        public static double StringToDouble(string s)
         {
             if (double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out double result) && double.IsFinite(result))
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlockProvider.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/ExternalMemoryBlockProvider.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Internal
         private byte* _memory;
         private int _size;
 
-        public unsafe ExternalMemoryBlockProvider(byte* memory, int size)
+        public ExternalMemoryBlockProvider(byte* memory, int size)
         {
             _memory = memory;
             _size = size;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/MemoryMappedFileBlock.cs
@@ -60,7 +60,7 @@ namespace System.Reflection.Internal
         private readonly DisposableData _data;
         private readonly int _size;
 
-        internal unsafe MemoryMappedFileBlock(IDisposable accessor, SafeBuffer safeBuffer, long offset, int size)
+        internal MemoryMappedFileBlock(IDisposable accessor, SafeBuffer safeBuffer, long offset, int size)
         {
             _data = new DisposableData(accessor, safeBuffer, offset);
             _size = size;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
@@ -114,7 +114,7 @@ namespace System.Reflection.Internal
         }
 
         /// <exception cref="IOException">IO error while mapping memory or not enough memory to create the mapping.</exception>
-        private unsafe MemoryMappedFileBlock CreateMemoryMappedFileBlock(long start, int size)
+        private MemoryMappedFileBlock CreateMemoryMappedFileBlock(long start, int size)
         {
             if (_lazyMemoryMap == null)
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
@@ -249,7 +249,7 @@ namespace System.Reflection.Metadata.Ecma335
         /// </summary>
         /// <param name="value">Constant value.</param>
         /// <returns>Handle to the added or existing blob.</returns>
-        public unsafe BlobHandle GetOrAddConstantBlob(object? value)
+        public BlobHandle GetOrAddConstantBlob(object? value)
         {
             if (value is string str)
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.EmbeddedPortablePdb.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.EmbeddedPortablePdb.cs
@@ -31,7 +31,7 @@ namespace System.Reflection.PortableExecutable
         /// <exception cref="ArgumentException"><paramref name="entry"/> is not a <see cref="DebugDirectoryEntryType.EmbeddedPortablePdb"/> entry.</exception>
         /// <exception cref="BadImageFormatException">Bad format of the data.</exception>
         /// <exception cref="InvalidOperationException">PE image not available.</exception>
-        public unsafe MetadataReaderProvider ReadEmbeddedPortablePdbDebugDirectoryData(DebugDirectoryEntry entry)
+        public MetadataReaderProvider ReadEmbeddedPortablePdbDebugDirectoryData(DebugDirectoryEntry entry)
         {
             if (entry.Type != DebugDirectoryEntryType.EmbeddedPortablePdb)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
@@ -273,7 +273,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        public static unsafe Task BindAssemblyExports(string? assemblyName)
+        public static Task BindAssemblyExports(string? assemblyName)
         {
             Interop.Runtime.BindAssemblyExports(Marshal.StringToCoTaskMemUTF8(assemblyName));
             return Task.CompletedTask;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
@@ -80,7 +80,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void Initialize()
+        public void Initialize()
         {
             slot.Type = MarshalerType.None;
 #if FEATURE_WASM_MANAGED_THREADS

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
@@ -365,7 +365,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        public unsafe void ReleasePromiseHolder(nint holderGCHandle)
+        public void ReleasePromiseHolder(nint holderGCHandle)
         {
 #if FEATURE_WASM_MANAGED_THREADS
             lock (this)
@@ -396,8 +396,11 @@ namespace System.Runtime.InteropServices.JavaScript
                     handle.Free();
                 }
 #if FEATURE_WASM_MANAGED_THREADS
-                Marshal.FreeHGlobal((IntPtr)holder.State);
-                holder.State = null;
+                unsafe
+                {
+                    Marshal.FreeHGlobal((IntPtr)holder.State);
+                    holder.State = null;
+                }
 #endif
             }
         }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.BigInt64.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.BigInt64.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManagedBig(out long value)
+        public void ToManagedBig(out long value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManagedBig(out long? value)
+        public void ToManagedBig(out long? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Bool.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Bool.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out bool value)
+        public void ToManaged(out bool value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out bool? value)
+        public void ToManaged(out bool? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Byte.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Byte.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out byte value)
+        public void ToManaged(out byte value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out byte? value)
+        public void ToManaged(out byte? value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -83,7 +83,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// It's used by JSImport code generator and should not be used by developers in source code.
         /// </summary>
         /// <param name="value">The value to be marshaled.</param>
-        public unsafe void ToManaged(out byte[]? value)
+        public void ToManaged(out byte[]? value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -100,7 +100,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// It's used by JSImport code generator and should not be used by developers in source code.
         /// </summary>
         /// <param name="value">The value to be marshaled.</param>
-        public unsafe void ToJS(byte[]? value)
+        public void ToJS(byte[]? value)
         {
             if (value == null)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Char.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Char.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out char value)
+        public void ToManaged(out char value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out char? value)
+        public void ToManaged(out char? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.DateTime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.DateTime.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out DateTimeOffset value)
+        public void ToManaged(out DateTimeOffset value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out DateTimeOffset? value)
+        public void ToManaged(out DateTimeOffset? value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -86,7 +86,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out DateTime value)
+        public void ToManaged(out DateTime value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -118,7 +118,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out DateTime? value)
+        public void ToManaged(out DateTime? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Double.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Double.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out double value)
+        public void ToManaged(out double value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out double? value)
+        public void ToManaged(out double? value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -86,7 +86,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out double[]? value)
+        public void ToManaged(out double[]? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Exception.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Exception.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out Exception? value)
+        public void ToManaged(out Exception? value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -53,7 +53,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToJS(Exception? value)
+        public void ToJS(Exception? value)
         {
             if (value == null)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Func.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Func.cs
@@ -162,7 +162,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// It's used by JSImport code generator and should not be used by developers in source code.
         /// </summary>
         /// <param name="value">The value to be marshaled.</param>
-        public unsafe void ToManaged(out Action? value)
+        public void ToManaged(out Action? value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -182,7 +182,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <typeparam name="T">The type of the marshaled argument of the Action.</typeparam>
         /// <param name="value">The value to be marshaled.</param>
         /// <param name="arg1Marshaler">The generated callback which marshals the argument of the Action.</param>
-        public unsafe void ToManaged<T>(out Action<T>? value, ArgumentToJSCallback<T> arg1Marshaler)
+        public void ToManaged<T>(out Action<T>? value, ArgumentToJSCallback<T> arg1Marshaler)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -204,7 +204,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <param name="value">The value to be marshaled.</param>
         /// <param name="arg1Marshaler">The generated callback which marshals the argument of the Action.</param>
         /// <param name="arg2Marshaler">The generated callback which marshals the argument of the Action.</param>
-        public unsafe void ToManaged<T1, T2>(out Action<T1, T2>? value, ArgumentToJSCallback<T1> arg1Marshaler, ArgumentToJSCallback<T2> arg2Marshaler)
+        public void ToManaged<T1, T2>(out Action<T1, T2>? value, ArgumentToJSCallback<T1> arg1Marshaler, ArgumentToJSCallback<T2> arg2Marshaler)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -228,7 +228,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <param name="arg1Marshaler">The generated callback which marshals the argument of the Action.</param>
         /// <param name="arg2Marshaler">The generated callback which marshals the argument of the Action.</param>
         /// <param name="arg3Marshaler">The generated callback which marshals the argument of the Action.</param>
-        public unsafe void ToManaged<T1, T2, T3>(out Action<T1, T2, T3>? value, ArgumentToJSCallback<T1> arg1Marshaler, ArgumentToJSCallback<T2> arg2Marshaler, ArgumentToJSCallback<T3> arg3Marshaler)
+        public void ToManaged<T1, T2, T3>(out Action<T1, T2, T3>? value, ArgumentToJSCallback<T1> arg1Marshaler, ArgumentToJSCallback<T2> arg2Marshaler, ArgumentToJSCallback<T3> arg3Marshaler)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -418,7 +418,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <typeparam name="TResult">Type of marshaled result of the Func.</typeparam>
         /// <param name="value">The value to be marshaled.</param>
         /// <param name="resMarshaler">The generated callback which marshals the result of the Func.</param>
-        public unsafe void ToManaged<TResult>(out Func<TResult>? value, ArgumentToManagedCallback<TResult> resMarshaler)
+        public void ToManaged<TResult>(out Func<TResult>? value, ArgumentToManagedCallback<TResult> resMarshaler)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -440,7 +440,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <param name="value">The value to be marshaled.</param>
         /// <param name="arg1Marshaler">The generated callback which marshals the argument of the Func.</param>
         /// <param name="resMarshaler">The generated callback which marshals the result of the Func.</param>
-        public unsafe void ToManaged<T, TResult>(out Func<T, TResult>? value, ArgumentToJSCallback<T> arg1Marshaler, ArgumentToManagedCallback<TResult> resMarshaler)
+        public void ToManaged<T, TResult>(out Func<T, TResult>? value, ArgumentToJSCallback<T> arg1Marshaler, ArgumentToManagedCallback<TResult> resMarshaler)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -465,7 +465,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <param name="arg1Marshaler">The generated callback which marshals the argument of the Func.</param>
         /// <param name="arg2Marshaler">The generated callback which marshals the argument of the Func.</param>
         /// <param name="resMarshaler">The generated callback which marshals the result of the Func.</param>
-        public unsafe void ToManaged<T1, T2, TResult>(out Func<T1, T2, TResult>? value, ArgumentToJSCallback<T1> arg1Marshaler, ArgumentToJSCallback<T2> arg2Marshaler, ArgumentToManagedCallback<TResult> resMarshaler)
+        public void ToManaged<T1, T2, TResult>(out Func<T1, T2, TResult>? value, ArgumentToJSCallback<T1> arg1Marshaler, ArgumentToJSCallback<T2> arg2Marshaler, ArgumentToManagedCallback<TResult> resMarshaler)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -491,7 +491,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <param name="arg2Marshaler">The generated callback which marshals the argument of the Func.</param>
         /// <param name="arg3Marshaler">The generated callback which marshals the argument of the Func.</param>
         /// <param name="resMarshaler">The generated callback which marshals the result of the Func.</param>
-        public unsafe void ToManaged<T1, T2, T3, TResult>(out Func<T1, T2, T3, TResult>? value, ArgumentToJSCallback<T1> arg1Marshaler, ArgumentToJSCallback<T2> arg2Marshaler, ArgumentToJSCallback<T3> arg3Marshaler, ArgumentToManagedCallback<TResult> resMarshaler)
+        public void ToManaged<T1, T2, T3, TResult>(out Func<T1, T2, T3, TResult>? value, ArgumentToJSCallback<T1> arg1Marshaler, ArgumentToJSCallback<T2> arg2Marshaler, ArgumentToJSCallback<T3> arg3Marshaler, ArgumentToManagedCallback<TResult> resMarshaler)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Int16.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Int16.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out short value)
+        public void ToManaged(out short value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out short? value)
+        public void ToManaged(out short? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Int32.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Int32.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out int value)
+        public void ToManaged(out int value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out int? value)
+        public void ToManaged(out int? value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -83,7 +83,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// It's used by JSImport code generator and should not be used by developers in source code.
         /// </summary>
         /// <param name="value">The value to be marshaled.</param>
-        public unsafe void ToManaged(out int[]? value)
+        public void ToManaged(out int[]? value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -100,7 +100,7 @@ namespace System.Runtime.InteropServices.JavaScript
         /// It's used by JSImport code generator and should not be used by developers in source code.
         /// </summary>
         /// <param name="value">The value to be marshaled.</param>
-        public unsafe void ToJS(int[]? value)
+        public void ToJS(int[]? value)
         {
             if (value == null)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Int52.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Int52.cs
@@ -18,7 +18,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out long value)
+        public void ToManaged(out long value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -55,7 +55,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out long? value)
+        public void ToManaged(out long? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.IntPtr.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.IntPtr.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out IntPtr value)
+        public void ToManaged(out IntPtr value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out IntPtr? value)
+        public void ToManaged(out IntPtr? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.JSObject.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.JSObject.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out JSObject? value)
+        public void ToManaged(out JSObject? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Object.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Object.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out object? value)
+        public void ToManaged(out object? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Single.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Single.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out float value)
+        public void ToManaged(out float value)
         {
             if (slot.Type == MarshalerType.None)
             {
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        public unsafe void ToManaged(out float? value)
+        public void ToManaged(out float? value)
         {
             if (slot.Type == MarshalerType.None)
             {

--- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
@@ -57,7 +57,7 @@ namespace System
             return true;
         }
 
-        internal static unsafe ParsingStatus TryParseBigInteger(ReadOnlySpan<char> value, NumberStyles style, NumberFormatInfo info, out BigInteger result)
+        internal static ParsingStatus TryParseBigInteger(ReadOnlySpan<char> value, NumberStyles style, NumberFormatInfo info, out BigInteger result)
         {
             if (!TryValidateParseStyleInteger(style, out ArgumentException? e))
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.EC.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.EC.cs
@@ -70,12 +70,9 @@ namespace System.Security.Cryptography
         internal static CngProperty GetPropertyFromNamedCurve(ECCurve curve)
         {
             string curveName = curve.Oid.FriendlyName!;
-            unsafe
-            {
-                byte[] curveNameBytes = new byte[(curveName.Length + 1) * sizeof(char)]; // +1 to add trailing null
-                System.Text.Encoding.Unicode.GetBytes(curveName, 0, curveName.Length, curveNameBytes, 0);
-                return new CngProperty(KeyPropertyName.ECCCurveName, curveNameBytes, CngPropertyOptions.None);
-            }
+            byte[] curveNameBytes = new byte[(curveName.Length + 1) * sizeof(char)]; // +1 to add trailing null
+            System.Text.Encoding.Unicode.GetBytes(curveName, 0, curveName.Length, curveNameBytes, 0);
+            return new CngProperty(KeyPropertyName.ECCCurveName, curveNameBytes, CngPropertyOptions.None);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAWrapper.cs
@@ -85,19 +85,19 @@ namespace System.Security.Cryptography
         public override bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) =>
             _wrapped.TryExportSubjectPublicKeyInfo(destination, out bytesWritten);
 
-        public override unsafe void ImportEncryptedPkcs8PrivateKey(
+        public override void ImportEncryptedPkcs8PrivateKey(
             ReadOnlySpan<byte> passwordBytes,
             ReadOnlySpan<byte> source,
             out int bytesRead) =>
             _wrapped.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
 
-        public override unsafe void ImportEncryptedPkcs8PrivateKey(
+        public override void ImportEncryptedPkcs8PrivateKey(
             ReadOnlySpan<char> password,
             ReadOnlySpan<byte> source,
             out int bytesRead) =>
             _wrapped.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
 
-        public override unsafe void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead) =>
+        public override void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead) =>
             _wrapped.ImportPkcs8PrivateKey(source, out bytesRead);
 
         public override void ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source, out int bytesRead) =>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaWrapper.cs
@@ -88,7 +88,7 @@ namespace System.Security.Cryptography
             out int bytesRead) =>
             _wrapped.ImportSubjectPublicKeyInfo(source, out bytesRead);
 
-        public override unsafe void ImportECPrivateKey(
+        public override void ImportECPrivateKey(
             ReadOnlySpan<byte> source,
             out int bytesRead) =>
             _wrapped.ImportECPrivateKey(source, out bytesRead);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderCng.cs
@@ -79,7 +79,7 @@ namespace System.Security.Cryptography
             _running = running;
         }
 
-        public sealed override unsafe void AppendHashData(ReadOnlySpan<byte> source)
+        public sealed override void AppendHashData(ReadOnlySpan<byte> source)
         {
             Debug.Assert(_hHash != null);
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Windows.cs
@@ -109,7 +109,7 @@ namespace System.Security.Cryptography
                 }
             }
 
-            public static unsafe int MacData(
+            public static int MacData(
                 string hashAlgorithmId,
                 ReadOnlySpan<byte> key,
                 ReadOnlySpan<byte> source,
@@ -149,7 +149,7 @@ namespace System.Security.Cryptography
                 HashDataUsingPseudoHandle(hashAlgorithmId, source, key: default, isHmac: false, destination, out _);
             }
 
-            public static unsafe int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
+            public static int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
             {
                 int hashSize; // in bytes
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Windows.cs
@@ -21,7 +21,7 @@ namespace System.Security.Cryptography
         // A cached instance of PBKDF2 for Windows 8, where pseudo handles are not supported.
         private static SafeBCryptAlgorithmHandle? s_pbkdf2AlgorithmHandle;
 
-        public static unsafe void Fill(
+        public static void Fill(
             ReadOnlySpan<byte> password,
             ReadOnlySpan<byte> salt,
             int iterations,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSABCrypt.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSABCrypt.cs
@@ -354,7 +354,7 @@ namespace System.Security.Cryptography
 
         public override KeySizes[] LegalKeySizes => new KeySizes[] { s_keySizes };
 
-        public override unsafe void ImportEncryptedPkcs8PrivateKey(
+        public override void ImportEncryptedPkcs8PrivateKey(
             ReadOnlySpan<byte> passwordBytes,
             ReadOnlySpan<byte> source,
             out int bytesRead)
@@ -363,7 +363,7 @@ namespace System.Security.Cryptography
             base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
         }
 
-        public override unsafe void ImportEncryptedPkcs8PrivateKey(
+        public override void ImportEncryptedPkcs8PrivateKey(
             ReadOnlySpan<char> password,
             ReadOnlySpan<byte> source,
             out int bytesRead)
@@ -372,7 +372,7 @@ namespace System.Security.Cryptography
             base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
         }
 
-        public override unsafe void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead)
+        public override void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead)
         {
             ThrowIfDisposed();
             base.ImportPkcs8PrivateKey(source, out bytesRead);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RandomNumberGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RandomNumberGenerator.cs
@@ -226,7 +226,7 @@ namespace System.Security.Cryptography
         /// <seealso cref="GetItems{T}(ReadOnlySpan{T}, Span{T})" />
         /// <seealso cref="GetItems{T}(ReadOnlySpan{T}, int)" />
         /// <seealso cref="GetHexString(Span{char}, bool)" />
-        public static unsafe string GetString(ReadOnlySpan<char> choices, int length)
+        public static string GetString(ReadOnlySpan<char> choices, int length)
         {
             if (choices.IsEmpty)
                 throw new ArgumentException(SR.Arg_EmptySpan, nameof(choices));

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
@@ -394,7 +394,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        public unsafe string GetNameInfo(X509NameType nameType, bool forIssuer) =>
+        public string GetNameInfo(X509NameType nameType, bool forIssuer) =>
             Interop.crypt32.CertGetNameString(
                 _certContext,
                 MapNameType(nameType),
@@ -515,7 +515,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        private unsafe string GetIssuerOrSubject(bool issuer, bool reverse) =>
+        private string GetIssuerOrSubject(bool issuer, bool reverse) =>
             Interop.crypt32.CertGetNameString(
                 _certContext,
                 Interop.Crypt32.CertNameType.CERT_NAME_RDN_TYPE,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.Windows.cs
@@ -470,7 +470,7 @@ namespace System.Security.Cryptography.X509Certificates
             return true;
         }
 
-        private static unsafe string GetCertNameInfo(SafeCertContextHandle pCertContext, Interop.Crypt32.CertNameType dwNameType, Interop.Crypt32.CertNameFlags dwNameFlags)
+        private static string GetCertNameInfo(SafeCertContextHandle pCertContext, Interop.Crypt32.CertNameType dwNameType, Interop.Crypt32.CertNameFlags dwNameFlags)
         {
             Debug.Assert(dwNameType != Interop.Crypt32.CertNameType.CERT_NAME_ATTR_TYPE);
             return Interop.crypt32.CertGetNameString(

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
@@ -127,7 +127,7 @@ namespace System.Text
         }
 
         [StructLayout(LayoutKind.Explicit, Pack = 2)]
-        internal unsafe struct CodePageIndex
+        internal struct CodePageIndex
         {
             [FieldOffset(0)]
             internal char CodePageName;     // WORD[16]
@@ -162,7 +162,7 @@ namespace System.Text
         }
 
         [StructLayout(LayoutKind.Explicit)]
-        internal unsafe struct CodePageHeader
+        internal struct CodePageHeader
         {
             [FieldOffset(0)]
             internal char CodePageName;     // WORD[16]
@@ -247,7 +247,7 @@ namespace System.Text
         }
 
         // We need to load tables for our code page
-        private unsafe void LoadCodePageTables()
+        private void LoadCodePageTables()
         {
             if (!FindCodePage(dataTableCodePage))
             {
@@ -359,7 +359,7 @@ namespace System.Text
         }
 
         // We have a managed code page entry, so load our tables
-        protected abstract unsafe void LoadManagedCodePage();
+        protected abstract void LoadManagedCodePage();
 
         // Allocate memory to load our code page
         protected unsafe byte* GetNativeMemory(int iSize)
@@ -375,7 +375,7 @@ namespace System.Text
             return (byte*)safeNativeMemoryHandle.DangerousGetHandle();
         }
 
-        protected abstract unsafe void ReadBestFitTable();
+        protected abstract void ReadBestFitTable();
 
         internal char[] GetBestFitUnicodeToBytesData()
         {
@@ -403,7 +403,7 @@ namespace System.Text
         // invalid. We detect that by validating the memory section handle then re-initializing the memory
         // section by calling LoadManagedCodePage() method and eventually the mapped file handle and
         // the memory section pointer will get finalized one more time.
-        internal unsafe void CheckMemorySection()
+        internal void CheckMemorySection()
         {
             if (safeNativeMemoryHandle != null && safeNativeMemoryHandle.DangerousGetHandle() == IntPtr.Zero)
             {

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DecoderBestFitFallback.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DecoderBestFitFallback.cs
@@ -135,7 +135,7 @@ namespace System.Text
         }
 
         // Clear the buffer
-        public override unsafe void Reset()
+        public override void Reset()
         {
             iCount = -1;
         }

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DecoderFallbackBufferHelper.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DecoderFallbackBufferHelper.cs
@@ -20,7 +20,7 @@ namespace System.Text
             charEnd = null;
         }
 
-        internal unsafe void InternalReset()
+        internal void InternalReset()
         {
             Debug.Assert(_fallbackBuffer != null);
             byteStart = null;

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
@@ -72,7 +72,7 @@ namespace System.Text
             m_fallbackBuffer?.Reset();
         }
 
-        public override unsafe int GetCharCount(byte[] bytes, int index, int count)
+        public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return GetCharCount(bytes, index, count, false);
         }
@@ -110,8 +110,8 @@ namespace System.Text
             return m_encoding.GetCharCount(bytes, count, this);
         }
 
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
-                                             char[] chars, int charIndex)
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
+                                     char[] chars, int charIndex)
         {
             return GetChars(bytes, byteIndex, byteCount, chars, charIndex, false);
         }

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncoderBestFitFallback.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncoderBestFitFallback.cs
@@ -158,7 +158,7 @@ namespace System.Text
         }
 
         // Clear the buffer
-        public override unsafe void Reset()
+        public override void Reset()
         {
             _iCount = -1;
         }

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingByteBuffer.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingByteBuffer.cs
@@ -63,34 +63,34 @@ namespace System.Text
             return true;
         }
 
-        internal unsafe bool AddByte(byte b1)
+        internal bool AddByte(byte b1)
         {
             return (AddByte(b1, 0));
         }
 
-        internal unsafe bool AddByte(byte b1, byte b2)
+        internal bool AddByte(byte b1, byte b2)
         {
             return (AddByte(b1, b2, 0));
         }
 
-        internal unsafe bool AddByte(byte b1, byte b2, int moreBytesExpected)
+        internal bool AddByte(byte b1, byte b2, int moreBytesExpected)
         {
             return (AddByte(b1, 1 + moreBytesExpected) && AddByte(b2, moreBytesExpected));
         }
 
-        internal unsafe bool AddByte(byte b1, byte b2, byte b3)
+        internal bool AddByte(byte b1, byte b2, byte b3)
         {
             return AddByte(b1, b2, b3, (int)0);
         }
 
-        internal unsafe bool AddByte(byte b1, byte b2, byte b3, int moreBytesExpected)
+        internal bool AddByte(byte b1, byte b2, byte b3, int moreBytesExpected)
         {
             return (AddByte(b1, 2 + moreBytesExpected) &&
                     AddByte(b2, 1 + moreBytesExpected) &&
                     AddByte(b3, moreBytesExpected));
         }
 
-        internal unsafe bool AddByte(byte b1, byte b2, byte b3, byte b4)
+        internal bool AddByte(byte b1, byte b2, byte b3, byte b4)
         {
             return (AddByte(b1, 3) &&
                     AddByte(b2, 2) &&
@@ -152,7 +152,7 @@ namespace System.Text
             }
         }
 
-        internal unsafe int Count
+        internal int Count
         {
             get
             {

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingCharBuffer.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingCharBuffer.cs
@@ -63,7 +63,7 @@ namespace System.Text
             return true;
         }
 
-        internal unsafe bool AddChar(char ch)
+        internal bool AddChar(char ch)
         {
             return AddChar(ch, 1);
         }
@@ -124,7 +124,7 @@ namespace System.Text
             }
         }
 
-        internal unsafe bool Fallback(byte fallbackByte)
+        internal bool Fallback(byte fallbackByte)
         {
             // Build our buffer
             byte[] byteBuffer = new byte[] { fallbackByte };
@@ -133,7 +133,7 @@ namespace System.Text
             return Fallback(byteBuffer);
         }
 
-        internal unsafe bool Fallback(byte byte1, byte byte2)
+        internal bool Fallback(byte byte1, byte byte2)
         {
             // Build our buffer
             byte[] byteBuffer = new byte[] { byte1, byte2 };
@@ -142,7 +142,7 @@ namespace System.Text
             return Fallback(byteBuffer);
         }
 
-        internal unsafe bool Fallback(byte byte1, byte byte2, byte byte3, byte byte4)
+        internal bool Fallback(byte byte1, byte byte2, byte byte3, byte byte4)
         {
             // Build our buffer
             byte[] byteBuffer = new byte[] { byte1, byte2, byte3, byte4 };
@@ -175,7 +175,7 @@ namespace System.Text
             return true;
         }
 
-        internal unsafe int Count
+        internal int Count
         {
             get
             {

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/TransactionShim.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/TransactionShim.cs
@@ -62,7 +62,7 @@ internal sealed class TransactionShim
         transactionNative = returnTransaction;
     }
 
-    public unsafe byte[] GetPropagationToken()
+    public byte[] GetPropagationToken()
     {
         ITransactionTransmitter transmitter = _shimFactory.GetCachedTransmitter(Transaction);
 


### PR DESCRIPTION
Removed in a semi-automated way, some places might require it back once "unsafe callers" is implemented (although, mostly as inner unsafe scopes, not modifiers).