### PR TITLE
Fix Thread::IsAddressInStack for interpreter

### DIFF
--- a/src/coreclr/vm/interpexec.h
+++ b/src/coreclr/vm/interpexec.h
@@ -50,14 +50,14 @@ struct InterpMethodContextFrame
 
 struct InterpThreadContext
 {
-    int8_t *pStackStart;
-    int8_t *pStackEnd;
+    PTR_INT8 pStackStart;
+    PTR_INT8 pStackEnd;
 
     // This stack pointer is the highest stack memory that can be used by the current frame. This does not
     // change throughout the execution of a frame and it is essentially the upper limit of the execution
     // stack pointer. It is needed when re-entering interp, to know from which address we can start using
     // stack, and also needed for the GC to be able to scan the stack.
-    int8_t *pStackPointer;
+    PTR_INT8 pStackPointer;
 
     FrameDataAllocator frameDataAllocator;
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7796,7 +7796,7 @@ BOOL Thread::IsAddressInCurrentStack(PTR_VOID addr)
 
 #ifdef FEATURE_INTERPRETER
     InterpThreadContext* pInterpThreadContext = currentThread->m_pInterpThreadContext;
-    if ((pInterpThreadContext != NULL) && ((PTR_VOID)pInterpThreadContext->pStackStart < addr) && (addr <= (PTR_VOID)pInterpThreadContext->pStackPointer))
+    if ((pInterpThreadContext != NULL) && ((PTR_VOID)pInterpThreadContext->pStackStart <= addr) && (addr < (PTR_VOID)pInterpThreadContext->pStackPointer))
     {
         return TRUE;
     }
@@ -7817,7 +7817,7 @@ BOOL Thread::IsAddressInStack (PTR_VOID addr) const
     _ASSERTE(m_CacheStackLimit != NULL);
     _ASSERTE(m_CacheStackLimit < m_CacheStackBase);
 #ifdef FEATURE_INTERPRETER
-    if ((m_pInterpThreadContext != NULL) && ((PTR_VOID)m_pInterpThreadContext->pStackStart < addr) && (addr <= (PTR_VOID)m_pInterpThreadContext->pStackPointer))
+    if ((m_pInterpThreadContext != NULL) && ((PTR_VOID)m_pInterpThreadContext->pStackStart <= addr) && (addr < (PTR_VOID)m_pInterpThreadContext->pStackPointer))
     {
         return TRUE;
     }

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7798,7 +7798,7 @@ BOOL Thread::IsAddressInCurrentStack(PTR_VOID addr)
     InterpThreadContext* pInterpThreadContext = currentThread->m_pInterpThreadContext;
     if ((pInterpThreadContext != NULL) && ((PTR_VOID)pInterpThreadContext->pStackStart < addr) && (addr <= (PTR_VOID)pInterpThreadContext->pStackPointer))
     {
-        return true;
+        return TRUE;
     }
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7784,7 +7784,46 @@ InterpThreadContext* Thread::GetInterpThreadContext()
 }
 #endif // FEATURE_INTERPRETER
 
+/* static */
+BOOL Thread::IsAddressInCurrentStack(PTR_VOID addr)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    Thread* currentThread = GetThreadNULLOk();
+    if (currentThread == NULL)
+    {
+        return FALSE;
+    }
+
+#ifdef FEATURE_INTERPRETER
+    InterpThreadContext* pInterpThreadContext = currentThread->m_pInterpThreadContext;
+    if ((pInterpThreadContext != NULL) && ((PTR_VOID)pInterpThreadContext->pStackStart < addr) && (addr <= (PTR_VOID)pInterpThreadContext->pStackPointer))
+    {
+        return true;
+    }
+#endif // FEATURE_INTERPRETER
+
+    PTR_VOID sp = dac_cast<PTR_VOID>(GetCurrentSP());
+    _ASSERTE(currentThread->m_CacheStackBase != NULL);
+    _ASSERTE(sp < currentThread->m_CacheStackBase);
+    return sp < addr && addr <= currentThread->m_CacheStackBase;
+}
+
 #endif // #ifndef DACCESS_COMPILE
+
+BOOL Thread::IsAddressInStack (PTR_VOID addr) const
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+    _ASSERTE(m_CacheStackBase != NULL);
+    _ASSERTE(m_CacheStackLimit != NULL);
+    _ASSERTE(m_CacheStackLimit < m_CacheStackBase);
+#ifdef FEATURE_INTERPRETER
+    if ((m_pInterpThreadContext != NULL) && ((PTR_VOID)m_pInterpThreadContext->pStackStart < addr) && (addr <= (PTR_VOID)m_pInterpThreadContext->pStackPointer))
+    {
+        return TRUE;
+    }
+#endif // FEATURE_INTERPRETER
+    return m_CacheStackLimit < addr && addr <= m_CacheStackBase;
+}
 
 #ifdef DACCESS_COMPILE
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -2485,29 +2485,8 @@ public:
 public:
     static BOOL UniqueStack(void* startLoc = 0);
 
-    BOOL IsAddressInStack (PTR_VOID addr) const
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        _ASSERTE(m_CacheStackBase != NULL);
-        _ASSERTE(m_CacheStackLimit != NULL);
-        _ASSERTE(m_CacheStackLimit < m_CacheStackBase);
-        return m_CacheStackLimit < addr && addr <= m_CacheStackBase;
-    }
-
-    static BOOL IsAddressInCurrentStack (PTR_VOID addr)
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        Thread* currentThread = GetThreadNULLOk();
-        if (currentThread == NULL)
-        {
-            return FALSE;
-        }
-
-        PTR_VOID sp = dac_cast<PTR_VOID>(GetCurrentSP());
-        _ASSERTE(currentThread->m_CacheStackBase != NULL);
-        _ASSERTE(sp < currentThread->m_CacheStackBase);
-        return sp < addr && addr <= currentThread->m_CacheStackBase;
-    }
+    BOOL IsAddressInStack (PTR_VOID addr) const;
+    static BOOL IsAddressInCurrentStack (PTR_VOID addr);
 
     // DetermineIfGuardPagePresent returns TRUE if the thread's stack contains a proper guard page. This function
     // makes a physical check of the stack, rather than relying on whether or not the CLR is currently processing a


### PR DESCRIPTION
The check is used at several places to verify that e.g. `StringHandleOnStack` is really on stack. It needs to be updated to take the interpreter stack into account too.