### PR TITLE
Harden CancelSendPingAsync tests

### DIFF
--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -13,7 +13,6 @@ using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 using Xunit.Abstractions;
 using System.Threading;
-using System.Runtime.CompilerServices;
 
 namespace System.Net.NetworkInformation.Tests
 {

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -712,7 +712,7 @@ namespace System.Net.NetworkInformation.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
-        [OuterLoop] // Depends on external host and assumption that successful ping takes long enough for cancellation to go through first
+        [OuterLoop("Depends on external host and runs long on Windows.")]
         public async Task CancelSendPingAsync_IPAddress(bool useCancellationToken)
         {
             if (await TestCore(TestSettings.UnreachableAddress)) return;

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 using Xunit.Abstractions;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
 namespace System.Net.NetworkInformation.Tests
 {
@@ -687,24 +688,15 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        [OuterLoop] // Depends on external host and assumption that successful ping takes long enough for cancellation to go through first
-        public async Task CancelSendPingAsync(bool useIPAddress, bool useCancellationToken)
+        [InlineData(false)]
+        [InlineData(true)]
+        [OuterLoop("Depends on external host.")]
+        public async Task CancelSendPingAsync_HostName(bool useCancellationToken)
         {
-            if (PlatformDetection.IsOSX && useIPAddress && !useCancellationToken)
-            {
-                throw new SkipTestException("[ActiveIssue(https://github.com/dotnet/runtime/issues/114782)]");
-            }
-
             using CancellationTokenSource source = new();
 
             using Ping ping = new();
-            Task pingTask = useIPAddress
-                ? ping.SendPingAsync((await Dns.GetHostAddressesAsync(Test.Common.Configuration.Ping.PingHost))[0], TimeSpan.FromSeconds(5), cancellationToken: source.Token)
-                : ping.SendPingAsync(Test.Common.Configuration.Ping.PingHost, TimeSpan.FromSeconds(5), cancellationToken: source.Token);
+            Task pingTask = ping.SendPingAsync(Test.Common.Configuration.Ping.PingHost, TimeSpan.FromSeconds(5), cancellationToken: source.Token);
             if (useCancellationToken)
             {
                 source.Cancel();
@@ -715,6 +707,52 @@ namespace System.Net.NetworkInformation.Tests
             }
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pingTask);
             Assert.True(pingTask.IsCanceled);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(false)]
+        [InlineData(true)]
+        [OuterLoop] // Depends on external host and assumption that successful ping takes long enough for cancellation to go through first
+        public async Task CancelSendPingAsync_IPAddress(bool useCancellationToken)
+        {
+            if (await TestCore(TestSettings.UnreachableAddress)) return;
+            if (await TestCore(TestSettings.UnreachableAddress2)) return;
+            if (await TestCore(TestSettings.UnreachableAddress3)) return;
+
+            Assert.Fail("No OperationCanceledException has been thrown after attempting cancellation with various unreachable hosts.");
+
+            async Task<bool> TestCore(string unreachableIPString)
+            {
+                IPAddress address = IPAddress.Parse(unreachableIPString);
+                using CancellationTokenSource source = new();
+
+                using Ping ping = new();
+                Task<PingReply> pingTask = ping.SendPingAsync(address, TimeSpan.FromSeconds(5), cancellationToken: source.Token);
+                if (useCancellationToken)
+                {
+                    source.Cancel();
+                }
+                else
+                {
+                    ping.SendAsyncCancel();
+                }
+
+                try
+                {
+                    PingReply reply = await pingTask;
+                    if (reply.Status == IPStatus.DestinationNetworkUnreachable)
+                    {
+                        _output.WriteLine($"We got a DestinationNetworkUnreachable reply before cancellation for {address}. Retry on a different address.");
+                        return false;
+                    }
+
+                    Assert.Fail("No OperationCanceledException has been thrown.");
+                }
+                catch (OperationCanceledException) { }
+
+                Assert.True(pingTask.IsCanceled);
+                return true;
+            }
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]


### PR DESCRIPTION
Fixes #113831.

Separate `SendPingAsync(hostname)` and `SendPingAsync(IPAddress)` test implementations:
- `SendPingAsync(hostname)`: we didn't see issues with this variant in the CI. It effectively tests if the resolution of `www.microsoft.com` is cancelled as part of the `SendPingAsync` call. Keep the existing logic in a separate method.
- `SendPingAsync(IPAddress)`: occasionally, pinging the valid IP likely resulted in replies before the cancellation could kick in on Helix Mac machines. Instead, let's ping an unreachable IP to avoid this. Since that can also sometimes result to an ICMP reply instead of a timeout, use the same trick as in #116500, repeating the test with other hosts if it happens.