### PR TITLE
Simplify generic floating point->integer conversions

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -1420,16 +1420,24 @@ namespace System
             }
             else if (typeof(TOther) == typeof(uint))
             {
+#if MONO
                 uint actualResult = (value >= uint.MaxValue) ? uint.MaxValue :
                                     (value <= uint.MinValue) ? uint.MinValue : (uint)value;
+#else
+                uint actualResult = (uint)value;
+#endif
                 result = (TOther)(object)actualResult;
                 return true;
             }
             else if (typeof(TOther) == typeof(ulong))
             {
+#if MONO
                 ulong actualResult = (value >= ulong.MaxValue) ? ulong.MaxValue :
                                      (value <= ulong.MinValue) ? ulong.MinValue :
                                      IsNaN(value) ? 0 : (ulong)value;
+#else
+                ulong actualResult = (ulong)value;
+#endif
                 result = (TOther)(object)actualResult;
                 return true;
             }
@@ -1442,17 +1450,19 @@ namespace System
             }
             else if (typeof(TOther) == typeof(nuint))
             {
+#if MONO
 #if TARGET_64BIT
                 nuint actualResult = (value >= ulong.MaxValue) ? unchecked((nuint)ulong.MaxValue) :
                                      (value <= ulong.MinValue) ? unchecked((nuint)ulong.MinValue) : (nuint)value;
-                result = (TOther)(object)actualResult;
-                return true;
 #else
                 nuint actualResult = (value >= uint.MaxValue) ? uint.MaxValue :
                                      (value <= uint.MinValue) ? uint.MinValue : (nuint)value;
+#endif
+#else
+                nuint actualResult = (nuint)value;
+#endif
                 result = (TOther)(object)actualResult;
                 return true;
-#endif
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -1002,8 +1002,12 @@ namespace System
             if (typeof(TOther) == typeof(double))
             {
                 double actualValue = (double)(object)value;
+#if MONO
                 result = (actualValue >= MaxValue) ? MaxValue :
                          (actualValue <= MinValue) ? MinValue : (int)actualValue;
+#else
+                result = (int)actualValue;
+#endif
                 return true;
             }
             else if (typeof(TOther) == typeof(Half))
@@ -1049,8 +1053,12 @@ namespace System
             else if (typeof(TOther) == typeof(float))
             {
                 float actualValue = (float)(object)value;
+#if MONO
                 result = (actualValue >= MaxValue) ? MaxValue :
                          (actualValue <= MinValue) ? MinValue : (int)actualValue;
+#else
+                result = (int)actualValue;
+#endif
                 return true;
             }
             else
@@ -1080,8 +1088,12 @@ namespace System
             if (typeof(TOther) == typeof(double))
             {
                 double actualValue = (double)(object)value;
+#if MONO
                 result = (actualValue >= MaxValue) ? MaxValue :
                          (actualValue <= MinValue) ? MinValue : (int)actualValue;
+#else
+                result = (int)actualValue;
+#endif
                 return true;
             }
             else if (typeof(TOther) == typeof(Half))
@@ -1124,8 +1136,12 @@ namespace System
             else if (typeof(TOther) == typeof(float))
             {
                 float actualValue = (float)(object)value;
+#if MONO
                 result = (actualValue >= MaxValue) ? MaxValue :
                          (actualValue <= MinValue) ? MinValue : (int)actualValue;
+#else
+                result = (int)actualValue;
+#endif
                 return true;
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -999,8 +999,12 @@ namespace System
             if (typeof(TOther) == typeof(double))
             {
                 double actualValue = (double)(object)value;
+#if MONO
                 result = (actualValue >= MaxValue) ? MaxValue :
                          (actualValue <= MinValue) ? MinValue : (long)actualValue;
+#else
+                result = (long)actualValue;
+#endif
                 return true;
             }
             else if (typeof(TOther) == typeof(Half))
@@ -1044,8 +1048,12 @@ namespace System
             else if (typeof(TOther) == typeof(float))
             {
                 float actualValue = (float)(object)value;
+#if MONO
                 result = (actualValue >= MaxValue) ? MaxValue :
                          (actualValue <= MinValue) ? MinValue : (long)actualValue;
+#else
+                result = (long)actualValue;
+#endif
                 return true;
             }
             else
@@ -1075,8 +1083,12 @@ namespace System
             if (typeof(TOther) == typeof(double))
             {
                 double actualValue = (double)(object)value;
+#if MONO
                 result = (actualValue >= MaxValue) ? MaxValue :
                          (actualValue <= MinValue) ? MinValue : (long)actualValue;
+#else
+                result = (long)actualValue;
+#endif
                 return true;
             }
             else if (typeof(TOther) == typeof(Half))
@@ -1119,8 +1131,12 @@ namespace System
             else if (typeof(TOther) == typeof(float))
             {
                 float actualValue = (float)(object)value;
+#if MONO
                 result = (actualValue >= MaxValue) ? MaxValue :
                          (actualValue <= MinValue) ? MinValue : (long)actualValue;
+#else
+                result = (long)actualValue;
+#endif
                 return true;
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -994,8 +994,12 @@ namespace System
             if (typeof(TOther) == typeof(double))
             {
                 double actualValue = (double)(object)value;
+#if MONO
                 result = (actualValue >= nint_t.MaxValue) ? unchecked((nint)nint_t.MaxValue) :
                          (actualValue <= nint_t.MinValue) ? unchecked((nint)nint_t.MinValue) : (nint)actualValue;
+#else
+                result = (nint)actualValue;
+#endif
                 return true;
             }
             else if (typeof(TOther) == typeof(Half))
@@ -1040,8 +1044,12 @@ namespace System
             else if (typeof(TOther) == typeof(float))
             {
                 float actualValue = (float)(object)value;
+#if MONO
                 result = (actualValue >= nint_t.MaxValue) ? unchecked((nint)nint_t.MaxValue) :
                          (actualValue <= nint_t.MinValue) ? unchecked((nint)nint_t.MinValue) : (nint)actualValue;
+#else
+                result = (nint)actualValue;
+#endif
                 return true;
             }
             else
@@ -1071,8 +1079,12 @@ namespace System
             if (typeof(TOther) == typeof(double))
             {
                 double actualValue = (double)(object)value;
+#if MONO
                 result = (actualValue >= nint_t.MaxValue) ? unchecked((nint)nint_t.MaxValue) :
                          (actualValue <= nint_t.MinValue) ? unchecked((nint)nint_t.MinValue) : (nint)actualValue;
+#else
+                result = (nint)actualValue;
+#endif
                 return true;
             }
             else if (typeof(TOther) == typeof(Half))
@@ -1115,8 +1127,12 @@ namespace System
             else if (typeof(TOther) == typeof(float))
             {
                 float actualValue = (float)(object)value;
+#if MONO
                 result = (actualValue >= nint_t.MaxValue) ? unchecked((nint)nint_t.MaxValue) :
                          (actualValue <= nint_t.MinValue) ? unchecked((nint)nint_t.MinValue) : (nint)actualValue;
+#else
+                result = (nint)actualValue;
+#endif
                 return true;
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -1439,16 +1439,24 @@ namespace System
             }
             else if (typeof(TOther) == typeof(uint))
             {
+#if MONO
                 uint actualResult = (value >= uint.MaxValue) ? uint.MaxValue :
                                     (value <= uint.MinValue) ? uint.MinValue : (uint)value;
+#else
+                uint actualResult = (uint)value;
+#endif
                 result = (TOther)(object)actualResult;
                 return true;
             }
             else if (typeof(TOther) == typeof(ulong))
             {
+#if MONO
                 ulong actualResult = (value >= ulong.MaxValue) ? ulong.MaxValue :
                                      (value <= ulong.MinValue) ? ulong.MinValue :
                                      IsNaN(value) ? 0 : (ulong)value;
+#else
+                ulong actualResult = (ulong)value;
+#endif
                 result = (TOther)(object)actualResult;
                 return true;
             }
@@ -1461,17 +1469,19 @@ namespace System
             }
             else if (typeof(TOther) == typeof(nuint))
             {
+#if MONO
 #if TARGET_64BIT
                 nuint actualResult = (value >= ulong.MaxValue) ? unchecked((nuint)ulong.MaxValue) :
                                      (value <= ulong.MinValue) ? unchecked((nuint)ulong.MinValue) : (nuint)value;
-                result = (TOther)(object)actualResult;
-                return true;
 #else
                 nuint actualResult = (value >= uint.MaxValue) ? uint.MaxValue :
                                      (value <= uint.MinValue) ? uint.MinValue : (nuint)value;
+#endif
+#else
+                nuint actualResult = (nuint)value;
+#endif
                 result = (TOther)(object)actualResult;
                 return true;
-#endif
             }
             else
             {


### PR DESCRIPTION
Floating point to integer conversions for 32-bit and 64-bit integers have predictable truncating behavior on all platforms now. The manual truncation should be unnecessary.