### PR TITLE
Enable TensorPrimitive vectorization for Half for lots of methods

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.ITernaryOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.ITernaryOperator.cs
@@ -13,6 +13,7 @@ namespace System.Numerics.Tensors
         /// <summary>Operator that takes three input values and returns a single value.</summary>
         private interface ITernaryOperator<T>
         {
+            static abstract bool Vectorizable { get; }
             static abstract T Invoke(T x, T y, T z);
             static abstract Vector128<T> Invoke(Vector128<T> x, Vector128<T> y, Vector128<T> z);
             static abstract Vector256<T> Invoke(Vector256<T> x, Vector256<T> y, Vector256<T> z);
@@ -22,6 +23,7 @@ namespace System.Numerics.Tensors
         private readonly struct SwappedYZTernaryOperator<TOperator, T> : ITernaryOperator<T>
             where TOperator : struct, ITernaryOperator<T>
         {
+            public static bool Vectorizable => TOperator.Vectorizable;
             public static T Invoke(T x, T y, T z) => TOperator.Invoke(x, z, y);
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y, Vector128<T> z) => TOperator.Invoke(x, z, y);
             public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y, Vector256<T> z) => TOperator.Invoke(x, z, y);
@@ -67,7 +69,7 @@ namespace System.Numerics.Tensors
 
             nuint remainder = (uint)x.Length;
 
