### PR TITLE
[mono][1/2] Add SIMD Support for s390x

### DIFF
--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -220,8 +220,8 @@ mono_regstate_alloc_general (MonoRegState *rs, regmask_t allow, int bank)
 				return i;
 
 			rs->free_mask [mirrored_bank] = (((MONO_ARCH_CALLEE_FREGS & MONO_ARCH_CALLEE_XREGS) & rs->free_mask [bank])
-                                |((MONO_ARCH_CALLEE_FREGS ^ MONO_ARCH_CALLEE_XREGS) & rs->free_mask [mirrored_bank]));
-            return i;
+								|((MONO_ARCH_CALLEE_FREGS ^ MONO_ARCH_CALLEE_XREGS) & rs->free_mask [mirrored_bank]));
+			return i;
 		}
 	}
 	return -1;
@@ -239,8 +239,8 @@ mono_regstate_free_general (MonoRegState *rs, int reg, int bank)
 		mirrored_bank = get_mirrored_bank (bank);
 		if (mirrored_bank == -1)
 			return;
-        rs->free_mask [mirrored_bank] = (((MONO_ARCH_CALLEE_FREGS & MONO_ARCH_CALLEE_XREGS) & rs->free_mask [bank])
-                                |((MONO_ARCH_CALLEE_FREGS ^ MONO_ARCH_CALLEE_XREGS) & rs->free_mask [mirrored_bank]));
+		rs->free_mask [mirrored_bank] = (((MONO_ARCH_CALLEE_FREGS & MONO_ARCH_CALLEE_XREGS) & rs->free_mask [bank])
+								|((MONO_ARCH_CALLEE_FREGS ^ MONO_ARCH_CALLEE_XREGS) & rs->free_mask [mirrored_bank]));
 		rs->symbolic [mirrored_bank][reg] = 0;
 	}
 }
@@ -649,7 +649,7 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 			g_string_append_printf (sbuf, " [B%d]", ins->inst_true_bb->block_num);
 		else
 			g_string_append_printf (sbuf, " [T:B%d F:B%d]", ins->inst_true_bb->block_num,
-			                        ins->inst_false_bb->block_num);
+									ins->inst_false_bb->block_num);
 		break;
 	case OP_LIVERANGE_START:
 	case OP_LIVERANGE_END:
@@ -1081,8 +1081,8 @@ assign_reg (MonoCompile *cfg, MonoRegState *rs, int reg, int hreg, int bank)
 		/* Make sure the other logical reg bank that this bank shares
 		 * a single hard reg bank knows that this hard reg is not free.
 		 */
-        rs->free_mask [mirrored_bank] = (((MONO_ARCH_CALLEE_FREGS & MONO_ARCH_CALLEE_XREGS) & rs->free_mask [bank])
-                                |((MONO_ARCH_CALLEE_FREGS ^ MONO_ARCH_CALLEE_XREGS) & rs->free_mask [mirrored_bank]));
+		rs->free_mask [mirrored_bank] = (((MONO_ARCH_CALLEE_FREGS & MONO_ARCH_CALLEE_XREGS) & rs->free_mask [bank])
+								|((MONO_ARCH_CALLEE_FREGS ^ MONO_ARCH_CALLEE_XREGS) & rs->free_mask [mirrored_bank]));
 		/* Mark the other logical bank that the this bank shares
 		 * a single hard reg bank with as mirrored.
 		 */
@@ -1566,7 +1566,7 @@ mono_local_regalloc (MonoCompile *cfg, MonoBasicBlock *bb)
 			val = rs->vassign [ins->dreg];
 			if (is_soft_reg (ins->dreg, bank) && (val >= 0) && (!(regmask (val) & dreg_mask))) {
 				/* DREG is already allocated to a register needed for sreg1 */
-			    spill_vreg (cfg, bb, tmp, ins, ins->dreg, 0);
+				spill_vreg (cfg, bb, tmp, ins, ins->dreg, 0);
 			}
 		}
 

