### PR TITLE
[9.0] Backport 115546 FLS initialization fix to 9. 

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -862,6 +862,7 @@ void EEStartupHelper()
 
 #ifdef PROFILING_SUPPORTED
         // Initialize the profiling services.
+        // This must happen before Thread::HasStarted() that fires profiler notifications is called on the finalizer thread.
         hr = ProfilingAPIUtility::InitializeProfiling();
 
         _ASSERTE(SUCCEEDED(hr));
@@ -891,7 +892,12 @@ void EEStartupHelper()
 
         // This isn't done as part of InitializeGarbageCollector() above because
         // debugger must be initialized before creating EE thread objects 
+#ifdef TARGET_WINDOWS
+        // Create the finalizer thread on windows earlier, as we will need to wait for
+        // the completion of its initialization part that initializes COM as that has to be done
+        // before the first Thread is attached. Thus we want to give the thread a bit more time.
         FinalizerThread::FinalizerThreadCreate();
+#endif
 
         InitPreStubManager();
 
@@ -906,8 +912,6 @@ void EEStartupHelper()
         InitJITHelpers1();
         InitJITHelpers2();
 
-        SyncBlockCache::Attach();
-
         // Set up the sync block
         SyncBlockCache::Start();
 
@@ -921,6 +925,48 @@ void EEStartupHelper()
         }
 
         IfFailGo(hr);
+
+        InitializeExceptionHandling();
+
+        //
+        // Install our global exception filter
+        //
+        if (!InstallUnhandledExceptionFilter())
+        {
+            IfFailGo(E_FAIL);
+        }
+
+#ifdef TARGET_WINDOWS
+        // g_pGCHeap->Initialize() above could take nontrivial time, so by now the finalizer thread
+        // should have initialized FLS slot for thread cleanup notifications.
+        // And ensured that COM is initialized (must happen before allocating FLS slot).
+        // Make sure that this was done before we start creating Thread objects
+        // Ex: The call to SetupThread below will create and attach a Thread object.
+        //     Event pipe might also do that.
+        FinalizerThread::WaitForFinalizerThreadStart();
+#endif
+
+        // throws on error
+        _ASSERTE(GetThreadNULLOk() == NULL);
+        SetupThread();
+
+#ifdef DEBUGGING_SUPPORTED
+        // Notify debugger once the first thread is created to finish initialization.
+        if (g_pDebugInterface != NULL)
+        {
+            g_pDebugInterface->StartupPhase2(GetThread());
+        }
+#endif
+
+#ifndef TARGET_WINDOWS
+        // This isn't done as part of InitializeGarbageCollector() above because
+        // debugger must be initialized before creating EE thread objects
+        FinalizerThread::FinalizerThreadCreate();
+#else
+        // On windows the finalizer thread is already partially created and is waiting
+        // right before doing HasStarted(). We will release it now.
+        FinalizerThread::EnableFinalization();
+#endif
 
 #ifdef FEATURE_PERFTRACING
         // Finish setting up rest of EventPipe - specifically enable SampleProfiler if it was requested at startup.
@@ -982,12 +1028,6 @@ void EEStartupHelper()
                                                 g_MiniMetaDataBuffMaxSize, MEM_COMMIT, PAGE_READWRITE);
 #endif // FEATURE_MINIMETADATA_IN_TRIAGEDUMPS
 
-#ifdef TARGET_WINDOWS
-        // By now finalizer thread should have initialized FLS slot for thread cleanup notifications.
-        // And ensured that COM is initialized (must happen before allocating FLS slot).
-        // Make sure that this was done.
-        FinalizerThread::WaitForFinalizerThreadStart();
-#endif
         g_fEEStarted = TRUE;
         g_EEStartupStatus = S_OK;
         hr = S_OK;
@@ -1794,6 +1834,8 @@ void InitFlsSlot()
 //  thread        - thread to attach
 static void OsAttachThread(void* thread)
 {
+    _ASSERTE(g_flsIndex != FLS_OUT_OF_INDEXES);
+
     if (t_flsState == FLS_STATE_INVOKED)
     {
         _ASSERTE_ALL_BUILDS(!"Attempt to execute managed code after the .NET runtime thread state has been destroyed.");

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -869,29 +869,6 @@ void EEStartupHelper()
         IfFailGo(hr);
 #endif // PROFILING_SUPPORTED
 
-        InitializeExceptionHandling();
-
-        //
-        // Install our global exception filter
-        //
-        if (!InstallUnhandledExceptionFilter())
-        {
-            IfFailGo(E_FAIL);
-        }
-
-        // throws on error
-        SetupThread();
-
-#ifdef DEBUGGING_SUPPORTED
-        // Notify debugger once the first thread is created to finish initialization.
-        if (g_pDebugInterface != NULL)
-        {
-            g_pDebugInterface->StartupPhase2(GetThread());
-        }
-#endif
-
-        // This isn't done as part of InitializeGarbageCollector() above because
-        // debugger must be initialized before creating EE thread objects 
 #ifdef TARGET_WINDOWS
         // Create the finalizer thread on windows earlier, as we will need to wait for
         // the completion of its initialization part that initializes COM as that has to be done

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -445,6 +445,7 @@ DWORD WINAPI FinalizerThread::FinalizerThreadStart(void *args)
 
     // handshake with EE initialization, as now we can attach Thread objects to native threads.
     hEventFinalizerDone->Set();
+    WaitForFinalizerEvent (hEventFinalizer);
 #endif
 
     s_FinalizerThreadOK = GetFinalizerThread()->HasStarted();

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -627,13 +627,6 @@ void SyncBlockCache::CleanupSyncBlocks()
 
 // create the sync block cache
 /* static */
-void SyncBlockCache::Attach()
-{
-    LIMITED_METHOD_CONTRACT;
-}
-
-// create the sync block cache
-/* static */
 void SyncBlockCache::Start()
 {
     CONTRACTL


### PR DESCRIPTION
Backports https://github.com/dotnet/runtime/pull/115546 to 9.0. 

## Summary 
In the previous fix we tried to call FinalizerThread::WaitForFinalizerThreadStart(); as late as possible in EEStartupHelper() - to make sure finalizer has enough time to do its part in initializing COM and FLS slot.

But if calls that happen before FinalizerThread::WaitForFinalizerThreadStart(); can result in Thread objects created and registered for OS destruction, then those threads will see g_flsIndex != FLS_OUT_OF_INDEXES, that includes the call to SetupThread(), which EEStartupHelper() itself does.

The change moves FinalizerThread::WaitForFinalizerThreadStart(); earlier, before any Threads could be created and registered for OS destruction.
We still have GC heap initialization happening before that, which will typically result in finalizer thread completing its part before the EE init thread needs to check for the completion.

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Found by customer here: https://github.com/dotnet/runtime/issues/116755

## Regression

- [x] Yes
- [ ] No

## Testing

Validated by the customer who reported it: https://github.com/dotnet/runtime/issues/116755#issuecomment-2988917676

## Risk

Medium. Touches critical code but this fixes an issue with an earlier servicing fix: https://github.com/dotnet/runtime/pull/113055.