-            if (Vector512.IsHardwareAccelerated && Vector512<T>.IsSupported)
+            if (TTernaryOperator.Vectorizable && Vector512.IsHardwareAccelerated && Vector512<T>.IsSupported)
             {
                 if (remainder >= (uint)Vector512<T>.Count)
                 {
@@ -85,7 +87,7 @@ namespace System.Numerics.Tensors
                 return;
             }
 
-            if (Vector256.IsHardwareAccelerated && Vector256<T>.IsSupported)
+            if (TTernaryOperator.Vectorizable && Vector256.IsHardwareAccelerated && Vector256<T>.IsSupported)
             {
                 if (remainder >= (uint)Vector256<T>.Count)
                 {
@@ -103,7 +105,7 @@ namespace System.Numerics.Tensors
                 return;
             }
 
-            if (Vector128.IsHardwareAccelerated && Vector128<T>.IsSupported)
+            if (TTernaryOperator.Vectorizable && Vector128.IsHardwareAccelerated && Vector128<T>.IsSupported)
             {
                 if (remainder >= (uint)Vector128<T>.Count)
                 {
@@ -1542,7 +1544,7 @@ namespace System.Numerics.Tensors
 
             nuint remainder = (uint)x.Length;
 
-            if (Vector512.IsHardwareAccelerated && Vector512<T>.IsSupported)
+            if (TTernaryOperator.Vectorizable && Vector512.IsHardwareAccelerated && Vector512<T>.IsSupported)
             {
                 if (remainder >= (uint)Vector512<T>.Count)
                 {
@@ -1560,7 +1562,7 @@ namespace System.Numerics.Tensors
                 return;
             }
 
-            if (Vector256.IsHardwareAccelerated && Vector256<T>.IsSupported)
+            if (TTernaryOperator.Vectorizable && Vector256.IsHardwareAccelerated && Vector256<T>.IsSupported)
             {
                 if (remainder >= (uint)Vector256<T>.Count)
                 {
@@ -1578,7 +1580,7 @@ namespace System.Numerics.Tensors
                 return;
             }
 
-            if (Vector128.IsHardwareAccelerated && Vector128<T>.IsSupported)
+            if (TTernaryOperator.Vectorizable && Vector128.IsHardwareAccelerated && Vector128<T>.IsSupported)
             {
                 if (remainder >= (uint)Vector128<T>.Count)
                 {
@@ -3028,7 +3030,7 @@ namespace System.Numerics.Tensors
 
             nuint remainder = (uint)x.Length;
 
-            if (Vector512.IsHardwareAccelerated && Vector512<T>.IsSupported)
+            if (TTernaryOperator.Vectorizable && Vector512.IsHardwareAccelerated && Vector512<T>.IsSupported)
             {
                 if (remainder >= (uint)Vector512<T>.Count)
                 {
@@ -3046,7 +3048,7 @@ namespace System.Numerics.Tensors
                 return;
             }
 
-            if (Vector256.IsHardwareAccelerated && Vector256<T>.IsSupported)
+            if (TTernaryOperator.Vectorizable && Vector256.IsHardwareAccelerated && Vector256<T>.IsSupported)
             {
                 if (remainder >= (uint)Vector256<T>.Count)
                 {
@@ -3064,7 +3066,7 @@ namespace System.Numerics.Tensors
                 return;
             }
 
-            if (Vector128.IsHardwareAccelerated && Vector128<T>.IsSupported)
+            if (TTernaryOperator.Vectorizable && Vector128.IsHardwareAccelerated && Vector128<T>.IsSupported)
             {
                 if (remainder >= (uint)Vector128<T>.Count)
                 {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Abs.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Abs.cs
@@ -29,7 +29,7 @@ namespace System.Numerics.Tensors
         public static void Abs<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, AbsoluteOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, AbsoluteOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Abs.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Abs.cs
@@ -27,8 +27,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Abs<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, AbsoluteOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, AbsoluteOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Abs(x)</summary>
         internal readonly struct AbsoluteOperator<T> : IUnaryOperator<T, T> where T : INumberBase<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Add.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Add.cs
@@ -24,8 +24,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Add<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IAdditionOperators<T, T, T>, IAdditiveIdentity<T, T> =>
+            where T : IAdditionOperators<T, T, T>, IAdditiveIdentity<T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, AddOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, AddOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise addition of numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -42,8 +49,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Add<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : IAdditionOperators<T, T, T>, IAdditiveIdentity<T, T> =>
+            where T : IAdditionOperators<T, T, T>, IAdditiveIdentity<T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, AddOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, AddOperator<T>>(x, y, destination);
+        }
 
         /// <summary>x + y</summary>
         internal readonly struct AddOperator<T> : IAggregationOperator<T> where T : IAdditionOperators<T, T, T>, IAdditiveIdentity<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Add.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Add.cs
@@ -26,7 +26,7 @@ namespace System.Numerics.Tensors
         public static void Add<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IAdditionOperators<T, T, T>, IAdditiveIdentity<T, T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, AddOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, AddOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -51,7 +51,7 @@ namespace System.Numerics.Tensors
         public static void Add<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : IAdditionOperators<T, T, T>, IAdditiveIdentity<T, T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, AddOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, AddOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AddMultiply.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AddMultiply.cs
@@ -28,7 +28,7 @@ namespace System.Numerics.Tensors
         public static void AddMultiply<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> multiplier, Span<T> destination)
             where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, AddMultiplyOperator<float>>(x, y, multiplier, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, AddMultiplyOperator<float>>(x, y, multiplier, destination))
             {
                 return;
             }
@@ -56,7 +56,7 @@ namespace System.Numerics.Tensors
         public static void AddMultiply<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T multiplier, Span<T> destination)
             where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, AddMultiplyOperator<float>>(x, y, multiplier, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, AddMultiplyOperator<float>>(x, y, multiplier, destination))
             {
                 return;
             }
@@ -84,7 +84,7 @@ namespace System.Numerics.Tensors
         public static void AddMultiply<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> multiplier, Span<T> destination)
             where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, AddMultiplyOperator<float>>(x, y, multiplier, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, AddMultiplyOperator<float>>(x, y, multiplier, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AddMultiply.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AddMultiply.cs
@@ -26,8 +26,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void AddMultiply<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> multiplier, Span<T> destination)
-            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T> =>
+            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, AddMultiplyOperator<float>>(x, y, multiplier, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanSpanIntoSpan<T, AddMultiplyOperator<T>>(x, y, multiplier, destination);
+        }
 
         /// <summary>Computes the element-wise result of <c>(<paramref name="x" /> + <paramref name="y" />) * <paramref name="multiplier" /></c> for the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -47,8 +54,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void AddMultiply<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T multiplier, Span<T> destination)
-            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T> =>
+            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, AddMultiplyOperator<float>>(x, y, multiplier, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanScalarIntoSpan<T, AddMultiplyOperator<T>>(x, y, multiplier, destination);
+        }
 
         /// <summary>Computes the element-wise result of <c>(<paramref name="x" /> + <paramref name="y" />) * <paramref name="multiplier" /></c> for the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -68,12 +82,20 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void AddMultiply<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> multiplier, Span<T> destination)
-            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T> =>
+            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, AddMultiplyOperator<float>>(x, y, multiplier, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarSpanIntoSpan<T, AddMultiplyOperator<T>>(x, y, multiplier, destination);
+        }
 
         /// <summary>(x + y) * z</summary>
         internal readonly struct AddMultiplyOperator<T> : ITernaryOperator<T> where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
         {
+            public static bool Vectorizable => true;
             public static T Invoke(T x, T y, T z) => (x + y) * z;
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y, Vector128<T> z) => (x + y) * z;
             public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y, Vector256<T> z) => (x + y) * z;

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseAnd.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseAnd.cs
@@ -23,7 +23,7 @@ namespace System.Numerics.Tensors
         public static void BitwiseAnd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IBitwiseOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, BitwiseAndOperator<short>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsInt16<T, BitwiseAndOperator<short>>(x, y, destination))
             {
                 return;
             }
@@ -45,7 +45,7 @@ namespace System.Numerics.Tensors
         public static void BitwiseAnd<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : IBitwiseOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, BitwiseAndOperator<short>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsInt16<T, BitwiseAndOperator<short>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseAnd.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseAnd.cs
@@ -21,8 +21,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void BitwiseAnd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IBitwiseOperators<T, T, T> =>
+            where T : IBitwiseOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, BitwiseAndOperator<short>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, BitwiseAndOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise bitwise AND of numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -36,8 +43,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void BitwiseAnd<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : IBitwiseOperators<T, T, T> =>
+            where T : IBitwiseOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, BitwiseAndOperator<short>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, BitwiseAndOperator<T>>(x, y, destination);
+        }
 
         /// <summary>x &amp; y</summary>
         private readonly struct BitwiseAndOperator<T> : IBinaryOperator<T> where T : IBitwiseOperators<T, T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseOr.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseOr.cs
@@ -21,8 +21,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void BitwiseOr<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IBitwiseOperators<T, T, T> =>
+            where T : IBitwiseOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, BitwiseOrOperator<short>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, BitwiseOrOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise bitwise OR of numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -36,8 +43,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void BitwiseOr<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : IBitwiseOperators<T, T, T> =>
+            where T : IBitwiseOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, BitwiseOrOperator<short>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, BitwiseOrOperator<T>>(x, y, destination);
+        }
 
         /// <summary>x | y</summary>
         private readonly struct BitwiseOrOperator<T> : IBinaryOperator<T> where T : IBitwiseOperators<T, T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseOr.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseOr.cs
@@ -23,7 +23,7 @@ namespace System.Numerics.Tensors
         public static void BitwiseOr<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IBitwiseOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, BitwiseOrOperator<short>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsInt16<T, BitwiseOrOperator<short>>(x, y, destination))
             {
                 return;
             }
@@ -45,7 +45,7 @@ namespace System.Numerics.Tensors
         public static void BitwiseOr<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : IBitwiseOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, BitwiseOrOperator<short>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsInt16<T, BitwiseOrOperator<short>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Ceiling.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Ceiling.cs
@@ -19,8 +19,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Ceiling<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IFloatingPoint<T> =>
+            where T : IFloatingPoint<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, CeilingOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, CeilingOperator<T>>(x, destination);
+        }
 
         private readonly struct CeilingOperator<T> : IUnaryOperator<T, T> where T : IFloatingPoint<T>
         {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Ceiling.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Ceiling.cs
@@ -21,7 +21,7 @@ namespace System.Numerics.Tensors
         public static void Ceiling<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IFloatingPoint<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, CeilingOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, CeilingOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
@@ -32,7 +32,7 @@ namespace System.Numerics.Tensors
         public static void Clamp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> min, ReadOnlySpan<T> max, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
             {
                 return;
             }
@@ -61,7 +61,7 @@ namespace System.Numerics.Tensors
         public static void Clamp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> min, T max, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
             {
                 return;
             }
@@ -90,7 +90,7 @@ namespace System.Numerics.Tensors
         public static void Clamp<T>(ReadOnlySpan<T> x, T min, ReadOnlySpan<T> max, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
             {
                 return;
             }
@@ -119,7 +119,7 @@ namespace System.Numerics.Tensors
         public static void Clamp<T>(T x, ReadOnlySpan<T> min, ReadOnlySpan<T> max, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorMinMaxX<float>>(min, max, x, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, ClampOperatorMinMaxX<float>>(min, max, x, destination))
             {
                 return;
             }
@@ -151,7 +151,7 @@ namespace System.Numerics.Tensors
                 ThrowHelper.ThrowArgument_MinGreaterThanMax();
             }
 
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
             {
                 return;
             }
@@ -178,7 +178,7 @@ namespace System.Numerics.Tensors
         public static void Clamp<T>(T x, ReadOnlySpan<T> min, T max, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorMinMaxX<float>>(min, max, x, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, ClampOperatorMinMaxX<float>>(min, max, x, destination))
             {
                 return;
             }
@@ -205,7 +205,7 @@ namespace System.Numerics.Tensors
         public static void Clamp<T>(T x, T min, ReadOnlySpan<T> max, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorMaxXMin<float>>(max, x, min, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, ClampOperatorMaxXMin<float>>(max, x, min, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Clamp.cs
@@ -30,8 +30,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Clamp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> min, ReadOnlySpan<T> max, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanSpanIntoSpan<T, ClampOperatorXMinMax<T>>(x, min, max, destination);
+        }
 
         /// <summary>
         /// Computes the element-wise result of clamping <paramref name="x"/> to within the inclusive range specified
@@ -52,8 +59,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Clamp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> min, T max, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanScalarIntoSpan<T, ClampOperatorXMinMax<T>>(x, min, max, destination);
+        }
 
         /// <summary>
         /// Computes the element-wise result of clamping <paramref name="x"/> to within the inclusive range specified
@@ -74,8 +88,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Clamp<T>(ReadOnlySpan<T> x, T min, ReadOnlySpan<T> max, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarSpanIntoSpan<T, ClampOperatorXMinMax<T>>(x, min, max, destination);
+        }
 
         /// <summary>
         /// Computes the element-wise result of clamping <paramref name="x"/> to within the inclusive range specified
@@ -96,8 +117,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Clamp<T>(T x, ReadOnlySpan<T> min, ReadOnlySpan<T> max, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorMinMaxX<float>>(min, max, x, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanScalarIntoSpan<T, ClampOperatorMinMaxX<T>>(min, max, x, destination);
+        }
 
         /// <summary>
         /// Computes the element-wise result of clamping <paramref name="x"/> to within the inclusive range specified
@@ -123,6 +151,11 @@ namespace System.Numerics.Tensors
                 ThrowHelper.ThrowArgument_MinGreaterThanMax();
             }
 
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorXMinMax<float>>(x, min, max, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarScalarIntoSpan<T, ClampOperatorXMinMax<T>>(x, min, max, destination);
         }
 
@@ -143,8 +176,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Clamp<T>(T x, ReadOnlySpan<T> min, T max, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorMinMaxX<float>>(min, max, x, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarScalarIntoSpan<T, ClampOperatorMinMaxX<T>>(min, max, x, destination);
+        }
 
         /// <summary>
         /// Computes the element-wise result of clamping <paramref name="x"/> to within the inclusive range specified
@@ -163,8 +203,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Clamp<T>(T x, T min, ReadOnlySpan<T> max, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, ClampOperatorMaxXMin<float>>(max, x, min, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarScalarIntoSpan<T, ClampOperatorMaxXMin<T>>(max, x, min, destination);
+        }
 
         /// <summary>T.Clamp(x, min, max)</summary>
         internal readonly struct ClampOperatorXMinMax<T> : ITernaryOperator<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CopySign.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CopySign.cs
@@ -21,8 +21,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void CopySign<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> sign, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, CopySignOperator<float>>(x, sign, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, CopySignOperator<T>>(x, sign, destination);
+        }
 
         /// <summary>Computes the element-wise result of copying the sign from one number to another number in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -36,8 +43,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void CopySign<T>(ReadOnlySpan<T> x, T sign, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, CopySignOperator<float>>(x, sign, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, CopySignOperator<T>>(x, sign, destination);
+        }
 
         private readonly struct CopySignOperator<T> : IBinaryOperator<T> where T : INumber<T>
         {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CopySign.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CopySign.cs
@@ -23,7 +23,7 @@ namespace System.Numerics.Tensors
         public static void CopySign<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> sign, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, CopySignOperator<float>>(x, sign, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, CopySignOperator<float>>(x, sign, destination))
             {
                 return;
             }
@@ -45,7 +45,7 @@ namespace System.Numerics.Tensors
         public static void CopySign<T>(ReadOnlySpan<T> x, T sign, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, CopySignOperator<float>>(x, sign, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, CopySignOperator<float>>(x, sign, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cos.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cos.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.Intrinsics;
+using static System.Numerics.Tensors.TensorOperation;
 
 namespace System.Numerics.Tensors
 {
@@ -26,8 +27,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Cos<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ITrigonometricFunctions<T> =>
+            where T : ITrigonometricFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, CosOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, CosOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Cos(x)</summary>
         private readonly struct CosOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cos.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cos.cs
@@ -29,7 +29,7 @@ namespace System.Numerics.Tensors
         public static void Cos<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ITrigonometricFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, CosOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, CosOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CosPi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CosPi.cs
@@ -26,8 +26,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void CosPi<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ITrigonometricFunctions<T> =>
+            where T : ITrigonometricFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, CosPiOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, CosPiOperator<T>>(x, destination);
+        }
 
         /// <summary>T.CosPi(x)</summary>
         private readonly struct CosPiOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CosPi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CosPi.cs
@@ -28,7 +28,7 @@ namespace System.Numerics.Tensors
         public static void CosPi<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ITrigonometricFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, CosPiOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, CosPiOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cosh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cosh.cs
@@ -30,8 +30,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Cosh<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IHyperbolicFunctions<T> =>
+            where T : IHyperbolicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, CoshOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, CoshOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Cosh(x)</summary>
         internal readonly struct CoshOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cosh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cosh.cs
@@ -32,7 +32,7 @@ namespace System.Numerics.Tensors
         public static void Cosh<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IHyperbolicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, CoshOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, CoshOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Decrement.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Decrement.cs
@@ -20,7 +20,7 @@ namespace System.Numerics.Tensors
         public static void Decrement<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IDecrementOperators<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, DecrementOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, DecrementOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Decrement.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Decrement.cs
@@ -18,8 +18,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Decrement<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IDecrementOperators<T> =>
+            where T : IDecrementOperators<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, DecrementOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, DecrementOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Decrement(x)</summary>
         private readonly struct DecrementOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.DegreesToRadians.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.DegreesToRadians.cs
@@ -19,8 +19,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void DegreesToRadians<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ITrigonometricFunctions<T> =>
+            where T : ITrigonometricFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, DegreesToRadiansOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, DegreesToRadiansOperator<T>>(x, destination);
+        }
 
         /// <summary>T.DegreesToRadians(x)</summary>
         private readonly struct DegreesToRadiansOperator<T> : IUnaryOperator<T, T> where T : ITrigonometricFunctions<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.DegreesToRadians.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.DegreesToRadians.cs
@@ -21,7 +21,7 @@ namespace System.Numerics.Tensors
         public static void DegreesToRadians<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ITrigonometricFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, DegreesToRadiansOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, DegreesToRadiansOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Divide.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Divide.cs
@@ -26,7 +26,7 @@ namespace System.Numerics.Tensors
         public static void Divide<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IDivisionOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, DivideOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, DivideOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -52,7 +52,7 @@ namespace System.Numerics.Tensors
         public static void Divide<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : IDivisionOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, DivideOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, DivideOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -78,7 +78,7 @@ namespace System.Numerics.Tensors
         public static void Divide<T>(T x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IDivisionOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, DivideOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, DivideOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Divide.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Divide.cs
@@ -24,8 +24,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Divide<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IDivisionOperators<T, T, T> =>
+            where T : IDivisionOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, DivideOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, DivideOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise division of numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -43,8 +50,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Divide<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : IDivisionOperators<T, T, T> =>
+            where T : IDivisionOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, DivideOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, DivideOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise division of numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a scalar.</param>
@@ -62,8 +76,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Divide<T>(T x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IDivisionOperators<T, T, T> =>
+            where T : IDivisionOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, DivideOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeScalarSpanIntoSpan<T, DivideOperator<T>>(x, y, destination);
+        }
 
         /// <summary>x / y</summary>
         internal readonly struct DivideOperator<T> : IBinaryOperator<T> where T : IDivisionOperators<T, T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp.cs
@@ -27,8 +27,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Exp<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IExponentialFunctions<T> =>
+            where T : IExponentialFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ExpOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, ExpOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Exp(x)</summary>
         internal readonly struct ExpOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp.cs
@@ -29,7 +29,7 @@ namespace System.Numerics.Tensors
         public static void Exp<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IExponentialFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ExpOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, ExpOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp10.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp10.cs
@@ -22,8 +22,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Exp10<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IExponentialFunctions<T> =>
+            where T : IExponentialFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Exp10Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, Exp10Operator<T>>(x, destination);
+        }
 
         /// <summary>T.Exp10(x)</summary>
         private readonly struct Exp10Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp10.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp10.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tensors
         public static void Exp10<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IExponentialFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Exp10Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, Exp10Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp10M1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp10M1.cs
@@ -22,8 +22,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Exp10M1<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IExponentialFunctions<T> =>
+            where T : IExponentialFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Exp10M1Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, Exp10M1Operator<T>>(x, destination);
+        }
 
         /// <summary>T.Exp10M1(x)</summary>
         private readonly struct Exp10M1Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp10M1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp10M1.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tensors
         public static void Exp10M1<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IExponentialFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Exp10M1Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, Exp10M1Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp2.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp2.cs
@@ -22,8 +22,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Exp2<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IExponentialFunctions<T> =>
+            where T : IExponentialFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Exp2Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, Exp2Operator<T>>(x, destination);
+        }
 
         /// <summary>T.Exp2(x)</summary>
         private readonly struct Exp2Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp2.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp2.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tensors
         public static void Exp2<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IExponentialFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Exp2Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, Exp2Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp2M1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp2M1.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tensors
         public static void Exp2M1<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IExponentialFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Exp2M1Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, Exp2M1Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp2M1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Exp2M1.cs
@@ -22,8 +22,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Exp2M1<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IExponentialFunctions<T> =>
+            where T : IExponentialFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Exp2M1Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, Exp2M1Operator<T>>(x, destination);
+        }
 
         /// <summary>T.Exp2M1(x)</summary>
         private readonly struct Exp2M1Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.ExpM1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.ExpM1.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tensors
         public static void ExpM1<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IExponentialFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ExpM1Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, ExpM1Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.ExpM1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.ExpM1.cs
@@ -22,8 +22,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void ExpM1<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IExponentialFunctions<T> =>
+            where T : IExponentialFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ExpM1Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, ExpM1Operator<T>>(x, destination);
+        }
 
         /// <summary>T.ExpM1(x)</summary>
         private readonly struct ExpM1Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Floor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Floor.cs
@@ -19,8 +19,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Floor<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IFloatingPoint<T> =>
+            where T : IFloatingPoint<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, FloorOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, FloorOperator<T>>(x, destination);
+        }
 
         private readonly struct FloorOperator<T> : IUnaryOperator<T, T> where T : IFloatingPoint<T>
         {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Floor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Floor.cs
@@ -21,7 +21,7 @@ namespace System.Numerics.Tensors
         public static void Floor<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IFloatingPoint<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, FloorOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, FloorOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.FusedMultiplyAdd.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.FusedMultiplyAdd.cs
@@ -37,7 +37,7 @@ namespace System.Numerics.Tensors
         public static void FusedMultiplyAdd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> addend, Span<T> destination)
             where T : IFloatingPointIeee754<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, FusedMultiplyAddOperator<float>>(x, y, addend, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, FusedMultiplyAddOperator<float>>(x, y, addend, destination))
             {
                 return;
             }
@@ -72,7 +72,7 @@ namespace System.Numerics.Tensors
         public static void FusedMultiplyAdd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T addend, Span<T> destination)
             where T : IFloatingPointIeee754<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, FusedMultiplyAddOperator<float>>(x, y, addend, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, FusedMultiplyAddOperator<float>>(x, y, addend, destination))
             {
                 return;
             }
@@ -106,7 +106,7 @@ namespace System.Numerics.Tensors
         public static void FusedMultiplyAdd<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> addend, Span<T> destination)
             where T : IFloatingPointIeee754<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, FusedMultiplyAddOperator<float>>(x, y, addend, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, FusedMultiplyAddOperator<float>>(x, y, addend, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.FusedMultiplyAdd.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.FusedMultiplyAdd.cs
@@ -35,8 +35,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void FusedMultiplyAdd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> addend, Span<T> destination)
-            where T : IFloatingPointIeee754<T> =>
+            where T : IFloatingPointIeee754<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, FusedMultiplyAddOperator<float>>(x, y, addend, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanSpanIntoSpan<T, FusedMultiplyAddOperator<T>>(x, y, addend, destination);
+        }
 
         /// <summary>Computes the element-wise result of <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c> for the specified tensors of numbers.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -63,8 +70,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void FusedMultiplyAdd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T addend, Span<T> destination)
-            where T : IFloatingPointIeee754<T> =>
+            where T : IFloatingPointIeee754<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, FusedMultiplyAddOperator<float>>(x, y, addend, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanScalarIntoSpan<T, FusedMultiplyAddOperator<T>>(x, y, addend, destination);
+        }
 
         /// <summary>Computes the element-wise result of <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c> for the specified tensors of numbers.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -90,12 +104,21 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void FusedMultiplyAdd<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> addend, Span<T> destination)
-            where T : IFloatingPointIeee754<T> =>
+            where T : IFloatingPointIeee754<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, FusedMultiplyAddOperator<float>>(x, y, addend, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarSpanIntoSpan<T, FusedMultiplyAddOperator<T>>(x, y, addend, destination);
+        }
 
         /// <summary>(x * y) + z</summary>
         private readonly struct FusedMultiplyAddOperator<T> : ITernaryOperator<T> where T : IFloatingPointIeee754<T>
         {
+            public static bool Vectorizable => true;
+
             public static T Invoke(T x, T y, T z) => T.FusedMultiplyAdd(x, y, z);
 
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y, Vector128<T> z)

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Half.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Half.cs
@@ -1,6 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
 namespace System.Numerics.Tensors
 {
     public static partial class TensorPrimitives
@@ -40,5 +44,448 @@ namespace System.Numerics.Tensors
         /// </remarks>
         public static void ConvertToSingle(ReadOnlySpan<Half> source, Span<float> destination) =>
             ConvertTruncating(source, destination);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryUnaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, Span<T> destination)
+            where TOp : struct, IUnaryOperator<float, float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
+            {
+                InvokeSpanIntoSpan<short, HalfAsShortUnaryOperator<TOp>>(
+                    Rename<T, short>(x),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryUnaryBitwiseInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, Span<T> destination)
+            where TOp : struct, IUnaryOperator<short, short>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable) // not checking IsVectorizable(x) because there's no runtime overhead to the Half<=>short conversion
+            {
+                InvokeSpanIntoSpan<short, TOp>(
+                    Rename<T, short>(x),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryBinaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
+            where TOp : struct, IBinaryOperator<float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
+            {
+                InvokeSpanSpanIntoSpan<short, HalfAsShortBinaryOperator<TOp>>(
+                    Rename<T, short>(x),
+                    Rename<T, short>(y),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryBinaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, Span<T> destination)
+            where TOp : struct, IBinaryOperator<float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
+            {
+                InvokeSpanScalarIntoSpan<short, HalfAsShortBinaryOperator<TOp>>(
+                    Rename<T, short>(x),
+                    BitConverter.HalfToInt16Bits((Half)(object)y!),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryBinaryInvokeHalfAsShort<T, TOp>(T x, ReadOnlySpan<T> y, Span<T> destination)
+            where TOp : struct, IBinaryOperator<float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(y)))
+            {
+                InvokeScalarSpanIntoSpan<short, HalfAsShortBinaryOperator<TOp>>(
+                    BitConverter.HalfToInt16Bits((Half)(object)x!),
+                    Rename<T, short>(y),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryBinaryBitwiseInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
+            where TOp : struct, IBinaryOperator<short>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable) // not checking IsVectorizable(x) because there's no runtime overhead to the Half<=>short conversion
+            {
+                InvokeSpanSpanIntoSpan<short, TOp>(
+                    Rename<T, short>(x),
+                    Rename<T, short>(y),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryBinaryBitwiseInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, Span<T> destination)
+            where TOp : struct, IBinaryOperator<short>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable) // not checking IsVectorizable(x) because there's no runtime overhead to the Half<=>short conversion
+            {
+                InvokeSpanScalarIntoSpan<short, TOp>(
+                    Rename<T, short>(x),
+                    BitConverter.HalfToInt16Bits((Half)(object)y!),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryAggregateInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
+            where TOp : struct, IAggregationOperator<float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
+            {
+                InvokeSpanSpanIntoSpan<short, HalfAsShortAggregationOperator<TOp>>(
+                    Rename<T, short>(x),
+                    Rename<T, short>(y),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryAggregateInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, Span<T> destination)
+            where TOp : struct, IAggregationOperator<float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
+            {
+                InvokeSpanScalarIntoSpan<short, HalfAsShortAggregationOperator<TOp>>(
+                    Rename<T, short>(x),
+                    BitConverter.HalfToInt16Bits((Half)(object)y!),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryMinMaxHalfAsShort<T, TOp>(ReadOnlySpan<T> x, out T result)
+            where TOp : struct, IAggregationOperator<float>
+        {
+            if (typeof(T) == typeof(Half) && IsVectorizable(Rename<T, Half>(x)))
+            {
+                result = (T)(object)BitConverter.Int16BitsToHalf(
+                    MinMaxCore<short, HalfAsShortAggregationOperator<TOp>>(
+                        Rename<T, short>(x)));
+                return true;
+            }
+
+            result = default!;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryTernaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> z, Span<T> destination)
+            where TOp : struct, ITernaryOperator<float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
+            {
+                InvokeSpanSpanSpanIntoSpan<short, HalfAsShortTernaryOperator<TOp>>(
+                    Rename<T, short>(x),
+                    Rename<T, short>(y),
+                    Rename<T, short>(z),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryTernaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> z, Span<T> destination)
+            where TOp : struct, ITernaryOperator<float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
+            {
+                InvokeSpanScalarSpanIntoSpan<short, HalfAsShortTernaryOperator<TOp>>(
+                    Rename<T, short>(x),
+                    BitConverter.HalfToInt16Bits((Half)(object)y!),
+                    Rename<T, short>(z),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryTernaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T z, Span<T> destination)
+            where TOp : struct, ITernaryOperator<float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
+            {
+                InvokeSpanSpanScalarIntoSpan<short, HalfAsShortTernaryOperator<TOp>>(
+                    Rename<T, short>(x),
+                    Rename<T, short>(y),
+                    BitConverter.HalfToInt16Bits((Half)(object)z!),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryTernaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, T z, Span<T> destination)
+            where TOp : struct, ITernaryOperator<float>
+        {
+            Debug.Assert(typeof(T) == typeof(Half));
+
+            if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
+            {
+                InvokeSpanScalarScalarIntoSpan<short, HalfAsShortTernaryOperator<TOp>>(
+                    Rename<T, short>(x),
+                    BitConverter.HalfToInt16Bits((Half)(object)y!),
+                    BitConverter.HalfToInt16Bits((Half)(object)z!),
+                    Rename<T, short>(destination));
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// To vectorize Half, we need to reinterpret to short, widen to float, operate on floats, then narrow back to short, and reinterpret back to Half.
+        /// Those widening and narrowing operations add overhead. If we're able to actually vectorize, it's worthwhile, but if it's not, we want to take
+        /// the normal scalar path rather than going through the short-based path that won't actually be fruitful.
+        /// </summary>
+        private static bool IsVectorizable(ReadOnlySpan<Half> source) =>
+            Vector128.IsHardwareAccelerated &&
+            source.Length >= Vector128<short>.Count;
+
+        /// <summary><see cref="IUnaryOperator{T, T}"/> wrapper for working with <see cref="Half"/> reinterpreted as <see cref="short"/> in order to enable vectorization.</summary>
+        private readonly struct HalfAsShortUnaryOperator<TUnary> : IUnaryOperator<short, short>
+            where TUnary : struct, IUnaryOperator<float, float>
+        {
+            public static bool Vectorizable => TUnary.Vectorizable;
+
+            public static short Invoke(short x) =>
+                BitConverter.HalfToInt16Bits(
+                    (Half)TUnary.Invoke((float)BitConverter.Int16BitsToHalf(x)));
+
+            public static Vector128<short> Invoke(Vector128<short> x)
+            {
+                (Vector128<float> xVecLower, Vector128<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TUnary.Invoke(xVecLower),
+                    TUnary.Invoke(xVecUpper)).AsInt16();
+            }
+
+            public static Vector256<short> Invoke(Vector256<short> x)
+            {
+                (Vector256<float> xVecLower, Vector256<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TUnary.Invoke(xVecLower),
+                    TUnary.Invoke(xVecUpper)).AsInt16();
+            }
+
+            public static Vector512<short> Invoke(Vector512<short> x)
+            {
+                (Vector512<float> xVecLower, Vector512<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TUnary.Invoke(xVecLower),
+                    TUnary.Invoke(xVecUpper)).AsInt16();
+            }
+        }
+
+        /// <summary><see cref="IBinaryOperator{T}"/> wrapper for working with <see cref="Half"/> reinterpreted as <see cref="short"/> in order to enable vectorization.</summary>
+        private readonly struct HalfAsShortBinaryOperator<TBinary> : IBinaryOperator<short>
+            where TBinary : struct, IBinaryOperator<float>
+        {
+            public static bool Vectorizable => TBinary.Vectorizable;
+
+            public static short Invoke(short x, short y) =>
+                BitConverter.HalfToInt16Bits((Half)TBinary.Invoke(
+                    (float)BitConverter.Int16BitsToHalf(x),
+                    (float)BitConverter.Int16BitsToHalf(y)));
+
+            public static Vector128<short> Invoke(Vector128<short> x, Vector128<short> y)
+            {
+                (Vector128<float> xVecLower, Vector128<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                (Vector128<float> yVecLower, Vector128<float> yVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(y);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TBinary.Invoke(xVecLower, yVecLower),
+                    TBinary.Invoke(xVecUpper, yVecUpper)).AsInt16();
+            }
+
+            public static Vector256<short> Invoke(Vector256<short> x, Vector256<short> y)
+            {
+                (Vector256<float> xVecLower, Vector256<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                (Vector256<float> yVecLower, Vector256<float> yVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(y);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TBinary.Invoke(xVecLower, yVecLower),
+                    TBinary.Invoke(xVecUpper, yVecUpper)).AsInt16();
+            }
+
+            public static Vector512<short> Invoke(Vector512<short> x, Vector512<short> y)
+            {
+                (Vector512<float> xVecLower, Vector512<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                (Vector512<float> yVecLower, Vector512<float> yVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(y);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TBinary.Invoke(xVecLower, yVecLower),
+                    TBinary.Invoke(xVecUpper, yVecUpper)).AsInt16();
+            }
+        }
+
+        /// <summary><see cref="IAggregationOperator{T}"/> wrapper for working with <see cref="Half"/> reinterpreted as <see cref="short"/> in order to enable vectorization.</summary>
+        private readonly struct HalfAsShortAggregationOperator<TAggregate> : IAggregationOperator<short>
+            where TAggregate : struct, IAggregationOperator<float>
+        {
+            public static bool Vectorizable => TAggregate.Vectorizable;
+
+            public static short Invoke(short x, short y) =>
+                BitConverter.HalfToInt16Bits((Half)TAggregate.Invoke(
+                    (float)BitConverter.Int16BitsToHalf(x),
+                    (float)BitConverter.Int16BitsToHalf(y)));
+
+            public static Vector128<short> Invoke(Vector128<short> x, Vector128<short> y)
+            {
+                (Vector128<float> xVecLower, Vector128<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                (Vector128<float> yVecLower, Vector128<float> yVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(y);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TAggregate.Invoke(xVecLower, yVecLower),
+                    TAggregate.Invoke(xVecUpper, yVecUpper)).AsInt16();
+            }
+
+            public static Vector256<short> Invoke(Vector256<short> x, Vector256<short> y)
+            {
+                (Vector256<float> xVecLower, Vector256<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                (Vector256<float> yVecLower, Vector256<float> yVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(y);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TAggregate.Invoke(xVecLower, yVecLower),
+                    TAggregate.Invoke(xVecUpper, yVecUpper)).AsInt16();
+            }
+
+            public static Vector512<short> Invoke(Vector512<short> x, Vector512<short> y)
+            {
+                (Vector512<float> xVecLower, Vector512<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                (Vector512<float> yVecLower, Vector512<float> yVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(y);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TAggregate.Invoke(xVecLower, yVecLower),
+                    TAggregate.Invoke(xVecUpper, yVecUpper)).AsInt16();
+            }
+
+            public static short Invoke(Vector128<short> x)
+            {
+                (Vector128<float> xVecLower, Vector128<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                return BitConverter.HalfToInt16Bits((Half)TAggregate.Invoke(
+                    TAggregate.Invoke(xVecLower),
+                    TAggregate.Invoke(xVecUpper)));
+            }
+
+            public static short Invoke(Vector256<short> x)
+            {
+                (Vector256<float> xVecLower, Vector256<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                return BitConverter.HalfToInt16Bits((Half)TAggregate.Invoke(
+                    TAggregate.Invoke(xVecLower),
+                    TAggregate.Invoke(xVecUpper)));
+            }
+
+            public static short Invoke(Vector512<short> x)
+            {
+                (Vector512<float> xVecLower, Vector512<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                return BitConverter.HalfToInt16Bits((Half)TAggregate.Invoke(
+                    TAggregate.Invoke(xVecLower),
+                    TAggregate.Invoke(xVecUpper)));
+            }
+
+            public static short IdentityValue => BitConverter.HalfToInt16Bits((Half)TAggregate.IdentityValue);
+        }
+
+        /// <summary><see cref="ITernaryOperator{T}"/> wrapper for working with <see cref="Half"/> reinterpreted as <see cref="short"/> in order to enable vectorization.</summary>
+        private readonly struct HalfAsShortTernaryOperator<TTernary> : ITernaryOperator<short>
+            where TTernary : struct, ITernaryOperator<float>
+        {
+            public static bool Vectorizable => TTernary.Vectorizable;
+
+            public static short Invoke(short x, short y, short z) =>
+                BitConverter.HalfToInt16Bits((Half)TTernary.Invoke(
+                    (float)BitConverter.Int16BitsToHalf(x),
+                    (float)BitConverter.Int16BitsToHalf(y),
+                    (float)BitConverter.Int16BitsToHalf(z)));
+
+            public static Vector128<short> Invoke(Vector128<short> x, Vector128<short> y, Vector128<short> z)
+            {
+                (Vector128<float> xVecLower, Vector128<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                (Vector128<float> yVecLower, Vector128<float> yVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(y);
+                (Vector128<float> zVecLower, Vector128<float> zVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(z);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TTernary.Invoke(xVecLower, yVecLower, zVecLower),
+                    TTernary.Invoke(xVecUpper, yVecUpper, zVecUpper)).AsInt16();
+            }
+
+            public static Vector256<short> Invoke(Vector256<short> x, Vector256<short> y, Vector256<short> z)
+            {
+                (Vector256<float> xVecLower, Vector256<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                (Vector256<float> yVecLower, Vector256<float> yVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(y);
+                (Vector256<float> zVecLower, Vector256<float> zVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(z);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TTernary.Invoke(xVecLower, yVecLower, zVecLower),
+                    TTernary.Invoke(xVecUpper, yVecUpper, zVecUpper)).AsInt16();
+            }
+
+            public static Vector512<short> Invoke(Vector512<short> x, Vector512<short> y, Vector512<short> z)
+            {
+                (Vector512<float> xVecLower, Vector512<float> xVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(x);
+                (Vector512<float> yVecLower, Vector512<float> yVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(y);
+                (Vector512<float> zVecLower, Vector512<float> zVecUpper) = WidenHalfAsInt16ToSingleOperator.Invoke(z);
+                return NarrowSingleToHalfAsUInt16Operator.Invoke(
+                    TTernary.Invoke(xVecLower, yVecLower, zVecLower),
+                    TTernary.Invoke(xVecUpper, yVecUpper, zVecUpper)).AsInt16();
+            }
+        }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Half.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Half.cs
@@ -46,14 +46,14 @@ namespace System.Numerics.Tensors
             ConvertTruncating(source, destination);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryUnaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, Span<T> destination)
+        private static bool TryUnaryInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, Span<T> destination)
             where TOp : struct, IUnaryOperator<float, float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
             {
-                InvokeSpanIntoSpan<short, HalfAsShortUnaryOperator<TOp>>(
+                InvokeSpanIntoSpan<short, HalfAsInt16UnaryOperator<TOp>>(
                     Rename<T, short>(x),
                     Rename<T, short>(destination));
                 return true;
@@ -63,7 +63,7 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryUnaryBitwiseInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, Span<T> destination)
+        private static bool TryUnaryBitwiseInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, Span<T> destination)
             where TOp : struct, IUnaryOperator<short, short>
         {
             Debug.Assert(typeof(T) == typeof(Half));
@@ -80,14 +80,14 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryBinaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
+        private static bool TryBinaryInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where TOp : struct, IBinaryOperator<float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
             {
-                InvokeSpanSpanIntoSpan<short, HalfAsShortBinaryOperator<TOp>>(
+                InvokeSpanSpanIntoSpan<short, HalfAsInt16BinaryOperator<TOp>>(
                     Rename<T, short>(x),
                     Rename<T, short>(y),
                     Rename<T, short>(destination));
@@ -98,14 +98,14 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryBinaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, Span<T> destination)
+        private static bool TryBinaryInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where TOp : struct, IBinaryOperator<float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
             {
-                InvokeSpanScalarIntoSpan<short, HalfAsShortBinaryOperator<TOp>>(
+                InvokeSpanScalarIntoSpan<short, HalfAsInt16BinaryOperator<TOp>>(
                     Rename<T, short>(x),
                     BitConverter.HalfToInt16Bits((Half)(object)y!),
                     Rename<T, short>(destination));
@@ -116,14 +116,14 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryBinaryInvokeHalfAsShort<T, TOp>(T x, ReadOnlySpan<T> y, Span<T> destination)
+        private static bool TryBinaryInvokeHalfAsInt16<T, TOp>(T x, ReadOnlySpan<T> y, Span<T> destination)
             where TOp : struct, IBinaryOperator<float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(y)))
             {
-                InvokeScalarSpanIntoSpan<short, HalfAsShortBinaryOperator<TOp>>(
+                InvokeScalarSpanIntoSpan<short, HalfAsInt16BinaryOperator<TOp>>(
                     BitConverter.HalfToInt16Bits((Half)(object)x!),
                     Rename<T, short>(y),
                     Rename<T, short>(destination));
@@ -134,7 +134,7 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryBinaryBitwiseInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
+        private static bool TryBinaryBitwiseInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where TOp : struct, IBinaryOperator<short>
         {
             Debug.Assert(typeof(T) == typeof(Half));
@@ -152,7 +152,7 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryBinaryBitwiseInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, Span<T> destination)
+        private static bool TryBinaryBitwiseInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where TOp : struct, IBinaryOperator<short>
         {
             Debug.Assert(typeof(T) == typeof(Half));
@@ -170,14 +170,14 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryAggregateInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
+        private static bool TryAggregateInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where TOp : struct, IAggregationOperator<float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
             {
-                InvokeSpanSpanIntoSpan<short, HalfAsShortAggregationOperator<TOp>>(
+                InvokeSpanSpanIntoSpan<short, HalfAsInt16AggregationOperator<TOp>>(
                     Rename<T, short>(x),
                     Rename<T, short>(y),
                     Rename<T, short>(destination));
@@ -188,14 +188,14 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryAggregateInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, Span<T> destination)
+        private static bool TryAggregateInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where TOp : struct, IAggregationOperator<float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
             {
-                InvokeSpanScalarIntoSpan<short, HalfAsShortAggregationOperator<TOp>>(
+                InvokeSpanScalarIntoSpan<short, HalfAsInt16AggregationOperator<TOp>>(
                     Rename<T, short>(x),
                     BitConverter.HalfToInt16Bits((Half)(object)y!),
                     Rename<T, short>(destination));
@@ -206,13 +206,13 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryMinMaxHalfAsShort<T, TOp>(ReadOnlySpan<T> x, out T result)
+        private static bool TryMinMaxHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, out T result)
             where TOp : struct, IAggregationOperator<float>
         {
             if (typeof(T) == typeof(Half) && IsVectorizable(Rename<T, Half>(x)))
             {
                 result = (T)(object)BitConverter.Int16BitsToHalf(
-                    MinMaxCore<short, HalfAsShortAggregationOperator<TOp>>(
+                    MinMaxCore<short, HalfAsInt16AggregationOperator<TOp>>(
                         Rename<T, short>(x)));
                 return true;
             }
@@ -222,14 +222,14 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryTernaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> z, Span<T> destination)
+        private static bool TryTernaryInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> z, Span<T> destination)
             where TOp : struct, ITernaryOperator<float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
             {
-                InvokeSpanSpanSpanIntoSpan<short, HalfAsShortTernaryOperator<TOp>>(
+                InvokeSpanSpanSpanIntoSpan<short, HalfAsInt16TernaryOperator<TOp>>(
                     Rename<T, short>(x),
                     Rename<T, short>(y),
                     Rename<T, short>(z),
@@ -241,14 +241,14 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryTernaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> z, Span<T> destination)
+        private static bool TryTernaryInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> z, Span<T> destination)
             where TOp : struct, ITernaryOperator<float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
             {
-                InvokeSpanScalarSpanIntoSpan<short, HalfAsShortTernaryOperator<TOp>>(
+                InvokeSpanScalarSpanIntoSpan<short, HalfAsInt16TernaryOperator<TOp>>(
                     Rename<T, short>(x),
                     BitConverter.HalfToInt16Bits((Half)(object)y!),
                     Rename<T, short>(z),
@@ -260,14 +260,14 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryTernaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T z, Span<T> destination)
+        private static bool TryTernaryInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T z, Span<T> destination)
             where TOp : struct, ITernaryOperator<float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
             {
-                InvokeSpanSpanScalarIntoSpan<short, HalfAsShortTernaryOperator<TOp>>(
+                InvokeSpanSpanScalarIntoSpan<short, HalfAsInt16TernaryOperator<TOp>>(
                     Rename<T, short>(x),
                     Rename<T, short>(y),
                     BitConverter.HalfToInt16Bits((Half)(object)z!),
@@ -279,14 +279,14 @@ namespace System.Numerics.Tensors
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryTernaryInvokeHalfAsShort<T, TOp>(ReadOnlySpan<T> x, T y, T z, Span<T> destination)
+        private static bool TryTernaryInvokeHalfAsInt16<T, TOp>(ReadOnlySpan<T> x, T y, T z, Span<T> destination)
             where TOp : struct, ITernaryOperator<float>
         {
             Debug.Assert(typeof(T) == typeof(Half));
 
             if (TOp.Vectorizable && IsVectorizable(Rename<T, Half>(x)))
             {
-                InvokeSpanScalarScalarIntoSpan<short, HalfAsShortTernaryOperator<TOp>>(
+                InvokeSpanScalarScalarIntoSpan<short, HalfAsInt16TernaryOperator<TOp>>(
                     Rename<T, short>(x),
                     BitConverter.HalfToInt16Bits((Half)(object)y!),
                     BitConverter.HalfToInt16Bits((Half)(object)z!),
@@ -307,7 +307,7 @@ namespace System.Numerics.Tensors
             source.Length >= Vector128<short>.Count;
 
         /// <summary><see cref="IUnaryOperator{T, T}"/> wrapper for working with <see cref="Half"/> reinterpreted as <see cref="short"/> in order to enable vectorization.</summary>
-        private readonly struct HalfAsShortUnaryOperator<TUnary> : IUnaryOperator<short, short>
+        private readonly struct HalfAsInt16UnaryOperator<TUnary> : IUnaryOperator<short, short>
             where TUnary : struct, IUnaryOperator<float, float>
         {
             public static bool Vectorizable => TUnary.Vectorizable;
@@ -342,7 +342,7 @@ namespace System.Numerics.Tensors
         }
 
         /// <summary><see cref="IBinaryOperator{T}"/> wrapper for working with <see cref="Half"/> reinterpreted as <see cref="short"/> in order to enable vectorization.</summary>
-        private readonly struct HalfAsShortBinaryOperator<TBinary> : IBinaryOperator<short>
+        private readonly struct HalfAsInt16BinaryOperator<TBinary> : IBinaryOperator<short>
             where TBinary : struct, IBinaryOperator<float>
         {
             public static bool Vectorizable => TBinary.Vectorizable;
@@ -381,7 +381,7 @@ namespace System.Numerics.Tensors
         }
 
         /// <summary><see cref="IAggregationOperator{T}"/> wrapper for working with <see cref="Half"/> reinterpreted as <see cref="short"/> in order to enable vectorization.</summary>
-        private readonly struct HalfAsShortAggregationOperator<TAggregate> : IAggregationOperator<short>
+        private readonly struct HalfAsInt16AggregationOperator<TAggregate> : IAggregationOperator<short>
             where TAggregate : struct, IAggregationOperator<float>
         {
             public static bool Vectorizable => TAggregate.Vectorizable;
@@ -446,7 +446,7 @@ namespace System.Numerics.Tensors
         }
 
         /// <summary><see cref="ITernaryOperator{T}"/> wrapper for working with <see cref="Half"/> reinterpreted as <see cref="short"/> in order to enable vectorization.</summary>
-        private readonly struct HalfAsShortTernaryOperator<TTernary> : ITernaryOperator<short>
+        private readonly struct HalfAsInt16TernaryOperator<TTernary> : ITernaryOperator<short>
             where TTernary : struct, ITernaryOperator<float>
         {
             public static bool Vectorizable => TTernary.Vectorizable;

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Hypot.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Hypot.cs
@@ -22,8 +22,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Hypot<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IRootFunctions<T> =>
+            where T : IRootFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, HypotOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, HypotOperator<T>>(x, y, destination);
+        }
 
         /// <summary>T.Hypot(x, y)</summary>
         private readonly struct HypotOperator<T> : IBinaryOperator<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Hypot.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Hypot.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tensors
         public static void Hypot<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IRootFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, HypotOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, HypotOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Increment.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Increment.cs
@@ -20,7 +20,7 @@ namespace System.Numerics.Tensors
         public static void Increment<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IIncrementOperators<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, IncrementOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, IncrementOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Increment.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Increment.cs
@@ -18,8 +18,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Increment<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IIncrementOperators<T> =>
+            where T : IIncrementOperators<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, IncrementOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, IncrementOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Increment(x)</summary>
         private readonly struct IncrementOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Lerp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Lerp.cs
@@ -27,8 +27,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Lerp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> amount, Span<T> destination)
-            where T : IFloatingPointIeee754<T> =>
+            where T : IFloatingPointIeee754<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, LerpOperator<float>>(x, y, amount, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanSpanIntoSpan<T, LerpOperator<T>>(x, y, amount, destination);
+        }
 
         /// <summary>Computes the element-wise linear interpolation between two values based on the given weight in the specified tensors of numbers.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -48,8 +55,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Lerp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T amount, Span<T> destination)
-            where T : IFloatingPointIeee754<T> =>
+            where T : IFloatingPointIeee754<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, LerpOperator<float>>(x, y, amount, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanScalarIntoSpan<T, LerpOperator<T>>(x, y, amount, destination);
+        }
 
         /// <summary>Computes the element-wise linear interpolation between two values based on the given weight in the specified tensors of numbers.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -69,12 +83,21 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Lerp<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> amount, Span<T> destination)
-            where T : IFloatingPointIeee754<T> =>
+            where T : IFloatingPointIeee754<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, LerpOperator<float>>(x, y, amount, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarSpanIntoSpan<T, LerpOperator<T>>(x, y, amount, destination);
+        }
 
         /// <summary>(x * (1 - z)) + (y * z)</summary>
         private readonly struct LerpOperator<T> : ITernaryOperator<T> where T : IFloatingPointIeee754<T>
         {
+            public static bool Vectorizable => true;
+
             public static T Invoke(T x, T y, T amount) => T.Lerp(x, y, amount);
 
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y, Vector128<T> amount)

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Lerp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Lerp.cs
@@ -29,7 +29,7 @@ namespace System.Numerics.Tensors
         public static void Lerp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> amount, Span<T> destination)
             where T : IFloatingPointIeee754<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, LerpOperator<float>>(x, y, amount, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, LerpOperator<float>>(x, y, amount, destination))
             {
                 return;
             }
@@ -57,7 +57,7 @@ namespace System.Numerics.Tensors
         public static void Lerp<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T amount, Span<T> destination)
             where T : IFloatingPointIeee754<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, LerpOperator<float>>(x, y, amount, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, LerpOperator<float>>(x, y, amount, destination))
             {
                 return;
             }
@@ -85,7 +85,7 @@ namespace System.Numerics.Tensors
         public static void Lerp<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> amount, Span<T> destination)
             where T : IFloatingPointIeee754<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, LerpOperator<float>>(x, y, amount, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, LerpOperator<float>>(x, y, amount, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log.cs
@@ -29,8 +29,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Log<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ILogarithmicFunctions<T> =>
+            where T : ILogarithmicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, LogOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, LogOperator<T>>(x, destination);
+        }
 
         /// <summary>Computes the element-wise logarithm of the numbers in a specified tensor to the specified base in another specified tensor.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -50,8 +57,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Log<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : ILogarithmicFunctions<T> =>
+            where T : ILogarithmicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, LogBaseOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, LogBaseOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise logarithm of the numbers in a specified tensor to the specified base in another specified tensor.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -69,8 +83,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Log<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : ILogarithmicFunctions<T> =>
+            where T : ILogarithmicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, LogBaseOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, LogBaseOperator<T>>(x, y, destination);
+        }
 
         /// <summary>T.Log(x)</summary>
         internal readonly struct LogOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log.cs
@@ -31,7 +31,7 @@ namespace System.Numerics.Tensors
         public static void Log<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ILogarithmicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, LogOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, LogOperator<float>>(x, destination))
             {
                 return;
             }
@@ -59,7 +59,7 @@ namespace System.Numerics.Tensors
         public static void Log<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : ILogarithmicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, LogBaseOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, LogBaseOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -85,7 +85,7 @@ namespace System.Numerics.Tensors
         public static void Log<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : ILogarithmicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, LogBaseOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, LogBaseOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log10.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log10.cs
@@ -28,8 +28,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Log10<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ILogarithmicFunctions<T> =>
+            where T : ILogarithmicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Log10Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, Log10Operator<T>>(x, destination);
+        }
 
         /// <summary>T.Log10(x)</summary>
         private readonly struct Log10Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log10.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log10.cs
@@ -30,7 +30,7 @@ namespace System.Numerics.Tensors
         public static void Log10<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ILogarithmicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Log10Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, Log10Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log10P1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log10P1.cs
@@ -30,7 +30,7 @@ namespace System.Numerics.Tensors
         public static void Log10P1<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ILogarithmicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Log10P1Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, Log10P1Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log10P1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log10P1.cs
@@ -28,8 +28,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Log10P1<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ILogarithmicFunctions<T> =>
+            where T : ILogarithmicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Log10P1Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, Log10P1Operator<T>>(x, destination);
+        }
 
         /// <summary>T.Log10P1(x)</summary>
         private readonly struct Log10P1Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log2.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log2.cs
@@ -31,7 +31,7 @@ namespace System.Numerics.Tensors
         public static void Log2<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ILogarithmicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Log2Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, Log2Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log2.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log2.cs
@@ -29,8 +29,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Log2<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ILogarithmicFunctions<T> =>
+            where T : ILogarithmicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Log2Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, Log2Operator<T>>(x, destination);
+        }
 
         /// <summary>T.Log2(x)</summary>
         internal readonly struct Log2Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log2P1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log2P1.cs
@@ -30,7 +30,7 @@ namespace System.Numerics.Tensors
         public static void Log2P1<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ILogarithmicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Log2P1Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, Log2P1Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log2P1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log2P1.cs
@@ -28,8 +28,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Log2P1<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ILogarithmicFunctions<T> =>
+            where T : ILogarithmicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, Log2P1Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, Log2P1Operator<T>>(x, destination);
+        }
 
         /// <summary>T.Log2P1(x)</summary>
         private readonly struct Log2P1Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.LogP1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.LogP1.cs
@@ -30,7 +30,7 @@ namespace System.Numerics.Tensors
         public static void LogP1<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ILogarithmicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, LogP1Operator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, LogP1Operator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.LogP1.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.LogP1.cs
@@ -28,8 +28,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void LogP1<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ILogarithmicFunctions<T> =>
+            where T : ILogarithmicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, LogP1Operator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, LogP1Operator<T>>(x, destination);
+        }
 
         /// <summary>T.LogP1(x)</summary>
         private readonly struct LogP1Operator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Max.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Max.cs
@@ -26,8 +26,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static T Max<T>(ReadOnlySpan<T> x)
-            where T : INumber<T> =>
-            MinMaxCore<T, MaxOperator<T>>(x);
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MaxOperator<float>>(x, out T result))
+            {
+                return result;
+            }
+
+            return MinMaxCore<T, MaxOperator<T>>(x);
+        }
 
         /// <summary>Computes the element-wise maximum of the numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -51,8 +58,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Max<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, MaxOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise maximum of the numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -74,8 +88,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Max<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, MaxOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Max(x, y)</summary>
         internal readonly struct MaxOperator<T> : IAggregationOperator<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Max.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Max.cs
@@ -28,7 +28,7 @@ namespace System.Numerics.Tensors
         public static T Max<T>(ReadOnlySpan<T> x)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MaxOperator<float>>(x, out T result))
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsInt16<T, MaxOperator<float>>(x, out T result))
             {
                 return result;
             }
@@ -60,7 +60,7 @@ namespace System.Numerics.Tensors
         public static void Max<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MaxOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -90,7 +90,7 @@ namespace System.Numerics.Tensors
         public static void Max<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MaxOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitude.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitude.cs
@@ -24,8 +24,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static T MaxMagnitude<T>(ReadOnlySpan<T> x)
-            where T : INumberBase<T> =>
-            MinMaxCore<T, MaxMagnitudeOperator<T>>(x);
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MaxMagnitudeOperator<float>>(x, out T result))
+            {
+                return result;
+            }
+
+            return MinMaxCore<T, MaxMagnitudeOperator<T>>(x);
+        }
 
         /// <summary>Computes the element-wise number with the largest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -43,8 +50,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MaxMagnitude<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxMagnitudeOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, MaxMagnitudeOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise number with the largest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -60,8 +74,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MaxMagnitude<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxMagnitudeOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, MaxMagnitudeOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Operator to get x or y based on which has the larger MathF.Abs</summary>
         internal readonly struct MaxMagnitudeOperator<T> : IAggregationOperator<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitude.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitude.cs
@@ -26,7 +26,7 @@ namespace System.Numerics.Tensors
         public static T MaxMagnitude<T>(ReadOnlySpan<T> x)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MaxMagnitudeOperator<float>>(x, out T result))
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsInt16<T, MaxMagnitudeOperator<float>>(x, out T result))
             {
                 return result;
             }
@@ -52,7 +52,7 @@ namespace System.Numerics.Tensors
         public static void MaxMagnitude<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxMagnitudeOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MaxMagnitudeOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -76,7 +76,7 @@ namespace System.Numerics.Tensors
         public static void MaxMagnitude<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxMagnitudeOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MaxMagnitudeOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitudeNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitudeNumber.cs
@@ -25,8 +25,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static T MaxMagnitudeNumber<T>(ReadOnlySpan<T> x)
-            where T : INumberBase<T> =>
-            MinMaxCore<T, MaxMagnitudeNumberOperator<T>>(x);
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MaxMagnitudeNumberOperator<float>>(x, out T result))
+            {
+                return result;
+            }
+
+            return MinMaxCore<T, MaxMagnitudeNumberOperator<T>>(x);
+        }
 
         /// <summary>Computes the element-wise number with the largest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -51,8 +58,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MaxMagnitudeNumber<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxMagnitudeNumberOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, MaxMagnitudeNumberOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise number with the largest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -75,8 +89,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MaxMagnitudeNumber<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxMagnitudeNumberOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, MaxMagnitudeNumberOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Operator to get x or y based on which has the larger MathF.Abs</summary>
         internal readonly struct MaxMagnitudeNumberOperator<T> : IAggregationOperator<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitudeNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitudeNumber.cs
@@ -27,7 +27,7 @@ namespace System.Numerics.Tensors
         public static T MaxMagnitudeNumber<T>(ReadOnlySpan<T> x)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MaxMagnitudeNumberOperator<float>>(x, out T result))
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsInt16<T, MaxMagnitudeNumberOperator<float>>(x, out T result))
             {
                 return result;
             }
@@ -60,7 +60,7 @@ namespace System.Numerics.Tensors
         public static void MaxMagnitudeNumber<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxMagnitudeNumberOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MaxMagnitudeNumberOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -91,7 +91,7 @@ namespace System.Numerics.Tensors
         public static void MaxMagnitudeNumber<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxMagnitudeNumberOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MaxMagnitudeNumberOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxNumber.cs
@@ -27,7 +27,7 @@ namespace System.Numerics.Tensors
         public static T MaxNumber<T>(ReadOnlySpan<T> x)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MaxNumberOperator<float>>(x, out T result))
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsInt16<T, MaxNumberOperator<float>>(x, out T result))
             {
                 return result;
             }
@@ -59,7 +59,7 @@ namespace System.Numerics.Tensors
         public static void MaxNumber<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxNumberOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MaxNumberOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -89,7 +89,7 @@ namespace System.Numerics.Tensors
         public static void MaxNumber<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxNumberOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MaxNumberOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxNumber.cs
@@ -25,8 +25,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static T MaxNumber<T>(ReadOnlySpan<T> x)
-            where T : INumber<T> =>
-            MinMaxCore<T, MaxNumberOperator<T>>(x);
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MaxNumberOperator<float>>(x, out T result))
+            {
+                return result;
+            }
+
+            return MinMaxCore<T, MaxNumberOperator<T>>(x);
+        }
 
         /// <summary>Computes the element-wise maximum of the numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -50,8 +57,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MaxNumber<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxNumberOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, MaxNumberOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise maximum of the numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -73,8 +87,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MaxNumber<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MaxNumberOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, MaxNumberOperator<T>>(x, y, destination);
+        }
 
         /// <summary>T.MaxNumber(x, y)</summary>
         internal readonly struct MaxNumberOperator<T> : IAggregationOperator<T> where T : INumber<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Min.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Min.cs
@@ -26,7 +26,7 @@ namespace System.Numerics.Tensors
         public static T Min<T>(ReadOnlySpan<T> x)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MinOperator<float>>(x, out T result))
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsInt16<T, MinOperator<float>>(x, out T result))
             {
                 return result;
             }
@@ -58,7 +58,7 @@ namespace System.Numerics.Tensors
         public static void Min<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MinOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -88,7 +88,7 @@ namespace System.Numerics.Tensors
         public static void Min<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MinOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Min.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Min.cs
@@ -24,8 +24,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static T Min<T>(ReadOnlySpan<T> x)
-            where T : INumber<T> =>
-            MinMaxCore<T, MinOperator<T>>(x);
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MinOperator<float>>(x, out T result))
+            {
+                return result;
+            }
+
+            return MinMaxCore<T, MinOperator<T>>(x);
+        }
 
         /// <summary>Computes the element-wise minimum of the numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -49,8 +56,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Min<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, MinOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise minimum of the numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -72,8 +86,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Min<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, MinOperator<T>>(x, y, destination);
+        }
 
         /// <summary>T.Min(x, y)</summary>
         internal readonly struct MinOperator<T> : IAggregationOperator<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitude.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitude.cs
@@ -24,8 +24,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static T MinMagnitude<T>(ReadOnlySpan<T> x)
-            where T : INumberBase<T> =>
-            MinMaxCore<T, MinMagnitudeOperator<T>>(x);
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MinMagnitudeOperator<float>>(x, out T result))
+            {
+                return result;
+            }
+
+            return MinMaxCore<T, MinMagnitudeOperator<T>>(x);
+        }
 
         /// <summary>Computes the element-wise number with the smallest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -48,8 +55,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MinMagnitude<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinMagnitudeOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, MinMagnitudeOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise number with the smallest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -70,8 +84,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MinMagnitude<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinMagnitudeOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, MinMagnitudeOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Operator to get x or y based on which has the smaller MathF.Abs</summary>
         internal readonly struct MinMagnitudeOperator<T> : IAggregationOperator<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitude.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitude.cs
@@ -26,7 +26,7 @@ namespace System.Numerics.Tensors
         public static T MinMagnitude<T>(ReadOnlySpan<T> x)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MinMagnitudeOperator<float>>(x, out T result))
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsInt16<T, MinMagnitudeOperator<float>>(x, out T result))
             {
                 return result;
             }
@@ -57,7 +57,7 @@ namespace System.Numerics.Tensors
         public static void MinMagnitude<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinMagnitudeOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MinMagnitudeOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -86,7 +86,7 @@ namespace System.Numerics.Tensors
         public static void MinMagnitude<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinMagnitudeOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MinMagnitudeOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitudeNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitudeNumber.cs
@@ -25,8 +25,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static T MinMagnitudeNumber<T>(ReadOnlySpan<T> x)
-            where T : INumberBase<T> =>
-            MinMaxCore<T, MinMagnitudeNumberOperator<T>>(x);
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MinMagnitudeNumberOperator<float>>(x, out T result))
+            {
+                return result;
+            }
+
+            return MinMaxCore<T, MinMagnitudeNumberOperator<T>>(x);
+        }
 
         /// <summary>Computes the element-wise number with the smallest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -51,8 +58,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MinMagnitudeNumber<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinMagnitudeNumberOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, MinMagnitudeNumberOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise number with the smallest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -75,8 +89,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MinMagnitudeNumber<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinMagnitudeNumberOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, MinMagnitudeNumberOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Operator to get x or y based on which has the smaller MathF.Abs</summary>
         internal readonly struct MinMagnitudeNumberOperator<T> : IAggregationOperator<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitudeNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitudeNumber.cs
@@ -27,7 +27,7 @@ namespace System.Numerics.Tensors
         public static T MinMagnitudeNumber<T>(ReadOnlySpan<T> x)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MinMagnitudeNumberOperator<float>>(x, out T result))
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsInt16<T, MinMagnitudeNumberOperator<float>>(x, out T result))
             {
                 return result;
             }
@@ -60,7 +60,7 @@ namespace System.Numerics.Tensors
         public static void MinMagnitudeNumber<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinMagnitudeNumberOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MinMagnitudeNumberOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -91,7 +91,7 @@ namespace System.Numerics.Tensors
         public static void MinMagnitudeNumber<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinMagnitudeNumberOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MinMagnitudeNumberOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinNumber.cs
@@ -27,7 +27,7 @@ namespace System.Numerics.Tensors
         public static T MinNumber<T>(ReadOnlySpan<T> x)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MinNumberOperator<float>>(x, out T result))
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsInt16<T, MinNumberOperator<float>>(x, out T result))
             {
                 return result;
             }
@@ -59,7 +59,7 @@ namespace System.Numerics.Tensors
         public static void MinNumber<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinNumberOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MinNumberOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -89,7 +89,7 @@ namespace System.Numerics.Tensors
         public static void MinNumber<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : INumber<T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinNumberOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MinNumberOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinNumber.cs
@@ -25,8 +25,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static T MinNumber<T>(ReadOnlySpan<T> x)
-            where T : INumber<T> =>
-            MinMaxCore<T, MinNumberOperator<T>>(x);
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryMinMaxHalfAsShort<T, MinNumberOperator<float>>(x, out T result))
+            {
+                return result;
+            }
+
+            return MinMaxCore<T, MinNumberOperator<T>>(x);
+        }
 
         /// <summary>Computes the element-wise minimum of the numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -50,8 +57,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MinNumber<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinNumberOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, MinNumberOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise minimum of the numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -73,8 +87,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MinNumber<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : INumber<T> =>
+            where T : INumber<T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MinNumberOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, MinNumberOperator<T>>(x, y, destination);
+        }
 
         /// <summary>T.MinNumber(x, y)</summary>
         internal readonly struct MinNumberOperator<T> : IAggregationOperator<T> where T : INumber<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Multiply.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Multiply.cs
@@ -26,7 +26,7 @@ namespace System.Numerics.Tensors
         public static void Multiply<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IMultiplyOperators<T, T, T>, IMultiplicativeIdentity<T, T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MultiplyOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MultiplyOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -52,7 +52,7 @@ namespace System.Numerics.Tensors
         public static void Multiply<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : IMultiplyOperators<T, T, T>, IMultiplicativeIdentity<T, T>
         {
-            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MultiplyOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsInt16<T, MultiplyOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Multiply.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Multiply.cs
@@ -24,8 +24,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Multiply<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IMultiplyOperators<T, T, T>, IMultiplicativeIdentity<T, T> =>
+            where T : IMultiplyOperators<T, T, T>, IMultiplicativeIdentity<T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MultiplyOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, MultiplyOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise product of numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -43,8 +50,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Multiply<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : IMultiplyOperators<T, T, T>, IMultiplicativeIdentity<T, T> =>
+            where T : IMultiplyOperators<T, T, T>, IMultiplicativeIdentity<T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryAggregateInvokeHalfAsShort<T, MultiplyOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, MultiplyOperator<T>>(x, y, destination);
+        }
 
         /// <summary>x * y</summary>
         internal readonly struct MultiplyOperator<T> : IAggregationOperator<T> where T : IMultiplyOperators<T, T, T>, IMultiplicativeIdentity<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAdd.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAdd.cs
@@ -28,7 +28,7 @@ namespace System.Numerics.Tensors
         public static void MultiplyAdd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> addend, Span<T> destination)
             where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddOperator<float>>(x, y, addend, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, MultiplyAddOperator<float>>(x, y, addend, destination))
             {
                 return;
             }
@@ -57,7 +57,7 @@ namespace System.Numerics.Tensors
         public static void MultiplyAdd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T addend, Span<T> destination)
             where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddOperator<float>>(x, y, addend, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, MultiplyAddOperator<float>>(x, y, addend, destination))
             {
                 return;
             }
@@ -85,7 +85,7 @@ namespace System.Numerics.Tensors
         public static void MultiplyAdd<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> addend, Span<T> destination)
             where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddOperator<float>>(x, y, addend, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, MultiplyAddOperator<float>>(x, y, addend, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAdd.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAdd.cs
@@ -26,8 +26,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MultiplyAdd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> addend, Span<T> destination)
-            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T> =>
+            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddOperator<float>>(x, y, addend, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanSpanIntoSpan<T, MultiplyAddOperator<T>>(x, y, addend, destination);
+        }
 
         /// <summary>Computes the element-wise result of <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c> for the specified tensors of numbers.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -48,8 +55,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MultiplyAdd<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T addend, Span<T> destination)
-            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T> =>
+            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddOperator<float>>(x, y, addend, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanScalarIntoSpan<T, MultiplyAddOperator<T>>(x, y, addend, destination);
+        }
 
         /// <summary>Computes the element-wise result of <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c> for the specified tensors of numbers.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -69,12 +83,20 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MultiplyAdd<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> addend, Span<T> destination)
-            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T> =>
+            where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddOperator<float>>(x, y, addend, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarSpanIntoSpan<T, MultiplyAddOperator<T>>(x, y, addend, destination);
+        }
 
         /// <summary>(x * y) + z</summary>
         internal readonly struct MultiplyAddOperator<T> : ITernaryOperator<T> where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
         {
+            public static bool Vectorizable => true;
             public static T Invoke(T x, T y, T z) => (x * y) + z;
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y, Vector128<T> z) => (x * y) + z;
             public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y, Vector256<T> z) => (x * y) + z;

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAddEstimate.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAddEstimate.cs
@@ -36,7 +36,7 @@ namespace System.Numerics.Tensors
         public static void MultiplyAddEstimate<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> addend, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddEstimateOperator<float>>(x, y, addend, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, MultiplyAddEstimateOperator<float>>(x, y, addend, destination))
             {
                 return;
             }
