### PR TITLE
Remove `AppDomain` parameter for `Debugger::InitIPCEvent`

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -1597,7 +1597,7 @@ void Debugger::RaiseStartupNotification()
     // If we are remote debugging, don't send the event now if a debugger is not attached.  No one will be
     // listening, and we will fail.  However, we still want to initialize the variable above.
     DebuggerIPCEvent startupEvent;
-    InitIPCEvent(&startupEvent, DB_IPCE_LEFTSIDE_STARTUP, NULL, VMPTR_AppDomain::NullPtr());
+    InitIPCEvent(&startupEvent, DB_IPCE_LEFTSIDE_STARTUP, NULL);
 
     SendRawEvent(&startupEvent);
 
@@ -1711,7 +1711,7 @@ void Debugger::SendCreateProcess(DebuggerLockHolder * pDbgLockHolder)
     // The RS will then update the DCB with enough information so that we can send the sync-complete.
     // (such as letting us know whether we're interop-debugging or not).
     DebuggerIPCEvent event;
-    InitIPCEvent(&event, DB_IPCE_CREATE_PROCESS, NULL, VMPTR_AppDomain::NullPtr());
+    InitIPCEvent(&event, DB_IPCE_CREATE_PROCESS, NULL);
     SendRawEvent(&event);
 
     // @dbgtodo  inspection- it doesn't really make sense to sync on a CreateProcess. We only have 1 thread
@@ -5827,8 +5827,7 @@ void Debugger::SuspendForGarbageCollectionCompleted()
         DebuggerIPCEvent* ipce1 = m_pRCThread->GetIPCEventSendBuffer();
         InitIPCEvent(ipce1,
             DB_IPCE_BEFORE_GARBAGE_COLLECTION,
-            pThread,
-            AppDomain::GetCurrentDomain());
+            pThread);
 
         m_pRCThread->SendIPCEvent();
         this->SuspendComplete(true);
@@ -5865,8 +5864,7 @@ void Debugger::ResumeForGarbageCollectionStarted()
         DebuggerIPCEvent* ipce1 = m_pRCThread->GetIPCEventSendBuffer();
         InitIPCEvent(ipce1,
             DB_IPCE_AFTER_GARBAGE_COLLECTION,
-            pThread,
-            AppDomain::GetCurrentDomain());
+            pThread);
 
         m_pRCThread->SendIPCEvent();
         this->SuspendComplete(true);
@@ -5914,9 +5912,7 @@ void Debugger::SendDataBreakpoint(Thread *thread, CONTEXT *context,
     memcpy(&(ipce->DataBreakpointData.context), context, sizeof(CONTEXT));
     InitIPCEvent(ipce,
         DB_IPCE_DATA_BREAKPOINT,
-        thread,
-        AppDomain::GetCurrentDomain());
-    //_ASSERTE(breakpoint->m_pAppDomain == ipce->vmAppDomain.GetRawPtr());
+        thread);
 
     m_pRCThread->SendIPCEvent();
 }
@@ -5960,8 +5956,7 @@ void Debugger::SendBreakpoint(Thread *thread, CONTEXT *context,
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(ipce,
                  DB_IPCE_BREAKPOINT,
-                 thread,
-                 AppDomain::GetCurrentDomain());
+                 thread);
     ipce->BreakpointData.breakpointToken.Set(breakpoint);
     _ASSERTE( breakpoint->m_pAppDomain == ipce->vmAppDomain.GetRawPtr());
 
@@ -6033,8 +6028,7 @@ void Debugger::SendRawUserBreakpoint(Thread * pThread)
     DebuggerIPCEvent* pEvent = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(pEvent,
                  DB_IPCE_USER_BREAKPOINT,
-                 pThread,
-                 AppDomain::GetCurrentDomain());
+                 pThread);
 
     m_pRCThread->SendIPCEvent();
 }
@@ -6065,8 +6059,7 @@ void Debugger::SendInterceptExceptionComplete(Thread *thread)
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(ipce,
                  DB_IPCE_INTERCEPT_EXCEPTION_COMPLETE,
-                 thread,
-                 AppDomain::GetCurrentDomain());
+                 thread);
 
     m_pRCThread->SendIPCEvent();
 }
