### PR TITLE
Add trimming intrinsic for EventInfo.EventHandlerType.GetMethod("Invoke")

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodReturnValue.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodReturnValue.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using ILCompiler.Dataflow;
 using ILLink.Shared.DataFlow;
+using ILLink.Shared.TypeSystemProxy;
 using Internal.TypeSystem;
 
 #nullable enable
@@ -21,19 +22,20 @@ namespace ILLink.Shared.TrimAnalysis
         {
             Debug.Assert(!isNewObj || method.IsConstructor, "isNewObj can only be true for constructors");
             StaticType = isNewObj ? method.OwningType : method.Signature.ReturnType;
-            Method = method;
+            MethodDesc = method;
+            Method = new MethodProxy(method);
             DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
         }
 
-        public readonly MethodDesc Method;
+        public readonly MethodDesc MethodDesc;
 
         public override DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes { get; }
 
         public override IEnumerable<string> GetDiagnosticArgumentsForAnnotationMismatch()
-            => new string[] { DiagnosticUtilities.GetMethodSignatureDisplayName(Method) };
+            => new string[] { DiagnosticUtilities.GetMethodSignatureDisplayName(MethodDesc) };
 
         public override SingleValue DeepCopy() => this; // This value is immutable
 
-        public override string ToString() => this.ValueToString(Method, DynamicallyAccessedMemberTypes);
+        public override string ToString() => this.ValueToString(MethodDesc, DynamicallyAccessedMemberTypes);
     }
 }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodReturnValue.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodReturnValue.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using ILLink.RoslynAnalyzer;
 using ILLink.Shared.DataFlow;
+using ILLink.Shared.TypeSystemProxy;
 using Microsoft.CodeAnalysis;
 
 namespace ILLink.Shared.TrimAnalysis
@@ -21,6 +22,7 @@ namespace ILLink.Shared.TrimAnalysis
 		{
 			Debug.Assert (!isNewObj || methodSymbol.MethodKind == MethodKind.Constructor, "isNewObj can only be true for constructors");
 			MethodSymbol = methodSymbol;
+			Method = new MethodProxy (methodSymbol);
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			StaticType = new (isNewObj ? methodSymbol.ContainingType : methodSymbol.ReturnType);
 		}

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/MethodReturnValue.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/MethodReturnValue.cs
@@ -11,5 +11,7 @@ namespace ILLink.Shared.TrimAnalysis
 	internal sealed partial record class MethodReturnValue : ValueWithDynamicallyAccessedMembers, IValueWithStaticType
 	{
 		public TypeProxy? StaticType { get; }
+
+		public MethodProxy Method { get; }
 	}
 }

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodReturnValue.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodReturnValue.cs
@@ -24,25 +24,26 @@ namespace ILLink.Shared.TrimAnalysis
 			Debug.Assert (!isNewObj || method.Definition.IsConstructor, "isNewObj can only be true for constructors");
 			var methodRef = method.Method;
 			var staticType = isNewObj ? methodRef.DeclaringType : methodRef.ReturnType.InflateFrom (methodRef as IGenericInstance ?? methodRef.DeclaringType as IGenericInstance);
-			return new MethodReturnValue (staticType, method.Definition, dynamicallyAccessedMemberTypes, resolver);
+			return new MethodReturnValue (staticType, method, dynamicallyAccessedMemberTypes, resolver);
 		}
 
-		private MethodReturnValue (TypeReference? staticType, MethodDefinition method, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes, ITryResolveMetadata resolver)
+		private MethodReturnValue (TypeReference? staticType, MethodProxy method, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes, ITryResolveMetadata resolver)
 		{
 			StaticType = staticType == null ? null : new (staticType, resolver);
+			MethodDefinition = method.Definition;
 			Method = method;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 		}
 
-		public readonly MethodDefinition Method;
+		public readonly MethodDefinition MethodDefinition;
 
 		public override DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes { get; }
 
 		public override IEnumerable<string> GetDiagnosticArgumentsForAnnotationMismatch ()
-			=> new string[] { DiagnosticUtilities.GetMethodSignatureDisplayName (Method) };
+			=> new string[] { DiagnosticUtilities.GetMethodSignatureDisplayName (MethodDefinition) };
 
 		public override SingleValue DeepCopy () => this; // This value is immutable
 
