### PR TITLE
JSON: Don't mark unmapped properties as read

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -628,8 +628,8 @@ namespace System.Text.Json.Serialization.Converters
                 out bool useExtensionProperty,
                 createExtensionProperty: false);
 
-            // Mark the property as read from the payload if required.
-            if (!useExtensionProperty)
+            // Mark the property as read from the payload if it is mapped to a non-extension member.
+            if (!useExtensionProperty && jsonPropertyInfo != JsonPropertyInfo.s_missingProperty)
             {
                 state.Current.MarkPropertyAsRead(jsonPropertyInfo);
             }

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1611,7 +1611,7 @@ namespace System.Text.Json.Serialization.Tests
             Class_With_Parameters_Default_Values result = await Serializer.DeserializeWrapper<Class_With_Parameters_Default_Values>(json);
             result.Verify();
         }
-        
+
         [Fact]
         public async Task TestClassWithCustomConverterOnCtorParameter_ShouldPassCorrectTypeToConvertParameter()
         {
@@ -1820,6 +1820,26 @@ namespace System.Text.Json.Serialization.Tests
 
             [JsonExtensionData]
             public Dictionary<string, object> ExtensionData { get; set; }
+        }
+
+        [Fact]
+        public async Task RequiredMemberWithUnmappedMember()
+        {
+            // https://github.com/dotnet/runtime/issues/116801
+            string json = """
+                {
+                    "Bar": "asdf",
+                    "Baz": "hello"
+                }
+                """;
+
+            ClassWithRequiredProperty obj = await Serializer.DeserializeWrapper<ClassWithRequiredProperty>(json);
+            Assert.Equal("asdf", obj.Bar);
+        }
+
+        public class ClassWithRequiredProperty
+        {
+            public required string? Bar { get; set; }
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
@@ -158,6 +158,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(Class_ExtraProperty_ExtData))]
         [JsonSerializable(typeof(Class_ExtraProperty_JsonElementDictionaryExtData))]
         [JsonSerializable(typeof(Class_ManyParameters_ExtraProperty_ExtData))]
+        [JsonSerializable(typeof(ClassWithRequiredProperty))]
         internal sealed partial class ConstructorTestsContext_Metadata : JsonSerializerContext
         {
         }
@@ -311,6 +312,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(Class_ExtraProperty_ExtData))]
         [JsonSerializable(typeof(Class_ExtraProperty_JsonElementDictionaryExtData))]
         [JsonSerializable(typeof(Class_ManyParameters_ExtraProperty_ExtData))]
+        [JsonSerializable(typeof(ClassWithRequiredProperty))]
         internal sealed partial class ConstructorTestsContext_Default : JsonSerializerContext
         {
         }


### PR DESCRIPTION
During deserialization we keep track of the properties that are read in order to do duplicate detection and required property validation. When a parametrized constructor is specified for deserialization, there are four types of JSON properties:

1) Properties that map to a constructor parameter
2) Properties that don't map to a constructor parameter but still map to a property on the class
3) Properties that map to the ExtensionData property
4) Properties that are unmapped

(The last two cases are only differentiated by whether the class has a property with the ExtensionData attribute.)

#115856 added duplicate detection by keeping track of properties that were assigned. Paths to handle cases 1, 2 and 3 were added but case 4 was an edge case that was not considered. So when this case was hit we would try to find the mapping like we do for case 1 or 2 when we actually don't have one. This PR fixes this case by explicitly checking for it and skipping duplicate detection for it.

Fixes #116801