### PR TITLE
IG can be extended empty block if used for imm helper

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2873,9 +2873,6 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
     }
     else
     {
-        // This is not an EXTEND group.
-        assert((emitCurIG->igFlags & IGF_EXTEND) == 0);
-
 #if defined(DEBUG) || defined(LATE_DISASM)
         emitCurIG->igWeight    = getCurrentBlockWeight();
         emitCurIG->igPerfScore = 0.0;


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/80599, we added bunch of asserts around IG. However, I am hitting one of the asserts in my agnostic VL work (see [logs](https://helixr18s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-115948-merge-c31577d9629f414485/HardwareIntrinsics_Arm_ro/1/console.a0b77a3e.log?helixlogtype=result)). We are trying to generate code for `DuplicateSelectedScalarToVector` which takes immediate value. Since it is non-constant, we add a table of labels for the immediate value and jump to it based on that. After the last entry, we always create the label, which is an extended IG, where the continuation code resides.  Now, after this, if the next block is a label, we would create another IG, but if we see that there is already an empty IG, we don't want it to be extended. However, it should be ok to reuse the extended IG that we created for immediate lookup table.

```
Assert failure(PID 8120 [0x00001fb8], Thread: 8316 [0x207c]): Assertion failed '(emitCurIG->igFlags & IGF_EXTEND) == 0' in 'JIT.HardwareIntrinsics.Arm._Sve.SimpleUnaryOpTest__Sve_ReverseElement_float:ValidateConditionalSelectResult_FalseValue(System.Numerics.Vector`1[float],System.Numerics.Vector`1[float],System.Numerics.Vector`1[float],ptr,System.String):this' during 'Generate code' (IL size 450; hash 0x203e7be5; FullOpts)

    File: D:\a\_work\1\s\src\coreclr\jit\emit.cpp:2877
    Image: C:\h\w\A15808D6\p\corerun.exe
```