### PR TITLE
[mono][gc] Fix gc descriptor computation for InlineArray structs

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -906,9 +906,13 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 
 			guint32 field_iter = 1;
 			guint32 field_instance_offset = field_offset;
+			int field_size = 0;
 			// If struct has InlineArray attribute, iterate `length` times to set a bitmap
-			if (m_class_is_inlinearray (p))
+			if (m_class_is_inlinearray (p)) {
+				int align;
 				field_iter = mono_class_get_inlinearray_value (p);
+				field_size = mono_type_size (field->type, &align);
+			}
 
 			if (field_iter > 500)
 				g_warning ("Large number of iterations detected when creating a GC bitmap, might affect performance.");
@@ -973,7 +977,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 					break;
 				}
 
-				field_instance_offset += field_offset;
+				field_instance_offset += field_size;
 				field_iter--;
 			}
 		}


### PR DESCRIPTION
`compute_class_bitmap` iterates over all ref field slots in the current class so we can produce a GC descriptor. `field_iter` represents how many times the type in question is repeated in the current struct. Instead of bumping the current offset by the size of the repeated field, for each iteration, we were adding `field_offset` which is wrong. 

Fixes https://github.com/Humanizr/Humanizer/issues/1572