### PR TITLE
Update CoreCLR interpreter float->int saturation to match JIT

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -167,15 +167,19 @@ template <typename THelper> static THelper GetPossiblyIndirectHelper(void* dataI
         return (THelper)helperDirectOrIndirect;
 }
 
-template <typename TResult, typename TSource> static void ConvFpHelper(int8_t *stack, const int32_t *ip)
+// At present our behavior for float to int conversions is to perform a saturating conversion down to either 32 or 64 bits
+//  and then perform an unchecked truncation from that intermediate size down to the actual result size.
+// See https://github.com/dotnet/runtime/issues/116823
+template <typename TResult, typename TIntermediate, typename TSource> static void ConvFpHelper(int8_t *stack, const int32_t *ip)
 {
     static_assert(!std::numeric_limits<TSource>::is_integer, "ConvFpHelper is only for use on floats and doubles");
+    static_assert(sizeof(TIntermediate) >= sizeof(TResult), "Intermediate type must not be smaller than result type");
     static_assert(std::numeric_limits<TResult>::is_integer, "ConvFpHelper is only for use on floats and doubles to be converted to integers");
 
     // First, promote the source value to double
     double src = LOCAL_VAR(ip[2], TSource),
-        minValue = (double)std::numeric_limits<TResult>::lowest(),
-        maxValue = (double)std::numeric_limits<TResult>::max();
+        minValue = (double)std::numeric_limits<TIntermediate>::lowest(),
+        maxValue = (double)std::numeric_limits<TIntermediate>::max();
 
     // (src != src) checks for NaN, then we check whether the min and max values (as represented by their closest double)
     //  properly bound the source value so that when it is truncated it will be in range
@@ -184,13 +188,13 @@ template <typename TResult, typename TSource> static void ConvFpHelper(int8_t *s
     if (src != src)
         result = 0;
     else if (src >= maxValue)
-        result = std::numeric_limits<TResult>::max();
-    else if (!std::numeric_limits<TResult>::is_signed && (src <= -1))
+        result = (TResult)std::numeric_limits<TIntermediate>::max();
+    else if (!std::numeric_limits<TIntermediate>::is_signed && (src <= -1))
         result = 0;
-    else if (std::numeric_limits<TResult>::is_signed && (src < minValue))
-        result = std::numeric_limits<TResult>::lowest();
+    else if (std::numeric_limits<TIntermediate>::is_signed && (src < minValue))
+        result = (TResult)std::numeric_limits<TIntermediate>::lowest();
     else
-        result = (TResult)src;
+        result = (TResult)(TIntermediate)src;
 
     // According to spec, for result types smaller than int32, we store them on the stack as int32
     if (sizeof(TResult) >= 4)
@@ -459,11 +463,11 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_I1_R4:
-                    ConvFpHelper<int8_t, float>(stack, ip);
+                    ConvFpHelper<int8_t, int32_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I1_R8:
-                    ConvFpHelper<int8_t, double>(stack, ip);
+                    ConvFpHelper<int8_t, int32_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U1_I4:
@@ -475,11 +479,11 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_U1_R4:
-                    ConvFpHelper<uint8_t, float>(stack, ip);
+                    ConvFpHelper<uint8_t, uint32_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U1_R8:
-                    ConvFpHelper<uint8_t, double>(stack, ip);
+                    ConvFpHelper<uint8_t, uint32_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I2_I4:
@@ -491,11 +495,11 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_I2_R4:
-                    ConvFpHelper<int16_t, float>(stack, ip);
+                    ConvFpHelper<int16_t, int32_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I2_R8:
-                    ConvFpHelper<int16_t, double>(stack, ip);
+                    ConvFpHelper<int16_t, int32_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U2_I4:
@@ -507,27 +511,27 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_U2_R4:
-                    ConvFpHelper<uint16_t, float>(stack, ip);
+                    ConvFpHelper<uint16_t, uint32_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U2_R8:
-                    ConvFpHelper<uint16_t, float>(stack, ip);
+                    ConvFpHelper<uint16_t, uint32_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I4_R4:
-                    ConvFpHelper<int32_t, float>(stack, ip);
+                    ConvFpHelper<int32_t, int32_t, float>(stack, ip);
                     ip += 3;
                     break;;
                 case INTOP_CONV_I4_R8:
-                    ConvFpHelper<int32_t, double>(stack, ip);
+                    ConvFpHelper<int32_t, int32_t, double>(stack, ip);
                     ip += 3;
                     break;;
                 case INTOP_CONV_U4_R4:
-                    ConvFpHelper<uint32_t, float>(stack, ip);
+                    ConvFpHelper<uint32_t, uint32_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U4_R8:
-                    ConvFpHelper<uint32_t, double>(stack, ip);
+                    ConvFpHelper<uint32_t, uint32_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I8_I4:
@@ -539,11 +543,11 @@ MAIN_LOOP:
                     ip += 3;
                     break;;
                 case INTOP_CONV_I8_R4:
-                    ConvFpHelper<int64_t, float>(stack, ip);
+                    ConvFpHelper<int64_t, int64_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I8_R8:
-                    ConvFpHelper<int64_t, double>(stack, ip);
+                    ConvFpHelper<int64_t, int64_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_R4_I4:
@@ -571,11 +575,11 @@ MAIN_LOOP:
                     ip += 3;
                     break;
                 case INTOP_CONV_U8_R4:
-                    ConvFpHelper<uint64_t, float>(stack, ip);
+                    ConvFpHelper<uint64_t, uint64_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U8_R8:
-                    ConvFpHelper<uint64_t, double>(stack, ip);
+                    ConvFpHelper<uint64_t, uint64_t, double>(stack, ip);
                     ip += 3;
                     break;
 

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -1573,8 +1573,11 @@ public class InterpreterTest
             int c = (int)inRangeInt,
                 d = (int)outOfRangeInt;
 
-            if (a != b)
+            // See https://github.com/dotnet/runtime/issues/116823 - they should *not* currently match if target size is smaller than int32
+            // if (a != b)
+            if (a == b)
                 return false;
+
             if (c != d)
                 return false;
         }

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -522,9 +522,6 @@
 
     <!-- Crossgen2 specific -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TestBuildMode)' == 'crossgen2' or '$(TestBuildMode)' == 'crossgen') and '$(RuntimeFlavor)' == 'coreclr'">
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/interpreter/InterpreterTester/*">
-            <Issue>https://github.com/dotnet/runtime/issues/116823</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/IJW/NativeVarargs/NativeVarargsTest/*">
             <Issue>https://github.com/dotnet/runtime/issues/83942</Issue>
         </ExcludeList>


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/116823
The test for this was causing outerloop failures because the interpreter's expected behavior does not match ryujit. The best course of action right now is to make the interpreter match ryujit so the test can be re-enabled on outerloop.