### PR TITLE
Generate module rundown events

### DIFF
--- a/src/coreclr/nativeaot/Runtime/Pal.h
+++ b/src/coreclr/nativeaot/Runtime/Pal.h
@@ -161,7 +161,7 @@ bool PalInit();
 // Given the OS handle of a loaded module, compute the upper and lower virtual address bounds (inclusive).
 void PalGetModuleBounds(HANDLE hOsHandle, _Out_ uint8_t ** ppLowerBound, _Out_ uint8_t ** ppUpperBound);
 
-void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdwAge, _Out_writes_z_(cchPath) TCHAR * wszPath, int32_t cchPath);
+void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdwAge, _Out_writes_z_(cchPath) WCHAR * wszPath, int32_t cchPath);
 
 struct NATIVE_CONTEXT;
 

--- a/src/coreclr/nativeaot/Runtime/Pal.h
+++ b/src/coreclr/nativeaot/Runtime/Pal.h
@@ -159,6 +159,8 @@ bool PalInit();
 // Given the OS handle of a loaded module, compute the upper and lower virtual address bounds (inclusive).
 void PalGetModuleBounds(HANDLE hOsHandle, _Out_ uint8_t ** ppLowerBound, _Out_ uint8_t ** ppUpperBound);
 
+void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdwAge, _Out_writes_z_(cchPath) TCHAR * wszPath, int32_t cchPath);
+
 struct NATIVE_CONTEXT;
 
 #if _WIN32

--- a/src/coreclr/nativeaot/Runtime/Pal.h
+++ b/src/coreclr/nativeaot/Runtime/Pal.h
@@ -87,6 +87,13 @@ struct FILETIME
     uint32_t dwHighDateTime;
 };
 
+typedef struct _GUID {
+    uint32_t Data1;
+    uint16_t Data2;
+    uint16_t Data3;
+    uint8_t Data4[8];
+} GUID;
+
 typedef struct _CONTEXT CONTEXT, *PCONTEXT;
 
 typedef struct _EXCEPTION_RECORD EXCEPTION_RECORD, *PEXCEPTION_RECORD;

--- a/src/coreclr/nativeaot/Runtime/Pal.h
+++ b/src/coreclr/nativeaot/Runtime/Pal.h
@@ -23,6 +23,8 @@
 #include <pthread.h>
 #endif
 
+#include <minipal/guid.h>
+
 #include "CommonTypes.h"
 #include "CommonMacros.h"
 #include "PalLimitedContext.h"
@@ -86,13 +88,6 @@ struct FILETIME
     uint32_t dwLowDateTime;
     uint32_t dwHighDateTime;
 };
-
-typedef struct _GUID {
-    uint32_t Data1;
-    uint16_t Data2;
-    uint16_t Data3;
-    uint8_t Data4[8];
-} GUID;
 
 typedef struct _CONTEXT CONTEXT, *PCONTEXT;
 

--- a/src/coreclr/nativeaot/Runtime/disabledeventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/disabledeventtrace.cpp
@@ -9,6 +9,7 @@
 #include "common.h"
 
 #include "eventtrace.h"
+#include "eventtracebase.h"
 
 void EventTracing_Initialize() { }
 
@@ -18,6 +19,7 @@ bool IsRuntimeProviderEnabled(uint8_t level, uint64_t keyword)
 }
 
 void ETW::GCLog::FireGcStart(ETW_GC_INFO * pGcInfo) { }
+void ETW::LoaderLog::ModuleLoad(HANDLE pModule) { }
 
 #ifdef FEATURE_ETW
 BOOL ETW::GCLog::ShouldTrackMovementForEtw() { return FALSE; }

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
@@ -81,6 +81,17 @@ ep_rt_aot_providers_validate_all_disabled (void)
 }
 
 void
