### PR TITLE
Add StringComparison to ClaimsIdentity

### DIFF
--- a/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
+++ b/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
@@ -49,7 +49,7 @@ namespace System.Security.Claims
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         protected ClaimsIdentity(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         protected ClaimsIdentity(System.Security.Claims.ClaimsIdentity other) { }
-        public ClaimsIdentity(System.Security.Claims.ClaimsIdentity other, System.StringComparison stringComparison) { }
+        protected ClaimsIdentity(System.Security.Claims.ClaimsIdentity other, System.StringComparison stringComparison) { }
         public ClaimsIdentity(System.Security.Principal.IIdentity? identity) { }
         public ClaimsIdentity(System.Security.Principal.IIdentity? identity, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>? claims) { }
         public ClaimsIdentity(System.Security.Principal.IIdentity? identity, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>? claims, string? authenticationType, string? nameType, string? roleType) { }

--- a/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
+++ b/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
@@ -41,6 +41,7 @@ namespace System.Security.Claims
         public ClaimsIdentity(System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>? claims, string? authenticationType) { }
         public ClaimsIdentity(System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>? claims, string? authenticationType, string? nameType, string? roleType) { }
         public ClaimsIdentity(System.IO.BinaryReader reader) { }
+        public ClaimsIdentity(System.IO.BinaryReader reader, System.StringComparison stringComparison) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         protected ClaimsIdentity(System.Runtime.Serialization.SerializationInfo info) { }
@@ -48,9 +49,11 @@ namespace System.Security.Claims
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         protected ClaimsIdentity(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         protected ClaimsIdentity(System.Security.Claims.ClaimsIdentity other) { }
+        public ClaimsIdentity(System.Security.Claims.ClaimsIdentity other, System.StringComparison stringComparison) { }
         public ClaimsIdentity(System.Security.Principal.IIdentity? identity) { }
         public ClaimsIdentity(System.Security.Principal.IIdentity? identity, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>? claims) { }
         public ClaimsIdentity(System.Security.Principal.IIdentity? identity, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>? claims, string? authenticationType, string? nameType, string? roleType) { }
+        public ClaimsIdentity(System.Security.Principal.IIdentity? identity = null, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>? claims = null, string? authenticationType = null, string? nameType = null, string? roleType = null, System.StringComparison stringComparison = System.StringComparison.OrdinalIgnoreCase) { }
         public ClaimsIdentity(string? authenticationType) { }
         public ClaimsIdentity(string? authenticationType, string? nameType, string? roleType) { }
         public System.Security.Claims.ClaimsIdentity? Actor { get { throw null; } set { } }

--- a/src/libraries/System.Security.Claims/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Claims/src/Resources/Strings.resx
@@ -57,6 +57,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ArgumentException_StringComparisonCultureAware" xml:space="preserve">
+    <value>The StringComparison must be one of Ordinal, OrdinalIgnoreCase, InvariantCulture, InvariantCultureIgnoreCase.</value>
+  </data>
   <data name="InvalidOperation_ClaimCannotBeRemoved" xml:space="preserve">
     <value>The Claim '{0}' was not able to be removed.  It is either not part of this Identity or it is a Claim that is owned by the Principal that contains this Identity. For example, the Principal will own the Claim when creating a GenericPrincipal with roles. The roles will be exposed through the Identity that is passed in the constructor, but not actually owned by the Identity.  Similar logic exists for a RolePrincipal.</value>
   </data>

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -206,6 +206,17 @@ namespace System.Security.Claims
             Initialize(reader);
         }
 
+        /// <summary>
+        ///   Initializes an instance of <see cref="ClaimsIdentity" /> with the specified <see cref="BinaryReader" />.
+        /// </summary>
+        /// <param name="reader">A <see cref="BinaryReader" /> pointing to a <see cref="ClaimsIdentity" />.</param>
+        /// <param name="stringComparison">The string comparison to use when comparing claim types.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="reader"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="stringComparison"/> is out of range or a not supported value.
+        /// </exception>
         public ClaimsIdentity(BinaryReader reader, StringComparison stringComparison)
         {
             ArgumentNullException.ThrowIfNull(reader);

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -271,7 +271,7 @@ namespace System.Security.Claims
         /// </exception>
         /// <exception cref="InvalidOperationException">
         ///   <paramref name="identity"/> is a <see cref="ClaimsIdentity"/> and <see cref="Actor" />
-        ///   results in a circular reference back to this.
+        ///   results in a circular reference back to <see langword="this"/>.
         /// </exception>
         public ClaimsIdentity(
             IIdentity? identity = null,

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -206,10 +206,13 @@ namespace System.Security.Claims
             Initialize(reader);
         }
 
-        public ClaimsIdentity(BinaryReader reader, StringComparison stringComparison) : this(reader)
+        public ClaimsIdentity(BinaryReader reader, StringComparison stringComparison)
         {
+            ArgumentNullException.ThrowIfNull(reader);
             ValidateStringComparison(stringComparison);
             _stringComparison = stringComparison;
+
+            Initialize(reader);
         }
 
         /// <summary>
@@ -220,29 +223,14 @@ namespace System.Security.Claims
         protected ClaimsIdentity(ClaimsIdentity other)
         {
             ArgumentNullException.ThrowIfNull(other);
-
-            if (other._actor != null)
-            {
-                _actor = other._actor.Clone();
-            }
-
-            _authenticationType = other._authenticationType;
-            _bootstrapContext = other._bootstrapContext;
-            _label = other._label;
-            _nameClaimType = other._nameClaimType;
-            _roleClaimType = other._roleClaimType;
-            if (other._userSerializationData != null)
-            {
-                _userSerializationData = other._userSerializationData.Clone() as byte[];
-            }
-
-            SafeAddClaims(other._instanceClaims);
+            Initialize(other);
         }
 
-        public ClaimsIdentity(ClaimsIdentity other, StringComparison stringComparison) : this(other)
+        public ClaimsIdentity(ClaimsIdentity other, StringComparison stringComparison)
         {
             ValidateStringComparison(stringComparison);
             _stringComparison = stringComparison;
+            Initialize(other);
         }
 
         public ClaimsIdentity(
@@ -706,6 +694,26 @@ namespace System.Security.Claims
             }
 
             return false;
+        }
+
+        private void Initialize(ClaimsIdentity other)
+        {
+            if (other._actor != null)
+            {
+                _actor = other._actor.Clone();
+            }
+
+            _authenticationType = other._authenticationType;
+            _bootstrapContext = other._bootstrapContext;
+            _label = other._label;
+            _nameClaimType = other._nameClaimType;
+            _roleClaimType = other._roleClaimType;
+            if (other._userSerializationData != null)
+            {
+                _userSerializationData = other._userSerializationData.Clone() as byte[];
+            }
+
+            SafeAddClaims(other._instanceClaims);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -246,8 +246,12 @@ namespace System.Security.Claims
         /// <exception cref="ArgumentException">
         ///   <paramref name="stringComparison"/> is out of range or a not supported value.
         /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="other"/> is <see langword="null"/> .
+        /// </exception>
         protected ClaimsIdentity(ClaimsIdentity other, StringComparison stringComparison)
         {
+            ArgumentNullException.ThrowIfNull(other);
             ValidateStringComparison(stringComparison);
             _stringComparison = stringComparison;
             Initialize(other);
@@ -264,6 +268,10 @@ namespace System.Security.Claims
         /// <param name="stringComparison">The string comparison to use when comparing claim types.</param>
         /// <exception cref="ArgumentException">
         ///   <paramref name="stringComparison"/> is out of range or a not supported value.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   <paramref name="identity"/> is a <see cref="ClaimsIdentity"/> and <see cref="Actor" />
+        ///   results in a circular reference back to this.
         /// </exception>
         public ClaimsIdentity(
             IIdentity? identity = null,

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -226,6 +226,15 @@ namespace System.Security.Claims
             Initialize(other);
         }
 
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ClaimsIdentity" /> class from an existing
+        ///   <see cref="ClaimsIdentity" /> instance.
+        /// </summary>
+        /// <param name="other">The <see cref="ClaimsIdentity" /> to copy.</param>
+        /// <param name="stringComparison">The string comparison to use when comparing claim types.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="stringComparison"/> is out of range or a not supported value.
+        /// </exception>
         public ClaimsIdentity(ClaimsIdentity other, StringComparison stringComparison)
         {
             ValidateStringComparison(stringComparison);
@@ -233,6 +242,18 @@ namespace System.Security.Claims
             Initialize(other);
         }
 
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ClaimsIdentity" /> class.
+        /// </summary>
+        /// <param name="identity">The identity from which to base the new claims identity.</param>
+        /// <param name="claims">The claims with which to populate the claims identity.</param>
+        /// <param name="authenticationType">The type of authentication used.</param>
+        /// <param name="nameType">The claim type to use for name claims.</param>
+        /// <param name="roleType">The claim type to use for role claims.</param>
+        /// <param name="stringComparison">The string comparison to use when comparing claim types.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="stringComparison"/> is out of range or a not supported value.
+        /// </exception>
         public ClaimsIdentity(
             IIdentity? identity = null,
             IEnumerable<Claim>? claims = null,
@@ -580,7 +601,6 @@ namespace System.Security.Claims
         /// </summary>
         /// <param name="type">The type of the claim to match.</param>
         /// <returns>A <see cref="IEnumerable{Claim}"/> of matched claims.</returns>
-        /// <remarks>Comparison is: StringComparison.OrdinalIgnoreCase.</remarks>
         /// <exception cref="ArgumentNullException">if 'type' is null.</exception>
         public virtual IEnumerable<Claim> FindAll(string type)
         {
@@ -628,7 +648,6 @@ namespace System.Security.Claims
         /// </summary>
         /// <param name="type">The type of the claim to match.</param>
         /// <returns>A <see cref="Claim"/>, null if nothing matches.</returns>
-        /// <remarks>Comparison is: StringComparison.OrdinalIgnoreCase.</remarks>
         /// <exception cref="ArgumentNullException">if 'type' is null.</exception>
         public virtual Claim? FindFirst(string type)
         {
@@ -675,7 +694,6 @@ namespace System.Security.Claims
         /// <param name="type">the type of the claim to match.</param>
         /// <param name="value">the value of the claim to match.</param>
         /// <returns>true if a claim is matched, false otherwise.</returns>
-        /// <remarks>Comparison is: StringComparison.OrdinalIgnoreCase for Claim.Type, StringComparison.Ordinal for Claim.Value.</remarks>
         /// <exception cref="ArgumentNullException">if 'type' is null.</exception>
         /// <exception cref="ArgumentNullException">if 'value' is null.</exception>
         public virtual bool HasClaim(string type, string value)

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -246,7 +246,7 @@ namespace System.Security.Claims
         /// <exception cref="ArgumentException">
         ///   <paramref name="stringComparison"/> is out of range or a not supported value.
         /// </exception>
-        public ClaimsIdentity(ClaimsIdentity other, StringComparison stringComparison)
+        protected ClaimsIdentity(ClaimsIdentity other, StringComparison stringComparison)
         {
             ValidateStringComparison(stringComparison);
             _stringComparison = stringComparison;

--- a/src/libraries/System.Security.Claims/tests/ClaimsIdentityTests.cs
+++ b/src/libraries/System.Security.Claims/tests/ClaimsIdentityTests.cs
@@ -489,6 +489,37 @@ namespace System.Security.Claims
             Assert.Equal("value", f2.Value);
         }
 
+        [Theory]
+        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase)]
+        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase)]
+        public void FindFirst_WithStringComparison_Match(string claimType, string findType, StringComparison stringComparison)
+        {
+            Claim claim = new(claimType, "value");
+
+            ClaimsIdentity id = new(
+                claims: [claim],
+                stringComparison: stringComparison);
+
+            Claim found = id.FindFirst(findType);
+            Assert.NotNull(found);
+            Assert.Equal(claimType, found.Type);
+        }
+
+        [Theory]
+        [InlineData("Type", "type", StringComparison.InvariantCulture)]
+        [InlineData("Type", "type", StringComparison.Ordinal)]
+        public void FindFirst_WithStringComparison_NoMatch(string claimType, string findType, StringComparison stringComparison)
+        {
+            Claim claim = new(claimType, "value");
+
+            ClaimsIdentity id = new(
+                claims: [claim],
+                stringComparison: stringComparison);
+
+            Claim found = id.FindFirst(findType);
+            Assert.Null(found);
+        }
+
         [Fact]
         public void HasClaim_TypeValue()
         {

--- a/src/libraries/System.Security.Claims/tests/ClaimsIdentityTests.cs
+++ b/src/libraries/System.Security.Claims/tests/ClaimsIdentityTests.cs
@@ -497,6 +497,30 @@ namespace System.Security.Claims
         }
 
         [Fact]
+        public static void Ctor_NullClaimsIdentity()
+        {
+            AssertExtensions.Throws<ArgumentNullException>(
+                "other",
+                static () => new CustomClaimsIdentity(null));
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "other",
+                static () => new CustomClaimsIdentity(null, StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public static void Ctor_NullBinaryReader()
+        {
+            AssertExtensions.Throws<ArgumentNullException>(
+                "reader",
+                static () => new ClaimsIdentity((BinaryReader)null));
+
+            AssertExtensions.Throws<ArgumentNullException>(
+                "reader",
+                static () => new ClaimsIdentity((BinaryReader)null, StringComparison.Ordinal));
+        }
+
+        [Fact]
         public void Find_CaseInsensivity()
         {
             var claim_type = new Claim("TYpe", "value");
@@ -832,7 +856,10 @@ namespace System.Security.Claims
             public CustomClaimsIdentity(ClaimsIdentity claimsIdentity, StringComparison comparison)
                 : base(claimsIdentity, comparison)
             {
+            }
 
+            public CustomClaimsIdentity(ClaimsIdentity claimsIdentity): base(claimsIdentity)
+            {
             }
 
             void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)

--- a/src/libraries/System.Security.Claims/tests/ClaimsIdentityTests.cs
+++ b/src/libraries/System.Security.Claims/tests/ClaimsIdentityTests.cs
@@ -493,7 +493,7 @@ namespace System.Security.Claims
 
             AssertExtensions.Throws<ArgumentException>(
                 "stringComparison",
-                () => new ClaimsIdentity(new ClaimsIdentity(), stringComparison));
+                () => new CustomClaimsIdentity(new ClaimsIdentity(), stringComparison));
         }
 
         [Fact]
@@ -532,7 +532,7 @@ namespace System.Security.Claims
 
             if (copy)
             {
-                id = new ClaimsIdentity(id, stringComparison);
+                id = new CustomClaimsIdentity(id, stringComparison);
             }
 
             Claim found = id.FindFirst(findType);
@@ -561,7 +561,7 @@ namespace System.Security.Claims
 
             if (copy)
             {
-                id = new ClaimsIdentity(id, stringComparison);
+                id = new CustomClaimsIdentity(id, stringComparison);
             }
 
             Claim found = id.FindFirst(findType);
@@ -589,7 +589,7 @@ namespace System.Security.Claims
 
             if (copy)
             {
-                id = new ClaimsIdentity(id, stringComparison);
+                id = new CustomClaimsIdentity(id, stringComparison);
             }
 
             Claim found = Assert.Single(id.FindAll(findType));
@@ -618,7 +618,7 @@ namespace System.Security.Claims
 
             if (copy)
             {
-                id = new ClaimsIdentity(id, stringComparison);
+                id = new CustomClaimsIdentity(id, stringComparison);
             }
 
             Assert.Empty(id.FindAll(findType));
@@ -645,7 +645,7 @@ namespace System.Security.Claims
 
             if (copy)
             {
-                id = new ClaimsIdentity(id, stringComparison);
+                id = new CustomClaimsIdentity(id, stringComparison);
             }
 
             AssertExtensions.TrueExpression(id.HasClaim(findType, "value"));
@@ -672,7 +672,7 @@ namespace System.Security.Claims
 
             if (copy)
             {
-                id = new ClaimsIdentity(id, stringComparison);
+                id = new CustomClaimsIdentity(id, stringComparison);
             }
 
             AssertExtensions.FalseExpression(id.HasClaim(findType, "value"));
@@ -827,6 +827,12 @@ namespace System.Security.Claims
 
             public CustomClaimsIdentity(SerializationInfo info, StreamingContext context) : base(info, context)
             {
+            }
+
+            public CustomClaimsIdentity(ClaimsIdentity claimsIdentity, StringComparison comparison)
+                : base(claimsIdentity, comparison)
+            {
+
             }
 
             void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)

--- a/src/libraries/System.Security.Claims/tests/ClaimsIdentityTests.cs
+++ b/src/libraries/System.Security.Claims/tests/ClaimsIdentityTests.cs
@@ -512,16 +512,28 @@ namespace System.Security.Claims
         }
 
         [Theory]
