### PR TITLE
[benchmark] Use unsafe indexing for `Guid.DecodeByte`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -817,8 +817,8 @@ namespace System
         {
             ReadOnlySpan<byte> lookup = HexConverter.CharToHexLookup;
             Debug.Assert(lookup.Length == 256);
-            int upper = (sbyte)lookup[byte.CreateTruncating(ch1)];
-            int lower = (sbyte)lookup[byte.CreateTruncating(ch2)];
+            int upper = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), byte.CreateTruncating(ch1));
+            int lower = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), byte.CreateTruncating(ch2));
             int result = (upper << 4) | lower;
 
             uint c1 = TChar.CastToUInt32(ch1);


### PR DESCRIPTION
| Method            | Toolchain               | Mean        | Error      | Ratio | Allocated | Alloc Ratio |
|------------------ |------------------------ |------------:|-----------:|------:|----------:|------------:|
| ParseExactD       | Main |  18.4946 ns |  0.0146 ns |  1.00 |         - |          NA |
| ParseExactD       | PR   |  17.6553 ns |  0.0168 ns |  0.95 |         - |          NA |
|                   |                         |             |            |       |           |             |
| ctor_str          | Main |  18.5661 ns |  0.0642 ns |  1.00 |         - |          NA |
| ctor_str          | PR   |  17.7325 ns |  0.0835 ns |  0.96 |         - |          NA |
|                   |                         |             |            |       |           |             |
| Parse             | Main |  18.9283 ns |  0.3844 ns |  1.00 |         - |          NA |
| Parse             | PR   |  18.5971 ns |  0.9702 ns |  0.98 |         - |          NA |
