### PR TITLE
Enable ML-DSA on Windows

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Cng.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Cng.cs
@@ -31,6 +31,7 @@ namespace Internal.NativeCrypto
             public const string ECDsaP521 = "ECDSA_P521";       // BCRYPT_ECDSA_P521_ALGORITHM
             public const string RSA = "RSA";                    // BCRYPT_RSA_ALGORITHM
             public const string MD5 = "MD5";                    // BCRYPT_MD5_ALGORITHM
+            public const string MLDsa = "ML-DSA";               // BCRYPT_MLDSA_ALGORITHM
             public const string Sha1 = "SHA1";                  // BCRYPT_SHA1_ALGORITHM
             public const string Sha256 = "SHA256";              // BCRYPT_SHA256_ALGORITHM
             public const string Sha384 = "SHA384";              // BCRYPT_SHA384_ALGORITHM

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.AsymmetricEncryption.Types.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.AsymmetricEncryption.Types.cs
@@ -53,5 +53,24 @@ internal static partial class Interop
             /// </summary>
             internal int cbSalt;
         }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct BCRYPT_PQDSA_PADDING_INFO
+        {
+            /// <summary>
+            ///     Address of the context buffer.
+            /// </summary>
+            internal IntPtr pbCtx;
+
+            /// <summary>
+            ///     The size, in bytes, of the context buffer.
+            /// </summary>
+            internal int cbCtx;
+
+            /// <summary>
+            ///     Null-terminated Unicode string that identifies the pre-hash algorithm used to create the hash.
+            /// </summary>
+            internal IntPtr pszPreHashAlgId;
+        }
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenerateKeyPair.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenerateKeyPair.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
 
         internal static SafeBCryptKeyHandle BCryptGenerateKeyPair(
             SafeBCryptAlgorithmHandle hAlgorithm,
-            int keyLength)
+            int keyLength = 0)
         {
             NTSTATUS status = BCryptGenerateKeyPair(
                 hAlgorithm,

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenerateKeyPair.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptGenerateKeyPair.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
 
         internal static SafeBCryptKeyHandle BCryptGenerateKeyPair(
             SafeBCryptAlgorithmHandle hAlgorithm,
-            int keyLength = 0)
+            int keyLength)
         {
             NTSTATUS status = BCryptGenerateKeyPair(
                 hAlgorithm,

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptPropertyStrings.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptPropertyStrings.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
             internal const string BCRYPT_HASH_LENGTH = "HashDigestLength";
             internal const string BCRYPT_KEY_STRENGTH = "KeyStrength";
             internal const string BCRYPT_MESSAGE_BLOCK_LENGTH = "MessageBlockLength";
+            internal const string BCRYPT_PARAMETER_SET_NAME = "ParameterSetName";
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptSetProperty.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptSetProperty.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 using Microsoft.Win32.SafeHandles;
@@ -14,18 +15,20 @@ internal static partial class Interop
             SafeBCryptHandle hObject,
             string pszProperty,
             void* pbInput,
-            int cbInput,
-            int dwFlags);
+            uint cbInput,
+            uint dwFlags);
 
         internal static unsafe void BCryptSetSZProperty(SafeBCryptHandle hObject, string pszProperty, string pszValue)
         {
+            Debug.Assert(pszValue is not null);
+
             fixed (void* pbInput = pszValue)
             {
                 NTSTATUS status = BCryptSetProperty(
                     hObject,
                     pszProperty,
                     pbInput,
-                    (pszValue.Length + 1) * 2,
+                    checked(((uint)pszValue.Length + 1) * 2),
                     0);
 
                 if (status != NTSTATUS.STATUS_SUCCESS)

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptSetProperty.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptSetProperty.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class BCrypt
+    {
+        [LibraryImport(Libraries.BCrypt, StringMarshalling = StringMarshalling.Utf16)]
+        internal static unsafe partial NTSTATUS BCryptSetProperty(
+            SafeBCryptHandle hObject,
+            string pszProperty,
+            void* pbInput,
+            int cbInput,
+            int dwFlags);
+
+        internal static unsafe void BCryptSetSZProperty(SafeBCryptHandle hObject, string pszProperty, string pszValue)
+        {
+            fixed (void* pbInput = pszValue)
+            {
+                NTSTATUS status = BCryptSetProperty(
+                    hObject,
+                    pszProperty,
+                    pbInput,
+                    (pszValue.Length + 1) * 2,
+                    0);
+
+                if (status != NTSTATUS.STATUS_SUCCESS)
+                {
+                    throw CreateCryptographicException(status);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptSignHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptSignHash.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Internal.Cryptography;
 
@@ -72,6 +73,59 @@ internal static partial class Interop
                     destination.Length,
                     out bytesWritten,
                     BCryptSignVerifyFlags.BCRYPT_PAD_PSS);
+            }
+        }
+
+        internal static unsafe void BCryptSignHashPure(
+            SafeBCryptKeyHandle key,
+            ReadOnlySpan<byte> data,
+            ReadOnlySpan<byte> context,
+            Span<byte> destination)
+        {
+            NTSTATUS status;
+            int bytesWritten;
+
+            fixed (byte* pData = &MemoryMarshal.GetReference(data))
+            fixed (byte* pDest = &Helpers.GetNonNullPinnableReference(destination))
+            {
+                if (context.Length == 0)
+                {
+                    status = BCryptSignHash(
+                        key,
+                        pPaddingInfo: null,
+                        pData,
+                        data.Length,
+                        pDest,
+                        destination.Length,
+                        out bytesWritten,
+                        default(BCryptSignVerifyFlags));
+                }
+                else
+                {
+                    fixed (byte* pContext = &MemoryMarshal.GetReference(context))
+                    {
+                        BCRYPT_PQDSA_PADDING_INFO paddingInfo = default;
+                        paddingInfo.pbCtx = (IntPtr)pContext;
+                        paddingInfo.cbCtx = context.Length;
+
+                        status = BCryptSignHash(
+                            key,
+                            &paddingInfo,
+                            pData,
+                            data.Length,
+                            pDest,
+                            destination.Length,
+                            out bytesWritten,
+                            BCryptSignVerifyFlags.BCRYPT_PAD_PQDSA);
+                    }
+                }
+            }
+
+            Debug.Assert(bytesWritten == destination.Length);
+
+            if (status != Interop.BCrypt.NTSTATUS.STATUS_SUCCESS)
+            {
+                throw Interop.BCrypt.CreateCryptographicException(status);
             }
         }
     }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptVerifySignature.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptVerifySignature.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Internal.Cryptography;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
@@ -15,6 +16,7 @@ internal static partial class Interop
         {
             BCRYPT_PAD_PKCS1 = 2,
             BCRYPT_PAD_PSS = 8,
+            BCRYPT_PAD_PQDSA = 32,
         }
 
         [LibraryImport(Libraries.BCrypt)]
@@ -80,6 +82,51 @@ internal static partial class Interop
                     pSignature,
                     signature.Length,
                     BCryptSignVerifyFlags.BCRYPT_PAD_PSS);
+            }
+
+            return status == NTSTATUS.STATUS_SUCCESS;
+        }
+
+        internal static unsafe bool BCryptVerifySignaturePure(
+            SafeBCryptKeyHandle key,
+            ReadOnlySpan<byte> data,
+            ReadOnlySpan<byte> context,
+            ReadOnlySpan<byte> signature)
+        {
+            NTSTATUS status;
+
+            fixed (byte* pData = &Helpers.GetNonNullPinnableReference(data))
+            fixed (byte* pSignature = &MemoryMarshal.GetReference(signature))
+            {
+                if (context.Length == 0)
+                {
+                    status = BCryptVerifySignature(
+                        key,
+                        pPaddingInfo: null,
+                        pData,
+                        data.Length,
+                        pSignature,
+                        signature.Length,
+                        default(BCryptSignVerifyFlags));
+                }
+                else
+                {
+                    fixed (byte* pContext = &MemoryMarshal.GetReference(context))
+                    {
+                        BCRYPT_PQDSA_PADDING_INFO paddingInfo = default;
+                        paddingInfo.pbCtx = (IntPtr)pContext;
+                        paddingInfo.cbCtx = context.Length;
+
+                        status = BCryptVerifySignature(
+                            key,
+                            &paddingInfo,
+                            pData,
+                            data.Length,
+                            pSignature,
+                            signature.Length,
+                            BCryptSignVerifyFlags.BCRYPT_PAD_PQDSA);
+                    }
+                }
             }
 
             return status == NTSTATUS.STATUS_SUCCESS;

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.Blobs.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.Blobs.cs
@@ -246,12 +246,12 @@ internal static partial class Interop
         /// <summary>
         ///     Used as a header to PQC parameters including the parameters set and key/seed.
         /// </summary>
-        [StructLayout(LayoutKind.Explicit, Pack = 1)]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct BCRYPT_PQDSA_KEY_BLOB
         {
-            [FieldOffset(0)] internal KeyBlobMagicNumber Magic;
-            [FieldOffset(4)] internal int cbParameterSet;           // Byte size of parameterSet[]
-            [FieldOffset(8)] internal int cbKey;                    // Byte size of key[]
+            internal KeyBlobMagicNumber Magic;
+            internal int cbParameterSet;        // Byte size of parameterSet[]
+            internal int cbKey;                 // Byte size of key[]
             // The rest of the buffer contains the data
         }
 

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.Blobs.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.Blobs.cs
@@ -106,6 +106,10 @@ internal static partial class Interop
             BCRYPT_ECDSA_PUBLIC_GENERIC_MAGIC = 0x50444345,
             BCRYPT_ECDSA_PRIVATE_GENERIC_MAGIC = 0x56444345,
 
+            BCRYPT_MLDSA_PUBLIC_MAGIC = 0x4B505344,
+            BCRYPT_MLDSA_PRIVATE_MAGIC = 0x4B535344,
+            BCRYPT_MLDSA_PRIVATE_SEED_MAGIC = 0x53535344,
+
             BCRYPT_RSAPUBLIC_MAGIC = 0x31415352,
             BCRYPT_RSAPRIVATE_MAGIC = 0x32415352,
             BCRYPT_RSAFULLPRIVATE_MAGIC = 0x33415352,
@@ -133,6 +137,10 @@ internal static partial class Interop
             internal const string BCRYPT_ECCPRIVATE_BLOB = "ECCPRIVATEBLOB";
             internal const string BCRYPT_ECCFULLPUBLIC_BLOB = "ECCFULLPUBLICBLOB";
             internal const string BCRYPT_ECCFULLPRIVATE_BLOB = "ECCFULLPRIVATEBLOB";
+
+            internal const string BCRYPT_PQDSA_PUBLIC_BLOB = "PQDSAPUBLICBLOB";
+            internal const string BCRYPT_PQDSA_PRIVATE_BLOB = "PQDSAPRIVATEBLOB";
+            internal const string BCRYPT_PQDSA_PRIVATE_SEED_BLOB = "PQDSAPRIVATESEEDBLOB";
         }
 
         /// <summary>
