### PR TITLE
Update host test command execution logging: include PID on exit, remove confusing OK/FAIL, add caller name

### DIFF
--- a/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
@@ -172,7 +172,7 @@ namespace AppHost.Bundle.Tests
                 command.Process.Kill();
 
                 command
-                    .WaitForExit(true)
+                    .WaitForExit()
                     .Should().Fail()
                     .And.HaveStdErrContaining("Bundle header version compatibility check failed.")
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(singleFile)}' - error code: 0x{expectedErrorCode}")

--- a/src/installer/tests/AppHost.Bundle.Tests/BundleRename.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/BundleRename.cs
@@ -23,7 +23,7 @@ namespace AppHost.Bundle.Tests
         [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/38013")]
         [InlineData(true)]  // Test renaming the single-exe when contents are extracted
-        [InlineData(false)] // Test renaming the single-exe when contents are not extracted 
+        [InlineData(false)] // Test renaming the single-exe when contents are not extracted
         private void Bundle_can_be_renamed_while_running(bool testExtraction)
         {
             string singleFile = sharedTestState.App.Bundle(testExtraction ? BundleOptions.BundleAllContent : BundleOptions.None);
@@ -51,7 +51,7 @@ namespace AppHost.Bundle.Tests
             File.Move(singleFile, renameFile);
             File.Create(resumeFile).Close();
 
-            singleExe.WaitForExit(expectedToFail: false, twoMinutes)
+            singleExe.WaitForExit(twoMinutes)
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World!");
         }

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ComponentSharedTestStateBase.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ComponentSharedTestStateBase.cs
@@ -5,6 +5,7 @@ using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 {
@@ -44,12 +45,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         {
         }
 
-        public CommandResult RunComponentResolutionTest(TestApp component, Action<Command> commandCustomizer = null)
+        public CommandResult RunComponentResolutionTest(TestApp component, Action<Command> commandCustomizer = null, [CallerMemberName] string caller = "")
         {
-            return RunComponentResolutionTest(component.AppDll, FrameworkReferenceApp, DotNetWithNetCoreApp.GreatestVersionHostFxrPath, commandCustomizer);
+            return RunComponentResolutionTest(component.AppDll, FrameworkReferenceApp, DotNetWithNetCoreApp.GreatestVersionHostFxrPath, commandCustomizer, caller);
         }
 
-        public CommandResult RunComponentResolutionTest(string componentPath, TestApp hostApp, string hostFxrFolder, Action<Command> commandCustomizer = null)
+        public CommandResult RunComponentResolutionTest(string componentPath, TestApp hostApp, string hostFxrFolder, Action<Command> commandCustomizer = null, [CallerMemberName] string caller = "")
         {
             string[] args =
             {
@@ -65,16 +66,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 .MultilevelLookup(false);
             commandCustomizer?.Invoke(command);
 
-            return command.Execute()
+            return command.Execute(caller)
                 .StdErrAfter("corehost_resolve_component_dependencies = {");
         }
 
-        public CommandResult RunComponentResolutionMultiThreadedTest(TestApp componentOne, TestApp componentTwo)
+        public CommandResult RunComponentResolutionMultiThreadedTest(TestApp componentOne, TestApp componentTwo, [CallerMemberName] string caller = "")
         {
-            return RunComponentResolutionMultiThreadedTest(componentOne.AppDll, componentTwo.AppDll, FrameworkReferenceApp, DotNetWithNetCoreApp.GreatestVersionHostFxrPath);
+            return RunComponentResolutionMultiThreadedTest(componentOne.AppDll, componentTwo.AppDll, FrameworkReferenceApp, DotNetWithNetCoreApp.GreatestVersionHostFxrPath, caller);
         }
 
-        public CommandResult RunComponentResolutionMultiThreadedTest(string componentOnePath, string componentTwoPath, TestApp hostApp, string hostFxrFolder)
+        public CommandResult RunComponentResolutionMultiThreadedTest(string componentOnePath, string componentTwoPath, TestApp hostApp, string hostFxrFolder, [CallerMemberName] string caller = "")
         {
             string[] args =
             {
@@ -89,7 +90,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             return Command.Create(NativeHostPath, args)
                 .EnableTracingAndCaptureOutputs()
                 .MultilevelLookup(false)
-                .Execute();
+                .Execute(caller);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DepsFile.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DepsFile.cs
@@ -53,11 +53,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         {
             // Test that .deps.json files with UTF8 BOM are parsed correctly
             TestApp app = sharedState.FrameworkReferenceApp;
-            
+
             // Create a copy of the existing deps.json with UTF8 BOM
-            string depsJsonWithBom = Path.Combine(Path.GetDirectoryName(sharedState.DepsJsonPath), 
+            string depsJsonWithBom = Path.Combine(Path.GetDirectoryName(sharedState.DepsJsonPath),
                 Path.GetFileNameWithoutExtension(sharedState.DepsJsonPath) + "_bom.deps.json");
-            
+
             try
             {
                 // Read the original deps.json content and write with UTF8 BOM

--- a/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             TestContext.BuiltDotNet.Exec(appExe)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute()
+                .Execute(expectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining("BadImageFormatException");
         }
@@ -439,7 +439,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 command.Process.Kill();
 
                 string expectedMissingFramework = $"'{Constants.MicrosoftNETCoreApp}', version '{TestContext.MicrosoftNETCoreAppVersion}' ({TestContext.BuildArchitecture})";
-                var result = command.WaitForExit(true)
+                var result = command.WaitForExit()
                     .Should().Fail()
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
@@ -469,7 +469,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 command.Process.Kill();
 
                 var expectedErrorCode = Constants.ErrorCode.CoreHostLibMissingFailure.ToString("x");
-                var result = command.WaitForExit(true)
+                var result = command.WaitForExit()
                     .Should().Fail()
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?missing_runtime=true")
@@ -504,7 +504,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 command.Process.Kill();
 
                 string expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure.ToString("x");
-                command.WaitForExit(true)
+                command.WaitForExit()
                     .Should().Fail()
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining("You must install or update .NET to run this application.")

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/ApplyPatchesSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/ApplyPatchesSettings.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -118,8 +119,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .ShouldHaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3");
         }
 
-        private CommandResult RunTest(TestSettings testSettings) =>
-            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings);
+        private CommandResult RunTest(TestSettings testSettings, [CallerMemberName] string caller = "") =>
+            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings, caller: caller);
 
         public class SharedTestState : SharedTestStateBase
         {

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/ComplexHierarchies.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/ComplexHierarchies.cs
@@ -4,6 +4,7 @@
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using System;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 using static Microsoft.DotNet.CoreSetup.Test.Constants;
@@ -71,7 +72,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         private CommandResult RunTest(
             Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
             Action<DotNetCliExtensions.DotNetCliCustomizer> customizeDotNet = null,
-            bool rollForwardToPreRelease = false)
+            bool rollForwardToPreRelease = false,
+            [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetWithMultipleFrameworks,
@@ -79,7 +81,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 new TestSettings()
                     .WithRuntimeConfigCustomizer(runtimeConfig)
                     .WithDotnetCustomizer(customizeDotNet)
-                    .WithEnvironment(Constants.RollForwardToPreRelease.EnvironmentVariable, rollForwardToPreRelease ? "1" : "0"));
+                    .WithEnvironment(Constants.RollForwardToPreRelease.EnvironmentVariable, rollForwardToPreRelease ? "1" : "0"),
+                caller: caller);
         }
     }
 }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 
@@ -21,7 +22,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             DotNetCli dotnet,
             TestApp app,
             TestSettings settings,
-            bool? multiLevelLookup = false)
+            bool? multiLevelLookup = false,
+            [CallerMemberName] string caller = "")
         {
             using (DotNetCliExtensions.DotNetCliCustomizer dotnetCustomizer = settings.DotnetCustomizer == null ? null : dotnet.Customize())
             {
@@ -48,7 +50,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .EnableTracingAndCaptureOutputs()
                     .MultilevelLookup(multiLevelLookup)
                     .Environment(settings.Environment)
-                    .Execute();
+                    .Execute(caller);
 
                 return result;
             }
@@ -56,7 +58,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 
         protected CommandResult RunSelfContainedTest(
             TestApp app,
-            TestSettings settings)
+            TestSettings settings,
+            [CallerMemberName] string caller = "")
         {
             if (settings.RuntimeConfigCustomizer != null)
             {
@@ -75,7 +78,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             CommandResult result = command
                 .EnableTracingAndCaptureOutputs()
                 .Environment(settings.Environment)
-                .Execute();
+                .Execute(caller);
 
             return result;
         }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/FxVersionCLI.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/FxVersionCLI.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -109,8 +110,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .ShouldHaveResolvedFramework(MicrosoftNETCoreApp, "2.5.5");
         }
 
