### PR TITLE
Disable core dumps in host tests that intentionally crash

### DIFF
--- a/src/installer/tests/Assets/Projects/AppWithCustomEntryPoints/AppWithCustomEntryPoints.csproj
+++ b/src/installer/tests/Assets/Projects/AppWithCustomEntryPoints/AppWithCustomEntryPoints.csproj
@@ -5,4 +5,8 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="..\CoreDump.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/installer/tests/Assets/Projects/AppWithCustomEntryPoints/Program.cs
+++ b/src/installer/tests/Assets/Projects/AppWithCustomEntryPoints/Program.cs
@@ -53,6 +53,9 @@ namespace AppWithCustomEntryPoints
         {
             functionPointerCallCount++;
             PrintFunctionPointerCallLog(nameof(ThrowException), arg, size);
+
+            // Disable core dumps - test is intentionally crashing
+            Utilities.CoreDump.Disable();
             throw new InvalidOperationException(nameof(ThrowException));
         }
 

--- a/src/installer/tests/Assets/Projects/Component/Component.cs
+++ b/src/installer/tests/Assets/Projects/Component/Component.cs
@@ -47,6 +47,9 @@ namespace Component
         {
             componentCallCount++;
             PrintComponentCallLog(nameof(ThrowException), arg, size);
+
+            // Disable core dumps - test is intentionally crashing
+            Utilities.CoreDump.Disable();
             throw new InvalidOperationException(nameof(ThrowException));
         }
 

--- a/src/installer/tests/Assets/Projects/Component/Component.csproj
+++ b/src/installer/tests/Assets/Projects/Component/Component.csproj
@@ -5,4 +5,8 @@
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="..\CoreDump.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/installer/tests/Assets/Projects/CoreDump.cs
+++ b/src/installer/tests/Assets/Projects/CoreDump.cs
@@ -15,7 +15,7 @@ namespace Utilities
             {
                 if (prctl(PR_SET_DUMPABLE, 0) != 0)
                 {
-                    throw new Exception($"Failed to disable core dump. Error: {Marshal.GetLastPInvokeError()}.");
+                    throw new InvalidOperationException($"Failed to disable core dump. Error: {Marshal.GetLastPInvokeError()}.");
                 }
             }
             else if (OperatingSystem.IsMacOS())
@@ -23,7 +23,7 @@ namespace Utilities
                 RLimit rlimit = new() { rlim_cur = 0, rlim_max = 0 };
                 if (setrlimit(RLIMIT_CORE, rlimit) != 0)
                 {
-                    throw new Exception($"Failed to disable core dump. Error: {Marshal.GetLastPInvokeError()}.");
+                    throw new InvalidOperationException($"Failed to disable core dump. Error: {Marshal.GetLastPInvokeError()}.");
                 }
             }
         }

