### PR TITLE
Re-enable terminal logger

### DIFF
--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,2 +1,0 @@
-# disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
--tl:false

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -138,7 +138,7 @@ if (-not $PSBoundParameters.ContainsKey("subset") -and $properties.Length -gt 0 
 }
 
 if ($subset -eq 'help') {
-  Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" -restore -build /p:subset=help /clp:nosummary /tl:false"
+  Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" -restore -build /p:subset=help /clp:nosummary /v:detailed"
   exit 0
 }
 
@@ -332,9 +332,6 @@ foreach ($argument in $PSBoundParameters.Keys)
 if ($env:TreatWarningsAsErrors -eq 'false') {
   $arguments += " -warnAsError `$false"
 }
-
-# disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
-$arguments += " /tl:false"
 
 # Disable targeting pack caching as we reference a partially constructed targeting pack and update it later.
 # The later changes are ignored when using the cache.

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -150,7 +150,7 @@ initDistroRid()
 
 showSubsetHelp()
 {
-  "$scriptroot/common/build.sh" "-restore" "-build" "/p:Subset=help" "/clp:nosummary /tl:false"
+  "$scriptroot/common/build.sh" "-restore" "-build" "/p:Subset=help" "/clp:nosummary /v:detailed"
 }
 
 arguments=()
@@ -568,9 +568,6 @@ fi
 if [[ "${TreatWarningsAsErrors:-}" == "false" ]]; then
     arguments+=("-warnAsError" "false")
 fi
-
-# disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
-arguments+=("-tl:false")
 
 initDistroRid "$os" "$arch" "$crossBuild"
 

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -195,7 +195,7 @@ TEST_ARCH=$(_AndroidArchitecture)
       <TestRunErrorMessage Condition="Exists('$(TestResultsPath)')">$(TestRunErrorMessage) Please check $(TestResultsPath) for details!</TestRunErrorMessage>
     </PropertyGroup>
 
-    <!-- Note: The substring 'interactive' with two leading '-' needs to be in this message as a workaround for https://github.com/dotnet/msbuild/issues/9667 -->
+    <!-- Note: The substring 'interactive' with two leading '-' needs to be in this message. -->
     <Message Importance="High" Condition="'$(TestRunExitCode)' != '0'" Text="--interactive test output, because a test failed--$([System.Environment]::NewLine)@(TestRunConsoleOutput, '$([System.Environment]::NewLine)')" />
     <Error Condition="'$(TestRunExitCode)' != '0'" Text="$(TestRunErrorMessage)" />
   </Target>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -182,8 +182,11 @@ TEST_ARCH=$(_AndroidArchitecture)
     <Exec Command="$(RunTestsCommand)"
           ContinueOnError="true"
           IgnoreExitCode="true"
-          IgnoreStandardErrorWarningFormat="true">
+          IgnoreStandardErrorWarningFormat="true"
+          StandardOutputImportance="low"
+          ConsoleToMsBuild="true">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
+      <Output ItemName="TestRunConsoleOutput" TaskParameter="ConsoleOutput" />
     </Exec>
 
     <PropertyGroup Condition="'$(TestRunExitCode)' != '0'">
@@ -192,6 +195,8 @@ TEST_ARCH=$(_AndroidArchitecture)
       <TestRunErrorMessage Condition="Exists('$(TestResultsPath)')">$(TestRunErrorMessage) Please check $(TestResultsPath) for details!</TestRunErrorMessage>
     </PropertyGroup>
 
+    <!-- Note: The substring 'interactive' with two leading '-' needs to be in this message as a workaround for https://github.com/dotnet/msbuild/issues/9667 -->
+    <Message Importance="High" Condition="'$(TestRunExitCode)' != '0'" Text="--interactive test output, because a test failed--$([System.Environment]::NewLine)@(TestRunConsoleOutput, '$([System.Environment]::NewLine)')" />
     <Error Condition="'$(TestRunExitCode)' != '0'" Text="$(TestRunErrorMessage)" />
   </Target>
 


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/97211 for more details
This allows runtime to use the "new" terminal logger feature which has improved output.