-        private CommandResult RunTest(TestSettings testSettings) =>
-            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings);
+        private CommandResult RunTest(TestSettings testSettings, [CallerMemberName] string caller = "") =>
+            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings, caller: caller);
 
         public class SharedTestState : SharedTestStateBase
         {

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -68,11 +69,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .And.HaveStdOutContaining("mock is_framework_dependent: 0");
         }
 
-        private CommandResult RunFrameworkDependentTest(TestSettings testSettings) =>
-            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings);
+        private CommandResult RunFrameworkDependentTest(TestSettings testSettings, [CallerMemberName] string caller = "") =>
+            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings, caller: caller);
 
-        private CommandResult RunSelfContainedTest(TestSettings testSettings) =>
-            RunSelfContainedTest(SharedState.SelfContainedApp, testSettings);
+        private CommandResult RunSelfContainedTest(TestSettings testSettings, [CallerMemberName] string caller = "") =>
+            RunSelfContainedTest(SharedState.SelfContainedApp, testSettings, caller: caller);
 
         public class SharedTestState : SharedTestStateBase
         {

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
@@ -214,7 +214,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             }
         }
 
-        private CommandResult RunTest(Func<RuntimeConfig, RuntimeConfig> runtimeConfig, bool? multiLevelLookup = true, [CallerMemberName] string caller = "")
+        private CommandResult RunTest(Func<RuntimeConfig, RuntimeConfig> runtimeConfig, bool? multiLevelLookup, [CallerMemberName] string caller = "")
             => RunTest(new TestSettings().WithRuntimeConfigCustomizer(runtimeConfig), multiLevelLookup, caller);
 
         private CommandResult RunTest(TestSettings testSettings, bool? multiLevelLookup, [CallerMemberName] string caller = "")

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -213,24 +214,22 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             }
         }
 
