### PR TITLE
Add System.Security.Cryptography.Pkcs to aspnetcore transport package

### DIFF
--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -224,6 +224,7 @@
       Microsoft.Extensions.Primitives;
       System.Diagnostics.EventLog;
       System.Formats.Cbor;
+      System.Security.Cryptography.Pkcs;
       System.Security.Cryptography.Xml;
       System.Threading.AccessControl;
       System.Threading.RateLimiting;


### PR DESCRIPTION
This library is in aspnetcore's shared framework (but not its ref pack). Adding it to the aspnetcore transport package will allow aspnetcore to redist its .pdb.