### PR TITLE
[RISC-V] Lowering multiplication by power of 2 

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1045,7 +1045,14 @@ void CodeGen::genCodeForMul(GenTreeOp* treeNode)
 
     if (!needCheckOv && !(treeNode->gtFlags & GTF_UNSIGNED))
     {
-        emit->emitIns_R_R_I(INS_slli, attr, dstReg, src1Reg, shiftAmount);
+        if (attr == EA_4BYTE) 
+        {
+            emit->emitIns_R_R_I(INS_slliw, attr, dstReg, src1Reg, shiftAmount);
+        }
+        else
+        {
+            emit->emitIns_R_R_I(INS_slli, attr, dstReg, src1Reg, shiftAmount);
+        }
     }
     else
     {
@@ -1060,7 +1067,7 @@ void CodeGen::genCodeForMul(GenTreeOp* treeNode)
             {
                 if (attr == EA_4BYTE)
                 {
-                    emit->emitIns_R_R_I(INS_srli, attr, tempReg, src1Reg, 32 - shiftAmount);
+                    emit->emitIns_R_R_I(INS_srliw, attr, tempReg, src1Reg, 32 - shiftAmount);
                 }
                 else
                 {
@@ -1080,7 +1087,7 @@ void CodeGen::genCodeForMul(GenTreeOp* treeNode)
             }
         }
 
-        // n * n bytes will storoe n bytes result
+        // n * n bytes will store n bytes result
         emit->emitIns_R_R_I(INS_slli, attr, dstReg, src1Reg, shiftAmount);
     
         if (isUnsigned)

--- a/src/coreclr/jit/lowerriscv64.cpp
+++ b/src/coreclr/jit/lowerriscv64.cpp
@@ -117,8 +117,20 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
 {
     assert(mul->OperIsMul());
 
-    ContainCheckMul(mul);
+    GenTree* op2 = mul->gtGetOp2();
+    if (op2->IsCnsIntOrI())
+    {
+        GenTreeIntConCommon* cns    = op2->AsIntConCommon();
+        ssize_t              cnsVal = cns->IconValue();
+        if (isPow2(cnsVal))
+        {
+            MakeSrcContained(mul, op2);
 
+            return mul->gtNext;
+        }
+    }
+
+    ContainCheckMul(mul);
     return mul->gtNext;
 }
 


### PR DESCRIPTION
Lowering multiplication operations by power of 2, for optimization. 
Added codegen for `GT_MUL`, which emits `slli` for `GT_MUL` with overflow handling.

@SkyShield
@credo-quia-absurdum

part of #84834, cc @dotnet/samsung