-        private CommandResult RunTest(Func<RuntimeConfig, RuntimeConfig> runtimeConfig, bool? multiLevelLookup = true)
-            => RunTest(new TestSettings().WithRuntimeConfigCustomizer(runtimeConfig), multiLevelLookup);
+        private CommandResult RunTest(Func<RuntimeConfig, RuntimeConfig> runtimeConfig, bool? multiLevelLookup = true, [CallerMemberName] string caller = "")
+            => RunTest(new TestSettings().WithRuntimeConfigCustomizer(runtimeConfig), multiLevelLookup, caller);
 
-        private CommandResult RunTest(TestSettings testSettings, bool? multiLevelLookup)
-            => RunTest(testSettings, multiLevelLookup, SharedState.FrameworkReferenceApp);
-
-        private CommandResult RunTest(TestSettings testSettings, bool? multiLevelLookup, TestApp testApp)
+        private CommandResult RunTest(TestSettings testSettings, bool? multiLevelLookup, [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetMainHive,
-                testApp,
+                SharedState.FrameworkReferenceApp,
                 testSettings
                     .WithEnvironment(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, SharedState.DotNetGlobalHive.BinPath)
                     .WithEnvironment( // Redirect the default install location to an invalid location so that a machine-wide install is not used
                         Constants.TestOnlyEnvironmentVariables.DefaultInstallPath,
                         System.IO.Path.Combine(SharedState.DotNetMainHive.BinPath, "invalid")),
                 // Must enable multi-level lookup otherwise multiple hives are not enabled
-                multiLevelLookup: multiLevelLookup);
+                multiLevelLookup: multiLevelLookup,
+                caller: caller);
         }
 
         public class SharedTestState : SharedTestStateBase
