### PR TITLE
Fix struct ReturnKind on SysV AMD64.

### DIFF
--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -41,7 +41,7 @@ ReturnKind VarTypeToReturnKind(var_types type)
 
 ReturnKind GCInfo::getReturnKind()
 {
-    // Note the JIT32 GCInfo representation only supports structs with 1 pointer.
+    // Note the JIT32 GCInfo representation only supports structs with 1 GC pointer.
     ReturnTypeDesc retTypeDesc = compiler->compRetTypeDesc;
     const unsigned regCount    = retTypeDesc.GetReturnRegCount();
 

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -50,8 +50,21 @@ ReturnKind GCInfo::getReturnKind()
         case 1:
             return VarTypeToReturnKind(retTypeDesc.GetReturnRegType(0));
         case 2:
-            return GetStructReturnKind(VarTypeToReturnKind(retTypeDesc.GetReturnRegType(0)),
-                                       VarTypeToReturnKind(retTypeDesc.GetReturnRegType(1)));
+        {
+            var_types first = retTypeDesc.GetReturnRegType(0);
+            var_types second = retTypeDesc.GetReturnRegType(1);
+#ifdef UNIX_AMD64_ABI
+            if (varTypeUsesFloatReg(first))
+            {
+                // first does not consume an int register in this case so an obj/ref
+                // in the second ReturnKind would actually be found in the first int reg.
+                first = second;
+                second = TYP_UNDEF;
+            }
+#endif // UNIX_AMD64_ABI
+            return GetStructReturnKind(VarTypeToReturnKind(first),
+                                       VarTypeToReturnKind(second));
+        }
         default:
 #ifdef DEBUG
             for (unsigned i = 0; i < regCount; i++)

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -21,6 +21,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "gcinfotypes.h"
 #include "patchpointinfo.h"
 
+#ifdef JIT32_GCENCODER
+
 ReturnKind VarTypeToReturnKind(var_types type)
 {
     switch (type)
@@ -29,11 +31,9 @@ ReturnKind VarTypeToReturnKind(var_types type)
             return RT_Object;
         case TYP_BYREF:
             return RT_ByRef;
-#ifdef TARGET_X86
         case TYP_FLOAT:
         case TYP_DOUBLE:
             return RT_Float;
-#endif // TARGET_X86
         default:
             return RT_Scalar;
     }
@@ -41,40 +41,27 @@ ReturnKind VarTypeToReturnKind(var_types type)
 
 ReturnKind GCInfo::getReturnKind()
 {
-    // Note the GCInfo representation only supports structs with up to 2 GC pointers.
+    // Note the JIT32 GCInfo representation only supports structs with 1 pointer.
     ReturnTypeDesc retTypeDesc = compiler->compRetTypeDesc;
     const unsigned regCount    = retTypeDesc.GetReturnRegCount();
 
-    switch (regCount)
+    if (regCount == 1)
     {
-        case 1:
-            return VarTypeToReturnKind(retTypeDesc.GetReturnRegType(0));
-        case 2:
-        {
-            var_types first = retTypeDesc.GetReturnRegType(0);
-            var_types second = retTypeDesc.GetReturnRegType(1);
-#ifdef UNIX_AMD64_ABI
-            if (varTypeUsesFloatReg(first))
-            {
-                // first does not consume an int register in this case so an obj/ref
-                // in the second ReturnKind would actually be found in the first int reg.
-                first = second;
-                second = TYP_UNDEF;
-            }
-#endif // UNIX_AMD64_ABI
-            return GetStructReturnKind(VarTypeToReturnKind(first),
-                                       VarTypeToReturnKind(second));
-        }
-        default:
+        return VarTypeToReturnKind(retTypeDesc.GetReturnRegType(0));
+    }
+    else
+    {
 #ifdef DEBUG
-            for (unsigned i = 0; i < regCount; i++)
-            {
-                assert(!varTypeIsGC(retTypeDesc.GetReturnRegType(i)));
-            }
+        for (unsigned i = 0; i < regCount; i++)
+        {
+            assert(!varTypeIsGC(retTypeDesc.GetReturnRegType(i)));
+        }
 #endif // DEBUG
-            return RT_Scalar;
+        return RT_Scalar;
     }
 }
+
+#endif // JIT32_GCENCODER
 
 // gcMarkFilterVarsPinned - Walk all lifetimes and make it so that anything
 //     live in a filter is marked as pinned (often by splitting the lifetime

--- a/src/coreclr/jit/jitgcinfo.h
+++ b/src/coreclr/jit/jitgcinfo.h
@@ -365,6 +365,8 @@ public:
 
 private:
     static size_t gcRecordEpilog(void* pCallBackData, unsigned offset);
+
+    ReturnKind getReturnKind();
 #else // JIT32_GCENCODER
     void gcInfoBlockHdrSave(GcInfoEncoder* gcInfoEncoder, unsigned methodSize, unsigned prologSize);
 
@@ -398,9 +400,6 @@ private:
 public:
     // This method updates the appropriate reg masks when a variable is moved.
     void gcUpdateForRegVarMove(regMaskTP srcMask, regMaskTP dstMask, LclVarDsc* varDsc);
-
-private:
-    ReturnKind getReturnKind();
 };
 
 inline unsigned char encodeUnsigned(BYTE* dest, unsigned value)

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -307,7 +307,6 @@ set(VM_SOURCES_WKS
     cachelinealloc.cpp
     callconvbuilder.cpp
     callhelpers.cpp
-    callsiteinspect.cpp
     callstubgenerator.cpp
     clrconfignative.cpp
     clrex.cpp
@@ -589,6 +588,7 @@ if(CLR_CMAKE_TARGET_WIN32)
 
     # COM interop scenarios
     list(APPEND VM_SOURCES_WKS
+        callsiteinspect.cpp
         classcompat.cpp
         comcache.cpp
         comcallablewrapper.cpp

--- a/src/coreclr/vm/arm/asmconstants.h
+++ b/src/coreclr/vm/arm/asmconstants.h
@@ -103,26 +103,6 @@ ASMCONSTANTS_C_ASSERT(SIZEOF__FloatArgumentRegisters == sizeof(FloatArgumentRegi
 #define ASM_ENREGISTERED_RETURNTYPE_MAXSIZE 0x20
 ASMCONSTANTS_C_ASSERT(ASM_ENREGISTERED_RETURNTYPE_MAXSIZE == ENREGISTERED_RETURNTYPE_MAXSIZE)
 
-#ifdef FEATURE_COMINTEROP
-
-#define Stub__m_pCode DBG_FRE(0x10, 0x0c)
-ASMCONSTANTS_C_ASSERT(Stub__m_pCode == sizeof(Stub))
-
-#define SIZEOF__ComMethodFrame 0x24
-ASMCONSTANTS_C_ASSERT(SIZEOF__ComMethodFrame == sizeof(ComMethodFrame))
-
-#define UnmanagedToManagedFrame__m_pvDatum 0x08
-ASMCONSTANTS_C_ASSERT(UnmanagedToManagedFrame__m_pvDatum == offsetof(UnmanagedToManagedFrame, m_pvDatum))
-
-// In ComCallPreStub and GenericCLRToCOMCallStub, we setup R12 to contain address of ComCallMethodDesc after doing the following:
-//
-// mov r12, pc
-//
-// This constant defines where ComCallMethodDesc is post execution of the above instruction.
-#define ComCallMethodDesc_Offset_FromR12 0x8
-
-#endif // FEATURE_COMINTEROP
-
 #define               Thread__m_fPreemptiveGCDisabled   0x04
 ASMCONSTANTS_C_ASSERT(Thread__m_fPreemptiveGCDisabled == offsetof(Thread, m_fPreemptiveGCDisabled));
 #define Thread_m_fPreemptiveGCDisabled Thread__m_fPreemptiveGCDisabled

--- a/src/coreclr/vm/callsiteinspect.cpp
+++ b/src/coreclr/vm/callsiteinspect.cpp
@@ -194,11 +194,9 @@ namespace
 
                 _ASSERTE((*src) != NULL || Nullable::IsNullableType(ty));
 #ifdef TARGET_UNIX
-                // Unboxing on non-Windows ABIs must be special cased
-                COMPlusThrowHR(COR_E_NOTSUPPORTED);
-#else
-                ty.GetMethodTable()->UnBoxIntoUnchecked(pvDest, (*src));
+#error Non-Windows ABIs must be special cased
 #endif
+                ty.GetMethodTable()->UnBoxIntoUnchecked(pvDest, (*src));
 
                 // return the object so it can be stored in the frame and
                 // propagated to the root set

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1713,7 +1713,6 @@ CLRToCOMMethodFrame::CLRToCOMMethodFrame(TransitionBlock * pTransitionBlock, Met
 }
 #endif // #ifndef DACCESS_COMPILE
 
-//virtual
 void CLRToCOMMethodFrame::GcScanRoots_Impl(promote_func* fn, ScanContext* sc)
 {
     WRAPPER_NO_CONTRACT;
@@ -1732,11 +1731,11 @@ void CLRToCOMMethodFrame::GcScanRoots_Impl(promote_func* fn, ScanContext* sc)
 
     TypeHandle thValueType;
     CorElementType et = sig.GetReturnTypeNormalized(&thValueType);
-    if (CorTypeInfo::IsObjRef(et))
+    if (CorTypeInfo::IsObjRef_NoThrow(et))
     {
         (*fn)(GetReturnObjectPtr(), sc, CHECK_APP_DOMAIN);
     }
-    else if (CorTypeInfo::IsByRef(et))
+    else if (CorTypeInfo::IsByRef_NoThrow(et))
     {
         PromoteCarefully(fn, GetReturnObjectPtr(), sc, GC_CALL_INTERIOR | CHECK_APP_DOMAIN);
     }

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1724,22 +1724,32 @@ void CLRToCOMMethodFrame::GcScanRoots_Impl(promote_func* fn, ScanContext* sc)
     FramedMethodFrame::GcScanRoots_Impl(fn, sc);
     PromoteCallerStack(fn, sc);
 
-
+    //
     // Promote the returned object
-    MethodDesc* methodDesc = GetFunction();
-    ReturnKind returnKind = methodDesc->GetReturnKind();
-    if (returnKind == RT_Object)
+    //
+
+    MetaSig sig(GetFunction());
+
+    TypeHandle thValueType;
+    CorElementType et = sig.GetReturnTypeNormalized(&thValueType);
+    if (CorTypeInfo::IsObjRef(et))
     {
         (*fn)(GetReturnObjectPtr(), sc, CHECK_APP_DOMAIN);
     }
-    else if (returnKind == RT_ByRef)
+    else if (CorTypeInfo::IsByRef(et))
     {
         PromoteCarefully(fn, GetReturnObjectPtr(), sc, GC_CALL_INTERIOR | CHECK_APP_DOMAIN);
     }
-    else
+    else if (et == ELEMENT_TYPE_VALUETYPE)
     {
-        _ASSERTE_MSG(!IsStructReturnKind(returnKind), "NYI: We can't promote multiregs struct returns");
-        _ASSERTE_MSG(IsScalarReturnKind(returnKind), "Non-scalar types must be promoted.");
+        ArgIterator argit(&sig);
+        if (!argit.HasRetBuffArg())
+        {
+#ifdef TARGET_UNIX
+#error Non-Windows ABIs must be special cased
+#endif
+            ReportPointersFromValueType(fn, sc, thValueType.AsMethodTable(), GetReturnObjectPtr());
+        }
     }
 }
 #endif // FEATURE_COMINTEROP

--- a/src/coreclr/vm/gccover.cpp
+++ b/src/coreclr/vm/gccover.cpp
@@ -438,44 +438,16 @@ static MethodDesc* getTargetMethodDesc(PCODE target)
 
 void ReplaceInstrAfterCall(PBYTE instrToReplace, MethodDesc* callMD)
 {
-    ReturnKind returnKind = callMD->GetReturnKind(true);
+    ReturnKind returnKind = callMD->GetReturnKind();
     if (!IsValidReturnKind(returnKind))
     {
         // SKip GC coverage after the call.
         return;
     }
-    _ASSERTE(IsValidReturnKind(returnKind));
 
-    bool ispointerKind = IsPointerReturnKind(returnKind);
-    if (ispointerKind)
+    if (IsPointerReturnKind(returnKind))
     {
-        bool protectRegister[2] = { false, false };
-
-        bool moreRegisters = false;
-
-        ReturnKind fieldKind1 = ExtractRegReturnKind(returnKind, 0, moreRegisters);
-        if (IsPointerFieldReturnKind(fieldKind1))
-        {
-            protectRegister[0] = true;
-        }
-        if (moreRegisters)
-        {
-            ReturnKind fieldKind2 = ExtractRegReturnKind(returnKind, 1, moreRegisters);
-            if (IsPointerFieldReturnKind(fieldKind2))
-            {
-                protectRegister[1] = true;
-            }
-        }
-        _ASSERTE(!moreRegisters);
-
-        if (protectRegister[0] && !protectRegister[1])
-        {
-            *instrToReplace = INTERRUPT_INSTR_PROTECT_FIRST_RET;
-        }
-        else
-        {
-            _ASSERTE(!"Not expected multi reg return with pointers.");
-        }
+        *instrToReplace = INTERRUPT_INSTR_PROTECT_FIRST_RET;
     }
     else
     {

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1299,6 +1299,15 @@ ReturnKind MethodDesc::ParseReturnKindFromSig(INDEBUG(bool supportStringConstruc
                                     regKinds[i] = RT_Scalar;
                                 }
                             }
+
+                            if (eeClass->GetEightByteClassification(0) == SystemVClassificationTypeSSE)
+                            {
+                                // Skip over SSE types since they do not consume integer registers.
+                                // An obj/byref in the 2nd eight bytes will be in the first integer register.
+                                regKinds[0] = regKinds[1];
+                                regKinds[1] = RT_Scalar;
+                            }
+
                             ReturnKind structReturnKind = GetStructReturnKind(regKinds[0], regKinds[1]);
                             return structReturnKind;
                         }

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1691,8 +1691,7 @@ public:
 #if defined(TARGET_X86) || defined(FEATURE_COMINTEROP)
 public:
     // This method is used to restore ReturnKind using the class handle.
-    // It does not support multi-reg return case with pointers. Use this
-    // method only when you can't hit
+    // It does not support multi-reg return case with pointers. Use this method only when you can't hit
     // this case (like CLRToCOMMethodFrame::GcScanRoots) or when you can tolerate RT_Illegal return.
     // Also, for a single field struct return case the function can't distinguish RT_Object and RT_ByRef.
     ReturnKind GetReturnKind(INDEBUG(bool supportStringConstructors = false));

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1688,14 +1688,13 @@ public:
     // corresponding instantiation of the target of a call.
     MethodDesc *ResolveGenericVirtualMethod(OBJECTREF *orThis);
 
-#if defined(TARGET_X86) || defined(FEATURE_COMINTEROP)
+#if defined(TARGET_X86) && defined(HAVE_GCCOVER)
 public:
-    // This method is used to restore ReturnKind using the class handle.
-    // It does not support multi-reg return case with pointers. Use this method only when you can't hit
-    // this case (like CLRToCOMMethodFrame::GcScanRoots) or when you can tolerate RT_Illegal return.
-    // Also, for a single field struct return case the function can't distinguish RT_Object and RT_ByRef.
-    ReturnKind GetReturnKind(INDEBUG(bool supportStringConstructors = false));
-#endif // TARGET_X86 || FEATURE_COMINTEROP
+    // This method is used to restore ReturnKind using the class handle. It will return
+    // RT_Illegal for rare cases like byref-like types. Use this method only when you can tolerate
+    // RT_Illegal return.
+    ReturnKind GetReturnKind();
+#endif // TARGET_X86 && HAVE_GCCOVER
 
 public:
     // In general you don't want to call GetCallTarget - you want to

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1688,18 +1688,15 @@ public:
     // corresponding instantiation of the target of a call.
     MethodDesc *ResolveGenericVirtualMethod(OBJECTREF *orThis);
 
-
-private:
-    ReturnKind ParseReturnKindFromSig(INDEBUG(bool supportStringConstructors = false));
-
+#if defined(TARGET_X86) || defined(FEATURE_COMINTEROP)
 public:
-    // This method is used to restore ReturnKind using the class handle, it is fully supported only on x64 Ubuntu,
-    // other platforms do not support multi-reg return case with pointers.
-    // Use this method only when you can't hit this case
-    // (like CLRToCOMMethodFrame::GcScanRoots) or when you can tolerate RT_Illegal return.
-    // Also, on the other platforms for a single field struct return case
-    // the function can't distinguish RT_Object and RT_ByRef.
+    // This method is used to restore ReturnKind using the class handle,e
+    // It does not support multi-reg return case with pointers. Use this
+    // method only when you can't hit
+    // this case (like CLRToCOMMethodFrame::GcScanRoots) or when you can tolerate RT_Illegal return.
+    // Also, for a single field struct return case the function can't distinguish RT_Object and RT_ByRef.
     ReturnKind GetReturnKind(INDEBUG(bool supportStringConstructors = false));
+#endif // TARGET_X86 || FEATURE_COMINTEROP
 
 public:
     // In general you don't want to call GetCallTarget - you want to

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1690,7 +1690,7 @@ public:
 
 #if defined(TARGET_X86) || defined(FEATURE_COMINTEROP)
 public:
-    // This method is used to restore ReturnKind using the class handle,e
+    // This method is used to restore ReturnKind using the class handle.
     // It does not support multi-reg return case with pointers. Use this
     // method only when you can't hit
     // this case (like CLRToCOMMethodFrame::GcScanRoots) or when you can tolerate RT_Illegal return.


### PR DESCRIPTION
On SysV AMD64, structs returned in a float and int reg pair were being classified as RT_Scalar_XX. This causes downstream consumers (e.g., HijackFrame::GcScanRoots) to look for obj/byref's in the second int reg. Per the ABI, however, the first float is passed through a float reg and the obj/byref is passed through the _first_ int reg. We now detect and fix this case by skipping the first float type in the ReturnKind encoding and moving the second type into the first.

Fix #115815