### PR TITLE
Revert "Make mutable generic collection interfaces implement read-only collection interfaces" and related changes

### DIFF
--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -962,14 +962,29 @@ MethodDesc* GetActualImplementationForArrayGenericIListOrIReadOnlyListMethod(Met
     }
     CONTRACTL_END
 
+    int slot = pItfcMeth->GetSlot();
+
+    // We need to pick the right starting method depending on the depth of the inheritance chain
+    static const BinderMethodID startingMethod[] = {
+        METHOD__SZARRAYHELPER__GETENUMERATOR,   // First method of IEnumerable`1
+        METHOD__SZARRAYHELPER__GET_COUNT,       // First method of ICollection`1/IReadOnlyCollection`1
+        METHOD__SZARRAYHELPER__GET_ITEM         // First method of IList`1/IReadOnlyList`1
+    };
+
     // Subtract one for the non-generic IEnumerable that the generic enumerable inherits from
     unsigned int inheritanceDepth = pItfcMeth->GetMethodTable()->GetNumInterfaces() - 1;
+    _ASSERTE(0 <= inheritanceDepth && inheritanceDepth < ARRAY_SIZE(startingMethod));
 
-    MethodDesc *pGenericImplementor = MemberLoader::FindMethodByName(g_pSZArrayHelperClass, pItfcMeth->GetName());
+    MethodDesc *pGenericImplementor = CoreLibBinder::GetMethod((BinderMethodID)(startingMethod[inheritanceDepth] + slot));
+
+    // The most common reason for this assert is that the order of the SZArrayHelper methods in
+    // corelib.h does not match the order they are implemented on the generic interfaces.
+    _ASSERTE(pGenericImplementor == MemberLoader::FindMethodByName(g_pSZArrayHelperClass, pItfcMeth->GetName()));
 
     // OPTIMIZATION: For any method other than GetEnumerator(), we can safely substitute
     // "Object" for reference-type theT's. This causes fewer methods to be instantiated.
-    if (inheritanceDepth != 0 && !theT.IsValueType())
+    if (startingMethod[inheritanceDepth] != METHOD__SZARRAYHELPER__GETENUMERATOR &&
+        !theT.IsValueType())
     {
         theT = TypeHandle(g_pObjectClass);
     }

--- a/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
+++ b/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
@@ -35,22 +35,14 @@ namespace System.Diagnostics
             int size = count / (sizeof(ulong) * 8) + 1;
             BitMapper bitMapper = new BitMapper((uint)size <= 100 ? stackalloc ulong[size] : new ulong[size]);
 
-#if NET10_0_OR_GREATER // ICollection<T> : IReadOnlyCollection<T> on .NET 10+
-            if (tags2 is IReadOnlyCollection<KeyValuePair<string, object?>> tagsCol)
-#else
             if (tags2 is ICollection<KeyValuePair<string, object?>> tagsCol)
-#endif
             {
                 if (tagsCol.Count != count)
                 {
                     return false;
                 }
 
-#if NET10_0_OR_GREATER // IList<T> : IReadOnlyList<T> on .NET 10+
-                if (tagsCol is IReadOnlyList<KeyValuePair<string, object?>> secondList)
-#else
                 if (tagsCol is IList<KeyValuePair<string, object?>> secondList)
-#endif
                 {
                     for (int i = 0; i < count; i++)
                     {

--- a/src/libraries/Common/tests/System/Collections/CollectionAsserts.cs
+++ b/src/libraries/Common/tests/System/Collections/CollectionAsserts.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -10,151 +9,6 @@ namespace System.Collections.Tests
 {
     internal static class CollectionAsserts
     {
-        public static void HasCount<T>(ICollection<T> collection, int count)
-        {
-            Assert.Equal(count, collection.Count);
-#if !NETFRAMEWORK
-            IReadOnlyCollection<T> readOnlyCollection = collection;
-            Assert.Equal(count, readOnlyCollection.Count);
-#endif
-        }
-
-        public static void EqualAt<T>(IList<T> list, int index, T expected)
-        {
-            Assert.Equal(expected, list[index]);
-#if !NETFRAMEWORK
-            IReadOnlyList<T> readOnlyList = list;
-            Assert.Equal(expected, readOnlyList[index]);
-#endif
-        }
-
-        public static void NotEqualAt<T>(IList<T> list, int index, T expected)
-        {
-            Assert.NotEqual(expected, list[index]);
-#if !NETFRAMEWORK
-            IReadOnlyList<T> readOnlyList = list;
-            Assert.NotEqual(expected, readOnlyList[index]);
-#endif
-        }
-
-        public static void ThrowsElementAt<T>(IList<T> list, int index, Type exceptionType)
-        {
-            Assert.Throws(exceptionType, () => list[index]);
-#if !NETFRAMEWORK
-            IReadOnlyList<T> readOnlyList = list;
-            Assert.Throws(exceptionType, () => readOnlyList[index]);
-#endif
-        }
-
-        public static void ElementAtSucceeds<T>(IList<T> list, int index)
-        {
-            T result = list[index];
-#if !NETFRAMEWORK
-            IReadOnlyList<T> readOnlyList = list;
-            Assert.Equal(result, readOnlyList[index]);
-#endif
-        }
-
-        public static void EqualAt<TKey, TValue>(IDictionary<TKey, TValue> dictionary, TKey key, TValue expected)
-        {
-            Assert.Equal(expected, dictionary[key]);
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-            Assert.Equal(expected, readOnlyDictionary[key]);
-#endif
-        }
-
-        public static void ContainsKey<TKey, TValue>(IDictionary<TKey, TValue> dictionary, TKey key, bool expected)
-        {
-            Assert.Equal(expected, dictionary.ContainsKey(key));
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-            Assert.Equal(expected, readOnlyDictionary.ContainsKey(key));
-#endif
-        }
-
-        public static void TryGetValue<TKey, TValue>(IDictionary<TKey, TValue> dictionary, TKey key, bool expected, TValue expectedValue = default)
-        {
-            Assert.Equal(expected, dictionary.TryGetValue(key, out TValue value));
-            if (expected)
-            {
-                Assert.Equal(expectedValue, value);
-            }
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-            Assert.Equal(expected, readOnlyDictionary.TryGetValue(key, out value));
-            if (expected)
-            {
-                Assert.Equal(expectedValue, value);
-            }
-#endif
-        }
-
-        public static void Contains<T>(ISet<T> set, T expected)
-        {
-            Assert.True(set.Contains(expected));
-#if !NETFRAMEWORK
-            ICollection<T> collection = set;
-            Assert.True(collection.Contains(expected));
-            IReadOnlySet<T> readOnlySet = set;
-            Assert.True(readOnlySet.Contains(expected));
-#endif
-        }
-
-        public static void IsProperSubsetOf<T>(ISet<T> set, IEnumerable<T> enumerable, bool expected)
-        {
-            Assert.Equal(expected, set.IsProperSubsetOf(enumerable));
-#if !NETFRAMEWORK
-            IReadOnlySet<T> readOnlySet = set;
-            Assert.Equal(expected, readOnlySet.IsProperSubsetOf(enumerable));
-#endif
-        }
-
-        public static void IsProperSupersetOf<T>(ISet<T> set, IEnumerable<T> enumerable, bool expected)
-        {
-            Assert.Equal(expected, set.IsProperSupersetOf(enumerable));
-#if !NETFRAMEWORK
-            IReadOnlySet<T> readOnlySet = set;
-            Assert.Equal(expected, readOnlySet.IsProperSupersetOf(enumerable));
-#endif
-        }
-
-        public static void IsSubsetOf<T>(ISet<T> set, IEnumerable<T> enumerable, bool expected)
-        {
-            Assert.Equal(expected, set.IsSubsetOf(enumerable));
-#if !NETFRAMEWORK
-            IReadOnlySet<T> readOnlySet = set;
-            Assert.Equal(expected, readOnlySet.IsSubsetOf(enumerable));
-#endif
-        }
-
-        public static void IsSupersetOf<T>(ISet<T> set, IEnumerable<T> enumerable, bool expected)
-        {
-            Assert.Equal(expected, set.IsSupersetOf(enumerable));
-#if !NETFRAMEWORK
-            IReadOnlySet<T> readOnlySet = set;
-            Assert.Equal(expected, readOnlySet.IsSupersetOf(enumerable));
-#endif
-        }
-
-        public static void Overlaps<T>(ISet<T> set, IEnumerable<T> enumerable, bool expected)
-        {
-            Assert.Equal(expected, set.Overlaps(enumerable));
-#if !NETFRAMEWORK
-            IReadOnlySet<T> readOnlySet = set;
-            Assert.Equal(expected, readOnlySet.Overlaps(enumerable));
-#endif
-        }
-
-        public static void SetEquals<T>(ISet<T> set, IEnumerable<T> enumerable, bool expected)
-        {
-            Assert.Equal(expected, set.SetEquals(enumerable));
-#if !NETFRAMEWORK
-            IReadOnlySet<T> readOnlySet = set;
-            Assert.Equal(expected, readOnlySet.SetEquals(enumerable));
-#endif
-        }
-
         public static void Equal(ICollection expected, ICollection actual)
         {
             Assert.Equal(expected == null, actual == null);
@@ -189,12 +43,6 @@ namespace System.Collections.Tests
                 return;
             }
             Assert.Equal(expected.Count, actual.Count);
-#if !NETFRAMEWORK
-            IReadOnlyCollection<T> readOnlyExpected = expected;
-            Assert.Equal(expected.Count, readOnlyExpected.Count);
-            IReadOnlyCollection<T> readOnlyActual = actual;
-            Assert.Equal(actual.Count, readOnlyActual.Count);
-#endif
             IEnumerator<T> e = expected.GetEnumerator();
             IEnumerator<T> a = actual.GetEnumerator();
             while (e.MoveNext())

--- a/src/libraries/Common/tests/System/Collections/ICollection.Generic.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/ICollection.Generic.Tests.cs
@@ -130,7 +130,7 @@ namespace System.Collections.Tests
         public void ICollection_Generic_Count_Validity(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
-            CollectionAsserts.HasCount(collection, count);
+            Assert.Equal(count, collection.Count);
         }
 
         #endregion
@@ -145,7 +145,7 @@ namespace System.Collections.Tests
             {
                 ICollection<T> collection = GenericICollectionFactory(count);
                 collection.Add(default(T));
-                CollectionAsserts.HasCount(collection, count + 1);
+                Assert.Equal(count + 1, collection.Count);
             }
         }
 
@@ -161,7 +161,7 @@ namespace System.Collections.Tests
                     collection.Add(invalidValue);
                     for (int i = 0; i < count; i++)
                         collection.Add(CreateT(i));
-                    CollectionAsserts.HasCount(collection, count * 2);
+                    Assert.Equal(count * 2, collection.Count);
                 });
             }
         }
@@ -178,7 +178,7 @@ namespace System.Collections.Tests
                     collection.Add(invalidValue);
                     for (int i = 0; i < count; i++)
                         collection.Add(CreateT(i));
-                    CollectionAsserts.HasCount(collection, count);
+                    Assert.Equal(count, collection.Count);
                 });
             }
         }
@@ -192,9 +192,8 @@ namespace System.Collections.Tests
                 Assert.All(InvalidValues, invalidValue =>
                 {
                     ICollection<T> collection = GenericICollectionFactory(count);
-                    
                     collection.Add(invalidValue);
-                    CollectionAsserts.HasCount(collection, count);
+                    Assert.Equal(count, collection.Count);
                 });
             }
         }
