### PR TITLE
Reflection.Emit should respect RVAs of 0

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeMethodBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeMethodBuilder.cs
@@ -701,25 +701,8 @@ namespace System.Reflection.Emit
                 m_module.GetMethodMetadataToken(con),
                 binaryAttribute);
 
-            if (IsKnownCA(con))
-                ParseCA(con);
-        }
-
-        // this method should return true for any and every ca that requires more work
-        // than just setting the ca
-        private static bool IsKnownCA(ConstructorInfo con)
-        {
-            Type? caType = con.DeclaringType;
-            return caType == typeof(MethodImplAttribute) || caType == typeof(DllImportAttribute);
-        }
-
-        private void ParseCA(ConstructorInfo con)
-        {
-            Type? caType = con.DeclaringType;
-            if (caType == typeof(DllImportAttribute))
-            {
+            if (con.DeclaringType == typeof(DllImportAttribute))
                 m_isDllImport = true;
-            }
         }
 
         internal bool m_isDllImport;
@@ -733,7 +716,7 @@ namespace System.Reflection.Emit
         // and namespace information with a given active lexical scope.
 
         #region Internal Data Members
-        internal string[] m_strName = null!;  // All these arrys initialized in helper method
+        internal string[] m_strName = null!;  // All these arrays initialized in helper method
         internal byte[][] m_ubSignature = null!;
         internal int[] m_iLocalSlot = null!;
         internal int[] m_iStartOffset = null!;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeMethodBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeMethodBuilder.cs
@@ -657,8 +657,6 @@ namespace System.Reflection.Emit
 
             m_dwMethodImplFlags = attributes;
 
-            m_canBeRuntimeImpl = true;
-
             RuntimeModuleBuilder module = m_module;
             RuntimeTypeBuilder.SetMethodImpl(new QCallModule(ref module), MetadataToken, attributes);
         }
@@ -718,23 +716,12 @@ namespace System.Reflection.Emit
         private void ParseCA(ConstructorInfo con)
         {
             Type? caType = con.DeclaringType;
-            if (caType == typeof(MethodImplAttribute))
+            if (caType == typeof(DllImportAttribute))
             {
-                // dig through the blob looking for the MethodImplAttributes flag
-                // that must be in the MethodCodeType field
-
-                // for now we simply set a flag that relaxes the check when saving and
-                // allows this method to have no body when any kind of MethodImplAttribute is present
-                m_canBeRuntimeImpl = true;
-            }
-            else if (caType == typeof(DllImportAttribute))
-            {
-                m_canBeRuntimeImpl = true;
                 m_isDllImport = true;
             }
         }
 
-        internal bool m_canBeRuntimeImpl;
         internal bool m_isDllImport;
 
         #endregion

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
@@ -1586,16 +1586,6 @@ namespace System.Reflection.Emit
                 }
 
                 MethodAttributes methodAttrs = meth.Attributes;
-
-                // Any of these flags in the implementation flags is set, we will not attach the IL method body
-                if (((meth.GetMethodImplementationFlags() & (MethodImplAttributes.CodeTypeMask | MethodImplAttributes.PreserveSig | MethodImplAttributes.Unmanaged)) != MethodImplAttributes.IL) ||
-                    ((methodAttrs & MethodAttributes.PinvokeImpl) != (MethodAttributes)0))
-                {
-                    continue;
-                }
-
-                byte[] localSig = meth.GetLocalSignature(out int sigLength);
-
                 // Check that they haven't declared an abstract method on a non-abstract class
                 if (((methodAttrs & MethodAttributes.Abstract) != 0) && ((m_iAttr & TypeAttributes.Abstract) == 0))
                 {
@@ -1603,16 +1593,10 @@ namespace System.Reflection.Emit
                 }
 
                 byte[]? body = meth.GetBody();
-
-                // If this is an abstract method or an interface, we don't need to set the IL.
-
                 if ((methodAttrs & MethodAttributes.Abstract) != 0)
                 {
                     // We won't check on Interface because we can have class static initializer on interface.
                     // We will just let EE or validator to catch the problem.
-
-                    // ((m_iAttr & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface))
-
                     if (body != null)
                         throw new InvalidOperationException(SR.Format(SR.InvalidOperation_BadMethodBody, meth.Name));
                 }
@@ -1627,11 +1611,14 @@ namespace System.Reflection.Emit
 
                     body = meth.GetBody();
 
-                    if ((body == null || body.Length == 0) && !meth.m_canBeRuntimeImpl)
-                        throw new InvalidOperationException(
-                            SR.Format(SR.InvalidOperation_BadEmptyMethodBody, meth.Name));
+                    // No IL body means we can avoid attempting to set method IL.
+                    if (body == null)
+                    {
+                        continue;
+                    }
                 }
 
