### PR TITLE
Disable `System.Runtime.InteropServices.JavaScript.Tests` on Windows

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -40,6 +40,11 @@
     <HighAOTResourceRequiringProject Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
   </ItemGroup>
 
+  <!-- ActiveIssue https://github.com/dotnet/runtime/issues/116695 missing dev cert on Windows -->
+  <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(OS)' == 'Windows_NT' and '$(ContinuousIntegrationBuild)' == 'true'">
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System.Runtime.InteropServices.JavaScript.Tests.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetOS)' == 'browser'">
     <!-- Samples which are too complex for CI -->
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\console-node-ts\Wasm.Console.Node.TS.Sample.csproj" />


### PR DESCRIPTION
Active issue: https://github.com/dotnet/runtime/issues/116695. Disable until fix is found, the hit count is very high.