### PR TITLE
Isolate DiagnosticsTest by disabling its prallelization

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -17,8 +17,6 @@ using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
-
 namespace System.Net.Http.Functional.Tests
 {
     [Collection(nameof(DisableParallelization))]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -17,9 +17,11 @@ using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace System.Net.Http.Functional.Tests
 {
+    [Collection(nameof(DisableParallelization))]
     public abstract class DiagnosticsTest : DiagnosticsTestBase
     {
         private const string EnableActivityPropagationEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_ENABLEACTIVITYPROPAGATION";


### PR DESCRIPTION
Fixing: [System.Net.Http.Functional.Tests timeouts #115683](https://github.com/dotnet/runtime/issues/115683)

### Context
Functional tests were starting to intermittently hang. 
After analyzing I found that just-running diagnostics tests are causing inserting `ActivityRecorder` test listener which is failing on some verification by `Assert.Same`. Some of our test expect that sending request by client part of the client <-> server communication will always succeed and hang on server part accepting incoming request.

### Changes made
Since Diagnostics tests use process wide telemetry configuration, which is reverted after test runs, I decided to isolate diagnostic tests which leverage `ActivityRecorder` from other tests by applying `[Collection(nameof(DisableParallelization))]` to do its job.

### Testing
I was able to consistently reproduce this error by running tests in loop. After changes I am no longer able to repro it.

### Note
I noticed that after this changes previously detected intermittent test failures also disappeared.