@@ -6103,8 +6096,7 @@ void Debugger::SendStep(Thread *thread, CONTEXT *context,
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(ipce,
                  DB_IPCE_STEP_COMPLETE,
-                 thread,
-                 AppDomain::GetCurrentDomain());
+                 thread);
     ipce->StepData.stepperToken.Set(stepper);
     ipce->StepData.reason = reason;
     m_pRCThread->SendIPCEvent();
@@ -6144,8 +6136,7 @@ void Debugger::LockAndSendEnCRemapEvent(DebuggerJitInfo * dji, SIZE_T currentIP,
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(ipce,
                  DB_IPCE_ENC_REMAP,
-                 thread,
-                 AppDomain::GetCurrentDomain());
+                 thread);
 
     ipce->EnCRemap.currentVersionNumber = dji->m_encVersion;
     ipce->EnCRemap.resumeVersionNumber = dji->m_methodInfo->GetCurrentEnCVersion();;
@@ -6196,8 +6187,7 @@ void Debugger::LockAndSendEnCRemapCompleteEvent(MethodDesc *pMD)
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(ipce,
                  DB_IPCE_ENC_REMAP_COMPLETE,
-                 thread,
-                 AppDomain::GetCurrentDomain());
+                 thread);
 
     ipce->EnCRemapComplete.funcMetadataToken = pMD->GetMemberDef();
 
@@ -6253,7 +6243,6 @@ void Debugger::SendEnCUpdateEvent(DebuggerIPCEventType eventType,
     DebuggerIPCEvent* event = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(event,
                  eventType,
-                 NULL,
                  NULL);
 
     event->EnCUpdate.newVersionNumber = enCVersion;
@@ -6318,7 +6307,7 @@ void Debugger::LockAndSendBreakpointSetError(PATCH_UNORDERED_ARRAY * listUnbinda
             i+1, count, controller, controller->GetDCType()));
 
         // Send a breakpoint set error event to the Right Side.
-        InitIPCEvent(ipce, DB_IPCE_BREAKPOINT_SET_ERROR, thread, AppDomain::GetCurrentDomain());
+        InitIPCEvent(ipce, DB_IPCE_BREAKPOINT_SET_ERROR, thread);
 
         ipce->BreakpointSetErrorData.breakpointToken.Set(static_cast<DebuggerBreakpoint*> (controller));
 
