### PR TITLE
Fix no-argument ./build.sh invocation

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -153,7 +153,7 @@ showSubsetHelp()
   "$scriptroot/common/build.sh" "-restore" "-build" "/p:Subset=help" "/clp:nosummary /tl:false"
 }
 
-arguments=()
+arguments=("")
 cmakeargs=''
 extraargs=()
 crossBuild=0


### PR DESCRIPTION
Fixes issue reported in https://github.com/dotnet/runtime/pull/116145#discussion_r2127121041