### PR TITLE
HPackDecoder with faster zeroing of HeaderStaticIndex, HeaderNameRange, and HeaderValueRange

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
@@ -200,7 +200,7 @@ namespace System.Net.Http.HPack
                 EnsureStringCapacity(ref _headerNameOctets, _headerNameLength);
                 _headerName = _headerNameOctets;
 
-                ReadOnlySpan<byte> headerBytes = data.Slice(_headerNameRange.GetValueOrDefault().start, _headerNameRange.GetValueOrDefault().length);
+                ReadOnlySpan<byte> headerBytes = data.Slice(_headerData.HeaderNameRange.GetValueOrDefault().start, _headerData.HeaderNameRange.GetValueOrDefault().length);
                 headerBytes.CopyTo(_headerName);
                 _headerData.HeaderNameRange = null;
             }
@@ -510,22 +510,22 @@ namespace System.Net.Http.HPack
         {
             ReadOnlySpan<byte> headerValueSpan = _headerData.HeaderValueRange == null
                 ? _headerValueOctets.AsSpan(0, _headerValueLength)
-                : data.Slice(_headerValueRange.GetValueOrDefault().start, _headerValueRange.GetValueOrDefault().length);
+                : data.Slice(_headerData.HeaderValueRange.GetValueOrDefault().start, _headerData.HeaderValueRange.GetValueOrDefault().length);
 
             if (_headerData.HeaderStaticIndex > 0)
             {
-                handler.OnStaticIndexedHeader(_headerStaticIndex, headerValueSpan);
+                handler.OnStaticIndexedHeader(_headerData.HeaderStaticIndex, headerValueSpan);
 
                 if (_index)
                 {
-                    _dynamicTable.Insert(_headerStaticIndex, H2StaticTable.Get(_headerData.HeaderStaticIndex - 1).Name, headerValueSpan);
+                    _dynamicTable.Insert(_headerData.HeaderStaticIndex, H2StaticTable.Get(_headerData.HeaderStaticIndex - 1).Name, headerValueSpan);
                 }
             }
             else
             {
                 ReadOnlySpan<byte> headerNameSpan = _headerData.HeaderNameRange == null
                     ? _headerName.AsSpan(0, _headerNameLength)
-                    : data.Slice(_headerNameRange.GetValueOrDefault().start, _headerNameRange.GetValueOrDefault().length);
+                    : data.Slice(_headerData.HeaderNameRange.GetValueOrDefault().start, _headerData.HeaderNameRange.GetValueOrDefault().length);
 
                 handler.OnHeader(headerNameSpan, headerValueSpan);
 


### PR DESCRIPTION
Instead of setting three fields to the default value individually, move them to a struct and clear it with `default`, so that the JIT can emit more streamlined code for clearing.

Basically this is:
```diff
-xor eax, eax
-mov [rcx+8], eax
-vxorps xmm0, xmm0, xmm0
-vmovdqu [rcx+0x10], xmm0
-vxorps xmm0, xmm0, xmm0
+vxorps ymm0, ymm0, ymm0
+vmovdqu [rcx+8], ymm0
vmovdqu [rcx+0x20], xmm0
```

All other accesses to these fields produce the same codegen.

See [sharplab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIGYACMhgYQZoG8aGeGAHKAEsAbtgwwGggHYYGAfQAWMbABMYUAMoYxgsAEkpahAG5uvASLESAFNNm5tUDGkkyGAGxhSA5hgUBKAH55JVV1ADlsfBgAJWwfGFNqXn4hUXEGWzcHbCcXOw8vXwDgxWU1KAA1bHcAV1j470SzHhamRmIUBgBZa392ZN4uQZSeMrDNbQxdAyMGAF4GAAYk0d5xisjouISFhila93dVtZDy9Wq6ht3Fg6OTngBfNrb6V1kAMQgIPoWAPjOEy21yaADoAOIwDCXeoAeSgABEYAAzbCHDB9UGeHx+JLPag0N7MBEDYYpCzpCQOKC1MCyBFibADFJk05vAoACXOkx0+kMMBMbRSbyy9kcznehRxJQYXKBURBzRGoxFBRyeUl2OKQVl3JhioeDHxKTaFKsDAZ2nkKkZhteHS6vX6bVZazkNqtizUqPRhuNvHtkq+P368wB7sZoLlmwVOzBkOhNThiJRaPcGP8WKKuJojyAA) for a fuller example.