### PR TITLE
Make GCDump work on Linux

### DIFF
--- a/src/coreclr/nativeaot/Runtime/disabledeventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/disabledeventtrace.cpp
@@ -20,10 +20,7 @@ bool IsRuntimeProviderEnabled(uint8_t level, uint64_t keyword)
 
 void ETW::GCLog::FireGcStart(ETW_GC_INFO * pGcInfo) { }
 void ETW::LoaderLog::ModuleLoad(HANDLE pModule) { }
-
-#ifdef FEATURE_ETW
 BOOL ETW::GCLog::ShouldTrackMovementForEtw() { return FALSE; }
 void ETW::GCLog::BeginMovedReferences(size_t * pProfilingContext) { }
 void ETW::GCLog::EndMovedReferences(size_t profilingContext, BOOL fAllowProfApiNotification) { }
 void ETW::GCLog::WalkHeap() { }
-#endif // FEATURE_ETW

--- a/src/coreclr/nativeaot/Runtime/eventpipe/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/CMakeLists.txt
@@ -136,18 +136,10 @@ list(APPEND AOT_EVENTPIPE_MANAGED_TO_NATIVE_SOURCES
 if (FEATURE_EVENT_TRACE)
   list(APPEND AOT_EVENTTRACE_SOURCES
     ${NATIVEAOT_RUNTIME_DIR}/eventtrace.cpp
+    ${NATIVEAOT_RUNTIME_DIR}/eventtrace_bulktype.cpp
+    ${NATIVEAOT_RUNTIME_DIR}/eventtrace_gcheap.cpp
     ${NATIVEAOT_RUNTIME_DIR}/profheapwalkhelper.cpp
   )
-
-  # These are carry-overs from .NET Native and only included for ETW currently
-  #   bulktype : directly emits via ETW with EventWrite
-  #   gcheap : GCHeapDump, GCHeapSurvivalAndMovement - not prioritizing for nativeaot yet
-  if (FEATURE_ETW)
-    list(APPEND AOT_EVENTTRACE_SOURCES
-      ${NATIVEAOT_RUNTIME_DIR}/eventtrace_bulktype.cpp
-      ${NATIVEAOT_RUNTIME_DIR}/eventtrace_gcheap.cpp
-    )
-  endif()
 
   if(CLR_CMAKE_TARGET_WIN32)
     set_source_files_properties(${GEN_EVENTPIPE_PROVIDER_SOURCES} PROPERTIES COMPILE_FLAGS "/FI\"${NATIVEAOT_RUNTIME_DIR}/eventpipe/NativeaotEventPipeSupport.h\"")

--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -250,8 +250,6 @@ void EtwCallbackCommon(
         GCHeapUtilities::RecordEventStateChange(bIsPublicTraceHandle, keywords, level);
     }
 
-// NativeAOT currently only supports forcing a GC with ManagedHeapCollectKeyword via ETW
-#ifdef FEATURE_ETW
     // Special check for a profiler requested GC.
     // A full GC will be forced if:
     // 1. The GC Heap is initialized.
@@ -273,10 +271,11 @@ void EtwCallbackCommon(
         // Profilers may (optionally) specify extra data in the filter parameter
         // to log with the GCStart event.
         LONGLONG l64ClientSequenceNumber = 0;
+#if !defined(HOST_UNIX)
         ParseFilterDataClientSequenceNumber((EVENT_FILTER_DESCRIPTOR*)pFilterData, &l64ClientSequenceNumber);
+#endif // !defined(HOST_UNIX)
         ETW::GCLog::ForceGC(l64ClientSequenceNumber);
     }
-#endif
 }
 
 #ifdef FEATURE_ETW

--- a/src/coreclr/nativeaot/Runtime/eventtrace.h
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.h
@@ -202,25 +202,4 @@ namespace ETW
 inline void ETW::GCLog::FireGcStart(ETW_GC_INFO * pGcInfo) { }
 #endif
 