@@ -209,7 +208,7 @@ namespace System.Collections.Tests
                 T duplicateValue = CreateT(700);
                 collection.Add(duplicateValue);
                 collection.Add(duplicateValue);
-                CollectionAsserts.HasCount(collection, count + 2);
+                Assert.Equal(count + 2, collection.Count);
             }
         }
 
@@ -222,7 +221,7 @@ namespace System.Collections.Tests
                 ICollection<T> collection = GenericICollectionFactory(count);
                 collection.Clear();
                 AddToCollection(collection, 5);
-                CollectionAsserts.HasCount(collection, 5);
+                Assert.Equal(5, collection.Count);
             }
         }
 
@@ -262,7 +261,7 @@ namespace System.Collections.Tests
                 for (int i = 0; i < count; i++)
                     collection.Remove(collection.ElementAt(0));
                 collection.Add(CreateT(254));
-                CollectionAsserts.HasCount(collection, 1);
+                Assert.Equal(1, collection.Count);
             }
         }
 
@@ -274,7 +273,7 @@ namespace System.Collections.Tests
             {
                 ICollection<T> collection = GenericICollectionFactory(count);
                 Assert.Throws<NotSupportedException>(() => collection.Add(CreateT(0)));
-                CollectionAsserts.HasCount(collection, count);
+                Assert.Equal(count, collection.Count);
             }
         }
 
@@ -307,12 +306,12 @@ namespace System.Collections.Tests
             if (IsReadOnly || AddRemoveClear_ThrowsNotSupported)
             {
                 Assert.Throws<NotSupportedException>(() => collection.Clear());
-                CollectionAsserts.HasCount(collection, count);
+                Assert.Equal(count, collection.Count);
             }
             else
             {
                 collection.Clear();
-                CollectionAsserts.HasCount(collection, 0);
+                Assert.Equal(0, collection.Count);
             }
         }
 
@@ -326,14 +325,14 @@ namespace System.Collections.Tests
                 Assert.Throws<NotSupportedException>(() => collection.Clear());
                 Assert.Throws<NotSupportedException>(() => collection.Clear());
                 Assert.Throws<NotSupportedException>(() => collection.Clear());
-                CollectionAsserts.HasCount(collection, count);
+                Assert.Equal(count, collection.Count);
             }
             else
             {
                 collection.Clear();
                 collection.Clear();
                 collection.Clear();
-                CollectionAsserts.HasCount(collection, 0);
+                Assert.Equal(0, collection.Count);
             }
         }
 
@@ -435,7 +434,7 @@ namespace System.Collections.Tests
                 T item = CreateT(12);
                 collection.Add(item);
                 collection.Add(item);
-                CollectionAsserts.HasCount(collection, count + 2);
+                Assert.Equal(count + 2, collection.Count);
             }
         }
 
@@ -568,7 +567,7 @@ namespace System.Collections.Tests
                     count--;
                 }
                 Assert.False(collection.Remove(value));
-                CollectionAsserts.HasCount(collection, count);
+                Assert.Equal(count, collection.Count);
             }
         }
 
@@ -584,7 +583,7 @@ namespace System.Collections.Tests
                 while (collection.Contains(value) || Enumerable.Contains(InvalidValues, value))
                     value = CreateT(seed++);
                 Assert.False(collection.Remove(value));
-                CollectionAsserts.HasCount(collection, count);
+                Assert.Equal(count, collection.Count);
             }
         }
 
@@ -603,7 +602,7 @@ namespace System.Collections.Tests
                     count++;
                 }
                 Assert.True(collection.Remove(value));
-                CollectionAsserts.HasCount(collection, count - 1);
+                Assert.Equal(count - 1, collection.Count);
             }
         }
 
@@ -622,7 +621,7 @@ namespace System.Collections.Tests
                     count++;
                 }
                 Assert.True(collection.Remove(value));
-                CollectionAsserts.HasCount(collection, count - 1);
+                Assert.Equal(count - 1, collection.Count);
             }
         }
 
@@ -640,7 +639,7 @@ namespace System.Collections.Tests
                 count += 2;
                 Assert.True(collection.Remove(value));
                 Assert.True(collection.Contains(value));
-                CollectionAsserts.HasCount(collection, count - 1);
+                Assert.Equal(count - 1, collection.Count);
             }
         }
 
@@ -655,7 +654,7 @@ namespace System.Collections.Tests
                 {
                     Assert.True(collection.Remove(value));
                 });
-                CollectionAsserts.HasCount(collection, 0);
+                Assert.Empty(collection);
             }
         }
 
@@ -668,7 +667,7 @@ namespace System.Collections.Tests
             {
                 Assert.Throws<ArgumentException>(() => collection.Remove(value));
             });
-            CollectionAsserts.HasCount(collection, count);
+            Assert.Equal(count, collection.Count);
         }
 
         [Theory]

--- a/src/libraries/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/IDictionary.Generic.Tests.cs
@@ -266,16 +266,12 @@ namespace System.Collections.Tests
                 if (!DefaultValueAllowed)
                 {
                     Assert.Throws<ArgumentNullException>(() => dictionary[default(TKey)]);
-#if !NETFRAMEWORK
-                    IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-                    Assert.Throws<ArgumentNullException>(() => readOnlyDictionary[default(TKey)]);
-#endif
                 }
                 else
                 {
                     TValue value = CreateTValue(3452);
                     dictionary[default(TKey)] = value;
-                    CollectionAsserts.EqualAt(dictionary, default(TKey), value);
+                    Assert.Equal(value, dictionary[default(TKey)]);
                 }
             }
         }
@@ -287,10 +283,6 @@ namespace System.Collections.Tests
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
             TKey missingKey = GetNewKey(dictionary);
             Assert.Throws<KeyNotFoundException>(() => dictionary[missingKey]);
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-            Assert.Throws<KeyNotFoundException>(() => readOnlyDictionary[missingKey]);
-#endif
         }
 
         [Theory]
@@ -304,10 +296,6 @@ namespace System.Collections.Tests
                 while (dictionary.ContainsKey(missingKey))
                     dictionary.Remove(missingKey);
                 Assert.Throws<KeyNotFoundException>(() => dictionary[missingKey]);
-#if !NETFRAMEWORK
-                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-                Assert.Throws<KeyNotFoundException>(() => readOnlyDictionary[missingKey]);
-#endif
             }
         }
 
@@ -318,7 +306,7 @@ namespace System.Collections.Tests
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
             foreach (KeyValuePair<TKey, TValue> pair in dictionary)
             {
-                CollectionAsserts.EqualAt(dictionary, pair.Key, pair.Value);
+                Assert.Equal(pair.Value, dictionary[pair.Key]);
             }
         }
 
@@ -341,7 +329,7 @@ namespace System.Collections.Tests
                 {
                     TValue value = CreateTValue(3452);
                     dictionary[default(TKey)] = value;
-                    CollectionAsserts.EqualAt(dictionary, default(TKey), value);
+                    Assert.Equal(value, dictionary[default(TKey)]);
                 }
             }
         }
@@ -367,7 +355,7 @@ namespace System.Collections.Tests
                 IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
                 TKey missingKey = GetNewKey(dictionary);
                 dictionary[missingKey] = CreateTValue(543);
-                CollectionAsserts.HasCount(dictionary, count + 1);
+                Assert.Equal(count + 1, dictionary.Count);
             }
         }
 
@@ -382,8 +370,8 @@ namespace System.Collections.Tests
                 dictionary.Add(existingKey, CreateTValue(5342));
                 TValue newValue = CreateTValue(1234);
                 dictionary[existingKey] = newValue;
-                CollectionAsserts.HasCount(dictionary, count + 1);
-                CollectionAsserts.EqualAt(dictionary, existingKey, newValue);
+                Assert.Equal(count + 1, dictionary.Count);
+                Assert.Equal(newValue, dictionary[existingKey]);
             }
         }
 
@@ -398,10 +386,6 @@ namespace System.Collections.Tests
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
             IEnumerable<TKey> expected = dictionary.Select((pair) => pair.Key);
             Assert.True(expected.SequenceEqual(dictionary.Keys));
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-            Assert.True(expected.SequenceEqual(readOnlyDictionary.Keys));
-#endif
         }
 
         [Theory]
@@ -412,10 +396,6 @@ namespace System.Collections.Tests
             {
                 IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
                 ICollection<TKey> keys = dictionary.Keys;
-#if !NETFRAMEWORK
-                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-                IEnumerable<TKey> readOnlyKeys = readOnlyDictionary.Keys;
-#endif
                 int previousCount = keys.Count;
                 if (count > 0)
                     Assert.NotEmpty(keys);
@@ -423,16 +403,10 @@ namespace System.Collections.Tests
                 if (IDictionary_Generic_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection)
                 {
                     Assert.Empty(keys);
-#if !NETFRAMEWORK
-                    Assert.Empty(readOnlyKeys);
-#endif
                 }
                 else
                 {
                     Assert.Equal(previousCount, keys.Count);
-#if !NETFRAMEWORK
-                    Assert.Equal(previousCount, readOnlyKeys.Count());
-#endif
                 }
             }
         }
@@ -446,20 +420,11 @@ namespace System.Collections.Tests
                 IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
                 ICollection<TKey> keys = dictionary.Keys;
                 IEnumerator<TKey> keysEnum = keys.GetEnumerator();
-#if !NETFRAMEWORK
-                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-                IEnumerable<TKey> readOnlyKeys = readOnlyDictionary.Keys;
-                IEnumerator<TKey> readOnlyKeysEnum = readOnlyKeys.GetEnumerator();
-#endif
                 dictionary.Add(GetNewKey(dictionary), CreateTValue(3432));
                 if (count == 0 ? Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException : IDictionary_Generic_Keys_Values_Enumeration_ThrowsInvalidOperation_WhenParentModified)
                 {
                     Assert.Throws<InvalidOperationException>(() => keysEnum.MoveNext());
                     Assert.Throws<InvalidOperationException>(() => keysEnum.Reset());
-#if !NETFRAMEWORK
-                    Assert.Throws<InvalidOperationException>(() => readOnlyKeysEnum.MoveNext());
-                    Assert.Throws<InvalidOperationException>(() => readOnlyKeysEnum.Reset());
-#endif
                 }
                 else
                 {
@@ -468,13 +433,6 @@ namespace System.Collections.Tests
                         _ = keysEnum.Current;
                     }
                     keysEnum.Reset();
-#if !NETFRAMEWORK
-                    if (readOnlyKeysEnum.MoveNext())
-                    {
-                        _ = readOnlyKeysEnum.Current;
-                    }
-                    readOnlyKeysEnum.Reset();
-#endif
                 }
             }
         }
@@ -498,25 +456,10 @@ namespace System.Collections.Tests
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
             ICollection<TKey> keys = dictionary.Keys;
             IEnumerator<TKey> enumerator = keys.GetEnumerator();
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-            IEnumerable<TKey> readOnlyKeys = readOnlyDictionary.Keys;
-            IEnumerator<TKey> readOnlyEnumerator = readOnlyKeys.GetEnumerator();
-#endif
             if (IDictionary_Generic_Keys_Values_Enumeration_ResetImplemented)
