### PR TITLE
Fix minidump generation - check if IsIL before calling methods related to it

### DIFF
--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1208,7 +1208,7 @@ COR_ILMETHOD* MethodDesc::GetILHeader()
     // Always pickup overrides like reflection emit, EnC, etc.
     TADDR pIL = pModule->GetDynamicIL(GetMemberDef());
 
-    if (pIL == (TADDR)NULL && !IsNDirect())
+    if (pIL == (TADDR)NULL)
     {
         pIL = pModule->GetIL(GetRVA());
     }
@@ -3763,18 +3763,21 @@ MethodDesc::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 
 #ifdef FEATURE_CODE_VERSIONING
     // Make sure the active IL and native code version are in triage dumps.
-    CodeVersionManager* pCodeVersionManager = GetCodeVersionManager();
-    ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(dac_cast<PTR_MethodDesc>(this));
-    if (!ilVersion.IsNull())
-    {
-        EX_TRY
+    if (IsIL())
+    {    
+        CodeVersionManager* pCodeVersionManager = GetCodeVersionManager();
+        ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(dac_cast<PTR_MethodDesc>(this));
+        if (!ilVersion.IsNull())
         {
-            ilVersion.GetActiveNativeCodeVersion(dac_cast<PTR_MethodDesc>(this));
-            ilVersion.GetVersionId();
-            ilVersion.GetRejitState();
-            ilVersion.GetIL();
+            EX_TRY
+            {
+                ilVersion.GetActiveNativeCodeVersion(dac_cast<PTR_MethodDesc>(this));
+                ilVersion.GetVersionId();
+                ilVersion.GetRejitState();
+                ilVersion.GetIL();
+            }
+            EX_CATCH_RETHROW_ONLY_COR_E_OPERATIONCANCELLED
         }
-        EX_CATCH_RETHROW_ONLY_COR_E_OPERATIONCANCELLED
     }
 #endif
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1208,7 +1208,7 @@ COR_ILMETHOD* MethodDesc::GetILHeader()
     // Always pickup overrides like reflection emit, EnC, etc.
     TADDR pIL = pModule->GetDynamicIL(GetMemberDef());
 
-    if (pIL == (TADDR)NULL)
+    if (pIL == (TADDR)NULL && !IsNDirect())
     {
         pIL = pModule->GetIL(GetRVA());
     }


### PR DESCRIPTION
Check if IsIL before calling the things related to active IL and native code version.