### PR TITLE
Convert STORE_BLK into STORIND for SIMD

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -11145,6 +11145,7 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     GenTree* src = blkNode->Data();
     if (varTypeIsSIMD(regType) && src->IsConstInitVal())
     {
+#if defined(FEATURE_HW_INTRINSICS)
         assert(!blkNode->ContainsReferences());
         if (src->OperIsInitVal())
         {
@@ -11152,9 +11153,9 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
             src = src->gtGetOp1();
         }
 
-        uint8_t  initVal = static_cast<uint8_t>(static_cast<size_t>(src->AsIntCon()->IconValue()));
-        simd64_t vec     = {};
-        memset(&vec, initVal, sizeof(simd64_t));
+        uint8_t initVal = static_cast<uint8_t>(static_cast<size_t>(src->AsIntCon()->IconValue()));
+        simd_t  vec     = {};
+        memset(&vec, initVal, sizeof(simd_t));
         GenTreeVecCon* cnsVec = comp->gtNewVconNode(regType, &vec);
 
         BlockRange().InsertAfter(src, cnsVec);
@@ -11164,6 +11165,9 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
         blkNode->ChangeType(regType);
         LowerStoreIndirCommon(blkNode->AsStoreInd());
         return true;
+#else
+        return false;
+#endif
     }
 
     if (varTypeIsGC(regType))

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -11153,10 +11153,8 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
             src = src->gtGetOp1();
         }
 
-        uint8_t initVal = static_cast<uint8_t>(static_cast<size_t>(src->AsIntCon()->IconValue()));
-        simd_t  vec     = {};
-        memset(&vec, initVal, sizeof(simd_t));
-        GenTreeVecCon* cnsVec = comp->gtNewVconNode(regType, &vec);
+        uint8_t initVal = static_cast<uint8_t>(src->AsIntCon()->IconValue());
+        GenTree* cnsVec = comp->gtNewConWithPattern(regType, initVal);
 
         BlockRange().InsertAfter(src, cnsVec);
         BlockRange().Remove(src);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -11145,7 +11145,7 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     GenTree* src = blkNode->Data();
     if (varTypeIsSIMD(regType) && src->IsConstInitVal())
     {
-#if defined(FEATURE_HW_INTRINSICS)
+#if defined(FEATURE_HW_INTRINSICS) && defined(TARGET_XARCH)
         assert(!blkNode->ContainsReferences());
         if (src->OperIsInitVal())
         {

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -11123,11 +11123,6 @@ void Lowering::LowerBlockStoreCommon(GenTreeBlk* blkNode)
 // Return value:
 //    true if the replacement was made, false otherwise.
 //
-// Notes:
-//    TODO-CQ: this method should do the transformation when possible
-//    and STOREIND should always generate better or the same code as
-//    STORE_BLK for the same copy.
-//
 bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
 {
     assert(blkNode->OperIs(GT_STORE_BLK));
@@ -11143,31 +11138,6 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     }
 
     GenTree* src = blkNode->Data();
-    if (varTypeIsSIMD(regType) && src->IsConstInitVal())
-    {
-#if defined(FEATURE_HW_INTRINSICS) && defined(TARGET_XARCH)
-        assert(!blkNode->ContainsReferences());
-        if (src->OperIsInitVal())
-        {
-            BlockRange().Remove(src);
-            src = src->gtGetOp1();
-        }
-
-        uint8_t initVal = static_cast<uint8_t>(src->AsIntCon()->IconValue());
-        GenTree* cnsVec = comp->gtNewConWithPattern(regType, initVal);
-
-        BlockRange().InsertAfter(src, cnsVec);
-        BlockRange().Remove(src);
-        blkNode->SetData(cnsVec);
-        blkNode->ChangeOper(GT_STOREIND);
-        blkNode->ChangeType(regType);
-        LowerStoreIndirCommon(blkNode->AsStoreInd());
-        return true;
-#else
-        return false;
-#endif
-    }
-
     if (varTypeIsGC(regType))
     {
         // TODO-CQ: STOREIND does not try to contain src if we need a barrier,
@@ -11180,28 +11150,42 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
         return false;
     }
 
-    JITDUMP("Replacing STORE_BLK with STOREIND for [%06u]\n", blkNode->gtTreeID);
-    blkNode->ChangeOper(GT_STOREIND);
-    blkNode->ChangeType(regType);
+    if (src->IsConstInitVal())
+    {
+#if !defined(TARGET_XARCH)
+        if (varTypeIsSIMD(regType) && (src->AsIntCon()->IconValue() == 0))
+        {
+            // Platforms with zero-regs may produce better/more compact codegen
+            return false;
+        }
+#endif
 
-    if (varTypeIsStruct(src))
+        assert(!blkNode->ContainsReferences());
+        if (src->OperIsInitVal())
+        {
+            BlockRange().Remove(src);
+            src = src->gtGetOp1();
+        }
+
+        uint8_t  initVal = static_cast<uint8_t>(src->AsIntCon()->IconValue());
+        GenTree* cnsVec  = comp->gtNewConWithPattern(regType, initVal);
+        BlockRange().InsertAfter(src, cnsVec);
+        BlockRange().Remove(src);
+        blkNode->SetData(cnsVec);
+    }
+    else if (varTypeIsStruct(src))
     {
         src->ChangeType(regType);
         LowerNode(blkNode->Data());
     }
-    else if (src->OperIsInitVal())
-    {
-        GenTreeUnOp* initVal = src->AsUnOp();
-        src                  = src->gtGetOp1();
-        assert(src->IsCnsIntOrI());
-        src->AsIntCon()->FixupInitBlkValue(regType);
-        blkNode->SetData(src);
-        BlockRange().Remove(initVal);
-    }
     else
     {
-        assert(src->TypeIs(regType) || src->IsCnsIntOrI() || src->IsCall());
+        unreached();
     }
+
+    JITDUMP("Replacing STORE_BLK with STOREIND for [%06u]\n", blkNode->gtTreeID);
+    blkNode->ChangeOper(GT_STOREIND);
+    blkNode->ChangeType(regType);
 
 #if defined(TARGET_XARCH)
     if (varTypeIsSmall(regType) && src->OperIs(GT_IND, GT_LCL_FLD))

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -11153,7 +11153,7 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     if (src->IsConstInitVal())
     {
 #if !defined(TARGET_XARCH)
-        if (varTypeIsSIMD(regType) && (src->AsIntCon()->IconValue() == 0))
+        if (varTypeIsSIMD(regType))
         {
             // Platforms with zero-regs may produce better/more compact codegen
             return false;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/116258

```diff
       xor      eax, eax
       mov      dword ptr [rdi+0x08], eax
       vxorps   xmm0, xmm0, xmm0
-      vmovdqu  xmmword ptr [rdi+0x10], xmm0
-      vxorps   xmm0, xmm0, xmm0
+      vmovdqu  ymmword ptr [rdi+0x10], ymm0
```

`STORE_IND<SIMD*>` is more coalescing-friendly

Some minor [diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1058075&view=ms.vss-build-web.run-extensions-tab)