-        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase)]
-        [InlineData("Type", "typ\u0000e", StringComparison.InvariantCultureIgnoreCase)]
-        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase)]
-        public void FindFirst_WithStringComparison_Match(string claimType, string findType, StringComparison stringComparison)
+        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase, true)]
+        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase, false)]
+        [InlineData("Type", "typ\u0000e", StringComparison.InvariantCultureIgnoreCase, true)]
+        [InlineData("Type", "typ\u0000e", StringComparison.InvariantCultureIgnoreCase, false)]
+        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase, true)]
+        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase, false)]
+        public void FindFirst_WithStringComparison_Match(
+            string claimType,
+            string findType,
+            StringComparison stringComparison,
+            bool copy)
         {
             Claim claim = new(claimType, "value");
 
             ClaimsIdentity id = new(
                 claims: [claim],
                 stringComparison: stringComparison);
+
+            if (copy)
+            {
+                id = new ClaimsIdentity(id, stringComparison);
+            }
 
             Claim found = id.FindFirst(findType);
             Assert.NotNull(found);
@@ -529,32 +541,56 @@ namespace System.Security.Claims
         }
 
         [Theory]
-        [InlineData("Type", "type", StringComparison.InvariantCulture)]
-        [InlineData("Type", "type", StringComparison.Ordinal)]
-        [InlineData("Type", "typ\u0000e", StringComparison.Ordinal)]
-        public void FindFirst_WithStringComparison_NoMatch(string claimType, string findType, StringComparison stringComparison)
+        [InlineData("Type", "type", StringComparison.InvariantCulture, false)]
+        [InlineData("Type", "type", StringComparison.InvariantCulture, true)]
+        [InlineData("Type", "type", StringComparison.Ordinal, false)]
+        [InlineData("Type", "type", StringComparison.Ordinal, true)]
+        [InlineData("Type", "typ\u0000e", StringComparison.Ordinal, false)]
+        [InlineData("Type", "typ\u0000e", StringComparison.Ordinal, true)]
+        public void FindFirst_WithStringComparison_NoMatch(
+            string claimType,
+            string findType,
+            StringComparison stringComparison,
+            bool copy)
         {
             Claim claim = new(claimType, "value");
 
             ClaimsIdentity id = new(
                 claims: [claim],
                 stringComparison: stringComparison);
+
+            if (copy)
+            {
+                id = new ClaimsIdentity(id, stringComparison);
+            }
 
             Claim found = id.FindFirst(findType);
             Assert.Null(found);
         }
 
         [Theory]