-            {
                 enumerator.Reset();
-#if !NETFRAMEWORK
-                readOnlyEnumerator.Reset();
-#endif
-            }
             else
-            {
                 Assert.Throws<NotSupportedException>(() => enumerator.Reset());
-#if !NETFRAMEWORK
-                Assert.Throws<NotSupportedException>(() => readOnlyEnumerator.Reset());
-#endif
-            }
         }
 
         #endregion
@@ -530,10 +473,6 @@ namespace System.Collections.Tests
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
             IEnumerable<TValue> expected = dictionary.Select((pair) => pair.Value);
             Assert.True(expected.SequenceEqual(dictionary.Values));
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-            Assert.True(expected.SequenceEqual(readOnlyDictionary.Values));
-#endif
         }
 
         [Theory]
@@ -552,10 +491,6 @@ namespace System.Collections.Tests
                     dictionary.Add(missingKey, pair.Value);
                 }
                 Assert.Equal(count * 2, dictionary.Values.Count);
-#if !NETFRAMEWORK
-                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-                Assert.Equal(count * 2, readOnlyDictionary.Values.Count());
-#endif
             }
         }
 
@@ -565,18 +500,9 @@ namespace System.Collections.Tests
         {
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
             ICollection<TValue> values = dictionary.Values;
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-            IEnumerable<TValue> readOnlyValues = readOnlyDictionary.Values;
-#endif
             int previousCount = values.Count;
             if (count > 0)
-            {
                 Assert.NotEmpty(values);
-#if !NETFRAMEWORK
-                Assert.NotEmpty(readOnlyValues);
-#endif
-            }
 
             if (!IsReadOnly)
             {
@@ -584,16 +510,10 @@ namespace System.Collections.Tests
                 if (IDictionary_Generic_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection)
                 {
                     Assert.Empty(values);
-#if !NETFRAMEWORK
-                    Assert.Empty(readOnlyValues);
-#endif
                 }
                 else
                 {
                     Assert.Equal(previousCount, values.Count);
-#if !NETFRAMEWORK
-                    Assert.Equal(previousCount, readOnlyValues.Count());
-#endif
                 }
             }
         }
@@ -607,20 +527,11 @@ namespace System.Collections.Tests
                 IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
                 ICollection<TValue> values = dictionary.Values;
                 IEnumerator<TValue> valuesEnum = values.GetEnumerator();
-#if !NETFRAMEWORK
-                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-                IEnumerable<TValue> readOnlyValues = readOnlyDictionary.Values;
-                IEnumerator<TValue> readOnlyValuesEnum = readOnlyValues.GetEnumerator();
-#endif
                 dictionary.Add(GetNewKey(dictionary), CreateTValue(3432));
                 if (count == 0 ? Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException : IDictionary_Generic_Keys_Values_Enumeration_ThrowsInvalidOperation_WhenParentModified)
                 {
                     Assert.Throws<InvalidOperationException>(() => valuesEnum.MoveNext());
                     Assert.Throws<InvalidOperationException>(() => valuesEnum.Reset());
-#if !NETFRAMEWORK
-                    Assert.Throws<InvalidOperationException>(() => readOnlyValuesEnum.MoveNext());
-                    Assert.Throws<InvalidOperationException>(() => readOnlyValuesEnum.Reset());
-#endif
                 }
                 else
                 {
@@ -629,13 +540,6 @@ namespace System.Collections.Tests
                         _ = valuesEnum.Current;
                     }
                     valuesEnum.Reset();
-#if !NETFRAMEWORK
-                    if (readOnlyValuesEnum.MoveNext())
-                    {
-                        _ = readOnlyValuesEnum.Current;
-                    }
-                    readOnlyValuesEnum.Reset();
-#endif
                 }
             }
         }
@@ -659,25 +563,10 @@ namespace System.Collections.Tests
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
             ICollection<TValue> values = dictionary.Values;
             IEnumerator<TValue> enumerator = values.GetEnumerator();
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-            IEnumerable<TValue> readOnlyValues = readOnlyDictionary.Values;
-            IEnumerator<TValue> readOnlyEnumerator = readOnlyValues.GetEnumerator();
-#endif
             if (IDictionary_Generic_Keys_Values_Enumeration_ResetImplemented)
-            {
                 enumerator.Reset();
-#if !NETFRAMEWORK
-                readOnlyEnumerator.Reset();
-#endif
-            }
             else
-            {
                 Assert.Throws<NotSupportedException>(() => enumerator.Reset());
-#if !NETFRAMEWORK
-                Assert.Throws<NotSupportedException>(() => readOnlyEnumerator.Reset());
-#endif
-            }
         }
 
         #endregion
@@ -705,8 +594,8 @@ namespace System.Collections.Tests
             if (DefaultValueAllowed && !IsReadOnly)
             {
                 dictionary.Add(missingKey, value);
-                CollectionAsserts.HasCount(dictionary, count + 1);
-                CollectionAsserts.EqualAt(dictionary, missingKey, value);
+                Assert.Equal(count + 1, dictionary.Count);
+                Assert.Equal(value, dictionary[missingKey]);
             }
             else if (!IsReadOnly)
             {
@@ -724,8 +613,8 @@ namespace System.Collections.Tests
             if (DefaultValueAllowed && !IsReadOnly)
             {
                 dictionary.Add(missingKey, value);
-                CollectionAsserts.HasCount(dictionary, count + 1);
-                CollectionAsserts.EqualAt(dictionary, missingKey, value);
+                Assert.Equal(count + 1, dictionary.Count);
+                Assert.Equal(value, dictionary[missingKey]);
             }
             else if (!IsReadOnly)
             {
@@ -743,8 +632,8 @@ namespace System.Collections.Tests
                 TKey missingKey = GetNewKey(dictionary);
                 TValue value = default(TValue);
                 dictionary.Add(missingKey, value);
-                CollectionAsserts.HasCount(dictionary, count + 1);
-                CollectionAsserts.EqualAt(dictionary, missingKey, value);
+                Assert.Equal(count + 1, dictionary.Count);
+                Assert.Equal(value, dictionary[missingKey]);
             }
         }
 
@@ -758,8 +647,8 @@ namespace System.Collections.Tests
                 TKey missingKey = GetNewKey(dictionary);
                 TValue value = CreateTValue(1342);
                 dictionary.Add(missingKey, value);
-                CollectionAsserts.HasCount(dictionary, count + 1);
-                CollectionAsserts.EqualAt(dictionary, missingKey, value);
+                Assert.Equal(count + 1, dictionary.Count);
+                Assert.Equal(value, dictionary[missingKey]);
             }
         }
 
@@ -777,10 +666,6 @@ namespace System.Collections.Tests
                 dictionary.Add(GetNewKey(dictionary), duplicate);
                 dictionary.Add(GetNewKey(dictionary), duplicate);
                 Assert.Equal(2, dictionary.Values.Count((value) => value.Equals(duplicate)));
-#if !NETFRAMEWORK
-                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-                Assert.Equal(2, readOnlyDictionary.Values.Count((value) => value.Equals(duplicate)));
-#endif
             }
         }
 
@@ -807,7 +692,7 @@ namespace System.Collections.Tests
                 if (dictionary != null)
                 {
                     AddToCollection(dictionary, count);
-                    CollectionAsserts.HasCount(dictionary, count);
+                    Assert.Equal(count, dictionary.Count);
                 }
             }
         }
@@ -824,7 +709,7 @@ namespace System.Collections.Tests
             {
                 IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
                 TKey missingKey = GetNewKey(dictionary);
-                CollectionAsserts.ContainsKey(dictionary, missingKey, false);
+                Assert.False(dictionary.ContainsKey(missingKey));
             }
         }
 
@@ -837,7 +722,7 @@ namespace System.Collections.Tests
                 IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
                 TKey missingKey = GetNewKey(dictionary);
                 dictionary.Add(missingKey, CreateTValue(34251));
-                CollectionAsserts.ContainsKey(dictionary, missingKey, true);
+                Assert.True(dictionary.ContainsKey(missingKey));
             }
         }
 
@@ -854,17 +739,13 @@ namespace System.Collections.Tests
                     TKey missingKey = default(TKey);
                     while (dictionary.ContainsKey(missingKey))
                         dictionary.Remove(missingKey);
-                    CollectionAsserts.ContainsKey(dictionary, missingKey, false);
+                    Assert.False(dictionary.ContainsKey(missingKey));
                 }
             }
             else
             {
                 // throws ArgumentNullException
                 Assert.Throws<ArgumentNullException>(() => dictionary.ContainsKey(default(TKey)));
-#if !NETFRAMEWORK
-                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-                Assert.Throws<ArgumentNullException>(() => readOnlyDictionary.ContainsKey(default(TKey)));
-#endif
             }
         }
 
@@ -878,7 +759,7 @@ namespace System.Collections.Tests
                 TKey missingKey = default(TKey);
                 if (!dictionary.ContainsKey(missingKey))
                     dictionary.Add(missingKey, CreateTValue(5341));
-                CollectionAsserts.ContainsKey(dictionary, missingKey, true);
+                Assert.True(dictionary.ContainsKey(missingKey));
             }
         }
 
@@ -908,7 +789,7 @@ namespace System.Collections.Tests
                 {
                     Assert.True(dictionary.Remove(key));
                 });
-                CollectionAsserts.HasCount(dictionary, 0);
+                Assert.Empty(dictionary);
             }
         }
 
@@ -921,7 +802,7 @@ namespace System.Collections.Tests
                 IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
                 TKey missingKey = GetNewKey(dictionary);
                 Assert.False(dictionary.Remove(missingKey));
-                CollectionAsserts.HasCount(dictionary, count);
+                Assert.Equal(count, dictionary.Count);
             }
         }
 
@@ -935,7 +816,7 @@ namespace System.Collections.Tests
                 TKey missingKey = GetNewKey(dictionary);
                 dictionary.Add(missingKey, CreateTValue(34251));
                 Assert.True(dictionary.Remove(missingKey));
-                CollectionAsserts.HasCount(dictionary, count);
+                Assert.Equal(count, dictionary.Count);
             }
         }
 
@@ -1028,7 +909,8 @@ namespace System.Collections.Tests
             IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
             TKey missingKey = GetNewKey(dictionary);
             TValue value = CreateTValue(5123);
-            CollectionAsserts.TryGetValue(dictionary, missingKey, false);
+            TValue outValue;
+            Assert.False(dictionary.TryGetValue(missingKey, out outValue));
         }
 
         [Theory]
@@ -1040,8 +922,10 @@ namespace System.Collections.Tests
                 IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
                 TKey missingKey = GetNewKey(dictionary);
                 TValue value = CreateTValue(5123);
+                TValue outValue;
                 dictionary.TryAdd(missingKey, value);
-                CollectionAsserts.TryGetValue(dictionary, missingKey, true, value);
+                Assert.True(dictionary.TryGetValue(missingKey, out outValue));
+                Assert.Equal(value, outValue);
             }
         }
 
@@ -1058,16 +942,12 @@ namespace System.Collections.Tests
                     TKey missingKey = default(TKey);
                     while (dictionary.ContainsKey(missingKey))
                         dictionary.Remove(missingKey);
