### PR TITLE
Fix various HTTP header parsing issues

### DIFF
--- a/src/libraries/Fuzzing/.gitignore
+++ b/src/libraries/Fuzzing/.gitignore
@@ -3,3 +3,5 @@ publish
 deployment
 inputs
 crash-*
+timeout-*
+inputs-*

--- a/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/HttpHeadersFuzzer.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/HttpHeadersFuzzer.cs
@@ -73,7 +73,22 @@ internal sealed class HttpHeadersFuzzer : IFuzzer
                 }
                 catch (FormatException) { }
 
-                foreach (var _ in headers) { }
+                // If values were added with validation, they should not contain CR or LF characters.
+                foreach ((_, HeaderStringValues values) in headers.NonValidated)
+                {
+                    foreach (string headerValue in values)
+                    {
+                        Assert.False(headerValue.ContainsAny('\r', '\n'));
+                    }
+                }
+
+                foreach ((_, IEnumerable<string> values) in headers)
+                {
+                    foreach (string headerValue in values)
+                    {
+                        Assert.False(headerValue.ContainsAny('\r', '\n'));
+                    }
+                }
             }
         }
     }

--- a/src/libraries/Fuzzing/README.md
+++ b/src/libraries/Fuzzing/README.md
@@ -24,7 +24,7 @@ Build the runtime with the desired configuration if you haven't already:
 ```
 
 > [!TIP]
-> The `-rc release` configuration here builds runime in `Release` and libraries in `Debug` mode.
+> The `-rc release` configuration here builds runtime in `Release` and libraries in `Debug` mode.
 > Automated fuzzing runs use a `Checked` runtime + `Debug` libraries configuration by default.
 > You can use any configuration locally, but `Checked` is recommended when testing changes in `System.Private.CoreLib`.
 
@@ -44,10 +44,10 @@ dotnet build
 ```
 
 Run `run.bat`, which will create separate directories for each fuzzing target, instrument the relevant assemblies, and generate a helper script for running them locally.
-When iterating on changes, remember to rebuild the project again: `dotnet build; .\run.bat`.
+When iterating on changes, remember to rebuild the project again.
 
 ```cmd
-run.bat
+dotnet build; .\run.bat
 ```
 
 Start fuzzing by running the `local-run.bat` script in the folder of the fuzzer you are interested in.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
@@ -259,14 +259,14 @@ namespace System.Net.Http.Headers
                     builder.Append(value.Slice(0, idx));
                 }
 
-                if ((value.Length - idx) < 3 || !TryReadAlpnHexDigit(value[1], out int hi) || !TryReadAlpnHexDigit(value[2], out int lo))
+                if ((value.Length - idx) < 3 || !TryReadAlpnHexDigit(value[idx + 1], out int hi) || !TryReadAlpnHexDigit(value[idx + 2], out int lo))
                 {
                     builder.Dispose();
                     result = null;
                     return false;
                 }
 
-                builder.Append((char)((hi << 8) | lo));
+                builder.Append((char)((hi << 4) | lo));
 
                 value = value.Slice(idx + 3);
                 idx = value.IndexOf('%');
@@ -279,7 +279,7 @@ namespace System.Net.Http.Headers
             }
 
             result = builder.ToString();
-            return true;
+            return !HttpRuleParser.ContainsNewLine(result);
         }
 
         /// <summary>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/CookieHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/CookieHeaderParser.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net.Http.Headers