@@ -69,7 +69,7 @@ namespace System.Numerics.Tensors
         public static void MultiplyAddEstimate<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T addend, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddEstimateOperator<float>>(x, y, addend, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, MultiplyAddEstimateOperator<float>>(x, y, addend, destination))
             {
                 return;
             }
@@ -101,7 +101,7 @@ namespace System.Numerics.Tensors
         public static void MultiplyAddEstimate<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> addend, Span<T> destination)
             where T : INumberBase<T>
         {
-            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddEstimateOperator<float>>(x, y, addend, destination))
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsInt16<T, MultiplyAddEstimateOperator<float>>(x, y, addend, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAddEstimate.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MultiplyAddEstimate.cs
@@ -34,8 +34,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MultiplyAddEstimate<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, ReadOnlySpan<T> addend, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddEstimateOperator<float>>(x, y, addend, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanSpanIntoSpan<T, MultiplyAddEstimateOperator<T>>(x, y, addend, destination);
+        }
 
         /// <summary>Computes the element-wise result of <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c> for the specified tensors of numbers.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -60,8 +67,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MultiplyAddEstimate<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, T addend, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddEstimateOperator<float>>(x, y, addend, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanScalarIntoSpan<T, MultiplyAddEstimateOperator<T>>(x, y, addend, destination);
+        }
 
         /// <summary>Computes the element-wise result of <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c> for the specified tensors of numbers.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -85,13 +99,22 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void MultiplyAddEstimate<T>(ReadOnlySpan<T> x, T y, ReadOnlySpan<T> addend, Span<T> destination)
