### PR TITLE
Use LSB of vector when converting from vector to mask

### DIFF
--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1400,6 +1400,12 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
         delayFreeOp = getDelayFreeOperand(embeddedOp, /* embedded */ true);
     }
 
+    if (intrin.id == NI_Sve_ConvertVectorToMask)
+    {
+        // Need an extra temp to test LSB of source vector
+        buildInternalFloatRegisterDefForNode(intrinsicTree);
+    }
+
     // Build any immediates
     BuildHWIntrinsicImmediate(intrinsicTree, intrin);
 

--- a/src/coreclr/jit/optimizemaskconversions.cpp
+++ b/src/coreclr/jit/optimizemaskconversions.cpp
@@ -20,8 +20,8 @@ struct MaskConversionsWeight
     static constexpr const weight_t costOfConvertMaskToVector = 1.0;
 
 #if defined(TARGET_ARM64)
-    // Conversion of vector to mask is two instructions.
-    static constexpr const weight_t costOfConvertVectorToMask = 2.0;
+    // Conversion of vector to mask is three instructions.
+    static constexpr const weight_t costOfConvertVectorToMask = 3.0;
 #else
     // Conversion of vector to mask is one instructions.
     static constexpr const weight_t costOfConvertVectorToMask = 1.0;


### PR DESCRIPTION
Today, when converting vector to mask, we just check if the lane value is non-zero and if yes, we consider the lane to be active and set it such in the predicate register:

```asm
ptrue p0
cmpne p1, p0, zsrc, 0
```

This actually is not true as per Arm manual and the predicate registers conceptually only represents a bit (LSB) of the corresponding vector lanes. As such a vector with value `0x2` will be considered to be "active" when we convert to predicate, but ideally should be "inactive", because the LSB for that value is "0". This was not problem until now because we were not doing any major optimization around the constant masks. However, with https://github.com/dotnet/runtime/pull/115566, we have started seeing problems where the codegen we produce do not match with how the constant masks are converted to pattern internally during optimization. During optimization, we should only check the LSB and accordingly set the corresponding lane as active or inactive.

This was also called out last year in [Engineering SVE blogpost](https://devblogs.microsoft.com/dotnet/engineering-sve-in-dotnet/#2.4-vector-%3C%E2%80%94%3E-predicate-conversion) 

>  This reveals a subtle difference in how the vector and predicate values are interpreted in .NET compared to the behavior outlined in the Arm manual. Despite this distinction, we believe this approach remains functionally correct, as vector and predicate values are handled with consistent rules throughout the .NET ecosystem.

I have updated the codegen to now do something like:

```asm
ptrue p0
lsl ztemp, zsrc, #size - 1
cmpne p1, p0, ztemp, #0
```

This will increase the number of instructions to convert vector to mask from 2 to 3. Hence I have also updated the heuristics to take that into account.
