### PR TITLE
JIT: avoid some unnecessary retyping in escape analysis

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -2803,6 +2803,11 @@ void ObjectAllocator::RewriteUses()
                         varTypeName(newType));
                 lclVarDsc->lvType = newType;
             }
+            else
+            {
+                JITDUMP("V%02u already properly typed\n", lclNum);
+                lclVarDsc->lvTracked = 0;
+            }
         }
     }
 


### PR DESCRIPTION
We may discover a TYP_BYREF local can point to stack objects, in which case it will remain a TYP_BYREF local, so no retyping is needed.

Fixes #116213