### PR TITLE
Use emitLastGroup that works for single/multi align instructions

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2856,8 +2856,9 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
     {
 #if FEATURE_LOOP_ALIGN
 
-        if (!currIGWasNonEmpty && (emitAlignLast != nullptr) && (emitAlignLast->idaLoopHeadPredIG != nullptr) &&
-            (emitAlignLast->idaLoopHeadPredIG->igNext == emitCurIG))
+        if (!currIGWasNonEmpty && (emitAlignLastGroup != nullptr) &&
+            (emitAlignLastGroup->idaLoopHeadPredIG != nullptr) &&
+            (emitAlignLastGroup->idaLoopHeadPredIG->igNext == emitCurIG))
         {
             // If the emitCurIG was thought to be a loop-head, but if it didn't turn out that way and we end up
             // creating a new IG from which the loop starts, make sure to update the LoopHeadPred of last align
@@ -2865,7 +2866,7 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
             // notice a loop that encloses another loop, this information helps in removing the align field from
             // such loops.
             // We need to only update emitAlignLast because we do not align intermingled or overlapping loops.
-            emitAlignLast->idaLoopHeadPredIG = emitCurIG;
+            emitAlignLastGroup->idaLoopHeadPredIG = emitCurIG;
         }
 #endif // FEATURE_LOOP_ALIGN
 


### PR DESCRIPTION
In https://github.com/dotnet/runtime/issues/114569, I was relying on `emitAlignLast` to update the pred head, if we end up creating an extra IG. However, for arm64, since we emit 4 align instructions and just keep the first of those align instructions with updates, it is not accurate to rely on `emitAlignLast` because it points to the last of the 4 align instructions. Instead use `emitAlignLastGroup` which is more accurate and designed for such purposes.

Fixes: https://github.com/dotnet/runtime/issues/116836