--- a/src/installer/tests/Assets/Projects/CoreDump.cs
+++ b/src/installer/tests/Assets/Projects/CoreDump.cs
@@ -11,6 +11,14 @@ namespace Utilities
     {
         public static void Disable()
         {
+            string? envValue = Environment.GetEnvironmentVariable("DOTNET_DbgEnableMiniDump");
+            if (envValue is not null && envValue != "0")
+                throw new InvalidOperationException("DOTNET_DbgEnableMiniDump is set and not 0. Ensure it is unset or set to 0 to disable dumps.");
+
+            envValue = Environment.GetEnvironmentVariable("COMPlus_DbgEnableMiniDump");
+            if (envValue is not null && envValue != "0")
+                throw new InvalidOperationException("COMPlus_DbgEnableMiniDump is set and not 0. Ensure it is unset or set to 0 to disable dumps.");
+
             if (OperatingSystem.IsLinux())
             {
                 if (prctl(PR_SET_DUMPABLE, 0) != 0)

--- a/src/installer/tests/Assets/Projects/CoreDump.cs
+++ b/src/installer/tests/Assets/Projects/CoreDump.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Utilities
+{
+    public static partial class CoreDump
+    {
+        public static void Disable()
+        {
+            if (OperatingSystem.IsLinux())
+            {
+                if (prctl(PR_SET_DUMPABLE, 0) != 0)
+                {
+                    throw new Exception($"Failed to disable core dump. Error: {Marshal.GetLastPInvokeError()}.");
+                }
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                RLimit rlimit = new() { rlim_cur = 0, rlim_max = 0 };
+                if (setrlimit(RLIMIT_CORE, rlimit) != 0)
+                {
+                    throw new Exception($"Failed to disable core dump. Error: {Marshal.GetLastPInvokeError()}.");
+                }
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RLimit
+        {
+            // These are rlim_t. All macOS platforms we use this on currently define it as unsigned 64-bit
+            public ulong rlim_cur; // Soft limit
+            public ulong rlim_max; // Hard limit
+        }
+
+        // Max core file size
+        private const int RLIMIT_CORE = 4;
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int setrlimit(int resource, in RLimit rlim);
+
+        // "dumpable" attribute of the calling process
+        private const int PR_SET_DUMPABLE = 4;
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int prctl(int option, int arg2);
+    }
+}

--- a/src/installer/tests/Assets/Projects/HelloWorld/HelloWorld.csproj
+++ b/src/installer/tests/Assets/Projects/HelloWorld/HelloWorld.csproj
@@ -12,4 +12,8 @@
     </PropertyGroup>
   </Target>
 
+  <ItemGroup>
+    <Compile Include="..\CoreDump.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/installer/tests/Assets/Projects/HelloWorld/Program.cs
+++ b/src/installer/tests/Assets/Projects/HelloWorld/Program.cs
@@ -50,6 +50,8 @@ namespace HelloWorld
                     }
                     break;
                 case "throw_exception":
+                    // Disable core dumps - test is intentionally crashing
+                    Utilities.CoreDump.Disable();
                     throw new Exception("Goodbye World!");
                 default:
                     break;

--- a/src/installer/tests/Assets/Projects/HelloWorld/SelfContained.csproj
+++ b/src/installer/tests/Assets/Projects/HelloWorld/SelfContained.csproj
@@ -12,4 +12,9 @@
     <_SupportedArchitecture Condition="'$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'">true</_SupportedArchitecture>
     <RuntimeIdentifier Condition="'$(_SupportedPlatform)' == 'true' and '$(_SupportedArchitecture)' == 'true'">$(TargetRid)</RuntimeIdentifier>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\CoreDump.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/installer/tests/HostActivation.Tests/Breadcrumbs.cs
+++ b/src/installer/tests/HostActivation.Tests/Breadcrumbs.cs
@@ -37,7 +37,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             TestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll, "throw_exception")
                 .EnvironmentVariable(Constants.Breadcrumbs.EnvironmentVariable, sharedTestState.BreadcrumbLocation)
                 .EnableTracingAndCaptureOutputs()
-                .Execute(expectedToFail: true)
+                .DisableDumps() // Expected to throw an exception
+                .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("Unhandled exception.")
                 .And.HaveStdErrContaining("System.Exception: Goodbye World")

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalDeps.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalDeps.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
             CommandResult result = SharedState.DotNetWithNetCoreApp.Exec(Constants.AdditionalDeps.CommandLineArgument, additionalDepsFile, app.AppDll)
                 .EnableTracingAndCaptureOutputs()
-                .Execute(expectedToFail: !dependencyExists);
+                .Execute();
 
             result.Should().HaveUsedAdditionalDeps(additionalDepsFile);
             if (dependencyExists)
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
                 SharedState.DotNetWithNetCoreApp.Exec(Constants.AdditionalDeps.CommandLineArgument, invalidDepsFile, SharedState.FrameworkReferenceApp.AppDll)
                     .EnableTracingAndCaptureOutputs()
-                    .Execute(expectedToFail: true)
+                    .Execute()
                     .Should().Fail()
                     .And.HaveUsedAdditionalDeps(invalidDepsFile)
                     .And.HaveStdErrContaining($"Error initializing the dependency resolver: An error occurred while parsing: {invalidDepsFile}");

--- a/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
+++ b/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
@@ -25,7 +25,7 @@ namespace HostActivation.Tests
             TestContext.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(expectedToFail: true)
+                .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining($"The application to execute does not exist: '{assemblyName}'");
         }
@@ -37,7 +37,7 @@ namespace HostActivation.Tests
             TestContext.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(expectedToFail: true)
+                .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining($"The application to execute does not exist: '{assemblyName}'");
         }
@@ -52,7 +52,7 @@ namespace HostActivation.Tests
             TestContext.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(expectedToFail: true)
+                .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining($"dotnet exec needs a managed .dll or .exe extension. The application specified was '{assemblyName}'");
         }