-                    CollectionAsserts.TryGetValue(dictionary, missingKey, false);
+                    Assert.False(dictionary.TryGetValue(missingKey, out outValue));
                 }
             }
             else
             {
                 Assert.Throws<ArgumentNullException>(() => dictionary.TryGetValue(default(TKey), out outValue));
-#if !NETFRAMEWORK
-                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary = dictionary;
-                Assert.Throws<ArgumentNullException>(() => readOnlyDictionary.TryGetValue(default(TKey), out outValue));
-#endif
             }
         }
 
@@ -1080,8 +960,10 @@ namespace System.Collections.Tests
                 IDictionary<TKey, TValue> dictionary = GenericIDictionaryFactory(count);
                 TKey missingKey = default(TKey);
                 TValue value = CreateTValue(5123);
+                TValue outValue;
                 dictionary.TryAdd(missingKey, value);
-                CollectionAsserts.TryGetValue(dictionary, missingKey, true, value);
+                Assert.True(dictionary.TryGetValue(missingKey, out outValue));
+                Assert.Equal(value, outValue);
             }
         }
 

--- a/src/libraries/Common/tests/System/Collections/IList.Generic.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/IList.Generic.Tests.cs
@@ -107,10 +107,11 @@ namespace System.Collections.Tests
             Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => list[-1]);
             Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => list[int.MinValue]);
 
-            IReadOnlyList<T> rol = (IReadOnlyList<T>)list;
-            
-            Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => rol[-1]);
-            Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => rol[int.MinValue]);
+            if (list is IReadOnlyList<T> rol)
+            {
+                Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => rol[-1]);
+                Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => rol[int.MinValue]);
+            }
         }
 
         [Theory]
@@ -122,10 +123,11 @@ namespace System.Collections.Tests
             Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => list[count]);
             Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => list[count + 1]);
 
-            IReadOnlyList<T> rol = (IReadOnlyList<T>)list;
-            
-            Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => rol[count]);
-            Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => rol[count + 1]);
+            if (list is IReadOnlyList<T> rol)
+            {
+                Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => rol[count]);
+                Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => rol[count + 1]);
+            }
         }
 
         [Theory]
@@ -138,10 +140,11 @@ namespace System.Collections.Tests
             Assert.All(Enumerable.Range(0, count), index => result = list[index]);
             Assert.All(Enumerable.Range(0, count), index => Assert.Equal(list[index], list[index]));
 
-            IReadOnlyList<T> rol = (IReadOnlyList<T>)list;
-            
-            Assert.All(Enumerable.Range(0, count), index => result = rol[index]);
-            Assert.All(Enumerable.Range(0, count), index => Assert.Equal(rol[index], rol[index]));
+            if (list is IReadOnlyList<T> rol)
+            {
+                Assert.All(Enumerable.Range(0, count), index => result = rol[index]);
+                Assert.All(Enumerable.Range(0, count), index => Assert.Equal(rol[index], rol[index]));
+            }
         }
 
         #endregion
@@ -158,7 +161,7 @@ namespace System.Collections.Tests
                 T validAdd = CreateT(0);
                 Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => list[-1] = validAdd);
                 Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => list[int.MinValue] = validAdd);
-                CollectionAsserts.HasCount(list, count);
+                Assert.Equal(count, list.Count);
             }
         }
 
@@ -172,7 +175,7 @@ namespace System.Collections.Tests
                 T validAdd = CreateT(0);
                 Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => list[count] = validAdd);
                 Assert.Throws(IList_Generic_Item_InvalidIndex_ThrowType, () => list[count + 1] = validAdd);
-                CollectionAsserts.HasCount(list, count);
+                Assert.Equal(count, list.Count);
             }
         }
 
@@ -185,7 +188,7 @@ namespace System.Collections.Tests
                 IList<T> list = GenericIListFactory(count);
                 T before = list[count / 2];
                 Assert.Throws<NotSupportedException>(() => list[count / 2] = CreateT(321432));
-                CollectionAsserts.EqualAt(list, count / 2, before);
+                Assert.Equal(before, list[count / 2]);
             }
         }
 
@@ -198,7 +201,7 @@ namespace System.Collections.Tests
                 IList<T> list = GenericIListFactory(count);
                 T value = CreateT(123452);
                 list[0] = value;
-                CollectionAsserts.EqualAt(list, 0, value);
+                Assert.Equal(value, list[0]);
             }
         }
 
@@ -212,12 +215,12 @@ namespace System.Collections.Tests
                 if (DefaultValueAllowed)
                 {
                     list[0] = default(T);
-                    CollectionAsserts.EqualAt(list, 0, default(T));
+                    Assert.Equal(default(T), list[0]);
                 }
                 else
                 {
                     Assert.Throws<ArgumentNullException>(() => list[0] = default(T));
-                    CollectionAsserts.NotEqualAt(list, 0, default(T));
+                    Assert.NotEqual(default(T), list[0]);
                 }
             }
         }
@@ -232,7 +235,7 @@ namespace System.Collections.Tests
                 T value = CreateT(123452);
                 int lastIndex = count > 0 ? count - 1 : 0;
                 list[lastIndex] = value;
-                CollectionAsserts.EqualAt(list, lastIndex, value);
+                Assert.Equal(value, list[lastIndex]);
             }
         }
 
@@ -247,12 +250,12 @@ namespace System.Collections.Tests
                 if (DefaultValueAllowed)
                 {
                     list[lastIndex] = default(T);
-                    CollectionAsserts.EqualAt(list, lastIndex, default(T));
+                    Assert.Equal(default(T), list[lastIndex]);
                 }
                 else
                 {
                     Assert.Throws<ArgumentNullException>(() => list[lastIndex] = default(T));
-                    CollectionAsserts.NotEqualAt(list, lastIndex, default(T));
+                    Assert.NotEqual(default(T), list[lastIndex]);
                 }
             }
         }
@@ -267,8 +270,8 @@ namespace System.Collections.Tests
                 T value = CreateT(123452);
                 list[0] = value;
                 list[1] = value;
-                CollectionAsserts.EqualAt(list, 0, value);
-                CollectionAsserts.EqualAt(list, 1, value);
+                Assert.Equal(value, list[0]);
+                Assert.Equal(value, list[1]);
             }
         }
 
@@ -415,7 +418,7 @@ namespace System.Collections.Tests
                 T validAdd = CreateT(0);
                 Assert.Throws<ArgumentOutOfRangeException>(() => list.Insert(-1, validAdd));
                 Assert.Throws<ArgumentOutOfRangeException>(() => list.Insert(int.MinValue, validAdd));
-                CollectionAsserts.HasCount(list, count);
+                Assert.Equal(count, list.Count);
             }
         }
 
@@ -428,8 +431,8 @@ namespace System.Collections.Tests
                 IList<T> list = GenericIListFactory(count);
                 T validAdd = CreateT(12350);
                 list.Insert(count, validAdd);
-                CollectionAsserts.HasCount(list, count + 1);
-                CollectionAsserts.EqualAt(list, count, validAdd);
+                Assert.Equal(count + 1, list.Count);
+                Assert.Equal(validAdd, list[count]);
             }
         }
 
@@ -441,7 +444,7 @@ namespace System.Collections.Tests
             {
                 IList<T> list = GenericIListFactory(count);
                 Assert.Throws<NotSupportedException>(() => list.Insert(count / 2, CreateT(321432)));
-                CollectionAsserts.HasCount(list, count);
+                Assert.Equal(count, list.Count);
             }
         }
 
@@ -454,8 +457,8 @@ namespace System.Collections.Tests
                 IList<T> list = GenericIListFactory(count);
                 T value = CreateT(123452);
                 list.Insert(0, value);
-                CollectionAsserts.EqualAt(list, 0, value);
-                CollectionAsserts.HasCount(list, count + 1);
+                Assert.Equal(value, list[0]);
+                Assert.Equal(count + 1, list.Count);
             }
         }
 
@@ -468,8 +471,8 @@ namespace System.Collections.Tests
                 IList<T> list = GenericIListFactory(count);
                 T value = default(T);
                 list.Insert(0, value);
-                CollectionAsserts.EqualAt(list, 0, value);
-                CollectionAsserts.HasCount(list, count + 1);
+                Assert.Equal(value, list[0]);
+                Assert.Equal(count + 1, list.Count);
             }
         }
 
@@ -483,8 +486,8 @@ namespace System.Collections.Tests
                 T value = CreateT(123452);
                 int lastIndex = count > 0 ? count - 1 : 0;
                 list.Insert(lastIndex, value);
-                CollectionAsserts.EqualAt(list, lastIndex, value);
-                CollectionAsserts.HasCount(list, count + 1);
+                Assert.Equal(value, list[lastIndex]);
+                Assert.Equal(count + 1, list.Count);
             }
         }
 
@@ -498,8 +501,8 @@ namespace System.Collections.Tests
                 T value = default(T);
                 int lastIndex = count > 0 ? count - 1 : 0;
                 list.Insert(lastIndex, value);
-                CollectionAsserts.EqualAt(list, lastIndex, value);
-                CollectionAsserts.HasCount(list, count + 1);
+                Assert.Equal(value, list[lastIndex]);
+                Assert.Equal(count + 1, list.Count);
             }
         }
 
@@ -519,9 +522,9 @@ namespace System.Collections.Tests
                 {
                     list.Insert(0, value);
                     list.Insert(1, value);
-                    CollectionAsserts.EqualAt(list, 0, value);
-                    CollectionAsserts.EqualAt(list, 1, value);
-                    CollectionAsserts.HasCount(list, count + 2);
+                    Assert.Equal(value, list[0]);
+                    Assert.Equal(value, list[1]);
+                    Assert.Equal(count + 2, list.Count);
                 }
             }
         }
@@ -554,7 +557,7 @@ namespace System.Collections.Tests
                 T validAdd = CreateT(0);
                 Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(-1));
                 Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(int.MinValue));
-                CollectionAsserts.HasCount(list, count);
+                Assert.Equal(count, list.Count);
             }
         }
 
@@ -568,7 +571,7 @@ namespace System.Collections.Tests
                 T validAdd = CreateT(0);
                 Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(count));
                 Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(count + 1));
-                CollectionAsserts.HasCount(list, count);
+                Assert.Equal(count, list.Count);
             }
         }
 
@@ -580,7 +583,7 @@ namespace System.Collections.Tests
             {
                 IList<T> list = GenericIListFactory(count);
                 Assert.Throws<NotSupportedException>(() => list.RemoveAt(count / 2));
-                CollectionAsserts.HasCount(list, count);
+                Assert.Equal(count, list.Count);
             }
         }
 
@@ -591,11 +594,11 @@ namespace System.Collections.Tests
             if (!IsReadOnly && !AddRemoveClear_ThrowsNotSupported)
             {
                 IList<T> list = GenericIListFactory(count);
-                CollectionAsserts.HasCount(list, count);
+                Assert.Equal(count, list.Count);
                 Assert.All(Enumerable.Range(0, count).Reverse(), index =>
                 {
                     list.RemoveAt(index);
-                    CollectionAsserts.HasCount(list, index);
+                    Assert.Equal(index, list.Count);
                 });
             }
         }
@@ -610,7 +613,7 @@ namespace System.Collections.Tests
                 Assert.All(Enumerable.Range(0, count), index =>
                 {
                     list.RemoveAt(0);
-                    CollectionAsserts.HasCount(list, count - index - 1);
+                    Assert.Equal(count - index - 1, list.Count);
                 });
             }
         }