+ep_rt_aot_provider_config_init (
+    EventPipeProviderConfiguration *provider_config)
+{
+    if (!ep_rt_utf8_string_compare (ep_config_get_rundown_provider_name_utf8 (), ep_provider_config_get_provider_name (provider_config))) {
+        MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.Level = (uint8_t) ep_provider_config_get_logging_level (provider_config);
+        MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.EnabledKeywordsBitmask = ep_provider_config_get_keywords (provider_config);
+        MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.IsEnabled = true;
+    }
+}
+
+void
 ep_rt_aot_sample_profiler_write_sampling_event_for_threads (
     ep_rt_thread_handle_t sampling_thread,
     EventPipeEvent *sampling_event)

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
@@ -25,6 +25,7 @@
 #include "threadstore.h"
 #include "threadstore.inl"
 #include "eventtrace_context.h"
+#include "eventtracebase.h"
 
 // Uses _rt_aot_lock_internal_t that has CrstStatic as a field
 // This is initialized at the beginning and EventPipe library requires the lock handle to be maintained by the runtime
@@ -75,7 +76,8 @@ bool
 ep_rt_aot_providers_validate_all_disabled (void)
 {
     return !MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context.EventPipeProvider.IsEnabled
-        && !MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_DOTNET_Context.EventPipeProvider.IsEnabled;
+        && !MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_DOTNET_Context.EventPipeProvider.IsEnabled
+        && !MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.IsEnabled;
 }
 
 void
@@ -192,6 +194,12 @@ ep_rt_aot_entrypoint_assembly_name_get_utf8 (void)
     }
 
     return entrypoint_assembly_name;
+}
+
+void
+ep_rt_aot_execute_rundown (dn_vector_ptr_t* execution_checkpoints)
+{
+    ETW::EnumerationLog::EndRundown();
 }
 
 const ep_char8_t *

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
@@ -23,7 +23,6 @@
 #include "rhassert.h"
 #include <RhConfig.h>
 #include <runtime_version.h>
-#include "eventtrace_context.h"
 
 #ifdef TARGET_UNIX
 #define sprintf_s snprintf
@@ -347,12 +346,8 @@ void
 ep_rt_provider_config_init (EventPipeProviderConfiguration *provider_config)
 {
     STATIC_CONTRACT_NOTHROW;
-
-    if (!ep_rt_utf8_string_compare (ep_config_get_rundown_provider_name_utf8 (), ep_provider_config_get_provider_name (provider_config))) {
-		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.Level = (UCHAR) ep_provider_config_get_logging_level (provider_config);
-		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.EnabledKeywordsBitmask = ep_provider_config_get_keywords (provider_config);
-		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.IsEnabled = true;
-	}
+    extern void ep_rt_aot_provider_config_init (EventPipeProviderConfiguration *provider_config);
+    ep_rt_aot_provider_config_init(provider_config);
 }
 
 // This function is auto-generated from /src/scripts/genEventPipe.py
@@ -1454,8 +1449,8 @@ void
 ep_rt_thread_setup (void)
 {
     STATIC_CONTRACT_NOTHROW;
-
-    // Likely not needed and do nothing until testing shows to be required
+    extern ep_rt_thread_handle_t ep_rt_aot_setup_thread (void);
+    ep_rt_aot_setup_thread ();
 }
 
 static

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
@@ -23,6 +23,7 @@
 #include "rhassert.h"
 #include <RhConfig.h>
 #include <runtime_version.h>
+#include "eventtrace_context.h"
 
 #ifdef TARGET_UNIX
 #define sprintf_s snprintf