+                byte[] localSig = meth.GetLocalSignature(out int sigLength);
                 int maxStack = meth.GetMaxStack();
 
                 ExceptionHandler[]? exceptions = meth.GetExceptionHandlers();

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
@@ -1600,16 +1600,15 @@ namespace System.Reflection.Emit
                     if (body != null)
                         throw new InvalidOperationException(SR.Format(SR.InvalidOperation_BadMethodBody, meth.Name));
                 }
-                else if (body == null || body.Length == 0)
+                else if (body == null)
                 {
                     // If it's not an abstract or an interface, set the IL.
                     if (meth.m_ilGenerator != null)
                     {
                         // we need to bake the method here.
                         meth.CreateMethodBodyHelper(((RuntimeILGenerator)meth.GetILGenerator()));
+                        body = meth.GetBody();
                     }
-
-                    body = meth.GetBody();
 
                     // No IL body means we can avoid attempting to set method IL.
                     if (body == null)

--- a/src/coreclr/md/ceefilegen/cceegen.cpp
+++ b/src/coreclr/md/ceefilegen/cceegen.cpp
@@ -115,7 +115,7 @@ STDMETHODIMP CCeeGen::AllocateMethodBuffer(ULONG cchBuffer, UCHAR **lpBuffer, UL
     _ASSERTE(lpBuffer != NULL);
     _ASSERTE(RVA != NULL);
 
-    if (cchBufferRequest == 0)
+    if (cchBuffer == 0)
         return E_INVALIDARG;
 
     uint32_t const Alignment = sizeof(DWORD); // DWORD align

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2113,7 +2113,7 @@ PTR_READYTORUN_IMPORT_SECTION Module::GetImportSectionForRVA(RVA rva)
     return GetReadyToRunInfo()->GetImportSectionForRVA(rva);
 }
 
-TADDR Module::GetIL(DWORD target)
+TADDR Module::GetIL(RVA target)
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
@@ -4056,9 +4056,9 @@ TADDR ReflectionModule::GetIL(RVA il) // virtual
 {
 #ifndef DACCESS_COMPILE
     WRAPPER_NO_CONTRACT;
-
     BYTE* pByte = NULL;
-    m_pCeeFileGen->GetMethodBuffer(il, &pByte);
+    if (il != 0)
+        m_pCeeFileGen->GetMethodBuffer(il, &pByte);
     return TADDR(pByte);
 #else // DACCESS_COMPILE
     SUPPORTS_DAC;

--- a/src/coreclr/vm/comdynamic.cpp
+++ b/src/coreclr/vm/comdynamic.cpp
@@ -386,19 +386,14 @@ extern "C" void QCALLTYPE TypeBuilder_SetMethodIL(QCall::ModuleHandle pModule,
     ICeeGenInternal* pGen = pRCW->GetCeeGen();
     BYTE* buf = NULL;
     ULONG methodRVA = 0;
-    pGen->AllocateMethodBuffer(totalSize, &buf, &methodRVA);
-    if (buf == NULL)
-        COMPlusThrowOM();
+    IfFailThrow(pGen->AllocateMethodBuffer(totalSize, &buf, &methodRVA));
 
     _ASSERTE(buf != NULL);
-    _ASSERTE((((size_t) buf) & 3) == 0);   // header is dword aligned
+    _ASSERTE((((size_t) buf) & (sizeof(DWORD) - 1)) == 0);   // header is dword aligned
     _ASSERTE(methodRVA != 0); // Method RVAs should never be 0, since that is reserved in ECMA-335.
 
-#ifdef _DEBUG
-    BYTE* endbuf = &buf[totalSize];
-#endif
-
-    BYTE * startBuf = buf;
+    INDEBUG(BYTE* endbuf = &buf[totalSize]);
+    BYTE* startBuf = buf;
 
     // Emit the header
     buf += COR_ILMETHOD::Emit(headerSize, &fatHeader, moreSections, buf);

--- a/src/coreclr/vm/comdynamic.cpp
+++ b/src/coreclr/vm/comdynamic.cpp
@@ -385,13 +385,14 @@ extern "C" void QCALLTYPE TypeBuilder_SetMethodIL(QCall::ModuleHandle pModule,
     UINT32 totalSize = totalSizeSafe.Value();
     ICeeGenInternal* pGen = pRCW->GetCeeGen();
     BYTE* buf = NULL;
-    ULONG methodRVA;
+    ULONG methodRVA = 0;
     pGen->AllocateMethodBuffer(totalSize, &buf, &methodRVA);
     if (buf == NULL)
         COMPlusThrowOM();
 
     _ASSERTE(buf != NULL);
     _ASSERTE((((size_t) buf) & 3) == 0);   // header is dword aligned
+    _ASSERTE(methodRVA != 0); // Method RVAs should never be 0, since that is reserved in ECMA-335.
 
 #ifdef _DEBUG
     BYTE* endbuf = &buf[totalSize];

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -2952,7 +2952,7 @@ MethodTableBuilder::EnumerateClassMethods()
             // RVA : 0
             if (dwMethodRVA != 0)
             {
-                if(fIsClassComImport)
+                if(fIsClassComImport && !IsMdInstanceInitializer(dwMemberAttrs, strMethodName))
                 {
                     BuildMethodTableThrowException(BFA_METHOD_WITH_NONZERO_RVA);
                 }

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -2952,7 +2952,7 @@ MethodTableBuilder::EnumerateClassMethods()
             // RVA : 0
             if (dwMethodRVA != 0)
             {
-                if(fIsClassComImport && !IsMdInstanceInitializer(dwMemberAttrs, strMethodName))
+                if(fIsClassComImport)
                 {
                     BuildMethodTableThrowException(BFA_METHOD_WITH_NONZERO_RVA);
                 }

--- a/src/libraries/System.Reflection.Emit/src/Resources/Strings.resx
+++ b/src/libraries/System.Reflection.Emit/src/Resources/Strings.resx
@@ -258,9 +258,6 @@
   <data name="AmbiguousMatch_MemberInfo" xml:space="preserve">
     <value>Ambiguous match found for '{0} {1}'</value>
   </data>
-  <data name="InvalidOperation_BadEmptyMethodBody" xml:space="preserve">
-    <value>Method '{0}' does not have a method body.</value>
-  </data>
   <data name="Argument_RedefinedLabel" xml:space="preserve">
     <value>Label defined multiple times.</value>
   </data>

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
@@ -29,7 +29,6 @@ namespace System.Reflection.Emit
         internal Type[][]? _parameterTypeRequiredCustomModifiers;
         internal Type[][]? _parameterTypeOptionalCustomModifiers;
 
-        internal bool _canBeRuntimeImpl;
         internal DllImportData? _dllImportData;
         internal List<CustomAttributeWrapper>? _customAttributes;
         internal ParameterBuilderImpl[]? _parameterBuilders;
@@ -178,13 +177,11 @@ namespace System.Reflection.Emit
                 case "System.Runtime.CompilerServices.MethodImplAttribute":
                     int implValue = BinaryPrimitives.ReadUInt16LittleEndian(binaryAttribute.Slice(2));
                     _methodImplFlags |= (MethodImplAttributes)implValue;
-                    _canBeRuntimeImpl = true;
                     return;
                 case "System.Runtime.InteropServices.DllImportAttribute":
                     {
                         _dllImportData = DllImportData.Create(CustomAttributeInfo.DecodeCustomAttribute(con, binaryAttribute), out var preserveSig);
                         _attributes |= MethodAttributes.PinvokeImpl;
-                        _canBeRuntimeImpl = true;
                         if (preserveSig)
                         {
                             _methodImplFlags |= MethodImplAttributes.PreserveSig;
@@ -209,8 +206,6 @@ namespace System.Reflection.Emit
         protected override void SetImplementationFlagsCore(MethodImplAttributes attributes)
         {
             _declaringType.ThrowIfCreated();
-
-            _canBeRuntimeImpl = true;
             _methodImplFlags = attributes;
         }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -131,14 +131,6 @@ namespace System.Reflection.Emit
                 MethodBuilderImpl method = _methodDefinitions[i];
                 MethodAttributes methodAttrs = method.Attributes;
 
-                // Any of these flags in the implementation flags is set, we will not check the IL method body
-                if (((method.GetMethodImplementationFlags() & (MethodImplAttributes.CodeTypeMask | MethodImplAttributes.PreserveSig | MethodImplAttributes.Unmanaged)) != MethodImplAttributes.IL) ||
-                    ((methodAttrs & MethodAttributes.PinvokeImpl) != 0))
-                {
-                    continue;
-                }
-
-                ILGeneratorImpl? body = method.ILGeneratorImpl;
                 if ((methodAttrs & MethodAttributes.Abstract) != 0)
                 {
                     // Check if an abstract method declared on a non-abstract class
@@ -148,14 +140,11 @@ namespace System.Reflection.Emit
                     }
 
                     // If this is an abstract method or an interface should not have body.
+                    ILGeneratorImpl? body = method.ILGeneratorImpl;
                     if (body != null && body.ILOffset > 0)
                     {
                         throw new InvalidOperationException(SR.Format(SR.InvalidOperation_BadMethodBody, method.Name));
                     }
-                }
-                else if ((body == null || body.ILOffset == 0) && !method._canBeRuntimeImpl)
-                {
-                    throw new InvalidOperationException(SR.Format(SR.InvalidOperation_BadEmptyMethodBody, method.Name));
                 }
             }
         }

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
@@ -568,11 +568,6 @@ namespace System.Reflection.Emit.Tests
             dllImportMethod.SetCustomAttribute(new CustomAttributeBuilder(typeof(DllImportAttribute).GetConstructor([typeof(string)]), ["kernel32.dll"]));
             MethodBuilder implFlagsSetMethod = concreteTypeWithNativeAndPinvokeMethod.DefineMethod("InternalCall", MethodAttributes.Public);
             implFlagsSetMethod.SetImplementationFlags(MethodImplAttributes.InternalCall);
-
-            MethodBuilder methodNeedsIL = concreteTypeWithNativeAndPinvokeMethod.DefineMethod("MethodNeedsIL", MethodAttributes.Public);
-            Assert.Throws<InvalidOperationException>(() => concreteTypeWithNativeAndPinvokeMethod.CreateType()); // Method 'MethodNeedsIL' does not have a method body.
-            methodNeedsIL.GetILGenerator().Emit(OpCodes.Ret);
-            concreteTypeWithNativeAndPinvokeMethod.CreateType(); // succeeds
         }
 
         [Fact]

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
@@ -547,7 +547,6 @@ namespace System.Reflection.Emit.Tests
             }
         }
 
-
         [Fact]
         public void CreateType_ValidateMethods()
         {
@@ -568,6 +567,10 @@ namespace System.Reflection.Emit.Tests
             dllImportMethod.SetCustomAttribute(new CustomAttributeBuilder(typeof(DllImportAttribute).GetConstructor([typeof(string)]), ["kernel32.dll"]));
             MethodBuilder implFlagsSetMethod = concreteTypeWithNativeAndPinvokeMethod.DefineMethod("InternalCall", MethodAttributes.Public);
             implFlagsSetMethod.SetImplementationFlags(MethodImplAttributes.InternalCall);
+
+            MethodBuilder methodNeedsIL = concreteTypeWithNativeAndPinvokeMethod.DefineMethod("MethodNeedsIL", MethodAttributes.Public);
+            methodNeedsIL.GetILGenerator().Emit(OpCodes.Ret);
+            concreteTypeWithNativeAndPinvokeMethod.CreateType(); // succeeds
         }
 
         [Fact]

--- a/src/libraries/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderDefineConstructor.cs
+++ b/src/libraries/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderDefineConstructor.cs
@@ -114,14 +114,6 @@ namespace System.Reflection.Emit.Tests
             Assert.Throws<InvalidOperationException>(() => type.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, new Type[0]));
         }
 
