### PR TITLE
Fix NativeAOT outer loop test failure

### DIFF
--- a/src/coreclr/runtime/amd64/AllocFast.S
+++ b/src/coreclr/runtime/amd64/AllocFast.S
@@ -236,7 +236,7 @@ LEAF_ENTRY RhpNewPtrArrayFast, _TEXT
         // Delegate overflow handling to the generic helper conservatively
 
         cmp         rsi, (0x40000000 / 8) // sizeof(void*)
-        jae         C_FUNC(RhpNewVariableSizeObject)
+        jae         C_FUNC(RhpNewArrayFast)
 
         // In this case we know the element size is sizeof(void *), or 8 for x64
         // This helps us in two ways - we can shift instead of multiplying, and

--- a/src/coreclr/runtime/amd64/AllocFast.asm
+++ b/src/coreclr/runtime/amd64/AllocFast.asm
@@ -190,7 +190,7 @@ LEAF_ENTRY RhpNewPtrArrayFast, _TEXT
         ; Delegate overflow handling to the generic helper conservatively
 
         cmp         rdx, (40000000h / 8) ; sizeof(void*)
-        jae         RhpNewVariableSizeObject
+        jae         RhpNewArrayFast
 
         ; In this case we know the element size is sizeof(void *), or 8 for x64
         ; This helps us in two ways - we can shift instead of multiplying, and

--- a/src/coreclr/runtime/arm/AllocFast.S
+++ b/src/coreclr/runtime/arm/AllocFast.S
@@ -353,7 +353,7 @@ LEAF_ENTRY RhpNewPtrArrayFast, _TEXT
 
 LOCAL_LABEL(RhpNewPtrArrayFast_RarePath):
         NEW_ARRAY_FAST_TAIL_EPILOG
-        b           C_FUNC(RhpNewVariableSizeObject)
+        b           C_FUNC(RhpNewArrayFast)
 LEAF_END RhpNewPtrArrayFast, _TEXT
 
 

--- a/src/coreclr/runtime/arm64/AllocFast.S
+++ b/src/coreclr/runtime/arm64/AllocFast.S
@@ -222,7 +222,7 @@ LOCAL_LABEL(ArraySizeOverflow):
 #if defined(__APPLE__)
         bhs         1f
 #else
-        bhs         C_FUNC(RhpNewVariableSizeObject)
+        bhs         C_FUNC(RhpNewArrayFast)
 #endif
 
         // In this case we know the element size is sizeof(void *), or 8 for arm64

--- a/src/coreclr/runtime/arm64/AllocFast.asm
+++ b/src/coreclr/runtime/arm64/AllocFast.asm
@@ -200,7 +200,7 @@ ArraySizeOverflow
 
         mov         x2, #(0x40000000 / 8) ; sizeof(void*)
         cmp         x1, x2
-        bhs         RhpNewVariableSizeObject
+        bhs         RhpNewArrayFast
 
         ; In this case we know the element size is sizeof(void *), or 8 for arm64
         ; This helps us in two ways - we can shift instead of multiplying, and

--- a/src/coreclr/runtime/i386/AllocFast.S
+++ b/src/coreclr/runtime/i386/AllocFast.S
@@ -219,7 +219,7 @@ LEAF_ENTRY RhpNewPtrArrayFast, _TEXT
         // Delegate overflow handling to the generic helper conservatively
 
         cmp         edx, (0x40000000 / 4) // sizeof(void*)
-        jae         RhpNewVariableSizeObject
+        jae         RhpNewArrayFast
 
         // In this case we know the element size is sizeof(void *), or 4 for x86
         // This helps us in two ways - we can shift instead of multiplying, and

--- a/src/coreclr/runtime/i386/AllocFast.asm
+++ b/src/coreclr/runtime/i386/AllocFast.asm
@@ -211,7 +211,7 @@ FASTCALL_FUNC   RhpNewPtrArrayFast, 8
         ; Delegate overflow handling to the generic helper conservatively
 
         cmp         edx, (40000000h / 4) ; sizeof(void*)
-        jae         @RhpNewVariableSizeObject@8
+        jae         @RhpNewArrayFast@8
 
         ; In this case we know the element size is sizeof(void *), or 4 for x86
         ; This helps us in two ways - we can shift instead of multiplying, and

--- a/src/coreclr/runtime/loongarch64/AllocFast.S
+++ b/src/coreclr/runtime/loongarch64/AllocFast.S
@@ -199,7 +199,7 @@ LOCAL_LABEL(ArraySizeOverflow):
         // Delegate overflow handling to the generic helper conservatively
 
         li.w  $a2, (0x40000000 / 8) // sizeof(void*)
-        bgeu  $a1, $a2, C_FUNC(RhpNewVariableSizeObject)
+        bgeu  $a1, $a2, C_FUNC(RhpNewArrayFast)
 
         // In this case we know the element size is sizeof(void *), or 8 for arm64
         // This helps us in two ways - we can shift instead of multiplying, and

--- a/src/coreclr/runtime/riscv64/AllocFast.S
+++ b/src/coreclr/runtime/riscv64/AllocFast.S
@@ -233,7 +233,7 @@ LOCAL_LABEL(ArraySizeOverflow):
         // Delegate overflow handling to the generic helper conservatively
 
         li          t0, (0x40000000 / 8) // sizeof(void*)
-        bgeu        a1, t0, C_FUNC(RhpNewVariableSizeObject)
+        bgeu        a1, t0, C_FUNC(RhpNewArrayFast)
 
         // In this case we know the element size is sizeof(void *), or 8 for arm64
         // This helps us in two ways - we can shift instead of multiplying, and


### PR DESCRIPTION
The optimized path introduced in #116290 skipped error handling that's required for native AOT.