Remove the -tl:off settings in the .rsp and build files. Pass a detailed verbosity to the help subset build invocation.

Add the changes that @rainersigwald prepared in tests.targets to get more detailed output. The whitespace issue that was reported last year is already fixed.

### Validation

1. Here's the output of a `dotnet build /t:Test src\libraries\Microsoft.Bcl.AsyncInterfaces\tests\` invocation with a failing test:
```
  TestUtilities net481 succeeded (0.1s) → artifacts\bin\TestUtilities\Release\net481\TestUtilities.dll
  Microsoft.Bcl.AsyncInterfaces net462 succeeded (0.1s) → artifacts\bin\Microsoft.Bcl.AsyncInterfaces\Release\net462\Microsoft.Bcl.AsyncInterfaces.dll
--interactive test output, because a test failed--
========================= Begin custom configuration settings ==============================
set XUNIT_HIDE_PASSING_OUTPUT_DIAGNOSTICS=1
========================== End custom configuration settings ===============================
----- start Fri 06/13/2025 10:02:21.38 ===============  To repro directly: =====================================================
pushd C:\git\runtime\artifacts\bin\Microsoft.Bcl.AsyncInterfaces.Tests\Release\net481\
C:\Users\vihofer\.nuget\packages\xunit.runner.console\2.9.2\build\..\tools\net472\xunit.console.exe Microsoft.Bcl.AsyncInterfaces.Tests.dll -xml testResults.xml -nologo -notrait category=OuterLoop -notrait category=failing
popd
===========================================================================================================
  Discovering: Microsoft.Bcl.AsyncInterfaces.Tests (app domain = on [no shadow copy], method display = ClassAndMethod, method display options = None)
  Discovered:  Microsoft.Bcl.AsyncInterfaces.Tests (found 11 test cases)
  Starting:    Microsoft.Bcl.AsyncInterfaces.Tests (parallel test collections = on [8 threads], stop on fail = off)
    System.Runtime.CompilerServices.Tests.ConfiguredCancelableAsyncEnumerableTests.Default_GetAsyncEnumerator_Throws [FAIL]
      Assert.Throws() Failure: Exception type was not an exact match
      Expected: typeof(System.ArgumentOutOfRangeException)
      Actual:   typeof(System.NullReferenceException)
      ---- System.NullReferenceException : Object reference not set to an instance of an object.
      Stack Trace:
        C:\git\runtime\src\libraries\System.Runtime\tests\System.Threading.Tasks.Tests\System.Runtime.CompilerServices\ConfiguredCancelableAsyncEnumerableTests.cs(23,0): at System.Runtime.CompilerServices.Tests.ConfiguredCancelableAsyncEnumerableTests.Default_GetAsyncEnumerator_Throws()
        ----- Inner Stack Trace -----
        C:\git\runtime\src\libraries\System.Private.CoreLib\src\System\Runtime\CompilerServices\ConfiguredCancelableAsyncEnumerable.cs(47,0): at System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1.GetAsyncEnumerator()
        C:\git\runtime\src\libraries\System.Runtime\tests\System.Threading.Tasks.Tests\System.Runtime.CompilerServices\ConfiguredCancelableAsyncEnumerableTests.cs(22,0): at System.Runtime.CompilerServices.Tests.ConfiguredCancelableAsyncEnumerableTests.<>c__DisplayClass0_0.<Default_GetAsyncEnumerator_Throws>b__1()
  Finished:    Microsoft.Bcl.AsyncInterfaces.Tests
=== TEST EXECUTION SUMMARY ===
   Microsoft.Bcl.AsyncInterfaces.Tests  Total: 15, Errors: 0, Failed: 1, Skipped: 0, Time: 0.409s
----- end Fri 06/13/2025 10:02:22.14 ----- exit code 1 ----------------------------------------------------------
  Microsoft.Bcl.AsyncInterfaces.Tests net481 failed with 1 error(s) (1.1s) → artifacts\bin\Microsoft.Bcl.AsyncInterfaces.Tests\Release\net481\Microsoft.Bcl.AsyncInterfaces.Tests.dll
    C:\git\runtime\eng\testing\tests.targets(200,5): error : One or more tests failed while running tests from 'Microsoft.Bcl.AsyncInterfaces.Tests'. Please check C:\git\runtime\artifacts\bin\Microsoft.Bcl.AsyncInterfaces.Tests\Release\net481\testResults.xml for details!
```

