### PR TITLE
Fix trigger for linkable-framework label policy

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1676,10 +1676,7 @@ configuration:
       - payloadType: Pull_Request
       - or:
         - filesMatchPattern:
-            pattern: .*ILLink.*
-            matchAny: true
-        - filesMatchPattern:
-            pattern: .*illink.*
+            pattern: (?i).*ILLink.*
             matchAny: true
       - not:
           hasLabel:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1677,8 +1677,10 @@ configuration:
       - or:
         - filesMatchPattern:
             pattern: .*ILLink.*
+            matchAny: true
         - filesMatchPattern:
             pattern: .*illink.*
+            matchAny: true
       - not:
           hasLabel:
             label: linkable-framework
@@ -1693,8 +1695,10 @@ configuration:
       - or:
         - filesMatchPattern:
             pattern: .*ILLink.*
+            matchAny: true
         - filesMatchPattern:
             pattern: .*illink.*
+            matchAny: true
       - not:
           hasLabel:
             label: linkable-framework

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -1691,10 +1691,7 @@ configuration:
       - payloadType: Pull_Request
       - or:
         - filesMatchPattern:
-            pattern: .*ILLink.*
-            matchAny: true
-        - filesMatchPattern:
-            pattern: .*illink.*
+            pattern: (?i).*ILLink.*
             matchAny: true
       - not:
           hasLabel:


### PR DESCRIPTION
Add `matchAny: true` to the policy. This will make sure that the policy does not triggers on empty PR and that the policy triggers when the PR contains any `*ILLink*` files