@@ -242,8 +241,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             public DotNetCli DotNetGlobalHive { get; }
 
             public DotNetCli DotNetCurrentHive { get; }
-
-            private readonly IDisposable _testOnlyProductBehaviorScope;
 
             public SharedTestState()
             {
@@ -277,16 +274,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 
                 FrameworkReferenceApp = CreateFrameworkReferenceApp();
 
-                _testOnlyProductBehaviorScope = TestOnlyProductBehavior.Enable(DotNetMainHive.GreatestVersionHostFxrFilePath);
+                // Enable test-only behaviour. We don't bother disabling the behaviour later,
+                // as we just delete the entire copy after the tests run.
+                _ = TestOnlyProductBehavior.Enable(DotNetMainHive.GreatestVersionHostFxrFilePath);
             }
 
             protected override void Dispose(bool disposing)
             {
-                if (disposing)
-                {
-                    _testOnlyProductBehaviorScope.Dispose();
-                }
-
                 base.Dispose(disposing);
             }
         }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardAndRollForwardOnNoCandidateFxSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardAndRollForwardOnNoCandidateFxSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -121,8 +122,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             }
         }
 
-        private CommandResult RunTest(TestSettings testSettings) =>
-            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings);
+        private CommandResult RunTest(TestSettings testSettings, [CallerMemberName] string caller = "") =>
+            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings, caller: caller);
 
         public class SharedTestState : SharedTestStateBase
         {

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardMultipleFrameworks.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardMultipleFrameworks.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
-using System;
 using Xunit;
-
 using static Microsoft.DotNet.CoreSetup.Test.Constants;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
@@ -787,7 +787,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         private CommandResult RunTest(
             Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
             Action<DotNetCliExtensions.DotNetCliCustomizer> customizeDotNet = null,
-            bool rollForwardToPreRelease = false)
+            bool rollForwardToPreRelease = false,
+            [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetWithMultipleFrameworks,
@@ -795,7 +796,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 new TestSettings()
                     .WithRuntimeConfigCustomizer(runtimeConfig)
                     .WithDotnetCustomizer(customizeDotNet)
-                    .WithEnvironment(Constants.RollForwardToPreRelease.EnvironmentVariable, rollForwardToPreRelease ? "1" : "0"));
+                    .WithEnvironment(Constants.RollForwardToPreRelease.EnvironmentVariable, rollForwardToPreRelease ? "1" : "0"),
+                caller: caller);
         }
     }
 }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -229,13 +230,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3");
         }
 
-        private CommandResult RunTestWithOneFramework(Func<RuntimeConfig, RuntimeConfig> runtimeConfig)
+        private CommandResult RunTestWithOneFramework(Func<RuntimeConfig, RuntimeConfig> runtimeConfig, [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetWithOneFramework,
                 SharedState.FrameworkReferenceApp,
                 new TestSettings()
-                    .WithRuntimeConfigCustomizer(runtimeConfig));
+                    .WithRuntimeConfigCustomizer(runtimeConfig),
+                caller: caller);
         }
         #endregion
 
@@ -387,13 +389,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .ShouldFailToFindCompatibleFrameworkVersion(MicrosoftNETCoreApp, requestedVersion);
         }
 
-        private CommandResult RunTestWithPreReleaseFramework(Func<RuntimeConfig, RuntimeConfig> runtimeConfig)
+        private CommandResult RunTestWithPreReleaseFramework(Func<RuntimeConfig, RuntimeConfig> runtimeConfig, [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetWithPreReleaseFramework,
                 SharedState.FrameworkReferenceApp,
                 new TestSettings()
-                    .WithRuntimeConfigCustomizer(runtimeConfig));
+                    .WithRuntimeConfigCustomizer(runtimeConfig),
+                caller: caller);
         }
         #endregion
 
@@ -728,13 +731,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .ShouldHaveResolvedFramework(MicrosoftNETCoreApp, "6.1.1");
         }
 
