### PR TITLE
Arm64 SVE: re-enable use of predicate variants

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3205,7 +3205,7 @@ public:
                                     unsigned    simdSize);
 
 #if defined(FEATURE_MASKED_HW_INTRINSICS)
-    GenTree* gtNewSimdCvtVectorToMaskNode(var_types type, GenTree* op1, CorInfoType simdBaseJitType, unsigned simdSize);
+    GenTreeHWIntrinsic* gtNewSimdCvtVectorToMaskNode(var_types type, GenTree* op1, CorInfoType simdBaseJitType, unsigned simdSize);
 #endif // FEATURE_MASKED_HW_INTRINSICS
 
     GenTree* gtNewSimdCreateBroadcastNode(
@@ -6713,8 +6713,7 @@ private:
     GenTreeHWIntrinsic* fgOptimizeForMaskedIntrinsic(GenTreeHWIntrinsic* node);
 #endif // FEATURE_MASKED_HW_INTRINSICS
 #ifdef TARGET_ARM64
-    bool canMorphVectorOperandToMask(GenTree* node);
-    bool canMorphAllVectorOperandsToMasks(GenTreeHWIntrinsic* node);
+    void costMorphVectorOperandToMask(GenTree* node, GenTreeHWIntrinsic* parent, weight_t *currentCost, weight_t *switchCost);
     GenTree* doMorphVectorOperandToMask(GenTree* node, GenTreeHWIntrinsic* parent);
     GenTreeHWIntrinsic* fgMorphTryUseAllMaskVariant(GenTreeHWIntrinsic* node);
 #endif // TARGET_ARM64

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6713,7 +6713,7 @@ private:
     GenTreeHWIntrinsic* fgOptimizeForMaskedIntrinsic(GenTreeHWIntrinsic* node);
 #endif // FEATURE_MASKED_HW_INTRINSICS
 #ifdef TARGET_ARM64
-    void costMorphVectorOperandToMask(GenTree* node, GenTreeHWIntrinsic* parent, weight_t *currentCost, weight_t *switchCost);
+    void getVectorMaskVariantWeights(GenTree* node, GenTreeHWIntrinsic* parent, weight_t *currentCost, weight_t *switchCost);
     GenTree* doMorphVectorOperandToMask(GenTree* node, GenTreeHWIntrinsic* parent);
     GenTreeHWIntrinsic* fgMorphTryUseAllMaskVariant(GenTreeHWIntrinsic* node);
 #endif // TARGET_ARM64

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -21947,10 +21947,10 @@ GenTree* Compiler::gtNewSimdCvtNativeNode(var_types   type,
 // Return Value:
 //    The node converted to the a mask type
 //
-GenTree* Compiler::gtNewSimdCvtVectorToMaskNode(var_types   type,
-                                                GenTree*    op1,
-                                                CorInfoType simdBaseJitType,
-                                                unsigned    simdSize)
+GenTreeHWIntrinsic* Compiler::gtNewSimdCvtVectorToMaskNode(var_types   type,
+                                                           GenTree*    op1,
+                                                           CorInfoType simdBaseJitType,
+                                                           unsigned    simdSize)
 {
     assert(varTypeIsMask(type));
     assert(varTypeIsSIMD(op1));

--- a/src/coreclr/jit/simd.h
+++ b/src/coreclr/jit/simd.h
@@ -1906,7 +1906,7 @@ SveMaskPattern EvaluateSimdMaskToPattern(simdmask_t arg0)
     memcpy(&mask, &arg0.u8[0], sizeof(uint64_t));
     uint32_t finalOne = count;
 
-    // A mask pattern starts with zero of more 1s and then the rest of the mask is filled with 0s.
+    // A mask pattern starts with zero or more 1s and then the rest of the mask is filled with 0s.
 
     // Find an unbroken sequence of 1s.
     for (uint32_t i = 0; i < count; i++)
@@ -1985,6 +1985,104 @@ SveMaskPattern EvaluateSimdMaskToPattern(var_types baseType, simdmask_t arg0)
         case TYP_USHORT:
         {
             return EvaluateSimdMaskToPattern<TSimd, uint16_t>(arg0);
+        }
+
+        default:
+        {
+            unreached();
+        }
+    }
+}
+
+template <typename TSimd, typename TBase>
+SveMaskPattern EvaluateSimdVectorToPattern(TSimd arg0)
+{
+    uint32_t count    = sizeof(TSimd) / sizeof(TBase);
+    uint32_t finalOne = count;
+
+    // A mask pattern starts with zero or more 1s and then the rest of the mask is filled with 0s.
+    // This pattern is extracted using the least significant bits of the vector elements.
+
+    // Find an unbroken sequence of 1s.
+    for (uint32_t i = 0; i < count; i++)
+    {
+        TBase input0;
+        memcpy(&input0, &arg0.u8[i * sizeof(TBase)], sizeof(TBase));
+
+        // For Arm64 we have count total bits to read, but
+        // they are sizeof(TBase) bits apart. We set
+        // depending on if the corresponding input element
+        // has its least significant bit set
+
+        bool isSet = static_cast<uint64_t>(1) << (i * sizeof(TBase));
+        if (!isSet)
+        {
+            finalOne = i;
+            break;
+        }
+    }
+
+    // Find an unbroken sequence of 0s.
+    for (uint32_t i = finalOne; i < count; i++)
+    {
+        // For Arm64 we have count total bits to read, but
+        // they are sizeof(TBase) bits apart. We set
+        // depending on if the corresponding input element
+        // has its least significant bit set
+
+        bool isSet = static_cast<uint64_t>(1) << (i * sizeof(TBase));
+        if (isSet)
+        {
+            // Invalid sequence
+            return SveMaskPatternNone;
+        }
+    }
+
+    if (finalOne == count)
+    {
+        return SveMaskPatternAll;
+    }
+    else if (finalOne >= SveMaskPatternVectorCount1 && finalOne <= SveMaskPatternVectorCount8)
+    {
+        return (SveMaskPattern)finalOne;
+    }
+    else
+    {
+        // TODO: Add other patterns as required. These probably won't be seen until we get
+        //       to wider vector lengths.
+        return SveMaskPatternNone;
+    }
+}
+
+template <typename TSimd>
+SveMaskPattern EvaluateSimdVectorToPattern(var_types baseType, TSimd arg0)
+{
+    switch (baseType)
+    {
+        case TYP_FLOAT:
+        case TYP_INT:
+        case TYP_UINT:
+        {
+            return EvaluateSimdVectorToPattern<TSimd, uint32_t>(arg0);
+        }
+
+        case TYP_DOUBLE:
+        case TYP_LONG:
+        case TYP_ULONG:
+        {
+            return EvaluateSimdVectorToPattern<TSimd, uint64_t>(arg0);
+        }
+
+        case TYP_BYTE:
+        case TYP_UBYTE:
+        {
+            return EvaluateSimdVectorToPattern<TSimd, uint8_t>(arg0);
+        }
+
+        case TYP_SHORT:
+        case TYP_USHORT:
+        {
+            return EvaluateSimdVectorToPattern<TSimd, uint16_t>(arg0);
         }
 
         default:

--- a/src/coreclr/jit/simd.h
+++ b/src/coreclr/jit/simd.h
@@ -2014,7 +2014,8 @@ SveMaskPattern EvaluateSimdVectorToPattern(TSimd arg0)
         TBase input0;
         memcpy(&input0, &arg0.u8[i * sizeof(TBase)], sizeof(TBase));
 
-        if ((input0 & significantBit) != 0)
+        bool isSet = (input0 & significantBit) != 0;
+        if (!isSet)
         {
             finalOne = i;
             break;
@@ -2027,7 +2028,8 @@ SveMaskPattern EvaluateSimdVectorToPattern(TSimd arg0)
         TBase input0;
         memcpy(&input0, &arg0.u8[i * sizeof(TBase)], sizeof(TBase));
 
-        if ((input0 & significantBit) != 0)
+        bool isSet = (input0 & significantBit) != 0;
+        if (isSet)
         {
             // Invalid sequence
             return SveMaskPatternNone;

--- a/src/coreclr/jit/simd.h
+++ b/src/coreclr/jit/simd.h
@@ -1598,9 +1598,8 @@ void EvaluateSimdCvtVectorToMask(simdmask_t* result, TSimd arg0)
     uint32_t count = sizeof(TSimd) / sizeof(TBase);
     uint64_t mask  = 0;
 
-    TBase significantBit = 1;
 #if defined(TARGET_XARCH)
-    significantBit = static_cast<TBase>(1) << ((sizeof(TBase) * 8) - 1);
+    TBase significantBit = static_cast<TBase>(1) << ((sizeof(TBase) * 8) - 1);
 #endif
 
     for (uint32_t i = 0; i < count; i++)
@@ -1608,25 +1607,24 @@ void EvaluateSimdCvtVectorToMask(simdmask_t* result, TSimd arg0)
         TBase input0;
         memcpy(&input0, &arg0.u8[i * sizeof(TBase)], sizeof(TBase));
 
+#if defined(TARGET_XARCH)
+        // For xarch we have count sequential bits to write depending on if the
+        // corresponding the input element has its most significant bit set
         if ((input0 & significantBit) != 0)
         {
-#if defined(TARGET_XARCH)
-            // For xarch we have count sequential bits to write
-            // depending on if the corresponding the input element
-            // has its most significant bit set
-
             mask |= static_cast<uint64_t>(1) << i;
-#elif defined(TARGET_ARM64)
-            // For Arm64 we have count total bits to write, but
-            // they are sizeof(TBase) bits apart. We set
-            // depending on if the corresponding input element
-            // has its least significant bit set
-
-            mask |= static_cast<uint64_t>(1) << (i * sizeof(TBase));
-#else
-            unreached();
-#endif
         }
+#elif defined(TARGET_ARM64)
+        // For Arm64 we have count total bits to write, but they are sizeof(TBase)
+        // bits apart. We set depending on if the corresponding input element has
+        // any bit set (this matches the use of cmpne in outputted assembly).
+        if (input0 != 0)
+        {
+            mask |= static_cast<uint64_t>(1) << (i * sizeof(TBase));
+        }
+#else
+        unreached();
+#endif
     }
 
     memcpy(&result->u8[0], &mask, sizeof(uint64_t));
@@ -2000,13 +1998,12 @@ SveMaskPattern EvaluateSimdVectorToPattern(TSimd arg0)
     uint32_t count    = sizeof(TSimd) / sizeof(TBase);
     uint32_t finalOne = count;
 
-    TBase significantBit = 1;
-
     // A mask pattern starts with zero or more 1s and then the rest of the mask is filled with 0s.
     // This pattern is extracted using the least significant bits of the vector elements.
 
     // For Arm64 we have count total bits to read, but they are sizeof(TBase) bits apart. We set
-    // depending on if the corresponding input element has its least significant bit set
+    // depending on if the corresponding input element has any bit set (this matches the use
+    // of cmpne in outputted assembly)
 
     // Find an unbroken sequence of 1s.
     for (uint32_t i = 0; i < count; i++)
@@ -2014,7 +2011,7 @@ SveMaskPattern EvaluateSimdVectorToPattern(TSimd arg0)
         TBase input0;
         memcpy(&input0, &arg0.u8[i * sizeof(TBase)], sizeof(TBase));
 
-        bool isSet = (input0 & significantBit) != 0;
+        bool isSet = input0 != 0;
         if (!isSet)
         {
             finalOne = i;
@@ -2028,7 +2025,7 @@ SveMaskPattern EvaluateSimdVectorToPattern(TSimd arg0)
         TBase input0;
         memcpy(&input0, &arg0.u8[i * sizeof(TBase)], sizeof(TBase));
 
-        bool isSet = (input0 & significantBit) != 0;
+        bool isSet = input0 != 0;
         if (isSet)
         {
             // Invalid sequence

--- a/src/tests/JIT/opt/SVE/PredicateInstructions.cs
+++ b/src/tests/JIT/opt/SVE/PredicateInstructions.cs
@@ -17,66 +17,98 @@ public class PredicateInstructions
     {
         if (Sve.IsSupported)
         {
+            Vector<short> vecs  = Vector.Create<short>(2);
+            Vector<int>   veci  = Vector.Create<int>(3);
+            Vector<uint>  vecui = Vector.Create<uint>(5);
+            Vector<long>  vecl  = Vector.Create<long>(7);
+
             ZipLow();
-            ZipHigh();
+            ZipHigh(vecui);
             UnzipOdd();
             UnzipEven();
             TransposeOdd();
-            TransposeEven();
+            TransposeEven(vecl);
             ReverseElement();
             And();
             BitwiseClear();
             Xor();
             Or();
-            ConditionalSelect();
+            ConditionalSelect(veci);
+
+            ZipLowMask();
+            ZipHighMask(vecui);
+            UnzipOddMask();
+            UnzipEvenMask();
+            TransposeOddMask();
+            TransposeEvenMask(vecl);
+            ReverseElementMask();
+            AndMask();
+            BitwiseClearMask();
+            XorMask();
+            OrMask();
+            ConditionalSelectMask(veci);
+
+            UnzipEvenZipLowMask();
+            TransposeEvenAndMask(vecs);
+
         }
     }
+
+    // These should not use the predicate variants
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<short> ZipLow()
     {
+        //ARM64-FULL-LINE: zip1 {{z[0-9]+}}.h, {{z[0-9]+}}.h, {{z[0-9]+}}.h
         return Sve.ZipLow(Vector<short>.Zero, Sve.CreateTrueMaskInt16());
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static Vector<uint> ZipHigh()
+    static Vector<uint> ZipHigh(Vector<uint> v)
     {
-        return Sve.ZipHigh(Sve.CreateTrueMaskUInt32(), Sve.CreateTrueMaskUInt32());
+        //ARM64-FULL-LINE: zip2 {{z[0-9]+}}.s, {{z[0-9]+}}.s, {{z[0-9]+}}.s
+        return Sve.ZipHigh(Sve.CreateTrueMaskUInt32(), v);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<sbyte> UnzipEven()
     {
+        //ARM64-FULL-LINE: uzp1 {{z[0-9]+}}.b, {{z[0-9]+}}.b, {{z[0-9]+}}.b
         return Sve.UnzipEven(Sve.CreateTrueMaskSByte(), Vector<sbyte>.Zero);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<short> UnzipOdd()
     {
+        //ARM64-FULL-LINE: uzp2 {{z[0-9]+}}.h, {{z[0-9]+}}.h, {{z[0-9]+}}.h
         return Sve.UnzipOdd(Sve.CreateTrueMaskInt16(), Sve.CreateFalseMaskInt16());
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static Vector<long> TransposeEven()
+    static Vector<long> TransposeEven(Vector<long> v)
     {
-        return Sve.TransposeEven(Sve.CreateFalseMaskInt64(), Sve.CreateTrueMaskInt64());
+        //ARM64-FULL-LINE: trn1 {{z[0-9]+}}.d, {{z[0-9]+}}.d, {{z[0-9]+}}.d
+        return Sve.TransposeEven(v, Sve.CreateTrueMaskInt64());
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<short> TransposeOdd()
     {
+        //ARM64-FULL-LINE: trn2 {{z[0-9]+}}.h, {{z[0-9]+}}.h, {{z[0-9]+}}.h
         return Sve.TransposeOdd(Vector<short>.Zero, Sve.CreateTrueMaskInt16());
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<short> ReverseElement()
     {
+        //ARM64-FULL-LINE: rev {{z[0-9]+}}.h, {{z[0-9]+}}.h
         return Sve.ReverseElement(Sve.CreateTrueMaskInt16());
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<short> And()
     {
+        //ARM64-FULL-LINE: and {{z[0-9]+}}.h, {{z[0-9]+}}.h, {{z[0-9]+}}.h
         return Sve.ConditionalSelect(
             Sve.CreateTrueMaskInt16(),
             Sve.And(Sve.CreateTrueMaskInt16(), Sve.CreateTrueMaskInt16()),
@@ -87,8 +119,9 @@ public class PredicateInstructions
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<short> BitwiseClear()
     {
+        //ARM64-FULL-LINE: bic {{z[0-9]+}}.h, {{p[0-9]+}}/m, {{z[0-9]+}}.h, {{z[0-9]+}}.h
         return Sve.ConditionalSelect(
-            Sve.CreateFalseMaskInt16(),
+            Sve.CreateTrueMaskInt16(SveMaskPattern.VectorCount1),
             Sve.BitwiseClear(Sve.CreateTrueMaskInt16(), Sve.CreateTrueMaskInt16()),
             Vector<short>.Zero
         );
@@ -97,8 +130,9 @@ public class PredicateInstructions
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<int> Xor()
     {
+        //ARM64-FULL-LINE: eor {{z[0-9]+}}.s, {{p[0-9]+}}/m, {{z[0-9]+}}.s, {{z[0-9]+}}.s
         return Sve.ConditionalSelect(
-            Sve.CreateTrueMaskInt32(),
+            Sve.CreateTrueMaskInt32(SveMaskPattern.VectorCount3),
             Sve.Xor(Sve.CreateTrueMaskInt32(), Sve.CreateTrueMaskInt32()),
             Vector<int>.Zero
         );
@@ -107,20 +141,156 @@ public class PredicateInstructions
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<short> Or()
     {
+        //ARM64-FULL-LINE: orr {{z[0-9]+}}.h, {{p[0-9]+}}/m, {{z[0-9]+}}.h, {{z[0-9]+}}.h
         return Sve.ConditionalSelect(
-            Sve.CreateTrueMaskInt16(),
+            Sve.CreateTrueMaskInt16(SveMaskPattern.VectorCount1),
             Sve.Or(Sve.CreateTrueMaskInt16(), Sve.CreateTrueMaskInt16()),
             Vector<short>.Zero
         );
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static Vector<int> ConditionalSelect()
+    static Vector<int> ConditionalSelect(Vector<int> v)
     {
+        // Use a passed in vector for the mask to prevent optimising away the select
+        //ARM64-FULL-LINE: sel {{z[0-9]+}}.s, {{p[0-9]+}}, {{z[0-9]+}}.s, {{z[0-9]+}}.s
         return Sve.ConditionalSelect(
-            Vector<int>.Zero,
+            v,
             Sve.CreateFalseMaskInt32(),
             Sve.CreateTrueMaskInt32()
         );
+    }
+
+
+    // These should use the predicate variants.
+    // CreateBreakAfterMask is used as the first argument is a predicate.
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<short> ZipLowMask()
+    {
+        //ARM64-FULL-LINE: zip1 {{p[0-9]+}}.h, {{p[0-9]+}}.h, {{p[0-9]+}}.h
+        return Sve.CreateBreakAfterMask(Sve.ZipLow(Vector<short>.Zero, Sve.CreateTrueMaskInt16()), Sve.CreateTrueMaskInt16());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<uint> ZipHighMask(Vector<uint> v)
+    {
+        //ARM64-FULL-LINE: zip2 {{p[0-9]+}}.s, {{p[0-9]+}}.s, {{p[0-9]+}}.s
+        return Sve.CreateBreakAfterMask(Sve.ZipHigh(Sve.CreateTrueMaskUInt32(), v), Sve.CreateTrueMaskUInt32());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<sbyte> UnzipEvenMask()
+    {
+        //ARM64-FULL-LINE: uzp1 {{p[0-9]+}}.b, {{p[0-9]+}}.b, {{p[0-9]+}}.b
+        return Sve.CreateBreakAfterMask(Sve.UnzipEven(Sve.CreateTrueMaskSByte(), Vector<sbyte>.Zero), Sve.CreateTrueMaskSByte());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<short> UnzipOddMask()
+    {
+        //ARM64-FULL-LINE: uzp2 {{p[0-9]+}}.h, {{p[0-9]+}}.h, {{p[0-9]+}}.h
+        return Sve.CreateBreakAfterMask(Sve.UnzipOdd(Sve.CreateTrueMaskInt16(), Sve.CreateFalseMaskInt16()), Sve.CreateTrueMaskInt16());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<long> TransposeEvenMask(Vector<long> v)
+    {
+        //ARM64-FULL-LINE: trn1 {{p[0-9]+}}.d, {{p[0-9]+}}.d, {{p[0-9]+}}.d
+        return Sve.CreateBreakAfterMask(Sve.TransposeEven(v, Sve.CreateTrueMaskInt64()), Sve.CreateFalseMaskInt64());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<short> TransposeOddMask()
+    {
+        //ARM64-FULL-LINE: trn2 {{p[0-9]+}}.h, {{p[0-9]+}}.h, {{p[0-9]+}}.h
+        return Sve.CreateBreakAfterMask(Sve.TransposeOdd(Vector<short>.Zero, Sve.CreateTrueMaskInt16()), Sve.CreateTrueMaskInt16());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<short> ReverseElementMask()
+    {
+        //ARM64-FULL-LINE: rev {{p[0-9]+}}.h, {{p[0-9]+}}.h
+        return Sve.CreateBreakAfterMask(Sve.ReverseElement(Sve.CreateTrueMaskInt16()), Sve.CreateFalseMaskInt16());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<short> AndMask()
+    {
+        //ARM64-FULL-LINE: and {{p[0-9]+}}.b, {{p[0-9]+}}/z, {{p[0-9]+}}.b, {{p[0-9]+}}.b
+        return Sve.CreateBreakAfterMask(Sve.ConditionalSelect(
+            Sve.CreateTrueMaskInt16(),
+            Sve.And(Sve.CreateTrueMaskInt16(), Sve.CreateTrueMaskInt16()),
+            Vector<short>.Zero
+        ), Sve.CreateFalseMaskInt16());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<short> BitwiseClearMask()
+    {
+        //ARM64-FULL-LINE: bic {{p[0-9]+}}.b, {{p[0-9]+}}/z, {{p[0-9]+}}.b, {{p[0-9]+}}.b
+        return Sve.CreateBreakAfterMask(Sve.ConditionalSelect(
+            Sve.CreateTrueMaskInt16(),
+            Sve.BitwiseClear(Sve.CreateTrueMaskInt16(), Sve.CreateTrueMaskInt16()),
+            Vector<short>.Zero
+        ), Sve.CreateFalseMaskInt16());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<int> XorMask()
+    {
+        //ARM64-FULL-LINE: eor {{p[0-9]+}}.b, {{p[0-9]+}}/z, {{p[0-9]+}}.b, {{p[0-9]+}}.b
+        return Sve.CreateBreakAfterMask(Sve.ConditionalSelect(
+            Sve.CreateTrueMaskInt32(),
+            Sve.Xor(Sve.CreateTrueMaskInt32(), Sve.CreateTrueMaskInt32()),
+            Vector<int>.Zero
+        ), Sve.CreateFalseMaskInt32());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<short> OrMask()
+    {
+        //ARM64-FULL-LINE: orr {{p[0-9]+}}.b, {{p[0-9]+}}/z, {{p[0-9]+}}.b, {{p[0-9]+}}.b
+        return Sve.CreateBreakAfterMask(Sve.ConditionalSelect(
+            Sve.CreateTrueMaskInt16(),
+            Sve.Or(Sve.CreateTrueMaskInt16(), Sve.CreateTrueMaskInt16()),
+            Vector<short>.Zero
+        ), Sve.CreateFalseMaskInt16());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<int> ConditionalSelectMask(Vector<int> v)
+    {
+        // Use a passed in vector for the mask to prevent optimising away the select
+        //ARM64-FULL-LINE: sel {{p[0-9]+}}.b, {{p[0-9]+}}, {{p[0-9]+}}.b, {{p[0-9]+}}.b
+        return Sve.CreateBreakAfterMask(Sve.ConditionalSelect(
+            v,
+            Sve.CreateFalseMaskInt32(),
+            Sve.CreateTrueMaskInt32()
+        ), Sve.CreateFalseMaskInt32());
+    }
+
+    // These have multiple uses of the predicate variants
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<short> UnzipEvenZipLowMask()
+    {
+        //ARM64-FULL-LINE: zip1 {{p[0-9]+}}.h, {{p[0-9]+}}.h, {{p[0-9]+}}.h
+        //ARM64-FULL-LINE: uzp1 {{p[0-9]+}}.h, {{p[0-9]+}}.h, {{p[0-9]+}}.h
+        return Sve.CreateBreakAfterMask(Sve.UnzipEven(Sve.ZipLow(Vector<short>.Zero, Sve.CreateTrueMaskInt16()), Vector<short>.Zero), Sve.CreateTrueMaskInt16());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<short> TransposeEvenAndMask(Vector<short> v)
+    {
+        //ARM64-FULL-LINE: and {{p[0-9]+}}.b, {{p[0-9]+}}/z, {{p[0-9]+}}.b, {{p[0-9]+}}.b
+        //ARM64-FULL-LINE: trn1 {{p[0-9]+}}.h, {{p[0-9]+}}.h, {{p[0-9]+}}.h
+        return Sve.CreateBreakAfterMask(Sve.TransposeEven(Sve.CreateTrueMaskInt16(), Sve.ConditionalSelect(
+            Sve.CreateTrueMaskInt16(),
+            Sve.And(v, Sve.CreateTrueMaskInt16()),
+            Vector<short>.Zero
+        )), Sve.CreateFalseMaskInt16());
+
     }
 }


### PR DESCRIPTION
Fixes #101970

Predicate variants were implemented, and then turned off in #115566.

Adds a simple costing to fgMorphTryUseAllMaskVariant() and assumes nodes can always be converted to masks (using ConvertVectorToMask).