### PR TITLE
Remove a few unsafe bits in S.P.Uri, S.N.Ping, System.Transactions.Local

### DIFF
--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -106,16 +106,16 @@ namespace System.Net.NetworkInformation
             {
                 // If it is not multicast, use Connect to scope responses only to the target address.
                 socket.Connect(socketConfig.EndPoint);
-                ReadOnlySpan<byte> opt = BitConverter.IsLittleEndian ? [1, 0, 0, 0] : [0, 0, 0, 1];
+                int opt = 1;
                 if (ipv4)
                 {
                     // setsockopt(fd, IPPROTO_IP, IP_RECVERR, &value, sizeof(int))
-                    socket.SetRawSocketOption(0, 11, opt);
+                    socket.SetRawSocketOption(0, 11, MemoryMarshal.AsBytes(new ReadOnlySpan<int>(in opt)));
                 }
                 else
                 {
                     // setsockopt(fd, IPPROTO_IPV6, IPV6_RECVERR, &value, sizeof(int))
-                    socket.SetRawSocketOption(41, 25, opt);
+                    socket.SetRawSocketOption(41, 25, MemoryMarshal.AsBytes(new ReadOnlySpan<int>(in opt)));
                 }
             }
 #pragma warning restore 618

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -21,7 +21,7 @@ namespace System.Net.NetworkInformation
         private const int IpV6HeaderLengthInBytes = 40;
         private static readonly ushort DontFragment = OperatingSystem.IsFreeBSD() ? (ushort)IPAddress.HostToNetworkOrder((short)0x4000) : (ushort)0x4000;
 
