### PR TITLE
[APX] Make sure disasmembler log correct EGPR size when OSIZE is 32b.

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11789,17 +11789,8 @@ const char* emitter::emitRegName(regNumber reg, emitAttr attr, bool varName) con
 
         case EA_4BYTE:
         {
-            if (IsXMMReg(reg))
-            {
-                return emitXMMregName(reg);
-            }
-
+            assert(isGeneralRegister(reg));
 #if defined(TARGET_AMD64)
-            if (reg > REG_R31)
-            {
-                break;
-            }
-
             if (reg > REG_RDI)
             {
                 suffix = 'd';

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11795,7 +11795,7 @@ const char* emitter::emitRegName(regNumber reg, emitAttr attr, bool varName) con
             }
 
 #if defined(TARGET_AMD64)
-            if (reg > REG_R15)
+            if (reg > REG_R31)
             {
                 break;
             }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11789,6 +11789,10 @@ const char* emitter::emitRegName(regNumber reg, emitAttr attr, bool varName) con
 
         case EA_4BYTE:
         {
+            if (IsXMMReg(reg))
+            {
+                return emitXMMregName(reg);
+            }
             assert(isGeneralRegister(reg));
 #if defined(TARGET_AMD64)
             if (reg > REG_RDI)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4f6cce28-db42-4ab7-9ffe-9cc021f3ae62)

The disasmembler  was not printing the size suffix when OSIZE is 32b, this PR fixes the issue.