### PR TITLE
Upgrade Ubuntu 20.04 buildtools containers

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -21,11 +21,6 @@ extends:
         env:
           ROOTFS_DIR: /crossrootfs/arm
 
-      linux_armv6:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-cross-armv6-raspbian-10
-        env:
-          ROOTFS_DIR: /crossrootfs/armv6
-
       linux_arm64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64
         env:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -170,7 +170,7 @@ jobs:
 
     # WASI
     - ${{ if eq(parameters.platform, 'wasi_wasm') }}:
-      - (Ubuntu.2004.Amd64)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-wasm-amd64
+      - (Ubuntu.2204.Amd64)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-webassembly
 
     # Browser WebAssembly
     - ${{ if eq(parameters.platform, 'browser_wasm') }}:


### PR DESCRIPTION
* Updates the WASM Helix image from 20.04 to 22.04 due to EOL: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1449
* Removes the linux_armv6 container entry since it's unused