### PR TITLE
Preserve entitlements in the HostWriter and bundler for apphost and singlefilehost

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -141,7 +141,7 @@ namespace Microsoft.NET.HostModel.AppHost
                             BinaryUtils.WriteToStream(memoryMappedViewAccessor, fileStream, sourceAppHostLength);
 
                             // Remove the signature from MachO hosts.
-                            if (!appHostIsPEImage)
+                            if (!appHostIsPEImage && !enableMacOSCodeSign)
                             {
                                 MachOUtils.RemoveSignature(fileStream);
                             }
@@ -181,7 +181,7 @@ namespace Microsoft.NET.HostModel.AppHost
 
                     if (enableMacOSCodeSign && RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && HostModelUtils.IsCodesignAvailable())
                     {
-                        (int exitCode, string stdErr) = HostModelUtils.RunCodesign("-s -", appHostDestinationFilePath);
+                        (int exitCode, string stdErr) = HostModelUtils.RunCodesign("-s - --preserve-metadata=entitlements -f", appHostDestinationFilePath);
                         if (exitCode != 0)
                         {
                             throw new AppHostSigningException(exitCode, stdErr);

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -355,7 +355,7 @@ namespace Microsoft.NET.HostModel.Bundle
                 string args = "-s -";
                 if (File.Exists(entitlementsPath) && new FileInfo(entitlementsPath).Length != 0)
                 {
-                    args += " --entitlements " + entitlementsPath;
+                    args += $" --entitlements \"{entitlementsPath}\"";
                 }
                 var (exitCode, stdErr) = HostModelUtils.RunCodesign(args, bundlePath);
                 if (exitCode != 0)
@@ -383,7 +383,7 @@ namespace Microsoft.NET.HostModel.Bundle
                     string stdErr;
                     if (entitlementsPath != null)
                     {
-                        (exitCode, stdErr) = HostModelUtils.RunCodesign($"-d --entitlements {entitlementsPath} --xml", bundlePath);
+                        (exitCode, stdErr) = HostModelUtils.RunCodesign($"-d --entitlements \"{entitlementsPath}\" --xml", bundlePath);
                         if (exitCode != 0)
                         {
                             throw new InvalidOperationException($"Failed to get entitlements from '{bundlePath}': {stdErr}");

--- a/src/installer/tests/HostActivation.Tests/MachOHostSigningTests.cs
+++ b/src/installer/tests/HostActivation.Tests/MachOHostSigningTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
 using FluentAssertions;
@@ -46,8 +46,8 @@ namespace HostActivation.Tests
 
             HostWriter.CreateAppHost(testAppHostPath, signedHostPath, testAppHostPath + ".dll", enableMacOSCodeSign: true);
 
-            HasEntitlements(testAppHostPath).Should().BeTrue();
-            HasEntitlements(signedHostPath).Should().BeTrue();
+            SignatureHelpers.HasEntitlements(testAppHostPath).Should().BeTrue();
+            SignatureHelpers.HasEntitlements(signedHostPath).Should().BeTrue();
         }
 
         [Fact]
@@ -64,26 +64,8 @@ namespace HostActivation.Tests
             var bundlePath = new Bundler(Path.GetFileName(signedHostPath), testAppHostPath + ".bundle").GenerateBundle([new(signedHostPath, Path.GetFileName(signedHostPath))]);
 
 
-            HasEntitlements(testAppHostPath).Should().BeTrue();
-            HasEntitlements(bundlePath).Should().BeTrue();
-        }
-
-        private static bool HasEntitlements(string path)
-        {
-            ProcessStartInfo psi = new ProcessStartInfo
-            {
-                FileName = "codesign",
-                Arguments = $"-d --entitlements - \"{path}\"",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-            var process = Process.Start(psi);
-            process.WaitForExit();
-            process.StandardOutput.ReadLine(); // ExecutableName
-            var entitlements = process.StandardOutput.ReadLine(); // Entitlements
-            return !string.IsNullOrEmpty(entitlements);
+            SignatureHelpers.HasEntitlements(testAppHostPath).Should().BeTrue();
+            SignatureHelpers.HasEntitlements(bundlePath).Should().BeTrue();
         }
     }
 }

--- a/src/installer/tests/HostActivation.Tests/MachOHostSigningTests.cs
+++ b/src/installer/tests/HostActivation.Tests/MachOHostSigningTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using FluentAssertions;
+using System;
+using System.IO;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.NET.HostModel.AppHost;
+using Microsoft.NET.HostModel.Bundle;
+using System.Diagnostics;
+
+namespace HostActivation.Tests
+{
+    public class MachOHostSigningTests
+    {
+        [Fact]
+        [PlatformSpecific(TestPlatforms.OSX)]
+        public void SignedAppHostRuns()
+        {
+            using var testDirectory = TestArtifact.Create(nameof(SignedAppHostRuns));
+            var testAppHostPath = Path.Combine(testDirectory.Location, Path.GetFileName(Binaries.AppHost.FilePath));
+            File.Copy(Binaries.AppHost.FilePath, testAppHostPath);
+            long preRemovalSize = new FileInfo(testAppHostPath).Length;
+            string signedHostPath = testAppHostPath + ".signed";
+
+            HostWriter.CreateAppHost(testAppHostPath, signedHostPath, testAppHostPath + ".dll", enableMacOSCodeSign: true);
+
+            var executedCommand = Command.Create(testAppHostPath)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute();
+            executedCommand.Should().ExitWith(Constants.ErrorCode.AppHostExeNotBoundFailure);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.OSX)]
+        public void SigningAppHostPreservesEntitlements()
+        {
+            using var testDirectory = TestArtifact.Create(nameof(SignedAppHostRuns));
+            var testAppHostPath = Path.Combine(testDirectory.Location, Path.GetFileName(Binaries.AppHost.FilePath));
+            File.Copy(Binaries.AppHost.FilePath, testAppHostPath);
+            long preRemovalSize = new FileInfo(testAppHostPath).Length;
+            string signedHostPath = testAppHostPath + ".signed";
+
+            HostWriter.CreateAppHost(testAppHostPath, signedHostPath, testAppHostPath + ".dll", enableMacOSCodeSign: true);
+
+            HasEntitlements(testAppHostPath).Should().BeTrue();
+            HasEntitlements(signedHostPath).Should().BeTrue();
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.OSX)]
+        public void BundledAppHostHasEntitlements()
+        {
+            using var testDirectory = TestArtifact.Create(nameof(BundledAppHostHasEntitlements));
+            var testAppHostPath = Path.Combine(testDirectory.Location, Path.GetFileName(Binaries.SingleFileHost.FilePath));
+            File.Copy(Binaries.SingleFileHost.FilePath, testAppHostPath);
+            long preRemovalSize = new FileInfo(testAppHostPath).Length;
+            string signedHostPath = testAppHostPath + ".signed";
+
+            HostWriter.CreateAppHost(testAppHostPath, signedHostPath, testAppHostPath + ".dll", enableMacOSCodeSign: true);
+            var bundlePath = new Bundler(Path.GetFileName(signedHostPath), testAppHostPath + ".bundle").GenerateBundle([new(signedHostPath, Path.GetFileName(signedHostPath))]);
+
+
+            HasEntitlements(testAppHostPath).Should().BeTrue();
+            HasEntitlements(bundlePath).Should().BeTrue();
+        }
+
+        private static bool HasEntitlements(string path)
+        {
+            ProcessStartInfo psi = new ProcessStartInfo
+            {
+                FileName = "codesign",
+                Arguments = $"-d --entitlements - \"{path}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            var process = Process.Start(psi);
+            process.WaitForExit();
+            process.StandardOutput.ReadLine(); // ExecutableName
+            var entitlements = process.StandardOutput.ReadLine(); // Entitlements
+            return !string.IsNullOrEmpty(entitlements);
+        }
+    }
+}

