### PR TITLE
SPMI: Handle BRANCH26 relocs similar to REL32 relocs

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
@@ -854,15 +854,10 @@ void CompileResult::applyRelocs(RelocContext* rc, unsigned char* block1, ULONG b
                 {
                     if ((section_begin <= address) && (address < section_end)) // A reloc for our section?
                     {
-                        INT64 delta = (INT64)(tmp.target - fixupLocation);
-                        if (!FitsInRel28(delta))
-                        {
-                            // Assume here that we would need a jump stub for this relocation and pretend
-                            // that the jump stub is located right at the end of the method.
-                            DWORDLONG target = (DWORDLONG)originalAddr + (DWORDLONG)blocksize1;
-                            delta = (INT64)(target - fixupLocation);
-                        }
-                        PutArm64Rel28((UINT32*)address, (INT32)delta);
+                        // Similar to x64's IMAGE_REL_BASED_REL32 handling we
+                        // will handle this by also hardcoding the bottom bits
+                        // of the target into the instruction.
+                        PutArm64Rel28((UINT32*)address, (INT32)tmp.target);
                     }
                     wasRelocHandled = true;
                 }


### PR DESCRIPTION
BRANCH26 relocs were handled by seeing if we can fit a relative offset to the actual target in the instruction, and if so, doing that. Otherwise we would hardcode a jump to the end of the code.

It turns out that outside macOS we never hit the former case, so we always hardcode a jump to the end of the code section. That makes diffing work outside macOS.

On macOS, it happens rarely that the target (that comes from the original SPMI collection) is actually within range of the code that was allocated during SPMI replay. When that happens we end up with a two different immediates provided to the instruction by the base and the diff compilers, and hence diffing fails.

Now, `NearDiffer::compareOffsets` actually has code that tries to compensate for relative offsets like this, by seeing if the absolute offset computed by "address + instrLen + immediate" is the same for the base and the diff compilers. However, it turns out that LLVM does not scale the immediate in the b/bl instruction representation. So for the above to work, it would actually need to be something like `instrLen + immediate << 2`. We could do that, but it seems better to align this with x64, which just skips all of the troubles by hardcoding the lower bits of the absolute offsets as if it was the relative offset.