@@ -7290,7 +7279,7 @@ HRESULT Debugger::SendExceptionHelperAndBlock(
     //
     // Send pre-Whidbey EXCEPTION IPC event.
     //
-    InitIPCEvent(ipce, DB_IPCE_EXCEPTION, pThread, AppDomain::GetCurrentDomain());
+    InitIPCEvent(ipce, DB_IPCE_EXCEPTION, pThread);
 
     ipce->Exception.vmExceptionHandle.SetRawPtr(exceptionHandle);
     ipce->Exception.firstChance = (eventType == DEBUG_EXCEPTION_FIRST_CHANCE);
@@ -7302,7 +7291,7 @@ HRESULT Debugger::SendExceptionHelperAndBlock(
     //
     // Send Whidbey EXCEPTION IPC event.
     //
-    InitIPCEvent(ipce, DB_IPCE_EXCEPTION_CALLBACK2, pThread, AppDomain::GetCurrentDomain());
+    InitIPCEvent(ipce, DB_IPCE_EXCEPTION_CALLBACK2, pThread);
 
     ipce->ExceptionCallback2.framePointer = framePointer;
     ipce->ExceptionCallback2.eventType = eventType;
@@ -7455,7 +7444,7 @@ void Debugger::SendExceptionEventsWorker(
         {
             SENDIPCEVENT_BEGIN(this, pThread);
 
-            InitIPCEvent(ipce, DB_IPCE_EXCEPTION_CALLBACK2, pThread, AppDomain::GetCurrentDomain());
+            InitIPCEvent(ipce, DB_IPCE_EXCEPTION_CALLBACK2, pThread);
 
             ipce->ExceptionCallback2.framePointer = framePointer;
             ipce->ExceptionCallback2.eventType = DEBUG_EXCEPTION_USER_FIRST_CHANCE;
@@ -8114,7 +8103,7 @@ void Debugger::SendCatchHandlerFound(
                 //
                 // Send Whidbey EXCEPTION IPC event.
                 //
-                InitIPCEvent(ipce, DB_IPCE_EXCEPTION_CALLBACK2, pThread, AppDomain::GetCurrentDomain());
+                InitIPCEvent(ipce, DB_IPCE_EXCEPTION_CALLBACK2, pThread);
 
                 ipce->ExceptionCallback2.framePointer = fp;
                 ipce->ExceptionCallback2.eventType = DEBUG_EXCEPTION_CATCH_HANDLER_FOUND;
@@ -8217,7 +8206,7 @@ void Debugger::ManagedExceptionUnwindBegin(Thread *pThread)
                 //
                 // Send Whidbey EXCEPTION IPC event.
                 //
-                InitIPCEvent(ipce, DB_IPCE_EXCEPTION_UNWIND, pThread, AppDomain::GetCurrentDomain());
+                InitIPCEvent(ipce, DB_IPCE_EXCEPTION_UNWIND, pThread);
 
                 ipce->ExceptionUnwind.eventType = DEBUG_EXCEPTION_UNWIND_BEGIN;
                 ipce->ExceptionUnwind.dwFlags = 0;
@@ -9010,9 +8999,7 @@ void Debugger::ThreadStarted(Thread* pRuntimeThread)
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(ipce,
                  DB_IPCE_THREAD_ATTACH,
-                 pRuntimeThread,
-                 AppDomain::GetCurrentDomain());
-
+                 pRuntimeThread);
 
     m_pRCThread->SendIPCEvent();
 
@@ -9084,8 +9071,7 @@ void Debugger::DetachThread(Thread *pRuntimeThread)
 
         InitIPCEvent(pEvent,
                      DB_IPCE_THREAD_DETACH,
-                     pRuntimeThread,
-                     AppDomain::GetCurrentDomain());
+                     pRuntimeThread);
 
         m_pRCThread->SendIPCEvent();
 
@@ -9247,8 +9233,7 @@ void Debugger::SendCreateAppDomainEvent(AppDomain * pRuntimeAppDomain)
 
         InitIPCEvent(pEvent,
                      DB_IPCE_CREATE_APP_DOMAIN,
-                     pThread,
-                     pRuntimeAppDomain);
+                     pThread);
 
         // Only send a pointer to the AppDomain, the RS will get everything else via DAC.
         pEvent->AppDomainData.vmAppDomain.SetRawPtr(pRuntimeAppDomain);
@@ -9296,8 +9281,7 @@ void Debugger::LoadAssembly(DomainAssembly * pDomainAssembly)
         DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
         InitIPCEvent(ipce,
                      DB_IPCE_LOAD_ASSEMBLY,
-                     pThread,
-                     AppDomain::GetCurrentDomain());
+                     pThread);
 
         ipce->AssemblyData.vmDomainAssembly.SetRawPtr(pDomainAssembly);
 
@@ -9346,8 +9330,7 @@ void Debugger::UnloadAssembly(DomainAssembly * pDomainAssembly)
 
     InitIPCEvent(ipce,
                  DB_IPCE_UNLOAD_ASSEMBLY,
-                 thread,
-                 AppDomain::GetCurrentDomain());
+                 thread);
     ipce->AssemblyData.vmDomainAssembly.SetRawPtr(pDomainAssembly);
 
     SendSimpleIPCEventAndBlock();
@@ -9414,7 +9397,7 @@ void Debugger::LoadModule(Module* pRuntimeModule,
 
     // Send a load module event to the Right Side.
     ipce = m_pRCThread->GetIPCEventSendBuffer();
-    InitIPCEvent(ipce,DB_IPCE_LOAD_MODULE, pThread, AppDomain::GetCurrentDomain());
+    InitIPCEvent(ipce,DB_IPCE_LOAD_MODULE, pThread);
 
     ipce->LoadModuleData.vmDomainAssembly.SetRawPtr(pDomainAssembly);
 
@@ -9480,8 +9463,7 @@ void Debugger::SendRawUpdateModuleSymsEvent(Module *pRuntimeModule)
     DebuggerIPCEvent* ipce = NULL;
     ipce = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(ipce, DB_IPCE_UPDATE_MODULE_SYMS,
-                 g_pEEInterface->GetThread(),
-                 AppDomain::GetCurrentDomain());
+                 g_pEEInterface->GetThread());
 
     ipce->UpdateModuleSymsData.vmDomainAssembly.SetRawPtr((module ? module->GetDomainAssembly() : NULL));
 
@@ -9582,7 +9564,7 @@ void Debugger::UnloadModule(Module* pRuntimeModule)
 
         // Send the unload module event to the Right Side.
         DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
