### PR TITLE
Fix the compiler toolset override for runtime-async

### DIFF
--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -11,6 +11,7 @@
   <PropertyGroup>
     <!-- Override the compiler version with a private build that supports runtime-async -->
     <MicrosoftNetCompilersToolsetVersion>5.0.0-1.25259.6</MicrosoftNetCompilersToolsetVersion>
+    <RoslynCompilerType>Custom</RoslynCompilerType>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The compiler toolset branch we're using is lagging and doesn't have this property set. I'll manually set it here.