### PR TITLE
Ignore revocation checking failures on HTTPS tests on OSX

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -267,6 +267,27 @@ namespace System.Net.Http.Functional.Tests
 
                 handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
                 {
+                    if (chain != null)
+                    {
+                        for (int i = 0; i < chain.ChainElements.Count; i++)
+                        {
+                            var element = chain.ChainElements[i];
+                            _output.WriteLine($"Certificate {i}:");
+                            _output.WriteLine(element.Certificate.ToString(true));
+                            foreach (var status in element.ChainElementStatus)
+                            {
+                                _output.WriteLine($"  Status: {status.Status}");
+                                if (status.StatusInformation.Length > 0)
+                                {
+                                    _output.WriteLine($"  Status Information: {status.StatusInformation}");
+                                }
+                            }
+                            _output.WriteLine("");
+                        }
+                    }
+
+                    _output.WriteLine($"SSL Policy Errors: {errors}");
+
                     callbackCalled = true;
                     Assert.NotNull(request);
                     Assert.NotNull(cert);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -256,7 +256,6 @@ namespace System.Net.Http.Functional.Tests
         {
             new object[] { Configuration.Http.ExpiredCertRemoteServer, SslPolicyErrors.RemoteCertificateChainErrors },
             new object[] { Configuration.Http.WrongHostNameCertRemoteServer , SslPolicyErrors.RemoteCertificateNameMismatch},
-            new object[] { "https://smartermail.emclient.com/", SslPolicyErrors.None},
         };
 
         private async Task UseCallback_BadCertificate_ExpectedPolicyErrors_Helper(string url, string useHttp2String, SslPolicyErrors expectedErrors)
@@ -271,8 +270,7 @@ namespace System.Net.Http.Functional.Tests
                     // https://github.com/dotnet/corefx/issues/21922#issuecomment-315555237
                     X509ChainStatusFlags flags = chain.ChainStatus.Aggregate(X509ChainStatusFlags.NoError, (cur, status) => cur | status.Status);
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
-                        flags == X509ChainStatusFlags.RevocationStatusUnknown &&
-                        handler.CheckCertificateRevocationList)
+                        flags == X509ChainStatusFlags.RevocationStatusUnknown)
                     {
                         expectedErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
                     }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -268,26 +268,14 @@ namespace System.Net.Http.Functional.Tests
 
                 handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
                 {
-                    if (chain != null)
+                    // https://github.com/dotnet/corefx/issues/21922#issuecomment-315555237
+                    X509ChainStatusFlags flags = chain.ChainStatus.Aggregate(X509ChainStatusFlags.NoError, (cur, status) => cur | status.Status);
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+                        flags == X509ChainStatusFlags.RevocationStatusUnknown &&
+                        handler.CheckCertificateRevocationList)
                     {
-                        for (int i = 0; i < chain.ChainElements.Count; i++)
-                        {
-                            var element = chain.ChainElements[i];
-                            _output.WriteLine($"Certificate {i}:");
-                            _output.WriteLine(element.Certificate.ToString(true));
-                            foreach (var status in element.ChainElementStatus)
-                            {
-                                _output.WriteLine($"  Status: {status.Status}");
-                                if (status.StatusInformation.Length > 0)
-                                {
-                                    _output.WriteLine($"  Status Information: {status.StatusInformation}");
-                                }
-                            }
-                            _output.WriteLine("");
-                        }
+                        expectedErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
                     }
-
-                    _output.WriteLine($"SSL Policy Errors: {errors}");
 
                     callbackCalled = true;
                     Assert.NotNull(request);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -256,6 +256,7 @@ namespace System.Net.Http.Functional.Tests
         {
             new object[] { Configuration.Http.ExpiredCertRemoteServer, SslPolicyErrors.RemoteCertificateChainErrors },
             new object[] { Configuration.Http.WrongHostNameCertRemoteServer , SslPolicyErrors.RemoteCertificateNameMismatch},
+            new object[] { "https://smartermail.emclient.com/", SslPolicyErrors.None},
         };
 
         private async Task UseCallback_BadCertificate_ExpectedPolicyErrors_Helper(string url, string useHttp2String, SslPolicyErrors expectedErrors)


### PR DESCRIPTION
This PR applies similar fix as in https://github.com/dotnet/runtime/issues/22644 to Outerloop HTTPS tests where we check exact certificate validation errors. Additional context is also available at https://github.com/dotnet/runtime/issues/25872