### PR TITLE
Bump SDK version used by WASM since it was broken by dotnet/arcade codeflow

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -263,7 +263,7 @@
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- sdk version, for testing workloads -->
     <!-- <SdkVersionForWorkloadTesting>$(MicrosoftDotNetApiCompatTaskVersion)</SdkVersionForWorkloadTesting> -->
-    <SdkVersionForWorkloadTesting>9.0.105</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>9.0.106</SdkVersionForWorkloadTesting>
     <runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>9.0.0-alpha.1.24175.1</runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
     <EmsdkPackageVersion>$(MicrosoftNETRuntimeEmscriptenVersion)</EmsdkPackageVersion>
     <NodePackageVersion>$(runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion)</NodePackageVersion>


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/pull/115677#issuecomment-2957080374.