### PR TITLE
JIT: enable stack allocation of more arrays in R2R

### DIFF
--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -452,6 +452,10 @@ void DefaultPolicy::NoteBool(InlineObservation obs, bool value)
                 m_InsideThrowBlock = value;
                 break;
 
+            case InlineObservation::CALLEE_MAY_RETURN_SMALL_ARRAY:
+                m_MayReturnSmallArray = true;
+                break;
+
             default:
                 // Ignore the remainder for now
                 break;
@@ -762,6 +766,13 @@ double DefaultPolicy::DetermineMultiplier()
         multiplier += 3.0;
         JITDUMP("\nInline candidate has const arg that feeds a conditional.  Multiplier increased to %g.", multiplier);
     }
+
+    if (m_MayReturnSmallArray)
+    {
+        multiplier += 4.0;
+        JITDUMP("\nInline candidate may return small known-size array.  Multiplier increased to %g.", multiplier);
+    }
+
     // For prejit roots we do not see the call sites. To be suitably optimistic
     // assume that call sites may pass constants.
     else if (m_IsPrejitRoot && ((m_ArgFeedsConstantTest > 0) || (m_ArgFeedsTest > 0)))

--- a/src/coreclr/jit/inlinepolicy.h
+++ b/src/coreclr/jit/inlinepolicy.h
@@ -113,6 +113,7 @@ public:
         , m_ConstArgFeedsIsKnownConst(false)
         , m_ArgFeedsIsKnownConst(false)
         , m_InsideThrowBlock(false)
+        , m_MayReturnSmallArray(false)
     {
         // empty
     }
@@ -189,6 +190,7 @@ protected:
     bool                    m_ConstArgFeedsIsKnownConst  : 1;
     bool                    m_ArgFeedsIsKnownConst       : 1;
     bool                    m_InsideThrowBlock           : 1;
+    bool                    m_MayReturnSmallArray        : 1;
 };
 
 // ExtendedDefaultPolicy is a slightly more aggressive variant of
@@ -226,7 +228,6 @@ public:
         , m_NonGenericCallsGeneric(false)
         , m_IsCallsiteInNoReturnRegion(false)
         , m_HasProfileWeights(false)
-        , m_MayReturnSmallArray(false)
     {
         // Empty
     }
@@ -282,7 +283,6 @@ protected:
     bool     m_NonGenericCallsGeneric     : 1;
     bool     m_IsCallsiteInNoReturnRegion : 1;
     bool     m_HasProfileWeights          : 1;
-    bool     m_MayReturnSmallArray        : 1;
 };
 
 // DiscretionaryPolicy is a variant of the default policy.  It

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -1092,7 +1092,7 @@ bool ObjectAllocator::CanAllocateLclVarOnStack(unsigned int         lclNum,
         *reason = "[runtime disallows]";
         return false;
     }