-        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase)]
-        [InlineData("Type", "typ\u0000e", StringComparison.InvariantCultureIgnoreCase)]
-        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase)]
-        public void FindAll_WithStringComparison_Match(string claimType, string findType, StringComparison stringComparison)
+        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase, false)]
+        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase, true)]
+        [InlineData("Type", "typ\u0000e", StringComparison.InvariantCultureIgnoreCase, false)]
+        [InlineData("Type", "typ\u0000e", StringComparison.InvariantCultureIgnoreCase, true)]
+        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase, false)]
+        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase, true)]
+        public void FindAll_WithStringComparison_Match(
+            string claimType,
+            string findType,
+            StringComparison stringComparison,
+            bool copy)
         {
             Claim claim = new(claimType, "value");
 
             ClaimsIdentity id = new(
                 claims: [claim],
                 stringComparison: stringComparison);
+
+            if (copy)
+            {
+                id = new ClaimsIdentity(id, stringComparison);
+            }
 
             Claim found = Assert.Single(id.FindAll(findType));
             Assert.NotNull(found);
@@ -562,40 +598,71 @@ namespace System.Security.Claims
         }
 
         [Theory]
-        [InlineData("Type", "type", StringComparison.InvariantCulture)]
-        [InlineData("Type", "type", StringComparison.Ordinal)]
-        [InlineData("Type", "typ\u0000e", StringComparison.Ordinal)]
-        public void FindAll_WithStringComparison_NoMatch(string claimType, string findType, StringComparison stringComparison)
+        [InlineData("Type", "type", StringComparison.InvariantCulture, false)]
+        [InlineData("Type", "type", StringComparison.InvariantCulture, true)]
+        [InlineData("Type", "type", StringComparison.Ordinal, false)]
+        [InlineData("Type", "type", StringComparison.Ordinal, true)]
+        [InlineData("Type", "typ\u0000e", StringComparison.Ordinal, false)]
+        [InlineData("Type", "typ\u0000e", StringComparison.Ordinal, true)]
+        public void FindAll_WithStringComparison_NoMatch(
+            string claimType,
+            string findType,
+            StringComparison stringComparison,
+            bool copy)
         {
             Claim claim = new(claimType, "value");
 
             ClaimsIdentity id = new(
                 claims: [claim],
                 stringComparison: stringComparison);
+
+            if (copy)
+            {
+                id = new ClaimsIdentity(id, stringComparison);
+            }
 
             Assert.Empty(id.FindAll(findType));
         }
 
         [Theory]