-        InitIPCEvent(ipce, DB_IPCE_UNLOAD_MODULE, thread, AppDomain::GetCurrentDomain());
+        InitIPCEvent(ipce, DB_IPCE_UNLOAD_MODULE, thread);
         ipce->UnloadModuleData.vmDomainAssembly.SetRawPtr((module ? module->GetDomainAssembly() : NULL));
         ipce->UnloadModuleData.debuggerAssemblyToken.Set(pRuntimeModule->GetClassLoader()->GetAssembly());
         m_pRCThread->SendIPCEvent();
@@ -9751,7 +9733,7 @@ void Debugger::SendClassLoadUnloadEvent (mdTypeDef classMetadataToken,
         // V1.1 sent Sym Update first so that binding at the class load has the latest symbols.
         // However, The Class Load may need to be in sync with updating new metadata,
         // and that has to come before the Sym update.
-        InitIPCEvent(pEvent, DB_IPCE_LOAD_CLASS, g_pEEInterface->GetThread(), AppDomain::GetCurrentDomain());
+        InitIPCEvent(pEvent, DB_IPCE_LOAD_CLASS, g_pEEInterface->GetThread());
 
         pEvent->LoadClass.classMetadataToken = classMetadataToken;
         pEvent->LoadClass.vmDomainAssembly.SetRawPtr((pClassDebuggerModule ? pClassDebuggerModule->GetDomainAssembly() : NULL));
@@ -9763,7 +9745,7 @@ void Debugger::SendClassLoadUnloadEvent (mdTypeDef classMetadataToken,
     }
     else
     {
-        InitIPCEvent(pEvent, DB_IPCE_UNLOAD_CLASS, g_pEEInterface->GetThread(), AppDomain::GetCurrentDomain());
+        InitIPCEvent(pEvent, DB_IPCE_UNLOAD_CLASS, g_pEEInterface->GetThread());
 
         pEvent->UnloadClass.classMetadataToken = classMetadataToken;
         pEvent->UnloadClass.vmDomainAssembly.SetRawPtr((pClassDebuggerModule ? pClassDebuggerModule->GetDomainAssembly() : NULL));
@@ -9992,7 +9974,7 @@ void Debugger::FuncEvalComplete(Thread* pThread, DebuggerEval *pDE)
 
     // Send a func eval complete event to the Right Side.
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
-    InitIPCEvent(ipce, DB_IPCE_FUNC_EVAL_COMPLETE, pThread, pDomain);
+    InitIPCEvent(ipce, DB_IPCE_FUNC_EVAL_COMPLETE, pThread);
 
     ipce->FuncEvalComplete.funcEvalKey = pDE->m_funcEvalKey;
     ipce->FuncEvalComplete.successful = pDE->m_successful;
@@ -10385,8 +10367,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
 
             InitIPCEvent(pIPCResult,
                          DB_IPCE_DISABLE_OPTS_RESULT,
-                         g_pEEInterface->GetThread(),
-                         pEvent->vmAppDomain);
+                         g_pEEInterface->GetThread());
 
             pIPCResult->hr = hr;
 
@@ -10406,8 +10387,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
             DebuggerIPCEvent * pIPCResult = m_pRCThread->GetIPCEventReceiveBuffer();
             InitIPCEvent(pIPCResult,
                          DB_IPCE_CATCH_HANDLER_FOUND_RESULT,
-                         g_pEEInterface->GetThread(),
-                         pEvent->vmAppDomain);
+                         g_pEEInterface->GetThread());
 
             pIPCResult->hr = hr;
 
@@ -10426,8 +10406,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
             DebuggerIPCEvent * pIPCResult = m_pRCThread->GetIPCEventReceiveBuffer();
             InitIPCEvent(pIPCResult,
                          DB_IPCE_SET_ENABLE_CUSTOM_NOTIFICATION_RESULT,
-                         g_pEEInterface->GetThread(),
-                         pEvent->vmAppDomain);
+                         g_pEEInterface->GetThread());
 
             pIPCResult->hr = hr;
 
@@ -10509,8 +10488,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
 
             InitIPCEvent(pIPCResult,
                          DB_IPCE_BREAKPOINT_ADD_RESULT,
-                         g_pEEInterface->GetThread(),
-                         pEvent->vmAppDomain);
+                         g_pEEInterface->GetThread());
 
             pIPCResult->BreakpointData.breakpointToken.Set(pDebuggerBP);
             pIPCResult->hr = hr;