@@ -233,6 +241,18 @@ internal static partial class Interop
             internal int cbCofactor;             //Byte length of cofactor of G in E.
             internal int cbSeed;                 //Byte length of the seed used to generate the curve.
             // The rest of the buffer contains the domain parameters
+        }
+
+        /// <summary>
+        ///     Used as a header to PQC parameters including the parameters set and key/seed.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct BCRYPT_PQDSA_KEY_BLOB
+        {
+            internal KeyBlobMagicNumber Magic;
+            internal int cbParameterSet;    // Byte size of parameterSet[]
+            internal int cbKey;             // Byte size of key[]
+            // The rest of the buffer contains the data
         }
 
         /// <summary>

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.Blobs.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.Blobs.cs
@@ -246,12 +246,12 @@ internal static partial class Interop
         /// <summary>
         ///     Used as a header to PQC parameters including the parameters set and key/seed.
         /// </summary>
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Explicit, Pack = 1)]
         internal struct BCRYPT_PQDSA_KEY_BLOB
         {
-            internal KeyBlobMagicNumber Magic;
-            internal int cbParameterSet;    // Byte size of parameterSet[]
-            internal int cbKey;             // Byte size of key[]
+            [FieldOffset(0)] internal KeyBlobMagicNumber Magic;
+            [FieldOffset(4)] internal int cbParameterSet;           // Byte size of parameterSet[]
+            [FieldOffset(8)] internal int cbKey;                    // Byte size of key[]
             // The rest of the buffer contains the data
         }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.NotSupported.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.NotSupported.cs
