### PR TITLE
Correct sequence point comment

### DIFF
--- a/src/coreclr/inc/cordebuginfo.h
+++ b/src/coreclr/inc/cordebuginfo.h
@@ -27,7 +27,7 @@ public:
         NO_BOUNDARIES           = 0x00,     // No implicit boundaries
         STACK_EMPTY_BOUNDARIES  = 0x01,     // Boundary whenever the IL evaluation stack is empty
         NOP_BOUNDARIES          = 0x02,     // Before every CEE_NOP instruction
-        CALL_SITE_BOUNDARIES    = 0x04,     // Before every CEE_CALL, CEE_CALLVIRT, etc instruction
+        CALL_SITE_BOUNDARIES    = 0x04,     // After every CEE_CALL, CEE_CALLVIRT, etc instruction
 
         // Set of boundaries that debugger should always reasonably ask the JIT for.
         DEFAULT_BOUNDARIES      = STACK_EMPTY_BOUNDARIES | NOP_BOUNDARIES | CALL_SITE_BOUNDARIES


### PR DESCRIPTION
The sequence points fall after the CALL instructions, not before. Fixing the misleading code comment.