### PR TITLE
remove x86 ICF special handling

### DIFF
--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -3132,22 +3132,6 @@ void StackFrameIterator::PostProcessingForManagedFrames(void)
     m_exInfoWalk.WalkToPosition(GetRegdisplaySP(m_crawl.pRD), (m_flags & POPFRAMES));
 #endif // ELIMINATE_FEF
 
-#ifdef TARGET_X86
-#ifdef FEATURE_EH_FUNCLETS
-    bool hasReversePInvoke = false;
-    if (!m_crawl.codeInfo.IsFunclet())
-    {
-        hdrInfo *gcHdrInfo;
-        m_crawl.codeInfo.DecodeGCHdrInfo(&gcHdrInfo);
-        hasReversePInvoke = gcHdrInfo->revPInvokeOffset != INVALID_REV_PINVOKE_OFFSET;
-    }
-#else
-    hdrInfo *gcHdrInfo;
-    m_crawl.codeInfo.DecodeGCHdrInfo(&gcHdrInfo);
-    bool hasReversePInvoke = gcHdrInfo->revPInvokeOffset != INVALID_REV_PINVOKE_OFFSET;
-#endif // FEATURE_EH_FUNCLETS
-#endif // TARGET_X86
-
     ProcessIp(GetControlPC(m_crawl.pRD));
 
     // if we have unwound to a native stack frame, stop and set the frame state accordingly

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2992,12 +2992,7 @@ BOOL StackFrameIterator::CheckForSkippedFrames(void)
             m_crawl.pFunc->IsILStub() &&
             m_crawl.pFunc->AsDynamicMethodDesc()->HasMDContextArg();
 
-        if (fHandleSkippedFrames
-#ifdef TARGET_X86
-            || // On x86 we have already reported the InlinedCallFrame, don't report it again.
-            (InlinedCallFrame::FrameHasActiveCall(m_crawl.pFrame) && !fReportInteropMD)
-#endif // TARGET_X86
-            )
+        if (fHandleSkippedFrames)
         {
             m_crawl.GotoNextFrame();
 #ifdef STACKWALKER_MAY_POP_FRAMES
@@ -3161,18 +3156,6 @@ void StackFrameIterator::PostProcessingForManagedFrames(void)
         m_frameState = SFITER_NATIVE_MARKER_FRAME;
         m_crawl.isNativeMarker = true;
     }
-#ifdef TARGET_X86
-    else if (hasReversePInvoke)
-    {
-        // The managed frame we've unwound from had reverse PInvoke frame. Since we are on a frameless
-        // frame, that means that the method was called from managed code without any native frames in between.
-        // On x86, the InlinedCallFrame of the pinvoke would get skipped as we've just unwound to the pinvoke IL stub and
-        // for this architecture, the inlined call frames are supposed to be processed before the managed frame they are stored in.
-        // So we force the stack frame iterator to process the InlinedCallFrame before the IL stub.
-        _ASSERTE(InlinedCallFrame::FrameHasActiveCall(m_crawl.pFrame));
-        m_crawl.isFrameless = false;
-    }
-#endif
 } // StackFrameIterator::PostProcessingForManagedFrames()
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
Based on comments in https://github.com/dotnet/runtime/pull/116072

I ran against the diagnostics tests, looks like no regressions.

