### PR TITLE
Fix DAC-ification of the InterpreterFrame::SetContextToInterpMethodContextFrame

### DIFF
--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1893,7 +1893,7 @@ void InterpreterFrame::SetContextToInterpMethodContextFrame(T_CONTEXT * pContext
     SetIP(pContext, (TADDR)pFrame->ip);
     SetSP(pContext, dac_cast<TADDR>(pFrame));
     SetFP(pContext, (TADDR)pFrame->pStack);
-    SetFirstArgReg(pContext, (TADDR)this);
+    SetFirstArgReg(pContext, dac_cast<TADDR>(this));
 }
 
 void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)


### PR DESCRIPTION
There is an incorrect cast of `this` to TADDR that was resulting in the DAC side address being stored in the context. That was leading to an assert in the stack walking code on the DAC side that was crashing WinDbg.

This change replaces C-style cast with the proper dac_cast.