@@ -346,6 +347,12 @@ void
 ep_rt_provider_config_init (EventPipeProviderConfiguration *provider_config)
 {
     STATIC_CONTRACT_NOTHROW;
+
+    if (!ep_rt_utf8_string_compare (ep_config_get_rundown_provider_name_utf8 (), ep_provider_config_get_provider_name (provider_config))) {
+		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.Level = (UCHAR) ep_provider_config_get_logging_level (provider_config);
+		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.EnabledKeywordsBitmask = ep_provider_config_get_keywords (provider_config);
+		MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider.IsEnabled = true;
+	}
 }
 
 // This function is auto-generated from /src/scripts/genEventPipe.py

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
@@ -707,7 +707,9 @@ ep_rt_execute_rundown (dn_vector_ptr_t *execution_checkpoints)
 {
     STATIC_CONTRACT_NOTHROW;
 
-    // NativeAOT does not currently support rundown
+    extern void
+    ep_rt_aot_execute_rundown (dn_vector_ptr_t *execution_checkpoints);
+    ep_rt_aot_execute_rundown (execution_checkpoints);
 }
 
 /*

--- a/src/coreclr/nativeaot/Runtime/eventpipe/gen-eventing-event-inc.lst
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/gen-eventing-event-inc.lst
@@ -81,6 +81,7 @@ GenAwareBegin
 GenAwareEnd
 IncreaseMemoryPressure
 LockCreated
+ModuleDCEnd_V2
 ModuleLoad_V2
 PinObjectAtGCTime
 PinPlugAtGCTime

--- a/src/coreclr/nativeaot/Runtime/eventpipe/gen-eventing-event-inc.lst
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/gen-eventing-event-inc.lst
@@ -21,6 +21,8 @@ Contention
 ContentionLockCreated
 ContentionStart_V2
 ContentionStop_V1
+DCEndComplete_V1
+DCEndInit_V1
 DecreaseMemoryPressure
 DestroyGCHandle
 ExceptionCatchStart

--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -326,6 +326,8 @@ void EtwCallback(
     }
 }
 
+#endif // FEATURE_ETW
+
 /**************************************************************************************/
 /* Called when ETW is turned OFF on an existing process .Will be used by the controller for end rundown*/
 /**************************************************************************************/
@@ -363,8 +365,6 @@ VOID ETW::EnumerationLog::EndRundown()
             );
     }
 }
