### PR TITLE
Update MemoryMappedViewStream to override Read(Span<byte>) to leverage UnmanagedMemoryStream's ReadCore(Span<byte>) for no-alloc high performance block byte copy.

### DIFF
--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
@@ -29,6 +29,7 @@ namespace System.IO.MemoryMappedFiles
             throw new NotSupportedException(SR.NotSupported_MMViewStreamsFixedLength);
         }
 
+        public override int Read(Span<byte> buffer) => base.ReadCore(buffer);
 
         protected override void Dispose(bool disposing)
         {


### PR DESCRIPTION
Fixes Issue #116727

# Description

`MemoryMappedViewStream.Read(Span<byte>)` was resolving to a base class method that allocated temporary memory for reads instead of directly block transferring bytes into the destination Span which added an unnecessary performance overhead. 

Given the entire point of using `MemoryMappedViewStream` and the suite of Memory Mapped functions is associated with high performance workflows, it makes sense to tune the functionality provided by these classes for minimum overhead and maximum performance.

# Customer Impact

In my case, VS performance tracing showed my application spending 10% of its time borrowing/returning byte buffers without this fix.

# Regression

No.

# Testing

I'm letting the existing test suite handle this one. I've introduced nothing new here and just adjusted the override hierarchy of this one specific sealed class to use a more optimal helper.

# Risk

Low risk. Uses existing well qualified read methods from base class.