-        private CommandResult RunTestWithManyVersions(Func<RuntimeConfig, RuntimeConfig> runtimeConfig)
+        private CommandResult RunTestWithManyVersions(Func<RuntimeConfig, RuntimeConfig> runtimeConfig, [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetWithManyVersions,
                 SharedState.FrameworkReferenceApp,
                 new TestSettings()
-                    .WithRuntimeConfigCustomizer(runtimeConfig));
+                    .WithRuntimeConfigCustomizer(runtimeConfig),
+                caller: caller);
         }
         #endregion
     }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFxMultipleFrameworks.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFxMultipleFrameworks.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
-using System;
 using Xunit;
-
 using static Microsoft.DotNet.CoreSetup.Test.Constants;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
@@ -485,14 +485,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 
         private CommandResult RunTest(
             Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
-            Action<DotNetCliExtensions.DotNetCliCustomizer> customizeDotNet = null)
+            Action<DotNetCliExtensions.DotNetCliCustomizer> customizeDotNet = null,
+            [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetWithMultipleFrameworks,
                 SharedState.FrameworkReferenceApp,
                 new TestSettings()
                     .WithRuntimeConfigCustomizer(runtimeConfig)
-                    .WithDotnetCustomizer(customizeDotNet));
+                    .WithDotnetCustomizer(customizeDotNet),
+                caller: caller);
         }
     }
 }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -188,8 +189,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .ShouldHaveResolvedFrameworkOrFailToFind(MicrosoftNETCoreApp, appWins ? null : "5.1.3");
         }
 
-        private CommandResult RunTest(TestSettings testSettings) =>
-            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings);
+        private CommandResult RunTest(TestSettings testSettings, [CallerMemberName] string caller = "") =>
+            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings, caller: caller);
 
         public class SharedTestState : SharedTestStateBase
         {

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardPreReleaseOnly.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardPreReleaseOnly.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -303,7 +304,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         private CommandResult RunTest(
             string frameworkReferenceVersion,
             string rollForward,
-            bool? applyPatches)
+            bool? applyPatches,
+            [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetWithNETCoreAppPreRelease,
@@ -313,7 +315,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                         .WithApplyPatches(applyPatches)
                         .WithFramework(MicrosoftNETCoreApp, frameworkReferenceVersion))
                     // Using command line, so that it's possible to mix rollForward and applyPatches
-                    .With(RollForwardSetting(SettingLocation.CommandLine, rollForward)));
+                    .With(RollForwardSetting(SettingLocation.CommandLine, rollForward)),
+                caller: caller);
         }
     }
 }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardReleaseAndPreRelease.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardReleaseAndPreRelease.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -322,7 +323,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             string frameworkReferenceVersion,
             string rollForward,
             bool? applyPatches,
-            bool rollForwardToPreRelease = false)
+            bool rollForwardToPreRelease = false,
+            [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetWithNETCoreAppReleaseAndPreRelease,
@@ -333,7 +335,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                         .WithFramework(MicrosoftNETCoreApp, frameworkReferenceVersion))
                     // Using command line, so that it's possible to mix rollForward and applyPatches
                     .With(RollForwardSetting(SettingLocation.CommandLine, rollForward))
-                    .WithEnvironment(Constants.RollForwardToPreRelease.EnvironmentVariable, rollForwardToPreRelease ? "1" : "0"));
+                    .WithEnvironment(Constants.RollForwardToPreRelease.EnvironmentVariable, rollForwardToPreRelease ? "1" : "0"),
+                caller: caller);
         }
     }
 }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardReleaseOnly.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardReleaseOnly.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -215,7 +216,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         private CommandResult RunTest(
             string frameworkReferenceVersion,
             string rollForward,
-            bool? applyPatches)
+            bool? applyPatches,
+            [CallerMemberName] string caller = "")
         {
             return RunTest(
                 SharedState.DotNetWithNETCoreAppRelease,
@@ -225,7 +227,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                         .WithApplyPatches(applyPatches)
                         .WithFramework(MicrosoftNETCoreApp, frameworkReferenceVersion))
                    // Using command line, so that it's possible to mix rollForward and applyPatches
-                   .With(RollForwardSetting(SettingLocation.CommandLine, rollForward)));
+                   .With(RollForwardSetting(SettingLocation.CommandLine, rollForward)),
+                caller: caller);
         }
     }
 }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/RollForwardSettings.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
