### PR TITLE
Do not run SVE when HWIntrinsic is OFF

### DIFF
--- a/docs/workflow/testing/coreclr/disasm-checks.md
+++ b/docs/workflow/testing/coreclr/disasm-checks.md
@@ -84,11 +84,12 @@ Functionality that has been added or moved to SuperFileCheck:
 - `<check-prefix>-FULL-LINE:` - same as using FileCheck's `<check-prefix>:`, but checks that the line matches exactly; leading and trailing whitespace is ignored.
 - `<check-prefix>-FULL-LINE-NEXT:` - same as using FileCheck's `<check-prefix>-NEXT:`, but checks that the line matches exactly; leading and trailing whitespace is ignored.
 # Test Run Limitations
-1. Disasm checks will not run if these environment variables are set:
+1. Disasm checks will not work if these environment variables are set. The infrastructure need to be updated to skip disasm checks when these environment variables are present.
 - `DOTNET_JitStress`
 - `DOTNET_JitStressRegs`
 - `DOTNET_TailcallStress`
 - `DOTNET_TieredPGO`
+- `DOTNET_EnableHWIntrinsic=0`
 2. Disasm checks will not run under GCStress test modes.
 3. Disasm checks will not run under heap-verify test modes.
 4. Disasm checks will not run under cross-gen2 test modes.

--- a/src/tests/JIT/opt/SVE/PredicateInstructions.csproj
+++ b/src/tests/JIT/opt/SVE/PredicateInstructions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PredicateInstructions.cs">
-      <HasDisasmCheck>true</HasDisasmCheck>
+      <HasDisasmCheck Condition="'$(DOTNET_EnableHWIntrinsic)' != '0' and '$(DOTNET_EnableArm64Sve)' != '0'">true</HasDisasmCheck>
     </Compile>
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
     <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />

--- a/src/tests/JIT/opt/SVE/PredicateInstructions.csproj
+++ b/src/tests/JIT/opt/SVE/PredicateInstructions.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PredicateInstructions.cs">
-      <HasDisasmCheck Condition="'$(DOTNET_EnableHWIntrinsic)' != '0' and '$(DOTNET_EnableArm64Sve)' != '0'">true</HasDisasmCheck>
+      <HasDisasmCheck>true</HasDisasmCheck>
     </Compile>
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
     <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_EnableHWIntrinsic" Value="1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/116248

Thanks @snickolls-arm for suggesting the fix in https://github.com/dotnet/runtime/issues/116248#issuecomment-2949536656