-
-#endif // FEATURE_ETW
 
 void EventPipeEtwCallbackDotNETRuntime(
     _In_ GUID * SourceId,

--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -331,7 +331,7 @@ void EtwCallback(
 /**************************************************************************************/
 /* Called when ETW is turned OFF on an existing process .Will be used by the controller for end rundown*/
 /**************************************************************************************/
-VOID ETW::EnumerationLog::EndRundown()
+void ETW::EnumerationLog::EndRundown()
 {
     if (IsRuntimeRundownProviderEnabled(TRACE_LEVEL_INFORMATION, CLR_RUNDOWNLOADER_KEYWORD))
     {
@@ -345,7 +345,7 @@ VOID ETW::EnumerationLog::EndRundown()
         GUID nativeGuid;
         uint32_t dwAge;
         TCHAR wszPath[1024];
-        PalGetPDBInfo(pModule, &nativeGuid, &dwAge, wszPath, _countof(wszPath));
+        PalGetPDBInfo(pModule, &nativeGuid, &dwAge, wszPath, ARRAY_SIZE(wszPath));
 
         GUID zeroGuid = { 0 };
         FireEtwModuleDCEnd_V2(

--- a/src/coreclr/nativeaot/Runtime/eventtrace_context.h
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_context.h
@@ -31,11 +31,21 @@ typedef struct _DOTNET_TRACE_CONTEXT
 #endif // DOTNET_TRACE_CONTEXT_DEF
 
 extern "C" DOTNET_TRACE_CONTEXT MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context;
+extern "C" DOTNET_TRACE_CONTEXT MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context;
 extern "C" DOTNET_TRACE_CONTEXT MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_DOTNET_Context;
 
 struct _EventFilterDescriptor;
 typedef struct _EventFilterDescriptor EventFilterDescriptor;
 void EventPipeEtwCallbackDotNETRuntime(
+    _In_ GUID * SourceId,
+    _In_ ULONG ControlCode,
+    _In_ unsigned char Level,
+    _In_ ULONGLONG MatchAnyKeyword,
+    _In_ ULONGLONG MatchAllKeyword,
+    _In_opt_ EventFilterDescriptor* FilterData,
+    _Inout_opt_ PVOID CallbackContext);
+
+void EventPipeEtwCallbackDotNETRuntimeRundown(
     _In_ GUID * SourceId,
     _In_ ULONG ControlCode,
     _In_ unsigned char Level,

--- a/src/coreclr/nativeaot/Runtime/eventtracebase.h
+++ b/src/coreclr/nativeaot/Runtime/eventtracebase.h
@@ -149,7 +149,7 @@ namespace ETW
     class EnumerationLog
     {
         public:
-            static VOID EndRundown();
+            static void EndRundown();
     };
 
     // Class to wrap all Loader logic for ETW

--- a/src/coreclr/nativeaot/Runtime/eventtracebase.h
+++ b/src/coreclr/nativeaot/Runtime/eventtracebase.h
@@ -105,6 +105,7 @@ struct ProfilingScanContext;
 #define CLR_MANAGEDHEAPCOLLECT_KEYWORD 0x800000
 #define CLR_GCHEAPANDTYPENAMES_KEYWORD 0x1000000
 #define CLR_ALLOCATIONSAMPLING_KEYWORD 0x80000000000
+#define CLR_RUNDOWNLOADER_KEYWORD 0x8
 
 //
 // Using KEYWORDZERO means when checking the events category ignore the keyword

--- a/src/coreclr/nativeaot/Runtime/eventtracebase.h
+++ b/src/coreclr/nativeaot/Runtime/eventtracebase.h
@@ -106,6 +106,7 @@ struct ProfilingScanContext;
 #define CLR_GCHEAPANDTYPENAMES_KEYWORD 0x1000000
 #define CLR_ALLOCATIONSAMPLING_KEYWORD 0x80000000000
 #define CLR_RUNDOWNLOADER_KEYWORD 0x8
+#define CLR_RUNDOWNEND_KEYWORD 0x100
 
 //
 // Using KEYWORDZERO means when checking the events category ignore the keyword
@@ -149,32 +150,27 @@ namespace ETW
     // Class to wrap all the enumeration logic for ETW
     class EnumerationLog
     {
-        public:
-            static void EndRundown();
+    public:
+        typedef union _EnumerationStructs
+        {
+            typedef enum _EnumerationOptions
+            {
+                None=                               0x00000000,
+                DomainAssemblyModuleLoad=           0x00000001,
+                DomainAssemblyModuleDCEnd=          0x00000008,
+            }EnumerationOptions;
+        }EnumerationStructs;
+        static void EndRundown();
     };
 
     // Class to wrap all Loader logic for ETW
     class LoaderLog
     {
+        friend class ETW::EnumerationLog;
+        static void SendModuleEvent(HANDLE pModule, DWORD dwEventOptions);
     public:
         typedef union _LoaderStructs
         {
-            typedef enum _AppDomainFlags
-            {
-                DefaultDomain=0x1,
-                ExecutableDomain=0x2,
-                SharedDomain=0x4
-            }AppDomainFlags;
-
-            typedef enum _AssemblyFlags
-            {
-                DomainNeutralAssembly=0x1,
-                DynamicAssembly=0x2,
-                NativeAssembly=0x4,
-                CollectibleAssembly=0x8,
-                ReadyToRunAssembly=0x10,
-            }AssemblyFlags;
-
             typedef enum _ModuleFlags
             {
                 DomainNeutralModule=0x1,
@@ -185,12 +181,6 @@ namespace ETW
                 ReadyToRunModule=0x20,
                 PartialReadyToRunModule=0x40,
             }ModuleFlags;
-
-            typedef enum _RangeFlags
-            {
-                HotRange=0x0
-            }RangeFlags;
-
         }LoaderStructs;
     };
 }

--- a/src/coreclr/nativeaot/Runtime/eventtracebase.h
+++ b/src/coreclr/nativeaot/Runtime/eventtracebase.h
@@ -167,7 +167,7 @@ namespace ETW
     class LoaderLog
     {
         friend class ETW::EnumerationLog;
-        static void SendModuleEvent(HANDLE pModule, DWORD dwEventOptions);
+        static void SendModuleEvent(HANDLE pModule, uint32_t dwEventOptions);
     public:
         typedef union _LoaderStructs
         {
@@ -182,6 +182,7 @@ namespace ETW
                 PartialReadyToRunModule=0x40,
             }ModuleFlags;
         }LoaderStructs;
+        static void ModuleLoad(HANDLE pModule);
     };
 }
 

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -95,6 +95,15 @@ void RhFailFast()
     abort();
 }
 
+void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdwAge, _Out_writes_z_(cchPath) TCHAR * wszPath, int32_t cchPath)
+{
+    memset(pGuidSignature, 0, sizeof(*pGuidSignature));
+    *pdwAge = 0;
+    if (cchPath <= 0)
+        return;
+    wszPath[0] = L'\0';
+}
+
 static void UnmaskActivationSignal()
 {
     sigset_t signal_set;

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -95,7 +95,7 @@ void RhFailFast()
     abort();
 }
 
-void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdwAge, _Out_writes_z_(cchPath) TCHAR * wszPath, int32_t cchPath)
+void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdwAge, _Out_writes_z_(cchPath) WCHAR * wszPath, int32_t cchPath)
 {
     memset(pGuidSignature, 0, sizeof(*pGuidSignature));
     *pdwAge = 0;

--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
@@ -20,6 +20,8 @@
 #include "NativeContext.h"
 #include "UnwindHelpers.h"
 
+#include "eventtracebase.h"
+
 #define UBF_FUNC_KIND_MASK      0x03
 #define UBF_FUNC_KIND_ROOT      0x00
 #define UBF_FUNC_KIND_HANDLER   0x01
@@ -1439,6 +1441,8 @@ bool RhRegisterOSModule(void * pModule,
     }
 
     pUnixNativeCodeManager.SuppressRelease();
+
+    ETW::LoaderLog::ModuleLoad(pModule);
 
     return true;
 }