@@ -10540,8 +10518,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
 
             InitIPCEvent(pIPCResult,
                          DB_IPCE_STEP_RESULT,
-                         pThread,
-                         pEvent->vmAppDomain);
+                         pThread);
 
             if (temporaryHelp)
             {
@@ -10615,8 +10592,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
 
             InitIPCEvent(pIPCResult,
                          DB_IPCE_STEP_RESULT,
-                         pThread,
-                         pAppDomain);
+                         pThread);
 
             if (temporaryHelp)
             {
@@ -10709,7 +10685,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
 
             _ASSERTE(pIPCResult != NULL);
 
-            InitIPCEvent(pIPCResult, DB_IPCE_SET_DEBUG_STATE_RESULT, NULL, NULL);
+            InitIPCEvent(pIPCResult, DB_IPCE_SET_DEBUG_STATE_RESULT, NULL);
 
             pIPCResult->hr = S_OK;
 
@@ -10727,7 +10703,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
 
             _ASSERTE(pIPCResult != NULL);
 
-            InitIPCEvent(pIPCResult, DB_IPCE_GET_GCHANDLE_INFO_RESULT, NULL, NULL);
+            InitIPCEvent(pIPCResult, DB_IPCE_GET_GCHANDLE_INFO_RESULT, NULL);
 
             bool fValid = SUCCEEDED(ValidateGCHandle(objectHandle));
 
@@ -10961,7 +10937,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
 
             Thread * pThread = pEvent->FuncEval.vmThreadToken.GetRawPtr();
 
-            InitIPCEvent(pEvent, DB_IPCE_FUNC_EVAL_SETUP_RESULT, pThread, AppDomain::GetCurrentDomain());
+            InitIPCEvent(pEvent, DB_IPCE_FUNC_EVAL_SETUP_RESULT, pThread);
 
             BYTE * pbArgDataArea = NULL;
             DebuggerEval * pDebuggerEvalKey = NULL;
@@ -11175,7 +11151,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
             // Prepare reply
             pEvent = m_pRCThread->GetIPCEventReceiveBuffer();
 
-            InitIPCEvent(pEvent, DB_IPCE_SET_METHOD_JMC_STATUS_RESULT, NULL, NULL);
+            InitIPCEvent(pEvent, DB_IPCE_SET_METHOD_JMC_STATUS_RESULT, NULL);
 
             pEvent->hr = S_OK;
 
@@ -11221,7 +11197,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
 
             // Init reply
             pEvent = m_pRCThread->GetIPCEventReceiveBuffer();
-            InitIPCEvent(pEvent, DB_IPCE_GET_METHOD_JMC_STATUS_RESULT, NULL, NULL);
+            InitIPCEvent(pEvent, DB_IPCE_GET_METHOD_JMC_STATUS_RESULT, NULL);
 
             //
             // This may be called on an unjitted method, so we may
@@ -11311,7 +11287,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
             LOG((LF_CORDB, LL_INFO100000, "D::HIPCE hr is 0x%x\n", hr));
 
             DebuggerIPCEvent * pResult = m_pRCThread->GetIPCEventReceiveBuffer();
-            InitIPCEvent(pResult, DB_IPCE_RESOLVE_UPDATE_METADATA_1_RESULT, NULL, NULL);
+            InitIPCEvent(pResult, DB_IPCE_RESOLVE_UPDATE_METADATA_1_RESULT, NULL);
 
             pResult->MetadataUpdateRequest.pMetadataStart = pData;
             pResult->MetadataUpdateRequest.nMetadataSize = countBytes;
@@ -11330,7 +11306,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
             DeleteInteropSafe(pData);
 
             DebuggerIPCEvent * pResult = m_pRCThread->GetIPCEventReceiveBuffer();
-            InitIPCEvent(pResult, DB_IPCE_RESOLVE_UPDATE_METADATA_2_RESULT, NULL, NULL);
+            InitIPCEvent(pResult, DB_IPCE_RESOLVE_UPDATE_METADATA_2_RESULT, NULL);
             pResult->hr = S_OK;
             m_pRCThread->SendIPCReply();
         }
@@ -12044,7 +12020,7 @@ void Debugger::GetAndSendTransitionStubInfo(CORDB_ADDRESS_TYPE *stubAddress)
 
     // This is a synchronous event (reply required)
     DebuggerIPCEvent *event = m_pRCThread->GetIPCEventReceiveBuffer();