@@ -8,7 +8,7 @@ namespace System.Security.Cryptography
 {
     internal sealed partial class MLDsaImplementation : MLDsa
     {
-        public MLDsaImplementation(MLDsaAlgorithm algorithm)
+        private MLDsaImplementation(MLDsaAlgorithm algorithm)
             : base(algorithm)
         {
             ThrowIfNotSupported();

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.NotSupported.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.NotSupported.cs
@@ -8,6 +8,12 @@ namespace System.Security.Cryptography
 {
     internal sealed partial class MLDsaImplementation : MLDsa
     {
+        public MLDsaImplementation(MLDsaAlgorithm algorithm)
+            : base(algorithm)
+        {
+            ThrowIfNotSupported();
+        }
+
         internal static partial bool SupportsAny() => false;
 
         // The instance override methods are unreachable, as the constructor will always throw.
@@ -33,9 +39,6 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException();
 
         internal static partial MLDsaImplementation ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
-            throw new PlatformNotSupportedException();
-
-        internal static partial MLDsaImplementation ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
         internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
@@ -2,47 +2,188 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+using Internal.NativeCrypto;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography
 {
     internal sealed partial class MLDsaImplementation : MLDsa
     {
-        internal static partial bool SupportsAny() => false;
+        private static readonly SafeBCryptAlgorithmHandle s_algHandle =
+            Interop.BCrypt.BCryptOpenAlgorithmProvider(BCryptNative.AlgorithmName.MLDsa);
 
-        // TODO: Define this in terms of Windows BCrypt.dll (ephemeral keys)
+        private readonly bool _hasSeed;
+        private readonly bool _hasSecretKey;
+        private SafeBCryptKeyHandle _key;
+
+        private MLDsaImplementation(
+            MLDsaAlgorithm algorithm,
+            SafeBCryptKeyHandle key,
+            bool hasSeed,
+            bool hasSecretKey)
+            : base(algorithm)
+        {
+            _key = key;
+            _hasSeed = hasSeed;
+            _hasSecretKey = hasSecretKey;
+        }
+
+        internal static partial bool SupportsAny() => !s_algHandle.IsInvalid;
 
         protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) =>
-            throw new PlatformNotSupportedException();
+            Interop.BCrypt.BCryptSignHashPure(_key, data, context, destination);
 
         protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) =>
-            throw new PlatformNotSupportedException();
+            Interop.BCrypt.BCryptVerifySignaturePure(_key, data, context, signature);
 
-        protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) =>
-            throw new PlatformNotSupportedException();
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            return MLDsaPkcs8.TryExportPkcs8PrivateKey(
+                this,
+                _hasSeed,
+                _hasSecretKey,
+                destination,
+                out bytesWritten);
+        }
 
-        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination) =>
-            throw new PlatformNotSupportedException();
+        internal static partial MLDsaImplementation GenerateKeyImpl(MLDsaAlgorithm algorithm) //=>
+        {
+            string parameterSet = PqcBlobHelpers.GetParameterSet(algorithm);
+            SafeBCryptKeyHandle keyHandle = Interop.BCrypt.BCryptGenerateKeyPair(s_algHandle);
 
-        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) =>
-            throw new PlatformNotSupportedException();
+            try
+            {
+                Interop.BCrypt.BCryptSetSZProperty(keyHandle, Interop.BCrypt.BCryptPropertyStrings.BCRYPT_PARAMETER_SET_NAME, parameterSet);
+                Interop.BCrypt.BCryptFinalizeKeyPair(keyHandle);
+            }
+            catch
+            {
+                keyHandle?.Dispose();
+                throw;
+            }
 
-        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) =>
-            throw new PlatformNotSupportedException();
+            return new MLDsaImplementation(algorithm, keyHandle, hasSeed: true, hasSecretKey: true);
+        }
 
