### PR TITLE
Exclude tail call counts from check to prevent unnecessary EBP frame

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -6443,10 +6443,10 @@ void Compiler::compCompileFinish()
         {
             // clang-format off
             headerPrinted = true;
-            printf("         |  Profiled   | Method   |   Method has    |   calls   | Num |LclV |AProp| CSE |   Perf  |bytes | %3s codesize| \n", Target::g_tgtCPUName);
-            printf(" mdToken |  CNT |  RGN |    Hash  | EH | FRM | LOOP | NRM | IND | BBs | Cnt | Cnt | Cnt |  Score  |  IL  |   HOT | CLD | method name \n");
+            printf("         |  Profiled   | Method   |   Method has    |      calls      | Num |LclV |AProp| CSE |   Perf  |bytes | %3s codesize| \n", Target::g_tgtCPUName);
+            printf(" mdToken |  CNT |  RGN |    Hash  | EH | FRM | LOOP | NRM | IND | FTL | BBs | Cnt | Cnt | Cnt |  Score  |  IL  |   HOT | CLD | method name \n");
             printf("---------+------+------+----------+----+-----+------+-----+-----+-----+-----+-----+-----+---------+------+-------+-----+\n");
-            //      06001234 | 1234 |  HOT | 0f1e2d3c | EH | ebp | LOOP |  15 |   6 |  12 |  17 |  12 |   8 | 1234.56 |  145 |  1234 | 123 | System.Example(int)
+            //      06001234 | 1234 |  HOT | 0f1e2d3c | EH | ebp | LOOP |  15 |   6 |   0 |  12 |  17 |  12 |   8 | 1234.56 |  145 |  1234 | 123 | System.Example(int)
             // clang-format on
         }
 
@@ -6540,6 +6540,7 @@ void Compiler::compCompileFinish()
 
         printf(" %3d |", optCallCount);
         printf(" %3d |", optIndirectCallCount);
+        printf(" %3d |", optFastTailCallCount);
         printf(" %3d |", Metrics.BasicBlocksAtCodegen);
         printf(" %3d |", lvaCount);
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -6443,10 +6443,10 @@ void Compiler::compCompileFinish()
         {
             // clang-format off
             headerPrinted = true;
-            printf("         |  Profiled   | Method   |   Method has    |      calls      | Num |LclV |AProp| CSE |   Perf  |bytes | %3s codesize| \n", Target::g_tgtCPUName);
-            printf(" mdToken |  CNT |  RGN |    Hash  | EH | FRM | LOOP | NRM | IND | FTL | BBs | Cnt | Cnt | Cnt |  Score  |  IL  |   HOT | CLD | method name \n");
+            printf("         |  Profiled   | Method   |   Method has    |   calls   | Num |LclV |AProp| CSE |   Perf  |bytes | %3s codesize| \n", Target::g_tgtCPUName);
+            printf(" mdToken |  CNT |  RGN |    Hash  | EH | FRM | LOOP | NRM | IND | BBs | Cnt | Cnt | Cnt |  Score  |  IL  |   HOT | CLD | method name \n");
             printf("---------+------+------+----------+----+-----+------+-----+-----+-----+-----+-----+-----+---------+------+-------+-----+\n");
-            //      06001234 | 1234 |  HOT | 0f1e2d3c | EH | ebp | LOOP |  15 |   6 |   0 |  12 |  17 |  12 |   8 | 1234.56 |  145 |  1234 | 123 | System.Example(int)
+            //      06001234 | 1234 |  HOT | 0f1e2d3c | EH | ebp | LOOP |  15 |   6 |  12 |  17 |  12 |   8 | 1234.56 |  145 |  1234 | 123 | System.Example(int)
             // clang-format on
         }
 
@@ -6540,7 +6540,6 @@ void Compiler::compCompileFinish()
 
         printf(" %3d |", optCallCount);
         printf(" %3d |", optIndirectCallCount);
-        printf(" %3d |", optFastTailCallCount);
         printf(" %3d |", Metrics.BasicBlocksAtCodegen);
         printf(" %3d |", lvaCount);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7094,6 +7094,7 @@ protected:
     unsigned optCallCount = 0;         // number of calls made in the method
     unsigned optIndirectCallCount = 0; // number of virtual, interface and indirect calls made in the method
     unsigned optNativeCallCount = 0;   // number of Pinvoke/Native calls made in the method
