### PR TITLE
Cleanup LowLevelList usage in GCLayout

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -457,9 +457,9 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        private static bool IsAllGCPointers(LowLevelList<bool> bitfield)
+        private static bool IsAllGCPointers(bool[] bitfield)
         {
-            int count = bitfield.Count;
+            int count = bitfield.Length;
             Debug.Assert(count > 0);
 
             for (int i = 0; i < count; i++)
@@ -471,7 +471,7 @@ namespace Internal.Runtime.TypeLoader
             return true;
         }
 
-        private static unsafe int CreateArrayGCDesc(LowLevelList<bool> bitfield, int rank, bool isSzArray, void* gcdesc)
+        private static unsafe int CreateArrayGCDesc(bool[] bitfield, int rank, bool isSzArray, void* gcdesc)
         {
             if (bitfield == null)
                 return 0;
@@ -495,7 +495,7 @@ namespace Internal.Runtime.TypeLoader
             int first = -1;
             int last = 0;
             short numPtrs = 0;
-            while (i < bitfield.Count)
+            while (i < bitfield.Length)
             {
                 if (bitfield[i])
                 {
@@ -513,7 +513,7 @@ namespace Internal.Runtime.TypeLoader
                     numSeries++;
                     numPtrs = 0;
 
-                    while ((i < bitfield.Count) && (bitfield[i]))
+                    while ((i < bitfield.Length) && (bitfield[i]))
                     {
                         numPtrs++;
                         i++;
@@ -531,7 +531,7 @@ namespace Internal.Runtime.TypeLoader
             {
                 if (numSeries > 0)
                 {
-                    *ptr-- = (short)((first + bitfield.Count - last) * IntPtr.Size);
+                    *ptr-- = (short)((first + bitfield.Length - last) * IntPtr.Size);
                     *ptr-- = numPtrs;
 
                     *(void**)gcdesc = (void*)-numSeries;
@@ -542,7 +542,7 @@ namespace Internal.Runtime.TypeLoader
             return numSeries;
         }
 
-        private static unsafe int CreateGCDesc(LowLevelList<bool> bitfield, int size, bool isValueType, bool isStatic, void* gcdesc)
+        private static unsafe int CreateGCDesc(bool[] bitfield, int size, bool isValueType, bool isStatic, void* gcdesc)
         {
             int offs = 0;
             // if this type is a class we have to account for the gcdesc.
@@ -558,7 +558,7 @@ namespace Internal.Runtime.TypeLoader
 
             int numSeries = 0;
             int i = 0;
-            while (i < bitfield.Count)
+            while (i < bitfield.Length)
             {
                 if (bitfield[i])
                 {
@@ -566,7 +566,7 @@ namespace Internal.Runtime.TypeLoader
                     int seriesOffset = i * IntPtr.Size + offs;
                     int seriesSize = 0;
 
-                    while ((i < bitfield.Count) && (bitfield[i]))
+                    while ((i < bitfield.Length) && (bitfield[i]))
                     {
                         seriesSize += IntPtr.Size;
                         i++;

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -399,26 +399,19 @@ namespace Internal.Runtime.TypeLoader
                     pEEType->ContainsGCPointers = false;
                 }
             }
-            else if (gcBitfield != null)
+            else
             {
-                if (cbGCDesc != 0)
+                Debug.Assert(gcBitfield == null);
+
+                if (pTemplateEEType != null)
                 {
-                    pEEType->ContainsGCPointers = true;
-                    CreateGCDesc(gcBitfield, baseSize, isValueType, false, ((void**)pEEType) - 1);
+                    Buffer.MemoryCopy((byte*)pTemplateEEType - cbGCDesc, (byte*)pEEType - cbGCDesc, cbGCDesc, cbGCDesc);
+                    pEEType->ContainsGCPointers = pTemplateEEType->ContainsGCPointers;
                 }
                 else
                 {
                     pEEType->ContainsGCPointers = false;
                 }
-            }
-            else if (pTemplateEEType != null)
-            {
-                Buffer.MemoryCopy((byte*)pTemplateEEType - cbGCDesc, (byte*)pEEType - cbGCDesc, cbGCDesc, cbGCDesc);
-                pEEType->ContainsGCPointers = pTemplateEEType->ContainsGCPointers;
-            }
-            else
-            {
-                pEEType->ContainsGCPointers = false;
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -464,13 +464,13 @@ namespace Internal.Runtime.TypeLoader
             }
 
             /// <summary>
-            /// Writes this layout to the given bitfield.
+            /// Gets this layout in bitfield array.
             /// </summary>
             /// <returns>The layout in bitfield.</returns>
-            public bool[] WriteToBitfield()
+            public bool[] AsBitfield()
             {
-                if (IsNone)
-                    return TypeBuilderState.s_emptyLayout;
+                // This method should only be called when not none.
+                Debug.Assert(!IsNone);
 
                 // Ensure exactly one of these two are set.
                 Debug.Assert(_gcdesc != null ^ _bitfield != null);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -307,7 +307,7 @@ namespace Internal.Runtime.TypeLoader
         // Sentinel static to allow us to initialize _instanceLayout to something
         // and then detect that InstanceGCLayout should return null
 #pragma warning disable CA1825 // Can't use generic Array.Empty<T> within type loader
-        private static bool[] s_emptyLayout = new bool[0];
+        internal static bool[] s_emptyLayout = new bool[0];
 #pragma warning restore CA1825
 
         private bool[] _instanceGCLayout;
@@ -340,9 +340,7 @@ namespace Internal.Runtime.TypeLoader
                             TypeBuilder.GCLayout elementGcLayout = GetFieldGCLayout(arrayType.ElementType);
                             if (!elementGcLayout.IsNone)
                             {
-                                bool[] instanceGCLayout = s_emptyLayout;
-                                elementGcLayout.WriteToBitfield(ref instanceGCLayout, 0);
-                                _instanceGCLayout = instanceGCLayout;
+                                _instanceGCLayout = elementGcLayout.WriteToBitfield();
                             }
                         }
                         else

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -306,9 +306,11 @@ namespace Internal.Runtime.TypeLoader
 
         // Sentinel static to allow us to initialize _instanceLayout to something
         // and then detect that InstanceGCLayout should return null
-        private static LowLevelList<bool> s_emptyLayout = new LowLevelList<bool>();
+#pragma warning disable CA1825 // Can't use generic Array.Empty<T> within type loader
+        private static bool[] s_emptyLayout = new bool[0];
+#pragma warning restore CA1825
 
-        private LowLevelList<bool> _instanceGCLayout;
+        private bool[] _instanceGCLayout;
 
         /// <summary>
         /// The instance gc layout of a dynamically laid out type.
@@ -324,14 +326,12 @@ namespace Internal.Runtime.TypeLoader
         /// If the type is a valuetype array, this is the layout of the valuetype held in the array if the type has GC reference fields
         /// Otherwise, it is the layout of the fields in the type.
         /// </summary>
-        public LowLevelList<bool> InstanceGCLayout
+        public bool[] InstanceGCLayout
         {
             get
             {
                 if (_instanceGCLayout == null)
                 {
-                    LowLevelList<bool> instanceGCLayout;
-
                     if (TypeBeingBuilt is ArrayType)
                     {
                         if (!IsArrayOfReferenceTypes)
@@ -340,8 +340,8 @@ namespace Internal.Runtime.TypeLoader
                             TypeBuilder.GCLayout elementGcLayout = GetFieldGCLayout(arrayType.ElementType);
                             if (!elementGcLayout.IsNone)
                             {
-                                instanceGCLayout = new LowLevelList<bool>();
-                                elementGcLayout.WriteToBitfield(instanceGCLayout, 0);
+                                bool[] instanceGCLayout = s_emptyLayout;
+                                elementGcLayout.WriteToBitfield(ref instanceGCLayout, 0);
                                 _instanceGCLayout = instanceGCLayout;
                             }
                         }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -306,7 +306,7 @@ namespace Internal.Runtime.TypeLoader
 
         // Sentinel static to allow us to initialize _instanceLayout to something
         // and then detect that InstanceGCLayout should return null
-        internal static readonly bool[] s_emptyLayout = [];
+        private static readonly bool[] s_emptyLayout = [];
 
         private bool[] _instanceGCLayout;
 
@@ -338,7 +338,7 @@ namespace Internal.Runtime.TypeLoader
                             TypeBuilder.GCLayout elementGcLayout = GetFieldGCLayout(arrayType.ElementType);
                             if (!elementGcLayout.IsNone)
                             {
-                                _instanceGCLayout = elementGcLayout.WriteToBitfield();
+                                _instanceGCLayout = elementGcLayout.AsBitfield();
                             }
                         }
                         else

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -306,9 +306,7 @@ namespace Internal.Runtime.TypeLoader
 
         // Sentinel static to allow us to initialize _instanceLayout to something
         // and then detect that InstanceGCLayout should return null
-#pragma warning disable CA1825 // Can't use generic Array.Empty<T> within type loader
-        internal static bool[] s_emptyLayout = new bool[0];
-#pragma warning restore CA1825
+        internal static readonly bool[] s_emptyLayout = [];
 
         private bool[] _instanceGCLayout;
 


### PR DESCRIPTION
Extracted from #109114

The merging and _isReferenceTypeGCLayout paths looks unused. Not sure whether I missed anything.