### PR TITLE
Skip SSL key log test for OpenSSL 3.5+

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -25,6 +25,7 @@ namespace System.Net.Security.Tests
         [PlatformSpecific(TestPlatforms.Linux)] // SSLKEYLOGFILE is only supported on Linux for SslStream
         [InlineData(true)]
         [InlineData(false)]
+        //[ActiveIssue("https://github.com/dotnet/runtime/issues/116473")]
         public async Task SslKeyLogFile_IsCreatedAndFilled(bool enabledBySwitch)
         {
             if (PlatformDetection.IsDebugLibrary(typeof(SslStream).Assembly) && !enabledBySwitch)
@@ -34,7 +35,7 @@ namespace System.Net.Security.Tests
                 return;
             }
 
-            if (PlatformDetection.IsOpenSslSupported && PlatformDetection.OpenSslVersion >= new Version(3, 5, 0))
+            if (PlatformDetection.IsOpenSsl3_5)
             {
                 // OpenSSL 3.5 and later versions log into file in SSLKEYLOGFILE environment variable by default,
                 // regardless of AppContext switch.

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -34,6 +34,13 @@ namespace System.Net.Security.Tests
                 return;
             }
 
+            if (PlatformDetection.IsOpenSslSupported && PlatformDetection.OpenSslVersion >= new Version(3, 5, 0))
+            {
+                // OpenSSL 3.5 and later versions log into file in SSLKEYLOGFILE environment variable by default,
+                // regardless of AppContext switch.
+                return;
+            }
+
             var psi = new ProcessStartInfo();
             var tempFile = Path.GetTempFileName();
             psi.Environment.Add("SSLKEYLOGFILE", tempFile);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -35,7 +35,7 @@ namespace System.Net.Security.Tests
                 return;
             }
 
-            if (PlatformDetection.IsOpenSsl3_5)
+            if (PlatformDetection.IsOpenSsl3_5 && !enabledBySwitch)
             {
                 // OpenSSL 3.5 and later versions log into file in SSLKEYLOGFILE environment variable by default,
                 // regardless of AppContext switch.


### PR DESCRIPTION
## Context
OpenSSL 3.5.0 supports SSLKEYLOGFILE with just an environment variable, which is less strict than .NET's requirements. There's no way to check if this feature is enabled in the OpenSSL library, so we should disable the test based on the OpenSSL version for now.

### Affected tests
`System.Net.Security.Tests.SslStreamRemoteExecutorTests.SslKeyLogFile_IsCreatedAndFilled`

### Testing
Fix verified on previously stable failing CentOS 10 docker image `mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-helix-amd64`

### Notes
#116473 has been create to revisit it in future, lets say a year