-#ifndef FEATURE_ETW
-inline BOOL ETW::GCLog::ShouldWalkHeapObjectsForEtw() { return FALSE; }
-inline BOOL ETW::GCLog::ShouldWalkHeapRootsForEtw() { return FALSE; }
-inline BOOL ETW::GCLog::ShouldTrackMovementForEtw() { return FALSE; }
-inline BOOL ETW::GCLog::ShouldWalkStaticsAndCOMForEtw() { return FALSE; }
-inline void ETW::GCLog::EndHeapDump(ProfilerWalkHeapContext * profilerWalkHeapContext) { }
-inline void ETW::GCLog::BeginMovedReferences(size_t * pProfilingContext) { }
-inline void ETW::GCLog::MovedReference(BYTE * pbMemBlockStart, BYTE * pbMemBlockEnd, ptrdiff_t cbRelocDistance, size_t profilingContext, BOOL fCompacting, BOOL fAllowProfApiNotification) { }
-inline void ETW::GCLog::EndMovedReferences(size_t profilingContext, BOOL fAllowProfApiNotification) { }
-inline void ETW::GCLog::WalkStaticsAndCOMForETW() { }
-inline void ETW::GCLog::RootReference(
-    LPVOID pvHandle,
-    Object * pRootedNode,
-    Object * pSecondaryNodeForDependentHandle,
-    BOOL fDependentHandle,
-    ProfilingScanContext * profilingScanContext,
-    DWORD dwGCFlags,
-    DWORD rootFlags) { }
-inline void ETW::GCLog::WalkHeap() { }
-#endif
-
 #endif //_VMEVENTTRACE_H_

--- a/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
@@ -265,7 +265,7 @@ int BulkTypeEventLogger::LogSingleType(MethodTable * pEEType)
         FireBulkTypeEvent();
     }
 
-    _ASSERTE(m_nBulkTypeValueCount < _countof(m_rgBulkTypeValues));
+    _ASSERTE(m_nBulkTypeValueCount < (int)_countof(m_rgBulkTypeValues));
 
     BulkTypeValue * pVal = &m_rgBulkTypeValues[m_nBulkTypeValueCount];
 

--- a/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
@@ -7,7 +7,7 @@
 #include "eventtrace_etw.h"
 #include "rhbinder.h"
 #include "slist.h"
-#include "runtimeinstance.h"
+#include "RuntimeInstance.h"
 #include "shash.h"
 #include "eventtracebase.h"
 #include "eventtracepriv.h"
@@ -216,8 +216,9 @@ static CorElementType ElementTypeToCorElementType(EETypeElementType elementType)
         return CorElementType::ELEMENT_TYPE_I;
     case EETypeElementType::ElementType_UIntPtr:
         return CorElementType::ELEMENT_TYPE_U;
+    default:
+        return CorElementType::ELEMENT_TYPE_END;
     }
-    return CorElementType::ELEMENT_TYPE_END;
 }
 
 // Avoid reporting the same type twice by keeping a hash of logged types.
@@ -243,7 +244,11 @@ int BulkTypeEventLogger::LogSingleType(MethodTable * pEEType)
 #endif
     //Avoid logging the same type twice, but using the hash of loggged types.
     if (s_loggedTypesHash == NULL)
-        s_loggedTypesHash = new SHash<LoggedTypesTraits>();
+        s_loggedTypesHash = new (nothrow) SHash<LoggedTypesTraits>();
+
+    if (s_loggedTypesHash == NULL)
+        return -1;
+
     MethodTable* preexistingType = s_loggedTypesHash->Lookup(pEEType);
     if (preexistingType != NULL)
     {

--- a/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
@@ -415,7 +415,7 @@ void ETW::GCLog::ForceGC(LONGLONG l64ClientSequenceNumber)
     if (!GCHeapUtilities::IsGCHeapInitialized())
         return;
 
-    InterlockedExchange64(&s_l64LastClientSequenceNumber, l64ClientSequenceNumber);
+    PalInterlockedExchange64(&s_l64LastClientSequenceNumber, l64ClientSequenceNumber);
 
     ForceGCForDiagnostics();
 }

--- a/src/coreclr/nativeaot/Runtime/profheapwalkhelper.cpp
+++ b/src/coreclr/nativeaot/Runtime/profheapwalkhelper.cpp
@@ -172,7 +172,6 @@ bool HeapWalkHelper(Object * pBO, void * pvContext)
 
     HRESULT hr = E_FAIL;
 
-#ifdef FEATURE_ETW
     if (ETW::GCLog::ShouldWalkHeapObjectsForEtw())
     {
         ETW::GCLog::ObjectReference(
@@ -182,7 +181,6 @@ bool HeapWalkHelper(Object * pBO, void * pvContext)
             cNumRefs,
             (Object **) arrObjRef);
     }
-#endif // FEATURE_ETW
 
     // If the data was not allocated on the stack, need to clean it up.
     if ((arrObjRef != NULL) && !bOnStack)

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1071,13 +1071,6 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- NativeAOT Linux specific -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'linux'">
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/**">
-            <Issue>https://github.com/dotnet/runtime/issues/116686</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
     <!-- NativeAOT arm32 specific -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetArchitecture)' == 'arm'">
         <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetTotalAllocatedBytes/**">


### PR DESCRIPTION
Fixes #116686.

Turns out the test was failing because everything involved in GCDump was disabled outside Windows.

Cc @dotnet/ilc-contrib 