-        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase)]
-        [InlineData("Type", "typ\u0000e", StringComparison.InvariantCultureIgnoreCase)]
-        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase)]
-        public void HasClaim_WithStringComparison_Match(string claimType, string findType, StringComparison stringComparison)
+        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase, true)]
+        [InlineData("Type", "type", StringComparison.InvariantCultureIgnoreCase, false)]
+        [InlineData("Type", "typ\u0000e", StringComparison.InvariantCultureIgnoreCase, true)]
+        [InlineData("Type", "typ\u0000e", StringComparison.InvariantCultureIgnoreCase, false)]
+        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase, true)]
+        [InlineData("Type", "type", StringComparison.OrdinalIgnoreCase, false)]
+        public void HasClaim_WithStringComparison_Match(
+            string claimType,
+            string findType,
+            StringComparison stringComparison,
+            bool copy)
         {
             Claim claim = new(claimType, "value");
 
             ClaimsIdentity id = new(
                 claims: [claim],
                 stringComparison: stringComparison);
+
+            if (copy)
+            {
+                id = new ClaimsIdentity(id, stringComparison);
+            }
 
             AssertExtensions.TrueExpression(id.HasClaim(findType, "value"));
         }
 
         [Theory]
-        [InlineData("Type", "type", StringComparison.InvariantCulture)]
-        [InlineData("Type", "type", StringComparison.Ordinal)]
-        [InlineData("Type", "typ\u0000e", StringComparison.Ordinal)]
-        public void HasClaim_WithStringComparison_NoMatch(string claimType, string findType, StringComparison stringComparison)
+        [InlineData("Type", "type", StringComparison.InvariantCulture, true)]
+        [InlineData("Type", "type", StringComparison.InvariantCulture, false)]
+        [InlineData("Type", "type", StringComparison.Ordinal, true)]
+        [InlineData("Type", "type", StringComparison.Ordinal, false)]
+        [InlineData("Type", "typ\u0000e", StringComparison.Ordinal, true)]
+        [InlineData("Type", "typ\u0000e", StringComparison.Ordinal, false)]
+        public void HasClaim_WithStringComparison_NoMatch(
+            string claimType,
+            string findType,
+            StringComparison stringComparison,
+            bool copy)
         {
             Claim claim = new(claimType, "value");
 
@@ -603,24 +670,12 @@ namespace System.Security.Claims
                 claims: [claim],
                 stringComparison: stringComparison);
 
