### PR TITLE
Optimize '[Guid]' parsing on Native AOT

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -80,8 +80,17 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
                     if (guidStringArgumentHandle.HandleType != HandleType.ConstantStringValue)
                         continue;
 
+                    ConstantStringValueHandle constantStringValueHandle = guidStringArgumentHandle.ToConstantStringValueHandle(_reader);
+
+                    if (constantStringValueHandle.IsNil)
+                    {
+                        // We don't really have a parameter, so just match the name of the 'Guid.ctor' parameter.
+                        // The reason for throwing this exception is to keep semantics with the original behavior.
+                        ArgumentNullException.Throw("input");
+                    }
+
                     // Parse a 'Guid' directly from the encoded UTF8 buffer, instead of round-tripping through a 'string'
-                    return ConstantStringValue.ParseGuid(_reader, guidStringArgumentHandle.ToConstantStringValueHandle(_reader));
+                    return Guid.Parse(_reader.ReadStringAsBytes(constantStringValueHandle));
                 }
             }
             return null;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -80,26 +80,8 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
                     if (guidStringArgumentHandle.HandleType != HandleType.ConstantStringValue)
                         continue;
 
-                    static Guid ReadAndParseGuid(Handle handle, MetadataReader reader)
-                    {
-                        if (handle.IsNil)
-                        {
-                            // We don't really have a parameter, so just match the name of the 'Parse' parameter
-                            ArgumentNullException.Throw("utf8Text");
-                        }
-
-                        // 68 characters is the maximum length of a guid, when formatted as 'X'
-                        Span<byte> destination = stackalloc byte[68];
-
-                        int charsWritten = ConstantStringValue.GetRawStringDataUtf8(
-                            reader: reader,
-                            handle: handle.ToConstantStringValueHandle(reader),
-                            destinationUtf8: destination);
-
-                        return Guid.Parse(destination.Slice(0, charsWritten));
-                    }
-
-                    return ReadAndParseGuid(guidStringArgumentHandle, _reader);
+                    // Parse a 'Guid' directly from the encoded UTF8 buffer, instead of round-tripping through a 'string'
+                    return ConstantStringValue.ParseGuid(_reader, guidStringArgumentHandle.ToConstantStringValueHandle(_reader));
                 }
             }
             return null;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -82,13 +82,6 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
 
                     ConstantStringValueHandle constantStringValueHandle = guidStringArgumentHandle.ToConstantStringValueHandle(_reader);
 
-                    if (constantStringValueHandle.IsNil)
-                    {
-                        // We don't really have a parameter, so just match the name of the 'Guid.ctor' parameter.
-                        // The reason for throwing this exception is to keep semantics with the original behavior.
-                        ArgumentNullException.Throw("input");
-                    }
-
                     // Parse a 'Guid' directly from the encoded UTF8 buffer, instead of round-tripping through a 'string'
                     return Guid.Parse(_reader.ReadStringAsBytes(constantStringValueHandle));
                 }

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -2013,6 +2013,21 @@ namespace Internal.Metadata.NativeFormat
 
         public string Value => _value;
         private readonly string _value;
+
+        internal static int GetRawStringDataUtf8(MetadataReader reader, ConstantStringValueHandle handle, Span<byte> destinationUtf8)
+        {
+            if (handle.IsNil)
+            {
+                return 0;
+            }
+
+            uint offset = (uint)handle.Offset;
+
+            // We don't care about the final offset
+            _ = reader._streamReader.DecodeStringUtf8(offset, destinationUtf8, out int bytesWritten);
+
+            return bytesWritten;
+        }
     } // ConstantStringValue
 
 #if SYSTEM_PRIVATE_CORELIB

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -2022,7 +2022,11 @@ namespace Internal.Metadata.NativeFormat
             if (handle.IsNil)
             {
                 // We don't really have a parameter, so just match the name of the 'Guid.ctor' parameter
+#if SYSTEM_PRIVATE_CORELIB
                 ArgumentNullException.Throw("input");
+#else
+                throw new ArgumentNullException("input");
+#endif
             }
 
             return reader._streamReader.ParseGuid((uint)handle.Offset);

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -2014,19 +2014,18 @@ namespace Internal.Metadata.NativeFormat
         public string Value => _value;
         private readonly string _value;
 