---

2. Here's the output of a `build.cmd help` command:

```
C:\git\runtime>.\build.cmd help
Restore complete (0.6s)
    Determining projects to restore...
    Tool 'coverlet.console' (version '6.0.4') was restored. Available commands: coverlet
    Tool 'dotnet-reportgenerator-globaltool' (version '5.4.3') was restored. Available commands: reportgenerator
    Tool 'microsoft.dotnet.xharness.cli' (version '10.0.0-prerelease.25255.1') was restored. Available commands: xharness
    Tool 'microsoft.visualstudio.slngen.tool' (version '12.0.15') was restored. Available commands: slngen

    Restore was successful.
    All projects are up-to-date for restore.
  Build failed with 1 error(s) (0.0s)

Accepted Subset values:
- Clr
    The full CoreCLR runtime. Equivalent to: clr.native+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools+host.native
- Clr.NativePrereqs
    Managed tools that support building the native components of the runtime (such as DacTableGen).
- Clr.ILTools
    The CoreCLR IL tools (ilasm/ildasm).
- Clr.Runtime
    The CoreCLR .NET runtime. Includes clr.jit, clr.iltools, clr.hosts.
- Clr.Native
    All CoreCLR native non-test components, including the runtime, jits, and other native tools. Includes clr.hosts, clr.runtime, clr.jit, clr.alljits, clr.paltests, clr.iltools, clr.nativeaotruntime, clr.spmi.
- Clr.Aot
    Everything needed for Native AOT workloads, including clr.alljits, clr.tools, clr.nativeaotlibs, and clr.nativeaotruntime
- Clr.NativeAotLibs
    The CoreCLR native AOT CoreLib and other low level class libraries.
- Clr.NativeAotRuntime
    The stripped-down CoreCLR native AOT runtime.
- Clr.CrossArchTools
    The cross-targeted CoreCLR tools.
- Clr.PalTests [only runs on demand]
    The CoreCLR PAL tests.
- Clr.PalTestList [only runs on demand]
    Generate the list of the CoreCLR PAL tests. When using the command line, use Clr.PalTests instead.
- Clr.Hosts
    The CoreCLR corerun test host.
- Clr.Jit
    The JIT for the CoreCLR .NET runtime.
- Clr.AllJits
    All of the cross-targeting JIT compilers for the CoreCLR .NET runtime.
- Clr.AllJitsCommunity
    All of the cross-targeting JIT compilers for the CoreCLR .NET runtime, including community targets.
- Clr.Spmi
    SuperPMI, a tool for CoreCLR JIT testing.
- Clr.CoreLib
    The managed System.Private.CoreLib library for CoreCLR.
- Clr.NativeCoreLib
    Run crossgen on System.Private.CoreLib library for CoreCLR.
- Clr.Tools
    Managed tools that support CoreCLR development and testing.
- Clr.ToolsTests [only runs on demand]
    Unit tests for the clr.tools subset.
- Clr.Packages
    The projects that produce NuGet packages for the CoreCLR runtime, crossgen, and IL tools.
- LinuxDac [only runs on demand]
    The cross-OS Windows->libc-based Linux DAC. Skipped on x86.
- AlpineDac [only runs on demand]
    The cross-OS Windows->musl-libc-based Linux DAC. Skipped on x86
- CrossDacPack [only runs on demand]
    Packaging of cross OS DAC. Requires all assets needed to be present at a folder specified by . See 'Microsoft.CrossOsDiag.Private.CoreCLR.proj' for details.
- Mono
    The Mono runtime and CoreLib. Equivalent to: mono.runtime+mono.corelib+mono.packages+mono.tools+host.native+
- Mono.Runtime
    The Mono .NET runtime.
- Mono.EmSDK
    The emsdk provisioning.
- Mono.AotCross
    The cross-compiler runtime for Mono AOT.
- Mono.CoreLib
    The managed System.Private.CoreLib library for Mono.
- Mono.Manifests
    The NuGet packages with manifests defining the mobile and Blazor workloads.
- Mono.Packages
    The projects that produce NuGet packages for the Mono runtime.
- Mono.Tools
    Tooling that helps support Mono development and testing.
- Mono.WasmRuntime
    The Emscripten runtime.
- Mono.WasiRuntime
    The WASI runtime.
- Mono.WasmWorkload
    *Helper* subset for building some pre-requisites for wasm workload testing, useful on CI.
- Mono.MsCorDbi
    The implementation of ICorDebug interface.
- Mono.Workloads [only runs on demand]
    Builds the installers and the insertion metadata for Blazor workloads.
- Tools
    Additional runtime tools projects. Equivalent to: tools.illink+tools.cdac
- Tools.ILLink
    The projects that produce illink and analyzer tools for trimming.
- Tools.Cdac
    Diagnostic data contract reader and related projects.
- Tools.ILLinkTests [only runs on demand]
    Unit tests for the tools.illink subset.
- Tools.CdacTests [only runs on demand]
    Unit tests for the diagnostic data contract reader.
- Host
    The .NET hosts, packages, hosting libraries, and tests. Equivalent to: host.native+host.tools+host.pkg+host.pretest+host.tests
- Host.Native
    The .NET hosts.
- Host.Pkg
    The .NET host packages.
- Host.Tools
    The .NET hosting libraries.
- Host.PreTest
    Test assets which are necessary to run the .NET hosting tests.
- Host.Tests
    The .NET hosting tests.
- Libs
    The libraries native part, refs and source assemblies, test infra and packages, but NOT the tests (use Libs.Tests to request those explicitly). Equivalent to: libs.native+libs.sfx+libs.oob+libs.pretest
- Libs.Native
    The native libraries used in the shared framework.
- Libs.Sfx
    The managed shared framework libraries.
- Libs.Oob
    The managed out-of-band libraries.
- Libs.PreTest
    Test assets which are necessary to run tests.
- Libs.Tests [only runs on demand]
    The test projects. Note that building this doesn't execute tests: you must also pass the '-test' argument.
- Packs
    Builds the shared framework packs, archives, bundles, installers, and the framework pack tests. Equivalent to: packs.product+packs.installers+packs.tests
- Packs.Product
    Builds the shared framework packs, archives, bundles, and installers.
- Packs.Installers
    Builds the shared framework bundles and installers.
- Packs.Tests
    The framework pack tests.
- RegenerateDownloadTable [only runs on demand]
    Regenerates the nightly build download table
- RegenerateThirdPartyNotices [only runs on demand]
    Regenerates the THIRD-PARTY-NOTICES.TXT file based on other repos' TPN files.
- tasks [only runs on demand]
    Build the repo local task projects.
- bootstrap [only runs on demand]
    Build the projects needed to build shipping assets in the repo against live assets.

    C:\git\runtime\eng\SubsetValidation.targets(36,5): error : This is not an error. These are the available subsets. You can choose one or none at all for a full build.

Build failed with 1 error(s) in 1.1s
Build failed with exit code 1. Check errors above.
```

Also fixes https://github.com/dotnet/runtime/issues/116604