## Sample Trace
**main**
```
OS Thread Id: 0x9228 (0)
Child SP       IP Call Site
02F79CBC 772e970c [InlinedCallFrame: 02f79cbc] Interop+Kernel32.g____PInvoke|43_0(IntPtr, Byte*, Int32, Int32*, IntPtr)
02F79CA0 08d9d119 Interop+Kernel32.ReadFile(IntPtr, Byte*, Int32, Int32 ByRef, IntPtr) [C:\Users\maxcharlamb\source\reposA\runtime\artifacts\obj\System.Console\Release\net10.0-windows\Microsoft.Interop.LibraryImportGenerator\Microsoft.Interop.LibraryImportGenerator\LibraryImports.g.cs @ 412]
02F79D18 08d9d02b System.ConsolePal+WindowsConsoleStream.ReadFileNative(IntPtr, System.Span`1, Boolean, Int32 ByRef, Boolean) [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\ConsolePal.Windows.cs @ 1223]
02F79D50 08d9cf7f System.ConsolePal+WindowsConsoleStream.Read(System.Span`1) [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\ConsolePal.Windows.cs @ 1181]
02F79D78 08d9cee9 System.IO.ConsoleStream.Read(Byte[], Int32, Int32) [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\IO\ConsoleStream.cs @ 34]
02F79D98 65ab96eb System.IO.StreamReader.ReadBuffer()
02F79DB0 65ab9b3e System.IO.StreamReader.ReadLine()
02F79DFC 08d9ce62 System.IO.SyncTextReader.ReadLine() [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\IO\SyncTextReader.cs @ 77]
02F79E18 08d9c7d8 System.Console.ReadLine() [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\Console.cs @ 727]
02F79E24 08d9bab9 NibbleMapReplacement.C1.Block() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 379]
02F79E5C 08d9ba0b NibbleMapReplacement.C1.M2() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 269]
02F7A358 69ba3393 [InlinedCallFrame: 02f7a358] 
02F7A340 65a2aaf4 System.Runtime.EH.DispatchEx(System.Runtime.StackFrameIterator ByRef, ExInfo ByRef)
02F7A3D0 65a2a606 System.Runtime.EH.RhThrowEx(System.Object, ExInfo ByRef)
02F7B800 69ba2c77 [SoftwareExceptionFrame: 02f7b800] 
02F7BB5C 08d9b9f7 NibbleMapReplacement.C1.M2() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 265]
02F7BB70 08d9b98a NibbleMapReplacement.C1.F2(System.Exception) [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 372]
02F7BB88 08d9b924 NibbleMapReplacement.C1.M4() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 291]
02F7BE24 69ba33b2 [InlinedCallFrame: 02f7be24] 
02F7BE14 65a2acee System.Runtime.EH.FindFirstPassHandler(System.Object, UInt32, System.Runtime.StackFrameIterator ByRef, UInt32 ByRef, Byte* ByRef)
02F7BEBC 65a2a91b System.Runtime.EH.DispatchEx(System.Runtime.StackFrameIterator ByRef, ExInfo ByRef)
02F7BF3C 65a2a606 System.Runtime.EH.RhThrowEx(System.Object, ExInfo ByRef)
02F7D36C 69ba2c77 [SoftwareExceptionFrame: 02f7d36c] 
02F7D6C8 08d9b8e5 NibbleMapReplacement.C1.M4() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 289]
02F7D6F8 08d9b839 NibbleMapReplacement.C1.U1(IntPtr, Int32) [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 357]
02F7D738 08d9b734 [InlinedCallFrame: 02f7d738] 
02F7D730 08d9b734 ILStubClass.IL_STUB_PInvoke(IntPtr, Int32)
02F7D788 08d9b6b4 NibbleMapReplacement.C1.M5() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 301]
02F7DFE8 69ba2c77 [InlinedCallFrame: 02f7dfe8] 
02F7DFD4 65a64d4e System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(System.Object, IntPtr*)
02F7E038 65a64e03 System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(System.Object, System.Reflection.BindingFlags)
02F7E050 65a72a0b System.Reflection.RuntimeMethodInfo.Invoke(System.Object, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)
02F7E08C 65a64824 System.Reflection.MethodBase.Invoke(System.Object, System.Object[])
02F7E098 08d9b63e NibbleMapReplacement.C1.M6() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 308]
02F7E0B8 08d9b597 NibbleMapReplacement.Program.Main(System.String[]) [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 33]
```

**pr**
```
OS Thread Id: 0x9228 (0)
Child SP       IP Call Site
02F79CBC 772e970c [InlinedCallFrame: 02f79cbc] Interop+Kernel32.g____PInvoke|43_0(IntPtr, Byte*, Int32, Int32*, IntPtr)
02F79CBC 08d9d119 [InlinedCallFrame: 02f79cbc] Interop+Kernel32.g____PInvoke|43_0(IntPtr, Byte*, Int32, Int32*, IntPtr)
02F79CA0 08d9d119 Interop+Kernel32.ReadFile(IntPtr, Byte*, Int32, Int32 ByRef, IntPtr) [C:\Users\maxcharlamb\source\reposA\runtime\artifacts\obj\System.Console\Release\net10.0-windows\Microsoft.Interop.LibraryImportGenerator\Microsoft.Interop.LibraryImportGenerator\LibraryImports.g.cs @ 412]
02F79D18 08d9d02b System.ConsolePal+WindowsConsoleStream.ReadFileNative(IntPtr, System.Span`1, Boolean, Int32 ByRef, Boolean) [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\ConsolePal.Windows.cs @ 1223]
02F79D50 08d9cf7f System.ConsolePal+WindowsConsoleStream.Read(System.Span`1) [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\ConsolePal.Windows.cs @ 1181]
02F79D78 08d9cee9 System.IO.ConsoleStream.Read(Byte[], Int32, Int32) [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\IO\ConsoleStream.cs @ 34]
02F79D98 65ab96eb System.IO.StreamReader.ReadBuffer()
02F79DB0 65ab9b3e System.IO.StreamReader.ReadLine()
02F79DFC 08d9ce62 System.IO.SyncTextReader.ReadLine() [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\IO\SyncTextReader.cs @ 77]
02F79E18 08d9c7d8 System.Console.ReadLine() [C:\Users\maxcharlamb\source\reposA\runtime\src\libraries\System.Console\src\System\Console.cs @ 727]
02F79E24 08d9bab9 NibbleMapReplacement.C1.Block() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 379]
02F79E5C 08d9ba0b NibbleMapReplacement.C1.M2() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 269]
02F7A358 69ba3393 [InlinedCallFrame: 02f7a358] 
02F7A358 65a2aaf4 [InlinedCallFrame: 02f7a358] 
02F7A340 65a2aaf4 System.Runtime.EH.DispatchEx(System.Runtime.StackFrameIterator ByRef, ExInfo ByRef)
02F7A3D0 65a2a606 System.Runtime.EH.RhThrowEx(System.Object, ExInfo ByRef)
02F7B800 69ba2c77 [SoftwareExceptionFrame: 02f7b800] 
02F7BB5C 08d9b9f7 NibbleMapReplacement.C1.M2() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 265]
02F7BB70 08d9b98a NibbleMapReplacement.C1.F2(System.Exception) [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 372]
02F7BB88 08d9b924 NibbleMapReplacement.C1.M4() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 291]
02F7BE24 69ba33b2 [InlinedCallFrame: 02f7be24] 
02F7BE24 65a2acee [InlinedCallFrame: 02f7be24] 
02F7BE14 65a2acee System.Runtime.EH.FindFirstPassHandler(System.Object, UInt32, System.Runtime.StackFrameIterator ByRef, UInt32 ByRef, Byte* ByRef)
02F7BEBC 65a2a91b System.Runtime.EH.DispatchEx(System.Runtime.StackFrameIterator ByRef, ExInfo ByRef)
02F7BF3C 65a2a606 System.Runtime.EH.RhThrowEx(System.Object, ExInfo ByRef)
02F7D36C 69ba2c77 [SoftwareExceptionFrame: 02f7d36c] 
02F7D6C8 08d9b8e5 NibbleMapReplacement.C1.M4() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 289]
02F7D6F8 08d9b839 NibbleMapReplacement.C1.U1(IntPtr, Int32) [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 357]
02F7D738 08d9b734 [InlinedCallFrame: 02f7d738] 
02F7D738 08d9b734 ILStubClass.IL_STUB_PInvoke(IntPtr, Int32)
02F7D788 08d9b6b4 NibbleMapReplacement.C1.M5() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 301]
02F7DFE8 69ba2c77 [InlinedCallFrame: 02f7dfe8] 
02F7DFE8 65a64d4e [InlinedCallFrame: 02f7dfe8] 
02F7DFD4 65a64d4e System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(System.Object, IntPtr*)
02F7E038 65a64e03 System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(System.Object, System.Reflection.BindingFlags)
02F7E050 65a72a0b System.Reflection.RuntimeMethodInfo.Invoke(System.Object, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)
02F7E08C 65a64824 System.Reflection.MethodBase.Invoke(System.Object, System.Object[])
02F7E098 08d9b63e NibbleMapReplacement.C1.M6() [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 308]
02F7E0B8 08d9b597 NibbleMapReplacement.Program.Main(System.String[]) [C:\Users\maxcharlamb\source\repos\NibbleMapReplacement\Program.cs @ 33]
```