### PR TITLE
Revert back to JsonElement-backed JsonValue for deserialization

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonValueConverter.cs
@@ -27,39 +27,14 @@ namespace System.Text.Json.Serialization.Converters
                 return null;
             }
 
-            switch (reader.TokenType)
-            {
-                case JsonTokenType.String:
-                case JsonTokenType.False:
-                case JsonTokenType.True:
-                case JsonTokenType.Number:
-                    return ReadNonNullPrimitiveValue(ref reader, options.GetNodeOptions());
-                default:
-                    JsonElement element = JsonElement.ParseValue(ref reader, options.AllowDuplicateProperties);
-                    return JsonValue.CreateFromElement(ref element, options.GetNodeOptions());
-            }
+            JsonElement element = JsonElement.ParseValue(ref reader, options.AllowDuplicateProperties);
+            return JsonValue.CreateFromElement(ref element, options.GetNodeOptions());
         }
 
-        internal static JsonValue ReadNonNullPrimitiveValue(ref Utf8JsonReader reader, JsonNodeOptions options)
+        internal static JsonValue? ReadNonNullPrimitiveValue(ref Utf8JsonReader reader, JsonNodeOptions options)
         {
-            Debug.Assert(reader.TokenType is JsonTokenType.String or JsonTokenType.False or JsonTokenType.True or JsonTokenType.Number);
-
-            switch (reader.TokenType)
-            {
-                case JsonTokenType.String:
-                    return JsonValue.Create(reader.GetString()!, options);
-                case JsonTokenType.False:
-                    return JsonValue.Create(false, options);
-                case JsonTokenType.True:
-                    return JsonValue.Create(true, options);
-                case JsonTokenType.Number:
-                    // We can't infer CLR type for the number, so we parse it as a JsonElement.
-                    JsonElement element = JsonElement.ParseValue(ref reader);
-                    return JsonValue.CreateFromElement(ref element, options)!;
-                default:
-                    Debug.Fail("Unexpected token type for primitive value.");
-                    throw new JsonException();
-            }
+            JsonElement element = JsonElement.ParseValue(ref reader);
+            return JsonValue.CreateFromElement(ref element, options)!;
         }
 
         internal override JsonSchema? GetSchema(JsonNumberHandling _) => JsonSchema.CreateTrueSchema();


### PR DESCRIPTION
`JsonValueOfElement` is more permissive than other classes derived from `JsonValue`. For example, it allows `GetValue<Guid>` even when the underlying value's JSON type is a JSON string. The following method has the implementation:

https://github.com/dotnet/runtime/blob/2dbdff1a7aebd64b4b265d99b173cd77f088c36e/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfElement.cs#L50

#115856 changed deserialization of primitives to use `JsonValue.Create` instead of the `JsonElement`-backed creation, so the people relying on the previous behavior of `GetValue` will now be broken. This was a small part of that PR and only that part has been reverted in this PR.

In the long term, we can reintroduce this change in a different way: have another class derived from `JsonValue` that (1) stores the value instead of JsonElement and (2) also allows the same conversions that JsonValueOfElement does. But for now, we revert to get back to baseline.

Fixes #116730

/cc @eiriktsarpalis @jeffhandley I'm planning to cherry pick this to the release branch as well after merging in main.