### PR TITLE
[release/9.0-staging][mono][gc] Fix gc descriptor computation for InlineArray structs

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -906,9 +906,13 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 
 			guint32 field_iter = 1;
 			guint32 field_instance_offset = field_offset;
+			int field_size = 0;
 			// If struct has InlineArray attribute, iterate `length` times to set a bitmap
-			if (m_class_is_inlinearray (p))
+			if (m_class_is_inlinearray (p)) {
+				int align;
 				field_iter = m_class_inlinearray_value (p);
+				field_size = mono_type_size (field->type, &align);
+			}
 
 			if (field_iter > 500)
 				g_warning ("Large number of iterations detected when creating a GC bitmap, might affect performance.");
@@ -973,7 +977,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 					break;
 				}
 
-				field_instance_offset += field_offset;
+				field_instance_offset += field_size;
 				field_iter--;
 			}
 		}


### PR DESCRIPTION
`compute_class_bitmap` iterates over all ref field slots in the current class so we can produce a GC descriptor. `field_iter` represents how many times the type in question is repeated in the current struct. Instead of bumping the current offset by the size of the repeated field, for each iteration, we were adding `field_offset` which is wrong.

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Types having `InlineArray` attribute are not correctly scanned by the GC for refs. This can lead to GC crashes on Maui applications. User reported problem migrating from legacy xamarin to maui https://github.com/Humanizr/Humanizer/issues/1572.

## Regression

- [X] Yes
- [ ] No

`InlineArray` attribute for types was added around .NET8, with some uses showing up in the libraries code in .NET9, which could lead to regressions for some users. 

## Testing

Tested on local test that the GC descriptor is now computed correctly for types with `InlineArray` attribute. Verified fix on sample app provided by customer.

## Risk

Low. The fix is localized to types that have `InlineArray` attribute, where the previous implementation was completely broken. 