-            where T : INumberBase<T> =>
+            where T : INumberBase<T>
+        {
+            if (typeof(T) == typeof(Half) && TryTernaryInvokeHalfAsShort<T, MultiplyAddEstimateOperator<float>>(x, y, addend, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarSpanIntoSpan<T, MultiplyAddEstimateOperator<T>>(x, y, addend, destination);
+        }
 
         /// <summary>(x * y) + z</summary>
         private readonly struct MultiplyAddEstimateOperator<T> : ITernaryOperator<T>
             where T : INumberBase<T>
         {
+            public static bool Vectorizable => true;
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static T Invoke(T x, T y, T z)
             {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Negate.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Negate.cs
@@ -21,8 +21,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Negate<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IUnaryNegationOperators<T, T> =>
+            where T : IUnaryNegationOperators<T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, NegateOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, NegateOperator<T>>(x, destination);
+        }
 
         /// <summary>-x</summary>
         internal readonly struct NegateOperator<T> : IUnaryOperator<T, T> where T : IUnaryNegationOperators<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Negate.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Negate.cs
@@ -23,7 +23,7 @@ namespace System.Numerics.Tensors
         public static void Negate<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IUnaryNegationOperators<T, T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, NegateOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, NegateOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.OnesComplement.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.OnesComplement.cs
@@ -18,8 +18,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void OnesComplement<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IBitwiseOperators<T, T, T> =>
+            where T : IBitwiseOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryBitwiseInvokeHalfAsShort<T, OnesComplementOperator<short>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, OnesComplementOperator<T>>(x, destination);
+        }
 
         /// <summary>~x</summary>
         private readonly struct OnesComplementOperator<T> : IUnaryOperator<T, T> where T : IBitwiseOperators<T, T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.OnesComplement.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.OnesComplement.cs
@@ -20,7 +20,7 @@ namespace System.Numerics.Tensors
         public static void OnesComplement<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IBitwiseOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryBitwiseInvokeHalfAsShort<T, OnesComplementOperator<short>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryBitwiseInvokeHalfAsInt16<T, OnesComplementOperator<short>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Reciprocal.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Reciprocal.cs
@@ -21,8 +21,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Reciprocal<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IFloatingPoint<T> =>
+            where T : IFloatingPoint<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ReciprocalOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, ReciprocalOperator<T>>(x, destination);
+        }
 
         /// <summary>Computes the element-wise reciprocal of numbers in the specified tensor.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -36,8 +43,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void ReciprocalEstimate<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IFloatingPointIeee754<T> =>
+            where T : IFloatingPointIeee754<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ReciprocalEstimateOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, ReciprocalEstimateOperator<T>>(x, destination);
+        }
 
         /// <summary>Computes the element-wise reciprocal of the square root of numbers in the specified tensor.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -51,8 +65,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void ReciprocalSqrt<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IFloatingPointIeee754<T> =>