--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
@@ -20,6 +20,8 @@
 #define GCINFODECODER_NO_EE
 #include "gcinfodecoder.cpp"
 
+#include "eventtracebase.h"
+
 #ifdef TARGET_X86
 #define FEATURE_EH_FUNCLETS
 
@@ -1178,6 +1180,8 @@ bool RhRegisterOSModule(void * pModule,
     }
 
     pCoffNativeCodeManager.SuppressRelease();
+
+    ETW::LoaderLog::ModuleLoad(pModule);
 
     return true;
 }

--- a/src/coreclr/nativeaot/Runtime/windows/PalCommon.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalCommon.cpp
@@ -50,7 +50,7 @@ void PalGetModuleBounds(HANDLE hOsHandle, _Out_ uint8_t ** ppLowerBound, _Out_ u
 //
 // This is a simplification of similar code in CLR's GetCodeViewInfo
 // in eventtrace.cpp.
-void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdwAge, _Out_writes_z_(cchPath) TCHAR * wszPath, int32_t cchPath)
+void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdwAge, _Out_writes_z_(cchPath) WCHAR * wszPath, int32_t cchPath)
 {
     // Zero-init [out]-params
     ZeroMemory(pGuidSignature, sizeof(*pGuidSignature));

--- a/src/coreclr/nativeaot/Runtime/windows/PalCommon.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalCommon.cpp
@@ -105,12 +105,6 @@ void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdw
     int cEntries = cbDebugEntries / sizeof(IMAGE_DEBUG_DIRECTORY);
     for (int i = 0; i < cEntries; i++)
     {
-        if ((uint8_t*)(&rgDebugEntries[i]) + sizeof(rgDebugEntries[i]) >= pbModuleUpperBound)
-        {
-            // Bogus pointer
-            return;
-        }
-
         if (rgDebugEntries[i].Type != IMAGE_DEBUG_TYPE_CODEVIEW)
             continue;
 

--- a/src/coreclr/nativeaot/Runtime/windows/PalCommon.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalCommon.cpp
@@ -34,6 +34,184 @@ void PalGetModuleBounds(HANDLE hOsHandle, _Out_ uint8_t ** ppLowerBound, _Out_ u
     *ppUpperBound = pbModule + cbModule - 1;
 }
 
+// Reads through the PE header of the specified module, and returns
+// the module's matching PDB's signature GUID, age, and build path by
+// fishing them out of the last IMAGE_DEBUG_DIRECTORY of type
+// IMAGE_DEBUG_TYPE_CODEVIEW.  Used when sending the ModuleLoad event
+// to help profilers find matching PDBs for loaded modules.
+//
+// Arguments:
+//
+// [in] hOsHandle - OS Handle for module from which to get PDB info
+// [out] pGuidSignature - PDB's signature GUID to be placed here
+// [out] pdwAge - PDB's age to be placed here
+// [out] wszPath - PDB's build path to be placed here
+// [in] cchPath - Number of wide characters allocated in wszPath, including NULL terminator
+//
+// This is a simplification of similar code in CLR's GetCodeViewInfo
+// in eventtrace.cpp.
+void PalGetPDBInfo(HANDLE hOsHandle, GUID * pGuidSignature, _Out_ uint32_t * pdwAge, _Out_writes_z_(cchPath) TCHAR * wszPath, int32_t cchPath)
+{
+    // Zero-init [out]-params
+    ZeroMemory(pGuidSignature, sizeof(*pGuidSignature));
+    *pdwAge = 0;
+    if (cchPath <= 0)
+        return;
+    wszPath[0] = L'\0';
+
+    BYTE *pbModule = (BYTE*)hOsHandle;
+
+    IMAGE_NT_HEADERS const * pNtHeaders = (IMAGE_NT_HEADERS*)(pbModule + ((IMAGE_DOS_HEADER*)hOsHandle)->e_lfanew);
+    IMAGE_DATA_DIRECTORY const * rgDataDirectory = NULL;
+    if (pNtHeaders->OptionalHeader.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
+        rgDataDirectory = ((IMAGE_OPTIONAL_HEADER32 const *)&pNtHeaders->OptionalHeader)->DataDirectory;
+    else
+        rgDataDirectory = ((IMAGE_OPTIONAL_HEADER64 const *)&pNtHeaders->OptionalHeader)->DataDirectory;
+
+    IMAGE_DATA_DIRECTORY const * pDebugDataDirectory = &rgDataDirectory[IMAGE_DIRECTORY_ENTRY_DEBUG];
+
+    // In Redhawk, modules are loaded as MAPPED, so we don't have to worry about dealing
+    // with FLAT files (with padding missing), so header addresses can be used as is
+    IMAGE_DEBUG_DIRECTORY const *rgDebugEntries = (IMAGE_DEBUG_DIRECTORY const *) (pbModule + pDebugDataDirectory->VirtualAddress);
+    DWORD cbDebugEntries = pDebugDataDirectory->Size;
+    if (cbDebugEntries < sizeof(IMAGE_DEBUG_DIRECTORY))
+        return;
+
+    // Since rgDebugEntries is an array of IMAGE_DEBUG_DIRECTORYs, cbDebugEntries
+    // should be a multiple of sizeof(IMAGE_DEBUG_DIRECTORY).
+    if (cbDebugEntries % sizeof(IMAGE_DEBUG_DIRECTORY) != 0)
+        return;
+
+    // CodeView RSDS debug information -> PDB 7.00
+    struct CV_INFO_PDB70 
+    {
+        DWORD          magic; 
+        GUID           signature;       // unique identifier 
+        DWORD          age;             // an always-incrementing value 
+        _Field_z_ char  path[MAX_PATH];  // zero terminated string with the name of the PDB file 
+    };
+
+    // Temporary storage for a CV_INFO_PDB70 and its size (which could be less than
+    // sizeof(CV_INFO_PDB70); see below).
+    struct PdbInfo
+    {
+        CV_INFO_PDB70 *     m_pPdb70;
+        ULONG               m_cbPdb70;
+    };
+
+    // Grab module bounds so we can do some rough sanity checking before we follow any
+    // RVAs
+    uint8_t * pbModuleLowerBound = NULL;
+    uint8_t * pbModuleUpperBound = NULL;
+    PalGetModuleBounds(hOsHandle, &pbModuleLowerBound, &pbModuleUpperBound);
+
+    // Iterate through all debug directory entries. The convention is that debuggers &
+    // profilers typically just use the very last IMAGE_DEBUG_TYPE_CODEVIEW entry.  Treat raw
+    // bytes we read as untrusted.
+    PdbInfo pdbInfoLast = {0};
+    int cEntries = cbDebugEntries / sizeof(IMAGE_DEBUG_DIRECTORY);
+    for (int i = 0; i < cEntries; i++)
+    {
+        if ((uint8_t*)(&rgDebugEntries[i]) + sizeof(rgDebugEntries[i]) >= pbModuleUpperBound)
+        {
+            // Bogus pointer
+            return;
+        }
+
+        if (rgDebugEntries[i].Type != IMAGE_DEBUG_TYPE_CODEVIEW)
+            continue;
+
+        // Get raw data pointed to by this IMAGE_DEBUG_DIRECTORY
+
+        // AddressOfRawData is generally set properly for Redhawk modules, so we don't
+        // have to worry about using PointerToRawData and converting it to an RVA
+        if (rgDebugEntries[i].AddressOfRawData == NULL)
+            continue;
+
+        DWORD rvaOfRawData = rgDebugEntries[i].AddressOfRawData;
+        ULONG cbDebugData = rgDebugEntries[i].SizeOfData;
+        if (cbDebugData < size_t(&((CV_INFO_PDB70*)0)->magic) + sizeof(((CV_INFO_PDB70*)0)->magic))
+        {
+            // raw data too small to contain magic number at expected spot, so its format
+            // is not recognizable. Skip
+            continue;
+        }
+
+        // Verify the magic number is as expected
+        const DWORD CV_SIGNATURE_RSDS = 0x53445352;
+        CV_INFO_PDB70 * pPdb70 = (CV_INFO_PDB70 *) (pbModule + rvaOfRawData);
+        if ((uint8_t*)(pPdb70) + cbDebugData >= pbModuleUpperBound)
+        {
+            // Bogus pointer
+            return;
+        }
+
+        if (pPdb70->magic != CV_SIGNATURE_RSDS)
+        {
+            // Unrecognized magic number.  Skip
+            continue;
+        }
+
+        // From this point forward, the format should adhere to the expected layout of
+        // CV_INFO_PDB70. If we find otherwise, then assume the IMAGE_DEBUG_DIRECTORY is
+        // outright corrupt.
+
+        // Verify sane size of raw data
+        if (cbDebugData > sizeof(CV_INFO_PDB70))
+            return;
+
+        // cbDebugData actually can be < sizeof(CV_INFO_PDB70), since the "path" field
+        // can be truncated to its actual data length (i.e., fewer than MAX_PATH chars
+        // may be present in the PE file). In some cases, though, cbDebugData will
+        // include all MAX_PATH chars even though path gets null-terminated well before
+        // the MAX_PATH limit.
+        
+        // Gotta have at least one byte of the path
+        if (cbDebugData < offsetof(CV_INFO_PDB70, path) + sizeof(char))
+            return;
+        
+        // How much space is available for the path?
+        size_t cchPathMaxIncludingNullTerminator = (cbDebugData - offsetof(CV_INFO_PDB70, path)) / sizeof(char);
+        ASSERT(cchPathMaxIncludingNullTerminator >= 1);   // Guaranteed above
+
+        // Verify path string fits inside the declared size
+        size_t cchPathActualExcludingNullTerminator = strnlen_s(pPdb70->path, cchPathMaxIncludingNullTerminator);
+        if (cchPathActualExcludingNullTerminator == cchPathMaxIncludingNullTerminator)
+        {
+            // This is how strnlen indicates failure--it couldn't find the null
+            // terminator within the buffer size specified
+            return;
+        }
+
+        // Looks valid.  Remember it.
+        pdbInfoLast.m_pPdb70 = pPdb70;
+        pdbInfoLast.m_cbPdb70 = cbDebugData;
+    }
+
+    // Take the last IMAGE_DEBUG_TYPE_CODEVIEW entry we saw, and return it to the caller
+    if (pdbInfoLast.m_pPdb70 != NULL)
+    {
+        memcpy(pGuidSignature, &pdbInfoLast.m_pPdb70->signature, sizeof(GUID));
+        *pdwAge = pdbInfoLast.m_pPdb70->age;
+
+        // Convert build path from ANSI to UNICODE
+        errno_t ret;
+        size_t cchConverted;
+        ret = mbstowcs_s(
+            &cchConverted,
+            wszPath,
+            cchPath,
+            pdbInfoLast.m_pPdb70->path,
+            _countof(pdbInfoLast.m_pPdb70->path) - 1);
+        if ((ret != 0) && (ret != STRUNCATE))
+        {
+            // PDB path isn't essential.  An empty string will do if we hit an error.
+            ASSERT(cchPath > 0);        // Guaranteed at top of function
+            wszPath[0] = L'\0';
+        }
+    }
+}
+
 uint32_t g_RhNumberOfProcessors;
 
 int32_t PalGetProcessCpuCount()

--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -1189,6 +1189,21 @@ bool DotNETRuntimeProvider_IsEnabled(unsigned char level, unsigned long long key
 
     return (keyword == (ULONGLONG)0) || (keyword & context.EnabledKeywordsBitmask) != 0;
 }
+
+bool DotNETRuntimeRundownProvider_IsEnabled(unsigned char level, unsigned long long keyword)
+{
+    if (!ep_enabled())
+        return false;
+
+    EVENTPIPE_TRACE_CONTEXT& context = MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context.EventPipeProvider;
+    if (!context.IsEnabled)
+        return false;
+
+    if (level > context.Level)
+        return false;
+
+    return (keyword == (ULONGLONG)0) || (keyword & context.EnabledKeywordsBitmask) != 0;
+}
 """
 
 def generateEventPipeImplFiles(

--- a/src/coreclr/scripts/genEventing.py
+++ b/src/coreclr/scripts/genEventing.py
@@ -220,7 +220,7 @@ def getPalDataTypeMapping(runtimeFlavor):
 def includeProvider(providerName, runtimeFlavor):
     if (runtimeFlavor.coreclr or runtimeFlavor.nativeaot) and providerName == "Microsoft-DotNETRuntimeMonoProfiler":
         return False
-    elif runtimeFlavor.nativeaot and (providerName == "Microsoft-Windows-DotNETRuntimeRundown" or providerName == "Microsoft-Windows-DotNETRuntimeStress"):
+    elif runtimeFlavor.nativeaot and providerName == "Microsoft-Windows-DotNETRuntimeStress":
         return False
     else:
         return True

--- a/src/coreclr/scripts/genEventing.py
+++ b/src/coreclr/scripts/genEventing.py
@@ -604,14 +604,14 @@ def generateClrallEvents(eventNodes, allTemplates, target_cpp, runtimeFlavor, is
                 fnbody.append("status &= FireEtXplat" + eventName + "(" + ''.join(line) + ");\n")
 
             if runtimeFlavor.nativeaot:
-                if providerName == "Microsoft-Windows-DotNETRuntime" or providerName == "Microsoft-Windows-DotNETRuntimePrivate":
+                if providerName == "Microsoft-Windows-DotNETRuntime" or providerName == "Microsoft-Windows-DotNETRuntimePrivate" or providerName == "Microsoft-Windows-DotNETRuntimeRundown":
                     fnbody.append("#ifndef TARGET_UNIX\n")
                     fnbody.append(lindent)
                     fnbody.append("status &= ")
                 else:
                     fnbody.append("return ")
                 fnbody.append("FireEtXplat" + eventName + "(" + ''.join(line) + ");\n")
-                if providerName == "Microsoft-Windows-DotNETRuntime" or providerName == "Microsoft-Windows-DotNETRuntimePrivate":
+                if providerName == "Microsoft-Windows-DotNETRuntime" or providerName == "Microsoft-Windows-DotNETRuntimePrivate" or providerName == "Microsoft-Windows-DotNETRuntimeRundown":
                     fnbody.append("#endif\n")
 
             fnbody.append(lindent)

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -919,14 +919,8 @@
         <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/200</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051: not supported in net8</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/rundownvalidation/**">
             <Issue>https://github.com/dotnet/runtime/issues/83051: not supported in net8</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/nativeruntimeeventsource/**">
-            <Issue>https://github.com/dotnet/runtime/issues/90021</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/208</Issue>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1071,6 +1071,13 @@
         </ExcludeList>
     </ItemGroup>
 
+    <!-- NativeAOT Linux specific -->
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'linux'">
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/**">
+            <Issue>https://github.com/dotnet/runtime/issues/116686</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
     <!-- NativeAOT arm32 specific -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetArchitecture)' == 'arm'">
         <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetTotalAllocatedBytes/**">


### PR DESCRIPTION
This is sufficient to get module information in `dotnet-gcdump collect`. The tool itself will need tweaks because it only looks at IL paths right now, but this should be all that's necessary to build on top.

Cc @brianrob @noahfalk @dotnet/ilc-contrib 