### PR TITLE
Enable exceptions on wrong LDELEM arguments

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1377,13 +1377,13 @@ CALL_TARGET_IP:
 do {                                                                           \
     BASEARRAYREF arrayRef = LOCAL_VAR(ip[2], BASEARRAYREF);                    \
     if (arrayRef == NULL)                                                      \
-        assert(0);                                                             \
+        COMPlusThrow(kNullReferenceException);                                 \
                                                                                \
     ArrayBase* arr = (ArrayBase*)OBJECTREFToObject(arrayRef);                  \
     uint32_t len = arr->GetNumComponents();                                    \
     uint32_t idx = (uint32_t)LOCAL_VAR(ip[3], int32_t);                        \
     if (idx >= len)                                                            \
-        assert(0);                                                             \
+        COMPlusThrow(kIndexOutOfRangeException);                               \
                                                                                \
     uint8_t* pData = arr->GetDataPtr();                                        \
     etype* pElem = reinterpret_cast<etype*>(pData + idx * sizeof(etype));      \

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1435,13 +1435,13 @@ do {                                                                           \
 do {                                                                           \
     BASEARRAYREF arrayRef = LOCAL_VAR(ip[1], BASEARRAYREF);                    \
     if (arrayRef == NULL)                                                      \
-        assert(0);                                                             \
+        COMPlusThrow(kNullReferenceException);                                 \
                                                                                \
     ArrayBase* arr = (ArrayBase*)OBJECTREFToObject(arrayRef);                  \
     uint32_t len = arr->GetNumComponents();                                    \
     uint32_t idx = (uint32_t)LOCAL_VAR(ip[2], int32_t);                        \
     if (idx >= len)                                                            \
-        assert(0);                                                             \
+        COMPlusThrow(kIndexOutOfRangeException);                               \
                                                                                \
     uint8_t* pData = arr->GetDataPtr();                                        \
     etype* pElem = reinterpret_cast<etype*>(pData + idx * sizeof(etype));      \


### PR DESCRIPTION
When the array is null, throw NullReferenceException When the index is out of range, throw IndexOutOfRangeException

Until now, it was asserting instead.