### PR TITLE
[Android] Install brotli static libraries in CoreCLR Android pack

### DIFF
--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -213,4 +213,10 @@ install (TARGETS System.IO.Compression.Native-Static DESTINATION ${STATIC_LIB_DE
 
 if(CLR_CMAKE_HOST_ANDROID)
     install (TARGETS System.IO.Compression.Native-Static DESTINATION sharedFramework COMPONENT runtime)
+
+    foreach(BROTLI_LIB ${BROTLI_LIBRARIES})
+        if (TARGET "${BROTLI_LIB}")
+            install (TARGETS ${BROTLI_LIB} DESTINATION sharedFramework COMPONENT runtime)
+        endif()
+    endforeach()
 endif()


### PR DESCRIPTION
## Description

This PR updates the `System.IO.Compression.Native` build to install brotli static libraries into the Android CoreCLR runtime pack.

Fixes https://github.com/dotnet/runtime/issues/116297