### PR TITLE
Don't allow inlining the NativeAOT-only unsafe accessor

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -3067,6 +3067,7 @@ namespace System.ComponentModel
 
                 [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
                 [return: UnsafeAccessorType("System.Windows.Forms.ComponentModel.Com2Interop.ComNativeDescriptor, System.Windows.Forms")]
+                [MethodImpl(MethodImplOptions.NoInlining)]
                 static extern object CreateComNativeDescriptor();
             }
 

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -29,7 +29,8 @@ namespace System.Dynamic.Utils
             {
                 return CreateObjectArrayDelegate(null, delegateType, handler);
 
-                [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name="CreateObjectArrayDelegate")]
+                [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "CreateObjectArrayDelegate")]
+                [MethodImpl(MethodImplOptions.NoInlining)]
                 static extern Delegate CreateObjectArrayDelegate(
                     [UnsafeAccessorType("Internal.Runtime.Augments.DynamicDelegateAugments, System.Private.CoreLib")] object? _,
                     Type delegateType,

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -406,16 +406,13 @@ namespace System
                         principal = (IPrincipal)GetDefaultPrincipal(null);
                         break;
                     case PrincipalPolicy.WindowsPrincipal:
-                        try
-                        {
-                            principal = (IPrincipal)GetDefaultWindowsPrincipal(null);
-                            break;
-                        }
-                        catch (MissingMethodException ex)
-                        {
-                            // WindowsPrincipal is not available, throw PNSE
-                            throw new PlatformNotSupportedException(SR.PlatformNotSupported_Principal, ex);
-                        }
+#if TARGET_WINDOWS
+                        principal = (IPrincipal)GetDefaultWindowsPrincipal(null);
+                        break;
+#else
+                        // WindowsPrincipal is not available, throw PNSE
+                        throw new PlatformNotSupportedException(SR.PlatformNotSupported_Principal);
+#endif
                 }
             }
 
@@ -426,10 +423,12 @@ namespace System
             static extern object GetDefaultPrincipal(
                 [UnsafeAccessorType("System.Security.Principal.GenericPrincipal, System.Security.Claims")] object? _);
 
+#if TARGET_WINDOWS
             [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "GetDefaultInstance")]
             [return: UnsafeAccessorType("System.Security.Principal.WindowsPrincipal, System.Security.Principal.Windows")]
             static extern object GetDefaultWindowsPrincipal(
                 [UnsafeAccessorType("System.Security.Principal.WindowsPrincipal, System.Security.Principal.Windows")] object? _);
+#endif
         }
     }
 }


### PR DESCRIPTION
Should unblock https://github.com/dotnet/efcore/pull/36242

Implements workaround mentioned in https://github.com/dotnet/efcore/pull/36242#issuecomment-2970694716