@@ -63,7 +63,7 @@ namespace HostActivation.Tests
             TestContext.BuiltDotNet.Exec("--fx-version")
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(expectedToFail: true)
+                .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining($"Failed to parse supported options or their values:");
         }
@@ -76,7 +76,7 @@ namespace HostActivation.Tests
                 .WorkingDirectory(sharedTestState.BaseDirectory.Location)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(expectedToFail: true)
+                .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining($"The application '{fileName}' does not exist")
                 .And.FindAnySdk(false);

--- a/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             TestContext.BuiltDotNet.Exec(appOtherExt)
                 .CaptureStdErr()
-                .Execute(expectedToFail: true)
+                .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining($"The application '{appOtherExt}' does not exist or is not a managed .dll or .exe");
         }
@@ -143,7 +143,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             TestContext.BuiltDotNet.Exec(appExe)
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(expectedToFail: true)
+                .DisableDumps() // Expected to throw an exception
+                .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("BadImageFormatException");
         }
@@ -429,7 +430,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .EnableTracingAndCaptureOutputs()
                     .DotNetRoot(invalidDotNet.Location)
                     .MultilevelLookup(false)
-                    .Execute(expectedToFail: true);
+                    .Execute();
 
                 result.Should().Fail()
                     .And.HaveStdErrContaining($"https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")

--- a/src/installer/tests/HostActivation.Tests/InvalidHost.cs
+++ b/src/installer/tests/HostActivation.Tests/InvalidHost.cs
@@ -27,7 +27,7 @@ namespace HostActivation.Tests
             CommandResult result = Command.Create(sharedTestState.UnboundAppHost)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(expectedToFail: true);
+                .Execute();
 
             result.Should().Fail()
                 .And.HaveStdErrContaining("This executable is not bound to a managed DLL to execute.")
@@ -70,7 +70,7 @@ namespace HostActivation.Tests
             CommandResult result = Command.Create(sharedTestState.RenamedDotNet)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(expectedToFail: true);
+                .Execute();
 
             result.Should().Fail()
                 .And.HaveStdErrContaining($"Error: cannot execute dotnet when renamed to {Path.GetFileNameWithoutExtension(sharedTestState.RenamedDotNet)}")

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
@@ -53,7 +53,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             };
 
             sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
-                .Execute(expectedToFail: true)
+                .DisableDumps() // Expected to throw an exception
+                .Execute()
                 .Should().Fail()
                 .And.InitializeContextForApp(app.AppDll)
                 .And.ExecuteApplicationWithException(sharedState.NativeHostPath, app.AppDll);

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
@@ -205,7 +205,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             };
 
             sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
-                .Execute(expectedToFail: true)
+                .DisableDumps() // Expected to throw an exception
+                .Execute()
                 .Should().Fail()
                 .And.InitializeContextForApp(app.AppDll)
                 .And.ExecuteFunctionPointerWithException(entryPoint, 1);

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
@@ -226,7 +226,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             };
 
             sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
