### PR TITLE
Avoid CORINFO_..._HANDLEs in JIT helper signatures

### DIFF
--- a/src/coreclr/vm/appdomainnative.cpp
+++ b/src/coreclr/vm/appdomainnative.cpp
@@ -129,7 +129,7 @@ extern "C" void QCALLTYPE String_IsInterned(QCall::StringHandleOnStack str)
     END_QCALL;
 }
 
-extern "C" STRINGREF* QCALLTYPE String_StrCns(UINT32 rid, CORINFO_MODULE_HANDLE scopeHnd)
+extern "C" STRINGREF* QCALLTYPE String_StrCns(UINT32 rid, Module* pModule)
 {
     QCALL_CONTRACT;
 
@@ -138,7 +138,7 @@ extern "C" STRINGREF* QCALLTYPE String_StrCns(UINT32 rid, CORINFO_MODULE_HANDLE 
     BEGIN_QCALL;
 
     // Retrieve the handle to the CLR string object.
-    hndStr = ConstructStringLiteral(scopeHnd, RidToToken(rid, mdtString));
+    hndStr = pModule->ResolveStringRef(RidToToken(rid, mdtString));
 
     END_QCALL;
 

--- a/src/coreclr/vm/appdomainnative.hpp
+++ b/src/coreclr/vm/appdomainnative.hpp
@@ -16,7 +16,7 @@
 
 #include "qcall.h"
 
-extern "C" STRINGREF* QCALLTYPE String_StrCns(UINT32 rid, CORINFO_MODULE_HANDLE scopeHnd);
+extern "C" STRINGREF* QCALLTYPE String_StrCns(UINT32 rid, Module* pModule);
 extern "C" void QCALLTYPE String_Intern(QCall::StringHandleOnStack str);
 extern "C" void QCALLTYPE String_IsInterned(QCall::StringHandleOnStack str);
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -116,7 +116,7 @@ CallStubHeader *CreateNativeToInterpreterCallStub(InterpMethod* pInterpMethod)
 
 typedef void* (*HELPER_FTN_PP)(void*);
 typedef void* (*HELPER_FTN_BOX_UNBOX)(MethodTable*, void*);
-typedef Object* (*HELPER_FTN_NEWARR)(CORINFO_CLASS_HANDLE, intptr_t);
+typedef Object* (*HELPER_FTN_NEWARR)(MethodTable*, intptr_t);
 typedef void* (*HELPER_FTN_PP_2)(void*, void*);
 
 InterpThreadContext::InterpThreadContext()
@@ -131,9 +131,9 @@ InterpThreadContext::~InterpThreadContext()
     free(pStackStart);
 }
 
-CORINFO_GENERIC_HANDLE GenericHandleWorkerCore(MethodDesc * pMD, MethodTable * pMT, LPVOID signature, DWORD dictionaryIndexAndSlot, Module* pModule);
+DictionaryEntry GenericHandleWorkerCore(MethodDesc * pMD, MethodTable * pMT, LPVOID signature, DWORD dictionaryIndexAndSlot, Module* pModule);
 
-CORINFO_GENERIC_HANDLE GenericHandleCommon(MethodDesc * pMD, MethodTable * pMT, LPVOID signature)
+void* GenericHandleCommon(MethodDesc * pMD, MethodTable * pMT, LPVOID signature)
 {
     CONTRACTL
     {
@@ -1706,7 +1706,7 @@ CALL_INTERP_METHOD:
                     if (length < 0)
                         COMPlusThrow(kArgumentOutOfRangeException);
 
-                    CORINFO_CLASS_HANDLE arrayClsHnd = (CORINFO_CLASS_HANDLE)pMethod->pDataItems[ip[3]];
+                    MethodTable* arrayClsHnd = (MethodTable*)pMethod->pDataItems[ip[3]];
                     HELPER_FTN_NEWARR helper = GetPossiblyIndirectHelper<HELPER_FTN_NEWARR>(pMethod->pDataItems[ip[4]]);
 
                     Object* arr = helper(arrayClsHnd, (intptr_t)length);
@@ -1979,7 +1979,7 @@ do {                                                                           \
                 }
 #define DO_GENERIC_LOOKUP(mdParam, mtParam) \
                     CORINFO_RUNTIME_LOOKUP *pLookup = (CORINFO_RUNTIME_LOOKUP*)pMethod->pDataItems[ip[3]];  \
-                    CORINFO_GENERIC_HANDLE  result = 0;                                                     \
+                    void* result = 0;                                                                       \
                                                                                                             \
                     assert(!pLookup->indirectFirstOffset);                                                  \
                     assert(!pLookup->indirectSecondOffset);                                                 \
@@ -2007,9 +2007,9 @@ do {                                                                           \
                             result = GenericHandleCommon(mdParam, mtParam, pLookup->signature);             \
                             break;                                                                          \
                         }                                                                                   \
-                        result = (CORINFO_GENERIC_HANDLE)lookup;                                            \
+                        result = lookup;                                                                    \
                     } while (0);                                                                            \
-                    LOCAL_VAR(dreg, CORINFO_GENERIC_HANDLE) = result;                                       \
+                    LOCAL_VAR(dreg, void*) = result;                                                        \
                     ip += 4;
 
                 case INTOP_GENERICLOOKUP_THIS:

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12104,13 +12104,13 @@ InfoAccessType CEECodeGenInfo::constructStringLiteral(CORINFO_MODULE_HANDLE scop
     }
     else
     {
-        // If ConstructStringLiteral returns a pinned reference we can return it by value (IAT_VALUE)
-        void* ppPinnedString = nullptr;
-        STRINGREF* ptr = ConstructStringLiteral(scopeHnd, metaTok, &ppPinnedString);
+        // If ResolveStringRef returns a pinned reference we can return it by value (IAT_VALUE)
+        void* pPinnedString = nullptr;
+        STRINGREF* ptr = ((Module*)scopeHnd)->ResolveStringRef(metaTok, &pPinnedString);
 
-        if (ppPinnedString != nullptr)
+        if (pPinnedString != nullptr)
         {
-            *ppValue = ppPinnedString;
+            *ppValue = pPinnedString;
             result = IAT_VALUE;
         }
         else

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -1030,11 +1030,6 @@ BOOL OnGcCoverageInterrupt(PT_CONTEXT regs);
 void DoGcStress (PT_CONTEXT regs, NativeCodeVersion nativeCodeVersion);
 #endif //HAVE_GCCOVER
 
-// ppPinnedString: If the string is pinned (e.g. allocated in frozen heap),
-// the pointer to the pinned string is returned in *ppPinnedPointer. ppPinnedPointer == nullptr
-// means that the caller does not care whether the string is pinned or not.
-STRINGREF* ConstructStringLiteral(CORINFO_MODULE_HANDLE scopeHnd, mdToken metaTok, void** ppPinnedString = nullptr);
-
 BOOL ObjIsInstanceOf(Object *pObject, TypeHandle toTypeHnd, BOOL throwCastException = FALSE);
 
 class InlinedCallFrame;


### PR DESCRIPTION
CORINFO_..._HANDLEs are meant to be JIT/EE interface abstraction. Using them in JIT helper signatures causes confusion.