+            where T : IFloatingPointIeee754<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ReciprocalSqrtOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, ReciprocalSqrtOperator<T>>(x, destination);
+        }
 
         /// <summary>Computes the element-wise reciprocal of the square root of numbers in the specified tensor.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -66,8 +87,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void ReciprocalSqrtEstimate<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IFloatingPointIeee754<T> =>
+            where T : IFloatingPointIeee754<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ReciprocalSqrtEstimateOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, ReciprocalSqrtEstimateOperator<T>>(x, destination);
+        }
 
         private readonly struct ReciprocalOperator<T> : IUnaryOperator<T, T> where T : IFloatingPoint<T>
         {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Reciprocal.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Reciprocal.cs
@@ -23,7 +23,7 @@ namespace System.Numerics.Tensors
         public static void Reciprocal<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IFloatingPoint<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ReciprocalOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, ReciprocalOperator<float>>(x, destination))
             {
                 return;
             }
@@ -45,7 +45,7 @@ namespace System.Numerics.Tensors
         public static void ReciprocalEstimate<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IFloatingPointIeee754<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ReciprocalEstimateOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, ReciprocalEstimateOperator<float>>(x, destination))
             {
                 return;
             }
@@ -67,7 +67,7 @@ namespace System.Numerics.Tensors
         public static void ReciprocalSqrt<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IFloatingPointIeee754<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ReciprocalSqrtOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, ReciprocalSqrtOperator<float>>(x, destination))
             {
                 return;
             }