-        private static unsafe SocketConfig GetSocketConfig(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
+        private static SocketConfig GetSocketConfig(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
             // Use a random value as the identifier. This doesn't need to be perfectly random
             // or very unpredictable, rather just good enough to avoid unexpected conflicts.
@@ -35,7 +35,10 @@ namespace System.Net.NetworkInformation
             if (sendIpHeader)
             {
                 iph.VersionAndLength = 0x45;
-                totalLength = sizeof(IpHeader) + checked(sizeof(IcmpHeader) + buffer.Length);
+                unsafe
+                {
+                    totalLength = sizeof(IpHeader) + checked(sizeof(IcmpHeader) + buffer.Length);
+                }
                 // On OSX this strangely must be host byte order.
                 iph.TotalLength = OperatingSystem.IsFreeBSD() ? (ushort)IPAddress.HostToNetworkOrder((short)totalLength) : (ushort)totalLength;
                 iph.Protocol = 1; // ICMP
@@ -103,19 +106,16 @@ namespace System.Net.NetworkInformation
             {
                 // If it is not multicast, use Connect to scope responses only to the target address.
                 socket.Connect(socketConfig.EndPoint);
-                unsafe
+                ReadOnlySpan<byte> opt = BitConverter.IsLittleEndian ? [1, 0, 0, 0] : [0, 0, 0, 1];
+                if (ipv4)
                 {
-                    int opt = 1;
-                    if (ipv4)
-                    {
-                        // setsockopt(fd, IPPROTO_IP, IP_RECVERR, &value, sizeof(int))
-                        socket.SetRawSocketOption(0, 11, new ReadOnlySpan<byte>(&opt, sizeof(int)));
-                    }
-                    else
-                    {
-                        // setsockopt(fd, IPPROTO_IPV6, IPV6_RECVERR, &value, sizeof(int))
-                        socket.SetRawSocketOption(41, 25, new ReadOnlySpan<byte>(&opt, sizeof(int)));
-                    }
+                    // setsockopt(fd, IPPROTO_IP, IP_RECVERR, &value, sizeof(int))
+                    socket.SetRawSocketOption(0, 11, opt);
+                }
+                else
+                {
+                    // setsockopt(fd, IPPROTO_IPV6, IPV6_RECVERR, &value, sizeof(int))
+                    socket.SetRawSocketOption(41, 25, opt);
                 }
             }
 #pragma warning restore 618
@@ -247,7 +247,7 @@ namespace System.Net.NetworkInformation
             return true;
         }
 
-        private static unsafe PingReply SendIcmpEchoRequestOverRawSocket(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
+        private static PingReply SendIcmpEchoRequestOverRawSocket(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
             SocketConfig socketConfig = GetSocketConfig(address, buffer, timeout, options);
             using (Socket socket = GetRawSocket(socketConfig))

--- a/src/libraries/System.Private.Uri/src/System/IPv4AddressHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IPv4AddressHelper.cs
@@ -13,50 +13,43 @@ namespace System.Net
         // Parse and canonicalize
         internal static string ParseCanonicalName(string str, int start, int end, ref bool isLoopback)
         {
+            // end includes ports, so changedEnd may be different from end
+            int changedEnd = end;
+            long result;
+
             unsafe
             {
-                byte* numbers = stackalloc byte[NumberOfLabels];
-                isLoopback = Parse(str, numbers, start, end);
-
-                Span<char> stackSpace = stackalloc char[NumberOfLabels * 3 + 3];
-                int totalChars = 0, charsWritten;
-                for (int i = 0; i < 3; i++)
+                fixed (char* ipString = str)
                 {
-                    numbers[i].TryFormat(stackSpace.Slice(totalChars), out charsWritten);
-                    int periodPos = totalChars + charsWritten;
-                    stackSpace[periodPos] = '.';
-                    totalChars = periodPos + 1;
+                    result = ParseNonCanonical(ipString, start, ref changedEnd, true);
                 }
-                numbers[3].TryFormat(stackSpace.Slice(totalChars), out charsWritten);
-                return new string(stackSpace.Slice(0, totalChars + charsWritten));
             }
-        }
 
-        //
-        // Parse
-        //
-        //  Convert this IPv4 address into a sequence of 4 8-bit numbers
-        //
-        private static unsafe bool Parse(string name, byte* numbers, int start, int end)
-        {
-            fixed (char* ipString = name)
+            Debug.Assert(result != Invalid, $"Failed to parse after already validated: {str}");
+
+            Span<byte> numbers =
+                unchecked(
+                [
+                    (byte)(result >> 24),
+                    (byte)(result >> 16),
+                    (byte)(result >> 8),
+                    (byte)(result)
+                ]);
+
+            isLoopback = numbers[0] == 127;
+
+            Span<char> stackSpace = stackalloc char[NumberOfLabels * 3 + 3];
+            int totalChars = 0, charsWritten;
+            for (int i = 0; i < NumberOfLabels - 1; i++)
             {
-                // end includes ports, so changedEnd may be different from end
-                int changedEnd = end;
-                long result = IPv4AddressHelper.ParseNonCanonical(ipString, start, ref changedEnd, true);
-
-                Debug.Assert(result != Invalid, $"Failed to parse after already validated: {name}");
-
-                unchecked
-                {
-                    numbers[0] = (byte)(result >> 24);
-                    numbers[1] = (byte)(result >> 16);
-                    numbers[2] = (byte)(result >> 8);
-                    numbers[3] = (byte)(result);
-                }
+                numbers[i].TryFormat(stackSpace.Slice(totalChars), out charsWritten);
+                int periodPos = totalChars + charsWritten;
+                stackSpace[periodPos] = '.';
+                totalChars = periodPos + 1;
             }
 
-            return numbers[0] == 127;
+            numbers[3].TryFormat(stackSpace.Slice(totalChars), out charsWritten);
+            return new string(stackSpace.Slice(0, totalChars + charsWritten));
         }
     }
 }

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -891,7 +891,7 @@ namespace System
             return null;
         }
 
-        private unsafe string GetRelativeSerializationString(UriFormat format)
+        private string GetRelativeSerializationString(UriFormat format)
         {
             if (format == UriFormat.UriEscaped)
             {

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/Xactopt.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/Xactopt.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using System.Text;
@@ -24,14 +25,20 @@ internal struct Xactopt
     [CustomMarshaller(typeof(Xactopt), MarshalMode.UnmanagedToManagedIn, typeof(Marshaller))]
     internal static class Marshaller
     {
-        internal unsafe struct XactoptNative
+        internal struct XactoptNative
         {
             public uint UlTimeout;
 
-            public fixed byte SzDescription[40];
+            public SzDescription SzDescription;
         }
 
-        public static unsafe XactoptNative ConvertToUnmanaged(Xactopt managed)
+        [InlineArray(40)]
+        internal struct SzDescription
+        {
+            private byte _element0;
+        }
+
+        public static XactoptNative ConvertToUnmanaged(Xactopt managed)
         {
             XactoptNative native = new()
             {
@@ -39,12 +46,12 @@ internal struct Xactopt
             };
 
             // Usage of Xactopt never passes non-ASCII chars, so we can ignore them.
-            Encoding.ASCII.TryGetBytes(managed.SzDescription, new Span<byte>(native.SzDescription, 40), out _);
+            Encoding.ASCII.TryGetBytes(managed.SzDescription, native.SzDescription, out _);
 
             return native;
         }
 
-        public static unsafe Xactopt ConvertToManaged(XactoptNative unmanaged)
-        => new(unmanaged.UlTimeout, Encoding.ASCII.GetString(unmanaged.SzDescription, 40));
+        public static Xactopt ConvertToManaged(XactoptNative unmanaged)
+        => new(unmanaged.UlTimeout, Encoding.ASCII.GetString(unmanaged.SzDescription));
     }
 }


### PR DESCRIPTION
[diffs](https://github.com/MihuBot/runtime-utils/issues/1102) (size regression in ParseCanonicalName is due to inlining of Parse)