### PR TITLE
NativeAOT: Unhijack thread in sampling profiler before starting stack walk

### DIFF
--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -68,6 +68,12 @@ PInvokeTransitionFrame* Thread::GetTransitionFrameForStackTrace()
     return m_pDeferredTransitionFrame;
 }
 
+PInvokeTransitionFrame* Thread::GetTransitionFrameForSampling()
+{
+    CrossThreadUnhijack();
+    return GetTransitionFrame();
+}
+
 void Thread::WaitForGC(PInvokeTransitionFrame* pTransitionFrame)
 {
     ASSERT(!IsDoNotTriggerGcSet());

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -320,7 +320,7 @@ public:
     bool                IsCurrentThreadInCooperativeMode();
 
     PInvokeTransitionFrame* GetTransitionFrameForStackTrace();
-    PInvokeTransitionFrame* GetTransitionFrameForSampling() { return GetTransitionFrame(); }
+    PInvokeTransitionFrame* GetTransitionFrameForSampling();
     void *              GetCurrentThreadPInvokeReturnAddress();
 
     //


### PR DESCRIPTION
Fixes #116407