### PR TITLE
Implement CONV_OVF_xxx in the Interpreter

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1287,6 +1287,8 @@ void InterpCompiler::EmitConv(StackInfo *sp, StackType type, InterpOpcode convOp
     int32_t var = CreateVarExplicit(g_interpTypeFromStackType[type], NULL, INTERP_STACK_SLOT_SIZE);
     sp->var = var;
     newInst->SetDVar(var);
+
+    // NOTE: We rely on m_pLastNewIns == newInst upon return from this function. Make sure you preserve that if you change anything.
 }
 
 static InterpType GetInterpType(CorInfoType corInfoType)
@@ -2120,6 +2122,7 @@ int32_t InterpCompiler::GetMethodDataItemIndex(CORINFO_METHOD_HANDLE mHandle)
 
 int32_t InterpCompiler::GetDataItemIndexForHelperFtn(CorInfoHelpFunc ftn)
 {
+    // Interpreter-TODO: Find an existing data item index for this helper if possible and reuse it
     void *indirect;
     void *direct = m_compHnd->getHelperFtn(ftn, &indirect);
     size_t data = !direct
@@ -3520,6 +3523,245 @@ retry_emit:
                     break;
                 case StackTypeI4:
                     EmitConv(m_pStackPointer - 1, StackTypeR8, INTOP_CONV_R_UN_I4);
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_I1:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I1_R4);
+                    break;
+                case StackTypeR8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I1_R8);
+                    break;
+                case StackTypeI4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I1_I4);
+                    break;
+                case StackTypeI8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I1_I8);
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_U1:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U1_R4);
+                    break;
+                case StackTypeR8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U1_R8);
+                    break;
+                case StackTypeI4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U1_I4);
+                    break;
+                case StackTypeI8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U1_I8);
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_I2:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I2_R4);
+                    break;
+                case StackTypeR8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I2_R8);
+                    break;
+                case StackTypeI4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I2_I4);
+                    break;
+                case StackTypeI8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I2_I8);
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_U2:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U2_R4);
+                    break;
+                case StackTypeR8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U2_R8);
+                    break;
+                case StackTypeI4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U2_I4);
+                    break;
+                case StackTypeI8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U2_I8);
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_I4:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I4_R4);
+                    break;
+                case StackTypeR8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I4_R8);
+                    break;
+                case StackTypeI4:
+                    break;
+                case StackTypeI8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_I4_I8);
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_U4:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U4_R4);
+                    break;
+                case StackTypeR8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U4_R8);
+                    break;
+                case StackTypeI4:
+                    break;
+                case StackTypeI8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI4, INTOP_CONV_OVF_U4_I8);
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_I8:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI8, INTOP_CONV_OVF_I8_R4);
+                    break;
+                case StackTypeR8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI8, INTOP_CONV_OVF_I8_R8);
+                    break;
+                case StackTypeI4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI8, INTOP_CONV_I8_I4);
+                    break;
+                case StackTypeI8:
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_U8:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI8, INTOP_CONV_OVF_U8_R4);
+                    break;
+                case StackTypeR8:
+                    EmitConv(m_pStackPointer - 1, StackTypeI8, INTOP_CONV_OVF_U8_R8);
+                    break;
+                case StackTypeI4:
+                    EmitConv(m_pStackPointer - 1, StackTypeI8, INTOP_CONV_I8_U4);
+                    break;
+                case StackTypeI8:
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_I:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+#ifdef TARGET_64BIT
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_I8_R4);
+#else
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_I4_R4);
+#endif
+                    break;
+                case StackTypeR8:
+#ifdef TARGET_64BIT
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_I8_R8);
+#else
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_I4_R8);
+#endif
+                    break;
+                case StackTypeI4:
+#ifdef TARGET_64BIT
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_I8_I4);
+#else
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_MOV_4);
+#endif
+                    break;
+                case StackTypeI8:
+#ifdef TARGET_64BIT
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_MOV_8);
+#else
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_I4_I8);
+#endif
+                    break;
+                default:
+                    assert(0);
+                }
+                m_ip++;
+                break;
+            case CEE_CONV_OVF_U:
+                CHECK_STACK(1);
+                switch (m_pStackPointer[-1].type)
+                {
+                case StackTypeR4:
+#ifdef TARGET_64BIT
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_U8_R4);
+#else
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_U4_R4);
+#endif
+                    break;
+                case StackTypeR8:
+#ifdef TARGET_64BIT
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_U8_R8);
+#else
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_U4_R8);
+#endif
+                    break;
+                case StackTypeI4:
+#ifdef TARGET_64BIT
+                    // FIXME: Is this the right conv opcode?
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_I8_I4);
+#else
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_MOV_4);
+#endif
+                    break;
+                case StackTypeI8:
+#ifdef TARGET_64BIT
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_MOV_8);
+#else
+                    EmitConv(m_pStackPointer - 1, StackTypeI, INTOP_CONV_OVF_U4_I8);
+#endif
                     break;
                 default:
                     assert(0);
