### PR TITLE
Remove more bounds checks for switch by ignoring dont-cse flag for checked bounds

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3191,7 +3191,12 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
 
     if (lclNumIsCSE(lclNum))
     {
-        return nullptr;
+        // Ignore the CSE flag in Global Assertion Prop for checked bound as those usually
+        // unlock more opportunities for BCE.
+        if (optLocalAssertionProp || !vnStore->IsVNCheckedBound(optConservativeNormalVN(tree)))
+        {
+            return nullptr;
+        }
     }
 
     GenTree* newTree       = tree;


### PR DESCRIPTION
```cs
 static MyEnum Test(string str) => str switch
    {
        "aaaa" => MyEnum.aaaa,
        "bbbb" => MyEnum.bbbb,
        "ccccc" => MyEnum.ccccc,
        "ddddd" => MyEnum.ddddd,
        "eeeeee" => MyEnum.eeeeee,
        "ffffff" => MyEnum.ffffff,
        "hhhhhhh" => MyEnum.hhhhhhh,
        "iiiiiii" => MyEnum.iiiiiii,
        _ => MyEnum.none
    };
```
Codegen diff: https://www.diffchecker.com/eBDjDmMa/

SPMI [diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1064302&view=ms.vss-build-web.run-extensions-tab).