### PR TITLE
Improve handling of dynamic types in BulkType events

### DIFF
--- a/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
@@ -318,7 +318,8 @@ int BulkTypeEventLogger::LogSingleType(MethodTable * pEEType)
         // So no other type flags are applicable to set
     }
 
-    ULONGLONG rvaType = ULONGLONG(pEEType) - osModuleHandle;
+    MethodTable* pTypeForRva = pEEType->IsDynamicType() ? pEEType->GetDynamicTemplateType() : pEEType;
+    ULONGLONG rvaType = ULONGLONG(pTypeForRva) - osModuleHandle;
     pVal->fixedSizedData.TypeNameID = (DWORD) rvaType;
 
     // Now that we know the full size of this type's data, see if it fits in our

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -62,11 +62,14 @@ enum EETypeField
 {
     ETF_TypeManagerIndirection,
     ETF_WritableData,
+    ETF_DispatchMap,
     ETF_Finalizer,
     ETF_SealedVirtualSlots,
     ETF_DynamicTemplateType,
     ETF_GenericDefinition,
     ETF_GenericComposition,
+    ETF_FunctionPointerParameters,
+    ETF_DynamicTypeFlags,
     ETF_DynamicGcStatics,
     ETF_DynamicNonGcStatics,
     ETF_DynamicThreadStaticOffset,
@@ -128,10 +131,14 @@ private:
         // GC depends on this bit, this bit must be zero
         CollectibleFlag         = 0x00200000,
 
+        HasDispatchMapFlag      = 0x00040000,
+
         IsDynamicTypeFlag       = 0x00080000,
 
         // GC depends on this bit, this type requires finalization
         HasFinalizerFlag        = 0x00100000,
+
+        HasSealedVTableEntriesFlag = 0x00400000,
 
         // GC depends on this bit, this type contain gc pointers
         HasPointersFlag         = 0x01000000,
@@ -165,18 +172,30 @@ private:
         RequiresAlign8Flag = 0x1000
     };
 
+    enum FunctionPointerFlags
+    {
+        IsUnmanaged = 0x80000000,
+        FunctionPointerFlagsMask = IsUnmanaged
+    };
+
 public:
 
     enum Kinds
     {
         CanonicalEEType         = 0x00000000,
-        // unused               = 0x00010000,
+        FunctionPointerEEType   = 0x00010000,
         ParameterizedEEType     = 0x00020000,
         GenericTypeDefEEType    = 0x00030000,
     };
 
     uint32_t GetBaseSize()
         { return m_uBaseSize; }
+
+    uint32_t GetNumFunctionPointerParameters()
+    {
+        ASSERT(IsFunctionPointer());
+        return m_uBaseSize & ~FunctionPointerFlagsMask;
+    }
 
     Kinds GetKind();
 
@@ -191,6 +210,12 @@ public:
 
     bool IsParameterizedType()
         { return (GetKind() == ParameterizedEEType); }
+
+    bool IsGenericTypeDefinition()
+        { return GetKind() == GenericTypeDefEEType; }
+
+    bool IsFunctionPointer()
+        { return GetKind() == FunctionPointerEEType; }
 
     bool IsInterface()
         { return GetElementType() == ElementType_Interface; }
@@ -259,6 +284,8 @@ public:
 
     TypeManagerHandle* GetTypeManagerPtr();
 
+    MethodTable* GetDynamicTemplateType();
+
     // Used only by GC initialization, this initializes the MethodTable used to mark free entries in the GC heap.
     // It should be an array type with a component size of one (so the GC can easily size it as appropriate)
     // and should be marked as not containing any references. The rest of the fields don't matter: the GC does
@@ -272,6 +299,15 @@ public:
 
     EETypeElementType GetElementType()
         { return (EETypeElementType)((m_uFlags & ElementTypeMask) >> ElementTypeShift); }
+
+    bool IsGeneric()
+        { return (m_uFlags & IsGenericFlag) != 0; }
+
+    bool HasDispatchMap()
+        { return (m_uFlags & HasDispatchMapFlag) != 0; }
+
+    bool HasSealedVTableEntries()
+        { return (m_uFlags & HasSealedVTableEntriesFlag) != 0; }
 
     // Determine whether a type was created by dynamic type loader
     bool IsDynamicType()


### PR DESCRIPTION
Dynamically allocated types (e.g. result of `MakeGenericType`) don't have debug information associated with them so we can't really reconstruct their names from PDB. However, we know the canonical form of the type and that one does have debug info. Emit RVA of the canonical form instead a non-sensical number.

Consumers can still distinguish this is a different thing using the `TypeID` field (that is still the MethodTable pointer). The canonical form is only used for `TypeNameID`, which is RVA in native AOT case and definition token in the JIT case. The consumer can quickly see that `ModuleID + `TypeNameID != TypeID`.

We could generate enough information to fully reconstruct the type name because the event can actually carry composition information, but that support was deleted in #94673 on native AOT side and it's currently not consumed by any tools I know of. It can be done later; Project N went to retirement with not even having the canonical forms in traces.

Cc @dotnet/ilc-contrib 