@@ -18,8 +19,10 @@ namespace System.Net.Http.Headers
 
         public override bool TryParseValue(string? value, object? storeValue, ref int index, [NotNullWhen(true)] out object? parsedValue)
         {
+            Debug.Assert(index == 0);
+
             // Some headers support empty/null values. This one doesn't.
-            if (string.IsNullOrEmpty(value) || (index == value.Length))
+            if (string.IsNullOrEmpty(value) || HttpRuleParser.ContainsNewLine(value))
             {
                 parsedValue = null;
                 return false;

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/CookieHeaderParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/CookieHeaderParserTest.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Http.Headers;
+
+using Xunit;
+
+namespace System.Net.Http.Tests
+{
+    public class CookieHeaderParserTest
+    {
+        [Fact]
+        public void TryParse_ValidValueString_ReturnsTrue()
+        {
+            HttpHeaderParser parser = CookieHeaderParser.Parser;
+            string validInput = "Hello World";
+            int startIndex = 0;
+
+            Assert.True(parser.TryParseValue(validInput, null, ref startIndex, out object? parsedValue));
+            Assert.Equal(validInput.Length, startIndex);
+            Assert.Same(validInput, parsedValue);
+        }
+
+        [Fact]
+        public void TryParse_InvalidValueString_ReturnsFalse()
+        {
+            HttpHeaderParser parser = CookieHeaderParser.Parser;
+            string invalidInput = "Hello\r\nWorld";
+            int startIndex = 0;
+
+            Assert.False(parser.TryParseValue(invalidInput, null, ref startIndex, out object? parsedValue));
+            Assert.Equal(0, startIndex);
+            Assert.Null(parsedValue);
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/HostParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/GenericHeaderParserTest/HostParserTest.cs
@@ -51,9 +51,15 @@ namespace System.Net.Http.Tests
             CheckInvalidParsedValue("host host", 0);
             CheckInvalidParsedValue("host,", 0);
             CheckInvalidParsedValue("host ,", 0);
+            CheckInvalidParsedValue("host/", 0);
             CheckInvalidParsedValue("/", 0);
             CheckInvalidParsedValue(" , ", 0);
             CheckInvalidParsedValue(" host\r\n ", 0);
+            CheckInvalidParsedValue(" host\r\n ", 1);
+            CheckInvalidParsedValue("host#\r\n", 0);
+            CheckInvalidParsedValue(" host?\r\n", 0);
+            CheckInvalidParsedValue("foo:bar@host", 0);
+            CheckInvalidParsedValue("host\n", 0);
         }
 
         #region Helper methods

--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpRuleParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpRuleParserTest.cs
@@ -164,6 +164,10 @@ namespace System.Net.Http.Tests
             // only ASCII chars allowed in quoted-pair
             AssertGetQuotedPairLength("\\\u00FC", 0, 0, HttpParseResult.InvalidFormat);
 
+            // New lines are not allowed
+            AssertGetQuotedPairLength("\\\r", 0, 0, HttpParseResult.InvalidFormat);
+            AssertGetQuotedPairLength("\\\n", 0, 0, HttpParseResult.InvalidFormat);
+
             // a quoted-pair needs 1 char after '\'
             AssertGetQuotedPairLength("\\", 0, 0, HttpParseResult.InvalidFormat);
         }

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -267,6 +267,7 @@
     <Compile Include="Headers\ContentDispositionHeaderValueTest.cs" />
     <Compile Include="Headers\ContentRangeHeaderValueTest.cs" />
     <Compile Include="Headers\DateHeaderParserTest.cs" />
+    <Compile Include="Headers\CookieHeaderParserTest.cs" />
     <Compile Include="Headers\EntityTagHeaderParserTest.cs" />
     <Compile Include="Headers\EntityTagHeaderValueTest.cs" />
     <Compile Include="Headers\GenericHeaderParserTest\AuthenticationParserTest.cs" />


### PR DESCRIPTION
- Fix `Cookie` parser to block new line chars
  - Similar to how we did so for all other cases in #53505
- Block escaped new lines in quoted strings (e.g. `"Hello\\nWorld"`)
- Improve the `Host` parser to block more invalid hosts.
  - We are creating a test uri string like `$"http://{host}/"`, but weren't blocking characters like `'?'` or `'#'` that would end the host part
- Fixed the broken percent decoding logic in `Alt-Svc`:
  - The offsets used were wrong if `%` wasn't the first character. E.g. `A0A%AA` decoded into `A0A\n`
  - Decoding used `(high * 256) + low` instead of `* 16`, breaking all values with a non-zero high nibble
  - Block decoding new line chars
- Improved the headers fuzzer that discovered all of these ^