### PR TITLE
Fix build to use new method name

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
@@ -179,7 +179,7 @@ namespace System.Security.Cryptography
                     out ReadOnlySpan<char> parameterSet,
                     out string blobType);
 
-                string expectedParameterSet = PqcBlobHelpers.GetParameterSet(Algorithm);
+                string expectedParameterSet = PqcBlobHelpers.GetMLDsaParameterSet(Algorithm);
 
                 if (blobType != keyBlobType ||
                     keyBytes.Length != expectedKeySize ||

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.Cng.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.Cng.cs
@@ -8,7 +8,7 @@ namespace System.Security.Cryptography.Tests
         internal static MLDsaCng ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             CngKey key = PqcBlobHelpers.EncodeMLDsaBlob(
-                PqcBlobHelpers.GetParameterSet(algorithm),
+                PqcBlobHelpers.GetMLDsaParameterSet(algorithm),
                 source,
                 Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PUBLIC_BLOB,
                 blob => CngKey.Import(blob.ToArray(), CngKeyBlobFormat.PQDsaPublicBlob));
@@ -31,7 +31,7 @@ namespace System.Security.Cryptography.Tests
         internal static MLDsaCng ImportPrivateSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source, CngExportPolicies exportPolicies)
         {
             CngKey key = PqcBlobHelpers.EncodeMLDsaBlob(
-                PqcBlobHelpers.GetParameterSet(algorithm),
+                PqcBlobHelpers.GetMLDsaParameterSet(algorithm),
                 source,
                 Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB,
                 blob =>
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.Tests
         internal static MLDsaCng ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source, CngExportPolicies exportPolicies)
         {
             CngKey key = PqcBlobHelpers.EncodeMLDsaBlob(
-                PqcBlobHelpers.GetParameterSet(algorithm),
+                PqcBlobHelpers.GetMLDsaParameterSet(algorithm),
                 source,
                 Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB,
                 blob =>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaCng.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaCng.Windows.cs
@@ -308,7 +308,7 @@ namespace System.Security.Cryptography
             {
                 ReadOnlySpan<byte> keyBytes = PqcBlobHelpers.DecodeMLDsaBlob(blob, out ReadOnlySpan<char> parameterSet, out string blobType);
 
-                string expectedParameterSet = PqcBlobHelpers.GetParameterSet(Algorithm);
+                string expectedParameterSet = PqcBlobHelpers.GetMLDsaParameterSet(Algorithm);
 
                 if (blobType != blobFormat.Format ||
                     keyBytes.Length != expectedKeySize ||

--- a/src/libraries/System.Security.Cryptography/tests/MLDsaCngTests.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/tests/MLDsaCngTests.Windows.cs
@@ -86,7 +86,7 @@ namespace System.Security.Cryptography.Tests
         public void ImportPrivateSeed_Persisted()
         {
             CngKey key = PqcBlobHelpers.EncodeMLDsaBlob(
-                PqcBlobHelpers.GetParameterSet(MLDsaAlgorithm.MLDsa44),
+                PqcBlobHelpers.GetMLDsaParameterSet(MLDsaAlgorithm.MLDsa44),
                 MLDsaTestsData.IetfMLDsa44.PrivateSeed,
                 Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB,
                 blob =>
@@ -135,7 +135,7 @@ namespace System.Security.Cryptography.Tests
         public void ImportSecretKey_Persisted()
         {
             CngKey key = PqcBlobHelpers.EncodeMLDsaBlob(
-                PqcBlobHelpers.GetParameterSet(MLDsaAlgorithm.MLDsa44),
+                PqcBlobHelpers.GetMLDsaParameterSet(MLDsaAlgorithm.MLDsa44),
                 MLDsaTestsData.IetfMLDsa44.SecretKey,
                 Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB,
                 blob =>


### PR DESCRIPTION
In #116440, `GetParameterSet` was renamed to `GetMLDsaParameterSet`. However, #116394 was merged using the old name.

Fixes #116592