### PR TITLE
Include the frame register when copying arm32 debugger stackwalk context

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5647,8 +5647,9 @@ void DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContex
                     UpdateContextFromRegDisp(&tmpRd, &tmpContext);
                     CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
                     pContextBuffer->ContextFlags = DT_CONTEXT_CONTROL 
-#ifdef TARGET_AMD64
-                                                | DT_CONTEXT_INTEGER  // On AMD64, we also need to save RBP for stackwalking
+#if defined(TARGET_AMD64) || defined(TARGET_ARM)
+                                                | DT_CONTEXT_INTEGER  // DT_CONTEXT_INTEGER is needed to include the frame register on ARM32 and AMD64 architectures
+                                                                      // DT_CONTEXT_CONTROL already includes the frame register for X86 and ARM64 architectures
 #endif
                     ;
                     return;


### PR DESCRIPTION
In my previous change on #116617, I didn't include copying the frame pointer for arm32.  This change enables DT_CONTEXT_INTEGER for arm32 in addition to the previously enabled amd64 architecture.

Fixes: #115668