### PR TITLE
Fix ILLink check for function pointer equality

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -174,6 +174,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task FunctionPointerDataflow ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task GenericParameterDataFlow ()
 		{
 			return RunTest ();

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/TypeForwardingTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/TypeForwardingTests.g.cs
@@ -58,6 +58,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task NestedTypeForwarder ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task SecurityAttributeScope ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/WarningsTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/WarningsTests.g.cs
@@ -98,6 +98,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task MultipleMethodsUseSameAsyncStateMachine ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task NoWarnRegardlessOfWarnAsError ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FunctionPointerDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FunctionPointerDataflow.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SetupCompileArgument ("/unsafe")]
+	[Kept]
+	[ExpectedNoWarnings]
+	unsafe class FunctionPointerDataflow
+	{
+		public static void Main ()
+		{
+			UseFnPtr ();
+		}
+
+		[Kept]
+		static unsafe delegate*<void> fnptr1;
+		[Kept]
+		static unsafe delegate*<void> fnptr2;
+
+		[Kept]
+		[ExpectedWarning ("IL2026", nameof (RUC))]
+		static unsafe void UseFnPtr (bool b = true)
+		{
+			delegate*<void> f = fnptr1;
+			if (b) {
+				f = fnptr2;
+			}
+			f ();
+			RUC ();
+		}
+
+		[Kept]
+		[KeptAttributeAttribute (typeof (RequiresUnreferencedCodeAttribute))]
+		[RequiresUnreferencedCode ("")]
+		static void RUC () { }
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/113031 by implementing the missing case for function pointers.

Another way to fix it would be to avoid going down this path, since we shouldn't need to track function pointer values. Since we currently don't have a choke point to avoid creating typed dataflow values for types we don't care about (note this is different than the `IsTypeInterestingForDataflow` check, since we do need to track integers for example), I thought the simpler fix was to just implement equality.