+    unsigned optFastTailCallCount = 0; // number of fast tail calls made in the method
 
 #ifdef DEBUG
     void optCheckPreds();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7091,10 +7091,11 @@ public:
     bool fgHasLoops = false;
 
 protected:
-    unsigned optCallCount = 0;         // number of calls made in the method
-    unsigned optIndirectCallCount = 0; // number of virtual, interface and indirect calls made in the method
-    unsigned optNativeCallCount = 0;   // number of Pinvoke/Native calls made in the method
-    unsigned optFastTailCallCount = 0; // number of fast tail calls made in the method
+    unsigned optCallCount = 0;                 // number of calls made in the method
+    unsigned optIndirectCallCount = 0;         // number of virtual, interface and indirect calls made in the method
+    unsigned optNativeCallCount = 0;           // number of Pinvoke/Native calls made in the method
+    unsigned optFastTailCallCount = 0;         // number of fast tail calls made in the method
+    unsigned optIndirectFastTailCallCount = 0; // number of indirect (see above) fast tail calls made in the method
 
 #ifdef DEBUG
     void optCheckPreds();

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6370,15 +6370,15 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
     //
     if (fgGlobalMorph)
     {
-        if (call->IsFastTailCall())
-        {
-            optCallCount++;
-            optFastTailCallCount++;
-        }
-        else if (call->gtCallType == CT_INDIRECT)
+        if (call->gtCallType == CT_INDIRECT)
         {
             optCallCount++;
             optIndirectCallCount++;
+            if (call->IsFastTailCall())
+            {
+                optFastTailCallCount++;
+                optIndirectFastTailCallCount++;
+            }
         }
         else if (call->gtCallType == CT_USER_FUNC)
         {
@@ -6386,6 +6386,14 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             if (call->IsVirtual())
             {
                 optIndirectCallCount++;
+            }
+            if (call->IsFastTailCall())
+            {
+                optFastTailCallCount++;
+                if (call->IsVirtual())
+                {
+                    optIndirectFastTailCallCount++;
+                }
             }
         }
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6370,16 +6370,15 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
     //
     if (fgGlobalMorph)
     {
-        if (call->gtCallType == CT_INDIRECT)
+        if (call->IsFastTailCall())
         {
             optCallCount++;
-            // Do not count the tailcall morphed from fgMorphCall ->
-            // fgMorphPotentialTailCall -> fgMorphCall as indirect call
-            // to prevent forcing EBP frame later.
-            if ((call->gtCallMoreFlags & GTF_CALL_M_TAILCALL) == 0)
-            {
-                optIndirectCallCount++;
-            }
+            optFastTailCallCount++;
+        }
+        else if (call->gtCallType == CT_INDIRECT)
+        {
+            optCallCount++;
+            optIndirectCallCount++;
         }
         else if (call->gtCallType == CT_USER_FUNC)
         {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6373,7 +6373,13 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         if (call->gtCallType == CT_INDIRECT)
         {
             optCallCount++;
-            optIndirectCallCount++;
+            // Do not count the tailcall morphed from fgMorphCall ->
+            // fgMorphPotentialTailCall -> fgMorphCall as indirect call
+            // to prevent forcing EBP frame later.
+            if ((call->gtCallMoreFlags & GTF_CALL_M_TAILCALL) == 0)
+            {
+                optIndirectCallCount++;
+            }
         }
         else if (call->gtCallType == CT_USER_FUNC)
         {

--- a/src/coreclr/jit/regalloc.cpp
+++ b/src/coreclr/jit/regalloc.cpp
@@ -136,12 +136,12 @@ bool Compiler::rpMustCreateEBPFrame(INDEBUG(const char** wbReason))
         INDEBUG(reason = "Method has Loops");
         result = true;
     }
-    if (!result && (optCallCount >= 2))
+    if (!result && (optCallCount >= optFastTailCallCount + 2))
     {
         INDEBUG(reason = "Call Count");
         result = true;
     }
-    if (!result && (optIndirectCallCount >= 1))
+    if (!result && (optIndirectCallCount >= optIndirectFastTailCallCount + 1))
     {
         INDEBUG(reason = "Indirect Call");
         result = true;


### PR DESCRIPTION
This is common pattern in IL stubs. The SPMI diffs are likely to be small but there's something on linux-x64 and linux-arm.

https://github.com/dotnet/runtime/blob/0a1fb707fda0d7677d1e9a1c345f45fc2c52d40c/src/coreclr/jit/regalloc.cpp#L144-L148