### PR TITLE
Harden `Ping_TimedOut_*` tests

### DIFF
--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -756,13 +756,13 @@ namespace System.Net.NetworkInformation.Tests
             PingReply reply = await sendPing(sender, TestSettings.UnreachableAddress);
             if (reply.Status == IPStatus.DestinationNetworkUnreachable)
             {
-                // The network has dropped the packet towards UnreachableAddress. Repeat the PING attempt on another address.
+                // A network middleware has dropped the packed and replied with DestinationNetworkUnreachable. Repeat the PING attempt on another address.
                 reply = await sendPing(sender, TestSettings.UnreachableAddress2);
             }
 
             if (reply.Status == IPStatus.DestinationNetworkUnreachable)
             {
-                // Do another attempt.
+                // Do yet another attempt.
                 reply = await sendPing(sender, TestSettings.UnreachableAddress3);
             }
 

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -750,53 +750,64 @@ namespace System.Net.NetworkInformation.Tests
             Assert.NotEqual(IPAddress.Any, pingReply.Address);
         }
 
-        [Fact]
-        [OuterLoop]
-        public void Ping_TimedOut_Sync_Success()
+        private async Task Ping_TimedOut_Core(Func<Ping, string, Task<PingReply>> sendPing)
         {
-            var sender = new Ping();
-            PingReply reply = sender.Send(TestSettings.UnreachableAddress);
-            Assert.Equal(IPStatus.TimedOut, reply.Status);
-        }
-
-        [Fact]
-        [OuterLoop]
-        public async Task Ping_TimedOut_EAP_Success()
-        {
-            var sender = new Ping();
-            sender.PingCompleted += (s, e) =>
+            Ping sender = new Ping();
+            PingReply reply = await sendPing(sender, TestSettings.UnreachableAddress);
+            if (reply.Status == IPStatus.DestinationNetworkUnreachable)
             {
-                var tcs = (TaskCompletionSource<PingReply>)e.UserState;
+                // The network has dropped the packet towards UnreachableAddress. Repeat the PING attempt on another address.
+                reply = await sendPing(sender, TestSettings.UnreachableAddress2);
+            }
 
-                if (e.Cancelled)
-                {
-                    tcs.TrySetCanceled();
-                }
-                else if (e.Error != null)
-                {
-                    tcs.TrySetException(e.Error);
-                }
-                else
-                {
-                    tcs.TrySetResult(e.Reply);
-                }
-            };
+            if (reply.Status == IPStatus.DestinationNetworkUnreachable)
+            {
+                // Do another attempt.
+                reply = await sendPing(sender, TestSettings.UnreachableAddress3);
+            }
 
-            var tcs = new TaskCompletionSource<PingReply>();
-            sender.SendAsync(TestSettings.UnreachableAddress, tcs);
-
-            PingReply reply = await tcs.Task;
             Assert.Equal(IPStatus.TimedOut, reply.Status);
         }
 
         [Fact]
         [OuterLoop]
-        public async Task Ping_TimedOut_TAP_Success()
-        {
-            var sender = new Ping();
-            PingReply reply = await sender.SendPingAsync(TestSettings.UnreachableAddress);
-            Assert.Equal(IPStatus.TimedOut, reply.Status);
-        }
+        public Task Ping_TimedOut_Sync_Success()
+            => Ping_TimedOut_Core((sender, address) => Task.Run(() => sender.Send(address)));
+
+        [Fact]
+        [OuterLoop]
+        public Task Ping_TimedOut_EAP_Success()
+            => Ping_TimedOut_Core(async (sender, address) =>
+            {
+                static void PingCompleted(object sender, PingCompletedEventArgs e)
+                {
+                    var tcs = (TaskCompletionSource<PingReply>)e.UserState;
+
+                    if (e.Cancelled)
+                    {
+                        tcs.TrySetCanceled();
+                    }
+                    else if (e.Error != null)
+                    {
+                        tcs.TrySetException(e.Error);
+                    }
+                    else
+                    {
+                        tcs.TrySetResult(e.Reply);
+                    }
+                }
+                sender.PingCompleted += PingCompleted;
+                var tcs = new TaskCompletionSource<PingReply>();
+                sender.SendAsync(address, tcs);
+                PingReply reply = await tcs.Task;
+                sender.PingCompleted -= PingCompleted;
+                return reply;
+            });
+
+        [Fact]
+        [OuterLoop]
+        public Task Ping_TimedOut_TAP_Success()
+            => Ping_TimedOut_Core((sender, address) => sender.SendPingAsync(address));
 
         private static bool IsRemoteExecutorSupportedAndPrivilegedProcess => RemoteExecutor.IsSupported && PlatformDetection.IsPrivilegedProcess;
 

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/TestSettings.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/TestSettings.cs
@@ -11,6 +11,9 @@ namespace System.Net.NetworkInformation.Tests
     {
         public static readonly string LocalHost = "localhost";
         public static readonly string UnreachableAddress = "192.0.2.0"; // TEST-NET-1
+        public static readonly string UnreachableAddress2 = "100.64.0.1"; // CGNAT block
+        public static readonly string UnreachableAddress3 = "10.255.255.1"; // High address in the private 10.0.0.0/8 range. Likely unused and unrouted.
+
         public const int PingTimeout = 10 * 1000;
 
         public const string PayloadAsString = "'Post hoc ergo propter hoc'. 'After it, therefore because of it'. It means one thing follows the other, therefore it was caused by the other. But it's not always true. In fact it's hardly ever true.";


### PR DESCRIPTION
Fixes #115358.

Depending on the network configuration, we can get an ICMP with `Type=Destination Unreachable, Code=Network Unreachable` from middlewares when pinging an "unreachable" IP. In #115358 we see this happening on Helix Mac machines, but I was able to reproduce it on an office LAN-connected Windows PC too.

This PR attempts to fix address this problem by repeating the ping tests on other "types" of unreachable hosts until we actually catch a timeout. (We could instead just skip the test on the first `DestinationNetworkUnreachable`, but then we would loose some functional coverage.)

Marking as draft until we get a few successful outerloop runs.