### PR TITLE
JIT: Ensure profile synthesis converges for trivial cases

### DIFF
--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -1425,12 +1425,12 @@ void ProfileSynthesis::GaussSeidelSolver()
 
         // If there were no improper headers, we will have converged in one pass
         // (profile may still be inconsistent, if there were capped cyclic probabilities).
-        // After the importer runs, we require that synthesis achieves profile consistency
-        // unless the resultant profile is approximate, so don't skip the below checks.
-        //
-        if ((m_improperLoopHeaders == 0) && !m_comp->fgImportDone)
+        // If synthesis is running after the importer (in other words, we aren't building the initial profile),
+        // it has only one shot at establishing consistency until the profile is flagged as inconsistent,
+        // so check for entry/exit weight balance here to indicate if the profile converged.
+        if (m_improperLoopHeaders == 0)
         {
-            converged = true;
+            converged = !m_comp->fgImportDone || m_comp->fgProfileWeightsConsistent(entryWeight, exitWeight);
             break;
         }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -582,7 +582,7 @@ PhaseStatus Compiler::fgImport()
     }
 
     // Now that we've made it through the importer, we know the IL was valid.
-    // If we synthesized profile data and though it should be consistent,
+    // If we synthesized profile data and thought it should be consistent,
     // but it wasn't, assert now.
     //
     if (fgPgoSynthesized && fgPgoConsistent)


### PR DESCRIPTION
While triaging regressions from profile maintenance work, I noticed profile repair passes regularly fail to converge and mark the profile as inconsistent, despite the weights clearly being consistent. This is because the Gauss-Seidel solver will only run for one iteration when a method doesn't have unnatural loops, but the first iteration's relative residual calculation is always too large to be considered converged. We should skip the residual checks for trivial flowgraph shapes to avoid this (like we already do during profile incorporation), but we still need some mechanism to detect if the weight coming out of a loop exceeds the weight into it; so far, I think checking method entry/exit weights for balance is sufficient.

Here's an example of the behavior this fixes:
```
*************** Starting PHASE Repair profile post-morph
ccp: BB26 :: 1.0 (header)
ccp: BB12 :: 0
ccp: BB11 :: 1
ccp: BB06 :: 0.01460244
ccp backedge BB06 (0.01460244) -> BB26 likelihood 0.9466215
For loop at BB26 cyclic weight is 0.01382299 cyclic probability is 1.014017
Synthesis: entry BB01 has input weight 149534
Synthesis: exception weight 1e-05
Computing block weights
Synthesis solver: flow graph has 0 improper loop headers
Entry weight 149534 exit weight 149534 residual 2.910383e-11
iteration 0: max residual is at BB01 : 149534
iteration 0: max rel residual is at BB01 : 1.49534e+17

failed to converge at iteration 1 rel residual 1.49534e+17 eigenvalue 0
Profile is inconsistent. Bypassing post-phase consistency checks.
fgCalledCount is 149534

*************** Finishing PHASE Repair profile post-morph
Trees after Repair profile post-morph

---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight      IBC [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                             1    149534 [000..003)-> BB03(0.769),BB25(0.231) ( cond )                   i IBC
BB03 [0002]  1       BB01                  0.77 114934 [005..009)-> BB25(0.0534),BB28(0.947)  ( cond )                   i IBC idxlen
BB28 [0031]  1       BB03                  0.73 108799 [009..???)-> BB26(1)                 (always)                   IBC internal
BB26 [0029]  2       BB06,BB28             0.74 110324 [009..00A)-> BB12(0),BB11(1)         ( cond )                   i IBC idxlen bwd
BB11 [0009]  1       BB26                  0.74 110324 [009..00A)-> BB06(0.0146),BB05(0.985)  ( cond )                   i IBC bwd
BB12 [0010]  1       BB26                  0         0 [009..017)-> BB06(0.0146),BB05(0.985)  ( cond )                   i IBC rare hascall gcsafe bwd
BB06 [0005]  2       BB11,BB12             0.01   1611 [019..026)-> BB26(0.947),BB29(0.0534)  ( cond )                   i IBC idxlen bwd
BB05 [0004]  2       BB11,BB12             0.73 108713 [017..019)                           (return)                   i IBC
BB29 [0032]  1       BB06                  0.00     86 [003..???)-> BB25(1)                 (always)                   IBC internal
BB25 [0028]  3       BB01,BB03,BB29        0.27  40821 [003..028)                           (return)                   i IBC
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

This should improve TP a bit, as we won't needlessly run repair as often.