-            AssertExtensions.FalseExpression(id.HasClaim(findType, "value"));
-        }
-
-        //
-        //
-        private static BinaryReader CreateReaderWithClaim(string claimType)
-        {
-            Claim claim = new(claimType, "value");
-            ClaimsIdentity id = new(claims: [claim]);
-            MemoryStream stream = new();
-
-            using (BinaryWriter writer = new(stream, Encoding.UTF8, true))
+            if (copy)
             {
-                id.WriteTo(writer);
+                id = new ClaimsIdentity(id, stringComparison);
             }
 
-            stream.Position = 0;
-            return new BinaryReader(stream, Encoding.UTF8, false);
+            AssertExtensions.FalseExpression(id.HasClaim(findType, "value"));
         }
 
         [Theory]
@@ -746,6 +801,21 @@ namespace System.Security.Claims
 
             ClaimsIdentity clone = id.Clone();
             AssertExtensions.FalseExpression(clone.HasClaim("TYPE", "value"));
+        }
+
+        private static BinaryReader CreateReaderWithClaim(string claimType)
+        {
+            Claim claim = new(claimType, "value");
+            ClaimsIdentity id = new(claims: [claim]);
+            MemoryStream stream = new();
+
+            using (BinaryWriter writer = new(stream, Encoding.UTF8, true))
+            {
+                id.WriteTo(writer);
+            }
+
+            stream.Position = 0;
+            return new BinaryReader(stream, Encoding.UTF8, false);
         }
 
         [Serializable]


### PR DESCRIPTION
This adds constructors to `ClaimsIdentity` which allow specifying `StringComparison` option.

Closes #113562.