@@ -89,7 +89,7 @@ namespace System.Numerics.Tensors
         public static void ReciprocalSqrtEstimate<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IFloatingPointIeee754<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, ReciprocalSqrtEstimateOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, ReciprocalSqrtEstimateOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Remainder.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Remainder.cs
@@ -24,8 +24,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Remainder<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IModulusOperators<T, T, T> =>
+            where T : IModulusOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, RemainderOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, RemainderOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise remainder of numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -43,8 +50,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Remainder<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : IModulusOperators<T, T, T> =>
+            where T : IModulusOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, RemainderOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, RemainderOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise remainder of numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -62,8 +76,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Remainder<T>(T x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IModulusOperators<T, T, T> =>
+            where T : IModulusOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, RemainderOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeScalarSpanIntoSpan<T, RemainderOperator<T>>(x, y, destination);
+        }
 
         /// <summary>x % y</summary>
         internal readonly struct RemainderOperator<T> : IBinaryOperator<T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Remainder.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Remainder.cs
@@ -26,7 +26,7 @@ namespace System.Numerics.Tensors
         public static void Remainder<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IModulusOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, RemainderOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, RemainderOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -52,7 +52,7 @@ namespace System.Numerics.Tensors
         public static void Remainder<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : IModulusOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, RemainderOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, RemainderOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -78,7 +78,7 @@ namespace System.Numerics.Tensors
         public static void Remainder<T>(T x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IModulusOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, RemainderOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, RemainderOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Round.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Round.cs
@@ -24,7 +24,7 @@ namespace System.Numerics.Tensors
         public static void Round<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IFloatingPoint<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, RoundToEvenOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, RoundToEvenOperator<float>>(x, destination))
             {
                 return;
             }
