### PR TITLE
JIT: Fix likelihoods in range test bool opts

### DIFF
--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -825,6 +825,8 @@ bool OptBoolsDsc::optOptimizeRangeTests()
     FlowEdge* const oldFalseEdge = m_b1->GetFalseEdge();
     FlowEdge* const oldTrueEdge  = m_b1->GetTrueEdge();
     newEdge->setHeuristicBased(oldTrueEdge->isHeuristicBased());
+    newEdge->setLikelihood(inRangeLikelihood);
+    oldTrueEdge->setLikelihood(1.0 - inRangeLikelihood);
 
     if (!cmp2IsReversed)
     {
@@ -832,18 +834,12 @@ bool OptBoolsDsc::optOptimizeRangeTests()
         m_b1->SetTrueEdge(newEdge);
         assert(m_b1->TrueTargetIs(inRangeBb));
         assert(m_b1->FalseTargetIs(notInRangeBb));
-
-        newEdge->setLikelihood(inRangeLikelihood);
-        oldTrueEdge->setLikelihood(1.0 - inRangeLikelihood);
     }
     else
     {
         m_b1->SetFalseEdge(newEdge);
         assert(m_b1->TrueTargetIs(notInRangeBb));
         assert(m_b1->FalseTargetIs(inRangeBb));
-
-        oldTrueEdge->setLikelihood(inRangeLikelihood);
-        newEdge->setLikelihood(1.0 - inRangeLikelihood);
     }
 
     // Remove the 2nd condition block as we no longer need it


### PR DESCRIPTION
When optimizing compound conditionals into one check and branch, we'd expect the likelihood of the optimized branch to be the product of the conditionals' likelihoods. We currently get this wrong in range test opts if the second comparison is flipped, yielding behavior like this:

```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight     IBC [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                             1    33784 [000..00C)-> BB12(0.407),BB11(0.593) ( cond )                   i IBC
BB11 [0009]  1       BB01                  0.59 20037 [000..001)                           (throw )                   i IBC gcsafe
BB12 [0010]  1       BB01                  0.41 13747 [000..001)-> BB14(0.899),BB08(0.101) ( cond )                   i IBC
BB14 [0012]  3       BB03,BB08,BB12        0.37 12357 [000..021)                           (return)                   i IBC jmp
BB08 [0006]  1       BB12                  0.45 15138 [000..015)-> BB14(0.2),BB03(0.8)     ( cond )                   i IBC
BB03 [0002]  1       BB08                  0        0 [015..019)-> BB14(1)                 (always)                   i IBC rare
---------------------------------------------------------------------------------------------------------------------------------------------------------------------

*************** In optOptimizeBools()
setting likelihood of BB12 -> BB14 from 0.8988597 to 0.0809122
setting likelihood of BB12 -> BB03 to 0.9190878
fgRemoveBlock BB08, unreachable=true

Removing unreachable BB08


---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight     IBC [IL range]   [jump]                            [EH region]        [flags]
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
BB01 [0000]  1                             1    33784 [000..00C)-> BB12(0.407),BB11(0.593) ( cond )                   i IBC
BB11 [0009]  1       BB01                  0.59 20037 [000..001)                           (throw )                   i IBC gcsafe
BB12 [0010]  1       BB01                  0.41 13747 [000..001)-> BB14(0.0809),BB03(0.919)  ( cond )                   i IBC
BB14 [0012]  2       BB03,BB12             0.03  1112 [000..021)                           (return)                   i IBC jmp
BB03 [0002]  1       BB12                  0.37 12635 [015..019)-> BB14(1)                 (always)                   i IBC
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Based on what the profile initially looked like, the likelihoods out of `BB12` should be flipped.