-        internal static int GetRawStringDataUtf8(MetadataReader reader, ConstantStringValueHandle handle, Span<byte> destinationUtf8)
+        /// <summary>
+        /// Parses a <see cref="Guid"/> value, matching the behavior of decoding a <see cref="string"/> and parsing from that.
+        /// </summary>
+        internal static Guid ParseGuid(MetadataReader reader, ConstantStringValueHandle handle)
         {
             if (handle.IsNil)
             {
-                return 0;
+                // We don't really have a parameter, so just match the name of the 'Guid.ctor' parameter
+                ArgumentNullException.Throw("input");
             }
 
-            uint offset = (uint)handle.Offset;
-
-            // We don't care about the final offset
-            _ = reader._streamReader.DecodeStringUtf8(offset, destinationUtf8, out int bytesWritten);
-
-            return bytesWritten;
+            return reader._streamReader.ParseGuid((uint)handle.Offset);
         }
     } // ConstantStringValue
 

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -2013,24 +2013,6 @@ namespace Internal.Metadata.NativeFormat
 
         public string Value => _value;
         private readonly string _value;
-
-        /// <summary>
-        /// Parses a <see cref="Guid"/> value, matching the behavior of decoding a <see cref="string"/> and parsing from that.
-        /// </summary>
-        internal static Guid ParseGuid(MetadataReader reader, ConstantStringValueHandle handle)
-        {
-            if (handle.IsNil)
-            {
-                // We don't really have a parameter, so just match the name of the 'Guid.ctor' parameter
-#if SYSTEM_PRIVATE_CORELIB
-                ArgumentNullException.Throw("input");
-#else
-                throw new ArgumentNullException("input");
-#endif
-            }
-
-            return reader._streamReader.ParseGuid((uint)handle.Offset);
-        }
     } // ConstantStringValue
 
 #if SYSTEM_PRIVATE_CORELIB

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeMetadataReader.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeMetadataReader.cs
@@ -225,7 +225,7 @@ namespace Internal.Metadata.NativeFormat
         {
             if (handle.IsNil)
             {
-                return ReadOnlySpan<byte>.Empty;
+                return [];
             }
 
             return _streamReader.ReadStringAsBytes((uint)handle.Offset);

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeMetadataReader.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeMetadataReader.cs
@@ -223,6 +223,11 @@ namespace Internal.Metadata.NativeFormat
 
         internal ReadOnlySpan<byte> ReadStringAsBytes(ConstantStringValueHandle handle)
         {
+            if (handle.IsNil)
+            {
+                return ReadOnlySpan<byte>.Empty;
+            }
+
             return _streamReader.ReadStringAsBytes((uint)handle.Offset);
         }
     }

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeMetadataReader.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeMetadataReader.cs
@@ -220,6 +220,11 @@ namespace Internal.Metadata.NativeFormat
         {
             return _streamReader.StringEquals((uint)handle.Offset, value);
         }
+
+        internal ReadOnlySpan<byte> ReadStringAsBytes(ConstantStringValueHandle handle)
+        {
+            return _streamReader.ReadStringAsBytes((uint)handle.Offset);
+        }
     }
 
     internal sealed partial class MetadataHeader

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
@@ -7,6 +7,7 @@
 // UTF8 string reading methods
 // ---------------------------------------------------------------------------
 
+using System;
 using System.Text;
 
 namespace Internal.NativeFormat
@@ -59,6 +60,28 @@ namespace Internal.NativeFormat
 #else
             value = Encoding.UTF8.GetString(_base + offset, (int)numBytes);
 #endif
+
+            return endOffset;
+        }
+
+        public unsafe uint DecodeStringUtf8(uint offset, Span<byte> destinationUtf8, out int bytesWritten)
+        {
+            uint numBytes;
+            offset = DecodeUnsigned(offset, out numBytes);
+
+            if (numBytes == 0)
+            {
+                bytesWritten = 0;
+                return offset;
+            }
+
+            uint endOffset = offset + numBytes;
+            if (endOffset < numBytes || endOffset > _size)
+                ThrowBadImageFormatException();
+
+            new ReadOnlySpan<byte>(_base + offset, (int)numBytes).CopyTo(destinationUtf8);
+
+            bytesWritten = (int)numBytes;
 
             return endOffset;
         }

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
@@ -64,9 +64,14 @@ namespace Internal.NativeFormat
             return endOffset;
         }
 
