### PR TITLE
[cDAC] X86 support FuncEvalFrame

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/X86FrameHandler.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/X86FrameHandler.cs
@@ -11,7 +11,8 @@ internal class X86FrameHandler(Target target, ContextHolder<X86Context> contextH
 {
     private readonly ContextHolder<X86Context> _context = contextHolder;
 
-    void IPlatformFrameHandler.HandleFaultingExceptionFrame(FaultingExceptionFrame frame)
+
+    public void HandleFaultingExceptionFrame(FaultingExceptionFrame frame)
     {
         if (frame.TargetContext is not TargetPointer targetContext)
         {
@@ -24,9 +25,34 @@ internal class X86FrameHandler(Target target, ContextHolder<X86Context> contextH
         _context.Context.ContextFlags &= ~(uint)(ContextFlagsValues.CONTEXT_XSTATE & ContextFlagsValues.CONTEXT_AREA_MASK);
     }
 
-    void IPlatformFrameHandler.HandleHijackFrame(HijackFrame frame)
+    public void HandleHijackFrame(HijackFrame frame)
     {
         // TODO(cdacX86): Implement handling for HijackFrame
         throw new NotImplementedException();
+    }
+
+    public override void HandleFuncEvalFrame(FuncEvalFrame funcEvalFrame)
+    {
+        Data.DebuggerEval debuggerEval = _target.ProcessedData.GetOrAdd<Data.DebuggerEval>(funcEvalFrame.DebuggerEvalPtr);
+
+        // No context to update if we're doing a func eval from within exception processing.
+        if (debuggerEval.EvalDuringException)
+        {
+            return;
+        }
+
+        // Unlike other platforms, X86 doesn't copy the entire context
+        ContextHolder<X86Context> evalContext = new ContextHolder<X86Context>();
+        evalContext.ReadFromAddress(_target, debuggerEval.TargetContext);
+
+        _context.Context.Edi = evalContext.Context.Edi;
+        _context.Context.Esi = evalContext.Context.Esi;
+        _context.Context.Ebx = evalContext.Context.Ebx;
+        _context.Context.Edx = evalContext.Context.Edx;
+        _context.Context.Ecx = evalContext.Context.Ecx;
+        _context.Context.Eax = evalContext.Context.Eax;
+        _context.Context.Ebp = evalContext.Context.Ebp;
+        _context.Context.Eip = evalContext.Context.Eip;
+        _context.Context.Esp = evalContext.Context.Esp;
     }
 }


### PR DESCRIPTION
Contributes to #114019

Verified using VS to debug a dotnet program and hang the immediate evaluation with `Console.Read()`. Used `dotnet-dump` to collect a dump of the debugged process with a `[FuncEvalFrame]` on the stack.