### PR TITLE
[clr-interp] Implement support for `CEE_CASTCLASS` and static field helper

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5196,7 +5196,10 @@ DO_LDFTN:
                 m_pLastNewIns->data[1] = GetDataItemIndex(resolvedToken.hClass);
                 m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
                 m_pStackPointer--;
-                PushInterpType(InterpTypeI, NULL);
+                if (isCastClass)
+                    PushInterpType(InterpTypeO, resolvedToken.hClass);
+                else
+                    PushInterpType(InterpTypeI, NULL);
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_ip += 5;
                 break;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2869,6 +2869,23 @@ void InterpCompiler::EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORI
             m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
             break;
         }
+        case CORINFO_FIELD_STATIC_GENERICS_STATIC_HELPER:
+        {
+            AddIns(INTOP_CALL_HELPER_PP);
+            m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(pFieldInfo->helper);
+            m_pLastNewIns->data[1] = GetDataItemIndex(pResolvedToken->tokenContext);
+            PushInterpType(InterpTypeByRef, NULL);
+            m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+
+            // Add field offset
+            m_pStackPointer--;
+            AddIns(INTOP_ADD_P_IMM);
+            m_pLastNewIns->data[0] = (int32_t)pFieldInfo->offset;
+            m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
+            PushInterpType(InterpTypeByRef, NULL);
+            m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+            break;
+        }
         default:
             // TODO
             assert(0);
@@ -4632,7 +4649,7 @@ retry_emit:
                         {
                             goto DO_LDFTN;
                         }
-                        
+
                         EmitPushLdvirtftn(thisVar, &resolvedToken, &callInfo);
                         m_ip += 5;
                         break;
@@ -4643,7 +4660,7 @@ retry_emit:
                             CORINFO_RESOLVED_TOKEN resolvedToken;
                             uint32_t token = getU4LittleEndian(m_ip + 1);
                             ResolveToken(token, CORINFO_TOKENKIND_Method, &resolvedToken);
-                            
+
                             memset(&callInfo, 0, sizeof(callInfo));
                             m_compHnd->getCallInfo(&resolvedToken, pConstrainedToken, m_methodInfo->ftn, (CORINFO_CALLINFO_FLAGS)(CORINFO_CALLINFO_SECURITYCHECKS| CORINFO_CALLINFO_LDFTN), &callInfo);
                         }
@@ -4759,9 +4776,12 @@ DO_LDFTN:
             {
                 CORINFO_CLASS_HANDLE clsHnd = ResolveClassToken(getU4LittleEndian(m_ip + 1));
                 CHECK_STACK(1);
-                m_pStackPointer -= 1;
-                EmitBox(m_pStackPointer, clsHnd, false);
-                m_pStackPointer++;
+                if (m_compHnd->isValueClass(clsHnd))
+                {
+                    m_pStackPointer -= 1;
+                    EmitBox(m_pStackPointer, clsHnd, false);
+                    m_pStackPointer++;
+                }
                 m_ip += 5;
                 break;
             }
@@ -5161,19 +5181,42 @@ DO_LDFTN:
             }
 
             case CEE_ISINST:
+            case CEE_CASTCLASS:
             {
                 CHECK_STACK(1);
                 CORINFO_RESOLVED_TOKEN resolvedToken;
                 ResolveToken(getU4LittleEndian(m_ip + 1), CORINFO_TOKENKIND_Casting, &resolvedToken);
 
-                CorInfoHelpFunc castingHelper = m_compHnd->getCastingHelper(&resolvedToken, false /* throwing */);
-                AddIns(INTOP_CALL_HELPER_PP_2);
-                m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(castingHelper);
-                m_pLastNewIns->data[1] = GetDataItemIndex(resolvedToken.hClass);
-                m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
-                m_pStackPointer--;
-                PushInterpType(InterpTypeI, NULL);
-                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                bool isCastClass = (opcode == CEE_CASTCLASS);
+
+                CorInfoHelpFunc castingHelper = m_compHnd->getCastingHelper(&resolvedToken, isCastClass);
+
+                if (!isCastClass)
+                {
+                    AddIns(INTOP_CALL_HELPER_PP_2);
+                    m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(castingHelper);
+                    m_pLastNewIns->data[1] = GetDataItemIndex(resolvedToken.hClass);
+                    m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
+                    m_pStackPointer--;
+                    PushInterpType(InterpTypeI, NULL);
+                    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                }
+                else
+                {
+                    CORINFO_GENERICHANDLE_RESULT embedInfo;
+                    m_compHnd->embedGenericHandle(&resolvedToken, false, m_methodHnd, &embedInfo);
+                    int typeVar = EmitGenericHandleAsVar(embedInfo);
+
+                    AddIns(INTOP_CALL);
+                    m_pLastNewIns->SetSVar(typeVar);
+                    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                    m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(castingHelper);
+
+                    m_pStackPointer--;
+
+                    PushInterpType(InterpTypeO, NULL);
+                    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                }
                 m_ip += 5;
                 break;
             }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5191,32 +5191,13 @@ DO_LDFTN:
 
                 CorInfoHelpFunc castingHelper = m_compHnd->getCastingHelper(&resolvedToken, isCastClass);
 
-                if (!isCastClass)
-                {
-                    AddIns(INTOP_CALL_HELPER_PP_2);
-                    m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(castingHelper);
-                    m_pLastNewIns->data[1] = GetDataItemIndex(resolvedToken.hClass);
-                    m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
-                    m_pStackPointer--;
-                    PushInterpType(InterpTypeI, NULL);
-                    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
-                }
-                else
-                {
-                    CORINFO_GENERICHANDLE_RESULT embedInfo;
-                    m_compHnd->embedGenericHandle(&resolvedToken, false, m_methodHnd, &embedInfo);
-                    int typeVar = EmitGenericHandleAsVar(embedInfo);
-
-                    AddIns(INTOP_CALL);
-                    m_pLastNewIns->SetSVar(typeVar);
-                    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
-                    m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(castingHelper);
-
-                    m_pStackPointer--;
-
-                    PushInterpType(InterpTypeO, NULL);
-                    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
-                }
+                AddIns(INTOP_CALL_HELPER_PP_2);
+                m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(castingHelper);
+                m_pLastNewIns->data[1] = GetDataItemIndex(resolvedToken.hClass);
+                m_pLastNewIns->SetSVar(m_pStackPointer[-1].var);
+                m_pStackPointer--;
+                PushInterpType(InterpTypeI, NULL);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
                 m_ip += 5;
                 break;
             }


### PR DESCRIPTION
## Description

This PR adds support for `CEE_CASTCLASS` and the static field helper. These changes have been tested on the desktop startup compilation path.

## Changes
 - Implement support for `CEE_CASTCLASS`
 - Implement missing support for `CORINFO_FIELD_STATIC_GENERICS_STATIC_HELPER`
 - Prevent boxing of reference types

## Follow-up

The only method currently failing compilation on the startup path is `Task..cctor`, as it attempts to expand `Object..ctor`, which emits a `NOP` followed by `m_pStackPointer--`, resulting in an invalid stack.