### PR TITLE
[release/9.0-staging] [mono][interp] Minor SSA fixes

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -8981,6 +8981,10 @@ mono_ee_interp_init (const char *opts)
 	set_context (NULL);
 
 	interp_parse_options (opts);
+
+	const char *env_opts = g_getenv ("MONO_INTERPRETER_OPTIONS");
+	if (env_opts)
+		interp_parse_options (env_opts);
 	/* Don't do any optimizations if running under debugger */
 	if (mini_get_debug_options ()->mdb_optimizations)
 		mono_interp_opt = 0;

--- a/src/mono/mono/mini/interp/transform-opt.c
+++ b/src/mono/mono/mini/interp/transform-opt.c
@@ -3402,9 +3402,11 @@ interp_super_instructions (TransformData *td)
 		current_liveness.bb_dfs_index = bb->dfs_index;
 		current_liveness.ins_index = 0;
 		for (InterpInst *ins = bb->first_ins; ins != NULL; ins = ins->next) {
-			int opcode = ins->opcode;
+			int opcode;
 			if (bb->dfs_index >= td->bblocks_count_no_eh || bb->dfs_index == -1 || (ins->flags & INTERP_INST_FLAG_LIVENESS_MARKER))
 				current_liveness.ins_index++;
+retry_ins:
+			opcode = ins->opcode;
 			if (MINT_IS_NOP (opcode))
 				continue;
 
@@ -3803,9 +3805,7 @@ interp_super_instructions (TransformData *td)
 								g_print ("superins: ");
 								interp_dump_ins (ins, td->data_items);
 							}
-							// The newly added opcode could be part of further superinstructions. Retry
-							ins = ins->prev;
-							continue;
+							goto retry_ins;
 						}
 					}
 				}

--- a/src/mono/mono/mini/interp/transform-opt.c
+++ b/src/mono/mono/mini/interp/transform-opt.c
@@ -3124,6 +3124,7 @@ retry_instruction:
 						ins->data [2] = GINT_TO_UINT16 (ldsize);
 
 						interp_clear_ins (ins->prev);
+						td->var_values [ins->dreg].def = ins;
 					}
 					if (td->verbose_level) {
 						g_print ("Replace ldloca/ldobj_vt pair :\n\t");
@@ -3204,6 +3205,7 @@ retry_instruction:
 						ins->data [2] = vtsize;
 
 						interp_clear_ins (ins->prev);
+						td->var_values [ins->dreg].def = ins;
 
 						// MINT_MOV_DST_OFF doesn't work if dreg is allocated at the same location as the
 						// field value to be stored, because its behavior is not atomic in nature. We first


### PR DESCRIPTION
This PR is a backport of two low risk fixes for interpreter SSA, one observed on customer provided sample and another fix for issue observed from local testing from our test suites. In addition, this includes support for a configuration env var, to enable users to disable SSA optimizations if they run into additional issues.

More conservative approach to https://github.com/dotnet/runtime/pull/116250

## Customer Impact

- [x] Customer reported
- [ ] Found internally

This is currently impacting users of Maui on iOS, resulting in application crash. Multiple users reported crashes in https://github.com/dotnet/runtime/issues/115991

## Regression

- [X] Yes
- [ ] No

SSA optimization for interpreter was introduced in .NET9 so it is a regression from .NET8.

## Testing

Tested on sample projects where the issues occurred. Normal CI testing plus CI testing with tiering disabled to ensure these fixes don't cause regressions. 

## Risk

Low. The fixes are very localized.