-                .Execute(expectedToFail: true)
+                .DisableDumps() // Expected to throw an exception
+                .Execute()
                 .Should().Fail()
                 .And.InitializeContextForConfig(component.RuntimeConfigJson)
                 .And.ExecuteFunctionPointerWithException(entryPoint, 1);

--- a/src/installer/tests/HostActivation.Tests/SelfContainedAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/SelfContainedAppLaunch.cs
@@ -151,7 +151,7 @@ namespace HostActivation.Tests
             Command.Create(appExe)
                 .EnableTracingAndCaptureOutputs()
                 .DotNetRoot(app.Location)
-                .Execute(expectedToFail: true)
+                .Execute()
                 .Should().Fail()
                 .And.HaveUsedDotNetRootInstallLocation(Path.GetFullPath(app.Location), TestContext.BuildRID)
                 .And.HaveStdErrContaining($"The required library {Binaries.HostFxr.FileName} could not be found.");

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -96,7 +96,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .EnvironmentVariable("TEST_STARTUPHOOK_USE_DEPENDENCY", true.ToString())
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute(expectedToFail: true)
+                .DisableDumps() // Expected to throw an exception
+                .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("System.IO.FileNotFoundException: Could not load file or assembly 'SharedLibrary");
         }

--- a/src/installer/tests/TestUtils/Command.cs
+++ b/src/installer/tests/TestUtils/Command.cs
@@ -153,11 +153,6 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             return this;
         }
 
-        public CommandResult Execute([CallerMemberName] string caller = "")
-        {
-            return Execute(false, caller);
-        }
-
         public Command Start([CallerMemberName] string caller = "")
         {
             ThrowIfRunning();
@@ -245,17 +240,9 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         /// <summary>
         /// Execute the command and wait for it to exit.
         /// </summary>
-        /// <param name="expectedToFail">Whether or not the command is expected to fail (non-zero exit code)</param>
         /// <returns>Result of the command</returns>
-        public CommandResult Execute(bool expectedToFail, [CallerMemberName] string caller = "")
+        public CommandResult Execute([CallerMemberName] string caller = "")
         {
-            // Clear out any enabling of dump creation if failure is expected
-            if (expectedToFail)
-            {
-                RemoveEnvironmentVariable("COMPlus_DbgEnableMiniDump");
-                RemoveEnvironmentVariable("DOTNET_DbgEnableMiniDump");
-            }
-
             Start(caller);
             return WaitForExit(caller: caller);
         }

--- a/src/installer/tests/TestUtils/Command.cs
+++ b/src/installer/tests/TestUtils/Command.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         private StringWriter _stdOutCapture;
         private StringWriter _stdErrCapture;
 
+        private bool _disableDumps = false;
         private bool _running = false;
 
         public Process Process { get; }
@@ -133,6 +134,14 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             return false;
         }
 
