### PR TITLE
JIT: Generalize flow edge redirection logic

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1916,11 +1916,8 @@ void AsyncTransformation::CreateResumptionSwitch()
                 checkILOffsetBB->bbNum);
 
         // Redirect newEntryBB -> onContinuationBB into newEntryBB -> checkILOffsetBB -> onContinuationBB
-        m_comp->fgRemoveRefPred(newEntryBB->GetTrueEdge());
-
-        FlowEdge* toCheckILOffsetBB = m_comp->fgAddRefPred(checkILOffsetBB, newEntryBB);
-        newEntryBB->SetTrueEdge(toCheckILOffsetBB);
-        toCheckILOffsetBB->setLikelihood(0);
+        m_comp->fgRedirectEdge(newEntryBB->GetTrueEdgeRef(), checkILOffsetBB);
+        newEntryBB->GetTrueEdge()->setLikelihood(0);
         checkILOffsetBB->inheritWeightPercentage(newEntryBB, 0);
 
         FlowEdge* toOnContinuationBB = m_comp->fgAddRefPred(onContinuationBB, checkILOffsetBB);
@@ -1969,10 +1966,8 @@ void AsyncTransformation::CreateResumptionSwitch()
         BasicBlock* checkILOffsetBB    = m_comp->fgNewBBbefore(BBJ_COND, onContinuationBB, true);
 
         // Switch newEntryBB -> onContinuationBB into newEntryBB -> checkILOffsetBB
-        m_comp->fgRemoveRefPred(newEntryBB->GetTrueEdge());
-        FlowEdge* toCheckILOffset = m_comp->fgAddRefPred(checkILOffsetBB, newEntryBB);
-        newEntryBB->SetTrueEdge(toCheckILOffset);
-        toCheckILOffset->setLikelihood(0);
+        m_comp->fgRedirectEdge(newEntryBB->GetTrueEdgeRef(), checkILOffsetBB);
+        newEntryBB->GetTrueEdge()->setLikelihood(0);
         checkILOffsetBB->inheritWeightPercentage(newEntryBB, 0);
 
         // Make checkILOffsetBB ->(true)  onNoContinuationBB

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -684,15 +684,15 @@ public:
         return m_dupCount;
     }
 
-    void incrementDupCount()
+    void incrementDupCount(unsigned dupCount = 1)
     {
-        m_dupCount++;
+        m_dupCount += dupCount;
     }
 
-    void decrementDupCount()
+    void decrementDupCount(unsigned dupCount = 1)
     {
-        assert(m_dupCount >= 1);
-        m_dupCount--;
+        assert(m_dupCount >= dupCount);
+        m_dupCount -= dupCount;
     }
 
     bool visited() const

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -861,6 +861,14 @@ public:
         return bbTargetEdge;
     }
 
+    FlowEdge*& GetTargetEdgeRef()
+    {
+        assert(HasInitializedTarget());
+        assert(bbTargetEdge->getSourceBlock() == this);
+        assert(bbTargetEdge->getDestinationBlock() != nullptr);
+        return bbTargetEdge;
+    }
+
     void SetTargetEdge(FlowEdge* targetEdge)
     {
         // SetKindAndTarget() nulls target for non-jump kinds,
@@ -880,6 +888,15 @@ public:
     }
 
     FlowEdge* GetTrueEdge() const
+    {
+        assert(KindIs(BBJ_COND));
+        assert(bbTrueEdge != nullptr);
+        assert(bbTrueEdge->getSourceBlock() == this);
+        assert(bbTrueEdge->getDestinationBlock() != nullptr);
+        return bbTrueEdge;
+    }
+
+    FlowEdge*& GetTrueEdgeRef()
     {
         assert(KindIs(BBJ_COND));
         assert(bbTrueEdge != nullptr);
@@ -913,6 +930,15 @@ public:
     }
 
     FlowEdge* GetFalseEdge() const
