### PR TITLE
Make HttpWebRequest.GetRequestStream return same instance (fixes #41403)

### DIFF
--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1110,7 +1110,10 @@ namespace System.Net
                         // return a null stream to avoid blocking.
                         return Stream.Null;
                     }
-                    _requestStream = new RequestStream(await getStreamTask.ConfigureAwait(false), completeTcs);
+
+                    // Ensure that we only create the request stream once.
+                    _requestStream ??= new RequestStream(await getStreamTask.ConfigureAwait(false), completeTcs);
+
                 }
                 catch (Exception ex)
                 {
@@ -1119,7 +1122,8 @@ namespace System.Net
             }
             else
             {
-                _requestStream = new RequestBufferingStream();
+                // Ensure that we only create the request stream once.
+                _requestStream ??= new RequestBufferingStream();
             }
 
             return _requestStream;

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1089,6 +1089,12 @@ namespace System.Net
 
         private async Task<Stream> InternalGetRequestStream()
         {
+            // Ensure that we only create the request stream once.
+            if (_requestStream != null)
+            {
+                return _requestStream;
+            }
+
             // If we aren't buffering we need to open the connection right away.
             // Because we need to send the data as soon as possible when it's available from the RequestStream.
             // Making this allows us to keep the sync send request path for buffering cases.
@@ -1111,8 +1117,7 @@ namespace System.Net
                         return Stream.Null;
                     }
 
-                    // Ensure that we only create the request stream once.
-                    _requestStream ??= new RequestStream(await getStreamTask.ConfigureAwait(false), completeTcs);
+                    _requestStream = new RequestStream(await getStreamTask.ConfigureAwait(false), completeTcs);
 
                 }
                 catch (Exception ex)
@@ -1122,8 +1127,7 @@ namespace System.Net
             }
             else
             {
-                // Ensure that we only create the request stream once.
-                _requestStream ??= new RequestBufferingStream();
+                _requestStream = new RequestBufferingStream();
             }
 
             return _requestStream;

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1145,6 +1145,8 @@ namespace System.Net
 
         public override IAsyncResult BeginGetRequestStream(AsyncCallback? callback, object? state)
         {
+            _endGetRequestStreamCalled = false;
+
             CheckAbort();
 
             if (Interlocked.Exchange(ref _beginGetRequestStreamCalled, true))
@@ -1183,6 +1185,8 @@ namespace System.Net
             {
                 throw WebException.CreateCompatibleException(ex);
             }
+
+            _beginGetRequestStreamCalled = false;
 
             return stream;
         }

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1145,14 +1145,14 @@ namespace System.Net
 
         public override IAsyncResult BeginGetRequestStream(AsyncCallback? callback, object? state)
         {
-            _endGetRequestStreamCalled = false;
-
             CheckAbort();
 
             if (Interlocked.Exchange(ref _beginGetRequestStreamCalled, true))
             {
                 throw new InvalidOperationException(SR.net_repcall);
             }
+
+            Interlocked.Exchange(ref _endGetRequestStreamCalled, false);
 
             CheckRequestStream();
 
@@ -1186,7 +1186,7 @@ namespace System.Net
                 throw WebException.CreateCompatibleException(ex);
             }
 
-            _beginGetRequestStreamCalled = false;
+            Interlocked.Exchange(ref _beginGetRequestStreamCalled, false);
 
             return stream;
         }

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1116,9 +1116,7 @@ namespace System.Net
                         // return a null stream to avoid blocking.
                         return Stream.Null;
                     }
-
                     _requestStream = new RequestStream(await getStreamTask.ConfigureAwait(false), completeTcs);
-
                 }
                 catch (Exception ex)
                 {

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -2608,6 +2608,18 @@ namespace System.Net.Tests
 
             Assert.Same(s1, s2);
         }
+
+        [Fact]
+        public async Task GetRequestStream_ReturnsSameInstanceWithoutLoopback_Async()
+        {
+            var request = WebRequest.CreateHttp("http://localhost:12345");
+            request.Method = "POST";
+
+            var s1 = await request.GetRequestStreamAsync();
+            var s2 = await request.GetRequestStreamAsync();
+
+            Assert.Same(s1, s2);
+        }
     }
 
     public class RequestState

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -2596,6 +2596,18 @@ namespace System.Net.Tests
                 Assert.Throws<System.Runtime.Serialization.SerializationException>(() => formatter.Serialize(fs, hwr));
             }
         }
+
+        [Fact]
+        public void GetRequestStream_ReturnsSameInstanceWithoutLoopback()
+        {
+            var request = WebRequest.CreateHttp("http://localhost:12345");
+            request.Method = "POST";
+
+            var s1 = request.GetRequestStream();
+            var s2 = request.GetRequestStream();
+
+            Assert.Same(s1, s2);
+        }
     }
 
     public class RequestState


### PR DESCRIPTION
### Summary

Fixes a compatibility issue where `HttpWebRequest.GetRequestStream()` returned a new stream instance on each call, unlike .NET Framework which returns the same instance.
### Changes

- Added null coalescing operators on ``_requestStream`` inside ``InternalGetRequestStream``
- Added test `GetRequestStream_ReturnsSameInstanceWithoutLoopback`.

Fixes: #41403