-		public override string ToString () => this.ValueToString (Method, DynamicallyAccessedMemberTypes);
+		public override string ToString () => this.ValueToString (MethodDefinition, DynamicallyAccessedMemberTypes);
 	}
 }

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -35,6 +35,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task EventHanderTypeGetInvokeMethod ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task EventUsedViaReflection ()
 		{
 			return RunTest ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/EventHanderTypeGetInvokeMethod.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/EventHanderTypeGetInvokeMethod.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[ExpectedNoWarnings]
+	public class EventHanderTypeGetInvokeMethod
+	{
+		public static void Main()
+		{
+			EventDelegate.Test ();
+			NonDelegate.Test ();
+		}
+
+		class EventDelegate
+		{
+			[Kept]
+			[KeptBackingField]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			public static event EventHandler MyEvent;
+
+			public static void Test ()
+			{
+				var eventInfo = typeof(EventHanderTypeGetInvokeMethod).GetEvent(nameof(MyEvent));
+				var invoke = eventInfo.EventHandlerType.GetMethod("Invoke");
+			}
+		}
+
+		class NonDelegate
+		{
+			[Kept]
+			[KeptBaseType (typeof (EventInfo))]
+			[KeptMember (".ctor()")]
+			class CustomEventInfo : EventInfo
+			{
+				[Kept]
+				public override Type EventHandlerType {
+					[Kept]
+					get => typeof (NonDelegate);
+				}
+
+				[Kept]
+				public override bool IsDefined (Type type, bool inherit) => throw null;
+				[Kept]
+				public override object[] GetCustomAttributes (bool inherit) => throw null;
+				[Kept]
+				public override object[] GetCustomAttributes (Type attributeType, bool inherit) => throw null;
+				[Kept]
+				public override string Name {
+					[Kept]
+					get => throw null;
+				}
+				[Kept]
+				public override Type ReflectedType {
+					[Kept]
+					get => throw null;
+				}
+				[Kept]
+				public override Type DeclaringType {
+					[Kept]
+					get => throw null;
+				}
+				[Kept]
+				public override MethodInfo GetAddMethod (bool nonPublic) => throw null;
+				[Kept]
+				public override MethodInfo GetRemoveMethod (bool nonPublic) => throw null;
+				[Kept]
+				public override MethodInfo GetRaiseMethod (bool nonPublic) => throw null;
+				[Kept]
+				public override EventAttributes Attributes {
+					[Kept]
+					get => throw null;
+				}
+			}
+
+			// Strictly speaking this should be kept, but trimmer doesn't see through the custom event info.
+			// See discussion at https://github.com/dotnet/runtime/issues/114113.
+			[RequiresUnreferencedCode (nameof (Invoke))]
+			public void Invoke ()
+			{
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2075", nameof (Type.GetMethod), Tool.Analyzer,
+				"ILLink/ILC intrinsic handling assumes EventHandlerType is a delegate: https://github.com/dotnet/runtime/issues/114113")]
+			public static void Test ()
+			{
+				new CustomEventInfo ().EventHandlerType.GetMethod ("Invoke");
+			}
+		}
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/EventHanderTypeGetInvokeMethod.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/EventHanderTypeGetInvokeMethod.cs
@@ -3,13 +3,17 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {
 	[ExpectedNoWarnings]
+	// Necessary to allow trimming unused EventInfo methods,
+	// making the test behavior more consistent with ILC.
+	[SetupLinkerTrimMode ("link")]
 	public class EventHanderTypeGetInvokeMethod
 	{
-		public static void Main()
+		public static void Main ()
 		{
 			EventDelegate.Test ();
 			NonDelegate.Test ();
@@ -23,10 +27,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventRemoveMethod]
 			public static event EventHandler MyEvent;
 
+			[Kept]
 			public static void Test ()
 			{
-				var eventInfo = typeof(EventHanderTypeGetInvokeMethod).GetEvent(nameof(MyEvent));
-				var invoke = eventInfo.EventHandlerType.GetMethod("Invoke");
+				var eventInfo = typeof (EventDelegate).GetEvent (nameof (MyEvent));
+				var invoke = eventInfo.EventHandlerType.GetMethod ("Invoke");
 			}
 		}
 
@@ -43,38 +48,34 @@ namespace Mono.Linker.Tests.Cases.Reflection
 					get => typeof (NonDelegate);
 				}
 
-				[Kept]
+				// ILLink keeps more methods on MemberInfo due for stack trace support,
+				// but differences in this class are not important for this testcase.
+
+				[Kept (By = Tool.Trimmer)]
 				public override bool IsDefined (Type type, bool inherit) => throw null;
-				[Kept]
 				public override object[] GetCustomAttributes (bool inherit) => throw null;
-				[Kept]
+				[Kept (By = Tool.Trimmer)]
 				public override object[] GetCustomAttributes (Type attributeType, bool inherit) => throw null;
-				[Kept]
+				[Kept (By = Tool.Trimmer)]
 				public override string Name {
-					[Kept]
+					[Kept (By = Tool.Trimmer)]
 					get => throw null;
 				}
-				[Kept]
+				[Kept (By = Tool.Trimmer)]
 				public override Type ReflectedType {
-					[Kept]
+					[Kept (By = Tool.Trimmer)]
 					get => throw null;
 				}
-				[Kept]
+				[Kept (By = Tool.Trimmer)]
 				public override Type DeclaringType {
-					[Kept]
+					[Kept (By = Tool.Trimmer)]
 					get => throw null;
 				}
-				[Kept]
+				[Kept (By = Tool.Trimmer)]
 				public override MethodInfo GetAddMethod (bool nonPublic) => throw null;
-				[Kept]
 				public override MethodInfo GetRemoveMethod (bool nonPublic) => throw null;
-				[Kept]
 				public override MethodInfo GetRaiseMethod (bool nonPublic) => throw null;
-				[Kept]
-				public override EventAttributes Attributes {
-					[Kept]
-					get => throw null;
-				}
+				public override EventAttributes Attributes => throw null;
 			}
 
 			// Strictly speaking this should be kept, but trimmer doesn't see through the custom event info.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/114113

Because ILLink and ILC keep the `Invoke` method on delegates, there shouldn't be a warning for the common pattern of `EventInfo.EventHandlerType.GetMethod("Invoke")`.

It's possible to break this logic by using a custom `EventInfo` - see the testcase and discussion in the original issue.