### PR TITLE
Fix unhandled exception in tiered compilation thread

### DIFF
--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -2168,6 +2168,7 @@ HRESULT DispatchInfo::InvokeMember(SimpleComCallWrapper *pSimpleWrap, DISPID id,
         // which may swallow managed exceptions.  The debugger needs this in order to send a
         // CatchHandlerFound (CHF) notification.
         DebuggerU2MCatchHandlerFrame catchFrame(true /* catchesAllExceptions */);
+
         EX_TRY
         {
             InvokeMemberDebuggerWrapper(pDispMemberInfo,

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10471,7 +10471,7 @@ bool CEEInfo::runWithErrorTrap(void (*function)(void*), void* param)
 {
     CONTRACTL {
         THROWS;
-        GC_NOTRIGGER;
+        GC_TRIGGERS;
         MODE_PREEMPTIVE;
     }
     CONTRACTL_END;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10585,6 +10585,8 @@ bool CEEInfo::runWithErrorTrap(void (*function)(void*), void* param)
 
     bool success = true;
 
+    DebuggerU2MCatchHandlerFrame catchFrame(true /* catchesAllExceptions */);
+
 #if !defined(TARGET_UNIX)
 
     RunWithErrorTrapFilterParam trapParam;

--- a/src/tests/Regressions/coreclr/GitHub_116676/test116676.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116676/test116676.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Test116676
+{
+    [UnsafeAccessor(UnsafeAccessorKind.Method)]
+    extern static void DoesNotExist([UnsafeAccessorType("DoesNotExist")] object a);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Work(bool f)
+    {
+        if (f)
+            DoesNotExist(null);
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            Work(false);
+        }
+    }
+}
+

--- a/src/tests/Regressions/coreclr/GitHub_116676/test116676.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116676/test116676.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using System.Threading;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -19,9 +20,9 @@ public class Test116676
     [Fact]
     public static void TestEntryPoint()
     {
-        for (int i = 0; i < 1_000_000; i++)
+        for (int i = 0; i < 200; i++)
         {
-            Console.WriteLine(i);
+            Thread.Sleep(10);
             Work(false);
         }
     }

--- a/src/tests/Regressions/coreclr/GitHub_116676/test116676.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116676/test116676.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -20,6 +21,7 @@ public class Test116676
     {
         for (int i = 0; i < 1_000_000; i++)
         {
+            Console.WriteLine(i);
             Work(false);
         }
     }

--- a/src/tests/Regressions/coreclr/GitHub_116676/test116676.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116676/test116676.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test116676.cs" />

--- a/src/tests/Regressions/coreclr/GitHub_116676/test116676.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116676/test116676.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test116676.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The detection the unhandled exception is not working in the case of the tiered compilation thread, because there is no indication that the exception is going to be caught in the `CEEInfo::runWithErrorTrap`. So the EH assumes the exception is going to be unhandled and exits the process.
The unhandled exception message was not seen in the repro case of the issue likely because the tiered compilation thread console output didn't get flushed. When running under a debugger and stepping over the `InternalUnhandledExceptionFilter_Worker`, it was actually printed out.

The fix is to add `DebuggerU2MCatchHandlerFrame` to the `CEEInfo::runWithErrorTrap`. That allows the EH to see that the exception will be caught there and let it flow through the `CallDescrWorker` to reach that trap.

I have also taken this opportunity and renamed the confusing `invalidRevPInvoke` local variable.

Closes #116676