--- a/src/libraries/Common/tests/System/Collections/ISet.Generic.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/ISet.Generic.Tests.cs
@@ -84,8 +84,8 @@ namespace System.Collections.Tests
                 Assert.True(set.Add(newValue));
                 if (!DuplicateValuesAllowed)
                     Assert.False(set.Add(newValue));
-                CollectionAsserts.HasCount(set, count + 1);
-                CollectionAsserts.Contains(set, newValue);
+                Assert.Equal(count + 1, set.Count);
+                Assert.True(set.Contains(newValue));
             }
         }
 
@@ -104,7 +104,7 @@ namespace System.Collections.Tests
                         duplicateValue = CreateT(seed++);
                     collection.Add(duplicateValue);
                     collection.Add(duplicateValue);
-                    CollectionAsserts.HasCount(collection, count + 1);
+                    Assert.Equal(count + 1, collection.Count);
                 }
             }
         }
@@ -118,7 +118,7 @@ namespace System.Collections.Tests
             if (set.Count == 0 || enumerable == set)
             {
                 set.ExceptWith(enumerable);
-                CollectionAsserts.HasCount(set, 0);
+                Assert.Equal(0, set.Count);
             }
             else
             {
@@ -126,7 +126,7 @@ namespace System.Collections.Tests
                 foreach (T element in enumerable)
                     expected.Remove(element);
                 set.ExceptWith(enumerable);
-                CollectionAsserts.HasCount(set, expected.Count);
+                Assert.Equal(expected.Count, set.Count);
                 Assert.True(expected.SetEquals(set));
             }
         }
@@ -136,7 +136,7 @@ namespace System.Collections.Tests
             if (set.Count == 0 || Enumerable.Count(enumerable) == 0)
             {
                 set.IntersectWith(enumerable);
-                CollectionAsserts.HasCount(set, 0);
+                Assert.Equal(0, set.Count);
             }
             else if (set == enumerable)
             {
@@ -152,7 +152,7 @@ namespace System.Collections.Tests
                     if (enumerable.Contains(value, comparer))
                         expected.Add(value);
                 set.IntersectWith(enumerable);
-                CollectionAsserts.HasCount(set, expected.Count);
+                Assert.Equal(expected.Count, set.Count);
                 Assert.True(expected.SetEquals(set));
             }
         }
@@ -178,7 +178,7 @@ namespace System.Collections.Tests
                     break;
                 }
             }
-            CollectionAsserts.IsProperSubsetOf(set, enumerable, !setContainsValueNotInEnumerable && enumerableContainsValueNotInSet);
+            Assert.Equal(!setContainsValueNotInEnumerable && enumerableContainsValueNotInSet, set.IsProperSubsetOf(enumerable));
         }
 
         private void Validate_IsProperSupersetOf(ISet<T> set, IEnumerable<T> enumerable)
@@ -203,7 +203,7 @@ namespace System.Collections.Tests
                 }
             }
             isProperSuperset = isProperSuperset && setContainsElementsNotInEnumerable;
-            CollectionAsserts.IsProperSupersetOf(set, enumerable, isProperSuperset);
+            Assert.Equal(isProperSuperset, set.IsProperSupersetOf(enumerable));
         }
 
         private void Validate_IsSubsetOf(ISet<T> set, IEnumerable<T> enumerable)
@@ -212,10 +212,10 @@ namespace System.Collections.Tests
             foreach (T value in set)
                 if (!enumerable.Contains(value, comparer))
                 {
-                    CollectionAsserts.IsSubsetOf(set, enumerable, false);
+                    Assert.False(set.IsSubsetOf(enumerable));
                     return;
                 }
-            CollectionAsserts.IsSubsetOf(set, enumerable, true);
+            Assert.True(set.IsSubsetOf(enumerable));
         }
 
         private void Validate_IsSupersetOf(ISet<T> set, IEnumerable<T> enumerable)
@@ -224,10 +224,10 @@ namespace System.Collections.Tests
             foreach (T value in enumerable)
                 if (!set.Contains(value, comparer))
                 {
-                    CollectionAsserts.IsSupersetOf(set, enumerable, false);
+                    Assert.False(set.IsSupersetOf(enumerable));
                     return;
                 }
-            CollectionAsserts.IsSupersetOf(set, enumerable, true);
+            Assert.True(set.IsSupersetOf(enumerable));
         }
 
         private void Validate_Overlaps(ISet<T> set, IEnumerable<T> enumerable)
@@ -237,11 +237,11 @@ namespace System.Collections.Tests
             {
                 if (set.Contains(value, comparer))
                 {
-                    CollectionAsserts.Overlaps(set, enumerable, true);
+                    Assert.True(set.Overlaps(enumerable));
                     return;
                 }
             }
-            CollectionAsserts.Overlaps(set, enumerable, false);
+            Assert.False(set.Overlaps(enumerable));
         }
 
         private void Validate_SetEquals(ISet<T> set, IEnumerable<T> enumerable)
@@ -251,7 +251,7 @@ namespace System.Collections.Tests
             {
                 if (!enumerable.Contains(value, comparer))
                 {
-                    CollectionAsserts.SetEquals(set, enumerable, false);
+                    Assert.False(set.SetEquals(enumerable));
                     return;
                 }
             }
@@ -259,11 +259,11 @@ namespace System.Collections.Tests
             {
                 if (!set.Contains(value, comparer))
                 {
-                    CollectionAsserts.SetEquals(set, enumerable, false);
+                    Assert.False(set.SetEquals(enumerable));
                     return;
                 }
             }
-            CollectionAsserts.SetEquals(set, enumerable, true);
+            Assert.True(set.SetEquals(enumerable));
         }
 
         private void Validate_SymmetricExceptWith(ISet<T> set, IEnumerable<T> enumerable)
@@ -277,7 +277,7 @@ namespace System.Collections.Tests
                 if (!enumerable.Contains(element, comparer))
                     expected.Add(element);
             set.SymmetricExceptWith(enumerable);
-            CollectionAsserts.HasCount(set, expected.Count);
+            Assert.Equal(expected.Count, set.Count);
             Assert.True(expected.SetEquals(set));
         }
 
@@ -289,7 +289,7 @@ namespace System.Collections.Tests
                 if (!set.Contains(element, comparer))
                     expected.Add(element);
             set.UnionWith(enumerable);
-            CollectionAsserts.HasCount(set, expected.Count);
+            Assert.Equal(expected.Count, set.Count);
             Assert.True(expected.SetEquals(set));
         }
 
@@ -308,15 +308,6 @@ namespace System.Collections.Tests
             Assert.Throws<ArgumentNullException>(() => set.IsSupersetOf(null));
             Assert.Throws<ArgumentNullException>(() => set.Overlaps(null));
             Assert.Throws<ArgumentNullException>(() => set.SetEquals(null));
-#if !NETFRAMEWORK
-            IReadOnlySet<T> readOnlySet = set;
-            Assert.Throws<ArgumentNullException>(() => readOnlySet.IsProperSubsetOf(null));
-            Assert.Throws<ArgumentNullException>(() => readOnlySet.IsProperSupersetOf(null));
-            Assert.Throws<ArgumentNullException>(() => readOnlySet.IsSubsetOf(null));
-            Assert.Throws<ArgumentNullException>(() => readOnlySet.IsSupersetOf(null));
-            Assert.Throws<ArgumentNullException>(() => readOnlySet.Overlaps(null));
-            Assert.Throws<ArgumentNullException>(() => readOnlySet.SetEquals(null));
-#endif
             if (!IsReadOnly)
             {
                 Assert.Throws<ArgumentNullException>(() => set.ExceptWith(null));
@@ -511,7 +502,7 @@ namespace System.Collections.Tests
         public void ISet_Generic_SetEquals_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
-            CollectionAsserts.SetEquals(set, set, true);
+            Assert.True(set.SetEquals(set));
         }
 
         [Theory]
@@ -669,7 +660,7 @@ namespace System.Collections.Tests
                     if (!enumerable.Contains(element, comparer))
                         expected.Add(element);
                 set.SymmetricExceptWith(enumerable);
-                CollectionAsserts.HasCount(set, expected.Count);
+                Assert.Equal(expected.Count, set.Count);
                 Assert.True(expected.SetEquals(set));
             }
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSetInternalBase.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSetInternalBase.cs
@@ -32,11 +32,7 @@ namespace System.Collections.Frozen
         {
             Debug.Assert(_thisSet.Count != 0, "EmptyFrozenSet should have been used.");
 
-#if NET10_0_OR_GREATER // ICollection<T> : IReadOnlyCollection<T> on .NET 10+
-            if (other is IReadOnlyCollection<T> otherAsCollection)
-#else
             if (other is ICollection<T> otherAsCollection)
-#endif
             {
                 int otherCount = otherAsCollection.Count;
 
@@ -63,11 +59,7 @@ namespace System.Collections.Frozen
         {
             Debug.Assert(_thisSet.Count != 0, "EmptyFrozenSet should have been used.");
 
-#if NET10_0_OR_GREATER // ICollection<T> : IReadOnlyCollection<T> on .NET 10+
-            if (other is IReadOnlyCollection<T> otherAsCollection)
-#else
             if (other is ICollection<T> otherAsCollection)
-#endif
             {
                 int otherCount = otherAsCollection.Count;
 
@@ -111,11 +103,7 @@ namespace System.Collections.Frozen
             Debug.Assert(_thisSet.Count != 0, "EmptyFrozenSet should have been used.");
 
             // Try to compute the answer based purely on counts.
-#if NET10_0_OR_GREATER // ICollection<T> : IReadOnlyCollection<T> on .NET 10+
-            if (other is IReadOnlyCollection<T> otherAsCollection)
-#else
             if (other is ICollection<T> otherAsCollection)
-#endif
             {
                 int otherCount = otherAsCollection.Count;
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.Minimal.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.Minimal.cs
@@ -38,13 +38,11 @@ namespace System.Collections.Immutable
                 return true;
             }
 
-#if !NET10_0_OR_GREATER // ICollection<T> : IReadOnlyCollection<T> on .NET 10+
             if (sequence is ICollection<T> collectionOfT)
             {
                 count = collectionOfT.Count;
                 return true;
             }
-#endif
 
             if (sequence is IReadOnlyCollection<T> readOnlyCollection)
             {

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -50,12 +50,10 @@ namespace System.Collections.Immutable
                 return orderedCollection;
             }
 
-#if !NET10_0_OR_GREATER // ICollection<T> : IReadOnlyCollection<T> on .NET 10+
             if (sequence is IList<T> listOfT)
             {
                 return new ListOfTWrapper<T>(listOfT);
             }
-#endif
 
             // It would be great if SortedSet<T> and SortedDictionary<T> provided indexers into their collections,
             // but since they don't we have to clone them to an array.
@@ -103,7 +101,6 @@ namespace System.Collections.Immutable
             }
         }
 
-#if !NET10_0_OR_GREATER // ICollection<T> : IReadOnlyCollection<T> on .NET 10+
         /// <summary>
         /// Wraps a <see cref="IList{T}"/> as an ordered collection.
         /// </summary>
@@ -163,7 +160,6 @@ namespace System.Collections.Immutable
                 return this.GetEnumerator();
             }
         }
-#endif
 
         /// <summary>
         /// Wraps any <see cref="IEnumerable{T}"/> as an ordered, indexable list.

