### PR TITLE
Fix libhost scenarios (COM, C++/CLI, custom component host) incorrect coreclr path determination

### DIFF
--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
@@ -112,6 +112,35 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
+        public void ActivateClass_IgnoreWorkingDirectory()
+        {
+            using (TestArtifact cwd = TestArtifact.Create("cwd"))
+            {
+                // Validate that hosting components in the working directory will not be used
+                File.Copy(Binaries.CoreClr.MockPath, Path.Combine(cwd.Location, Binaries.CoreClr.FileName));
+                File.Copy(Binaries.HostFxr.MockPath_5_0, Path.Combine(cwd.Location, Binaries.HostFxr.FileName));
+                File.Copy(Binaries.HostPolicy.MockPath, Path.Combine(cwd.Location, Binaries.HostPolicy.FileName));
+
+                string[] args = {
+                    "comhost",
+                    "synchronous",
+                    "1",
+                    sharedState.ComHostPath,
+                    sharedState.ClsidString
+                };
+                sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
+                    .WorkingDirectory(cwd.Location)
+                    .Execute()
+                    .Should().Pass()
+                    .And.HaveStdOutContaining("New instance of Server created")
+                    .And.HaveStdOutContaining($"Activation of {sharedState.ClsidString} succeeded.")
+                    .And.ResolveHostFxr(TestContext.BuiltDotNet)
+                    .And.ResolveHostPolicy(TestContext.BuiltDotNet)
+                    .And.ResolveCoreClr(TestContext.BuiltDotNet);
+            }
+        }
+
+        [Fact]
         public void ActivateClass_ValidateIErrorInfoResult()
         {
             using (var library = sharedState.ComLibrary.Copy())

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
@@ -89,6 +89,32 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             }
         }
 
+        [Fact]
+        public void LoadLibrary_IgnoreWorkingDirectory()
+        {
+            using (TestArtifact cwd = TestArtifact.Create("cwd"))
+            {
+                // Validate that hosting components in the working directory will not be used
+                File.Copy(Binaries.CoreClr.MockPath, Path.Combine(cwd.Location, Binaries.CoreClr.FileName));
+                File.Copy(Binaries.HostFxr.MockPath_5_0, Path.Combine(cwd.Location, Binaries.HostFxr.FileName));
+                File.Copy(Binaries.HostPolicy.MockPath, Path.Combine(cwd.Location, Binaries.HostPolicy.FileName));
+
+                string [] args = {
+                    "ijwhost",
+                    sharedState.IjwApp.AppDll,
+                    "NativeEntryPoint"
+                };
+                sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
+                    .WorkingDirectory(cwd.Location)
+                    .Execute()
+                    .Should().Pass()
+                    .And.HaveStdOutContaining("[C++/CLI] NativeEntryPoint: calling managed class")
+                    .And.HaveStdOutContaining("[C++/CLI] ManagedClass: AssemblyLoadContext = \"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext")
+                    .And.ResolveHostFxr(TestContext.BuiltDotNet)
+                    .And.ResolveHostPolicy(TestContext.BuiltDotNet)
+                    .And.ResolveCoreClr(TestContext.BuiltDotNet);
+            }
+        }
 
         [Fact]
         public void LoadLibraryWithoutRuntimeConfigButActiveRuntime()

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 using Microsoft.DotNet.Cli.Build.Framework;
@@ -229,6 +230,37 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .Should().Fail()
                 .And.InitializeContextForConfig(component.RuntimeConfigJson)
                 .And.ExecuteFunctionPointerWithException(entryPoint, 1);
