### PR TITLE
[EventPipe][UserEvents] Add copy of user_events structs

### DIFF
--- a/src/native/eventpipe/ep-session-provider.c
+++ b/src/native/eventpipe/ep-session-provider.c
@@ -7,10 +7,6 @@
 #include "ep-session-provider.h"
 #include "ep-rt.h"
 
-#if HAVE_LINUX_USER_EVENTS_H
-#include <linux/user_events.h> // DIAG_IOCSREG
-#endif // HAVE_LINUX_USER_EVENTS_H
-
 #if HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h> // session_register_tracepoint
 #endif // HAVE_SYS_IOCTL_H
@@ -149,7 +145,7 @@ ep_on_error:
  * EventPipeSessionProviderTracepoint.
  */
 
-#if HAVE_LINUX_USER_EVENTS_H && HAVE_SYS_IOCTL_H
+#if HAVE_SYS_IOCTL_H
 static
 bool
 session_provider_tracepoint_register (
@@ -194,7 +190,7 @@ session_provider_tracepoint_unregister (
 
 	return true;
 }
-#else // HAVE_LINUX_USER_EVENTS_H && HAVE_SYS_IOCTL_H
+#else // HAVE_SYS_IOCTL_H
 static
 bool
 session_provider_tracepoint_register (
@@ -214,7 +210,7 @@ session_provider_tracepoint_unregister (
 	// Not Supported
 	return false;
 }
-#endif // HAVE_LINUX_USER_EVENTS_H && HAVE_SYS_IOCTL_H
+#endif // HAVE_SYS_IOCTL_H
 
 /*
  *  ep_session_provider_register_tracepoints

--- a/src/native/eventpipe/ep-session-provider.h
+++ b/src/native/eventpipe/ep-session-provider.h
@@ -11,6 +11,67 @@
 #endif
 #include "ep-getter-setter.h"
 
+#if HAVE_LINUX_USER_EVENTS_H
+#include <linux/user_events.h> // DIAG_IOCSREG
+#else // HAVE_LINUX_USER_EVENTS_H
+/*
+ * Describes an event registration and stores the results of the registration.
+ * This structure is passed to the DIAG_IOCSREG ioctl, callers at a minimum
+ * must set the size and name_args before invocation.
+ */
+struct user_reg {
+
+	/* Input: Size of the user_reg structure being used */
+	uint32_t size;
+
+	/* Input: Bit in enable address to use */
+	uint8_t enable_bit;
+
+	/* Input: Enable size in bytes at address */
+	uint8_t enable_size;
+
+	/* Input: Flags to use, if any */
+	uint16_t flags;
+
+	/* Input: Address to update when enabled */
+	uint64_t enable_addr;
+
+	/* Input: Pointer to string with event name, description and flags */
+	uint64_t name_args;
+
+	/* Output: Index of the event to use when writing data */
+	uint32_t write_index;
+} __attribute__((__packed__));
+
+/*
+ * Describes an event unregister, callers must set the size, address and bit.
+ * This structure is passed to the DIAG_IOCSUNREG ioctl to disable bit updates.
+ */
+struct user_unreg {
+	/* Input: Size of the user_unreg structure being used */
+	uint32_t size;
+
+	/* Input: Bit to unregister */
+	uint8_t disable_bit;
+
+	/* Input: Reserved, set to 0 */
+	uint8_t __reserved;
+
+	/* Input: Reserved, set to 0 */
+	uint16_t __reserved2;
+
+	/* Input: Address to unregister */
+	uint64_t disable_addr;
+} __attribute__((__packed__));
+
+/* Request to register a user_event */
+#define DIAG_IOCSREG 3221760512
+
+/* Requests to unregister a user_event */
+#define DIAG_IOCSUNREG 1074276866
+
+#endif // HAVE_LINUX_USER_EVENTS_H
+
 /*
  * EventPipeSessionProviderTracepoint.
  */

--- a/src/native/eventpipe/ep-session-provider.h
+++ b/src/native/eventpipe/ep-session-provider.h
@@ -65,10 +65,10 @@ struct user_unreg {
 } __attribute__((__packed__));
 
 /* Request to register a user_event */
-#define DIAG_IOCSREG 3221760512
+#define DIAG_IOCSREG 0xC0082A00
 
 /* Requests to unregister a user_event */
-#define DIAG_IOCSUNREG 1074276866
+#define DIAG_IOCSUNREG 0x40082A02
 
 #endif // HAVE_LINUX_USER_EVENTS_H
 

--- a/src/native/eventpipe/ep-session-provider.h
+++ b/src/native/eventpipe/ep-session-provider.h
@@ -41,7 +41,7 @@ struct user_reg {
 
 	/* Output: Index of the event to use when writing data */
 	uint32_t write_index;
-} __attribute__((__packed__));
+};
 
 /*
  * Describes an event unregister, callers must set the size, address and bit.
@@ -55,14 +55,14 @@ struct user_unreg {
 	uint8_t disable_bit;
 
 	/* Input: Reserved, set to 0 */
-	uint8_t __reserved;
+	uint8_t _reserved;
 
 	/* Input: Reserved, set to 0 */
-	uint16_t __reserved2;
+	uint16_t _reserved2;
 
 	/* Input: Address to unregister */
 	uint64_t disable_addr;
-} __attribute__((__packed__));
+};
 
 /* Request to register a user_event */
 #define DIAG_IOCSREG 0xC0082A00


### PR DESCRIPTION
The Linux .NET SDK build will build with `--cross`, which ends up not finding the `linux/user_events.h` header.
For now, as only the `user_reg`, `user_unreg`, `DIAG_IOCSREG`, and `DIAG_IOCSUNREG` types are needed, add a copy of those definitions in the event that the `linux/user_events.h` header is not found.

NOTE: DIAG_IOCSREG and DIAG_IOCSUNREG are a user facing ABI value, and I grabbed them by printing out the macros in the linux user_events example [here](https://github.com/torvalds/linux/blob/master/samples/user_events/example.c)

After figuring out how to properly include the `linux/user_events.h` header in the cross build, this change will be reverted.

### Testing

Grabbed the Linux daily SDK build, built a simple console app, and sent the IPC Command to enable a user_events eventpipe session, received `0x80004005` which corresponds to [DS_IPC_E_FAIL](https://github.com/dotnet/runtime/blob/6da0fa9a95ab50d9dd14496f3625cf10eeffefab/src/native/eventpipe/ds-types.h#L131C9-L131C23) for the diagnostic server.

Built these changes in a docker container running the same image that the machine that builds the SDK using `ROOTFS_DIR=/crossrootfs/x64 ./build.sh --cross -s clr -c Release`, copied over the artifacts into the console app's artifacts, and sent the IPC Command to enable a user_events eventpipe session and received a valid EventPipe Session ID.
Enabling the user_events tracepoint enable bits, saw the expected events written to the trace file.