### PR TITLE
Add placement of local functions to coding style guide

### DIFF
--- a/docs/coding-guidelines/coding-style.md
+++ b/docs/coding-guidelines/coding-style.md
@@ -33,6 +33,7 @@ The general rule we follow is "use Visual Studio defaults".
     - Using braces is always accepted, and required if any block of an `if`/`else if`/.../`else` compound statement uses braces or if a single statement body spans multiple lines.
     - Braces may be omitted only if the body of *every* block associated with an `if`/`else if`/.../`else` compound statement is placed on a single line.
 19. Make all internal and private types static or sealed unless derivation from them is required.  As with any implementation detail, they can be changed if/when derivation is required in the future.
+20. Place local functions at the end of the method after the return statement.
 
 An [EditorConfig](https://editorconfig.org "EditorConfig homepage") file (`.editorconfig`) has been provided at the root of the runtime repository, enabling C# auto-formatting conforming to the above guidelines.
 

--- a/docs/coding-guidelines/coding-style.md
+++ b/docs/coding-guidelines/coding-style.md
@@ -33,7 +33,7 @@ The general rule we follow is "use Visual Studio defaults".
     - Using braces is always accepted, and required if any block of an `if`/`else if`/.../`else` compound statement uses braces or if a single statement body spans multiple lines.
     - Braces may be omitted only if the body of *every* block associated with an `if`/`else if`/.../`else` compound statement is placed on a single line.
 19. Make all internal and private types static or sealed unless derivation from them is required.  As with any implementation detail, they can be changed if/when derivation is required in the future.
-20. Place local functions at the end of the method after the return statement.
+20. Place local functions at the end of the method after the return statement to improve clarity and readability of the method.
 
 An [EditorConfig](https://editorconfig.org "EditorConfig homepage") file (`.editorconfig`) has been provided at the root of the runtime repository, enabling C# auto-formatting conforming to the above guidelines.
 


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/116080/files#r2116720242 @AaronRobinsonMSFT suggested that we have a guideline to place local functions at the end of the method, however contributors can't know about this rule unless we state it.  Adding to our rules doc.

I looked for an editorconfig rule for this and did not find one.  It looks like this is tracked with https://github.com/dotnet/roslyn/issues/53613.