### PR TITLE
JIT: Update switch likelihoods after peeling dominant case

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -755,7 +755,7 @@ void BasicBlock::dspKind() const
                 const bool isDominant = bbSwtTargets->bbsHasDominantCase && (i == bbSwtTargets->bbsDominantCase);
                 if (isDominant)
                 {
-                    printf("[dom(" FMT_WT ")]", bbSwtTargets->bbsDominantFraction);
+                    printf("[dom]");
                 }
             }
 
@@ -1771,7 +1771,6 @@ BBswtDesc::BBswtDesc(const BBswtDesc* other)
     : bbsDstTab(nullptr)
     , bbsCount(other->bbsCount)
     , bbsDominantCase(other->bbsDominantCase)
-    , bbsDominantFraction(other->bbsDominantFraction)
     , bbsHasDefault(other->bbsHasDefault)
     , bbsHasDominantCase(other->bbsHasDominantCase)
 {
@@ -1788,7 +1787,6 @@ BBswtDesc::BBswtDesc(Compiler* comp, const BBswtDesc* other)
     : bbsDstTab(nullptr)
     , bbsCount(other->bbsCount)
     , bbsDominantCase(other->bbsDominantCase)
-    , bbsDominantFraction(other->bbsDominantFraction)
     , bbsHasDefault(other->bbsHasDefault)
     , bbsHasDominantCase(other->bbsHasDominantCase)
 {

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -2272,10 +2272,9 @@ struct BBswtDesc
     FlowEdge** bbsDstTab; // case label table address
     unsigned   bbsCount;  // count of cases (includes 'default' if bbsHasDefault)
 
-    // Case number and likelihood of most likely case
+    // Case number of most likely case
     // (only known with PGO, only valid if bbsHasDominantCase is true)
     unsigned bbsDominantCase;
-    weight_t bbsDominantFraction;
 
     bool bbsHasDefault;      // true if last switch case is a default case
     bool bbsHasDominantCase; // true if switch has a dominant case

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2059,7 +2059,7 @@ void Compiler::fgTableDispBasicBlock(const BasicBlock* block,
                     if (isDominant)
                     {
                         printf("[dom]");
-                        printedBlockWidth += 10;
+                        printedBlockWidth += 5;
                     }
                 }
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2058,7 +2058,7 @@ void Compiler::fgTableDispBasicBlock(const BasicBlock* block,
                     const bool isDominant = jumpSwt->bbsHasDominantCase && (i == jumpSwt->bbsDominantCase);
                     if (isDominant)
                     {
-                        printf("[dom(" FMT_WT ")]", jumpSwt->bbsDominantFraction);
+                        printf("[dom]");
                         printedBlockWidth += 10;
                     }
                 }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2835,7 +2835,8 @@ void Compiler::fgPeelSwitch(BasicBlock* block)
     // The dominant case should not be the default case, as we already peel that one.
     //
     assert(dominantCase < (block->GetSwitchTargets()->bbsCount - 1));
-    BasicBlock* const dominantTarget = block->GetSwitchTargets()->bbsDstTab[dominantCase]->getDestinationBlock();
+    FlowEdge* const   dominantEdge   = block->GetSwitchTargets()->bbsDstTab[dominantCase];
+    BasicBlock* const dominantTarget = dominantEdge->getDestinationBlock();
     Statement* const  switchStmt     = block->lastStmt();
     GenTree* const    switchTree     = switchStmt->GetRootNode();
     assert(switchTree->OperIs(GT_SWITCH));
@@ -2878,23 +2879,36 @@ void Compiler::fgPeelSwitch(BasicBlock* block)
 
     // Wire up the new control flow.
     //
-    FlowEdge* const blockToTargetEdge   = fgAddRefPred(dominantTarget, block);
+    FlowEdge* const blockToTargetEdge   = fgAddRefPred(dominantTarget, block, dominantEdge);
     FlowEdge* const blockToNewBlockEdge = newBlock->bbPreds;
     block->SetCond(blockToTargetEdge, blockToNewBlockEdge);
 
     // Update profile data
     //
-    const weight_t fraction            = newBlock->GetSwitchTargets()->bbsDominantFraction;
+    const weight_t fraction            = dominantEdge->getLikelihood();
     const weight_t blockToTargetWeight = block->bbWeight * fraction;
 
     newBlock->decreaseBBProfileWeight(blockToTargetWeight);
-
-    blockToTargetEdge->setLikelihood(fraction);
     blockToNewBlockEdge->setLikelihood(max(0.0, 1.0 - fraction));
 
-    JITDUMP("fgPeelSwitch: Updated flow into " FMT_BB " needs to be propagated. Data %s inconsistent.\n",
-            newBlock->bbNum, fgPgoConsistent ? "is now" : "was already");
-    fgPgoConsistent = false;
+    // Now that the dominant case has been peeled, set the case's edge likelihood to zero,
+    // and increase all other case likelihoods proportionally.
+    //
+    dominantEdge->setLikelihood(BB_ZERO_WEIGHT);
+    const SwitchUniqueSuccSet uniqueSuccSet = GetDescriptorForSwitch(newBlock);
+    const unsigned            numSucc       = uniqueSuccSet.numDistinctSuccs;
+    FlowEdge** const          jumpTab       = uniqueSuccSet.nonDuplicates;
+    for (unsigned i = 0; i < numSucc; i++)
+    {
+        // If we removed all of the flow out of 'block', distribute flow among the remaining edges evenly.
+        const weight_t currLikelihood = jumpTab[i]->getLikelihood();
+        const weight_t newLikelihood  = (fraction == 1.0) ? (1.0 / numSucc) : (currLikelihood / (1.0 - fraction));
+        jumpTab[i]->setLikelihood(min(1.0, newLikelihood));
+    }
+
+    // JITDUMP("fgPeelSwitch: Updated flow into " FMT_BB " needs to be propagated. Data %s inconsistent.\n",
+    //         newBlock->bbNum, fgPgoConsistent ? "is now" : "was already");
+    // fgPgoConsistent = false;
 
     // For now we leave the switch as is, since there's no way
     // to indicate that one of the cases is now unreachable.

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2906,10 +2906,6 @@ void Compiler::fgPeelSwitch(BasicBlock* block)
         jumpTab[i]->setLikelihood(min(1.0, newLikelihood));
     }
 
-    // JITDUMP("fgPeelSwitch: Updated flow into " FMT_BB " needs to be propagated. Data %s inconsistent.\n",
-    //         newBlock->bbNum, fgPgoConsistent ? "is now" : "was already");
-    // fgPgoConsistent = false;
-
     // For now we leave the switch as is, since there's no way
     // to indicate that one of the cases is now unreachable.
     //

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -4178,9 +4178,8 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
             "; marking for peeling\n",
             dominantCase, dominantEdge->m_targetBlock->bbNum, fraction);
 
-    block->GetSwitchTargets()->bbsHasDominantCase  = true;
-    block->GetSwitchTargets()->bbsDominantCase     = dominantCase;
-    block->GetSwitchTargets()->bbsDominantFraction = fraction;
+    block->GetSwitchTargets()->bbsHasDominantCase = true;
+    block->GetSwitchTargets()->bbsDominantCase    = dominantCase;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #116962. After peeling a switch block such that the switch is dominated by a conditional check for the dominant case, set the dominant switch case's edge likelihood to zero, and redistribute this extra likelihood among the other switch successor edges. This also replaces `BBswtDesc::bbsDominantFraction` with the edge likelihood of the dominant case, as the latter value is maintained through flow updates.