### PR TITLE
Update ILLink analyzer generated testcases

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/SubstitutionsTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/SubstitutionsTests.g.cs
@@ -8,12 +8,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 	{
 
 		[Fact]
-		public Task EmbeddedFieldSubstitutionsInReferencedAssembly ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
 		public Task EmbeddedMethodSubstitutionsInReferencedAssembly ()
 		{
 			return RunTest (allowMissingWarnings: true);
@@ -45,18 +39,6 @@ namespace ILLink.RoslynAnalyzer.Tests
 
 		[Fact]
 		public Task FeatureGuardSubstitutionsDisabled ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task InitField ()
-		{
-			return RunTest (allowMissingWarnings: true);
-		}
-
-		[Fact]
-		public Task InitFieldExistingCctor ()
 		{
 			return RunTest (allowMissingWarnings: true);
 		}


### PR DESCRIPTION
These tests were removed in https://github.com/dotnet/runtime/pull/107380 - the generated files should have been updated there too.