### PR TITLE
Fix a couple error cases in Json parsing

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -548,7 +548,7 @@ namespace System.Text.Json
             {
                 _bytePositionInLine += FindMismatch(span, literal);
 
-                int amountToWrite = Math.Min(span.Length, (int)_bytePositionInLine + 1);
+                int amountToWrite = AmountToWrite(span, _bytePositionInLine, readSoFar, written);
                 span.Slice(0, amountToWrite).CopyTo(readSoFar);
                 written += amountToWrite;
                 goto Throw;
@@ -558,7 +558,7 @@ namespace System.Text.Json
                 if (!literal.StartsWith(span))
                 {
                     _bytePositionInLine += FindMismatch(span, literal);
-                    int amountToWrite = Math.Min(span.Length, (int)_bytePositionInLine + 1);
+                    int amountToWrite = AmountToWrite(span, _bytePositionInLine, readSoFar, written);
                     span.Slice(0, amountToWrite).CopyTo(readSoFar);
                     written += amountToWrite;
                     goto Throw;
@@ -605,7 +605,7 @@ namespace System.Text.Json
                     {
                         _bytePositionInLine += FindMismatch(span, leftToMatch);
 
-                        amountToWrite = Math.Min(span.Length, (int)_bytePositionInLine + 1);
+                        amountToWrite = AmountToWrite(span, _bytePositionInLine, readSoFar, written);
                         span.Slice(0, amountToWrite).CopyTo(readSoFar.Slice(written));
                         written += amountToWrite;
 
@@ -615,6 +615,13 @@ namespace System.Text.Json
                     leftToMatch = leftToMatch.Slice(span.Length);
                     alreadyMatched = span.Length;
                 }
+            }
+
+            static int AmountToWrite(ReadOnlySpan<byte> span, long bytePositionInLine, ReadOnlySpan<byte> readSoFar, int written)
+            {
+                return Math.Min(
+                    readSoFar.Length - written,
+                    Math.Min(span.Length, (int)bytePositionInLine + 1));
             }
         Throw:
             _totalConsumed = prevTotalConsumed;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateOnlyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateOnlyConverter.cs
@@ -45,8 +45,8 @@ namespace System.Text.Json.Serialization.Converters
                 Span<byte> stackSpan = stackalloc byte[MaxEscapedFormatLength];
                 int bytesWritten = reader.CopyString(stackSpan);
 
-                // CopyString can unescape which can change the length, so we need to perform the range check again.
-                if (!JsonHelpers.IsInRangeInclusive(bytesWritten, FormatLength, MaxEscapedFormatLength))
+                // CopyString can unescape which can change the length, so we need to perform the length check again.
+                if (bytesWritten < FormatLength)
                 {
                     ThrowHelper.ThrowFormatException(DataType.DateOnly);
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateOnlyConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateOnlyConverter.cs
@@ -47,12 +47,14 @@ namespace System.Text.Json.Serialization.Converters
                 source = stackSpan.Slice(0, bytesWritten);
             }
 
-            if (!JsonHelpers.TryParseAsIso(source, out DateOnly value))
+            if (JsonHelpers.IsInRangeInclusive(source.Length, FormatLength, MaxEscapedFormatLength) &&
+                JsonHelpers.TryParseAsIso(source, out DateOnly value))
             {
-                ThrowHelper.ThrowFormatException(DataType.DateOnly);
+                return value;
             }
 
-            return value;
+            ThrowHelper.ThrowFormatException(DataType.DateOnly);
+            return default;
         }
 
         public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonTestHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonTestHelper.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.Json.Tests;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
@@ -227,6 +228,11 @@ namespace System.Text.Json
                 sequences.Add(sequence);
             }
             return sequences;
+        }
+
+        public static ReadOnlySequence<byte> GetSequence(IEnumerable<byte[]> json)
+        {
+            return BufferFactory.Create(json.ToArray());
         }
 
         internal static ReadOnlySequence<byte> SegmentInto(ReadOnlyMemory<byte> data, int segmentCount)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
@@ -650,6 +650,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("[]", false)]
         [InlineData("true", false)]
         [InlineData("null", false)]
+        [InlineData("05-1\\u0000", true)] // String length 10 before unescaping, less than 10 after escaping
         public static void DateOnly_Read_Failure(string json, bool addQuotes = true)
         {
             if (addQuotes)


### PR DESCRIPTION
Found a couple edge cases where `ArgumentException` would be thrown instead of a cleaner `JsonException`.

1. `DateOnlyConverter` didn't check the input length after doing escaping
2. `Utf8JsonReader.MultiSegment` was trying to copy a larger span into a smaller span in a couple edge cases