### PR TITLE
Scaffolding for CoreCLR interpreter intrinsics

### DIFF
--- a/src/coreclr/interpreter/CMakeLists.txt
+++ b/src/coreclr/interpreter/CMakeLists.txt
@@ -12,6 +12,7 @@ set(INTERPRETER_SOURCES
   stackmap.cpp
   naming.cpp
   methodset.cpp
+  intrinsics.cpp
   ../../native/containers/dn-simdhash.c
   ../../native/containers/dn-simdhash-ght-compatible.c
   ../../native/containers/dn-simdhash-ptr-ptr.c)

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2197,20 +2197,22 @@ bool InterpCompiler::EmitNamedIntrinsicCall(NamedIntrinsic ni, CORINFO_CLASS_HAN
             return true;
 
         case NI_Throw_PlatformNotSupportedException:
-            // Interpreter-FIXME: If an INTOP_THROW_PNSE is the first opcode in a try block, catch doesn't catch the exception
-            // For now, insert a safepoint as padding.
-            AddIns(INTOP_SAFEPOINT);
             AddIns(INTOP_THROW_PNSE);
             return true;
 
         default:
         {
-            const char* className = NULL;
-            const char* namespaceName = NULL;
-            const char* methodName = m_compHnd->getMethodNameFromMetadata(method, &className, &namespaceName, NULL, 0);
-            printf("WARNING: Intrinsic not implemented in EmitNamedIntrinsicCall: %d (for %s.%s.%s)\n", ni, namespaceName, className, methodName);
+#ifdef DEBUG
+            if (m_verbose)
+            {
+                const char* className = NULL;
+                const char* namespaceName = NULL;
+                const char* methodName = m_compHnd->getMethodNameFromMetadata(method, &className, &namespaceName, NULL, 0);
+                printf("WARNING: Intrinsic not implemented in EmitNamedIntrinsicCall: %d (for %s.%s.%s)\n", ni, namespaceName, className, methodName);
+            }
+#endif
             if (mustExpand)
-                assert(!"EmitNamedIntrinsicCall not implemented must-expand intrinsic");
+                NO_WAY("EmitNamedIntrinsicCall not implemented must-expand intrinsic");
             return false;
         }
     }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2420,7 +2420,7 @@ void InterpCompiler::EmitPushUnboxAnyNullable(const CORINFO_GENERICHANDLE_RESULT
         AddIns(INTOP_CALL_HELPER_V_AGS);
         m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(CORINFO_HELP_UNBOX_NULLABLE);
         m_pLastNewIns->data[1] = handleData.dataItemIndex;
-        
+
         m_pLastNewIns->SetSVars2(handleData.genericVar, arg2);
         m_pLastNewIns->SetDVar(resultVar);
     }
@@ -2520,7 +2520,7 @@ int InterpCompiler::EmitGenericHandleAsVar(const CORINFO_GENERICHANDLE_RESULT &e
     PushStackType(StackTypeI, NULL);
     int resultVar = m_pStackPointer[-1].var;
     m_pStackPointer--;
-    
+
     GenericHandleData handleData = GenericHandleToGenericHandleData(embedInfo);
 
     if (handleData.argType == HelperArgType::GenericResolution)
@@ -2622,8 +2622,6 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
         m_compHnd->getCallInfo(&resolvedCallToken, pConstrainedToken, m_methodInfo->ftn, flags, &callInfo);
         if (callInfo.methodFlags & CORINFO_FLG_INTRINSIC)
         {
-// Interpreter-FIXME: Necessary to work around InterpConfig members only being defined in DEBUG configurations.
-#if DEBUG
             if (InterpConfig.InterpMode() >= 3)
             {
                 NamedIntrinsic ni = GetNamedIntrinsic(m_compHnd, m_methodHnd, callInfo.hMethod);
@@ -2633,7 +2631,6 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                     return;
                 }
             }
-#endif
         }
 
         if (EmitCallIntrinsics(callInfo.hMethod, callInfo.sig))
@@ -2727,7 +2724,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             PushInterpType(ctorType, resolvedCallToken.hClass);
 
             CORINFO_GENERICHANDLE_RESULT newObjGenericHandleEmbedInfo;