--- a/src/installer/tests/TestUtils/SignatureHelpers.cs
+++ b/src/installer/tests/TestUtils/SignatureHelpers.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+public class SignatureHelpers
+{
+    public static bool HasEntitlements(string path)
+    {
+        ProcessStartInfo psi = new ProcessStartInfo
+        {
+            FileName = "codesign",
+            Arguments = $"-d --entitlements - \"{path}\" --xml",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using (Process process = Process.Start(psi))
+        {
+            process.WaitForExit();
+            var entitlements = process.StandardOutput.ReadToEnd();
+            return !string.IsNullOrEmpty(entitlements);
+        }
+    }
+}

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -286,3 +286,7 @@ target_link_libraries(
 target_link_libraries(singlefilehost PRIVATE hostmisc)
 
 add_sanitizer_runtime_support(singlefilehost)
+
+if (CLR_CMAKE_HOST_APPLE)
+    adhoc_sign_with_entitlements(singlefilehost "${CLR_ENG_NATIVE_DIR}/entitlements.plist")
+endif()


### PR DESCRIPTION
We can preserve the entitlements for the apphost and singlefile host in 9.0 for the customers hitting issues. We also need to add entitlements in the first place for the singlefile host. It's not a particularly large change, so I think it might be worth it, but it is fairly late and will be fixed in lts 10.0.

## Customer Impact:
We've hit a few customers internally and externally who have apps that fail in the latest versions of MacOS, particularly when the app is signed with the "hardened runtime" option on MacOS. The hardened runtime restricts the use of a JIT without explicit entitlements in the signature of the binary. The apphost has it when built, but it is removed in the process of rewriting the apphost and re-signing it. The singlefilehost currently does not have any entitlements when built. The workaround has been to sign the app again with the same entitlements, but it's not obvious that this would be necessary.

## Testing
Tests added to the managed codesigner that check for entitlements after writing the host have been ported.

## Risk:
Low. There is more complexity to the host writer, but not significantly so. There's no expected behavioral change for scenarios that already work.
