### PR TITLE
Fix typo in SpinOnceCore comment

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SpinWait.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SpinWait.cs
@@ -167,7 +167,7 @@ namespace System.Threading
             //   - When there are no threads to switch to, Yield and Sleep(0) become no-op and it turns the spin loop into a
             //     busy-spin that may quickly reach the max spin count and cause the thread to enter a wait state, or may
             //     just busy-spin for longer than desired before a Sleep(1). Completing the spin loop too early can cause
-            //     excessive context switcing if a wait follows, and entering the Sleep(1) stage too early can cause
+            //     excessive context switching if a wait follows, and entering the Sleep(1) stage too early can cause
             //     excessive delays.
             //   - If there are multiple threads doing Yield and Sleep(0) (typically from the same spin loop due to
             //     contention), they may switch between one another, delaying work that can make progress.


### PR DESCRIPTION
This PR fixes a typo in a comment by correcting the spelling