### PR TITLE
Disable CoreCLR interpreter test for JIT stress

### DIFF
--- a/src/tests/JIT/interpreter/InterpreterTester.csproj
+++ b/src/tests/JIT/interpreter/InterpreterTester.csproj
@@ -7,6 +7,8 @@
     <NativeAotIncompatible>true</NativeAotIncompatible>
     <!-- Temporarily disabled due to https://github.com/dotnet/runtime/issues/112827 -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- Temporarily disabled due to problems with generating interpreter bytecode for methods with existing prestub -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InterpreterTester.cs" />


### PR DESCRIPTION
There is a problem in the interpreter when handling calls to code that doesn't have native code yet, but that has precode already. The call to MethodDesc::PrepareInitialCode triggers an assert down its call chain due to the prestub existence.

This change disables running the interpreter test with JIT stress until the problem is solved.