-        [Fact]
-        public void DefineConstructor_ConstructorNotCreated_ThrowsInvalidOperationExceptionOnCreation()
-        {
-            TypeBuilder type = Helpers.DynamicType(TypeAttributes.Public);
-            type.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, new Type[0]);
-            Assert.Throws<InvalidOperationException>(() => type.CreateTypeInfo());
-        }
-
         [Theory]
         [InlineData(CallingConventions.Any)]
         [InlineData(CallingConventions.VarArgs)]

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/IsComObjectTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/IsComObjectTests.cs
@@ -48,6 +48,7 @@ namespace System.Runtime.InteropServices.Tests
             ModuleBuilder comImportModuleBuilder = comImportAssemblyBuilder.DefineDynamicModule("Module");
             TypeBuilder comImportTypeBuilder = comImportModuleBuilder.DefineType("Type");
             comImportTypeBuilder.SetCustomAttribute(comImportAttributeBuilder);
+            comImportTypeBuilder.DefineMethod(".ctor", MethodAttributes.SpecialName, null, null);
 
             Type collectibleComImportObject = comImportTypeBuilder.CreateType();
             yield return new object[] { collectibleComImportObject };


### PR DESCRIPTION
Fixes #116649

The underlying Reflection.Emit infrastructure was treating an RVA of 0 as "normal" and indexing into the dynamic IL data stream. This caused confusion in the rest of the system since an RVA of 0 means there is no IL body (that is, no IL Header). Making Reflection.Emit consistent ensures that scenarios relying on an RVA of 0 now operate identical with those emitted by .NET compilers.

This change also removes some of the checks that were put in place for Reflection.Emit and relies on the EE at runtime to handle those cases.