### PR TITLE
[release/8.0-staging] Fix absolute path check when loading hostfxr/hostpolicy/coreclr

### DIFF
--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -217,6 +217,33 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void AppHost_DotNetRoot_DevicePath()
+        {
+            string appExe = sharedTestState.PortableAppFixture_Published.TestProject.AppExe;
+
+            string dotnetPath = $@"\\?\{sharedTestState.PortableAppFixture_Published.BuiltDotnet.BinPath}";
+            Command.Create(appExe)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .DotNetRoot(dotnetPath, sharedTestState.RepoDirectories.BuildArchitecture)
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World")
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+
+            dotnetPath = $@"\\.\{sharedTestState.PortableAppFixture_Published.BuiltDotnet.BinPath}";
+            Command.Create(appExe)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .DotNetRoot(dotnetPath, sharedTestState.RepoDirectories.BuildArchitecture)
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World")
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+        }
+
+        [Fact]
         public void RuntimeConfig_FilePath_Breaks_MAX_PATH_Threshold()
         {
             var project = sharedTestState.PortableAppFixture_Published

--- a/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
@@ -255,6 +255,29 @@ namespace HostActivation.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void DevicePath()
+        {
+            string appExe = $@"\\?\{sharedTestState.StandaloneAppFixture_Published.TestProject.AppExe}";
+            Command.Create(appExe)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World")
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+
+            appExe = $@"\\.\{sharedTestState.StandaloneAppFixture_Published.TestProject.AppExe}";
+            Command.Create(appExe)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World")
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+        }
+
+        [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // GUI app host is only supported on Windows.
         public void Running_AppHost_with_GUI_No_Console()
         {

--- a/src/native/corehost/apphost/standalone/hostfxr_resolver.cpp
+++ b/src/native/corehost/apphost/standalone/hostfxr_resolver.cpp
@@ -38,7 +38,7 @@ hostfxr_resolver_t::hostfxr_resolver_t(const pal::string_t& app_root)
     {
         m_status_code = StatusCode::CoreHostLibMissingFailure;
     }
-    else if (!pal::is_path_rooted(m_fxr_path))
+    else if (!pal::is_path_fully_qualified(m_fxr_path))
     {
         // We should always be loading hostfxr from an absolute path
         m_status_code = StatusCode::CoreHostLibMissingFailure;

--- a/src/native/corehost/corehost.cpp
+++ b/src/native/corehost/corehost.cpp
@@ -187,6 +187,7 @@ int exe_start(const int argc, const pal::char_t* argv[])
     int rc = fxr.status_code();
     if (rc != StatusCode::Success)
     {
+        trace::error(_X("Failed to resolve %s [%s]. Error code: 0x%x"), LIBFXR_NAME, fxr.fxr_path().empty() ? _X("not found") : fxr.fxr_path().c_str(), rc);
         return rc;
     }
 

--- a/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
+++ b/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
@@ -181,7 +181,7 @@ int hostpolicy_resolver::load(
         }
 
         // We should always be loading hostpolicy from an absolute path
-        if (!pal::is_path_rooted(host_path))
+        if (!pal::is_path_fully_qualified(host_path))
             return StatusCode::CoreHostLibMissingFailure;
 
         // Load library

--- a/src/native/corehost/fxr_resolver.h
+++ b/src/native/corehost/fxr_resolver.h
@@ -45,7 +45,7 @@ int load_fxr_and_get_delegate(hostfxr_delegate_type type, THostPathToConfigCallb
         }
 
         // We should always be loading hostfxr from an absolute path
-        if (!pal::is_path_rooted(fxr_path))
+        if (!pal::is_path_fully_qualified(fxr_path))
             return StatusCode::CoreHostLibMissingFailure;
 
         // Load library

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -328,6 +328,7 @@ namespace pal
 
     bool get_default_breadcrumb_store(string_t* recv);
     bool is_path_rooted(const string_t& path);
+    bool is_path_fully_qualified(const string_t& path);
 
     // Returns a platform-specific, user-private directory
     // that can be used for extracting out components of a single-file app.

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -192,7 +192,7 @@ bool pal::get_loaded_library(
 {
     pal::string_t library_name_local;
 #if defined(TARGET_OSX)
-    if (!pal::is_path_rooted(library_name))
+    if (!pal::is_path_fully_qualified(library_name))
         library_name_local.append("@rpath/");
 #endif
     library_name_local.append(library_name);
@@ -200,7 +200,7 @@ bool pal::get_loaded_library(
     dll_t dll_maybe = dlopen(library_name_local.c_str(), RTLD_LAZY | RTLD_NOLOAD);
     if (dll_maybe == nullptr)
     {
-        if (pal::is_path_rooted(library_name))
+        if (pal::is_path_fully_qualified(library_name))
             return false;
 
         // dlopen on some systems only finds loaded libraries when given the full path
@@ -263,6 +263,11 @@ int pal::xtoi(const char_t* input)
 bool pal::is_path_rooted(const pal::string_t& path)
 {
     return path.front() == '/';
+}
+
+bool pal::is_path_fully_qualified(const pal::string_t& path)
+{
+    return is_path_rooted(path);
 }
 
 bool pal::get_default_breadcrumb_store(string_t* recv)

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -585,9 +585,31 @@ pal::string_t pal::get_current_os_rid_platform()
     return ridOS;
 }
 
+namespace
+{
+    bool is_directory_separator(pal::char_t c)
+    {
+        return c == DIR_SEPARATOR || c == L'/';
+    }
+}
+
 bool pal::is_path_rooted(const string_t& path)
 {
-    return path.length() >= 2 && path[1] == L':';
+    return (path.length() >= 1 && is_directory_separator(path[0])) // UNC or device paths
+        || (path.length() >= 2 && path[1] == L':'); // Drive letter paths
+}
+
+bool pal::is_path_fully_qualified(const string_t& path)
+{
+    if (path.length() < 2)
+        return false;
+
+    // Check for UNC and DOS device paths
+    if (is_directory_separator(path[0]))
+        return path[1] == L'?' || is_directory_separator(path[1]);
+
+    // Check for drive absolute path - for example C:\.
+    return path.length() >= 3 && path[1] == L':' && is_directory_separator(path[2]);
 }
 
 // Returns true only if an env variable can be read successfully to be non-empty.

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -601,7 +601,7 @@ void deps_resolver_t::init_known_entry_path(const deps_entry_t& entry, const pal
         return;
     }
 
-    assert(pal::is_path_rooted(path));
+    assert(pal::is_path_fully_qualified(path));
     if (m_coreclr_path.empty() && ends_with(path, DIR_SEPARATOR + pal::string_t(LIBCORECLR_NAME), false))
     {
         m_coreclr_path = path;

--- a/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
+++ b/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
@@ -14,7 +14,7 @@ bool coreclr_resolver_t::resolve_coreclr(const pal::string_t& libcoreclr_path, c
     append_path(&coreclr_dll_path, LIBCORECLR_NAME);
 
     // We should always be loading coreclr from an absolute path
-    if (!pal::is_path_rooted(coreclr_dll_path))
+    if (!pal::is_path_fully_qualified(coreclr_dll_path))
         return false;
 
     if (!pal::load_library(&coreclr_dll_path, &coreclr_resolver_contract.coreclr))


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/116597 to release/8.0-staging

On Windows, we were incorrectly only checking for `<letter>:` and incorrectly determining that UNC and device paths were not absolute. This updates `pal::is_path_rooted` to match the managed `Path.IsPathRooted` and adds a `pal::is_path_absolute` with the logic of `Path.IsPartiallyQualified`

cc @dotnet/appmodel @AaronRobinsonMSFT 

## Customer Impact

- [x] Customer reported
- [x] Found internally

Customers are unable to run self-contained apps from or point framework-dependent apps to use a .NET runtime from a UNC share or device path.

Issue: https://github.com/dotnet/runtime/issues/116521

## Regression

- [x] Yes
- [ ] No

Regressed in last servicing release.
https://github.com/dotnet/runtime/commit/b33d4e34e1cbf993583d78fc1b64ea8400935978

## Testing

Manual testing for UNC share and device path. Automated test added for device paths.

## Risk

Medium. The fix has to be in a path that every app will exercise. The updated logic is a mirror of existing logic in managed APIs.