### PR TITLE
Make SingleFile BundleID the expected length (12 bytes)

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.NET.HostModel.Bundle
             bundleHash.Dispose();
             bundleHash = null;
 
-            return Convert.ToBase64String(manifestHash).Substring(BundleIdLength).Replace('/', '_');
+            return Convert.ToBase64String(manifestHash).Substring(0, BundleIdLength).Replace('/', '_');
         }
 
         public long Write(BinaryWriter writer)

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -132,8 +133,9 @@ namespace Microsoft.NET.HostModel.Bundle
             byte[] manifestHash = bundleHash.Hash;
             bundleHash.Dispose();
             bundleHash = null;
-
-            return Convert.ToBase64String(manifestHash).Substring(0, BundleIdLength).Replace('/', '_');
+            string id = Convert.ToBase64String(manifestHash).Substring(0, BundleIdLength).Replace('/', '_');
+            Debug.Assert(id.Length == BundleIdLength);
+            return id;
         }
 
         public long Write(BinaryWriter writer)

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
@@ -67,8 +67,7 @@ namespace Microsoft.NET.HostModel.Bundle
         // with path-names so that the AppHost can use it in
         // extraction path.
         public string BundleID { get; private set; }
-        //Same as Path.GetRandomFileName
-        private const int BundleIdLength = 12;
+        private const int BundleIdLength = 32;
         private SHA256 bundleHash = SHA256.Create();
         public readonly uint BundleMajorVersion;
         // The Minor version is currently unused, and is always zero


### PR DESCRIPTION
It looks like https://github.com/dotnet/runtime/pull/52930 meant to have the BundleID be 12 characters, but used `Substring(12)`, which created a substring starting at offset 12 instead. This may end up being more of breaking change, though.