### PR TITLE
Fix FrameworkDependentAppLaunch.AppHost_GlobalLocation 'Failed to restore file' CI failure

### DIFF
--- a/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
@@ -187,28 +187,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             if (Binaries.CetCompat.IsSupported)
                 Assert.True(Binaries.CetCompat.IsMarkedCompatible(appExe));
 
-            // Get the framework location that was built
-            string builtDotnet = TestContext.BuiltDotNet.BinPath;
-
-            // Verify running with the default working directory
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(builtDotnet, TestContext.BuildArchitecture)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath, TestContext.BuildArchitecture)
                 .MultilevelLookup(false)
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
-
-
-            // Verify running from within the working directory
-            Command.Create(appExe)
-                .WorkingDirectory(sharedTestState.App.Location)
-                .DotNetRoot(builtDotnet, TestContext.BuildArchitecture)
-                .MultilevelLookup(false)
-                .CaptureStdErr()
-                .CaptureStdOut()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
@@ -233,26 +216,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] { (architecture, builtDotnet) });
                 }
 
-                // Verify running with the default working directory
                 Command.Create(appExe)
                     .CaptureStdErr()
                     .CaptureStdOut()
                     .MultilevelLookup(false)
-                    .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
-                    .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
-                    .DotNetRoot(null)
-                    .Execute()
-                    .Should().Pass()
-                    .And.HaveStdOutContaining("Hello World")
-                    .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion)
-                    .And.NotHaveStdErr();
-
-                // Verify running from within the working directory
-                Command.Create(appExe)
-                    .CaptureStdErr()
-                    .CaptureStdOut()
-                    .MultilevelLookup(false)
-                    .WorkingDirectory(sharedTestState.App.Location)
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
                     .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
                     .DotNetRoot(null)

--- a/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
@@ -198,39 +198,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void AppHost_GlobalLocation(bool useRegisteredLocation)
-        {
-            string appExe = sharedTestState.App.AppExe;
-
-            // Get the framework location that was built
-            string builtDotnet = TestContext.BuiltDotNet.BinPath;
-
-            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(appExe))
-            {
-                string architecture = TestContext.BuildArchitecture;
-                if (useRegisteredLocation)
-                {
-                    registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] { (architecture, builtDotnet) });
-                }
-
-                Command.Create(appExe)
-                    .CaptureStdErr()
-                    .CaptureStdOut()
-                    .MultilevelLookup(false)
-                    .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
-                    .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
-                    .DotNetRoot(null)
-                    .Execute()
-                    .Should().Pass()
-                    .And.HaveStdOutContaining("Hello World")
-                    .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion)
-                    .And.NotHaveStdErr();
-            }
-        }
-
         [ConditionalFact(typeof(Binaries.CetCompat), nameof(Binaries.CetCompat.IsSupported))]
         public void AppHost_DisableCetCompat()
         {

--- a/src/installer/tests/TestUtils/TestFileBackup.cs
+++ b/src/installer/tests/TestUtils/TestFileBackup.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
         }
 
-        private static void RetryOnIOError(Func<bool> action, string errorMessage, int maxRetries = 5)
+        private static void RetryOnIOError(Func<bool> action, string errorMessage, int maxRetries = 25)
         {
             IOException exception = null;
             for (int i = 0; i < maxRetries; i++)
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                         return;
                     }
                 }
-                catch (IOException e) 
+                catch (IOException e)
                 {
                     exception = e;
                 }


### PR DESCRIPTION
We're hitting an intermittent failure (particularly on Debug) trying to copy over files immediately after the process exits. Since this passes the majority of the time, it does not seem to indicate an actual issue where the files are left in use.

- Increase the existing retry we have for doing this restore
- Move tests to `InstallLocation` test class as it fits better there (testing registered and default install locations)
- Make `InstallLocation` test class create one app with test behaviour enabled instead of repeatedly doing it in half of its tests cases.

This also removes explicitly running the app with the app directory as the working directory, which doesn't seem interesting for us to keep testing.

Fixes https://github.com/dotnet/runtime/issues/115851

cc @dotnet/appmodel @AaronRobinsonMSFT 