@@ -5007,6 +5249,15 @@ void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int3
             CORINFO_CLASS_HANDLE ch = (CORINFO_CLASS_HANDLE)((size_t)m_dataItems.Get(*pData));
             printf(" ");
             PrintClassName(ch);
+            break;
+        }
+        case InterpOpHelperFtn:
+        {
+            size_t helperDirectOrIndirect = (size_t)m_dataItems.Get(*pData);
+            if (helperDirectOrIndirect & INTERP_INDIRECT_HELPER_TAG)
+                printf(" (indirect) %p", (void*)(helperDirectOrIndirect & ~INTERP_INDIRECT_HELPER_TAG));
+            else
+                printf(" (direct) %p", (void*)helperDirectOrIndirect);
             break;
         }
         default:

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -171,6 +171,40 @@ OPDEF(INTOP_CONV_R8_R4, "conv.r8.r4", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_CONV_U8_R4, "conv.u8.r4", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_CONV_U8_R8, "conv.u8.r8", 3, 1, 1, InterpOpNoArgs)
 
+OPDEF(INTOP_CONV_OVF_I1_I4, "conv.ovf.i1.i4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_I1_I8, "conv.ovf.i1.i8", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_I1_R4, "conv.ovf.i1.r4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_I1_R8, "conv.ovf.i1.r8", 3, 1, 1, InterpOpNoArgs)
+
+OPDEF(INTOP_CONV_OVF_U1_I4, "conv.ovf.u1.i4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_U1_I8, "conv.ovf.u1.i8", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_U1_R4, "conv.ovf.u1.r4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_U1_R8, "conv.ovf.u1.r8", 3, 1, 1, InterpOpNoArgs)
+
+OPDEF(INTOP_CONV_OVF_I2_I4, "conv.ovf.i2.i4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_I2_I8, "conv.ovf.i2.i8", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_I2_R4, "conv.ovf.i2.r4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_I2_R8, "conv.ovf.i2.r8", 3, 1, 1, InterpOpNoArgs)
+
+OPDEF(INTOP_CONV_OVF_U2_I4, "conv.ovf.u2.i4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_U2_I8, "conv.ovf.u2.i8", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_U2_R4, "conv.ovf.u2.r4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_U2_R8, "conv.ovf.u2.r8", 3, 1, 1, InterpOpNoArgs)
+
+OPDEF(INTOP_CONV_OVF_I4_I8, "conv.ovf.i4.i8", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_I4_R4, "conv.ovf.i4.r4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_I4_R8, "conv.ovf.i4.r8", 3, 1, 1, InterpOpNoArgs)
+
+OPDEF(INTOP_CONV_OVF_U4_I8, "conv.ovf.u4.i8", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_U4_R4, "conv.ovf.u4.r4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_U4_R8, "conv.ovf.u4.r8", 3, 1, 1, InterpOpNoArgs)
+
+OPDEF(INTOP_CONV_OVF_I8_R4, "conv.ovf.i8.r4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_I8_R8, "conv.ovf.i8.r8", 3, 1, 1, InterpOpNoArgs)
+
+OPDEF(INTOP_CONV_OVF_U8_R4, "conv.ovf.u8.r4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_OVF_U8_R8, "conv.ovf.u8.r8", 3, 1, 1, InterpOpNoArgs)
+
 OPDEF(INTOP_BOX, "box", 5, 1, 1, InterpOpClassHandle) // [class handle data item] [helper data item]
 OPDEF(INTOP_UNBOX, "unbox", 5, 1, 1, InterpOpClassHandle) // [class handle data item] [helper data item]
 OPDEF(INTOP_UNBOX_ANY, "unbox.any", 5, 1, 1, InterpOpClassHandle) // [class handle data item] [helper data item]
@@ -293,8 +327,8 @@ OPDEF(INTOP_NEWOBJ, "newobj", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_NEWOBJ_VAR, "newobj.var", 5, 1, 2, InterpOpMethodHandle)
 OPDEF(INTOP_NEWOBJ_VT, "newobj.vt", 5, 1, 1, InterpOpMethodHandle)
 
-OPDEF(INTOP_CALL_HELPER_PP, "call.helper.pp", 4, 1, 0, InterpOpTwoInts)
-OPDEF(INTOP_CALL_HELPER_PP_2, "call.helper.pp.2", 5, 1, 1, InterpOpTwoInts)
+OPDEF(INTOP_CALL_HELPER_PP, "call.helper.pp", 4, 1, 0, InterpOpHelperFtn)
+OPDEF(INTOP_CALL_HELPER_PP_2, "call.helper.pp.2", 5, 1, 1, InterpOpHelperFtn)
 
 OPDEF(INTOP_GENERICLOOKUP_METHOD, "generic.method", 4, 1, 1, InterpOpGenericLookup)
 OPDEF(INTOP_GENERICLOOKUP_CLASS, "generic.class", 4, 1, 1, InterpOpGenericLookup)

--- a/src/coreclr/interpreter/intops.h
+++ b/src/coreclr/interpreter/intops.h
@@ -24,6 +24,7 @@ typedef enum
     InterpOpClassHandle,
     InterpOpGenericLookup,
     InterpOpLdPtr,
+    InterpOpHelperFtn,
 } InterpOpArgType;
 
 extern const uint8_t g_interpOpLen[];

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -10,13 +10,7 @@
 
 // for numeric_limits
 #include <limits>
-// for nexttoward
-#include <cmath>
 
-FCDECL1(uint64_t, JIT_Dbl2ULng, double);
-FCDECL1(int64_t, JIT_Dbl2Lng, double);
-FCDECL1(uint32_t, JIT_Dbl2UInt, double);
-FCDECL1(int32_t, JIT_Dbl2Int, double);
 FCDECL1(float, JIT_ULng2Flt, uint64_t val);
 FCDECL1(double, JIT_ULng2Dbl, uint64_t val);
 FCDECL1(float, JIT_Lng2Flt, int64_t val);
@@ -172,7 +166,6 @@ template <typename TResult, typename TSource> static void ConvFpHelper(int8_t *s
     // (src != src) checks for NaN, then we check whether the min and max values (as represented by their closest double)
     //  properly bound the source value so that when it is truncated it will be in range
     // We assume that we are in round-towards-zero mode. For NaN we want to return 0, and for out of range values, saturate.
-    // We don't need to be fancy with nexttoward and 0.5 since we're saturating.
     TResult result;
     if (src != src)
         result = 0;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -194,7 +194,6 @@ template <typename TResult, typename TSource> static void ConvOvfFpHelper(int8_t
         minValue = (double)std::numeric_limits<TResult>::lowest() - 1,
         maxValue = (double)std::numeric_limits<TResult>::max() + 1;
 
-    // (src != src) checks for NaN, then we check whether the min and max values properly bound the source value
     // We assume that we are in round-towards-zero mode
     bool inRange = (src > minValue) && (src < maxValue);
 
@@ -224,7 +223,6 @@ template <typename TSource> static void ConvOvfFpHelperI64(int8_t *stack, const 
         COMPlusThrow(kOverflowException);
 
     int64_t truncated = (int64_t)src;
-    // According to spec, for result types smaller than int32, we store them on the stack as int32
     LOCAL_VAR(ip[1], int64_t) = truncated;
 }
 
@@ -243,7 +241,6 @@ template <typename TSource> static void ConvOvfFpHelperU64(int8_t *stack, const 
         COMPlusThrow(kOverflowException);
 
     uint64_t truncated = (uint64_t)src;
-    // According to spec, for result types smaller than int32, we store them on the stack as int32
     LOCAL_VAR(ip[1], uint64_t) = truncated;
 }
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -8,6 +8,11 @@
 #include "interpexec.h"
 #include "callstubgenerator.h"
 
+// for numeric_limits
+#include <limits>
+// for nexttoward
+#include <cmath>
+
 FCDECL1(uint64_t, JIT_Dbl2ULng, double);
 FCDECL1(int64_t, JIT_Dbl2Lng, double);
 FCDECL1(uint32_t, JIT_Dbl2UInt, double);
@@ -66,7 +71,7 @@ CallStubHeader *CreateNativeToInterpreterCallStub(InterpMethod* pInterpMethod)
     if (pHeader == NULL)
     {
         // Ensure that there is an interpreter thread context instance and thus an interpreter stack
-        // allocated for this thread. This allows us to not to have to check and allocate it from 
+        // allocated for this thread. This allows us to not to have to check and allocate it from
         // the interpreter stub right after this call.
         GetThread()->GetInterpThreadContext();
 
@@ -94,6 +99,8 @@ typedef void* (*HELPER_FTN_PP)(void*);
 typedef void* (*HELPER_FTN_BOX_UNBOX)(MethodTable*, void*);
 typedef Object* (*HELPER_FTN_NEWARR)(CORINFO_CLASS_HANDLE, intptr_t);
 typedef void* (*HELPER_FTN_PP_2)(void*, void*);
+typedef int32_t (*HELPER_FTN_R82I4)(double);
+typedef int64_t (*HELPER_FTN_R82I8)(double);
 
 InterpThreadContext::InterpThreadContext()
 {
@@ -142,6 +149,143 @@ static OBJECTREF CreateMultiDimArray(MethodTable* arrayClass, int8_t* stack, int
 #define LOCAL_VAR_ADDR(offset,type) ((type*)(stack + (offset)))
 #define LOCAL_VAR(offset,type) (*LOCAL_VAR_ADDR(offset, type))
 #define NULL_CHECK(o) do { if ((o) == NULL) { COMPlusThrow(kNullReferenceException); } } while (0)
+
+template <typename THelper> static THelper GetPossiblyIndirectHelper(void* dataItem)
+{
+    size_t helperDirectOrIndirect = (size_t)dataItem;
+    if (helperDirectOrIndirect & INTERP_INDIRECT_HELPER_TAG)
+        return *(THelper *)(helperDirectOrIndirect & ~INTERP_INDIRECT_HELPER_TAG);
+    else
+        return (THelper)helperDirectOrIndirect;
+}
+
+template <typename TResult, typename TSource> static void ConvFpHelper(int8_t *stack, const int32_t *ip)
+{
+    static_assert(!std::numeric_limits<TSource>::is_integer, "ConvFpHelper is only for use on floats and doubles");
+    static_assert(std::numeric_limits<TResult>::is_integer, "ConvFpHelper is only for use on floats and doubles to be converted to integers");
+
+    // First, promote the source value to double
+    double src = LOCAL_VAR(ip[2], TSource),
+        minValue = (double)std::numeric_limits<TResult>::lowest(),
+        maxValue = (double)std::numeric_limits<TResult>::max();
+
+    // (src != src) checks for NaN, then we check whether the min and max values (as represented by their closest double)
+    //  properly bound the source value so that when it is truncated it will be in range
+    // We assume that we are in round-towards-zero mode. For NaN we want to return 0, and for out of range values, saturate.
+    // We don't need to be fancy with nexttoward and 0.5 since we're saturating.
+    TResult result;
+    if (src != src)
+        result = 0;
+    else if (src >= maxValue)
+        result = std::numeric_limits<TResult>::max();
+    else if (std::numeric_limits<TResult>::is_signed && (src <= -1))
+        result = 0;
+    else if (!std::numeric_limits<TResult>::is_signed && (src < minValue))
+        result = std::numeric_limits<TResult>::lowest();
+    else
+        result = (TResult)src;
+
+    // According to spec, for result types smaller than int32, we store them on the stack as int32
+    if (sizeof(TResult) >= 4)
+        LOCAL_VAR(ip[1], TResult) = result;
+    else
+        LOCAL_VAR(ip[1], int32_t) = (int32_t)result;
+}
+
+template <typename TResult, typename TSource> static void ConvOvfFpHelper(int8_t *stack, const int32_t *ip)
+{
+    static_assert(!std::numeric_limits<TSource>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles");
+    static_assert(std::numeric_limits<TResult>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles to be converted to integers");
+    static_assert(sizeof(TResult) <= 4, "ConvOvfFpHelper's generic version is only for use on results <= 4 bytes in size");
+
+    // First, promote the source value to double
+    double src = LOCAL_VAR(ip[2], TSource),
+        minValue = (double)std::numeric_limits<TResult>::lowest() - 1,
+        maxValue = (double)std::numeric_limits<TResult>::max() + 1;
+
+    // (src != src) checks for NaN, then we check whether the min and max values properly bound the source value
+    // We assume that we are in round-towards-zero mode
+    bool outOfRange = (src != src) || (src < minValue) || (src > maxValue);
+
+    if (outOfRange)
+        COMPlusThrow(kOverflowException);
+
+    TResult truncated = (TResult)src;
+    // According to spec, for result types smaller than int32, we store them on the stack as int32
+    LOCAL_VAR(ip[1], int32_t) = (int32_t)truncated;
+}
+
+// I64 and U64 versions based on mono_math.h
+
+template <typename TSource> static void ConvOvfFpHelperI64(int8_t *stack, const int32_t *ip)
+{
+    static_assert(!std::numeric_limits<TSource>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles");
+
+	const double two63  = 2147483648.0 * 4294967296.0;
+    // First, promote the source value to double
+    double src = LOCAL_VAR(ip[2], TSource),
+        // Define the boundary values we need to be between (see mono_try_trunc_i64)
+        minValue = (-two63 - 0x402),
+        maxValue = two63;
+
+    bool inRange = (src > minValue) && (src < maxValue);
+    if (!inRange)
+        COMPlusThrow(kOverflowException);
+
+    int64_t truncated = (int64_t)src;
+    // According to spec, for result types smaller than int32, we store them on the stack as int32
+    LOCAL_VAR(ip[1], int64_t) = truncated;
+}
+
+template <typename TSource> static void ConvOvfFpHelperU64(int8_t *stack, const int32_t *ip)
+{
+    static_assert(!std::numeric_limits<TSource>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles");
+
+    // First, promote the source value to double
+    double src = LOCAL_VAR(ip[2], TSource),
+        // Define the boundary values we need to be between (see mono_try_trunc_u64)
+        minValue = -1.0,
+        maxValue = 4294967296.0 * 4294967296.0;
+
+    bool inRange = (src > minValue) && (src < maxValue);
+    if (!inRange)
+        COMPlusThrow(kOverflowException);
+
+    uint64_t truncated = (uint64_t)src;
+    // According to spec, for result types smaller than int32, we store them on the stack as int32
+    LOCAL_VAR(ip[1], uint64_t) = truncated;
+}
+
+template <typename TResult, typename TSource> void ConvOvfHelper(int8_t *stack, const int32_t *ip)
+{
+    static_assert(sizeof(TResult) < sizeof(TSource), "ConvOvfHelper only can convert to results smaller than the source value");
+    static_assert(std::numeric_limits<TSource>::is_integer, "ConvOvfHelper is only for use on integers");
+
+    TSource src = LOCAL_VAR(ip[2], TSource);
+    bool inRange;
+    if (std::numeric_limits<TSource>::is_signed)
+    {
+        inRange = (src >= (TSource)std::numeric_limits<TResult>::lowest()) && (src <= (TSource)std::numeric_limits<TResult>::max());
+    }
+    else
+    {
+        inRange = (src <= (TSource)std::numeric_limits<TResult>::max());
+    }
+
+    if (inRange)
+    {
+        // conv_ovf with floating point inputs is handled in ConvOvfFpHelper, so all possible conv_ovfs in this function are
+        // from int64 into int32-or-smaller, or int32-or-smaller into int16-or-smaller.
+        // The spec says that conversion results are stored on the evaluation stack as signed, so we always want to convert
+        //  the final truncated result into int32_t before storing it on the stack, even if the truncated result is unsigned.
+        TResult result = (TResult)src;
+        LOCAL_VAR(ip[1], int32_t) = (int32_t)result;
+    }
+    else
+    {
+        COMPlusThrow(kOverflowException);
+    }
+}
 
 void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFrame *pFrame, InterpThreadContext *pThreadContext, ExceptionClauseArgs *pExceptionClauseArgs)
 {
@@ -307,11 +451,11 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_I1_R4:
-                    LOCAL_VAR(ip[1], int32_t) = (int8_t)HCCALL1(JIT_Dbl2Int, (double)LOCAL_VAR(ip[2], float));
+                    ConvFpHelper<int8_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I1_R8:
-                    LOCAL_VAR(ip[1], int32_t) = (int8_t)HCCALL1(JIT_Dbl2Int, LOCAL_VAR(ip[2], double));
+                    ConvFpHelper<int8_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U1_I4:
@@ -323,11 +467,11 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_U1_R4:
-                    LOCAL_VAR(ip[1], int32_t) = (uint8_t)HCCALL1(JIT_Dbl2UInt, (double)LOCAL_VAR(ip[2], float));
+                    ConvFpHelper<uint8_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U1_R8:
-                    LOCAL_VAR(ip[1], int32_t) = (uint8_t)HCCALL1(JIT_Dbl2UInt, LOCAL_VAR(ip[2], double));
+                    ConvFpHelper<uint8_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I2_I4:
@@ -339,11 +483,11 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_I2_R4:
-                    LOCAL_VAR(ip[1], int32_t) = (int16_t)HCCALL1(JIT_Dbl2Int, (double)LOCAL_VAR(ip[2], float));
+                    ConvFpHelper<int16_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I2_R8:
-                    LOCAL_VAR(ip[1], int32_t) = (int16_t)HCCALL1(JIT_Dbl2Int, LOCAL_VAR(ip[2], double));
+                    ConvFpHelper<int16_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U2_I4:
@@ -355,27 +499,27 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_U2_R4:
-                    LOCAL_VAR(ip[1], int32_t) = (uint16_t)HCCALL1(JIT_Dbl2UInt, (double)LOCAL_VAR(ip[2], float));
+                    ConvFpHelper<uint16_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U2_R8:
-                    LOCAL_VAR(ip[1], int32_t) = (uint16_t)HCCALL1(JIT_Dbl2UInt, LOCAL_VAR(ip[2], double));
+                    ConvFpHelper<uint16_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I4_R4:
-                    LOCAL_VAR(ip[1], int32_t) = HCCALL1(JIT_Dbl2Int, (double)LOCAL_VAR(ip[2], float));
+                    ConvFpHelper<int32_t, float>(stack, ip);
                     ip += 3;
                     break;;
                 case INTOP_CONV_I4_R8:
-                    LOCAL_VAR(ip[1], int32_t) = HCCALL1(JIT_Dbl2Int, LOCAL_VAR(ip[2], double));
+                    ConvFpHelper<int32_t, double>(stack, ip);
                     ip += 3;
                     break;;
                 case INTOP_CONV_U4_R4:
-                    LOCAL_VAR(ip[1], uint32_t) = HCCALL1(JIT_Dbl2UInt, (double)LOCAL_VAR(ip[2], float));
+                    ConvFpHelper<uint32_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U4_R8:
-                    LOCAL_VAR(ip[1], uint32_t) = HCCALL1(JIT_Dbl2UInt, LOCAL_VAR(ip[2], double));
+                    ConvFpHelper<uint32_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I8_I4:
@@ -387,11 +531,11 @@ MAIN_LOOP:
                     ip += 3;
                     break;;
                 case INTOP_CONV_I8_R4:
-                    LOCAL_VAR(ip[1], int64_t) = HCCALL1(JIT_Dbl2Lng, (double)LOCAL_VAR(ip[2], float));
+                    ConvFpHelper<int64_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I8_R8:
-                    LOCAL_VAR(ip[1], int64_t) = HCCALL1(JIT_Dbl2Lng, LOCAL_VAR(ip[2], double));
+                    ConvFpHelper<int64_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_R4_I4:
@@ -419,11 +563,123 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_U8_R4:
-                    LOCAL_VAR(ip[1], uint64_t) = HCCALL1(JIT_Dbl2ULng, (double)LOCAL_VAR(ip[2], float));
+                    ConvFpHelper<uint64_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U8_R8:
-                    LOCAL_VAR(ip[1], uint64_t) = HCCALL1(JIT_Dbl2ULng, LOCAL_VAR(ip[2], double));
+                    ConvFpHelper<uint64_t, double>(stack, ip);
+                    ip += 3;
+                    break;
+
+                case INTOP_CONV_OVF_I1_I4:
+                    ConvOvfHelper<int8_t, int32_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_I1_I8:
+                    ConvOvfHelper<int8_t, int64_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_I1_R4:
+                    ConvOvfFpHelper<int8_t, float>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_I1_R8:
+                    ConvOvfFpHelper<int8_t, double>(stack, ip);
+                    ip += 3;
+                    break;
+
+                case INTOP_CONV_OVF_U1_I4:
+                    ConvOvfHelper<uint8_t, int32_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_U1_I8:
+                    ConvOvfHelper<uint8_t, int64_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_U1_R4:
+                    ConvOvfFpHelper<uint8_t, float>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_U1_R8:
+                    ConvOvfFpHelper<uint8_t, double>(stack, ip);
+                    ip += 3;
+                    break;
+
+                case INTOP_CONV_OVF_I2_I4:
+                    ConvOvfHelper<int16_t, int32_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_I2_I8:
+                    ConvOvfHelper<int16_t, int64_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_I2_R4:
+                    ConvOvfFpHelper<int16_t, float>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_I2_R8:
+                    ConvOvfFpHelper<int16_t, double>(stack, ip);
+                    ip += 3;
+                    break;
+
+                case INTOP_CONV_OVF_U2_I4:
+                    ConvOvfHelper<uint16_t, int32_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_U2_I8:
+                    ConvOvfHelper<uint16_t, int64_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_U2_R4:
+                    ConvOvfFpHelper<uint16_t, float>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_U2_R8:
+                    ConvOvfFpHelper<uint16_t, double>(stack, ip);
+                    ip += 3;
+                    break;
+
+                case INTOP_CONV_OVF_I4_I8:
+                    ConvOvfHelper<int32_t, int64_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_I4_R4:
+                    ConvOvfFpHelper<int32_t, float>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_I4_R8:
+                    ConvOvfFpHelper<int32_t, double>(stack, ip);
+                    ip += 3;
+                    break;
+
+                case INTOP_CONV_OVF_U4_I8:
+                    ConvOvfHelper<uint32_t, int64_t>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_U4_R4:
+                    ConvOvfFpHelper<uint32_t, float>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_U4_R8:
+                    ConvOvfFpHelper<uint32_t, double>(stack, ip);
+                    ip += 3;
+                    break;
+
+                case INTOP_CONV_OVF_I8_R4:
+                    ConvOvfFpHelperI64<float>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_I8_R8:
+                    ConvOvfFpHelperI64<double>(stack, ip);
+                    ip += 3;
+                    break;
+
+                case INTOP_CONV_OVF_U8_R4:
+                    ConvOvfFpHelperU64<float>(stack, ip);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_OVF_U8_R8:
+                    ConvOvfFpHelperU64<double>(stack, ip);
                     ip += 3;
                     break;
 
@@ -1164,13 +1420,7 @@ MAIN_LOOP:
                 {
                     int base = (*ip == INTOP_CALL_HELPER_PP) ? 2 : 3;
 
-                    size_t helperDirectOrIndirect = (size_t)pMethod->pDataItems[ip[base]];
-                    HELPER_FTN_PP helperFtn = nullptr;
-                    if (helperDirectOrIndirect & INTERP_INDIRECT_HELPER_TAG)
-                        helperFtn = *(HELPER_FTN_PP *)(helperDirectOrIndirect & ~INTERP_INDIRECT_HELPER_TAG);
-                    else
-                        helperFtn = (HELPER_FTN_PP)helperDirectOrIndirect;
-
+                    HELPER_FTN_PP helperFtn = GetPossiblyIndirectHelper<HELPER_FTN_PP>(pMethod->pDataItems[ip[base]]);
                     void* helperArg = pMethod->pDataItems[ip[base + 1]];
 
                     // This can call either native or compiled managed code. For an interpreter
@@ -1400,12 +1650,7 @@ CALL_INTERP_METHOD:
                     int dreg = ip[1];
                     int sreg = ip[2];
                     MethodTable *pMT = (MethodTable*)pMethod->pDataItems[ip[3]];
-                    size_t helperDirectOrIndirect = (size_t)pMethod->pDataItems[ip[4]];
-                    HELPER_FTN_BOX_UNBOX helper = nullptr;
-                    if (helperDirectOrIndirect & INTERP_INDIRECT_HELPER_TAG)
-                        helper = *(HELPER_FTN_BOX_UNBOX *)(helperDirectOrIndirect & ~INTERP_INDIRECT_HELPER_TAG);
-                    else
-                        helper = (HELPER_FTN_BOX_UNBOX)helperDirectOrIndirect;
+                    HELPER_FTN_BOX_UNBOX helper = GetPossiblyIndirectHelper<HELPER_FTN_BOX_UNBOX>(pMethod->pDataItems[ip[4]]);
 
                     if (opcode == INTOP_BOX) {
                         // internal static object Box(MethodTable* typeMT, ref byte unboxedData)
@@ -1431,12 +1676,7 @@ CALL_INTERP_METHOD:
                         COMPlusThrow(kArgumentOutOfRangeException);
 
                     CORINFO_CLASS_HANDLE arrayClsHnd = (CORINFO_CLASS_HANDLE)pMethod->pDataItems[ip[3]];
-                    size_t helperDirectOrIndirect = (size_t)pMethod->pDataItems[ip[4]];
-                    HELPER_FTN_NEWARR helper = nullptr;
-                    if (helperDirectOrIndirect & INTERP_INDIRECT_HELPER_TAG)
-                        helper = *(HELPER_FTN_NEWARR *)(helperDirectOrIndirect & ~INTERP_INDIRECT_HELPER_TAG);
-                    else
-                        helper = (HELPER_FTN_NEWARR)helperDirectOrIndirect;
+                    HELPER_FTN_NEWARR helper = GetPossiblyIndirectHelper<HELPER_FTN_NEWARR>(pMethod->pDataItems[ip[4]]);
 
                     Object* arr = helper(arrayClsHnd, (intptr_t)length);
                     LOCAL_VAR(ip[1], OBJECTREF) = ObjectToOBJECTREF(arr);
@@ -1792,12 +2032,7 @@ do {                                                                           \
                 {
                     int dreg = ip[1];
                     void *nativeHandle = pMethod->pDataItems[ip[3]];
-                    size_t helperDirectOrIndirect = (size_t)pMethod->pDataItems[ip[2]];
-                    HELPER_FTN_PP helper = nullptr;
-                    if (helperDirectOrIndirect & INTERP_INDIRECT_HELPER_TAG)
-                        helper = *(HELPER_FTN_PP *)(helperDirectOrIndirect & ~INTERP_INDIRECT_HELPER_TAG);
-                    else
-                        helper = (HELPER_FTN_PP)helperDirectOrIndirect;
+                    HELPER_FTN_PP helper = GetPossiblyIndirectHelper<HELPER_FTN_PP>(pMethod->pDataItems[ip[2]]);
                     void *managedHandle = helper(nativeHandle);
                     LOCAL_VAR(dreg, void*) = managedHandle;
                     ip += 4;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -212,10 +212,10 @@ template <typename TSource> static void ConvOvfFpHelperI64(int8_t *stack, const 
 {
     static_assert(!std::numeric_limits<TSource>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles");
 
-	const double two63  = 2147483648.0 * 4294967296.0;
+    const double two63  = 2147483648.0 * 4294967296.0;
     // First, promote the source value to double
     double src = LOCAL_VAR(ip[2], TSource),
-        // Define the boundary values we need to be between (see mono_try_trunc_i64)
+        // Define the boundary values we need to be between (see System.Math.ConvertToInt64Checked)
         minValue = (-two63 - 0x402),
         maxValue = two63;
 
@@ -234,7 +234,7 @@ template <typename TSource> static void ConvOvfFpHelperU64(int8_t *stack, const 
 
     // First, promote the source value to double
     double src = LOCAL_VAR(ip[2], TSource),
-        // Define the boundary values we need to be between (see mono_try_trunc_u64)
+        // Define the boundary values we need to be between (see System.Math.ConvertToUInt64Checked)
         minValue = -1.0,
         maxValue = 4294967296.0 * 4294967296.0;
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -171,9 +171,9 @@ template <typename TResult, typename TSource> static void ConvFpHelper(int8_t *s
         result = 0;
     else if (src >= maxValue)
         result = std::numeric_limits<TResult>::max();
-    else if (std::numeric_limits<TResult>::is_signed && (src <= -1))
+    else if (!std::numeric_limits<TResult>::is_signed && (src <= -1))
         result = 0;
-    else if (!std::numeric_limits<TResult>::is_signed && (src < minValue))
+    else if (std::numeric_limits<TResult>::is_signed && (src < minValue))
         result = std::numeric_limits<TResult>::lowest();
     else
         result = (TResult)src;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -196,9 +196,9 @@ template <typename TResult, typename TSource> static void ConvOvfFpHelper(int8_t
 
     // (src != src) checks for NaN, then we check whether the min and max values properly bound the source value
     // We assume that we are in round-towards-zero mode
-    bool outOfRange = (src != src) || (src <= minValue) || (src >= maxValue);
+    bool inRange = (src > minValue) && (src < maxValue);
 
-    if (outOfRange)
+    if (!inRange)
         COMPlusThrow(kOverflowException);
 
     TResult truncated = (TResult)src;
@@ -212,7 +212,7 @@ template <typename TSource> static void ConvOvfFpHelperI64(int8_t *stack, const 
 {
     static_assert(!std::numeric_limits<TSource>::is_integer, "ConvOvfFpHelper is only for use on floats and doubles");
 
-    const double two63  = 2147483648.0 * 4294967296.0;
+    const double two63 = 2147483648.0 * 4294967296.0;
     // First, promote the source value to double
     double src = LOCAL_VAR(ip[2], TSource),
         // Define the boundary values we need to be between (see System.Math.ConvertToInt64Checked)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -93,8 +93,6 @@ typedef void* (*HELPER_FTN_PP)(void*);
 typedef void* (*HELPER_FTN_BOX_UNBOX)(MethodTable*, void*);
 typedef Object* (*HELPER_FTN_NEWARR)(CORINFO_CLASS_HANDLE, intptr_t);
 typedef void* (*HELPER_FTN_PP_2)(void*, void*);
-typedef int32_t (*HELPER_FTN_R82I4)(double);
-typedef int64_t (*HELPER_FTN_R82I8)(double);
 
 InterpThreadContext::InterpThreadContext()
 {
@@ -198,7 +196,7 @@ template <typename TResult, typename TSource> static void ConvOvfFpHelper(int8_t
 
     // (src != src) checks for NaN, then we check whether the min and max values properly bound the source value
     // We assume that we are in round-towards-zero mode
-    bool outOfRange = (src != src) || (src < minValue) || (src > maxValue);
+    bool outOfRange = (src != src) || (src <= minValue) || (src >= maxValue);
 
     if (outOfRange)
         COMPlusThrow(kOverflowException);

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -8,6 +8,11 @@
 #include "interpexec.h"
 #include "callstubgenerator.h"
 
+// HACK: debugreturn.h breaks constexpr which is used by <limits>
+#if defined(debug_instrumented_return) || defined(_DEBUGRETURN_H_)
+#undef return
+#endif // debug_instrumented_return
+
 // for numeric_limits
 #include <limits>
 


### PR DESCRIPTION
* Implemented most possible forms of CONV_OVF_xxx opcodes in native C++
* Moved the existing CONV_xxx opcodes that do float->int conversions into native C++ as well
* Refactored uses of INTERP_INDIRECT_HELPER_TAG to use a helper to strip the tag in one place instead of duplicating the tag logic everywhere
* Added new InterpOp type for possibly indirect helper pointers