### PR TITLE
[WinHTTP] Validate header values for Latin1

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -135,4 +135,7 @@
   <data name="net_http_unsupported_version" xml:space="preserve">
     <value>Request version value must be one of 1.0, 1.1, 2.0, or 3.0.</value>
   </data>
+  <data name="net_http_invalid_header_value" xml:space="preserve">
+    <value>{0} headers must be valid Latin-1 characters.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -709,11 +709,12 @@ namespace System.Net.Http
             return chunkedMode;
         }
 
-#if NETFRAMEWORK
         private static bool ContainsOnlyValidLatin1(string headerString)
         {
             foreach (char c in headerString)
             {
+                // See https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5-5:
+                // "Field values containing CR, LF, or NUL characters are invalid and dangerous"
                 if (c <= 0 || c > 255 || c == '\r' || c == '\n')
                 {
                     return false;
@@ -721,7 +722,6 @@ namespace System.Net.Http
             }
             return true;
         }
-#endif
 
         private static void AddRequestHeaders(
             SafeWinHttpHandle requestHandle,
@@ -754,11 +754,7 @@ namespace System.Net.Http
 
             // Serialize general request headers.
             string requestHeaders = requestMessage.Headers.ToString();
-#if NETFRAMEWORK
             if (!ContainsOnlyValidLatin1(requestHeaders))
-#else
-            if (requestHeaders.ContainsAnyExceptInRange((char)1, (char)255))
-#endif
             {
                 throw new FormatException(SR.Format(SR.net_http_invalid_header_value, nameof(HttpRequestMessage)));
             }
@@ -778,11 +774,7 @@ namespace System.Net.Http
                 }
 
                 string contentHeaders = requestMessage.Content.Headers.ToString();
-#if NETFRAMEWORK
-            if (!ContainsOnlyValidLatin1(requestHeaders))
-#else
-            if (requestHeaders.ContainsAnyExceptInRange((char)1, (char)255))
-#endif
+                if (!ContainsOnlyValidLatin1(contentHeaders))
                 {
                     throw new FormatException(SR.Format(SR.net_http_invalid_header_value, nameof(HttpContent)));
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AuthenticationHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AuthenticationHeaderValue.cs
@@ -119,7 +119,7 @@ namespace System.Net.Http.Headers
 
             parsedValue = null;
 
-            if (string.IsNullOrEmpty(input) || (startIndex >= input.Length) || HttpRuleParser.ContainsNewLine(input, startIndex))
+            if (string.IsNullOrEmpty(input) || (startIndex >= input.Length) || HttpRuleParser.ContainsNewLineOrNull(input, startIndex))
             {
                 return 0;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/GenericHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/GenericHeaderParser.cs
@@ -119,7 +119,7 @@ namespace System.Net.Http.Headers
         /// </summary>
         private static int ParseWithoutValidation(string value, int startIndex, out object? parsedValue)
         {
-            if (HttpRuleParser.ContainsNewLine(value, startIndex))
+            if (HttpRuleParser.ContainsNewLineOrNull(value, startIndex))
             {
                 parsedValue = null;
                 return 0;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -806,7 +806,7 @@ namespace System.Net.Http.Headers
             Debug.Assert(Monitor.IsEntered(info));
             if (descriptor.Parser == null)
             {
-                if (HttpRuleParser.ContainsNewLine(rawValue))
+                if (HttpRuleParser.ContainsNewLineOrNull(rawValue))
                 {
                     if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, SR.Format(SR.net_http_log_headers_no_newlines, descriptor.Name, rawValue));
                     AddInvalidValue(info, rawValue);
@@ -1024,7 +1024,7 @@ namespace System.Net.Http.Headers
             if (descriptor.Parser == null)
             {
                 // If we don't have a parser for the header, we consider the value valid if it doesn't contains
-                // newline characters. We add the values as "parsed value". Note that we allow empty values.
+                // newline or \0 characters. We add the values as "parsed value". Note that we allow empty values.
                 CheckContainsNewLine(value);
                 AddParsedValue(info, value ?? string.Empty);
                 return;
@@ -1134,7 +1134,7 @@ namespace System.Net.Http.Headers
                 return;
             }
 
-            if (HttpRuleParser.ContainsNewLine(value))
+            if (HttpRuleParser.ContainsNewLineOrNull(value))
             {
                 throw new FormatException(SR.net_http_headers_no_newlines);
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
@@ -371,7 +371,7 @@ namespace System.Net.Http.Headers
                     ThrowFormatException(value);
                 }
             }
-            else if (HttpRuleParser.ContainsNewLine(value))
+            else if (HttpRuleParser.ContainsNewLineOrNull(value))
             {
                 ThrowFormatException(value);
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
@@ -90,7 +90,7 @@ namespace System.Net.Http
             }
             set
             {
-                if ((value != null) && HttpRuleParser.ContainsNewLine(value))
+                if ((value != null) && HttpRuleParser.ContainsNewLineOrNull(value))
                 {
                     throw new FormatException(SR.net_http_reasonphrase_format_error);
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -82,8 +82,10 @@ namespace System.Net.Http
             return input.Length - startIndex;
         }
 
-        internal static bool ContainsNewLine(string value, int startIndex = 0) =>
-            value.AsSpan(startIndex).ContainsAny('\r', '\n');
+        // See https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5-5:
+        // "Field values containing CR, LF, or NUL characters are invalid and dangerous"
+        internal static bool ContainsNewLineOrNull(string value, int startIndex = 0) =>
+            value.AsSpan(startIndex).ContainsAny('\r', '\n', '\0');
 
         internal static int GetNumberLength(string input, int startIndex, bool allowDecimal)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/115112
Replaces https://github.com/dotnet/runtime/pull/116256