-    InitIPCEvent(event, DB_IPCE_IS_TRANSITION_STUB_RESULT, NULL, NULL);
+    InitIPCEvent(event, DB_IPCE_IS_TRANSITION_STUB_RESULT, NULL);
     event->IsTransitionStubResult.isStub = result;
 
     // Send the result
@@ -12068,7 +12044,7 @@ HRESULT Debugger::GetAndSendBuffer(DebuggerRCThread* rcThread, ULONG bufSize)
     // This is a synchronous event (reply required)
     DebuggerIPCEvent* event = rcThread->GetIPCEventReceiveBuffer();
     _ASSERTE(event != NULL);
-    InitIPCEvent(event, DB_IPCE_GET_BUFFER_RESULT, NULL, NULL);
+    InitIPCEvent(event, DB_IPCE_GET_BUFFER_RESULT, NULL);
 
     // Allocate the buffer
     event->GetBufferResult.hr = AllocateRemoteBuffer( bufSize, &event->GetBufferResult.pBuffer );
@@ -12141,7 +12117,7 @@ HRESULT Debugger::SendReleaseBuffer(DebuggerRCThread* rcThread, void *pBuffer)
     // This is a synchronous event (reply required)
     DebuggerIPCEvent* event = rcThread->GetIPCEventReceiveBuffer();
     _ASSERTE(event != NULL);
-    InitIPCEvent(event, DB_IPCE_RELEASE_BUFFER_RESULT, NULL, NULL);
+    InitIPCEvent(event, DB_IPCE_RELEASE_BUFFER_RESULT, NULL);
 
     _ASSERTE(pBuffer != NULL);
 
@@ -12744,7 +12720,6 @@ HRESULT Debugger::ApplyChangesAndSendResult(DebuggerModule * pDebuggerModule,
     DebuggerIPCEvent* event = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(event,
                  DB_IPCE_APPLY_CHANGES_RESULT,
-                 NULL,
                  NULL);
 
     event->ApplyChangesResult.hr = hr;
@@ -14200,12 +14175,9 @@ void Debugger::SendRawMDANotification(
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
 
     Thread * pThread = params->m_pThread;
-    AppDomain *pAppDomain = (pThread != NULL) ? AppDomain::GetCurrentDomain() : NULL;
-
     InitIPCEvent(ipce,
                  DB_IPCE_MDA_NOTIFICATION,
-                 pThread,
-                 pAppDomain);
+                 pThread);
 
     SetLSBufferFromSString(&ipce->MDANotification.szName, *(params->m_szName));
     SetLSBufferFromSString(&ipce->MDANotification.szDescription, *(params->m_szDescription));
@@ -14440,8 +14412,7 @@ void Debugger::SendRawLogMessage(
     // Send a LogMessage event to the Right Side
     InitIPCEvent(ipce,
                  DB_IPCE_FIRST_LOG_MESSAGE,
-                 pThread,
-                 pAppDomain);
+                 pThread);
 
     ipce->FirstLogMessage.iLevel = iLevel;
     ipce->FirstLogMessage.szCategory.SetString(pCategory->GetUnicode());
@@ -14486,8 +14457,7 @@ void Debugger::SendLogSwitchSetting(int iLevel,
         DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
         InitIPCEvent(ipce,
                      DB_IPCE_LOGSWITCH_SET_MESSAGE,
-                     pThread,
-                     AppDomain::GetCurrentDomain());
+                     pThread);
 
         ipce->LogSwitchSettingMessage.iLevel = iLevel;
         ipce->LogSwitchSettingMessage.iReason = iReason;
@@ -14549,8 +14519,7 @@ void Debugger::SendCustomDebuggerNotification(Thread * pThread,
         DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
         InitIPCEvent(ipce,
                      DB_IPCE_CUSTOM_NOTIFICATION,
-                     curThread,
-                     AppDomain::GetCurrentDomain());
+                     curThread);
 
         VMPTR_DomainAssembly vmDomainAssembly = VMPTR_DomainAssembly::MakePtr(pDomain);
 
@@ -15685,13 +15654,12 @@ HRESULT Debugger::NameChangeEvent(AppDomain *pAppDomain, Thread *pThread)
             DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
         InitIPCEvent(ipce,
                      DB_IPCE_NAME_CHANGE,
-                     curThread,
-                     AppDomain::GetCurrentDomain());
+                     curThread);
 
         if (pAppDomain)
         {
             ipce->NameChange.eventType = APP_DOMAIN_NAME_CHANGE;
-                ipce->NameChange.vmAppDomain.SetRawPtr(pAppDomain);
+            ipce->NameChange.vmAppDomain.SetRawPtr(pAppDomain);
         }
         else
         {
@@ -15748,8 +15716,7 @@ BOOL Debugger::SendCtrlCToDebugger(DWORD dwCtrlType)
         DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
         InitIPCEvent(ipce,
                      DB_IPCE_CONTROL_C_EVENT,
-                     pThread,
-                     NULL);
+                     pThread);
 
         // The RS doesn't do anything with dwCtrlType
         m_pRCThread->SendIPCEvent();