-        internal static partial MLDsaImplementation GenerateKeyImpl(MLDsaAlgorithm algorithm) =>
-            throw new PlatformNotSupportedException();
+        internal static partial MLDsaImplementation ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
+        {
+            const string BlobType = Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PUBLIC_BLOB;
 
-        internal static partial MLDsaImplementation ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
-            throw new PlatformNotSupportedException();
+            SafeBCryptKeyHandle key =
+                PqcBlobHelpers.EncodeMLDsaBlob(
+                    PqcBlobHelpers.GetParameterSet(algorithm),
+                    source,
+                    BlobType,
+                    static blob => Interop.BCrypt.BCryptImportKeyPair(s_algHandle, BlobType, blob));
 
-        internal static partial MLDsaImplementation ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
-            throw new PlatformNotSupportedException();
+            return new MLDsaImplementation(algorithm, key, hasSeed: false, hasSecretKey: false);
+        }
 
-        internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
-            throw new PlatformNotSupportedException();
+        internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
+        {
+            const string BlobType = Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB;
 
-        internal static partial MLDsaImplementation ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
-            throw new PlatformNotSupportedException();
+            SafeBCryptKeyHandle key =
+                PqcBlobHelpers.EncodeMLDsaBlob(
+                    PqcBlobHelpers.GetParameterSet(algorithm),
+                    source,
+                    BlobType,
+                    static blob => Interop.BCrypt.BCryptImportKeyPair(s_algHandle, BlobType, blob));
+
+            return new MLDsaImplementation(algorithm, key, hasSeed: false, hasSecretKey: true);
+        }
+
+        internal static partial MLDsaImplementation ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
+        {
+            const string BlobType = Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB;
+
+            SafeBCryptKeyHandle key =
+                PqcBlobHelpers.EncodeMLDsaBlob(
+                    PqcBlobHelpers.GetParameterSet(algorithm),
+                    source,
+                    BlobType,
+                    static blob => Interop.BCrypt.BCryptImportKeyPair(s_algHandle, BlobType, blob));
+
+            return new MLDsaImplementation(algorithm, key, hasSeed: true, hasSecretKey: true);
+        }
+
+        protected override void ExportMLDsaPublicKeyCore(Span<byte> destination)
+        {
+            ArraySegment<byte> keyBlob = Interop.BCrypt.BCryptExportKey(_key, Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PUBLIC_BLOB);
+
+            try
+            {
+                ReadOnlySpan<byte> keyBytes = PqcBlobHelpers.DecodeMLDsaBlob(
+                    keyBlob,
+                    out ReadOnlySpan<char> parameterSet,
+                    out string blobType);
+
+                Debug.Assert(blobType == Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PUBLIC_BLOB);
+
+                // Length is known, but we'll slice just in case
+                MLDsaAlgorithm algorithm = PqcBlobHelpers.GetMLDsaAlgorithmFromParameterSet(parameterSet);
+                Debug.Assert(keyBytes.Length == algorithm.PublicKeySizeInBytes);
+                keyBytes.Slice(0, algorithm.PublicKeySizeInBytes).CopyTo(destination);
+            }
+            finally
+            {
+                // Public key doesn't need to be cleared
+                CryptoPool.Return(keyBlob, clearSize: 0);
+            }
+        }
+
+        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination)
+        {
+            ArraySegment<byte> keyBlob = Interop.BCrypt.BCryptExportKey(_key, Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB);
+
+            try
+            {
+                ReadOnlySpan<byte> keyBytes = PqcBlobHelpers.DecodeMLDsaBlob(
+                    keyBlob,
+                    out ReadOnlySpan<char> parameterSet,
+                    out string blobType);
+
+                Debug.Assert(blobType == Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB);
+
+                // Length is known, but we'll slice just in case
+                MLDsaAlgorithm algorithm = PqcBlobHelpers.GetMLDsaAlgorithmFromParameterSet(parameterSet);
+                Debug.Assert(keyBytes.Length == algorithm.SecretKeySizeInBytes);
+                keyBytes.Slice(0, algorithm.SecretKeySizeInBytes).CopyTo(destination);
+            }
+            finally
+            {
+                CryptoPool.Return(keyBlob, clearSize: keyBlob.Count);
+            }
+        }
+
+        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination)
+        {
+            ArraySegment<byte> keyBlob = Interop.BCrypt.BCryptExportKey(_key, Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB);
+
+            try
+            {
+                ReadOnlySpan<byte> keyBytes = PqcBlobHelpers.DecodeMLDsaBlob(
+                    keyBlob,
+                    out ReadOnlySpan<char> parameterSet,
+                    out string blobType);
+
+                Debug.Assert(blobType == Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB);
+
+                // Length is known, but we'll slice just in case
+                MLDsaAlgorithm algorithm = PqcBlobHelpers.GetMLDsaAlgorithmFromParameterSet(parameterSet);
+                Debug.Assert(keyBytes.Length == algorithm.PrivateSeedSizeInBytes);
+                keyBytes.Slice(0, algorithm.PrivateSeedSizeInBytes).CopyTo(destination);
+            }
+            finally
+            {
+                CryptoPool.Return(keyBlob, clearSize: keyBlob.Count);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _key?.Dispose();
+            _key = null!;
+        }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.cs
@@ -9,17 +9,10 @@ namespace System.Security.Cryptography
     [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
     internal sealed partial class MLDsaImplementation : MLDsa
     {
-        private MLDsaImplementation(MLDsaAlgorithm algorithm)
-            : base(algorithm)
-        {
-            ThrowIfNotSupported();
-        }
-
         internal static partial bool SupportsAny();
 
         internal static partial MLDsaImplementation GenerateKeyImpl(MLDsaAlgorithm algorithm);
         internal static partial MLDsaImplementation ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
-        internal static partial MLDsaImplementation ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
         internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
         internal static partial MLDsaImplementation ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
 

--- a/src/libraries/Common/src/System/Security/Cryptography/PqcBlobHelpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/PqcBlobHelpers.cs
@@ -1,0 +1,178 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using KeyBlobMagicNumber = Interop.BCrypt.KeyBlobMagicNumber;
+using BCRYPT_PQDSA_KEY_BLOB = Interop.BCrypt.BCRYPT_PQDSA_KEY_BLOB;
+
+namespace System.Security.Cryptography
+{
+    internal static class PqcBlobHelpers
+    {
+        internal const string BCRYPT_MLDSA_PARAMETER_SET_44 = "44";
+        internal const string BCRYPT_MLDSA_PARAMETER_SET_65 = "65";
+        internal const string BCRYPT_MLDSA_PARAMETER_SET_87 = "87";
+
+        internal static string GetParameterSet(MLDsaAlgorithm algorithm)
+        {
+            if (algorithm == MLDsaAlgorithm.MLDsa44)
+            {
+                return BCRYPT_MLDSA_PARAMETER_SET_44;
+            }
+            else if (algorithm == MLDsaAlgorithm.MLDsa65)
+            {
+                return BCRYPT_MLDSA_PARAMETER_SET_65;
+            }
+            else if (algorithm == MLDsaAlgorithm.MLDsa87)
+            {
+                return BCRYPT_MLDSA_PARAMETER_SET_87;
+            }
+
+            Debug.Fail($"Unknown MLDsaAlgorithm: {algorithm}");
+            throw new PlatformNotSupportedException();
+        }
+
+        internal static MLDsaAlgorithm GetMLDsaAlgorithmFromParameterSet(ReadOnlySpan<char> parameterSet)
+        {
+            if (parameterSet.SequenceEqual(BCRYPT_MLDSA_PARAMETER_SET_44))
+            {
+                return MLDsaAlgorithm.MLDsa44;
+            }
+            else if (parameterSet.SequenceEqual(BCRYPT_MLDSA_PARAMETER_SET_65))
+            {
+                return MLDsaAlgorithm.MLDsa65;
+            }
+            else if (parameterSet.SequenceEqual(BCRYPT_MLDSA_PARAMETER_SET_87))
+            {
+                return MLDsaAlgorithm.MLDsa87;
+            }
+
+            Debug.Fail($"Unknown parameter set: {parameterSet.ToString()}");
+            throw new PlatformNotSupportedException();
+        }
+
+        internal delegate TResult EncodeBlobFunc<TResult>(ReadOnlySpan<byte> blob);
+
+        internal static TResult EncodeMLDsaBlob<TResult>(
+            ReadOnlySpan<char> parameterSet,
+            ReadOnlySpan<byte> data,
+            string blobType,
+            EncodeBlobFunc<TResult> callback)
+        {
+            KeyBlobMagicNumber magic;
+
+            switch (blobType)
+            {
+                case Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PUBLIC_BLOB:
+                    magic = KeyBlobMagicNumber.BCRYPT_MLDSA_PUBLIC_MAGIC;
+                    break;
+                case Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB:
+                    magic = KeyBlobMagicNumber.BCRYPT_MLDSA_PRIVATE_MAGIC;
+                    break;
+                case Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB:
+                    magic = KeyBlobMagicNumber.BCRYPT_MLDSA_PRIVATE_SEED_MAGIC;
+                    break;
+                default:
+                    Debug.Fail("Unknown blob type.");
+                    throw new CryptographicException();
+            }
+
+            return EncodePQDsaBlob(magic, parameterSet, data, callback);
+        }
+
+        internal static ReadOnlySpan<byte> DecodeMLDsaBlob(
+            ReadOnlySpan<byte> blob,
+            out ReadOnlySpan<char> parameterSet,
+            out string blobType)
+        {
+            ReadOnlySpan<byte> data = DecodePQDsaBlob(blob, out KeyBlobMagicNumber magic, out parameterSet);
+
+            switch (magic)
+            {
+                case KeyBlobMagicNumber.BCRYPT_MLDSA_PUBLIC_MAGIC:
+                    blobType = Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PUBLIC_BLOB;
+                    break;
+                case KeyBlobMagicNumber.BCRYPT_MLDSA_PRIVATE_MAGIC:
+                    blobType = Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB;
+                    break;
+                case KeyBlobMagicNumber.BCRYPT_MLDSA_PRIVATE_SEED_MAGIC:
+                    blobType = Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB;
+                    break;
+                default:
+                    Debug.Fail("Unknown blob type.");
+                    throw new CryptographicException();
+            }
+
+            return data;
+        }
+
+        private static TResult EncodePQDsaBlob<TResult>(
+            KeyBlobMagicNumber magic,
+            ReadOnlySpan<char> parameterSet,
+            ReadOnlySpan<byte> data,
+            EncodeBlobFunc<TResult> callback)
+        {
+            int blobHeaderSize = Unsafe.SizeOf<BCRYPT_PQDSA_KEY_BLOB>();
+            int parameterSetLengthWithNullTerminator = sizeof(char) * (parameterSet.Length + 1);
+
+            int blobSize =
+                blobHeaderSize +
+                parameterSetLengthWithNullTerminator +  // Parameter set, '\0' terminated
+                data.Length;                            // Key
+
+            byte[] rented = CryptoPool.Rent(blobSize);
+            Span<byte> blobBytes = rented.AsSpan(0, blobSize);
+
+            try
+            {
+                int index = 0;
+
+                // Write header
+                ref BCRYPT_PQDSA_KEY_BLOB blobHeader = ref MemoryMarshal.AsRef<BCRYPT_PQDSA_KEY_BLOB>(blobBytes);
+                blobHeader.Magic = magic;
+                blobHeader.cbParameterSet = parameterSetLengthWithNullTerminator;
+                blobHeader.cbKey = data.Length;
+                index += blobHeaderSize;
+
+                // Write parameter set
+                Span<char> blobBodyChars = MemoryMarshal.Cast<byte, char>(blobBytes.Slice(index));
+                parameterSet.CopyTo(blobBodyChars);
+                blobBodyChars[parameterSet.Length] = '\0';
+                index += parameterSetLengthWithNullTerminator;
+
+                // Write key
+                data.CopyTo(blobBytes.Slice(index));
+                index += data.Length;
+
+                Debug.Assert(index == blobBytes.Length);
+                return callback(blobBytes);
+            }
+            finally
+            {
+                CryptoPool.Return(rented);
+            }
+        }
+
+        private static ReadOnlySpan<byte> DecodePQDsaBlob(
+            ReadOnlySpan<byte> blobBytes,
+            out KeyBlobMagicNumber magic,
+            out ReadOnlySpan<char> parameterSet)
+        {
+            int index = 0;
+
+            ref readonly BCRYPT_PQDSA_KEY_BLOB blob = ref MemoryMarshal.AsRef<BCRYPT_PQDSA_KEY_BLOB>(blobBytes);
+            magic = blob.Magic;
+            int parameterSetLength = blob.cbParameterSet - 2; // Null terminator char, '\0'
+            int keyLength = blob.cbKey;
+            index += Unsafe.SizeOf<BCRYPT_PQDSA_KEY_BLOB>();
+
+            parameterSet = MemoryMarshal.Cast<byte, char>(blobBytes.Slice(index, parameterSetLength));
+            index += blob.cbParameterSet;
+
+            return blobBytes.Slice(index, keyLength);
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
@@ -14,6 +14,12 @@ namespace System.Security.Cryptography.Tests
     {
         internal static bool MLDsaIsNotSupported => !MLDsa.IsSupported;
 
+        // Windows certificates for ML-DSA are not implemented yet. Remove this and use MLDsa.IsSupported (or remove condition) when they are.
+        internal static bool CertificatesAreSupported => MLDsa.IsSupported && !PlatformDetection.IsWindows;
+
+        // Windows does not support signing empty data. Remove this and use MLDsa.IsSupported (or remove condition) when it does.
+        internal static bool SigningEmptyDataIsSupported => MLDsa.IsSupported && !PlatformDetection.IsWindows;
+
         // DER encoding of ASN.1 BitString "foo"
         internal static readonly ReadOnlyMemory<byte> s_derBitStringFoo = new byte[] { 0x03, 0x04, 0x00, 0x66, 0x6f, 0x6f };
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
@@ -14,10 +14,10 @@ namespace System.Security.Cryptography.Tests
     {
         internal static bool MLDsaIsNotSupported => !MLDsa.IsSupported;
 
-        // Windows certificates for ML-DSA are not implemented yet. Remove this and use MLDsa.IsSupported (or remove condition) when they are.
+        // TODO: Windows certificates for ML-DSA are not implemented yet. Remove this and use MLDsa.IsSupported (or remove condition) when they are.
         internal static bool CertificatesAreSupported => MLDsa.IsSupported && !PlatformDetection.IsWindows;
 
-        // Windows does not support signing empty data. Remove this and use MLDsa.IsSupported (or remove condition) when it does.
+        // TODO: Windows does not support signing empty data. Remove this and use MLDsa.IsSupported (or remove condition) when it does.
         internal static bool SigningEmptyDataIsSupported => MLDsa.IsSupported && !PlatformDetection.IsWindows;
 
         // DER encoding of ASN.1 BitString "foo"

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTests.cs
@@ -35,7 +35,8 @@ namespace System.Security.Cryptography.Tests
             Assert.Equal(PlatformSupportsMLDsa(), MLDsa.IsSupported);
         }
 
-        private static bool PlatformSupportsMLDsa() => PlatformDetection.IsOpenSsl3_5;
+        private static bool PlatformSupportsMLDsa() =>
+            PlatformDetection.IsOpenSsl3_5 || PlatformDetection.IsWindows10Version27858OrGreater;
 
         [Fact]
         public static void DisposeIsCalledOnImplementation()

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestsBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestsBase.cs
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Tests
             ExerciseSuccessfulVerify(mldsa, data, signature, context);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SigningEmptyDataIsSupported))]
         [MemberData(nameof(MLDsaTestsData.AllMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void GenerateSignVerifyEmptyMessageNoContext(MLDsaAlgorithm algorithm)
         {
@@ -60,7 +60,7 @@ namespace System.Security.Cryptography.Tests
             ExerciseSuccessfulVerify(mldsa, [], signature, []);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SigningEmptyDataIsSupported))]
         [MemberData(nameof(MLDsaTestsData.AllMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void GenerateSignVerifyEmptyMessageWithContext(MLDsaAlgorithm algorithm)
         {

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Formats.Asn1;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography.Tests;
 using Xunit;
 
 // PQC types are used throughout, but only when the caller requests them.
@@ -1040,7 +1041,7 @@ SingleResponse ::= SEQUENCE {
             {
                 List<KeyFactory> factories = [RSA, ECDsa];
 
-                if (Cryptography.MLDsa.IsSupported)
+                if (MLDsaTestHelpers.CertificatesAreSupported)
                 {
                     factories.Add(MLDsa);
                 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -1040,12 +1040,11 @@ SingleResponse ::= SEQUENCE {
             {
                 List<KeyFactory> factories = [RSA, ECDsa];
 
-#if !WINDOWS // MLDsa certificate support on Windows is not available yet. Remove this once it is.
-                if (Cryptography.MLDsa.IsSupported)
+                // TODO: MLDsa certificate support on Windows is not available yet. Remove this once it is.
+                if (Cryptography.MLDsa.IsSupported && !PlatformDetection.IsWindows)
                 {
                     factories.Add(MLDsa);
                 }
-#endif
 
                 if (Cryptography.SlhDsa.IsSupported)
                 {

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Formats.Asn1;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.Tests;
 using Xunit;
 
 // PQC types are used throughout, but only when the caller requests them.
@@ -1041,10 +1040,12 @@ SingleResponse ::= SEQUENCE {
             {
                 List<KeyFactory> factories = [RSA, ECDsa];
 
-                if (MLDsaTestHelpers.CertificatesAreSupported)
+#if !WINDOWS // MLDsa certificate support on Windows is not available yet. Remove this once it is.
+                if (Cryptography.MLDsa.IsSupported)
                 {
                     factories.Add(MLDsa);
                 }
+#endif
 
                 if (Cryptography.SlhDsa.IsSupported)
                 {

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -69,6 +69,10 @@ namespace System
         // Windows 11 aka 21H2
         public static bool IsWindows10Version22000OrGreater => IsWindowsVersionOrLater(10, 0, 22000);
 
+        // TODO This is a canary build. Update this to the first official PQC supported build when available.
+        // Insiders build with PQC
+        public static bool IsWindows10Version27858OrGreater => IsWindowsVersionOrLater(10, 0, 27858);
+
         public static bool IsWindowsIoTCore
         {
             get

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -69,8 +69,8 @@ namespace System
         // Windows 11 aka 21H2
         public static bool IsWindows10Version22000OrGreater => IsWindowsVersionOrLater(10, 0, 22000);
 
-        // TODO This is a canary build. Update this to the first official PQC supported build when available.
-        // Insiders build with PQC
+        // TODO: Update this to the first official PQC supported build when available.
+        // Windows 11 Insider Preview Build 27871 (Canary Channel)
         public static bool IsWindows10Version27858OrGreater => IsWindowsVersionOrLater(10, 0, 27858);
 
         public static bool IsWindowsIoTCore

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -1635,6 +1635,8 @@
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptOpenAlgorithmProvider.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptSetProperty.cs"
+             Link="Common\Interop\Windows\BCrypt\Interop.BCryptSetProperty.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptSignHash.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptSignHash.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptVerifySignature.cs"
@@ -1913,6 +1915,8 @@
              Link="Common\System\Security\Cryptography\MLKemImplementation.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemImplementation.NotSupported.cs"
             Link="Common\System\Security\Cryptography\MLKemImplementation.NotSupported.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.cs"
+             Link="Common\System\Security\Cryptography\PqcBlobHelpers.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.cs"
              Link="Common\System\Security\Cryptography\RSACng.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\RSACng.EncryptDecrypt.cs"

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaImplementation.OpenSsl.cs
@@ -88,9 +88,6 @@ namespace System.Security.Cryptography
             return new MLDsaImplementation(algorithm, key, hasSeed: false, hasSecretKey: false);
         }
 
-        internal static partial MLDsaImplementation ImportPkcs8PrivateKeyValue(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
-            throw new PlatformNotSupportedException();
-
         internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             Debug.Assert(source.Length == algorithm.SecretKeySizeInBytes, $"Secret key was expected to be {algorithm.SecretKeySizeInBytes} bytes, but was {source.Length} bytes.");

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -145,7 +145,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         public static void PrivateKey_FromCertificate_CanExportPrivate_MLDsa()
         {
             string pem = PemEncoding.WriteString("CERTIFICATE", MLDsaTestsData.IetfMLDsa44.Certificate);

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestChainTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Security.Cryptography.Tests;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreation
@@ -28,7 +29,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
-        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         public static void CreateChain_MLDSA()
         {
             using (MLDsa rootKey = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa87))

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CrlBuilderTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CrlBuilderTests.cs
@@ -6,6 +6,7 @@ using System.Formats.Asn1;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography.Tests;
 using Test.Cryptography;
 using Xunit;
 
@@ -29,7 +30,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         {
             yield return new object[] { CertKind.ECDsa };
 
-            if (MLDsa.IsSupported)
+            if (MLDsaTestHelpers.CertificatesAreSupported)
             {
                 yield return new object[] { CertKind.MLDsa };
             }
@@ -45,7 +46,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
 
         public static IEnumerable<object[]> NoHashAlgorithmCertKinds()
         {
-            if (MLDsa.IsSupported)
+            if (MLDsaTestHelpers.CertificatesAreSupported)
             {
                 yield return new object[] { CertKind.MLDsa };
             }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.cs
@@ -707,7 +707,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
-        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         public static void GetMLDsaPublicKeyTest()
         {
             // Cert without private key
@@ -739,7 +739,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
-        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         public static void GetMLDsaPrivateKeyTest()
         {
             // Cert without private key
@@ -768,7 +768,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
-        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         public static void CheckCopyWithPrivateKey_MLDSA()
         {
             using (MLDsa privKey = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa65))
@@ -812,7 +812,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
-        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         public static void CheckCopyWithPrivateKey_MLDsa_OtherMLDsa_SecretKey()
         {
             using (X509Certificate2 pubOnly = X509CertificateLoader.LoadCertificate(MLDsaTestsData.IetfMLDsa44.Certificate))
@@ -862,7 +862,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             }
         }
 
-        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         public static void CheckCopyWithPrivateKey_MLDsa_OtherMLDsa_PrivateSeed()
         {
             using (X509Certificate2 pubOnly = X509CertificateLoader.LoadCertificate(MLDsaTestsData.IetfMLDsa44.Certificate))

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -391,7 +391,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalTheory(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         [MemberData(nameof(MLDsaTestsData.IetfMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public static void ExportPkcs12_MLDsa_Generated_Roundtrip(MLDsaKeyInfo info)
         {

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
@@ -670,7 +670,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             from ietfVector in ietfVectorWrapped
             select new object[] { storageFlag, ietfVector };
 
-        [ConditionalTheory(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         [MemberData(nameof(ReadMLDsa_Pfx_Ietf_Data))]
         public static void ReadMLDsa512PrivateKey_Seed_Pfx(X509KeyStorageFlags keyStorageFlags, MLDsaKeyInfo info)
         {
@@ -690,7 +690,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalTheory(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         [MemberData(nameof(ReadMLDsa_Pfx_Ietf_Data))]
         public static void ReadMLDsa512PrivateKey_ExpandedKey_Pfx(X509KeyStorageFlags keyStorageFlags, MLDsaKeyInfo info)
         {
@@ -711,7 +711,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalTheory(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         [MemberData(nameof(ReadMLDsa_Pfx_Ietf_Data))]
         public static void ReadMLDsa512PrivateKey_Both_Pfx(X509KeyStorageFlags keyStorageFlags, MLDsaKeyInfo info)
         {

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
@@ -444,7 +444,7 @@ MII
             }
         }
 
-        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         public static void CreateFromPem_MLDsa_Pkcs8_Success()
         {
             (string CertificatePem, string PrivateKeyPem, string Thumbprint)[] cases =
@@ -506,7 +506,7 @@ MII
             }
         }
 
-        [ConditionalFact(typeof(MLDsa), nameof(MLDsa.IsSupported))]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.CertificatesAreSupported))]
         public static void CreateFromEncryptedPem_MLDsa_Pkcs8_Success()
         {
             (string CertificatePem, string EncryptedPrivateKeyPem, string Thumbprint)[] cases =


### PR DESCRIPTION
Adds the Windows implementation of ML-DSA using BCrypt as the underlying crypto provider. The MLDsa factory methods will create this implementation when called on Windows.

Certificates are not supported yet so tests requiring them are disabled on Windows. A PR following this one will add NCrypt and re-enable the tests again.

Contributes to #113502