### PR TITLE
Fix BulkType event for GC static bases

### DIFF
--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -200,7 +200,7 @@ public:
     MethodTable* GetNonArrayBaseType()
     {
         ASSERT(!IsArray());
-        return PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_pRelatedParameterType));
+        return PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_pBaseType));
     }
 
     bool IsValueType()

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -197,6 +197,12 @@ public:
 
     MethodTable * GetRelatedParameterType();
 
+    MethodTable* GetNonArrayBaseType()
+    {
+        ASSERT(!IsArray());
+        return PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_pRelatedParameterType));
+    }
+
     bool IsValueType()
         { return GetElementType() < ElementType_Class; }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -101,7 +101,8 @@ namespace ILCompiler.DependencyAnalysis
             totalSize = Math.Max(totalSize, _target.PointerSize * 3); // minimum GC MethodTable size is 3 pointers
             dataBuilder.EmitInt(totalSize);
 
-            // Related type: System.Object. This allows storing an instance of this type in an array of objects.
+            // Related type: System.Object. This allows storing an instance of this type in an array of objects,
+            // or finding associated module from BulkType event source events.
             dataBuilder.EmitPointerReloc(factory.NecessaryTypeSymbol(factory.TypeSystemContext.GetWellKnownType(WellKnownType.Object)));
 
             return dataBuilder.ToObjectData();


### PR DESCRIPTION
.NET Native had extra code to handle this but it ended up under a ProjectN ifdef and that (unsurprisingly) got deleted:

https://github.com/dotnet/corert/blob/c2cc114e704bcf7a6af57d67b1e9e92d85eea1d2/src/Native/Runtime/rheventtrace.cpp#L200-L218

The `We will not be able to get the osModuleHandle for these` comment is more recent (#94673) but that approach will not work because event pipe consumers won't know what to do with these.

So restore .NET Native behavior (in spirit - we deleted most of the code the .NET native implementation relied on).

Cc @dotnet/ilc-contrib 