### PR TITLE
X86 GCDecoder RevPInvoke nits

### DIFF
--- a/src/coreclr/inc/gcdecoder.cpp
+++ b/src/coreclr/inc/gcdecoder.cpp
@@ -197,8 +197,7 @@ PTR_CBYTE FASTCALL decodeHeader(PTR_CBYTE table, UINT32 version, InfoHdr* header
                 header->syncStartOffset ^= HAS_SYNC_OFFSET;
                 break;
             case FLIP_REV_PINVOKE_FRAME:
-                header->revPInvokeOffset = header->revPInvokeOffset == INVALID_REV_PINVOKE_OFFSET ?
-                    HAS_REV_PINVOKE_FRAME_OFFSET : INVALID_REV_PINVOKE_OFFSET;
+                header->revPInvokeOffset ^= (INVALID_REV_PINVOKE_OFFSET ^ HAS_REV_PINVOKE_FRAME_OFFSET);
                 break;
 
             case NEXT_OPCODE:

--- a/src/coreclr/inc/gcdecoder.cpp
+++ b/src/coreclr/inc/gcdecoder.cpp
@@ -197,7 +197,8 @@ PTR_CBYTE FASTCALL decodeHeader(PTR_CBYTE table, UINT32 version, InfoHdr* header
                 header->syncStartOffset ^= HAS_SYNC_OFFSET;
                 break;
             case FLIP_REV_PINVOKE_FRAME:
-                header->revPInvokeOffset = INVALID_REV_PINVOKE_OFFSET ? HAS_REV_PINVOKE_FRAME_OFFSET : INVALID_REV_PINVOKE_OFFSET;
+                header->revPInvokeOffset = header->revPInvokeOffset == INVALID_REV_PINVOKE_OFFSET ?
+                    HAS_REV_PINVOKE_FRAME_OFFSET : INVALID_REV_PINVOKE_OFFSET;
                 break;
 
             case NEXT_OPCODE:

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
@@ -280,8 +280,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                                 header.SyncStartOffset ^= HAS_SYNC_OFFSET;
                                 break;
                             case (byte)InfoHdrAdjust.FLIP_REV_PINVOKE_FRAME:
-                                header.RevPInvokeOffset = header.RevPInvokeOffset == INVALID_REV_PINVOKE_OFFSET ?
-                                    HAS_REV_PINVOKE_FRAME_OFFSET : INVALID_REV_PINVOKE_OFFSET;
+                                header.RevPInvokeOffset ^= (INVALID_REV_PINVOKE_OFFSET ^ HAS_REV_PINVOKE_FRAME_OFFSET);
                                 break;
 
                             case (byte)InfoHdrAdjust.NEXT_OPCODE:

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
@@ -14,6 +14,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
     {
         private const uint INVALID_GS_COOKIE_OFFSET = 0;
         private const uint INVALID_SYNC_OFFSET = 0;
+        private const uint INVALID_REV_PINVOKE_OFFSET = 0xFFFFFFFF;
 
         public uint PrologSize { get; set; }
         public uint EpilogSize { get; set; }
@@ -82,7 +83,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             GsCookieOffset = 0;
             SyncStartOffset = 0;
             SyncEndOffset = 0;
-            RevPInvokeOffset = 0;
+            RevPInvokeOffset = INVALID_REV_PINVOKE_OFFSET;
             NoGCRegionCnt = 0;
 
             HasArgTabOffset = false;
@@ -163,7 +164,8 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         private const uint HAS_UNTRACKED = 0xFFFFFFFF;
         private const uint HAS_GS_COOKIE_OFFSET = 0xFFFFFFFF;
         private const uint HAS_SYNC_OFFSET = 0xFFFFFFFF;
-        private const uint HAS_REV_PINVOKE_FRAME_OFFSET = 0xFFFFFFFF;
+        private const uint INVALID_REV_PINVOKE_OFFSET = 0xFFFFFFFF;
+        private const uint HAS_REV_PINVOKE_FRAME_OFFSET = 0xFFFFFFFE;
         private const uint HAS_NOGCREGIONS = 0xFFFFFFFF;
         private const uint YES = HAS_VARPTR;
 
@@ -278,7 +280,8 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                                 header.SyncStartOffset ^= HAS_SYNC_OFFSET;
                                 break;
                             case (byte)InfoHdrAdjust.FLIP_REV_PINVOKE_FRAME:
-                                header.RevPInvokeOffset ^= HAS_REV_PINVOKE_FRAME_OFFSET;
+                                header.RevPInvokeOffset = header.RevPInvokeOffset == INVALID_REV_PINVOKE_OFFSET ?
+                                    HAS_REV_PINVOKE_FRAME_OFFSET : INVALID_REV_PINVOKE_OFFSET;
                                 break;
 
                             case (byte)InfoHdrAdjust.NEXT_OPCODE:


### PR DESCRIPTION
Found when porting the x86 GCInfo to managed code for https://github.com/dotnet/runtime/pull/116072.

* The runtime gcdecoder is probably not a real issue because having multiple `FLIP_REV_PINVOKE_FRAME` instructions would be an inefficient encoding, but this fix matches the intent of the instruction.

* The R2R gcdecoder would previously report a RevPInvokeOffset of `0` if there was not a RevPInvoke. However, `0` is a valid RevPInvoke offset so it was impossible to differentiate these cases. This change brings it in line with the runtime logic of using `0xFFFFFFFF` to indicate an `INVALID_REV_PINVOKE_OFFSET`