### PR TITLE
Disable WER for host test apps that intentionally crash

### DIFF
--- a/src/installer/tests/Assets/Projects/CoreDump.cs
+++ b/src/installer/tests/Assets/Projects/CoreDump.cs
@@ -34,6 +34,11 @@ namespace Utilities
                     throw new InvalidOperationException($"Failed to disable core dump. Error: {Marshal.GetLastPInvokeError()}.");
                 }
             }
+            else if (OperatingSystem.IsWindows())
+            {
+                uint errorMode = GetErrorMode();
+                SetErrorMode(errorMode | NOGPFAULTERRORBOX);
+            }
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -55,5 +60,13 @@ namespace Utilities
 
         [DllImport("libc", SetLastError = true)]
         private static extern int prctl(int option, int arg2);
+
+        private const uint NOGPFAULTERRORBOX = 0x0002;
+
+        [DllImport("kernel32", ExactSpelling = true)]
+        static extern uint GetErrorMode();
+
+        [DllImport("kernel32", ExactSpelling = true)]
+        static extern uint SetErrorMode(uint uMode);
     }
 }


### PR DESCRIPTION
Call `SetErrorMode` with `NOGPFAULTERRORBOX` per @MichalStrehovsky's suggestion in https://github.com/dotnet/runtime/pull/116725#issuecomment-2986596890

This disables dumps for the tests that intentionally crash when we are crashing from the app. For something like `Muxer_NonAssemblyWithExeExtension` where there is no test-specific code running, we don't have anywhere to hook in to do this, so that still ends up with a dump. But this change at least gets rid of the other ones.

cc @dotnet/appmodel @AaronRobinsonMSFT 