### PR TITLE
Remove PopCountOperator<T> guards in TrailingZeroCountOperator<T>.Invoke

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.TrailingZeroCount.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.TrailingZeroCount.cs
@@ -48,23 +48,15 @@ namespace System.Numerics.Tensors
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static Vector256<T> Invoke(Vector256<T> x)
             {
-                if (PopCountOperator<T>.Vectorizable)
-                {
-                    return PopCountOperator<T>.Invoke(~x & (x - Vector256<T>.One));
-                }
-
-                return Vector256.Create(Invoke(x.GetLower()), Invoke(x.GetUpper()));
+                Debug.Assert(PopCountOperator<T>.Vectorizable);
+                return PopCountOperator<T>.Invoke(~x & (x - Vector256<T>.One));
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static Vector512<T> Invoke(Vector512<T> x)
             {
-                if (PopCountOperator<T>.Vectorizable)
-                {
-                    return PopCountOperator<T>.Invoke(~x & (x - Vector512<T>.One));
-                }
-
-                return Vector512.Create(Invoke(x.GetLower()), Invoke(x.GetUpper()));
+                Debug.Assert(PopCountOperator<T>.Vectorizable);
+                return PopCountOperator<T>.Invoke(~x & (x - Vector512<T>.One));
             }
         }
     }


### PR DESCRIPTION
This is a small change that removes the redundant PopCountOperator<T>.Vectorizable guards from the TrailingZeroCount<T>.Invoke paths for Vector256 and Vector512. The Invoke functions inlines better by removing these guards and results in a performance gain.

```
| Type                                      | Method            | Job        | Toolchain                   | BufferLength | Mean       | Error     | StdDev    | Median     | Min        | Max        | Ratio | Allocated | Alloc Ratio |
|------------------------------------------ |------------------ |----------- |---------------------------- |------------- |-----------:|----------:|----------:|-----------:|-----------:|-----------:|------:|----------:|------------:|
| Perf_BinaryIntegerTensorPrimitives<Byte>  | TrailingZeroCount | Job-OWIWOI | \base\Core_Root\corerun.exe | 128          |  39.416 ns | 0.3226 ns | 0.3017 ns |  39.400 ns |  38.873 ns |  39.953 ns |  1.00 |         - |          NA |
| Perf_BinaryIntegerTensorPrimitives<Byte>  | TrailingZeroCount | Job-VUQMWI | \diff\Core_Root\corerun.exe | 128          |   5.588 ns | 0.0560 ns | 0.0467 ns |   5.603 ns |   5.494 ns |   5.647 ns |  0.14 |         - |          NA |
|                                           |                   |            |                             |              |            |           |           |            |            |            |       |           |             |
| Perf_BinaryIntegerTensorPrimitives<Int32> | TrailingZeroCount | Job-OWIWOI | \base\Core_Root\corerun.exe | 128          | 110.643 ns | 0.2528 ns | 0.2365 ns | 110.560 ns | 110.404 ns | 111.067 ns |  1.00 |         - |          NA |
| Perf_BinaryIntegerTensorPrimitives<Int32> | TrailingZeroCount | Job-VUQMWI | \diff\Core_Root\corerun.exe | 128          |  14.518 ns | 0.0879 ns | 0.0822 ns |  14.492 ns |  14.430 ns |  14.677 ns |  0.13 |         - |          NA |
|                                           |                   |            |                             |              |            |           |           |            |            |            |       |           |             |
| Perf_BinaryIntegerTensorPrimitives<Byte>  | TrailingZeroCount | Job-OWIWOI | \base\Core_Root\corerun.exe | 3079         | 204.174 ns | 0.5751 ns | 0.5098 ns | 204.422 ns | 202.991 ns | 204.618 ns |  1.00 |         - |          NA |
| Perf_BinaryIntegerTensorPrimitives<Byte>  | TrailingZeroCount | Job-VUQMWI | \diff\Core_Root\corerun.exe | 3079         |  62.966 ns | 0.2158 ns | 0.1802 ns |  62.942 ns |  62.719 ns |  63.306 ns |  0.31 |         - |          NA |
|                                           |                   |            |                             |              |            |           |           |            |            |            |       |           |             |
| Perf_BinaryIntegerTensorPrimitives<Int32> | TrailingZeroCount | Job-OWIWOI | \base\Core_Root\corerun.exe | 3079         | 800.225 ns | 7.7147 ns | 7.2163 ns | 800.139 ns | 790.602 ns | 814.042 ns |  1.00 |         - |          NA |
| Perf_BinaryIntegerTensorPrimitives<Int32> | TrailingZeroCount | Job-VUQMWI | \diff\Core_Root\corerun.exe | 3079         | 301.138 ns | 1.0371 ns | 0.8097 ns | 300.876 ns | 300.098 ns | 302.453 ns |  0.38 |         - |          NA |
```

