### PR TITLE
Copy integer registers on AMD64 architecture for debugger stackwalking

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5646,7 +5646,11 @@ void DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContex
                 {
                     UpdateContextFromRegDisp(&tmpRd, &tmpContext);
                     CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
-                    pContextBuffer->ContextFlags = DT_CONTEXT_CONTROL;
+                    pContextBuffer->ContextFlags = DT_CONTEXT_CONTROL 
+#ifdef TARGET_AMD64
+                                                | DT_CONTEXT_INTEGER  // On AMD64, we also need to save RBP for stackwalking
+#endif
+                    ;
                     return;
                 }
                 frame = frame->Next();


### PR DESCRIPTION
Fixes #115668 #116153

The out of process stackwalker on AMD64 requires RBP to be present.  Under certain circumstances, the debugger's stackwalker needs to make a copy of a particular frame's current context, and then create a temporary stackwalker from that location.  In that case, the threadcontext copy only copied the control registers (RIP and RSP) on AMD64, skipping RBP which is considered to be an integer register.  The out of process stackwalker would then attempt to de-reference the pointer located in RBP and AV.  This fix addresses that issue by copying the integer registers in addition to the control registers.

Note that with this change we will be copying some extra registers on AMD64. One alternative change would be to only copy the RBP register in addition to the control registers; however, since RBP is considered an integer register on AMD64, this PR keeps the change simple and consistent with Windows context register definitions by copying all integer registers.