--- a/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/OrderedDictionary.cs
@@ -197,7 +197,7 @@ namespace System.Collections.Generic
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="collection"/> is <see langword="null"/>.</exception>
         public OrderedDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer) :
-            this((collection as IReadOnlyCollection<KeyValuePair<TKey, TValue>>)?.Count ?? 0, comparer)
+            this((collection as ICollection<KeyValuePair<TKey, TValue>>)?.Count ?? 0, comparer)
         {
             ArgumentNullException.ThrowIfNull(collection);
 

--- a/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/PriorityQueue.cs
@@ -467,7 +467,7 @@ namespace System.Collections.Generic
             ArgumentNullException.ThrowIfNull(elements);
 
             int count;
-            if (elements is IReadOnlyCollection<TElement> collection &&
+            if (elements is ICollection<TElement> collection &&
                 (count = collection.Count) > _nodes.Length - _size)
             {
                 Grow(checked(_size + count));

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1323,7 +1323,7 @@ namespace System.Collections.Generic
             if (Count == 0)
                 return false;
 
-            if (other is IReadOnlyCollection<T> c && c.Count == 0)
+            if (other is ICollection<T> c && c.Count == 0)
                 return false;
 
             SortedSet<T>? asSorted = other as SortedSet<T>;

--- a/src/libraries/System.Collections/tests/Generic/CollectionExtensionsTests.cs
+++ b/src/libraries/System.Collections/tests/Generic/CollectionExtensionsTests.cs
@@ -62,10 +62,6 @@ namespace System.Collections.Tests
             IDictionary<string, string> dictionary = new SortedDictionary<string, string>();
             Assert.True(dictionary.TryAdd("key", "value"));
             Assert.Equal("value", dictionary["key"]);
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<string, string> readOnlyDictionary = dictionary;
-            Assert.Equal("value", readOnlyDictionary["key"]);
-#endif
         }
 
         [Fact]
@@ -74,10 +70,6 @@ namespace System.Collections.Tests
             IDictionary<string, string> dictionary = new SortedDictionary<string, string>() { ["key"] = "value" };
             Assert.False(dictionary.TryAdd("key", "value2"));
             Assert.Equal("value", dictionary["key"]);
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<string, string> readOnlyDictionary = dictionary;
-            Assert.Equal("value", readOnlyDictionary["key"]);
-#endif
         }
 
         [Fact]
@@ -105,10 +97,6 @@ namespace System.Collections.Tests
             Assert.True(dictionary.Remove("key", out var value));
             Assert.Equal("value", value);
             Assert.Throws<KeyNotFoundException>(() => dictionary["key"]);
-#if !NETFRAMEWORK
-            IReadOnlyDictionary<string, string> readOnlyDictionary = dictionary;
-            Assert.Throws<KeyNotFoundException>(() => readOnlyDictionary["key"]);
-#endif
         }
 
         [Fact]

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
@@ -1852,7 +1852,7 @@ namespace System.Linq
             // If the data source is a collection, we can just return the count right away.
             if (source is ParallelEnumerableWrapper<TSource> sourceAsWrapper)
             {
-                if (sourceAsWrapper.WrappedEnumerable is IReadOnlyCollection<TSource> sourceAsCollection)
+                if (sourceAsWrapper.WrappedEnumerable is ICollection<TSource> sourceAsCollection)
                 {
                     return sourceAsCollection.Count;
                 }
@@ -1923,7 +1923,7 @@ namespace System.Linq
             // If the data source is a collection, we can just return the count right away.
             if (source is ParallelEnumerableWrapper<TSource> sourceAsWrapper)
             {
-                if (sourceAsWrapper.WrappedEnumerable is IReadOnlyCollection<TSource> sourceAsCollection)
+                if (sourceAsWrapper.WrappedEnumerable is ICollection<TSource> sourceAsCollection)
                 {
                     return sourceAsCollection.Count;
                 }

--- a/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
@@ -15,7 +15,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (source is IReadOnlyCollection<TSource> gc)
+            if (source is ICollection<TSource> gc)
             {
                 return gc.Count != 0;
             }

--- a/src/libraries/System.Linq/src/System/Linq/AppendPrepend.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AppendPrepend.SpeedOpt.cs
@@ -127,7 +127,7 @@ namespace System.Linq
                     return count == -1 ? -1 : count + 1;
                 }
 
-                return !onlyIfCheap || _source is IReadOnlyCollection<TSource> ? _source.Count() + 1 : -1;
+                return !onlyIfCheap || _source is ICollection<TSource> ? _source.Count() + 1 : -1;
             }
 
             public override TSource? TryGetFirst(out bool found)
@@ -280,7 +280,7 @@ namespace System.Linq
                     return count == -1 ? -1 : count + _appendCount + _prependCount;
                 }
 
-                return !onlyIfCheap || _source is IReadOnlyCollection<TSource> ? _source.Count() + _appendCount + _prependCount : -1;
+                return !onlyIfCheap || _source is ICollection<TSource> ? _source.Count() + _appendCount + _prependCount : -1;
             }
 
             public override bool Contains(TSource value)

--- a/src/libraries/System.Linq/src/System/Linq/Count.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Count.cs
@@ -15,7 +15,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (source is IReadOnlyCollection<TSource> collectionoft)
+            if (source is ICollection<TSource> collectionoft)
             {
                 return collectionoft.Count;
             }