-    if (allocType == OAT_NEWARR)
+    if ((allocType == OAT_NEWARR) || (allocType == OAT_NEWARR_R2R))
     {
         if (!enableArrays)
         {
@@ -1186,10 +1186,22 @@ ObjectAllocator::ObjectAllocationType ObjectAllocator::AllocationKind(GenTree* t
         const bool isValueClass = comp->info.compCompHnd->isValueClass(clsHnd);
         bool const canBeOnStack = isValueClass || comp->info.compCompHnd->canAllocateOnStack(clsHnd);
         allocType               = canBeOnStack ? OAT_NEWOBJ : OAT_NEWOBJ_HEAP;
+
+        if (canBeOnStack)
+        {
+            JITDUMP("Checking if we can stack allocate object [%06u] (%s)\n", comp->dspTreeID(tree),
+                    comp->eeGetClassName(clsHnd));
+        }
+        else
+        {
+            JITDUMP("Object [%06u] must be allocated on the heap (%s)\n", comp->dspTreeID(tree),
+                    comp->eeGetClassName(clsHnd));
+        }
     }
-    else if (!m_isR2R && tree->IsHelperCall())
+    else if (tree->IsHelperCall())
     {
         GenTreeCall* const call = tree->AsCall();
+
         switch (call->GetHelperNum())
         {
             case CORINFO_HELP_NEWARR_1_VC:
@@ -1200,6 +1212,26 @@ ObjectAllocator::ObjectAllocationType ObjectAllocator::AllocationKind(GenTree* t
                 if ((call->gtArgs.CountUserArgs() == 2) && call->gtArgs.GetUserArgByIndex(1)->GetNode()->IsCnsIntOrI())
                 {
                     allocType = OAT_NEWARR;
+                    JITDUMP("Checking if we can stack allocate array [%06u]\n", comp->dspTreeID(call));
+                }
+                else
+                {
+                    JITDUMP("Can't handle unknown length newarr [%06u]\n", comp->dspTreeID(call));
+                }
+                break;
+            }
+
+            case CORINFO_HELP_READYTORUN_NEWARR_1:
+            {
+                assert(m_isR2R);
+                if ((call->gtArgs.CountUserArgs() == 1) && call->gtArgs.GetUserArgByIndex(0)->GetNode()->IsCnsIntOrI())
+                {
+                    allocType = OAT_NEWARR_R2R;
+                    JITDUMP("Checking if we can stack allocate array [%06u])\n", comp->dspTreeID(call));
+                }
+                else
+                {
+                    JITDUMP("Can't handle unknown length newarr [%06u]\n", comp->dspTreeID(call));
                 }
                 break;
             }
@@ -1370,6 +1402,7 @@ bool ObjectAllocator::MorphAllocObjNodeHelper(AllocationCandidate& candidate)
     switch (candidate.m_allocType)
     {
         case OAT_NEWARR:
+        case OAT_NEWARR_R2R:
             return MorphAllocObjNodeHelperArr(candidate);
         case OAT_NEWOBJ:
             return MorphAllocObjNodeHelperObj(candidate);
@@ -1394,14 +1427,7 @@ bool ObjectAllocator::MorphAllocObjNodeHelper(AllocationCandidate& candidate)
 bool ObjectAllocator::MorphAllocObjNodeHelperArr(AllocationCandidate& candidate)
 {
     assert(candidate.m_block->HasFlag(BBF_HAS_NEWARR));
-
-    // R2R not yet supported
-    //
-    if (m_isR2R)
-    {
-        candidate.m_onHeapReason = "[R2R array not yet supported]";
-        return false;
-    }
+    assert((candidate.m_allocType == OAT_NEWARR) || (candidate.m_allocType == OAT_NEWARR_R2R));
 
     GenTree* const data = candidate.m_tree->AsLclVar()->Data();
 
@@ -1423,7 +1449,8 @@ bool ObjectAllocator::MorphAllocObjNodeHelperArr(AllocationCandidate& candidate)
     bool                 isExact   = false;
     bool                 isNonNull = false;
     CORINFO_CLASS_HANDLE clsHnd    = comp->gtGetHelperCallClassHandle(data->AsCall(), &isExact, &isNonNull);
-    GenTree* const       len       = data->AsCall()->gtArgs.GetUserArgByIndex(1)->GetNode();
+    unsigned const       lengthArg = candidate.m_allocType == OAT_NEWARR_R2R ? 0 : 1;
+    GenTree* const       len       = data->AsCall()->gtArgs.GetUserArgByIndex(lengthArg)->GetNode();
 
     assert(len != nullptr);
 

--- a/src/coreclr/jit/objectalloc.h
+++ b/src/coreclr/jit/objectalloc.h
@@ -130,7 +130,8 @@ class ObjectAllocator final : public Phase
         OAT_NONE,
         OAT_NEWOBJ,
         OAT_NEWOBJ_HEAP,
-        OAT_NEWARR
+        OAT_NEWARR,
+        OAT_NEWARR_R2R
     };
 
     struct AllocationCandidate

--- a/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
@@ -422,7 +422,11 @@ namespace ObjectStackAllocation
             return c.i;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        // Array tests below will fail under R2R as the int[] handles cannot be embedded and
+        // our policy is not to sacrifce an R2R compilation for the sake of stack allocation.
+        // Bypass for now by adding AggressiveOptimization attribute.
+
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
         static int AllocateArrayWithNonGCElements()
         {
             int[] array = new int[42];
@@ -431,7 +435,7 @@ namespace ObjectStackAllocation
             return array[24] + array.Length;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
         static int AllocateArrayWithGCElements()
         {
             string[] array = new string[42];
@@ -440,7 +444,7 @@ namespace ObjectStackAllocation
             return array[24].Length * 21 + array.Length;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
         static int AllocateArrayT<T>()
         {
             T[] array = new T[42];
@@ -624,7 +628,7 @@ namespace ObjectStackAllocation
             return 1;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
         static int StructReferredObjects()
         {
             int[] a1 = new int[10];

--- a/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
@@ -454,7 +454,7 @@ namespace ObjectStackAllocation
             return array.Length + 42;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
         static int SpanCaptureArray1()
         {
             Span<int> span = new int[100];
@@ -465,6 +465,7 @@ namespace ObjectStackAllocation
         [MethodImpl(MethodImplOptions.NoInlining)]
         static int SpanCaptureArray2() => SpanCaptureArray2Helper(null);
 
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
         static int SpanCaptureArray2Helper(int[]? x)
         {
             Span<int> span = x ?? new int[100];
@@ -472,7 +473,7 @@ namespace ObjectStackAllocation
             return span[10] + span[42];
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
         static int SpanCaptureArray3()
         {
             Span<int> span = new int[128];
@@ -481,7 +482,7 @@ namespace ObjectStackAllocation
             return x[10] + span[42];
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
         static int SpanCaptureArrayT<T>()
         {
             Span<T> span = new T[37];

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -588,9 +588,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/lifetime/lifetime2/**">
             <Issue>https://github.com/dotnet/runtime/issues/109313</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests/**">
-            <Issue>https://github.com/dotnet/runtime/issues/109314</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/forceinlining/AttributeConflict/**">
             <Issue>https://github.com/dotnet/runtime/issues/109315</Issue>
         </ExcludeList>


### PR DESCRIPTION
In particular arrays that are created via `CORINFO_HELP_READYTORUN_NEWARR_1`.

Also:
* move inlining boost for "returns small array" to the default policy as well as the extended default policy. This addresses part of #113236.
* enable the stack allocation test for R2R, by marking certain methods where particular inlines are needed for non-escape that won't happen in R2R as aggressive opt.

Fixes #109314.

Contributes to #104936