### PR TITLE
Increase buffer size for readir_r and add support for enumerating filenames > 255 bytes

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -40,10 +40,13 @@ internal static partial class Interop
 
                 Debug.Assert(nameBytes.Length > 0, "we shouldn't have gotten a garbage value from the OS");
 
-                int charCount = Encoding.UTF8.GetChars(nameBytes, buffer);
-                ReadOnlySpan<char> value = buffer.Slice(0, charCount);
-                Debug.Assert(!value.Contains('\0'), "should not have embedded nulls");
-                return value;
+                ReadOnlySpan<char> result = !Encoding.UTF8.TryGetChars(nameBytes, buffer, out int charsWritten)
+                    ? Encoding.UTF8.GetString(nameBytes) // Fallback to allocation since this is a rare case
+                    : buffer.Slice(0, charsWritten);
+
+                Debug.Assert(!result.Contains('\0'), "should not have embedded nulls");
+
+                return result;
             }
         }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -29,26 +29,20 @@ internal static partial class Interop
             internal byte* Name;
             internal int NameLength;
             internal NodeType InodeType;
-            internal const int NameBufferSize = 256; // sizeof(dirent->d_name) == NAME_MAX + 1
 
             internal ReadOnlySpan<char> GetName(Span<char> buffer)
             {
-                // -1 for null terminator (buffer will not include one),
-                //  and -1 because GetMaxCharCount pessimistically assumes the buffer may start with a partial surrogate
-                Debug.Assert(buffer.Length >= Encoding.UTF8.GetMaxCharCount(NameBufferSize - 1 - 1));
-
                 Debug.Assert(Name != null, "should not have a null name");
 
                 ReadOnlySpan<byte> nameBytes = (NameLength == -1)
-                    // In this case the struct was allocated via struct dirent *readdir(DIR *dirp);
-                    ? new ReadOnlySpan<byte>(Name, new ReadOnlySpan<byte>(Name, NameBufferSize).IndexOf<byte>(0))
+                    ? MemoryMarshal.CreateReadOnlySpanFromNullTerminated(Name)
                     : new ReadOnlySpan<byte>(Name, NameLength);
 
                 Debug.Assert(nameBytes.Length > 0, "we shouldn't have gotten a garbage value from the OS");
 
                 int charCount = Encoding.UTF8.GetChars(nameBytes, buffer);
                 ReadOnlySpan<char> value = buffer.Slice(0, charCount);
-                Debug.Assert(NameLength != -1 || !value.Contains('\0'), "should not have embedded nulls if we parsed the end of string");
+                Debug.Assert(!value.Contains('\0'), "should not have embedded nulls");
                 return value;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -11,6 +11,7 @@ namespace System.IO.Enumeration
     /// </summary>
     public unsafe ref partial struct FileSystemEntry
     {
+        private const int DecodedNameMaxLength = 256;
         private Interop.Sys.DirectoryEntry _directoryEntry;
         private bool _isDirectory;
         private FileStatus _status;
@@ -22,7 +23,7 @@ namespace System.IO.Enumeration
         // Wrap the fixed buffer to workaround visibility issues in api compat verification
         private struct FileNameBuffer
         {
-            internal fixed char _buffer[Interop.Sys.DirectoryEntry.NameBufferSize];
+            internal fixed char _buffer[DecodedNameMaxLength];
         }
 
         internal static FileAttributes Initialize(
@@ -95,7 +96,7 @@ namespace System.IO.Enumeration
             {
                 if (_directoryEntry.NameLength != 0 && _fileName.Length == 0)
                 {
-                    Span<char> buffer = MemoryMarshal.CreateSpan(ref _fileNameBuffer._buffer[0], Interop.Sys.DirectoryEntry.NameBufferSize);
+                    Span<char> buffer = MemoryMarshal.CreateSpan(ref _fileNameBuffer._buffer[0], DecodedNameMaxLength);
                     _fileName = _directoryEntry.GetName(buffer);
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
@@ -260,17 +260,6 @@ namespace System
             return id;
         }
 
-        private static string? GetDirectoryEntryFullPath(ref Interop.Sys.DirectoryEntry dirent, string currentPath)
-        {
-            ReadOnlySpan<char> direntName = dirent.GetName(stackalloc char[Interop.Sys.DirectoryEntry.NameBufferSize]);
-
-            if ((direntName.Length == 1 && direntName[0] == '.') ||
-                (direntName.Length == 2 && direntName[0] == '.' && direntName[1] == '.'))
-                return null;
-
-            return Path.Join(currentPath.AsSpan(), direntName);
-        }
-
         private static bool CompareTimeZoneFile(string filePath, byte[] buffer, byte[] rawData)
         {
             try

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/EnumerableTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/EnumerableTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,6 +32,26 @@ namespace System.IO.Tests
             }
             catch (Exception e) when (!(e is IOException))
             {
+            }
+        }
+
+        [Fact]
+        public void FileEnumeratorIsThreadSafe_ParallelForEach()
+        {
+            List<string> expected = [];
+            string directory = Directory.CreateDirectory(GetTestFilePath()).FullName;
+            for (int i = 0; i < 100; i++)
+            {
+                string file = Path.Join(directory, GetTestFileName());
+                File.Create(file).Dispose();
+                expected.Add(file);
+            }
+
+            for (int i = 0; i < 100; i++) // test multiple times to ensure thread safety.
+            {
+                ConcurrentBag<string> result = [];
+                ParallelLoopResult parallelResult = Parallel.ForEach(Directory.EnumerateFiles(directory), f => result.Add(f));
+                AssertExtensions.CollectionEqual(expected, result, StringComparer.Ordinal);
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/ManualTests/NtfsOnLinuxSetup.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/ManualTests/NtfsOnLinuxSetup.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Xunit.Sdk;
+
+namespace System.IO.ManualTests
+{
+    public class NtfsOnLinuxSetup : IDisposable
+    {
+        public NtfsOnLinuxSetup()
+        {
+            if (!NtfsOnLinuxTests.IsManualTestsEnabledAndElevated)
+                throw new XunitException("Set MANUAL_TESTS envvar and run as elevated to execute this test setup.");
+            
+            ExecuteShell("""
+                dd if=/dev/zero of=my_loop_device.img bs=1M count=100
+                losetup /dev/loop99 my_loop_device.img
+                mkfs -t ntfs /dev/loop99
+                mkdir -p /mnt/ntfs
+                mount /dev/loop99 /mnt/ntfs
+                """);
+        }
+
+        public void Dispose()
+        {
+            ExecuteShell("""
+                umount /mnt/ntfs
+                losetup -d /dev/loop99
+                rm my_loop_device.img
+                """);
+        }
+        
+        private static void ExecuteShell(string command)
+        {
+            using Process process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/bin/sh",
+                    ArgumentList = { "-c", command },
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                }
+            };
+            process.OutputDataReceived += (sender, e) => Console.WriteLine($"[OUTPUT] {e.Data}");
+            process.ErrorDataReceived += (sender, e) => Console.WriteLine($"[ERROR] {e.Data}");
+
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            process.WaitForExit();
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/ManualTests/NtfsOnLinuxTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/ManualTests/NtfsOnLinuxTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.IO.ManualTests
+{
+    public class NtfsOnLinuxTests : IClassFixture<NtfsOnLinuxSetup>
+    {
+        internal static bool IsManualTestsEnabledAndElevated => FileSystemManualTests.ManualTestsEnabled && AdminHelpers.IsProcessElevated();
+
+        [ConditionalTheory(nameof(IsManualTestsEnabledAndElevated))]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        [InlineData("Ω", 255)]
+        [InlineData("あ", 255)]
+        [InlineData("😀", 127)]
+        public void NtfsOnLinux_FilenamesLongerThan255Bytes_FileEnumerationSucceeds(string codePoint, int maxAllowedLength)
+        {
+            string filename = string.Concat(Enumerable.Repeat(codePoint, maxAllowedLength));
+            Assert.True(Encoding.UTF8.GetByteCount(filename) > 255);
+
+            string filePath = $"/mnt/ntfs/{filename}";
+            File.Create(filePath).Dispose();
+            Assert.Contains(filePath, Directory.GetFiles("/mnt/ntfs"));
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/ManualTests/System.IO.FileSystem.Manual.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/ManualTests/System.IO.FileSystem.Manual.Tests.csproj
@@ -4,5 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ManualTests.cs" />
+    <Compile Include="NtfsOnLinuxSetup.cs" />
+    <Compile Include="NtfsOnLinuxTests.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
readdir_r is the re-entrant version of readdir; it works by calling readdir with a lock. On success it copies the next entry into a user buffer with memcpy(). It is prone to truncation errors if the following is true:

1. The user buffer (a `dirent*`) is allocated with a `d_name` field too small to hold the filename.  [POSIX is misleading](https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/basedefs/dirent.h.html) as it suggests that `d_name` "shall contain a filename of at most {NAME_MAX} + 1," hence why some libraries, including dotnet, assumed filenames do not exceed 256 bytes.
2. The filesystem allows filenames > 255 bytes. For example, NTFS filename limit is 255 UTF-16 code-units, which can expand to more than 255 bytes, [ZFS v2.3.0](https://github.com/openzfs/zfs/releases/tag/zfs-2.3.0) introduced support for 1023 bytes filenames.

I noticed trucation doesn't occur on macOS because they use a [1024 size for d_name](https://github.com/apple-oss-distributions/Libc/blob/63976b830a836a22649b806fe62e8614fe3e5555/exclave/dirent.h#L69-L77), I'm borrowing their approach here.

## Alternative
An alternative approach is to get rid of readdir_r entirely, but I was hesitant to implement it for the following reasons:
* it *may* de-stabilize platforms where readdir is not thread-safe when called using different directory handles.
* pal_io.c has [preprocessors](https://github.com/dotnet/runtime/blob/2fb0bc076f67ed3fcad0d7061ccb63fdbd3e29da/src/native/libs/System.Native/pal_io.c#L549) for platforms that I cannot verify would continue working if we change to readdir.  Specifically, for AIX, see its [licensing](https://www.ibm.com/support/pages/aix-licensing-information).

I will still list the reasons I believe support it:
* [POSIX version 2024](https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/functions/readdir_r.html) has updated its Rationale to mention "readdir_r() has been marked obsolescent and readdir() is now required to be thread safe as long as there are no concurrent calls to it on a single directory stream".  On top of that Future Directions states that the function may be removed in a future version.
* We are already prefering readdir in platforms that deprecate readdir_r; glibc and bionic are some examples.  musl and macOS are examples of the opposite but that I've tested that work with readdir.
* Increasing the buffer size may become just a temporary fix.
* Other libraries have been moving away from readdir_r, for example glibc as I already mentioned, and Rust https://github.com/rust-lang/rust/commit/bc04a4eac47dcdc9feb3061dcc683e9d420227ab.

cc @AustinWise @NattyNarwhal