### PR TITLE
ML-DSA: Add BCrypt support in Microsoft.Bcl.Cryptography

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using Internal.NativeCrypto;
 using Microsoft.Win32.SafeHandles;
 
@@ -29,6 +31,7 @@ namespace System.Security.Cryptography
             _hasSecretKey = hasSecretKey;
         }
 
+        [MemberNotNullWhen(true, nameof(s_algHandle))]
         internal static partial bool SupportsAny() => s_algHandle is not null;
 
         protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) =>
@@ -39,7 +42,7 @@ namespace System.Security.Cryptography
 
         internal static partial MLDsaImplementation GenerateKeyImpl(MLDsaAlgorithm algorithm)
         {
-            Debug.Assert(s_algHandle is not null, $"Check {nameof(SupportsAny)}() before calling.");
+            Debug.Assert(SupportsAny());
 
             string parameterSet = PqcBlobHelpers.GetMLDsaParameterSet(algorithm);
             SafeBCryptKeyHandle keyHandle = Interop.BCrypt.BCryptGenerateKeyPair(s_algHandle, keyLength: 0);
@@ -60,7 +63,7 @@ namespace System.Security.Cryptography
 
         internal static partial MLDsaImplementation ImportPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            Debug.Assert(s_algHandle is not null, $"Check {nameof(SupportsAny)}() before calling.");
+            Debug.Assert(SupportsAny());
 
             const string PublicBlobType = Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PUBLIC_BLOB;
 
@@ -76,7 +79,7 @@ namespace System.Security.Cryptography
 
         internal static partial MLDsaImplementation ImportSecretKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            Debug.Assert(s_algHandle is not null, $"Check {nameof(SupportsAny)}() before calling.");
+            Debug.Assert(SupportsAny());
 
             const string PrivateBlobType = Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB;
 
@@ -92,7 +95,7 @@ namespace System.Security.Cryptography
 
         internal static partial MLDsaImplementation ImportSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            Debug.Assert(s_algHandle is not null, $"Check {nameof(SupportsAny)}() before calling.");
+            Debug.Assert(SupportsAny());
 
             const string PrivateSeedBlobType = Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB;
 
@@ -140,34 +143,6 @@ namespace System.Security.Cryptography
             _key = null!;
         }
 
-        internal CngKey CreateEphemeralCng()
-        {
-            string bcryptBlobType =
-                _hasSeed ? Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB :
-                _hasSecretKey ? Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB :
-                Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PUBLIC_BLOB;
-
-            CngKeyBlobFormat cngBlobFormat =
-                _hasSecretKey ? CngKeyBlobFormat.PQDsaPrivateBlob :
-                _hasSeed ? CngKeyBlobFormat.PQDsaPrivateSeedBlob :
-                CngKeyBlobFormat.PQDsaPublicBlob;
-
-            ArraySegment<byte> keyBlob = Interop.BCrypt.BCryptExportKey(_key, bcryptBlobType);
-            CngKey key;
-
-            try
-            {
-                key = CngKey.Import(keyBlob, cngBlobFormat);
-            }
-            finally
-            {
-                CryptoPool.Return(keyBlob);
-            }
-
-            key.ExportPolicy = CngExportPolicies.AllowExport | CngExportPolicies.AllowPlaintextExport;
-            return key;
-        }
-
         private void ExportKey(string keyBlobType, int expectedKeySize, Span<byte> destination)
         {
             ArraySegment<byte> keyBlob = Interop.BCrypt.BCryptExportKey(_key, keyBlobType);
@@ -187,7 +162,7 @@ namespace System.Security.Cryptography
                 {
                     Debug.Fail(
                         $"{nameof(blobType)}: {blobType}, " +
-                        $"{nameof(parameterSet)}: {parameterSet}, " +
+                        $"{nameof(parameterSet)}: {parameterSet.ToString()}, " +
                         $"{nameof(keyBytes)}.Length: {keyBytes.Length} / {expectedKeySize}");
 
                     throw new CryptographicException();
@@ -203,6 +178,13 @@ namespace System.Security.Cryptography
 
         private static SafeBCryptAlgorithmHandle? OpenAlgorithmHandle()
         {
+#if !NETFRAMEWORK
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return null;
+            }
+#endif
+
             NTSTATUS status = Interop.BCrypt.BCryptOpenAlgorithmProvider(
                 out SafeBCryptAlgorithmHandle hAlgorithm,
                 BCryptNative.AlgorithmName.MLDsa,

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
@@ -115,17 +115,31 @@ namespace System.Security.Cryptography
                 Algorithm.PublicKeySizeInBytes,
                 destination);
 
-        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination) =>
+        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination)
+        {
+            if (!_hasSecretKey)
+            {
+                throw new CryptographicException(SR.Cryptography_MLDsaNoSecretKey);
+            }
+
             ExportKey(
                 Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB,
                 Algorithm.SecretKeySizeInBytes,
                 destination);
+        }
 