-            m_compHnd->embedGenericHandle(&resolvedCallToken, true, m_methodInfo->ftn, &newObjGenericHandleEmbedInfo); 
+            m_compHnd->embedGenericHandle(&resolvedCallToken, true, m_methodInfo->ftn, &newObjGenericHandleEmbedInfo);
             newObjData = GenericHandleToGenericHandleData(newObjGenericHandleEmbedInfo);
         }
         newObjDVar = m_pStackPointer[-2].var;
@@ -2875,9 +2872,9 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             else if ((callInfo.classFlags & CORINFO_FLG_ARRAY) && newObj)
             {
                 CORINFO_GENERICHANDLE_RESULT newObjGenericHandleEmbedInfo;
-                m_compHnd->embedGenericHandle(&resolvedCallToken, true, m_methodInfo->ftn, &newObjGenericHandleEmbedInfo); 
+                m_compHnd->embedGenericHandle(&resolvedCallToken, true, m_methodInfo->ftn, &newObjGenericHandleEmbedInfo);
                 newObjData = GenericHandleToGenericHandleData(newObjGenericHandleEmbedInfo);
-                
+
                 if (newObjData.argType == HelperArgType::GenericResolution)
                 {
                     AddIns(INTOP_NEWMDARR_GENERIC);
@@ -5430,17 +5427,17 @@ DO_LDFTN:
                     {
                         // Unbox.any of a reference type is just a cast
                         CorInfoHelpFunc castingHelper = m_compHnd->getCastingHelper(&resolvedToken, true /* throwing */);
-                        
+
                         CORINFO_GENERICHANDLE_RESULT embedInfo;
                         InterpEmbedGenericResult result;
                         m_compHnd->embedGenericHandle(&resolvedToken, false, m_methodInfo->ftn, &embedInfo);
-                        
+
                         EmitPushHelperCall_2(castingHelper, embedInfo, m_pStackPointer[0].var, g_stackTypeFromInterpType[InterpTypeO], NULL);
                     }
                     else
                     {
                         CorInfoHelpFunc helpFunc = m_compHnd->getUnBoxHelper((CORINFO_CLASS_HANDLE)embedInfo.compileTimeHandle);
-                        
+
                         if (helpFunc == CORINFO_HELP_UNBOX)
                         {
                             EmitPushUnboxAny(embedInfo, m_pStackPointer[0].var, g_stackTypeFromInterpType[GetInterpType(m_compHnd->asCorInfoType(resolvedToken.hClass))], resolvedToken.hClass);
@@ -5483,7 +5480,7 @@ DO_LDFTN:
                     AddIns(INTOP_NEWARR_GENERIC);
                     m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(helpFunc);
                     m_pLastNewIns->data[1] = handleData.dataItemIndex;
-                    
+
                     m_pLastNewIns->SetSVars2(handleData.genericVar, newArrLenVar);
                     m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 }

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -11,6 +11,7 @@
 #include <new>
 #include "failures.h"
 #include "simdhash.h"
+#include "intrinsics.h"
 
 struct InterpException
 {
@@ -695,6 +696,7 @@ private:
     void    EmitShiftOp(int32_t opBase);
     void    EmitCompareOp(int32_t opBase);
     void    EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool readonly, bool tailcall, bool newObj, bool isCalli);
+    bool    EmitNamedIntrinsicCall(NamedIntrinsic ni, CORINFO_CLASS_HANDLE clsHnd, CORINFO_METHOD_HANDLE method, CORINFO_SIG_INFO sig);
     bool    EmitCallIntrinsics(CORINFO_METHOD_HANDLE method, CORINFO_SIG_INFO sig);
     void    EmitLdind(InterpType type, CORINFO_CLASS_HANDLE clsHnd, int32_t offset);
     void    EmitStind(InterpType type, CORINFO_CLASS_HANDLE clsHnd, int32_t offset, bool reverseSVarOrder);

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -48,27 +48,59 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
                                    uint32_t*            nativeSizeOfCode)
 {
 
-    bool doInterpret;
+    bool doInterpret = false;
 
-    if (g_interpModule != NULL)
+    if ((g_interpModule != NULL) && (methodInfo->scope == g_interpModule))
+        doInterpret = true;
+
     {
-        if (methodInfo->scope == g_interpModule)
-            doInterpret = true;
-        else
-            doInterpret = false;
-    }
-    else
-    {
-        const char *methodName = compHnd->getMethodNameFromMetadata(methodInfo->ftn, nullptr, nullptr, nullptr, 0);
+// Interpreter-FIXME: Necessary to work around InterpConfig members only being defined in DEBUG.
+#if DEBUG
+        switch (InterpConfig.InterpMode())
+        {
+            // 0: default, do not use interpreter except explicit opt-in via DOTNET_Interpreter
+            case 0:
+                break;
+
+            // 1: use interpreter for everything except (1) methods that have R2R compiled code and (2) all code in System.Private.CoreLib. All code in System.Private.CoreLib falls back to JIT if there is no R2R available for it. This mode should have good balance between speed and coverage.
+            case 1:
+            {
+                doInterpret = true;
+                const char *assemblyName = compHnd->getClassAssemblyName(compHnd->getMethodClass(methodInfo->ftn));
+                if (assemblyName && !strcmp(assemblyName, "System.Private.CoreLib"))
+                    doInterpret = false;
+                break;
+            }
+
+            // 2: use interpreter for everything except intrinsics. All intrinsics fallback to JIT. Implies DOTNET_ReadyToRun=0.
+            case 2:
+                doInterpret = !(compHnd->getMethodAttribs(methodInfo->ftn) & CORINFO_FLG_INTRINSIC);
+                break;
+
+            // 3: use interpreter for everything, the full interpreter-only mode, no fallbacks to R2R or JIT whatsoever. Implies DOTNET_ReadyToRun=0, DOTNET_EnableHWIntrinsic=0,
+            case 3:
+                doInterpret = true;
+                break;
+
+            default:
+                assert(!"Unsupported value for DOTNET_InterpMode");
+                break;
+        }
+#endif
+
 #ifdef TARGET_WASM
         // interpret everything on wasm
         doInterpret = true;
 #else
-        doInterpret = (InterpConfig.Interpreter().contains(compHnd, methodInfo->ftn, compHnd->getMethodClass(methodInfo->ftn), &methodInfo->args));
-#endif
-
-        if (doInterpret)
+        // NOTE: We do this check even if doInterpret==true in order to populate g_interpModule
+        const char *methodName = compHnd->getMethodNameFromMetadata(methodInfo->ftn, nullptr, nullptr, nullptr, 0);
+        if (InterpConfig.Interpreter().contains(compHnd, methodInfo->ftn, compHnd->getMethodClass(methodInfo->ftn), &methodInfo->args))
+        {
+            doInterpret = true;
+            // FIXME: What if there are multiple modules specified by the DOTNET_Interpreter config variable?
             g_interpModule = methodInfo->scope;
+        }
+#endif
     }
 
     if (!doInterpret)

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -55,14 +55,13 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
 
     {
 // Interpreter-FIXME: Necessary to work around InterpConfig members only being defined in DEBUG.
-#if DEBUG
         switch (InterpConfig.InterpMode())
         {
             // 0: default, do not use interpreter except explicit opt-in via DOTNET_Interpreter
             case 0:
                 break;
 
-            // 1: use interpreter for everything except (1) methods that have R2R compiled code and (2) all code in System.Private.CoreLib. All code in System.Private.CoreLib falls back to JIT if there is no R2R available for it. This mode should have good balance between speed and coverage.
+            // 1: use interpreter for everything except (1) methods that have R2R compiled code and (2) all code in System.Private.CoreLib. All code in System.Private.CoreLib falls back to JIT if there is no R2R available for it.
             case 1:
             {
                 doInterpret = true;
@@ -77,16 +76,15 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
                 doInterpret = !(compHnd->getMethodAttribs(methodInfo->ftn) & CORINFO_FLG_INTRINSIC);
                 break;
 
-            // 3: use interpreter for everything, the full interpreter-only mode, no fallbacks to R2R or JIT whatsoever. Implies DOTNET_ReadyToRun=0, DOTNET_EnableHWIntrinsic=0,
+            // 3: use interpreter for everything, the full interpreter-only mode, no fallbacks to R2R or JIT whatsoever. Implies DOTNET_ReadyToRun=0, DOTNET_EnableHWIntrinsic=0
             case 3:
                 doInterpret = true;
                 break;
 
             default:
-                assert(!"Unsupported value for DOTNET_InterpMode");
+                NO_WAY("Unsupported value for DOTNET_InterpMode");
                 break;
         }
-#endif
 
 #ifdef TARGET_WASM
         // interpret everything on wasm

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -54,7 +54,6 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
         doInterpret = true;
 
     {
-// Interpreter-FIXME: Necessary to work around InterpConfig members only being defined in DEBUG.
         switch (InterpConfig.InterpMode())
         {
             // 0: default, do not use interpreter except explicit opt-in via DOTNET_Interpreter
@@ -95,7 +94,6 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
         if (InterpConfig.Interpreter().contains(compHnd, methodInfo->ftn, compHnd->getMethodClass(methodInfo->ftn), &methodInfo->args))
         {
             doInterpret = true;
-            // FIXME: What if there are multiple modules specified by the DOTNET_Interpreter config variable?
             g_interpModule = methodInfo->scope;
         }
 #endif

--- a/src/coreclr/interpreter/interpconfigvalues.h
+++ b/src/coreclr/interpreter/interpconfigvalues.h
@@ -23,6 +23,11 @@ RELEASE_CONFIG_METHODSET(Interpreter, "Interpreter")
 CONFIG_METHODSET(InterpHalt, "InterpHalt");
 CONFIG_METHODSET(InterpDump, "InterpDump");
 CONFIG_INTEGER(InterpList, "InterpList", 0); // List the methods which are compiled by the interpreter JIT
+CONFIG_INTEGER(InterpMode, "InterpMode", 0); // Interpreter mode, one of the following:
+// 0: default, do not use interpreter except explicit opt-in via DOTNET_Interpreter
+// 1: use interpreter for everything except (1) methods that have R2R compiled code and (2) all code in System.Private.CoreLib. All code in System.Private.CoreLib falls back to JIT if there is no R2R available for it. This mode should have good balance between speed and coverage.
+// 2: use interpreter for everything except intrinsics. All intrinsics fallback to JIT. Implies DOTNET_ReadyToRun=0.
+// 3: use interpreter for everything, the full interpreter-only mode, no fallbacks to R2R or JIT whatsoever. Implies DOTNET_ReadyToRun=0, DOTNET_EnableHWIntrinsic=0,
 
 #undef CONFIG_STRING
 #undef RELEASE_CONFIG_STRING

--- a/src/coreclr/interpreter/interpconfigvalues.h
+++ b/src/coreclr/interpreter/interpconfigvalues.h
@@ -23,11 +23,11 @@ RELEASE_CONFIG_METHODSET(Interpreter, "Interpreter")
 CONFIG_METHODSET(InterpHalt, "InterpHalt");
 CONFIG_METHODSET(InterpDump, "InterpDump");
 CONFIG_INTEGER(InterpList, "InterpList", 0); // List the methods which are compiled by the interpreter JIT
-CONFIG_INTEGER(InterpMode, "InterpMode", 0); // Interpreter mode, one of the following:
+RELEASE_CONFIG_INTEGER(InterpMode, "InterpMode", 0); // Interpreter mode, one of the following:
 // 0: default, do not use interpreter except explicit opt-in via DOTNET_Interpreter
-// 1: use interpreter for everything except (1) methods that have R2R compiled code and (2) all code in System.Private.CoreLib. All code in System.Private.CoreLib falls back to JIT if there is no R2R available for it. This mode should have good balance between speed and coverage.
+// 1: use interpreter for everything except (1) methods that have R2R compiled code and (2) all code in System.Private.CoreLib. All code in System.Private.CoreLib falls back to JIT if there is no R2R available for it.
 // 2: use interpreter for everything except intrinsics. All intrinsics fallback to JIT. Implies DOTNET_ReadyToRun=0.
-// 3: use interpreter for everything, the full interpreter-only mode, no fallbacks to R2R or JIT whatsoever. Implies DOTNET_ReadyToRun=0, DOTNET_EnableHWIntrinsic=0,
+// 3: use interpreter for everything, the full interpreter-only mode, no fallbacks to R2R or JIT whatsoever. Implies DOTNET_ReadyToRun=0, DOTNET_EnableHWIntrinsic=0
 
 #undef CONFIG_STRING
 #undef RELEASE_CONFIG_STRING

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -397,6 +397,7 @@ OPDEF(INTOP_LEAVE_FILTER, "leavefilter", 2, 0, 1, InterpOpNoArgs)
 OPDEF(INTOP_LEAVE_CATCH, "leavecatch", 2, 0, 0, InterpOpBranch)
 OPDEF(INTOP_LOAD_EXCEPTION, "load.exception", 2, 1, 0, InterpOpNoArgs)
 
+OPDEF(INTOP_THROW_PNSE, "throw.pnse", 1, 0, 0, InterpOpNoArgs)
 OPDEF(INTOP_FAILFAST, "failfast", 1, 0, 0, InterpOpNoArgs)
 OPDEF(INTOP_GC_COLLECT, "gc.collect", 1, 0, 0, InterpOpNoArgs)
 

--- a/src/coreclr/interpreter/intrinsics.cpp
+++ b/src/coreclr/interpreter/intrinsics.cpp
@@ -82,7 +82,7 @@ NamedIntrinsic GetNamedIntrinsic(COMP_HANDLE compHnd, CORINFO_METHOD_HANDLE comp
         {
             if (!strcmp(className, "MemoryMarshal"))
             {
-                if (!strcmp(methodName, "GetArrayDataReference`1"))
+                if (!strcmp(methodName, "GetArrayDataReference"))
                     return NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference;
             }
         }

--- a/src/coreclr/interpreter/intrinsics.cpp
+++ b/src/coreclr/interpreter/intrinsics.cpp
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "interpreter.h"
+#include "intrinsics.h"
+
+#define HAS_PREFIX(haystack, needle) \
+    (strncmp(haystack, needle, strlen(needle)) == 0)
+
+NamedIntrinsic GetNamedIntrinsic(COMP_HANDLE compHnd, CORINFO_METHOD_HANDLE compMethod, CORINFO_METHOD_HANDLE method)
+{
+    const char* className = NULL;
+    const char* namespaceName = NULL;
+    const char* methodName = compHnd->getMethodNameFromMetadata(method, &className, &namespaceName, NULL, 0);
+
+    // Array methods don't have metadata
+    if (!namespaceName)
+        return NI_Illegal;
+
+    if (!HAS_PREFIX(namespaceName, "System"))
+        return NI_Illegal;
+
+    if (!strcmp(namespaceName, "System"))
+    {
+        if (!strcmp(className, "Double") || !strcmp(className, "Single"))
+        {
+            if (!strcmp(methodName, "ConvertToIntegerNative"))
+                return NI_PRIMITIVE_ConvertToIntegerNative;
+            else if (!strcmp(methodName, "MultiplyAddEstimate"))
+                return NI_System_Math_MultiplyAddEstimate;
+        }
+        else if (!strcmp(className, "Debugger"))
+        {
+            // Interpreter-FIXME: No NI_ enum value for this?
+            if (!strcmp(methodName, "Break"))
+                return NI_Illegal;
+        }
+        else if (!strcmp(className, "Math") || !strcmp(className, "MathF"))
+        {
+            if (!strcmp(methodName, "ReciprocalEstimate"))
+                return NI_System_Math_ReciprocalEstimate;
+            else if (!strcmp(methodName, "ReciprocalSqrtEstimate"))
+                return NI_System_Math_ReciprocalSqrtEstimate;
+        }
+    }
+    else if (!strcmp(namespaceName, "System.Numerics"))
+    {
+        if (!strcmp(className, "Vector") && !strcmp(methodName, "get_IsHardwareAccelerated"))
+            return NI_IsSupported_False;
+
+        // Fall back to managed implementation for everything else.
+        return NI_Illegal;
+    }
+    else if (!strcmp(namespaceName, "System.Runtime.Intrinsics"))
+    {
+        // Vector128<T> etc
+        if (HAS_PREFIX(className, "Vector") && !strcmp(methodName, "get_IsHardwareAccelerated"))
+            return NI_IsSupported_False;
+
+        // Fall back to managed implementation for everything else.
+        return NI_Illegal;
+    }
+    else if (HAS_PREFIX(namespaceName, "System.Runtime.Intrinsics"))
+    {
+        // Architecture-specific intrinsics.
+        if (!strcmp(methodName, "get_IsSupported"))
+            return NI_IsSupported_False;
+
+        // Every intrinsic except IsSupported is PNSE in interpreted-only mode.
+        return NI_Throw_PlatformNotSupportedException;
+    }
+    else if (HAS_PREFIX(namespaceName, "System.Runtime"))
+    {
+        if (!strcmp(namespaceName, "System.Runtime.CompilerServices"))
+        {
+            if (!strcmp(className, "Unsafe"))
+            {
+                // The members of the S.R.CS.Unsafe namespace have IL generated for them elsewhere in the runtime;
+                //  we want to use that generated IL. It should Just Work once we support unsafe accessors.
+                // If the JIT is available our fallback to calling the JITted code will also work.
+                // Interpreter-FIXME: Identify the specific unsafe methods.
+                return NI_SRCS_UNSAFE_START;
+            }
+            else if (!strcmp(className, "StaticsHelpers"))
+            {
+                if (!strcmp(methodName, "VolatileReadAsByref"))
+                    return NI_System_Runtime_CompilerServices_StaticsHelpers_VolatileReadAsByref;
+            }
+            else if (!strcmp(className, "RuntimeHelpers"))
+            {
+                if (!strcmp(methodName, "IsReferenceOrContainsReferences"))
+                    return NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences;
+            }
+        }
+        else if (!strcmp(namespaceName, "System.Runtime.InteropServices"))
+        {
+            if (!strcmp(className, "MemoryMarshal"))
+            {
+                if (!strcmp(methodName, "GetArrayDataReference`1"))
+                    return NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference;
+            }
+        }
+    }
+    else if (!strcmp(namespaceName, "System.Threading"))
+    {
+        if (!strcmp(className, "Interlocked"))
+        {
+            if (!strcmp(methodName, "CompareExchange"))
+                return NI_System_Threading_Interlocked_CompareExchange;
+            else if (!strcmp(methodName, "MemoryBarrier"))
+                return NI_System_Threading_Interlocked_MemoryBarrier;
+        }
+        else if (!strcmp(className, "Thread"))
+        {
+            if (!strcmp(methodName, "FastPollGC"))
+                return NI_System_Threading_Thread_FastPollGC;
+        }
+        else if (!strcmp(className, "Volatile"))
+        {
+            if (!strcmp(methodName, "ReadBarrier"))
+                return NI_System_Threading_Volatile_ReadBarrier;
+            else if (!strcmp(methodName, "WriteBarrier"))
+                return NI_System_Threading_Volatile_WriteBarrier;
+        }
+    }
+
+    return NI_Illegal;
+}

--- a/src/coreclr/interpreter/intrinsics.cpp
+++ b/src/coreclr/interpreter/intrinsics.cpp
@@ -72,8 +72,7 @@ NamedIntrinsic GetNamedIntrinsic(COMP_HANDLE compHnd, CORINFO_METHOD_HANDLE comp
                 // The members of the S.R.CS.Unsafe namespace have IL generated for them elsewhere in the runtime;
                 //  we want to use that generated IL. It should Just Work once we support unsafe accessors.
                 // If the JIT is available our fallback to calling the JITted code will also work.
-                // Interpreter-FIXME: Identify the specific unsafe methods.
-                return NI_SRCS_UNSAFE_START;
+                return NI_Illegal;
             }
             else if (!strcmp(className, "StaticsHelpers"))
             {

--- a/src/coreclr/interpreter/intrinsics.cpp
+++ b/src/coreclr/interpreter/intrinsics.cpp
@@ -67,14 +67,7 @@ NamedIntrinsic GetNamedIntrinsic(COMP_HANDLE compHnd, CORINFO_METHOD_HANDLE comp
     {
         if (!strcmp(namespaceName, "System.Runtime.CompilerServices"))
         {
-            if (!strcmp(className, "Unsafe"))
-            {
-                // The members of the S.R.CS.Unsafe namespace have IL generated for them elsewhere in the runtime;
-                //  we want to use that generated IL. It should Just Work once we support unsafe accessors.
-                // If the JIT is available our fallback to calling the JITted code will also work.
-                return NI_Illegal;
-            }
-            else if (!strcmp(className, "StaticsHelpers"))
+            if (!strcmp(className, "StaticsHelpers"))
             {
                 if (!strcmp(methodName, "VolatileReadAsByref"))
                     return NI_System_Runtime_CompilerServices_StaticsHelpers_VolatileReadAsByref;

--- a/src/coreclr/interpreter/intrinsics.cpp
+++ b/src/coreclr/interpreter/intrinsics.cpp
@@ -29,12 +29,6 @@ NamedIntrinsic GetNamedIntrinsic(COMP_HANDLE compHnd, CORINFO_METHOD_HANDLE comp
             else if (!strcmp(methodName, "MultiplyAddEstimate"))
                 return NI_System_Math_MultiplyAddEstimate;
         }
-        else if (!strcmp(className, "Debugger"))
-        {
-            // Interpreter-FIXME: No NI_ enum value for this?
-            if (!strcmp(methodName, "Break"))
-                return NI_Illegal;
-        }
         else if (!strcmp(className, "Math") || !strcmp(className, "MathF"))
         {
             if (!strcmp(methodName, "ReciprocalEstimate"))

--- a/src/coreclr/interpreter/intrinsics.h
+++ b/src/coreclr/interpreter/intrinsics.h
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef __INTERPRETER_INTRINSICS_H__
+#define __INTERPRETER_INTRINSICS_H__
+
+#include "../jit/namedintrinsiclist.h"
+
+NamedIntrinsic GetNamedIntrinsic(COMP_HANDLE compHnd, CORINFO_METHOD_HANDLE compMethod, CORINFO_METHOD_HANDLE method);
+
+#endif // __INTERPRETER_INTRINSICS_H__

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -44,7 +44,7 @@ void InvokeCompiledMethod(MethodDesc *pMD, int8_t *pArgs, int8_t *pRet)
         }
     }
 
-    pHeader->SetTarget(pMD->GetMultiCallableAddrOfCode()); // The method to call
+    pHeader->SetTarget(pMD->GetMultiCallableAddrOfCode(CORINFO_ACCESS_ANY)); // The method to call
 
     pHeader->Invoke(pHeader->Routines, pArgs, pRet, pHeader->TotalStackSize);
 }
@@ -2391,6 +2391,9 @@ do {                                                                           \
                 case INTOP_LEAVE_CATCH:
                     *(const int32_t**)pFrame->pRetVal = ip + ip[1];
                     goto EXIT_FRAME;
+                case INTOP_THROW_PNSE:
+                    COMPlusThrow(kPlatformNotSupportedException);
+                    break;
                 case INTOP_FAILFAST:
                     assert(0);
                     break;

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -968,19 +968,6 @@ public class InterpreterTest
         Console.WriteLine(System.Runtime.Intrinsics.X86.X86Base.IsSupported);
         Console.WriteLine("ArmBase.IsSupported=");
         Console.WriteLine(System.Runtime.Intrinsics.Arm.ArmBase.IsSupported);
-
-        // HACK: The below try block is constructed to always throw and provides an easy way to test how intrinsics behave in the interpreter
-        //  depending on which of our various modes you're in (native fallback, all intrinsics disabled, etc.)
-        try {
-            // NOTE: Depending on the target architecture, these method calls will not have FLG_INTRINSIC, so the interpreter will not
-            //  recognize them as intrinsics and handle them. This *should* be fine, because we conditionally compile CoreLib based on
-            //  architecture, providing pure-managed implementations of the relevant methods that throw a PNSE.
-            System.Runtime.Intrinsics.X86.X86Base.Pause();
-            System.Runtime.Intrinsics.Arm.ArmBase.Yield();
-            return false;
-        } catch (PlatformNotSupportedException) {
-            return true;
-        }
     }
 
     public static void TestExceptionHandling()

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -972,10 +972,6 @@ public class InterpreterTest
         // HACK: The below try block is constructed to always throw and provides an easy way to test how intrinsics behave in the interpreter
         //  depending on which of our various modes you're in (native fallback, all intrinsics disabled, etc.)
         try {
-            // HACK: FIXME: This console writeline is needed right now because throws at the start of a try block in the interpreter
-            //  aren't currently caught correctly
-            Console.WriteLine("Inside try block");
-
             // NOTE: Depending on the target architecture, these method calls will not have FLG_INTRINSIC, so the interpreter will not
             //  recognize them as intrinsics and handle them. This *should* be fine, because we conditionally compile CoreLib based on
             //  architecture, providing pure-managed implementations of the relevant methods that throw a PNSE.

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -968,6 +968,7 @@ public class InterpreterTest
         Console.WriteLine(System.Runtime.Intrinsics.X86.X86Base.IsSupported);
         Console.WriteLine("ArmBase.IsSupported=");
         Console.WriteLine(System.Runtime.Intrinsics.Arm.ArmBase.IsSupported);
+        return true;
     }
 
     public static void TestExceptionHandling()


### PR DESCRIPTION
* Wire up basic support for intrinsics in the CoreCLR interpreter
* Add new DOTNET_InterpMode environment variable with 4 possible values (documented in the comments), where each higher value increases the amount of code we try to run in the interpreter, up to 'everything'