@@ -53,7 +53,7 @@ namespace System.Numerics.Tensors
                     return;
 
                 case MidpointRounding.AwayFromZero:
-                    if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, RoundAwayFromZeroOperator<float>>(x, destination))
+                    if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, RoundAwayFromZeroOperator<float>>(x, destination))
                     {
                         return;
                     }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Round.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Round.cs
@@ -22,8 +22,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Round<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IFloatingPoint<T> =>
+            where T : IFloatingPoint<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, RoundToEvenOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, RoundToEvenOperator<T>>(x, destination);
+        }
 
         /// <summary>Computes the element-wise rounding of the numbers in the specified tensor</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -46,8 +53,13 @@ namespace System.Numerics.Tensors
                     return;
 
                 case MidpointRounding.AwayFromZero:
+                    if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, RoundAwayFromZeroOperator<float>>(x, destination))
+                    {
+                        return;
+                    }
+
                     InvokeSpanIntoSpan<T, RoundAwayFromZeroOperator<T>>(x, destination);
-                    break;
+                    return;
 
                 case MidpointRounding.ToZero:
                     Truncate(x, destination);

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sigmoid.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sigmoid.cs
@@ -30,7 +30,7 @@ namespace System.Numerics.Tensors
                 ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
             }
 
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SigmoidOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, SigmoidOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sigmoid.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sigmoid.cs
@@ -30,6 +30,11 @@ namespace System.Numerics.Tensors
                 ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
             }
 
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SigmoidOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, SigmoidOperator<T>>(x, destination);
         }
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sin.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sin.cs
@@ -28,7 +28,7 @@ namespace System.Numerics.Tensors
         public static void Sin<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ITrigonometricFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SinOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, SinOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sin.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sin.cs
