### PR TITLE
[release/9.0-staging] Fix SysV first/second return register GC info mismatch

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6268,6 +6268,18 @@ void CodeGen::genCallInstruction(GenTreeCall* call X86_ARG(target_ssize_t stackA
         {
             retSize       = emitTypeSize(retTypeDesc->GetReturnRegType(0));
             secondRetSize = emitTypeSize(retTypeDesc->GetReturnRegType(1));
+
+            if (retTypeDesc->GetABIReturnReg(1, call->GetUnmanagedCallConv()) == REG_INTRET)
+            {
+                // If the second return register is REG_INTRET, then the first
+                // return is expected to be in a SIMD register.
+                // The emitter has hardcoded belief that retSize corresponds to
+                // REG_INTRET and secondRetSize to REG_INTRET_1, so fix up the
+                // situation here.
+                assert(!EA_IS_GCREF_OR_BYREF(retSize));
+                retSize       = secondRetSize;
+                secondRetSize = EA_UNKNOWN;
+            }
         }
         else
         {

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -49,8 +49,21 @@ ReturnKind GCInfo::getReturnKind()
         case 1:
             return VarTypeToReturnKind(retTypeDesc.GetReturnRegType(0));
         case 2:
-            return GetStructReturnKind(VarTypeToReturnKind(retTypeDesc.GetReturnRegType(0)),
-                                       VarTypeToReturnKind(retTypeDesc.GetReturnRegType(1)));
+        {
+            var_types first = retTypeDesc.GetReturnRegType(0);
+            var_types second = retTypeDesc.GetReturnRegType(1);
+#ifdef UNIX_AMD64_ABI
+            if (varTypeUsesFloatReg(first))
+            {
+                // first does not consume an int register in this case so an obj/ref
+                // in the second ReturnKind would actually be found in the first int reg.
+                first = second;
+                second = TYP_UNDEF;
+            }
+#endif // UNIX_AMD64_ABI
+            return GetStructReturnKind(VarTypeToReturnKind(first),
+                                       VarTypeToReturnKind(second));
+        }
         default:
 #ifdef DEBUG
             for (unsigned i = 0; i < regCount; i++)

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1324,6 +1324,15 @@ ReturnKind MethodDesc::ParseReturnKindFromSig(INDEBUG(bool supportStringConstruc
                                     regKinds[i] = RT_Scalar;
                                 }
                             }
+
+                            if (eeClass->GetEightByteClassification(0) == SystemVClassificationTypeSSE)
+                            {
+                                // Skip over SSE types since they do not consume integer registers.
+                                // An obj/byref in the 2nd eight bytes will be in the first integer register.
+                                regKinds[0] = regKinds[1];
+                                regKinds[1] = RT_Scalar;
+                            }
+
                             ReturnKind structReturnKind = GetStructReturnKind(regKinds[0], regKinds[1]);
                             return structReturnKind;
                         }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_115815
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        var destination = new KeyValuePair<Container, double>[1_000];
+
+        // loop to make this method fully interruptible + to get into OSR version
+        for (int i = 0; i < destination.Length * 1000; i++)
+        {
+            destination[i / 1000] = default;
+        }
+
+        for (int i = 0; i < 5; i++)
+        {
+            for (int j = 0; j < destination.Length; j++)
+            {
+                destination[j] = GetValue(j);
+            }
+
+            Thread.Sleep(10);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static KeyValuePair<Container, double> GetValue(int i)
+        => KeyValuePair.Create(new Container(i.ToString()), (double)i);
+
+    private struct Container
+    {
+        public string Name;
+        public Container(string name) { this.Name = name; }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_115815/Runtime_115815.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #115827 to release/9.0-staging. Includes @zengandrew's change in #116194.

## Customer Impact

- [x] Customer reported
- [ ] Found internally

The JIT may generate incorrect GC information on linux-x64 and osx-x64 for methods that return in two registers if the first returned register is a SIMD register and the second returned register is an integer register containing an object reference.
In that case the generated GC information incorrectly reports an object reference in the `rdx` register that is actually present in the `rax` register.

This requires a struct that is laid out by the VM as a float followed by an object reference. This is an unusual layout as the VM tries to reorder struct layouts to keep object references at the beginning. Yet the customer reported issue #115815 shows a case where it happens. A reduced test case looks something like:
```csharp
private struct Container
{
    public string Name;
}

[MethodImpl(MethodImplOptions.NoInlining)]
// KeyValuePair<Container, double> is laid out as (double, string) by VM
private static KeyValuePair<Container, double> GetValue(int i)
    => KeyValuePair.Create(new Container(i.ToString()), (double)i); 

... GetValue(i) ... // JIT reports a string in rdx after this call that is actually in rax
```

The GC info mismatch leads to unpredictable outcomes (segfaults, heap corruption, etc.).

The VM has a similar problem when it wants to suspend all running threads if it needs to suspend in a method like `GetValue` above. In those cases the VM may not properly preserve the GC reference returned, and may mistakenly treat the `double` as a GC reference instead.

The PR includes fixes for both the JIT and VM issue.

## Regression

- [ ] Yes
- [X] No

As far as I can tell this bug is present since the original introduction of SysV support.

## Testing

Regression test introduced.

## Risk

Low.