### PR TITLE
[release/9.0] Disable all MT tests on CI

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -233,16 +233,17 @@ jobs:
       publishArtifactsForWorkload: true
       publishWBT: true
 
-  - template: /eng/pipelines/common/templates/wasm-build-only.yml
-    parameters:
-      platforms:
-        - browser_wasm
-        - browser_wasm_win
-      nameSuffix: MultiThreaded
-      extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      condition: ne(variables['wasmMultiThreadedBuildOnlyNeededOnDefaultPipeline'], true)
-      publishArtifactsForWorkload: true
-      publishWBT: false
+  # disabled: https://github.com/dotnet/runtime/issues/116492
+  # - template: /eng/pipelines/common/templates/wasm-build-only.yml
+  #   parameters:
+  #     platforms:
+  #       - browser_wasm
+  #       - browser_wasm_win
+  #     nameSuffix: MultiThreaded
+  #     extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+  #     condition: ne(variables['wasmMultiThreadedBuildOnlyNeededOnDefaultPipeline'], true)
+  #     publishArtifactsForWorkload: true
+  #     publishWBT: false
 
   # Browser Wasm.Build.Tests
   - template: /eng/pipelines/common/templates/browser-wasm-build-tests.yml

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -364,23 +364,24 @@ extends:
                 parameters:
                   name: MonoRuntimePacks
 
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          runtimeFlavor: mono
-          platforms:
-          - browser_wasm
-          jobParameters:
-            templatePath: 'templates-official'
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-            nameSuffix: Mono_multithread
-            isOfficialBuild: ${{ variables.isOfficialBuild }}
-            runtimeVariant: multithread
-            postBuildSteps:
-              - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-                parameters:
-                  name: MonoRuntimePacks
+      # disabled: https://github.com/dotnet/runtime/issues/116492
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - browser_wasm
+      #     jobParameters:
+      #       templatePath: 'templates-official'
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #       nameSuffix: Mono_multithread
+      #       isOfficialBuild: ${{ variables.isOfficialBuild }}
+      #       runtimeVariant: multithread
+      #       postBuildSteps:
+      #         - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+      #           parameters:
+      #             name: MonoRuntimePacks
 
 
       # Build Mono AOT offset headers once, for consumption elsewhere

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -836,21 +836,22 @@ extends:
           scenarios:
             - WasmTestOnChrome
 
+      # disabled: https://github.com/dotnet/runtime/issues/116492
       # Library tests with full threading
-      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            #- browser_wasm_win
-          nameSuffix: _Threading
-          extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          extraHelixArguments: /p:WasmEnableThreads=true
-          alwaysRun: ${{ variables.isRollingBuild }}
-          shouldRunSmokeOnly: onLibrariesAndIllinkChanges
-          scenarios:
-            - WasmTestOnChrome
-            - WasmTestOnFirefox
-            #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592
+      # - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #       #- browser_wasm_win
+      #     nameSuffix: _Threading
+      #     extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     extraHelixArguments: /p:WasmEnableThreads=true
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     shouldRunSmokeOnly: onLibrariesAndIllinkChanges
+      #     scenarios:
+      #       - WasmTestOnChrome
+      #       - WasmTestOnFirefox
+      #       #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592
 
       # EAT Library tests - only run on linux
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -887,16 +888,17 @@ extends:
           publishArtifactsForWorkload: true
           publishWBT: true
 
-      - template: /eng/pipelines/common/templates/wasm-build-only.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            - browser_wasm_win
-          condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
-          nameSuffix: MultiThreaded
-          extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          publishArtifactsForWorkload: true
-          publishWBT: false
+      # disabled: https://github.com/dotnet/runtime/issues/116492
+      # - template: /eng/pipelines/common/templates/wasm-build-only.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #       - browser_wasm_win
+      #     condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
+      #     nameSuffix: MultiThreaded
+      #     extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     publishArtifactsForWorkload: true
+      #     publishWBT: false
 
       # Browser Wasm.Build.Tests
       - template: /eng/pipelines/common/templates/browser-wasm-build-tests.yml


### PR DESCRIPTION
Disables MT tests due to failures in https://github.com/dotnet/runtime/issues/116492.