### PR TITLE
Allow folding simple ops with one constant for Tier 0

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6707,7 +6707,6 @@ private:
     GenTree* fgOptimizeRelationalComparisonWithCasts(GenTreeOp* cmp);
     GenTree* fgOptimizeAddition(GenTreeOp* add);
     GenTree* fgOptimizeMultiply(GenTreeOp* mul);
-    GenTree* fgOptimizeBitwiseAnd(GenTreeOp* andOp);
     GenTree* fgOptimizeBitwiseXor(GenTreeOp* xorOp);
     GenTree* fgPropagateCommaThrow(GenTree* parent, GenTreeOp* commaThrow, GenTreeFlags precedingSideEffects);
     GenTree* fgMorphRetInd(GenTreeOp* tree);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -13633,12 +13633,6 @@ GenTree* Compiler::gtFoldExpr(GenTree* tree)
             // special operator that can use only one constant
             // to fold - e.g. booleans
 
-            if (opts.OptimizationDisabled())
-            {
-                // Too heavy for tier0
-                return tree;
-            }
-
             return gtFoldExprSpecial(tree);
         }
         else if (tree->OperIsCompare())

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14544,7 +14544,7 @@ GenTree* Compiler::gtFoldExprSpecial(GenTree* tree)
         case GT_DIV:
         case GT_UDIV:
         {
-            if ((op2 == cons) && (val == 1) && !op1->OperIsConst())
+            if ((op2 == cons) && (val == 1))
             {
                 goto DONE_FOLD;
             }
@@ -14568,6 +14568,14 @@ GenTree* Compiler::gtFoldExprSpecial(GenTree* tree)
                 op = gtWrapWithSideEffects(cons, op, GTF_ALL_EFFECT);
                 goto DONE_FOLD;
             }
+            else if (val == 1)
+            {
+                // Fold "cmp & 1" to just "cmp"
+                if (op->OperIsCompare())
+                {
+                    goto DONE_FOLD;
+                }
+            }
             else if (val == 0xFF)
             {
                 op = NewZeroExtendNode(tree->TypeGet(), op, TYP_UBYTE);
@@ -14587,6 +14595,15 @@ GenTree* Compiler::gtFoldExprSpecial(GenTree* tree)
         }
 
         case GT_OR:
+        {
+            if (val == 0)
+            {
+                goto DONE_FOLD;
+            }
+            break;
+        }
+
+        case GT_XOR:
         {
             if (val == 0)
             {


### PR DESCRIPTION
Checking the throughput hit of this. We currently manually do a lot of these optimizations in T0 as part of `fgMorphSmpOp` after having called `gtFoldExpr`. If the throughput hit isn't significant, we should be able to win some of it back and remove the duplicated logic from morph to simplify the codebase.