+        }
+
+        [Fact]
+        public void CallDelegateOnComponentContext_IgnoreWorkingDirectory()
+        {
+            using (TestArtifact cwd = TestArtifact.Create("cwd"))
+            {
+                // Validate that hosting components in the working directory will not be used
+                File.Copy(Binaries.CoreClr.MockPath, Path.Combine(cwd.Location, Binaries.CoreClr.FileName));
+                File.Copy(Binaries.HostPolicy.MockPath, Path.Combine(cwd.Location, Binaries.HostPolicy.FileName));
+
+                var component = sharedState.Component;
+                string[] args =
+                {
+                    ComponentLoadAssemblyAndGetFunctionPointerArg,
+                    sharedState.HostFxrPath,
+                    component.RuntimeConfigJson,
+                    component.AppDll,
+                    sharedState.ComponentTypeName,
+                    sharedState.ComponentEntryPoint1,
+                };
+
+                sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
+                    .WorkingDirectory(cwd.Location)
+                    .Execute()
+                    .Should().Pass()
+                    .And.InitializeContextForConfig(component.RuntimeConfigJson)
+                    .And.ExecuteFunctionPointer(sharedState.ComponentEntryPoint1, 1, 1)
+                    .And.ResolveHostPolicy(TestContext.BuiltDotNet)
+                    .And.ResolveCoreClr(TestContext.BuiltDotNet);
+            }
         }
 
         public class SharedTestState : SharedTestStateBase

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/NativeHostingResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/NativeHostingResultExtensions.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {
-    internal static class FunctionPointerResultExtensions
+    internal static class NativeHostingResultExtensions
     {
         public static FluentAssertions.AndConstraint<CommandResultAssertions> ExecuteFunctionPointer(this CommandResultAssertions assertion, string methodName, int callCount, int returnValue)
         {
@@ -46,6 +47,22 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         public static FluentAssertions.AndConstraint<CommandResultAssertions> ExecuteWithLocation(this CommandResultAssertions assertion, string assemblyName, string location)
         {
             return assertion.HaveStdOutContaining($"{assemblyName}: Location = '{location}'");
+        }
+
+        public static FluentAssertions.AndConstraint<CommandResultAssertions> ResolveHostFxr(this CommandResultAssertions assertion, Microsoft.DotNet.Cli.Build.DotNetCli dotnet)
+        {
+            return assertion.HaveStdErrContaining($"Resolved fxr [{dotnet.GreatestVersionHostFxrFilePath}]");
+        }
+
+        public static FluentAssertions.AndConstraint<CommandResultAssertions> ResolveHostPolicy(this CommandResultAssertions assertion, Microsoft.DotNet.Cli.Build.DotNetCli dotnet)
+        {
+            return assertion.HaveStdErrContaining($"{Binaries.HostPolicy.FileName} directory is [{dotnet.GreatestVersionSharedFxPath}]");
+        }
+
+        public static FluentAssertions.AndConstraint<CommandResultAssertions> ResolveCoreClr(this CommandResultAssertions assertion, Microsoft.DotNet.Cli.Build.DotNetCli dotnet)
+        {
+            return assertion.HaveStdErrContaining($"CoreCLR path = '{Path.Combine(dotnet.GreatestVersionSharedFxPath, Binaries.CoreClr.FileName)}'")
+                .And.HaveStdErrContaining($"CoreCLR dir = '{dotnet.GreatestVersionSharedFxPath}{Path.DirectorySeparatorChar}'");
         }
     }
 }

--- a/src/native/corehost/apphost/standalone/hostfxr_resolver.cpp
+++ b/src/native/corehost/apphost/standalone/hostfxr_resolver.cpp
@@ -118,6 +118,11 @@ hostfxr_resolver_t::hostfxr_resolver_t(const pal::string_t& app_root)
     {
         m_status_code = StatusCode::CoreHostLibMissingFailure;
     }
+    else if (!pal::is_path_rooted(m_fxr_path))
+    {
+        // We should always be loading hostfxr from an absolute path
+        m_status_code = StatusCode::CoreHostLibMissingFailure;
+    }
     else if (pal::load_library(&m_fxr_path, &m_hostfxr_dll))
     {
         m_status_code = StatusCode::Success;

--- a/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
+++ b/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
@@ -180,6 +180,10 @@ int hostpolicy_resolver::load(
             return StatusCode::CoreHostLibMissingFailure;
         }
 
+        // We should always be loading hostpolicy from an absolute path
+        if (!pal::is_path_rooted(host_path))
+            return StatusCode::CoreHostLibMissingFailure;
+
         // Load library
         // We expect to leak hostpolicy - just as we do not unload coreclr, we do not unload hostpolicy
         if (!pal::load_library(&host_path, &g_hostpolicy))

--- a/src/native/corehost/fxr_resolver.h
+++ b/src/native/corehost/fxr_resolver.h
@@ -55,6 +55,10 @@ int load_fxr_and_get_delegate(hostfxr_delegate_type type, THostPathToConfigCallb
             return StatusCode::CoreHostLibMissingFailure;
         }
 
+        // We should always be loading hostfxr from an absolute path
+        if (!pal::is_path_rooted(fxr_path))
+            return StatusCode::CoreHostLibMissingFailure;
+
         // Load library
         if (!pal::load_library(&fxr_path, &fxr))
         {

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -816,15 +816,21 @@ bool deps_resolver_t::resolve_probe_dirs(
         }
     }
 
-    // If the deps file is missing add known locations.
-    if (!get_app_deps().exists())
+    // If the deps file is missing for the app, add known locations.
+    // For libhost scenarios, there is no app or app path
+    if (m_host_mode != host_mode_t::libhost && !get_app_deps().exists())
     {
+        assert(!m_app_dir.empty());
+
         // App local path
         add_unique_path(asset_type, m_app_dir, &items, output, &non_serviced, core_servicing);
 
-        // deps_resolver treats being able to get the coreclr path as optional, so we ignore the return value here.
-        // The caller is responsible for checking whether coreclr path is set and handling as appropriate.
-        (void) file_exists_in_dir(m_app_dir, LIBCORECLR_NAME, &m_coreclr_path);
+        if (m_coreclr_path.empty())
+        {
+            // deps_resolver treats being able to get the coreclr path as optional, so we ignore the return value here.
+            // The caller is responsible for checking whether coreclr path is set and handling as appropriate.
+            (void) file_exists_in_dir(m_app_dir, LIBCORECLR_NAME, &m_coreclr_path);
+        }
     }
 
     // Handle any additional deps.json that were specified.

--- a/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
+++ b/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
@@ -13,6 +13,10 @@ bool coreclr_resolver_t::resolve_coreclr(const pal::string_t& libcoreclr_path, c
     pal::string_t coreclr_dll_path(libcoreclr_path);
     append_path(&coreclr_dll_path, LIBCORECLR_NAME);
 
+    // We should always be loading coreclr from an absolute path
+    if (!pal::is_path_rooted(coreclr_dll_path))
+        return false;
+
     if (!pal::load_library(&coreclr_dll_path, &coreclr_resolver_contract.coreclr))
     {
         return false;


### PR DESCRIPTION
There is a fallback for apps with no .deps.json where the host will consider the app directory for loading coreclr. In component hosting scenarios, we do not have an app path / directory. We were incorrectly going down the path of looking for coreclr next to the (empty) app directory.

This change skips that path for libhost scenarios. It also adds checks that the paths we determine for loading coreclr, hostpolicy, and hostfxr are absolute.