### PR TITLE
Override type load limit in AssemblyBinder::GetNameForDiagnosticsFromManagedALC

### DIFF
--- a/src/coreclr/vm/assemblybinder.cpp
+++ b/src/coreclr/vm/assemblybinder.cpp
@@ -174,6 +174,8 @@ void AssemblyBinder::GetNameForDiagnosticsFromManagedALC(INT_PTR managedALC, /* 
         return;
     }
 
+    OVERRIDE_TYPE_LOAD_LEVEL_LIMIT(CLASS_LOADED);
+
     OBJECTREF* alc = reinterpret_cast<OBJECTREF*>(managedALC);
 
     GCX_COOP();


### PR DESCRIPTION
GetNameForDiagnosticsFromManagedALC calls into user code that can trigger more type loading as side-effect.