### PR TITLE
[release/8.0-staging] Fix return in zlib-intel when window allocation fails

### DIFF
--- a/src/native/external/zlib-intel/inflate.c
+++ b/src/native/external/zlib-intel/inflate.c
@@ -251,7 +251,7 @@ int stream_size;
         if (state->window == Z_NULL) {
             ZFREE(strm, state);
             strm->state = Z_NULL;
-            ret = Z_MEM_ERROR;
+            return Z_MEM_ERROR;
         }
     }
     state->whave = 0;
@@ -727,7 +727,7 @@ int flush;
                 if (state->window == Z_NULL) {
                     ZFREE(strm, state);
                     strm->state = Z_NULL;
-                    ret = Z_MEM_ERROR;
+                    return Z_MEM_ERROR;
                 }
                 LOAD();
             }


### PR DESCRIPTION

## Customer Impact

- [ ] Customer reported
- [x] Found internally

If a process is running low on memory and fails window allocation in zlib on Windows, we weren't correctly returning the error to produce the correct ZlibException.   This creates a reliability issue as the failure looks like an application crash instead of out of memory. This issue is unique to the zlib-intel codebase.

## Regression

- [ ] Yes
- [x] No

## Testing

Unit tests, adhoc testing.

## Risk

Low.  This is likely a non-recoverable error, we're just making sure we surface in a way that diagnostics will correctly capture.