### PR TITLE
Remove Assert in Method.MakeGeneric on Invalid Arg

### DIFF
--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -2728,9 +2728,8 @@ reflection_bind_generic_method_parameters (MonoMethod *method, MonoArrayHandle t
 	tmp_context.method_inst = ginst;
 
 	inflated = mono_class_inflate_generic_method_checked (method, &tmp_context, error);
-	mono_error_assert_ok (error);
 
-	if (!mono_verifier_is_method_valid_generic_instantiation (inflated)) {
+	if (!is_ok(error) || !inflated || !mono_verifier_is_method_valid_generic_instantiation (inflated)) {
 		mono_error_set_argument (error, NULL, "Invalid generic arguments");
 		return NULL;
 	}


### PR DESCRIPTION
The call to `mono_class_inflate_generic_method_checked` will set error when there are invalid types (e.g. `typeof(void)`/`typeof(int*))` passed in.  This should not be an assert, we should fall to the "Invalid generic arguments" message below.   This does loose the error returned by `mono_class_inflate_generic_method_checked` but that error isn't user
friendly.  It would report be something like:

>     "MVAR 1 cannot be expanded with type 0x1"

Instead report the more general/readable error to the user.

Fix: https://github.com/dotnet/runtime/issues/71339.

Repro:

```
    internal class Program
    {
        static void Main(string[] args)
        {
            try
            {
                typeof(Program)!.GetMethod(nameof(Get))!.MakeGenericMethod(typeof(void));
            }
            catch ( Exception ex)
            {
                Console.WriteLine(ex);
            }
        }

        public T Get<T>() => default;
    }
```

Result Before:
```
* Assertion at \src\mono\mono\metadata\reflection.c:2731, condition `is_ok (error)' not met, function:reflection_bind_generic_method_parameters, MVAR 0 cannot be expanded with type 0x1
CRASH!
```

Result After:
```
System.ArgumentException: Invalid generic arguments
```