@@ -107,7 +107,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (source is IReadOnlyCollection<TSource> collectionoft)
+            if (source is ICollection<TSource> collectionoft)
             {
                 count = collectionoft.Count;
                 return true;

--- a/src/libraries/System.Linq/src/System/Linq/DefaultIfEmpty.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/DefaultIfEmpty.SpeedOpt.cs
@@ -30,7 +30,7 @@ namespace System.Linq
             public override int GetCount(bool onlyIfCheap)
             {
                 int count;
-                if (!onlyIfCheap || _source is IReadOnlyCollection<TSource> || _source is ICollection)
+                if (!onlyIfCheap || _source is ICollection<TSource> || _source is ICollection)
                 {
                     count = _source.Count();
                 }

--- a/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
@@ -16,7 +16,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (source is IReadOnlyList<TSource> list)
+            if (source is IList<TSource> list)
             {
                 return list[index];
             }
@@ -113,7 +113,7 @@ namespace System.Linq
 
         private static TSource? TryGetElementAt<TSource>(this IEnumerable<TSource> source, int index, out bool found)
         {
-            if (source is IReadOnlyList<TSource> list)
+            if (source is IList<TSource> list)
             {
                 return (found = (uint)index < (uint)list.Count) ?
                     list[index] :

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -76,7 +76,7 @@ namespace System.Linq
 
         private static TSource? TryGetFirstNonIterator<TSource>(IEnumerable<TSource> source, out bool found)
         {
-            if (source is IReadOnlyList<TSource> list)
+            if (source is IList<TSource> list)
             {
                 if (list.Count > 0)
                 {

--- a/src/libraries/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Grouping.cs
@@ -351,7 +351,7 @@ namespace System.Linq
 
     [DebuggerDisplay("Key = {Key}")]
     [DebuggerTypeProxy(typeof(SystemLinq_GroupingDebugView<,>))]
-    internal sealed class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>, IReadOnlyList<TElement>
+    internal sealed class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>
     {
         internal readonly TKey _key;
         internal readonly int _hashCode;
@@ -398,8 +398,6 @@ namespace System.Linq
 
         int ICollection<TElement>.Count => _count;
 
-        int IReadOnlyCollection<TElement>.Count => _count;
-
         bool ICollection<TElement>.IsReadOnly => true;
 
         void ICollection<TElement>.Add(TElement item) => ThrowHelper.ThrowNotSupportedException();
@@ -432,19 +430,6 @@ namespace System.Linq
             }
 
             set => ThrowHelper.ThrowNotSupportedException();
-        }
-
-        TElement IReadOnlyList<TElement>.this[int index]
-        {
-            get
-            {
-                if ((uint)index >= (uint)_count)
-                {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
-                }
-
-                return _elements[index];
-            }
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -75,7 +75,7 @@ namespace System.Linq
 
         private static TSource? TryGetLastNonIterator<TSource>(IEnumerable<TSource> source, out bool found)
         {
-            if (source is IReadOnlyList<TSource> list)
+            if (source is IList<TSource> list)
             {
                 int count = list.Count;
                 if (count > 0)
@@ -122,7 +122,7 @@ namespace System.Linq
                 return ordered.TryGetLast(predicate, out found);
             }
 
-            if (source is IReadOnlyList<TSource> list)
+            if (source is IList<TSource> list)
             {
                 for (int i = list.Count - 1; i >= 0; --i)
                 {

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -58,7 +58,7 @@ namespace System.Linq
                     return iterator.GetCount(onlyIfCheap);
                 }
 
-                return !onlyIfCheap || _source is IReadOnlyCollection<TElement> || _source is ICollection ? _source.Count() : -1;
+                return !onlyIfCheap || _source is ICollection<TElement> || _source is ICollection ? _source.Count() : -1;
             }
 
             internal TElement[] ToArray(int minIdx, int maxIdx)

--- a/src/libraries/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
@@ -30,7 +30,7 @@ namespace System.Linq
 
             public override TSource? TryGetElementAt(int index, out bool found)
             {
-                if (_source is IReadOnlyList<TSource> list)
+                if (_source is IList<TSource> list)
                 {
                     int count = list.Count;
                     if ((uint)index < (uint)count)
@@ -59,7 +59,7 @@ namespace System.Linq
                 {
                     return iterator.TryGetLast(out found);
                 }
-                else if (_source is IReadOnlyList<TSource> list)
+                else if (_source is IList<TSource> list)
                 {
                     int count = list.Count;
                     if (count > 0)
@@ -95,7 +95,7 @@ namespace System.Linq
                 {
                     return iterator.TryGetFirst(out found);
                 }
-                else if (_source is IReadOnlyList<TSource> list)
+                else if (_source is IList<TSource> list)
                 {
                     if (list.Count > 0)
                     {

--- a/src/libraries/System.Linq/src/System/Linq/SequenceEqual.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SequenceEqual.cs
@@ -22,7 +22,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.second);
             }
 
-            if (first is IReadOnlyCollection<TSource> firstCol && second is IReadOnlyCollection<TSource> secondCol)
+            if (first is ICollection<TSource> firstCol && second is ICollection<TSource> secondCol)
             {
                 if (first.TryGetSpan(out ReadOnlySpan<TSource> firstSpan) && second.TryGetSpan(out ReadOnlySpan<TSource> secondSpan))
                 {
@@ -34,7 +34,7 @@ namespace System.Linq
                     return false;
                 }
 
-                if (firstCol is IReadOnlyList<TSource> firstList && secondCol is IReadOnlyList<TSource> secondList)
+                if (firstCol is IList<TSource> firstList && secondCol is IList<TSource> secondList)
                 {
                     comparer ??= EqualityComparer<TSource>.Default;
 

--- a/src/libraries/System.Linq/src/System/Linq/Shuffle.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Shuffle.SpeedOpt.cs
@@ -47,7 +47,7 @@ namespace System.Linq
                         return iterator.TryGetElementAt(Random.Shared.Next(0, iteratorCount), out found);
                     }
                 }
-                else if (_source is IReadOnlyList<TSource> list)
+                else if (_source is IList<TSource> list)
                 {
                     int listCount = list.Count;
                     if ((uint)index < (uint)listCount)
@@ -172,7 +172,7 @@ namespace System.Linq
                         return iterator.TryGetElementAt(Random.Shared.Next(0, iteratorCount), out found);
                     }
                 }
-                else if (_source is IReadOnlyList<TSource> list)
+                else if (_source is IList<TSource> list)
                 {
                     int count = list.Count;
                     if ((uint)index < (uint)Math.Min(_takeCount, count))
@@ -203,7 +203,7 @@ namespace System.Linq
             {
                 List<TSource>? reservoir = null;
 
-                if (source is IReadOnlyList<TSource> list)
+                if (source is IList<TSource> list)
                 {
                     int listCount = list.Count;
                     Debug.Assert(listCount > takeCount, "Known listCount <= takeCount should have been handled by Iterator.Take override");

--- a/src/libraries/System.Linq/src/System/Linq/Single.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Single.cs
@@ -69,7 +69,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (source is IReadOnlyList<TSource> list)
+            if (source is IList<TSource> list)
             {
                 switch (list.Count)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -169,7 +169,7 @@ namespace System.Net.Http.Headers
         {
             ArgumentNullException.ThrowIfNull(values);
 
-            if (values is IReadOnlyList<string?> valuesList)
+            if (values is IList<string?> valuesList)
             {
                 int count = valuesList.Count;
 

--- a/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ServiceNameCollection.cs
+++ b/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ServiceNameCollection.cs
@@ -147,7 +147,7 @@ namespace System.Security.Authentication.ExtendedProtection
         /// </summary>
         private static int GetCountOrOne(IEnumerable collection)
         {
-            IReadOnlyCollection<string>? c = collection as IReadOnlyCollection<string>;
+            ICollection<string>? c = collection as ICollection<string>;
             return c != null ? c.Count : 1;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -89,7 +89,7 @@ namespace System.Collections.Concurrent
             // case we round its length up to a power of 2, as all segments must
             // be a power of 2 in length.
             int length = InitialSegmentLength;
-            if (collection is IReadOnlyCollection<T> c)
+            if (collection is ICollection<T> c)
             {
                 int count = c.Count;
                 if (count > length)

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -98,7 +98,7 @@ namespace System.Collections.Generic
         public Dictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection) : this(collection, null) { }
 
         public Dictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer) :
-            this((collection as IReadOnlyCollection<KeyValuePair<TKey, TValue>>)?.Count ?? 0, comparer)
+            this((collection as ICollection<KeyValuePair<TKey, TValue>>)?.Count ?? 0, comparer)
         {
             if (collection == null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -100,7 +100,7 @@ namespace System.Collections.Generic
             {
                 // To avoid excess resizes, first set size based on collection's count. The collection may
                 // contain duplicates, so call TrimExcess if resulting HashSet is larger than the threshold.
-                if (collection is IReadOnlyCollection<T> coll)
+                if (collection is ICollection<T> coll)
                 {
                     int count = coll.Count;
                     if (count > 0)
@@ -829,7 +829,7 @@ namespace System.Collections.Generic
             }
 
             // If other is known to be empty, intersection is empty set; remove all elements, and we're done.
-            if (other is IReadOnlyCollection<T> otherAsCollection)
+            if (other is ICollection<T> otherAsCollection)
             {
                 if (otherAsCollection.Count == 0)
                 {
@@ -933,7 +933,7 @@ namespace System.Collections.Generic
                 return true;
             }
 
-            if (other is IReadOnlyCollection<T> otherAsCollection)
+            if (other is ICollection<T> otherAsCollection)
             {
                 // If this has more elements then it can't be a subset.
                 if (Count > otherAsCollection.Count)
@@ -969,7 +969,7 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            if (other is IReadOnlyCollection<T> otherAsCollection)
+            if (other is ICollection<T> otherAsCollection)
             {
                 // No set is a proper subset of a set with less or equal number of elements.
                 if (otherAsCollection.Count <= Count)
@@ -1014,7 +1014,7 @@ namespace System.Collections.Generic
             }
 
             // Try to fall out early based on counts.
-            if (other is IReadOnlyCollection<T> otherAsCollection)
+            if (other is ICollection<T> otherAsCollection)
             {
                 // If other is the empty set then this is a superset.
                 if (otherAsCollection.Count == 0)
@@ -1058,7 +1058,7 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            if (other is IReadOnlyCollection<T> otherAsCollection)
+            if (other is ICollection<T> otherAsCollection)
             {
                 // If other is the empty set then this is a superset.
                 if (otherAsCollection.Count == 0)
@@ -1133,7 +1133,7 @@ namespace System.Collections.Generic
                 return true;
             }
 
-            if (other is IReadOnlyCollection<T> otherAsCollection)
+            if (other is ICollection<T> otherAsCollection)
             {
                 // If this is empty, they are equal iff other is empty.
                 if (Count == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ICollection.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ICollection.cs
@@ -9,9 +9,9 @@ namespace System.Collections.Generic
 {
     // Base interface for all collections, defining enumerators, size, and
     // synchronization methods.
-    public interface ICollection<T> : IReadOnlyCollection<T>
+    public interface ICollection<T> : IEnumerable<T>
     {
-        new int Count
+        int Count
         {
 #if MONO
             [DynamicDependency(nameof(Array.InternalArray__ICollection_get_Count), typeof(Array))]
@@ -53,7 +53,5 @@ namespace System.Collections.Generic
         [DynamicDependency(nameof(Array.InternalArray__ICollection_Remove) + "``1", typeof(Array))]
 #endif
         bool Remove(T item);
-
-        int IReadOnlyCollection<T>.Count => Count;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IDictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IDictionary.cs
@@ -9,32 +9,32 @@ namespace System.Collections.Generic
     // Keys can be any non-null object.  Values can be any object.
     // You can look up a value in an IDictionary via the default indexed
     // property, Items.
-    public interface IDictionary<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>
+    public interface IDictionary<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>
     {
         // Interfaces are not serializable
         // The Item property provides methods to read and edit entries
         // in the Dictionary.
-        new TValue this[TKey key]
+        TValue this[TKey key]
         {
             get;
             set;
         }
 
         // Returns a collections of the keys in this dictionary.
-        new ICollection<TKey> Keys
+        ICollection<TKey> Keys
         {
             get;
         }
 
         // Returns a collections of the values in this dictionary.
-        new ICollection<TValue> Values
+        ICollection<TValue> Values
         {
             get;
         }
 
         // Returns whether this dictionary contains a particular key.
         //
-        new bool ContainsKey(TKey key);
+        bool ContainsKey(TKey key);
 
         // Adds a key-value pair to the dictionary.
         //
@@ -44,16 +44,6 @@ namespace System.Collections.Generic
         //
         bool Remove(TKey key);
 
-        new bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value);
-
-        TValue IReadOnlyDictionary<TKey, TValue>.this[TKey key] => this[key];
-
-        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
-
-        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
-
-        bool IReadOnlyDictionary<TKey, TValue>.ContainsKey(TKey key) => ContainsKey(key);
-
-        bool IReadOnlyDictionary<TKey, TValue>.TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => TryGetValue(key, out value);
+        bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IList.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IList.cs
@@ -10,10 +10,10 @@ namespace System.Collections.Generic
     // An IList is an ordered collection of objects.  The exact ordering
     // is up to the implementation of the list, ranging from a sorted
     // order to insertion order.
-    public interface IList<T> : ICollection<T>, IReadOnlyList<T>
+    public interface IList<T> : ICollection<T>
     {
         // The Item property provides methods to read and edit entries in the List.
-        new T this[int index]
+        T this[int index]
         {
 #if MONO
             [DynamicDependency(nameof(Array.InternalArray__get_Item) + "``1", typeof(Array))]
@@ -46,7 +46,5 @@ namespace System.Collections.Generic
         [DynamicDependency(nameof(Array.InternalArray__RemoveAt), typeof(Array))]
 #endif
         void RemoveAt(int index);
-
-        T IReadOnlyList<T>.this[int index] => this[index];
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ISet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ISet.cs
@@ -8,7 +8,7 @@ namespace System.Collections.Generic
     /// by some comparer. It also supports basic set operations such as Union, Intersection,
     /// Complement and Exclusive Complement.
     /// </summary>
-    public interface ISet<T> : ICollection<T>, IReadOnlySet<T>
+    public interface ISet<T> : ICollection<T>
     {
         //Add ITEM to the set, return true if added, false if duplicate
         new bool Add(T item);
@@ -26,42 +26,21 @@ namespace System.Collections.Generic
         void SymmetricExceptWith(IEnumerable<T> other);
 
         //Check if this set is a subset of other
-        new bool IsSubsetOf(IEnumerable<T> other);
+        bool IsSubsetOf(IEnumerable<T> other);
 
         //Check if this set is a superset of other
-        new bool IsSupersetOf(IEnumerable<T> other);
+        bool IsSupersetOf(IEnumerable<T> other);
 
         //Check if this set is a subset of other, but not the same as it
-        new bool IsProperSupersetOf(IEnumerable<T> other);
+        bool IsProperSupersetOf(IEnumerable<T> other);
 
         //Check if this set is a superset of other, but not the same as it
-        new bool IsProperSubsetOf(IEnumerable<T> other);
+        bool IsProperSubsetOf(IEnumerable<T> other);
 
         //Check if this set has any elements in common with other
-        new bool Overlaps(IEnumerable<T> other);
+        bool Overlaps(IEnumerable<T> other);
 
         //Check if this set contains the same and only the same elements as other
-        new bool SetEquals(IEnumerable<T> other);
-
-        /// <summary>
-        /// Determines if the set contains a specific item
-        /// </summary>
-        /// <param name="item">The item to check if the set contains.</param>
-        /// <returns><see langword="true" /> if found; otherwise <see langword="false" />.</returns>
-        new bool Contains(T item) => ((ICollection<T>)this).Contains(item);
-
-        bool IReadOnlySet<T>.IsSubsetOf(IEnumerable<T> other) => IsSubsetOf(other);
-
-        bool IReadOnlySet<T>.IsSupersetOf(IEnumerable<T> other) => IsSupersetOf(other);
-
-        bool IReadOnlySet<T>.IsProperSupersetOf(IEnumerable<T> other) => IsProperSupersetOf(other);
-
-        bool IReadOnlySet<T>.IsProperSubsetOf(IEnumerable<T> other) => IsProperSubsetOf(other);
-
-        bool IReadOnlySet<T>.Overlaps(IEnumerable<T> other) => Overlaps(other);
-
-        bool IReadOnlySet<T>.SetEquals(IEnumerable<T> other) => SetEquals(other);
-
-        bool IReadOnlySet<T>.Contains(T value) => ((ICollection<T>)this).Contains(value);
+        bool SetEquals(IEnumerable<T> other);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -5934,7 +5934,7 @@ namespace System.Threading.Tasks
             }
 
             int? count = null;
-            if (tasks is IReadOnlyCollection<Task> taskCollection)
+            if (tasks is ICollection<Task> taskCollection)
             {
                 if (tasks is Task[] taskArray)
                 {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQuerySequence.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQuerySequence.cs
@@ -19,7 +19,7 @@ namespace System.Xml.Xsl.Runtime
     /// A sequence of Xml values that dynamically expands and allows random access to items.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class XmlQuerySequence<T> : IList<T>, IReadOnlyList<T>, System.Collections.IList
+    public class XmlQuerySequence<T> : IList<T>, System.Collections.IList
     {
         public static readonly XmlQuerySequence<T> Empty = new XmlQuerySequence<T>();
 
@@ -489,7 +489,7 @@ namespace System.Xml.Xsl.Runtime
     /// A sequence of Xml nodes that dynamically expands and allows random access to items.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public sealed class XmlQueryNodeSequence : XmlQuerySequence<XPathNavigator>, IList<XPathItem>, IReadOnlyList<XPathItem>
+    public sealed class XmlQueryNodeSequence : XmlQuerySequence<XPathNavigator>, IList<XPathItem>
     {
         public static new readonly XmlQueryNodeSequence Empty = new XmlQueryNodeSequence();
 
@@ -729,19 +729,6 @@ namespace System.Xml.Xsl.Runtime
                 return base[index];
             }
             set { throw new NotSupportedException(); }
-        }
-
-        /// <summary>
-        /// Return item at the specified index.
-        /// </summary>
-        XPathItem IReadOnlyList<XPathItem>.this[int index]
-        {
-            get
-            {
-                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
-
-                return base[index];
-            }
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -4881,8 +4881,8 @@ namespace System
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public static void ThrowIf([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(true)] bool condition, object instance) { throw null; }
-        public static void ThrowIf([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(true)] bool condition, System.Type type) { throw null; }
+        public static void ThrowIf([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(true)] bool condition, object instance) => throw null;
+        public static void ThrowIf([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(true)] bool condition, System.Type type) => throw null;
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Delegate | System.AttributeTargets.Enum | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Struct, Inherited=false)]
     public sealed partial class ObsoleteAttribute : System.Attribute
@@ -8256,7 +8256,7 @@ namespace System.Collections.Generic
         bool Contains(T item);
         void CopyTo(T[] array, int arrayIndex);
         bool Remove(T item);
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+        int System.Collections.Generic.IReadOnlyCollection<T>.Count => Count;
     }
     public partial interface IComparer<in T> where T : allows ref struct
     {
@@ -8271,11 +8271,11 @@ namespace System.Collections.Generic
         new bool ContainsKey(TKey key);
         bool Remove(TKey key);
         new bool TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value);
-        TValue System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.this[TKey key] { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
-        bool System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.ContainsKey(TKey key) { throw null; }
-        bool System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value) { throw null; }
+        TValue System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.this[TKey key] => this[key];
+        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.Values => Values;
+        bool System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.ContainsKey(TKey key) => ContainsKey(key);
+        bool System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value) => TryGetValue(key, out value);
     }
     public partial interface IEnumerable<out T> : System.Collections.IEnumerable where T : allows ref struct
     {
@@ -8296,7 +8296,7 @@ namespace System.Collections.Generic
         int IndexOf(T item);
         void Insert(int index, T item);
         void RemoveAt(int index);
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+        T System.Collections.Generic.IReadOnlyList<T>.this[int index] => this[index];
     }
     public partial interface IReadOnlyCollection<out T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
     {
@@ -8337,14 +8337,14 @@ namespace System.Collections.Generic
         new bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
         void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other);
         void UnionWith(System.Collections.Generic.IEnumerable<T> other);
-        new bool Contains(T item) { throw null; }
-        bool System.Collections.Generic.IReadOnlySet<T>.Contains(T item) { throw null; }
-        bool System.Collections.Generic.IReadOnlySet<T>.IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        bool System.Collections.Generic.IReadOnlySet<T>.IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        bool System.Collections.Generic.IReadOnlySet<T>.IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        bool System.Collections.Generic.IReadOnlySet<T>.IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        bool System.Collections.Generic.IReadOnlySet<T>.Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        bool System.Collections.Generic.IReadOnlySet<T>.SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+        new bool Contains(T item) => ((ICollection<T>)this).Contains(item);
+        bool System.Collections.Generic.IReadOnlySet<T>.Contains(T item) => ((ICollection<T>)this).Contains(item);
+        bool System.Collections.Generic.IReadOnlySet<T>.IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) => IsProperSubsetOf(other);
+        bool System.Collections.Generic.IReadOnlySet<T>.IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) => IsProperSupersetOf(other);
+        bool System.Collections.Generic.IReadOnlySet<T>.IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) => IsSubsetOf(other);
+        bool System.Collections.Generic.IReadOnlySet<T>.IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) => IsSupersetOf(other);
+        bool System.Collections.Generic.IReadOnlySet<T>.Overlaps(System.Collections.Generic.IEnumerable<T> other) => Overlaps(other);
+        bool System.Collections.Generic.IReadOnlySet<T>.SetEquals(System.Collections.Generic.IEnumerable<T> other) => SetEquals(other);
     }
     public partial class KeyNotFoundException : System.SystemException
     {
@@ -8643,10 +8643,10 @@ namespace System.Diagnostics
         public static void Close() { }
         [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Fail(string? message) { throw null; }
+        public static void Fail(string? message) => throw null;
         [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public static void Fail(string? message, string? detailMessage) { throw null; }
+        public static void Fail(string? message, string? detailMessage) => throw null;
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
         public static void Flush() { }
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
@@ -14154,9 +14154,9 @@ namespace System.Runtime.ExceptionServices
         public static System.Exception SetCurrentStackTrace(System.Exception source) { throw null; }
         public static System.Exception SetRemoteStackTrace(System.Exception source, string stackTrace) { throw null; }
         [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
-        public void Throw() { throw null; }
+        public void Throw() => throw null;
         [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
-        public static void Throw(System.Exception source) { throw null; }
+        public static void Throw(System.Exception source) => throw null;
     }
     public static partial class ExceptionHandling
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -8247,35 +8247,29 @@ namespace System.Collections.Generic
         T Current { get; }
         System.Threading.Tasks.ValueTask<bool> MoveNextAsync();
     }
-    public partial interface ICollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<T>
+    public partial interface ICollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
     {
-        new int Count { get; }
+        int Count { get; }
         bool IsReadOnly { get; }
         void Add(T item);
         void Clear();
         bool Contains(T item);
         void CopyTo(T[] array, int arrayIndex);
         bool Remove(T item);
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count => Count;
     }
     public partial interface IComparer<in T> where T : allows ref struct
     {
         int Compare(T? x, T? y);
     }
-    public partial interface IDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+    public partial interface IDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerable
     {
-        new TValue this[TKey key] { get; set; }
-        new System.Collections.Generic.ICollection<TKey> Keys { get; }
-        new System.Collections.Generic.ICollection<TValue> Values { get; }
+        TValue this[TKey key] { get; set; }
+        System.Collections.Generic.ICollection<TKey> Keys { get; }
+        System.Collections.Generic.ICollection<TValue> Values { get; }
         void Add(TKey key, TValue value);
-        new bool ContainsKey(TKey key);
+        bool ContainsKey(TKey key);
         bool Remove(TKey key);
-        new bool TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value);
-        TValue System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.this[TKey key] => this[key];
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.Values => Values;
-        bool System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.ContainsKey(TKey key) => ContainsKey(key);
-        bool System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>.TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value) => TryGetValue(key, out value);
+        bool TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value);
     }
     public partial interface IEnumerable<out T> : System.Collections.IEnumerable where T : allows ref struct
     {
@@ -8290,13 +8284,12 @@ namespace System.Collections.Generic
         bool Equals(T? x, T? y);
         int GetHashCode([System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T obj);
     }
-    public partial interface IList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.IReadOnlyCollection<T>
+    public partial interface IList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
     {
-        new T this[int index] { get; set; }
+        T this[int index] { get; set; }
         int IndexOf(T item);
         void Insert(int index, T item);
         void RemoveAt(int index);
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] => this[index];
     }
     public partial interface IReadOnlyCollection<out T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
     {
@@ -8324,27 +8317,19 @@ namespace System.Collections.Generic
         bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
         bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
     }
-    public partial interface ISet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlySet<T>, System.Collections.Generic.IReadOnlyCollection<T>
+    public partial interface ISet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
     {
         new bool Add(T item);
         void ExceptWith(System.Collections.Generic.IEnumerable<T> other);
         void IntersectWith(System.Collections.Generic.IEnumerable<T> other);
-        new bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        new bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        new bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        new bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        new bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        new bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
+        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
+        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
+        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
+        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
         void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other);
         void UnionWith(System.Collections.Generic.IEnumerable<T> other);
-        new bool Contains(T item) => ((ICollection<T>)this).Contains(item);
-        bool System.Collections.Generic.IReadOnlySet<T>.Contains(T item) => ((ICollection<T>)this).Contains(item);
-        bool System.Collections.Generic.IReadOnlySet<T>.IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) => IsProperSubsetOf(other);
-        bool System.Collections.Generic.IReadOnlySet<T>.IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) => IsProperSupersetOf(other);
-        bool System.Collections.Generic.IReadOnlySet<T>.IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) => IsSubsetOf(other);
-        bool System.Collections.Generic.IReadOnlySet<T>.IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) => IsSupersetOf(other);
-        bool System.Collections.Generic.IReadOnlySet<T>.Overlaps(System.Collections.Generic.IEnumerable<T> other) => Overlaps(other);
-        bool System.Collections.Generic.IReadOnlySet<T>.SetEquals(System.Collections.Generic.IEnumerable<T> other) => SetEquals(other);
     }
     public partial class KeyNotFoundException : System.SystemException
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -35,12 +35,7 @@ namespace System.Text.Json.Nodes
         /// <param name="options">Options to control the behavior.</param>
         public JsonObject(IEnumerable<KeyValuePair<string, JsonNode?>> properties, JsonNodeOptions? options = null) : this(options)
         {
-            int capacity =
-#if NET10_0_OR_GREATER // ICollection<T> : IReadOnlyCollection<T> on .NET 10+
-                properties is IReadOnlyCollection<KeyValuePair<string, JsonNode?>> propertiesCollection ? propertiesCollection.Count : 0;
-#else
-                properties is ICollection<KeyValuePair<string, JsonNode?>> propertiesCollection ? propertiesCollection.Count : 0;
-#endif
+            int capacity = properties is ICollection<KeyValuePair<string, JsonNode?>> propertiesCollection ? propertiesCollection.Count : 0;
             OrderedDictionary<string, JsonNode?> dictionary = CreateDictionary(options, capacity);
 
             foreach (KeyValuePair<string, JsonNode?> node in properties)


### PR DESCRIPTION
This was found to break F# as well, due to how F# currently supports implementing interfaces and DIMs.

In particular, F# does not support the general pattern of:
```csharp
public interface IA
{
    void M();
}

public interface IB : IA
{
    void M();
    void IA.M();
}
```

And so a type that does something like the following:
```fsharp
type C<'T> =
    // public members

    interface ICollection<'T> with

        member s.Add(x) = s.Add(x)

        member s.Clear() = s.Clear()

        member s.Remove(x) = s.Remove(x)

        member s.Contains(x) = s.Contains(x)

        member s.CopyTo(arr, arrIndex) = s.CopyTo(arr, arrIndex)

        member _.IsReadOnly = false

        member s.Count = s.Count
```

will get the following error:
```
error FS0361: The override 'get_Count: unit -> int' implements more than one abstract slot, e.g. 'ICollection.get_Count() : int' and 'IReadOnlyCollection.get_Count() : int'
```