### PR TITLE
Fix stackwalk from interpreted EH funclet

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -2787,8 +2787,9 @@ StackFrame ExInfo::FindParentStackFrameHelper(CrawlFrame* pCF,
         PCODE callerIP = dac_cast<PCODE>(GetIP(pRegDisplay->pCallerContext));
         BOOL fIsCallerInVM = FALSE;
 
-        // Check if the caller IP is in mscorwks.  If it is not, then it is an out-of-line finally.
-        // Normally, the caller of a finally is ExInfo::CallHandler().
+        // Check if the caller IP is in runtime native code.  If it is not, then it is an out-of-line finally.
+        // Normally, the caller of a finally is CallEHFunclet, or InterpreterFrame::DummyCallerIP
+        // for the interpreter.
 #ifdef TARGET_UNIX
         fIsCallerInVM = !ExecutionManager::IsManagedCode(callerIP);
 #else

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -2784,11 +2784,15 @@ StackFrame ExInfo::FindParentStackFrameHelper(CrawlFrame* pCF,
     // Check for out-of-line finally funclets.  Filter funclets can't be out-of-line.
     if (!fIsFilterFunclet)
     {
-        if (pRegDisplay->IsCallerContextValid)
-        {
-            PCODE callerIP = dac_cast<PCODE>(GetIP(pRegDisplay->pCallerContext));
-            BOOL fIsCallerInVM = FALSE;
+        PCODE callerIP = dac_cast<PCODE>(GetIP(pRegDisplay->pCallerContext));
+        BOOL fIsCallerInVM = FALSE;
 
+        if (callerIP == InterpreterFrame::DummyCallerIP)
+        {
+            fIsCallerInVM = TRUE;
+        }
+        else
+        {
             // Check if the caller IP is in mscorwks.  If it is not, then it is an out-of-line finally.
             // Normally, the caller of a finally is ExInfo::CallHandler().
 #ifdef TARGET_UNIX
@@ -2801,26 +2805,25 @@ StackFrame ExInfo::FindParentStackFrameHelper(CrawlFrame* pCF,
 #endif // !DACCESS_COMPILE
             fIsCallerInVM = IsIPInModule(eeBase, callerIP);
 #endif // TARGET_UNIX
-
-            if (!fIsCallerInVM)
+        }
+        if (!fIsCallerInVM)
+        {
+            if (!fForGCReporting)
             {
-                if (!fForGCReporting)
-                {
-                    sfResult.SetMaxVal();
-                    goto lExit;
-                }
-                else
-                {
-                    // We have run into a non-exceptionally invoked finally funclet (aka out-of-line finally funclet).
-                    // Since these funclets are invoked from JITted code, we will not find their EnclosingClauseCallerSP
-                    // in an exception tracker as one does not exist (remember, these funclets are invoked "non"-exceptionally).
-                    //
-                    // At this point, the caller context is that of the parent frame of the funclet. All we need is the CallerSP
-                    // of that parent. We leverage a helper function that will perform an unwind against the caller context
-                    // and return us the SP (of the caller of the funclet's parent).
-                    StackFrame sfCallerSPOfFuncletParent = ExInfo::GetCallerSPOfParentOfNonExceptionallyInvokedFunclet(pCF);
-                    return sfCallerSPOfFuncletParent;
-                }
+                sfResult.SetMaxVal();
+                goto lExit;
+            }
+            else
+            {
+                // We have run into a non-exceptionally invoked finally funclet (aka out-of-line finally funclet).
+                // Since these funclets are invoked from JITted code, we will not find their EnclosingClauseCallerSP
+                // in an exception tracker as one does not exist (remember, these funclets are invoked "non"-exceptionally).
+                //
+                // At this point, the caller context is that of the parent frame of the funclet. All we need is the CallerSP
+                // of that parent. We leverage a helper function that will perform an unwind against the caller context
+                // and return us the SP (of the caller of the funclet's parent).
+                StackFrame sfCallerSPOfFuncletParent = ExInfo::GetCallerSPOfParentOfNonExceptionallyInvokedFunclet(pCF);
+                return sfCallerSPOfFuncletParent;
             }
         }
     }
@@ -3939,9 +3942,10 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
     }
 
 #ifdef FEATURE_INTERPRETER
-    if ((pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME) && (GetIP(pThis->m_crawl.GetRegisterSet()->pCurrentContext) == 0))
+    if ((pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME) &&
+        (GetIP(pThis->m_crawl.GetRegisterSet()->pCurrentContext) == InterpreterFrame::DummyCallerIP))
     {
-        // The callerIP is 0 when we are going to unwind from the first interpreted frame belonging to an InterpreterFrame.
+        // The callerIP is InterpreterFrame::DummyCallerIP when we are going to unwind from the first interpreted frame belonging to an InterpreterFrame.
         // That means it is at a transition where non-interpreted code called interpreted one.
         // Move the stack frame iterator to the InterpreterFrame and extract the IP of the real caller of the interpreted code.
         retVal = pThis->Next();

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -2787,25 +2787,19 @@ StackFrame ExInfo::FindParentStackFrameHelper(CrawlFrame* pCF,
         PCODE callerIP = dac_cast<PCODE>(GetIP(pRegDisplay->pCallerContext));
         BOOL fIsCallerInVM = FALSE;
 
-        if (callerIP == InterpreterFrame::DummyCallerIP)
-        {
-            fIsCallerInVM = TRUE;
-        }
-        else
-        {
-            // Check if the caller IP is in mscorwks.  If it is not, then it is an out-of-line finally.
-            // Normally, the caller of a finally is ExInfo::CallHandler().
+        // Check if the caller IP is in mscorwks.  If it is not, then it is an out-of-line finally.
+        // Normally, the caller of a finally is ExInfo::CallHandler().
 #ifdef TARGET_UNIX
-            fIsCallerInVM = !ExecutionManager::IsManagedCode(callerIP);
+        fIsCallerInVM = !ExecutionManager::IsManagedCode(callerIP);
 #else
 #if defined(DACCESS_COMPILE)
-            PTR_VOID eeBase = DacGlobalBase();
+        PTR_VOID eeBase = DacGlobalBase();
 #else  // !DACCESS_COMPILE
-            PTR_VOID eeBase = GetClrModuleBase();
+        PTR_VOID eeBase = GetClrModuleBase();
 #endif // !DACCESS_COMPILE
-            fIsCallerInVM = IsIPInModule(eeBase, callerIP);
+        fIsCallerInVM = IsIPInModule(eeBase, callerIP);
 #endif // TARGET_UNIX
-        }
+
         if (!fIsCallerInVM)
         {
             if (!fForGCReporting)

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1849,6 +1849,9 @@ PCODE UnmanagedToManagedFrame::GetReturnAddress_Impl()
 #endif // FEATURE_COMINTEROP
 
 #ifdef FEATURE_INTERPRETER
+
+TADDR InterpreterFrame::DummyCallerIP = (TADDR)&InterpreterFrame::DummyFuncletCaller;
+
 PTR_InterpMethodContextFrame InterpreterFrame::GetTopInterpMethodContextFrame()
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2398,6 +2398,11 @@ typedef DPTR(class InterpreterFrame) PTR_InterpreterFrame;
 class InterpreterFrame : public FramedMethodFrame
 {
 public:
+
+    // This is a special value representing a caller of the first interpreter frame
+    // in a block of interpreter frames belonging to a single InterpreterFrame.
+    static constexpr TADDR DummyCallerIP = 0;
+
 #ifndef DACCESS_COMPILE
     InterpreterFrame(TransitionBlock* pTransitionBlock, InterpMethodContextFrame* pContextFrame)
         : FramedMethodFrame(FrameIdentifier::InterpreterFrame, pTransitionBlock, NULL),

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2397,11 +2397,12 @@ typedef DPTR(class InterpreterFrame) PTR_InterpreterFrame;
 
 class InterpreterFrame : public FramedMethodFrame
 {
+    static void DummyFuncletCaller() {}
 public:
 
     // This is a special value representing a caller of the first interpreter frame
     // in a block of interpreter frames belonging to a single InterpreterFrame.
-    static constexpr TADDR DummyCallerIP = 0;
+    static TADDR DummyCallerIP;
 
 #ifndef DACCESS_COMPILE
     InterpreterFrame(TransitionBlock* pTransitionBlock, InterpMethodContextFrame* pContextFrame)


### PR DESCRIPTION
The stack walking for GC is broken when an interpreted EH funclet was on the stack. The reason is that call to the interpreted funclet doesn't have a transition frame and that case was not handled properly. Also, I have found that the ExInfo::m_csfEHClause was not being set for the interpreted clauses at all.

This change fixes it by using the InterpreterFrame address as the m_csfEHClause (so that it is above all the interpreter frames) and fixing the `ExInfo::FindParentStackFrameHelper` to recognize the special instruction pointer value that we get as a parent IP for the first interpreted frame under an InterpreterFrame.

That special value has been zero and I have added a named constant for it so that it is clear at the points where it is being used.