@@ -193,8 +194,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .ShouldHaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3");
         }
 
-        private CommandResult RunTest(TestSettings testSettings) =>
-            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings);
+        private CommandResult RunTest(TestSettings testSettings, [CallerMemberName] string caller = "") =>
+            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings, caller: caller);
 
         public class SharedTestState : SharedTestStateBase
         {

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
@@ -1199,15 +1200,13 @@ namespace HostActivation.Tests
         private string ExpectedResolvedSdkOutput(string expectedVersion, string rootPath = null)
             => $"Using .NET SDK dll=[{Path.Combine(rootPath == null ? ExecutableDotNet.BinPath : rootPath, "sdk", expectedVersion, "dotnet.dll")}]";
 
-        private CommandResult RunTest() => RunTest("help");
-
-        private CommandResult RunTest(string command)
+        private CommandResult RunTest(string command = "help", [CallerMemberName] string caller = "")
         {
             return ExecutableDotNet.Exec(command)
                 .WorkingDirectory(SharedState.CurrentWorkingDir)
                 .EnableTracingAndCaptureOutputs()
                 .MultilevelLookup(false)
-                .Execute();
+                .Execute(caller);
         }
 
         public sealed class SharedTestState : IDisposable


### PR DESCRIPTION
When launching a process to test, host tests write to the console on launch, wait for exit, and exit. Currently, they also log OK/FAIL based on the exit code and a parameter for whether failure is expected. All tests already do their own validation for if the command should pass/fail - having this extra logging is not useful and can be actively confusing, since it relies on tests also passing in that parameter (even though that is not used for actual validation/asserts).

This PR updates the logging to remove the OK/FAIL, include the PID on exit, and add the caller name (for test identification).

Example of existing logging:
```
[EXEC >] [....] [00:00:30.516] C:\repos\runtime\artifacts\tests\host\windows.x64.Release\sharedFrameworkPublish\dotnet.exe C:\repos\runtime\artifacts\tests\host\windows.x64.Release\ha\l24mjfq5.zpz\HelloWorld\HelloWorld.dll throw_exception
[EXEC -] [....] [00:00:30.520] Waiting for process 65220 to exit...
[EXEC <] [ OK ] [00:00:30.657] C:\repos\runtime\artifacts\tests\host\windows.x64.Release\sharedFrameworkPublish\dotnet.exe C:\repos\runtime\artifacts\tests\host\windows.x64.Release\ha\l24mjfq5.zpz\HelloWorld\HelloWorld.dll throw_exception exited with -532462766. Expected: non-zero
```
With this PR:
```
[EXEC] [00:01:22.797] [UnhandledException_BreadcrumbThreadDoesNotFinish]
       C:\repos\runtime\artifacts\tests\host\windows.x64.Release\sharedFrameworkPublish\dotnet.exe C:\repos\runtime\artifacts\tests\host\windows.x64.Release\ha\lfasw0g2.ynl\HelloWorld\HelloWorld.dll throw_exception
[WAIT] [00:01:22.802] [UnhandledException_BreadcrumbThreadDoesNotFinish]
       PID: 50836 - C:\repos\runtime\artifacts\tests\host\windows.x64.Release\sharedFrameworkPublish\dotnet.exe C:\repos\runtime\artifacts\tests\host\windows.x64.Release\ha\lfasw0g2.ynl\HelloWorld\HelloWorld.dll throw_exception
[EXIT] [00:01:22.947] [UnhandledException_BreadcrumbThreadDoesNotFinish]
       PID: 50836 - Exit code: 0xe0434352 - C:\repos\runtime\artifacts\tests\host\windows.x64.Release\sharedFrameworkPublish\dotnet.exe C:\repos\runtime\artifacts\tests\host\windows.x64.Release\ha\lfasw0g2.ynl\HelloWorld\HelloWorld.dll throw_exception
```

Contributes to https://github.com/dotnet/runtime/issues/116520

cc @dotnet/appmodel @AaronRobinsonMSFT 