@@ -26,8 +26,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Sin<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ITrigonometricFunctions<T> =>
+            where T : ITrigonometricFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SinOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, SinOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Sin(x)</summary>
         internal readonly struct SinOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SinPi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SinPi.cs
@@ -26,8 +26,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void SinPi<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ITrigonometricFunctions<T> =>
+            where T : ITrigonometricFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SinPiOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, SinPiOperator<T>>(x, destination);
+        }
 
         /// <summary>T.SinPi(x)</summary>
         private readonly struct SinPiOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SinPi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SinPi.cs
@@ -28,7 +28,7 @@ namespace System.Numerics.Tensors
         public static void SinPi<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ITrigonometricFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SinPiOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, SinPiOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sinh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sinh.cs
@@ -32,7 +32,7 @@ namespace System.Numerics.Tensors
         public static void Sinh<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IHyperbolicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SinhOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, SinhOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sinh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sinh.cs
@@ -30,8 +30,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Sinh<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IHyperbolicFunctions<T> =>
+            where T : IHyperbolicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SinhOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, SinhOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Sinh(x)</summary>
         internal readonly struct SinhOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sqrt.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sqrt.cs
@@ -20,7 +20,7 @@ namespace System.Numerics.Tensors
         public static void Sqrt<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IRootFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SqrtOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, SqrtOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sqrt.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Sqrt.cs
@@ -18,8 +18,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Sqrt<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IRootFunctions<T> =>
+            where T : IRootFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, SqrtOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, SqrtOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Sqrt(x)</summary>
         private readonly struct SqrtOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Subtract.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Subtract.cs
@@ -24,8 +24,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Subtract<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : ISubtractionOperators<T, T, T> =>
+            where T : ISubtractionOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, SubtractOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, SubtractOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise difference between numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -42,8 +49,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Subtract<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : ISubtractionOperators<T, T, T> =>
+            where T : ISubtractionOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, SubtractOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, SubtractOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise difference between numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a scalar.</param>
@@ -60,8 +74,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Subtract<T>(T x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : ISubtractionOperators<T, T, T> =>
+            where T : ISubtractionOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, SubtractOperator<float>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeScalarSpanIntoSpan<T, SubtractOperator<T>>(x, y, destination);
+        }
 
         /// <summary>x - y</summary>
         internal readonly struct SubtractOperator<T> : IBinaryOperator<T> where T : ISubtractionOperators<T, T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Subtract.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Subtract.cs
@@ -26,7 +26,7 @@ namespace System.Numerics.Tensors
         public static void Subtract<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : ISubtractionOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, SubtractOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, SubtractOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -51,7 +51,7 @@ namespace System.Numerics.Tensors
         public static void Subtract<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : ISubtractionOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, SubtractOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, SubtractOperator<float>>(x, y, destination))
             {
                 return;
             }
@@ -76,7 +76,7 @@ namespace System.Numerics.Tensors
         public static void Subtract<T>(T x, ReadOnlySpan<T> y, Span<T> destination)
             where T : ISubtractionOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsShort<T, SubtractOperator<float>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryInvokeHalfAsInt16<T, SubtractOperator<float>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Tan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Tan.cs
@@ -28,7 +28,7 @@ namespace System.Numerics.Tensors
         public static void Tan<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ITrigonometricFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, TanOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, TanOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Tan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Tan.cs
@@ -26,8 +26,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Tan<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ITrigonometricFunctions<T> =>
+            where T : ITrigonometricFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, TanOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, TanOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Tan(x)</summary>
         private readonly struct TanOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.TanPi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.TanPi.cs
@@ -27,7 +27,7 @@ namespace System.Numerics.Tensors
         public static void TanPi<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : ITrigonometricFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, TanPiOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, TanPiOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.TanPi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.TanPi.cs
@@ -25,8 +25,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void TanPi<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : ITrigonometricFunctions<T> =>
+            where T : ITrigonometricFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, TanPiOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, TanPiOperator<T>>(x, destination);
+        }
 
         /// <summary>T.TanPi(x)</summary>
         private readonly struct TanPiOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Tanh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Tanh.cs
@@ -32,7 +32,7 @@ namespace System.Numerics.Tensors
         public static void Tanh<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IHyperbolicFunctions<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, TanhOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, TanhOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Tanh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Tanh.cs
@@ -30,8 +30,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Tanh<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IHyperbolicFunctions<T> =>
+            where T : IHyperbolicFunctions<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, TanhOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, TanhOperator<T>>(x, destination);
+        }
 
         /// <summary>T.Tanh(x)</summary>
         internal readonly struct TanhOperator<T> : IUnaryOperator<T, T>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Truncate.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Truncate.cs
@@ -23,7 +23,7 @@ namespace System.Numerics.Tensors
         public static void Truncate<T>(ReadOnlySpan<T> x, Span<T> destination)
             where T : IFloatingPoint<T>
         {
-            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, TruncateOperator<float>>(x, destination))
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsInt16<T, TruncateOperator<float>>(x, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Truncate.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Truncate.cs
@@ -21,8 +21,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Truncate<T>(ReadOnlySpan<T> x, Span<T> destination)
-            where T : IFloatingPoint<T> =>
+            where T : IFloatingPoint<T>
+        {
+            if (typeof(T) == typeof(Half) && TryUnaryInvokeHalfAsShort<T, TruncateOperator<float>>(x, destination))
+            {
+                return;
+            }
+
             InvokeSpanIntoSpan<T, TruncateOperator<T>>(x, destination);
+        }
 
         private readonly struct TruncateOperator<T> : IUnaryOperator<T, T> where T : IFloatingPoint<T>
         {

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Xor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Xor.cs
@@ -23,7 +23,7 @@ namespace System.Numerics.Tensors
         public static void Xor<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
             where T : IBitwiseOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, XorOperator<short>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsInt16<T, XorOperator<short>>(x, y, destination))
             {
                 return;
             }
@@ -45,7 +45,7 @@ namespace System.Numerics.Tensors
         public static void Xor<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
             where T : IBitwiseOperators<T, T, T>
         {
-            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, XorOperator<short>>(x, y, destination))
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsInt16<T, XorOperator<short>>(x, y, destination))
             {
                 return;
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Xor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Xor.cs
@@ -21,8 +21,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Xor<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> destination)
-            where T : IBitwiseOperators<T, T, T> =>
+            where T : IBitwiseOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, XorOperator<short>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanSpanIntoSpan<T, XorOperator<T>>(x, y, destination);
+        }
 
         /// <summary>Computes the element-wise XOR of numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -36,8 +43,15 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void Xor<T>(ReadOnlySpan<T> x, T y, Span<T> destination)
-            where T : IBitwiseOperators<T, T, T> =>
+            where T : IBitwiseOperators<T, T, T>
+        {
+            if (typeof(T) == typeof(Half) && TryBinaryBitwiseInvokeHalfAsShort<T, XorOperator<short>>(x, y, destination))
+            {
+                return;
+            }
+
             InvokeSpanScalarIntoSpan<T, XorOperator<T>>(x, y, destination);
+        }
 
         /// <summary>x ^ y</summary>
         private readonly struct XorOperator<T> : IBinaryOperator<T> where T : IBitwiseOperators<T, T, T>


### PR DESCRIPTION
This enables all of the following operators to be vectorized for T == Half:
Abs, Add, AddMultiply, BitwiseAnd, BitwiseOr, Ceiling, Clamp, CopySign, Cos, CosPi, Cosh, Decrement, DegreesToRadians, Divide, Exp, Exp10, Exp10M1, Exp2, Exp2M1, ExpM1, Floor, FusedAddMultiply, Hypot, Increment, Lerp, Log, Log10, Log10P1, Log2, Log2P1, LogP1, Max, MaxMagnitude, MaxMagnitudeNumber, MaxNumber, Min, MinMagnitude, MinMagnitudeNumber, MinNumber, Multiply, MultiplyAdd, MultiplyAddEstimate, Negate, OnesComplement, Reciprocal, Remainder, Round, Sigmoid, Sin, SinPi, Sinh, Sqrt, Subtract, Tan, TanPi, Tanh, Truncate, Xor.

I don't love that it required adding code to each of those methods, but I couldn't come up with anything better and kept the code per method to a minimum (I left the typeof(T) == typeof(Half) check at each call site, primarily for clarity).

I did not change the reductions, as anything that involved more than the same number of Half <-> float roundtrips as exists today ended up perturbing the results to the point where tests failed, and most of the reductions involve multiple operators.

Sample benchmarks:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Numerics.Tensors;

BenchmarkSwitcher.FromAssembly(typeof(Bench).Assembly).Run(args);

public class Bench
{
    private Half[] _x, _y, _d;

    [Params(1, 8, 800)]
    public int Length { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        _x = new Half[Length];
        _y = new Half[Length];
        _d = new Half[Length];
        var random = new Random(42);
        for (int i = 0; i < Length; i++)
        {
            _x[i] = (Half)random.NextSingle();
            _y[i] = (Half)random.NextSingle();
        }
    }

    [Benchmark]
    public void Add() => TensorPrimitives.Add(_x, _y, _d);

    [Benchmark]
    public void Exp() => TensorPrimitives.Exp(_x, _d);

    [Benchmark]
    public void Floor() => TensorPrimitives.Floor(_x, _d);

    [Benchmark]
    public void Xor() => TensorPrimitives.Xor(_x, _y, _d);
}
```

On my machine with AVX256 (not AVX512)...

Before:

| Method | Length | Mean         |
|------- |------- |-------------:|
| Add    | 1      |    12.173 ns |
| Exp    | 1      |    13.374 ns |
| Floor  | 1      |     7.554 ns |
| Xor    | 1      |     6.763 ns |
| Add    | 8      |    55.226 ns |
| Exp    | 8      |    86.672 ns |
| Floor  | 8      |    45.207 ns |
| Xor    | 8      |     7.802 ns |
| Add    | 800    | 5,119.294 ns |
| Exp    | 800    | 8,246.779 ns |
| Floor  | 800    | 4,235.245 ns |
| Xor    | 800    |   340.764 ns |

After:
| Method | Length | Mean         |
|------- |------- |-------------:|
| Add    | 1      |    12.286 ns |
| Exp    | 1      |    21.634 ns |
| Floor  | 1      |     8.812 ns |
| Xor    | 1      |     6.544 ns |
| Add    | 8      |    23.209 ns |
| Exp    | 8      |    29.455 ns |
| Floor  | 8      |    17.650 ns |
| Xor    | 8      |     6.620 ns |
| Add    | 800    |   896.571 ns |
| Exp    | 800    | 1,629.144 ns |
| Floor  | 800    |   678.427 ns |
| Xor    | 800    |    26.408 ns |
