### PR TITLE
Fix stresslog facility and log level mix-up.

### DIFF
--- a/src/coreclr/gc/env/gcenv.h
+++ b/src/coreclr/gc/env/gcenv.h
@@ -57,7 +57,7 @@
 
 #define STRESS_LOG_WRITE(facility, level, msg, ...) do {                            \
             if (StressLog::LogOn(facility, level))                                  \
-                StressLog::LogMsg(facility, level, StressLogMsg(msg, __VA_ARGS__)); \
+                StressLog::LogMsg(level, facility, StressLogMsg(msg, __VA_ARGS__)); \
             LOG((facility, level, msg, __VA_ARGS__));                               \
             } while(0)
 

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -75,7 +75,7 @@
 
 #define STRESS_LOG0(facility, level, msg) do {                                      \
             if (StressLog::StressLogOn(facility, level))                            \
-                StressLog::LogMsg(facility, level, 0, msg);                         \
+                StressLog::LogMsg(level, facility, 0, msg);                         \
             } while(0)
 
 #define STRESS_LOG1(facility, level, msg, data1) \


### PR DESCRIPTION
As part of commit:

https://github.com/dotnet/runtime/commit/6bd555eefd41282282da4c5dfe28b8600946b744

some stress log macro implementations got changed, but the call to StressLog::LogMsg in gcenv.h and stresslog.h got level and facility arguments switched, leading to no logging when these macros are used.

PR restore the order of the level and facility arguments in call to StressLog::LogMsg.