### PR TITLE
[Json] Remove unnecessary Debug.Asserts

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonArrayConverter.cs
@@ -31,7 +31,6 @@ namespace System.Text.Json.Serialization.Converters
                 case JsonTokenType.Null:
                     return null;
                 default:
-                    Debug.Assert(false);
                     throw ThrowHelper.GetInvalidOperationException_ExpectedArray(reader.TokenType);
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
@@ -69,7 +69,6 @@ namespace System.Text.Json.Serialization.Converters
                 case JsonTokenType.Null:
                     return null;
                 default:
-                    Debug.Assert(false);
                     throw ThrowHelper.GetInvalidOperationException_ExpectedObject(reader.TokenType);
             }
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
@@ -889,5 +889,13 @@ namespace System.Text.Json.Nodes.Tests
 
             static JsonArray PrepareData() => JsonSerializer.Deserialize<JsonArray>("[1,2,3,4,5]");
         }
+
+        [Theory]
+        [InlineData("42")]
+        [InlineData("{}")]
+        public static void Deserialize_WrongType(string json)
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<JsonArray>(json));
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonObjectTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonObjectTests.cs
@@ -1718,5 +1718,13 @@ namespace System.Text.Json.Nodes.Tests
                 () => JsonSerializer.Deserialize<JsonNode>(jsonPayload, options),
                 "An item with the same key has already been added.");
         }
+
+        [Theory]
+        [InlineData("42")]
+        [InlineData("[]")]
+        public static void Deserialize_WrongType(string json)
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<JsonObject>(json));
+        }
     }
 }


### PR DESCRIPTION
These `Debug.Asserts` are over-aggressive. It's perfectly valid to do something like `JsonSerializer.Deserialize<JsonArray>("\"str\":\"value\"");`. And we will get a `JsonException` in non-debug builds.