### PR TITLE
Actually change the length of BundleID to 12

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.NET.HostModel.Bundle
         // with path-names so that the AppHost can use it in
         // extraction path.
         public string BundleID { get; private set; }
-        private const int BundleIdLength = 32;
+        private const int BundleIdLength = 12;
         private SHA256 bundleHash = SHA256.Create();
         public readonly uint BundleMajorVersion;
         // The Minor version is currently unused, and is always zero

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
@@ -7,6 +7,11 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+#if NET
+using Base64Url = System.Buffers.Text.Base64Url;
+#else
+using Base64Url = Microsoft.NET.HostModel.Base64Url;
+#endif
 
 namespace Microsoft.NET.HostModel.Bundle
 {
@@ -133,10 +138,11 @@ namespace Microsoft.NET.HostModel.Bundle
             byte[] manifestHash = bundleHash.Hash;
             bundleHash.Dispose();
             bundleHash = null;
-            string id = Convert.ToBase64String(manifestHash).Substring(0, BundleIdLength).Replace('/', '_');
+            string id = Base64Url.EncodeToString(manifestHash).Substring(0, BundleIdLength);
             Debug.Assert(id.Length == BundleIdLength);
             return id;
         }
+
 
         public long Write(BinaryWriter writer)
         {

--- a/src/installer/managed/Microsoft.NET.HostModel/Utils/Base64Url.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Utils/Base64Url.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+namespace Microsoft.NET.HostModel;
+
+internal static class Base64Url
+{
+    internal static string EncodeToString(byte[] data)
+    {
+        return Convert.ToBase64String(data)
+            .Replace('/', '_')
+            .Replace('+', '-')
+            .Replace("=", "");
+    }
+}

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Base64UrlTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Base64UrlTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Xunit;
+using Microsoft.NET.HostModel;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+
+public class Base64UrlTests
+{
+    public static IEnumerable<object[]> GetTestCases()
+    {
+        yield return new object[] { Array.Empty<byte>() };
+        yield return new object[] { new byte[] { 1 } };
+        yield return new object[] { new byte[] { 255, 254, 253, 252 } };
+        yield return new object[] { new byte[] { 0, 0, 0, 0 } };
+        yield return new object[] { new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 } };
+        yield return new object[] { Guid.NewGuid().ToByteArray() };
+        yield return new object[] { new byte[256] };
+        SHA256 sha256 = SHA256.Create();
+        yield return new object[] { sha256.ComputeHash(new byte[1024]) };
+        yield return new object[] { sha256.ComputeHash(new byte[2048]) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GetTestCases))]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Base64Url is not in .NET Framework BCL.")]
+    public void CustomBase64UrlEncoderMatchesBCL(byte[] data)
+    {
+        var expected = System.Buffers.Text.Base64Url.EncodeToString(data);
+        var actual = Microsoft.NET.HostModel.Base64Url.EncodeToString(data);
+
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
I merged https://github.com/dotnet/runtime/pull/116656 before realizing that I had undone the length change and kept it at 32 bytes. This actually changes the length to 12.

Also uses Base64Url.EncodeToString on .NET and a custom implementation on .NET Framework rather than Convert.ToBase64().Replace(). Adds tests for the custom implementation.