@@ -15918,8 +15885,7 @@ void Debugger::CreateConnection(CONNID dwConnectionId, _In_z_ WCHAR *wzName)
         // Send a update module syns event to the Right Side.
         ipce = m_pRCThread->GetIPCEventSendBuffer();
         InitIPCEvent(ipce, DB_IPCE_CREATE_CONNECTION,
-                     pThread,
-                     NULL);
+                     pThread);
         ipce->CreateConnection.connectionId = dwConnectionId;
         _ASSERTE(wzName != NULL);
         ipce->CreateConnection.wzConnectionName.SetString(wzName);
@@ -15962,8 +15928,7 @@ void Debugger::DestroyConnection(CONNID dwConnectionId)
     // Send a update module syns event to the Right Side.
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(ipce, DB_IPCE_DESTROY_CONNECTION,
-                 thread,
-                 NULL);
+                 thread);
     ipce->ConnectionChange.connectionId = dwConnectionId;
 
     // IPC event is now initialized, so we can send it over.
@@ -15999,8 +15964,7 @@ void Debugger::ChangeConnection(CONNID dwConnectionId)
         // Send a update module syns event to the Right Side.
         ipce = m_pRCThread->GetIPCEventSendBuffer();
         InitIPCEvent(ipce, DB_IPCE_CHANGE_CONNECTION,
-                     pThread,
-                     NULL);
+                     pThread);
         ipce->ConnectionChange.connectionId = dwConnectionId;
         m_pRCThread->SendIPCEvent();
     }

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -2762,21 +2762,10 @@ private:
         // AppDomain, Thread, are already initialized
     }
 
-    void InitIPCEvent(DebuggerIPCEvent *ipce,
-                      DebuggerIPCEventType type,
-                      Thread *pThread,
-                      AppDomain* pAppDomain)
-    {
-        WRAPPER_NO_CONTRACT;
-
-        InitIPCEvent(ipce, type, pThread, VMPTR_AppDomain::MakePtr(pAppDomain));
-    }
-
     // Let this function to figure out the unique Id that we will use for Thread.
     void InitIPCEvent(DebuggerIPCEvent *ipce,
                       DebuggerIPCEventType type,
-                      Thread *pThread,
-                      VMPTR_AppDomain vmAppDomain)
+                      Thread *pThread)
     {
         CONTRACTL
         {
@@ -2790,7 +2779,7 @@ private:
         ipce->hr = S_OK;
         ipce->processId = m_processId;
         ipce->threadId = pThread ? pThread->GetOSThreadId() : 0;
-        ipce->vmAppDomain = vmAppDomain;
+        ipce->vmAppDomain = VMPTR_AppDomain::MakePtr(AppDomain::GetCurrentDomain());
         ipce->vmThread.SetRawPtr(pThread);
     }
 
@@ -2804,16 +2793,9 @@ private:
                  (type == DB_IPCE_TEST_RWLOCK));
 
         Thread *pThread = g_pEEInterface->GetThread();
-        AppDomain *pAppDomain = NULL;
-        if (pThread)
-        {
-            pAppDomain = AppDomain::GetCurrentDomain();
-        }
-
         InitIPCEvent(ipce,
                      type,
-                     pThread,
-                     VMPTR_AppDomain::MakePtr(pAppDomain));
+                     pThread);
     }
 #endif // DACCESS_COMPILE
 


### PR DESCRIPTION
Follow-up from https://github.com/dotnet/runtime/pull/101749#discussion_r1591518766
Always the one and only `AppDomain`.

cc @dotnet/dotnet-diag @AaronRobinsonMSFT 