### PR TITLE
Update openssl dependency for SLES

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-sles.12.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-sles.12.proj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <LinuxPackageDependency Include="libopenssl1_1;libicu;krb5" />
+    <LinuxPackageDependency Include="libopenssl3;libicu;krb5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates the openssl dependency for SLES to `libopenssl3`. We have updated the openSUSE dependency in March with https://github.com/dotnet/runtime/pull/113548

Based on discussion in https://github.com/dotnet/runtime/issues/116519, this should be updated in SLES as well.