### PR TITLE
[Json] Fix error case in HalfConverter when dealing with large values

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -43,6 +43,7 @@ namespace System.Text.Json
         public static ReadOnlySpan<byte> NaNValue => "NaN"u8;
         public static ReadOnlySpan<byte> PositiveInfinityValue => "Infinity"u8;
         public static ReadOnlySpan<byte> NegativeInfinityValue => "-Infinity"u8;
+        public const int MaximumFloatingPointConstantLength = 9;
 
         // Used to search for the end of a number
         public static ReadOnlySpan<byte> Delimiters => ",}] \n\r\t/"u8;

--- a/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
@@ -1950,5 +1950,56 @@ namespace System.Text.Json.Serialization.Tests
                 }
             }
         }
+
+        [Theory]
+        // -2 for Quotes
+        [InlineData(32 - 2)] // Common ArrayPool buffer size for numbers
+        [InlineData(256 - 2)] // Common stackalloc constant
+        [InlineData(512 - 2)] // Less common stackalloc constant
+        [InlineData(700)] // Random large number
+        public async Task JsonExceptionForVariousSizedValues(int size)
+        {
+            await DeserializeWithInvalidValue<byte>(size);
+            await DeserializeWithInvalidValue<sbyte>(size);
+            await DeserializeWithInvalidValue<short>(size);
+            await DeserializeWithInvalidValue<int>(size);
+            await DeserializeWithInvalidValue<long>(size);
+            await DeserializeWithInvalidValue<ushort>(size);
+            await DeserializeWithInvalidValue<uint>(size);
+            await DeserializeWithInvalidValue<ulong>(size);
+            await DeserializeWithInvalidValue<float>(size);
+            await DeserializeWithInvalidValue<decimal>(size);
+            await DeserializeWithInvalidValue<byte?>(size);
+            await DeserializeWithInvalidValue<sbyte?>(size);
+            await DeserializeWithInvalidValue<short?>(size);
+            await DeserializeWithInvalidValue<int?>(size);
+            await DeserializeWithInvalidValue<long?>(size);
+            await DeserializeWithInvalidValue<ushort?>(size);
+            await DeserializeWithInvalidValue<uint?>(size);
+            await DeserializeWithInvalidValue<ulong?>(size);
+            await DeserializeWithInvalidValue<float?>(size);
+            await DeserializeWithInvalidValue<decimal?>(size);
+#if NET
+            await DeserializeWithInvalidValue<Int128>(size);
+            await DeserializeWithInvalidValue<UInt128>(size);
+            await DeserializeWithInvalidValue<Half>(size);
+            await DeserializeWithInvalidValue<Int128?>(size);
+            await DeserializeWithInvalidValue<UInt128?>(size);
+            await DeserializeWithInvalidValue<Half?>(size);
+#endif
+        }
+
+        private async Task DeserializeWithInvalidValue<T>(int size)
+        {
+            await Assert.ThrowsAsync<JsonException>(
+                () => Serializer.DeserializeWrapper<T>(
+                    $"\"{string.Concat(Enumerable.Repeat("\\uFFFF", size / 6))}\"",
+                    s_optionReadFromStr));
+
+            await Assert.ThrowsAsync<JsonException>(
+                () => Serializer.DeserializeWrapper<T>(
+                    $"\"{string.Concat(Enumerable.Repeat("a", size))}\"",
+                    s_optionReadFromStr));
+        }
     }
 }


### PR DESCRIPTION
When deserializing `Half`, sending a large value like `123456789012345678901` would result in `ArgumentException: Destination is too short.` 