+    {
+        assert(KindIs(BBJ_COND));
+        assert(bbFalseEdge != nullptr);
+        assert(bbFalseEdge->getSourceBlock() == this);
+        assert(bbFalseEdge->getDestinationBlock() != nullptr);
+        return bbFalseEdge;
+    }
+
+    FlowEdge*& GetFalseEdgeRef()
     {
         assert(KindIs(BBJ_COND));
         assert(bbFalseEdge != nullptr);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6111,11 +6111,7 @@ private:
     FlowEdge** fgGetPredInsertPoint(BasicBlock* blockPred, BasicBlock* newTarget);
 
 public:
-    void fgRedirectTargetEdge(BasicBlock* block, BasicBlock* newTarget);
-
-    void fgRedirectTrueEdge(BasicBlock* block, BasicBlock* newTarget);
-
-    void fgRedirectFalseEdge(BasicBlock* block, BasicBlock* newTarget);
+    void fgRedirectEdge(FlowEdge*& edgeRef, BasicBlock* newTarget);
 
     void fgFindBasicBlocks();
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -481,6 +481,7 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* oldTarget, Bas
 {
     assert(block != nullptr);
     assert(fgPredsComputed);
+    assert(fgGetPredForBlock(oldTarget, block) != nullptr);
 
     switch (block->GetKind())
     {
@@ -491,36 +492,21 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* oldTarget, Bas
         case BBJ_EHFILTERRET:
         case BBJ_LEAVE: // This function can be called before import, so we still have BBJ_LEAVE
             assert(block->TargetIs(oldTarget));
-            fgRedirectTargetEdge(block, newTarget);
+            fgRedirectEdge(block->GetTargetEdgeRef(), newTarget);
             break;
 
         case BBJ_COND:
             if (block->TrueTargetIs(oldTarget))
             {
-                if (block->FalseEdgeIs(block->GetTrueEdge()))
-                {
-                    // Branch was degenerate, simplify it first
-                    //
-                    fgRemoveConditionalJump(block);
-                    assert(block->KindIs(BBJ_ALWAYS));
-                    assert(block->TargetIs(oldTarget));
-                    fgRedirectTargetEdge(block, newTarget);
-                }
-                else
-                {
-                    fgRedirectTrueEdge(block, newTarget);
-                }
+                fgRedirectEdge(block->GetTrueEdgeRef(), newTarget);
             }
             else
             {
-                // Already degenerate cases should have taken the true path above
-                //
                 assert(block->FalseTargetIs(oldTarget));
-                assert(!block->TrueEdgeIs(block->GetFalseEdge()));
-                fgRedirectFalseEdge(block, newTarget);
+                fgRedirectEdge(block->GetFalseEdgeRef(), newTarget);
             }
 
-            if (block->KindIs(BBJ_COND) && block->TrueEdgeIs(block->GetFalseEdge()))
+            if (block->TrueEdgeIs(block->GetFalseEdge()))
             {
                 // Block became degenerate, simplify
                 //
@@ -4132,7 +4118,7 @@ void Compiler::fgFixEntryFlowForOSR()
     fgCreateNewInitBB();
     assert(fgFirstBB->KindIs(BBJ_ALWAYS));
 
-    fgRedirectTargetEdge(fgFirstBB, fgOSREntryBB);
+    fgRedirectEdge(fgFirstBB->GetTargetEdgeRef(), fgOSREntryBB);
 
     fgFirstBB->bbWeight = fgCalledCount;
     fgFirstBB->CopyFlags(fgEntryBB, BBF_PROF_WEIGHT);

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -171,7 +171,7 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
                     fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
                     // Ref count updates.
-                    fgRedirectTargetEdge(currentBlock, postTryFinallyBlock);
+                    fgRedirectEdge(currentBlock->GetTargetEdgeRef(), postTryFinallyBlock);
                     currentBlock->SetKind(BBJ_ALWAYS);
                     currentBlock->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
 
@@ -1565,7 +1565,7 @@ PhaseStatus Compiler::fgCloneFinally()
                     fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
                     // Ref count updates.
-                    fgRedirectTargetEdge(currentBlock, firstCloneBlock);
+                    fgRedirectEdge(currentBlock->GetTargetEdgeRef(), firstCloneBlock);
 
                     // This call returns to the expected spot, so retarget it to branch to the clone.
                     currentBlock->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
@@ -2197,7 +2197,7 @@ bool Compiler::fgRetargetBranchesToCanonicalCallFinally(BasicBlock*      block,
             canonicalCallFinally->bbNum);
 
     assert(callFinally->bbRefs > 0);
-    fgRedirectTargetEdge(block, canonicalCallFinally);
+    fgRedirectEdge(block->GetTargetEdgeRef(), canonicalCallFinally);
 
     // Update profile counts
     //

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -367,154 +367,40 @@ FlowEdge** Compiler::fgGetPredInsertPoint(BasicBlock* blockPred, BasicBlock* new
 }
 
 //------------------------------------------------------------------------
-// fgRedirectTargetEdge: Sets block->bbTargetEdge's target block to newTarget,
-// updating pred lists as necessary.
+// fgRedirectEdge: Sets the given edge's target block to 'newTarget',
+// updating pred lists as needed.
 //
 // Arguments:
-//    block -- The block we want to make a predecessor of newTarget.
-//             It could be one already, in which case nothing changes.
-//    newTarget -- The new successor of block.
+//    edge -- The edge to update. Note that this is a reference type
+//    to support automatic updates to BasicBlock members (bbTargetEdge et al).
+//    newTarget -- The new successor of the edge.
 //
-void Compiler::fgRedirectTargetEdge(BasicBlock* block, BasicBlock* newTarget)
+void Compiler::fgRedirectEdge(FlowEdge*& edge, BasicBlock* newTarget)
 {
-    assert(block != nullptr);
+    assert(edge != nullptr);
     assert(newTarget != nullptr);
 
-    FlowEdge* edge = block->GetTargetEdge();
-    assert(edge->getDupCount() == 1);
+    BasicBlock* const block = edge->getSourceBlock();
+    fgRemoveAllRefPreds(edge->getDestinationBlock(), block);
 
-    // Update oldTarget's pred list.
-    // We could call fgRemoveRefPred, but since we're removing the one and only ref from block to oldTarget,
-    // fgRemoveAllRefPreds is slightly more efficient (one fewer branch, doesn't update edge's dup count, etc).
-    //
-    BasicBlock* oldTarget = edge->getDestinationBlock();
-    fgRemoveAllRefPreds(oldTarget, block);
-
-    // Splice edge into new target block's pred list
-    //
-    FlowEdge** predListPtr = fgGetPredInsertPoint(block, newTarget);
-    edge->setNextPredEdge(*predListPtr);
-    edge->setDestinationBlock(newTarget);
-    *predListPtr = edge;
-
-    // Pred list of target should (still) be ordered
-    //
-    assert(newTarget->checkPredListOrder());
-
-    // Edge should still have only one ref
-    assert(edge->getDupCount() == 1);
-    newTarget->bbRefs++;
-}
-
-//------------------------------------------------------------------------
-// fgRedirectTrueEdge: Sets block->bbTrueEdge's target block to newTarget,
-// updating pred lists as necessary.
-//
-// Arguments:
-//    block -- The block we want to make a predecessor of newTarget.
-//             It could be one already, in which case nothing changes.
-//    newTarget -- The new successor of block.
-//
-// Notes:
-//    This assumes block's true and false targets are different.
-//    If setting block's true target to its false target,
-//    fgRedirectTrueEdge increments the false edge's dup count,
-//    and ensures block->bbTrueEdge == block->bbFalseEdge.
-//    We don't update newTarget->bbPreds in this case,
-//    as we don't want to have more than one edge from the same predecessor.
-//
-void Compiler::fgRedirectTrueEdge(BasicBlock* block, BasicBlock* newTarget)
-{
-    assert(block != nullptr);
-    assert(newTarget != nullptr);
-    assert(block->KindIs(BBJ_COND));
-    assert(!block->TrueEdgeIs(block->GetFalseEdge()));
-
-    // Update oldTarget's pred list.
-    // We could call fgRemoveRefPred, but since we're removing the one and only ref from block to oldTarget,
-    // fgRemoveAllRefPreds is slightly more efficient (one fewer branch, doesn't update edge's dup count, etc).
-    //
-    FlowEdge*   trueEdge  = block->GetTrueEdge();
-    BasicBlock* oldTarget = trueEdge->getDestinationBlock();
-    fgRemoveAllRefPreds(oldTarget, block);
-
-    // Splice edge into new target block's pred list
-    //
     FlowEdge** predListPtr = fgGetPredInsertPoint(block, newTarget);
     FlowEdge*  predEdge    = *predListPtr;
 
-    if (block->FalseEdgeIs(predEdge))
+    if ((predEdge != nullptr) && (predEdge->getSourceBlock() == block))
     {
-        block->SetTrueEdge(predEdge);
-        predEdge->incrementDupCount();
+        edge = predEdge;
+        edge->incrementDupCount();
     }
     else
     {
-        trueEdge->setNextPredEdge(predEdge);
-        trueEdge->setDestinationBlock(newTarget);
-        *predListPtr = trueEdge;
+        edge->setNextPredEdge(predEdge);
+        *predListPtr = edge;
+        edge->setDestinationBlock(newTarget);
     }
 
     newTarget->bbRefs++;
 
-    // Pred list of target should (still) be ordered
-    //
-    assert(newTarget->checkPredListOrder());
-}
-
-//------------------------------------------------------------------------
-// fgRedirectFalseEdge: Sets block->bbFalseEdge's target block to newTarget,
-// updating pred lists as necessary.
-//
-// Arguments:
-//    block -- The block we want to make a predecessor of newTarget.
-//             It could be one already, in which case nothing changes.
-//    newTarget -- The new successor of block.
-//
-// Notes:
-//    This assumes block's true and false targets are different.
-//    If setting block's false target to its true target,
-//    fgRedirectFalseEdge increments the true edge's dup count,
-//    and ensures block->bbTrueEdge == block->bbFalseEdge.
-//    We don't update newTarget->bbPreds in this case,
-//    as we don't want to have more than one edge from the same predecessor.
-//
-void Compiler::fgRedirectFalseEdge(BasicBlock* block, BasicBlock* newTarget)
-{
-    assert(block != nullptr);
-    assert(newTarget != nullptr);
-    assert(block->KindIs(BBJ_COND));
-    assert(!block->TrueEdgeIs(block->GetFalseEdge()));
-
-    // Update oldTarget's pred list.
-    // We could call fgRemoveRefPred, but since we're removing the one and only ref from block to oldTarget,
-    // fgRemoveAllRefPreds is slightly more efficient (one fewer branch, doesn't update edge's dup count, etc).
-    //
-    FlowEdge*   falseEdge = block->GetFalseEdge();
-    BasicBlock* oldTarget = falseEdge->getDestinationBlock();
-    fgRemoveAllRefPreds(oldTarget, block);
-
-    // Splice edge into new target block's pred list
-    //
-    FlowEdge** predListPtr = fgGetPredInsertPoint(block, newTarget);
-    FlowEdge*  predEdge    = *predListPtr;
-
-    if (block->TrueEdgeIs(predEdge))
-    {
-        block->SetFalseEdge(predEdge);
-        predEdge->incrementDupCount();
-    }
-    else
-    {
-        falseEdge->setNextPredEdge(predEdge);
-        falseEdge->setDestinationBlock(newTarget);
-        *predListPtr = falseEdge;
-    }
-
-    newTarget->bbRefs++;
-
-    // Pred list of target should (still) be ordered
-    //
+    // Pred list of target should still be ordered
     assert(newTarget->checkPredListOrder());
 }
 

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -380,7 +380,8 @@ void Compiler::fgRedirectEdge(FlowEdge*& edge, BasicBlock* newTarget)
     assert(edge != nullptr);
     assert(newTarget != nullptr);
 
-    BasicBlock* const block = edge->getSourceBlock();
+    BasicBlock* const block    = edge->getSourceBlock();
+    const unsigned    dupCount = edge->getDupCount();
     fgRemoveAllRefPreds(edge->getDestinationBlock(), block);
 
     FlowEdge** predListPtr = fgGetPredInsertPoint(block, newTarget);
@@ -389,7 +390,7 @@ void Compiler::fgRedirectEdge(FlowEdge*& edge, BasicBlock* newTarget)
     if ((predEdge != nullptr) && (predEdge->getSourceBlock() == block))
     {
         edge = predEdge;
-        edge->incrementDupCount();
+        edge->incrementDupCount(dupCount);
     }
     else
     {
@@ -398,7 +399,7 @@ void Compiler::fgRedirectEdge(FlowEdge*& edge, BasicBlock* newTarget)
         edge->setDestinationBlock(newTarget);
     }
 
-    newTarget->bbRefs++;
+    newTarget->bbRefs += dupCount;
 
     // Pred list of target should still be ordered
     assert(newTarget->checkPredListOrder());

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1851,7 +1851,7 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
         // Insert inlinee's blocks into inliner's block list.
         assert(topBlock->KindIs(BBJ_ALWAYS));
         assert(topBlock->TargetIs(bottomBlock));
-        fgRedirectTargetEdge(topBlock, InlineeCompiler->fgFirstBB);
+        fgRedirectEdge(topBlock->GetTargetEdgeRef(), InlineeCompiler->fgFirstBB);
 
         topBlock->SetNext(InlineeCompiler->fgFirstBB);
         InlineeCompiler->fgLastBB->SetNext(bottomBlock);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2997,7 +2997,7 @@ void Compiler::fgInsertFuncletPrologBlock(BasicBlock* block)
                 case BBJ_CALLFINALLY:
                 {
                     noway_assert(predBlock->TargetIs(block));
-                    fgRedirectTargetEdge(predBlock, newHead);
+                    fgRedirectEdge(predBlock->GetTargetEdgeRef(), newHead);
                     incomingWeight += predBlock->bbWeight;
                     break;
                 }
@@ -3005,8 +3005,7 @@ void Compiler::fgInsertFuncletPrologBlock(BasicBlock* block)
                 default:
                     // The only way into the handler is via a BBJ_CALLFINALLY (to a finally handler), or
                     // via exception handling.
-                    noway_assert(false);
-                    break;
+                    unreached();
             }
         }
     }

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -386,7 +386,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     if (needsSizeCheck)
     {
         // sizeCheckBb is the first block after prevBb
-        fgRedirectTargetEdge(prevBb, sizeCheckBb);
+        fgRedirectEdge(prevBb->GetTargetEdgeRef(), sizeCheckBb);
 
         // sizeCheckBb flows into nullcheckBb in case if the size check passes
         {
@@ -404,7 +404,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     else
     {
         // nullcheckBb is the first block after prevBb
-        fgRedirectTargetEdge(prevBb, nullcheckBb);
+        fgRedirectEdge(prevBb->GetTargetEdgeRef(), nullcheckBb);
 
         // No size check, nullcheckBb jumps to fast path
         // fallbackBb is only reachable from nullcheckBb (jump destination)
@@ -746,7 +746,7 @@ bool Compiler::fgExpandThreadLocalAccessForCallNativeAOT(BasicBlock** pBlock, St
     // fallback will just execute first time
     fallbackBb->inheritWeightPercentage(tlsRootNullCondBB, 0);
 
-    fgRedirectTargetEdge(prevBb, tlsRootNullCondBB);
+    fgRedirectEdge(prevBb->GetTargetEdgeRef(), tlsRootNullCondBB);
 
     // All blocks are expected to be in the same EH region
     assert(BasicBlock::sameEHRegion(prevBb, block));
@@ -1033,7 +1033,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
         tlsBaseComputeBB->SetTargetEdge(newEdge);
 
         assert(prevBb->KindIs(BBJ_ALWAYS));
-        fgRedirectTargetEdge(prevBb, tlsBaseComputeBB);
+        fgRedirectEdge(prevBb->GetTargetEdgeRef(), tlsBaseComputeBB);
 
         // Inherit the weights
         block->inheritWeight(prevBb);
@@ -1142,7 +1142,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
         // Update preds in all new blocks
         //
         assert(prevBb->KindIs(BBJ_ALWAYS));
-        fgRedirectTargetEdge(prevBb, maxThreadStaticBlocksCondBB);
+        fgRedirectEdge(prevBb->GetTargetEdgeRef(), maxThreadStaticBlocksCondBB);
 
         {
             FlowEdge* const trueEdge  = fgAddRefPred(fallbackBb, maxThreadStaticBlocksCondBB);
@@ -1518,7 +1518,7 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
     //
 
     // Redirect prevBb from block to isInitedBb
-    fgRedirectTargetEdge(prevBb, isInitedBb);
+    fgRedirectEdge(prevBb->GetTargetEdgeRef(), isInitedBb);
     assert(prevBb->JumpsToNext());
 
     {
@@ -1845,7 +1845,7 @@ bool Compiler::fgVNBasedIntrinsicExpansionForCall_ReadUtf8(BasicBlock** pBlock, 
     // Update preds in all new blocks
     //
     // Redirect prevBb to lengthCheckBb
-    fgRedirectTargetEdge(prevBb, lengthCheckBb);
+    fgRedirectEdge(prevBb->GetTargetEdgeRef(), lengthCheckBb);
     lengthCheckBb->inheritWeight(prevBb);
     assert(prevBb->JumpsToNext());
 
@@ -2600,7 +2600,7 @@ bool Compiler::fgLateCastExpansionForCall(BasicBlock** pBlock, Statement* stmt, 
         }
     }
 
-    fgRedirectTargetEdge(firstBb, nullcheckBb);
+    fgRedirectEdge(firstBb->GetTargetEdgeRef(), nullcheckBb);
 
     //
     // Re-distribute weights and set edge likelihoods.

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4695,7 +4695,7 @@ void Compiler::impImportLeaveEHRegions(BasicBlock* block)
 
                 // callBlock calls the finally handler
                 assert(callBlock->HasInitializedTarget());
-                fgRedirectTargetEdge(callBlock, HBtab->ebdHndBeg);
+                fgRedirectEdge(callBlock->GetTargetEdgeRef(), HBtab->ebdHndBeg);
                 callBlock->SetKind(BBJ_CALLFINALLY);
 
                 if (endCatches)
@@ -4990,7 +4990,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 assert((step == block) || !step->HasInitializedTarget());
                 if (step == block)
                 {
-                    fgRedirectTargetEdge(step, exitBlock);
+                    fgRedirectEdge(step->GetTargetEdgeRef(), exitBlock);
                 }
                 else
                 {
@@ -5037,7 +5037,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 // the new BBJ_CALLFINALLY is in a different EH region, thus it can't just replace the BBJ_LEAVE,
                 // which might be in the middle of the "try". In most cases, the BBJ_ALWAYS will jump to the
                 // next block, and flow optimizations will remove it.
-                fgRedirectTargetEdge(block, callBlock);
+                fgRedirectEdge(block->GetTargetEdgeRef(), callBlock);
                 block->SetKind(BBJ_ALWAYS);
 
                 // The new block will inherit this block's weight.
@@ -5063,7 +5063,7 @@ void Compiler::impImportLeave(BasicBlock* block)
 
                 // callBlock calls the finally handler
                 assert(callBlock->HasInitializedTarget());
-                fgRedirectTargetEdge(callBlock, HBtab->ebdHndBeg);
+                fgRedirectEdge(callBlock->GetTargetEdgeRef(), HBtab->ebdHndBeg);
                 callBlock->SetKind(BBJ_CALLFINALLY);
 
 #ifdef DEBUG
@@ -5104,7 +5104,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                     BasicBlock* step2 = fgNewBBinRegion(BBJ_ALWAYS, XTnum + 1, 0, step);
                     if (step == block)
                     {
-                        fgRedirectTargetEdge(step, step2);
+                        fgRedirectEdge(step->GetTargetEdgeRef(), step2);
                     }
                     else
                     {
@@ -5154,7 +5154,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 callBlock = fgNewBBinRegion(BBJ_CALLFINALLY, callFinallyTryIndex, callFinallyHndIndex, step);
                 if (step == block)
                 {
-                    fgRedirectTargetEdge(step, callBlock);
+                    fgRedirectEdge(step->GetTargetEdgeRef(), callBlock);
                 }
                 else
                 {
@@ -5264,7 +5264,7 @@ void Compiler::impImportLeave(BasicBlock* block)
 
                 if (step == block)
                 {
-                    fgRedirectTargetEdge(step, catchStep);
+                    fgRedirectEdge(step->GetTargetEdgeRef(), catchStep);
                 }
                 else
                 {
@@ -5322,7 +5322,7 @@ void Compiler::impImportLeave(BasicBlock* block)
         // leaveTarget is the ultimate destination of the LEAVE
         if (step == block)
         {
-            fgRedirectTargetEdge(step, leaveTarget);
+            fgRedirectEdge(step->GetTargetEdgeRef(), leaveTarget);
         }
         else
         {
@@ -5415,7 +5415,7 @@ void Compiler::impResetLeaveBlock(BasicBlock* block, unsigned jmpAddr)
 
     fgInitBBLookup();
 
-    fgRedirectTargetEdge(block, fgLookupBB(jmpAddr));
+    fgRedirectEdge(block->GetTargetEdgeRef(), fgLookupBB(jmpAddr));
     block->SetKind(BBJ_LEAVE);
 
     // We will leave the BBJ_ALWAYS block we introduced. When it's reimported

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -1305,7 +1305,7 @@ private:
             // Rewire the cold block to jump to the else block,
             // not fall through to the check block.
             //
-            compiler->fgRedirectTargetEdge(coldBlock, elseBlock);
+            compiler->fgRedirectEdge(coldBlock->GetTargetEdgeRef(), elseBlock);
 
             // Update the profile data
             //

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -4492,9 +4492,9 @@ void Compiler::fgExtendEHRegionBefore(BasicBlock* block)
                     printf("EH#%u: Updating target for filter ret block: " FMT_BB " => " FMT_BB "\n", ehGetIndex(HBtab),
                            bFilterLast->bbNum, bPrev->bbNum);
                 }
-#endif // DEBUG
-       // Change the target for bFilterLast from the old first 'block' to the new first 'bPrev'
-                fgRedirectTargetEdge(bFilterLast, bPrev);
+#endif
+                // Change the target for bFilterLast from the old first 'block' to the new first 'bPrev'
+                fgRedirectEdge(bFilterLast->GetTargetEdgeRef(), bPrev);
             }
         }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1550,14 +1550,13 @@ bool Lowering::TryLowerSwitchToBitTest(FlowEdge*   jumpTable[],
 #endif
 
     //
-    // Rewire the blocks as needed.
+    // Set successor edge dup counts to 1 each
     //
 
-    comp->fgRemoveAllRefPreds(bbCase1, bbSwitch);
-    comp->fgRemoveAllRefPreds(bbCase0, bbSwitch);
-
-    case0Edge = comp->fgAddRefPred(bbCase0, bbSwitch, case0Edge);
-    case1Edge = comp->fgAddRefPred(bbCase1, bbSwitch, case1Edge);
+    bbCase0->bbRefs -= (case0Edge->getDupCount() - 1);
+    bbCase1->bbRefs -= (case1Edge->getDupCount() - 1);
+    case0Edge->decrementDupCount(case0Edge->getDupCount() - 1);
+    case1Edge->decrementDupCount(case1Edge->getDupCount() - 1);
 
     // If defaultLikelihood is not ~ 1.0
     //   up-scale case likelihoods by 1.0 / (1.0 - defaultLikelihood)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13906,7 +13906,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
     BasicBlock* elseBlock = fgNewBBafter(BBJ_ALWAYS, condBlock, true);
 
     // Update flowgraph
-    fgRedirectTargetEdge(block, condBlock);
+    fgRedirectEdge(block->GetTargetEdgeRef(), condBlock);
     condBlock->SetTargetEdge(fgAddRefPred(elseBlock, condBlock));
     elseBlock->SetTargetEdge(fgAddRefPred(remainderBlock, elseBlock));
 

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -4524,7 +4524,7 @@ void ObjectAllocator::CloneAndSpecialize(CloneInfo* info)
     BasicBlock*       firstClonedBlock = nullptr;
     bool const        firstFound       = map.Lookup(firstBlock, &firstClonedBlock);
     assert(firstFound);
-    comp->fgRedirectTargetEdge(info->m_allocBlock, firstClonedBlock);
+    comp->fgRedirectEdge(info->m_allocBlock->GetTargetEdgeRef(), firstClonedBlock);
 
     // If we are subsequently going to do the "empty collection static enumerator" opt,
     // then our profile is now consistent.

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1239,7 +1239,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
             // We will now reach via B1 true.
             // Modify flow for true side of B1
             //
-            m_comp->fgRedirectTrueEdge(m_b1, m_b2->GetTrueTarget());
+            m_comp->fgRedirectEdge(m_b1->GetTrueEdgeRef(), m_b2->GetTrueTarget());
             origB1TrueEdge->setHeuristicBased(origB2TrueEdge->isHeuristicBased());
 
             newB1TrueLikelihood =

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1681,7 +1681,7 @@ void Compiler::optRedirectPrevUnrollIteration(FlowGraphNaturalLoop* loop, BasicB
         }
 
         // Redirect exit edge from previous iteration to new entry.
-        fgRedirectTrueEdge(prevTestBlock, target);
+        fgRedirectEdge(prevTestBlock->GetTrueEdgeRef(), target);
         fgRemoveRefPred(prevTestBlock->GetFalseEdge());
         prevTestBlock->SetKindAndTargetEdge(BBJ_ALWAYS, prevTestBlock->GetTrueEdge());
 
@@ -2092,7 +2092,7 @@ bool Compiler::optTryInvertWhileLoop(FlowGraphNaturalLoop* loop)
     preheader->GetFalseEdge()->setLikelihood(condBlock->GetFalseEdge()->getLikelihood());
 
     // Redirect newPreheader from header to stayInLoopSucc
-    fgRedirectTargetEdge(newPreheader, stayInLoopSucc);
+    fgRedirectEdge(newPreheader->GetTargetEdgeRef(), stayInLoopSucc);
 
     // Duplicate all the code now
     for (int i = 0; i < duplicatedBlocks.Height(); i++)

--- a/src/coreclr/jit/rangecheckcloning.cpp
+++ b/src/coreclr/jit/rangecheckcloning.cpp
@@ -280,7 +280,7 @@ static BasicBlock* optRangeCheckCloning_DoClone(Compiler*             comp,
 
     // Wire up the edges
     //
-    comp->fgRedirectTargetEdge(prevBb, lowerBndBb);
+    comp->fgRedirectEdge(prevBb->GetTargetEdgeRef(), lowerBndBb);
     FlowEdge* fallbackToNextBb       = comp->fgAddRefPred(lastBb, fallbackBb);
     FlowEdge* lowerBndToUpperBndEdge = comp->fgAddRefPred(upperBndBb, lowerBndBb);
     FlowEdge* lowerBndToFallbackEdge = comp->fgAddRefPred(fallbackBb, lowerBndBb);


### PR DESCRIPTION
Replace `fgRedirect*Edge` helpers with an implementation agnostic to the source block's jump kind.

I was motivated to do this consolidation while looking at replacing a few flow optimizations with block compaction. For example, `fgOptimizeSwitchBranches` shouldn't be necessary when we can easily compact the switch's successors. However, block compaction currently skips blocks with switch predecessors to avoid invalidating the switch descriptor map. If we add support for redirecting switch successor edges, we can update their flow without needing to modify the map most of the time (and I've found from my local work that when we do need to update the map, it's quite easy to do).