-        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) =>
+        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination)
+        {
+            if (!_hasSeed)
+            {
+                throw new CryptographicException(SR.Cryptography_MLDsaNoSeed);
+            }
+
             ExportKey(
                 Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB,
                 Algorithm.PrivateSeedSizeInBytes,
                 destination);
+        }
 
         protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/PqcBlobHelpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/PqcBlobHelpers.cs
@@ -122,7 +122,7 @@ namespace System.Security.Cryptography
                 int index = 0;
 
                 // Write header
-                ref BCRYPT_PQDSA_KEY_BLOB blobHeader = ref MemoryMarshal.AsRef<BCRYPT_PQDSA_KEY_BLOB>(blobBytes);
+                ref BCRYPT_PQDSA_KEY_BLOB blobHeader = ref MemoryMarshal.Cast<byte, BCRYPT_PQDSA_KEY_BLOB>(blobBytes)[0];
                 blobHeader.Magic = magic;
                 blobHeader.cbParameterSet = parameterSetLengthWithNullTerminator;
                 blobHeader.cbKey = data.Length;
@@ -157,7 +157,7 @@ namespace System.Security.Cryptography
         {
             int index = 0;
 
-            ref readonly BCRYPT_PQDSA_KEY_BLOB blob = ref MemoryMarshal.AsRef<BCRYPT_PQDSA_KEY_BLOB>(blobBytes);
+            ref readonly BCRYPT_PQDSA_KEY_BLOB blob = ref MemoryMarshal.Cast<byte, BCRYPT_PQDSA_KEY_BLOB>(blobBytes)[0];
             magic = blob.Magic;
             int parameterSetLength = blob.cbParameterSet - 2; // Null terminator char, '\0'
             int keyLength = blob.cbKey;

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
@@ -363,6 +363,8 @@
     </Compile>
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Cng.cs"
              Link="Common\Interop\Windows\BCrypt\Cng.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs"
+             Link="Common\Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs" /> 
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDecapsulateEncapsulate.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptDecapsulateEncapsulate.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptExportKey.cs"
@@ -377,12 +379,20 @@
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptPropertyStrings.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptSetProperty.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptSetProperty.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptSignHash.cs"
+             Link="Common\Interop\Windows\BCrypt\Interop.BCryptSignHash.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptVerifySignature.cs"
+             Link="Common\Interop\Windows\BCrypt\Interop.BCryptVerifySignature.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs"
              Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKem.cs"
              Link="Common\System\Security\Cryptography\MLKem.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemAlgorithm.cs"
              Link="Common\System\Security\Cryptography\MLKemAlgorithm.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.Windows.cs"
+             Link="Common\System\Security\Cryptography\MLDsaImplementation.Windows.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaPkcs8.cs"
+             Link="Common\System\Security\Cryptography\MLDsaPkcs8.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemImplementation.Windows.cs"
              Link="Common\System\Security\Cryptography\MLKemImplementation.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemPkcs8.cs"
@@ -391,6 +401,8 @@
              Link="Common\System\Security\Cryptography\PemKeyHelpers.Factory.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\PemLabels.cs"
              Link="Common\System\Security\Cryptography\PemLabels.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.cs"
+             Link="Common\System\Security\Cryptography\PqcBlobHelpers.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.MLKem.cs"
              Link="Common\System\Security\Cryptography\PqcBlobHelpers.MLKem.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\SlhDsa.cs"
@@ -407,8 +419,6 @@
              Link="Common\System\Security\Cryptography\MLDsaAlgorithm.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.cs"
              Link="Common\System\Security\Cryptography\MLDsaImplementation.cs" />
-    <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.NotSupported.cs"
-             Link="Common\System\Security\Cryptography\MLDsaImplementation.NotSupported.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
@@ -171,6 +171,12 @@
   <data name="Cryptography_KeyWrongSizeForAlgorithm" xml:space="preserve">
     <value>The specified key is not the correct size for the indicated algorithm.</value>
   </data>
+  <data name="Cryptography_MLDsaNoSecretKey" xml:space="preserve">
+    <value>The current instance does not contain a secret key.</value>
+  </data>
+  <data name="Cryptography_MLDsaNoSeed" xml:space="preserve">
+    <value>The current instance does not contain a seed.</value>
+  </data>
   <data name="Cryptography_MLDsaPkcs8KeyMismatch" xml:space="preserve">
     <value>The specified PKCS#8 key contains a seed that does not match the expanded key.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -549,6 +549,12 @@
   <data name="Cryptography_MLDsaInvalidAlgorithmHandle" xml:space="preserve">
     <value>The specified EVP_PKEY handle is not a known ML-DSA algorithm.</value>
   </data>
+  <data name="Cryptography_MLDsaNoSecretKey" xml:space="preserve">
+    <value>The current instance does not contain a secret key.</value>
+  </data>
+  <data name="Cryptography_MLDsaNoSeed" xml:space="preserve">
+    <value>The current instance does not contain a seed.</value>
+  </data>
   <data name="Cryptography_MLDsaPkcs8KeyMismatch" xml:space="preserve">
     <value>The specified PKCS#8 key contains a seed that does not match the expanded key.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -1932,6 +1932,7 @@
     <Compile Include="System\Security\Cryptography\KeyPropertyName.cs" />
     <Compile Include="System\Security\Cryptography\LiteHash.Windows.cs" />
     <Compile Include="System\Security\Cryptography\MLDsaCng.Windows.cs" />
+    <Compile Include="System\Security\Cryptography\MLDsaImplementation.CreateCng.cs" />
     <Compile Include="System\Security\Cryptography\MLDsaOpenSsl.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\MLKemOpenSsl.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\OidLookup.Windows.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaImplementation.CreateCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaImplementation.CreateCng.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Security.Cryptography
+{
+    internal sealed partial class MLDsaImplementation
+    {
+        internal CngKey CreateEphemeralCng()
+        {
+            string bcryptBlobType =
+                _hasSeed ? Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_SEED_BLOB :
+                _hasSecretKey ? Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PRIVATE_BLOB :
+                Interop.BCrypt.KeyBlobType.BCRYPT_PQDSA_PUBLIC_BLOB;
+
+            CngKeyBlobFormat cngBlobFormat =
+                _hasSecretKey ? CngKeyBlobFormat.PQDsaPrivateBlob :
+                _hasSeed ? CngKeyBlobFormat.PQDsaPrivateSeedBlob :
+                CngKeyBlobFormat.PQDsaPublicBlob;
+
+            ArraySegment<byte> keyBlob = Interop.BCrypt.BCryptExportKey(_key, bcryptBlobType);
+            CngKey key;
+
+            try
+            {
+                key = CngKey.Import(keyBlob, cngBlobFormat);
+            }
+            finally
+            {
+                CryptoPool.Return(keyBlob);
+            }
+
+            key.ExportPolicy = CngExportPolicies.AllowExport | CngExportPolicies.AllowPlaintextExport;
+            return key;
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaImplementation.OpenSsl.cs
@@ -59,11 +59,25 @@ namespace System.Security.Cryptography
         protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) =>
             Interop.Crypto.MLDsaExportPublicKey(_key, destination);
 
-        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination) =>
-            Interop.Crypto.MLDsaExportSecretKey(_key, destination);
+        protected override void ExportMLDsaSecretKeyCore(Span<byte> destination)
+        {
+            if (!_hasSecretKey)
+            {
+                throw new CryptographicException(SR.Cryptography_MLDsaNoSecretKey);
+            }
 
-        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) =>
+            Interop.Crypto.MLDsaExportSecretKey(_key, destination);
+        }
+
+        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination)
+        {
+            if (!_hasSeed)
+            {
+                throw new CryptographicException(SR.Cryptography_MLDsaNoSeed);
+            }
+
             Interop.Crypto.MLDsaExportSeed(_key, destination);
+        }
 
         protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
         {


### PR DESCRIPTION
And fix failing tests.

Fixes #116598