--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -141,14 +141,9 @@ static void
 mono_regstate_assign (MonoRegState *rs)
 {
 #ifdef MONO_ARCH_USE_SHARED_FP_SIMD_BANK
-	/* The regalloc may fail if fp and simd logical regbanks share the same physical reg bank and
-	 * if the values here are not the same.
-	 */
-/* s390x has unequal regbank masks for vector and floats*/
-#ifndef TARGET_S390X
-	g_assert(regbank_callee_regs [MONO_REG_SIMD] == regbank_callee_regs [MONO_REG_DOUBLE]);
-	g_assert(regbank_size [MONO_REG_SIMD] == regbank_size [MONO_REG_DOUBLE]);
-#endif
+	/* fp and simd logical banks may share the same physical reg bank with unequal overlapping registers */
+	g_assert((regbank_callee_regs [MONO_REG_SIMD] & regbank_callee_regs[MONO_REG_DOUBLE]) == regbank_callee_regs [MONO_REG_DOUBLE]);
+	g_assert(regbank_size [MONO_REG_SIMD] >= regbank_size [MONO_REG_DOUBLE]);
 	g_assert(regbank_callee_saved_regs [MONO_REG_SIMD] == regbank_callee_saved_regs [MONO_REG_DOUBLE]);
 #endif
 

--- a/src/mono/mono/mini/mini-s390x.h
+++ b/src/mono/mono/mini/mini-s390x.h
@@ -83,7 +83,8 @@ struct SeqPointInfo {
 #define MONO_ARCH_HAVE_SETUP_RESUME_FROM_SIGNAL_HANDLER_CTX	1
 #define MONO_ARCH_HAVE_UNWIND_BACKTRACE 		1
 #define MONO_ARCH_FLOAT32_SUPPORTED			1
-
+#define MONO_ARCH_NEED_SIMD_BANK                       1
+#define MONO_ARCH_USE_SHARED_FP_SIMD_BANK              1
 #define S390_STACK_ALIGNMENT		 8
 #define S390_FIRST_ARG_REG 		s390_r2
 #define S390_LAST_ARG_REG 		s390_r6
@@ -147,8 +148,9 @@ struct SeqPointInfo {
 /*-----------------------------------------------*/
 /* SIMD Related Definitions                      */
 /*-----------------------------------------------*/
-
+/* f0 overlaps with v0 and vr16 is used internally */
 #define MONO_MAX_XREGS			31
+#define MONO_ARCH_CALLEE_XREGS 0xFFFEFFFE
 #define MONO_ARCH_CALLEE_XREGS		0x0
 #define MONO_ARCH_CALLEE_SAVED_XREGS	0x0
 

--- a/src/mono/mono/mini/mini-s390x.h
+++ b/src/mono/mono/mini/mini-s390x.h
@@ -83,8 +83,8 @@ struct SeqPointInfo {
 #define MONO_ARCH_HAVE_SETUP_RESUME_FROM_SIGNAL_HANDLER_CTX	1
 #define MONO_ARCH_HAVE_UNWIND_BACKTRACE 		1
 #define MONO_ARCH_FLOAT32_SUPPORTED			1
-#define MONO_ARCH_NEED_SIMD_BANK                       1
-#define MONO_ARCH_USE_SHARED_FP_SIMD_BANK              1
+#define MONO_ARCH_NEED_SIMD_BANK			1
+#define MONO_ARCH_USE_SHARED_FP_SIMD_BANK		1
 #define S390_STACK_ALIGNMENT		 8
 #define S390_FIRST_ARG_REG 		s390_r2
 #define S390_LAST_ARG_REG 		s390_r6
@@ -150,8 +150,7 @@ struct SeqPointInfo {
 /*-----------------------------------------------*/
 /* f0 overlaps with v0 and vr16 is used internally */
 #define MONO_MAX_XREGS			31
-#define MONO_ARCH_CALLEE_XREGS 0xFFFEFFFE
-#define MONO_ARCH_CALLEE_XREGS		0x0
+#define MONO_ARCH_CALLEE_XREGS		0xFFFEFFFE
 #define MONO_ARCH_CALLEE_SAVED_XREGS	0x0
 
 // Does the ABI have a volatile non-parameter register, so tailcall


### PR DESCRIPTION
This is the inital patch to support simd on s390x. on s390x we have 16 floating point registers and 32 vector registers out of which f0 - f15 overlap with v0 - v15.

redefine the mirrored_mask logic for unequal masks in the register allocator.