-#if !NETFX_45
         public unsafe Guid ParseGuid(uint offset)
         {
+#if NETFX_45
+            _ = DecodeString(offset, out string value);
+
+            return new(value);
+#else
+
             uint numBytes;
             offset = DecodeUnsigned(offset, out numBytes);
 
@@ -82,8 +87,8 @@ namespace Internal.NativeFormat
             }
 
             return Guid.Parse(bytes);
-        }
 #endif
+        }
 
         // Decode a string, but just skip it instead of returning it
         public uint SkipString(uint offset)

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
@@ -36,6 +36,23 @@ namespace Internal.NativeFormat
             return value;
         }
 
+        public unsafe ReadOnlySpan<byte> ReadStringAsBytes(uint offset)
+        {
+            uint numBytes;
+            offset = DecodeUnsigned(offset, out numBytes);
+
+            if (numBytes != 0)
+            {
+                uint endOffset = offset + numBytes;
+                if (endOffset < numBytes || endOffset > _size)
+                    ThrowBadImageFormatException();
+
+                return new(_base + offset, (int)numBytes);
+            }
+
+            return ReadOnlySpan<byte>.Empty;
+        }
+
         public unsafe uint DecodeString(uint offset, out string value)
         {
             uint numBytes;
@@ -62,32 +79,6 @@ namespace Internal.NativeFormat
 #endif
 
             return endOffset;
-        }
-
-        public unsafe Guid ParseGuid(uint offset)
-        {
-#if NETFX_45
-            _ = DecodeString(offset, out string value);
-
-            return new(value);
-#else
-
-            uint numBytes;
-            offset = DecodeUnsigned(offset, out numBytes);
-
-            ReadOnlySpan<byte> bytes = [];
-
-            if (numBytes != 0)
-            {
-                uint endOffset = offset + numBytes;
-                if (endOffset < numBytes || endOffset > _size)
-                    ThrowBadImageFormatException();
-
-                bytes = new ReadOnlySpan<byte>(_base + offset, (int)numBytes);
-            }
-
-            return Guid.Parse(bytes);
-#endif
         }
 
         // Decode a string, but just skip it instead of returning it

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
@@ -50,7 +50,7 @@ namespace Internal.NativeFormat
                 return new(_base + offset, (int)numBytes);
             }
 
-            return ReadOnlySpan<byte>.Empty;
+            return [];
         }
 
         public unsafe uint DecodeString(uint offset, out string value)

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatReader.String.cs
@@ -64,27 +64,26 @@ namespace Internal.NativeFormat
             return endOffset;
         }
 
-        public unsafe uint DecodeStringUtf8(uint offset, Span<byte> destinationUtf8, out int bytesWritten)
+#if !NETFX_45
+        public unsafe Guid ParseGuid(uint offset)
         {
             uint numBytes;
             offset = DecodeUnsigned(offset, out numBytes);
 
-            if (numBytes == 0)
+            ReadOnlySpan<byte> bytes = [];
+
+            if (numBytes != 0)
             {
-                bytesWritten = 0;
-                return offset;
+                uint endOffset = offset + numBytes;
+                if (endOffset < numBytes || endOffset > _size)
+                    ThrowBadImageFormatException();
+
+                bytes = new ReadOnlySpan<byte>(_base + offset, (int)numBytes);
             }
 
-            uint endOffset = offset + numBytes;
-            if (endOffset < numBytes || endOffset > _size)
-                ThrowBadImageFormatException();
-
-            new ReadOnlySpan<byte>(_base + offset, (int)numBytes).CopyTo(destinationUtf8);
-
-            bytesWritten = (int)numBytes;
-
-            return endOffset;
+            return Guid.Parse(bytes);
         }
+#endif
 
         // Decode a string, but just skip it instead of returning it
         public uint SkipString(uint offset)


### PR DESCRIPTION
We're going to need to use `[Guid]` in some scenarios in CsWinRT 3.0 (see #114179), and while looking at the `Type.GUID` logic in Native AOT I saw some potential small perf improvements we could do. Figured I'd give it a shot and see if it's well received 😄