+        public Command DisableDumps()
+        {
+            _disableDumps = true;
+            RemoveEnvironmentVariable("COMPlus_DbgEnableMiniDump");
+            RemoveEnvironmentVariable("DOTNET_DbgEnableMiniDump");
+            return this;
+        }
+
         public Command Environment(IDictionary<string, string> env)
         {
             if (env == null)
@@ -157,6 +166,22 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         {
             ThrowIfRunning();
             _running = true;
+
+            if (_disableDumps && (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()))
+            {
+                // Replace double quoted arguments with single quotes.
+                // We only want to replace non-escaped quotes - that is, ones not preceded by a backslash
+                // or preceded by an even number of backslashes.
+                string args = System.Text.RegularExpressions.Regex.Replace(
+                    Process.StartInfo.Arguments,
+                    @"((?:^|[^\\])(?:\\\\)*)""",
+                    m => m.Value.Substring(0, m.Value.Length - 1) + "'"
+                );
+
+                // Explicitly set the core file size to 0 before launching the process in the same shell
+                Process.StartInfo.Arguments = $"-c \"ulimit -c 0 && exec {Process.StartInfo.FileName} {args}\"";
+                Process.StartInfo.FileName = "/bin/bash";
+            }
 
             if (Process.StartInfo.RedirectStandardOutput)
             {

--- a/src/installer/tests/TestUtils/Command.cs
+++ b/src/installer/tests/TestUtils/Command.cs
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
 
                 // Explicitly set the core file size to 0 before launching the process in the same shell
                 Process.StartInfo.Arguments = $"-c \"ulimit -c 0 && exec {Process.StartInfo.FileName} {args}\"";
-                Process.StartInfo.FileName = "/bin/bash";
+                Process.StartInfo.FileName = "/bin/sh";
             }
 
             if (Process.StartInfo.RedirectStandardOutput)

--- a/src/installer/tests/TestUtils/CommandExtensions.cs
+++ b/src/installer/tests/TestUtils/CommandExtensions.cs
@@ -41,6 +41,13 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 .CaptureStdErr();
         }
 
+        public static Command DisableDumps(this Command command)
+        {
+            return command
+                .RemoveEnvironmentVariable("COMPlus_DbgEnableMiniDump")
+                .RemoveEnvironmentVariable("DOTNET_DbgEnableMiniDump");
+        }
+
         public static Command DotNetRoot(this Command command, string dotNetRoot, string architecture = null)
         {
             if (!string.IsNullOrEmpty(architecture))

--- a/src/installer/tests/TestUtils/CommandExtensions.cs
+++ b/src/installer/tests/TestUtils/CommandExtensions.cs
@@ -41,13 +41,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 .CaptureStdErr();
         }
 
-        public static Command DisableDumps(this Command command)
-        {
-            return command
-                .RemoveEnvironmentVariable("COMPlus_DbgEnableMiniDump")
-                .RemoveEnvironmentVariable("DOTNET_DbgEnableMiniDump");
-        }
-
         public static Command DotNetRoot(this Command command, string dotNetRoot, string architecture = null)
         {
             if (!string.IsNullOrEmpty(architecture))


### PR DESCRIPTION
For tests that intentionally crash, we were already clearing out `DOTNET_DbgEnableMiniDump`/`COMPlus_DbgEnableMiniDump`, but OS core dumps were still enabled.
- In tests that are explicitly throwing an unhandled exception, call into OS APIs to disable dumps for the current process
- When launching a command that should have dumps disabled, call `ulimit -c 0` before the command (for cases where the test doesn't have control over the process)

In this PR build, we no longer have dump files:
[linux-x64](https://helix.dot.net/api/jobs/201fe8e0-89d4-4ea5-ace5-e8c123ad28f3/workitems/HostActivation.Tests?api-version=2019-06-17)
[osx-x64](https://helix.dot.net/api/jobs/3b70af1b-8658-4e0a-a4d0-9c2570412914/workitems/HostActivation.Tests?api-version=2019-06-17)

Before - six core dumps created / uploaded:
[linux-x64](https://helix.dot.net/api/jobs/c789fb97-87ef-48c3-8e49-aad7dbb77d92/workitems/HostActivation.Tests?api-version=2019-06-17)
[osx-x64](https://helix.dot.net/api/jobs/43199517-d965-4036-9648-ac7f3a31a248/workitems/HostActivation.Tests?api-version=2019-06-17)

On [Windows](https://helix.dot.net/api/jobs/760ceb25-d542-4984-b6ef-b56d6686017c/workitems/HostActivation.Tests?api-version=2019-06-17), we still have two created/uploaded for `Muxer_NonAssemblyWithExeExtension` and `UnhandledException_BreadcrumbThreadDoesNotFinish`. I couldn't find a way to disable dump creation just for the process we were launching.

Fixes https://github.com/dotnet/runtime/issues/116520

cc @dotnet/appmodel @AaronRobinsonMSFT 