### PR TITLE
Add option to run coreclr tests using interpreter

### DIFF
--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -398,6 +398,11 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
   TakeLock
 fi
 
+if [ ! -z "$RunInterpreter" ]; then
+# $(InputAssemblyName)
+  export DOTNET_Interpreter='$(AssemblyName)!*'
+fi
+
 echo $LAUNCHER $ExePath %24(printf "'%s' " "${CLRTestExecutionArguments[@]}")
 $LAUNCHER $ExePath "${CLRTestExecutionArguments[@]}"
 

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -336,6 +336,10 @@ if defined RunCrossGen2 (
   call :TakeLock
 )
 
+if defined RunInterpreter (
+  SET "DOTNET_Interpreter=$(AssemblyName)^!*"
+)
+
 ECHO %LAUNCHER% %ExePath% %CLRTestExecutionArguments%
 %LAUNCHER% %ExePath% %CLRTestExecutionArguments%
 set CLRTestExitCode=!ERRORLEVEL!

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -31,6 +31,7 @@ set __PrintLastResultsOnly=
 set LogsDirArg=
 set RunInUnloadableContext=
 set TieringTest=
+set RunInterpreter=
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -74,6 +75,7 @@ if /i "%1" == "timeout"                                 (set __TestTimeout=%2&sh
 if /i "%1" == "runincontext"                            (set RunInUnloadableContext=1&shift&goto Arg_Loop)
 if /i "%1" == "tieringtest"                             (set TieringTest=1&shift&goto Arg_Loop)
 if /i "%1" == "runnativeaottests"                       (set RunNativeAot=1&shift&goto Arg_Loop)
+if /i "%1" == "interpreter"                             (set RunInterpreter=1&shift&goto Arg_Loop)
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.
@@ -169,6 +171,10 @@ if defined RunNativeAot (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_nativeaot_tests
 )
 
+if defined RunInterpreter (
+    set __RuntestPyArgs=%__RuntestPyArgs% --interpreter
+)
+
 REM Find python and set it to the variable PYTHON
 set _C=-c "import sys; sys.stdout.write(sys.executable)"
 (py -3 %_C% || py -2 %_C% || python3 %_C% || python2 %_C% || python %_C%) > %TEMP%\pythonlocation.txt 2> NUL
@@ -233,6 +239,7 @@ echo                             Note: some options override this ^(gcstressleve
 echo logsdir ^<dir^>             - Specify the logs directory ^(default: artifacts/log^)
 echo msbuildargs ^<args...^>     - Pass all subsequent args directly to msbuild invocations.
 echo ^<CORE_ROOT^>               - Path to the runtime to test ^(if specified^).
+echo interpreter               - Runs the tests with the interpreter enabled.
 echo.
 echo Note that arguments are not case-sensitive.
 echo.

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -105,6 +105,7 @@ parser.add_argument("--run_crossgen2_tests", dest="run_crossgen2_tests", action=
 parser.add_argument("--large_version_bubble", dest="large_version_bubble", action="store_true", default=False)
 parser.add_argument("--synthesize_pgo", dest="synthesize_pgo", action="store_true", default=False)
 parser.add_argument("--sequential", dest="sequential", action="store_true", default=False)
+parser.add_argument("--interpreter", dest="interpreter", action="store_true", default=False)
 
 parser.add_argument("--analyze_results_only", dest="analyze_results_only", action="store_true", default=False)
 parser.add_argument("--verbose", dest="verbose", action="store_true", default=False)
@@ -856,6 +857,11 @@ def run_tests(args,
         print("Running tests NativeAOT")
         os.environ["CLRCustomTestLauncher"] = args.nativeaottest_script_path
 
+    if args.interpreter:
+        print("Running tests with the interpreter")
+        print("Setting RunInterpreter=1")
+        os.environ["RunInterpreter"] = "1"
+
     if gc_stress:
         per_test_timeout *= 8
         print("Running GCStress, extending test timeout to cater for slower runtime.")
@@ -1009,6 +1015,11 @@ def setup_args(args):
                               "run_nativeaot_tests",
                               lambda arg: True,
                               "Error setting run_nativeaot_tests")
+
+    coreclr_setup_args.verify(args,
+                              "interpreter",
+                              lambda arg: True,
+                              "Error setting interpreter")
 
     if coreclr_setup_args.sequential and coreclr_setup_args.parallel:
         print("Error: don't specify both --sequential and -parallel")

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -41,6 +41,7 @@ function print_usage {
     echo '  --runincontext                   : Run each tests in an unloadable AssemblyLoadContext'
     echo '  --tieringtest                    : Run each test to encourage tier1 rejitting'
     echo '  --runnativeaottests              : Run NativeAOT compiled tests'
+    echo '  --interpreter                    : Runs the tests with the interpreter enabled'
     echo '  --limitedDumpGeneration          : '
 }
 
@@ -191,6 +192,9 @@ do
         --runnativeaottests)
             nativeaottest=1
             ;;
+        --interpreter)
+            export RunInterpreter=1
+            ;;
         *)
             echo "Unknown switch: $i"
             print_usage
@@ -295,6 +299,11 @@ fi
 if [[ "$nativeaottest" -ne 0 ]]; then
     echo "Running NativeAOT compiled tests"
     runtestPyArguments+=("--run_nativeaot_tests")
+fi
+
+if [[ -n "$RunInterpreter" ]]; then
+    echo "Running tests with the interpreter"
+    runtestPyArguments+=("--interpreter")
 fi
 
 # Default to python3 if it is installed


### PR DESCRIPTION
This change adds support for running tests using interpreter to the generated .cmd files of the tests. It also adds a command line option to the src/tests/run.{cmd|sh} that makes the test infrastructure to run the tests using the interpreter.