### PR TITLE
Add missing CultureInfo.InvariantCulture use to LogValuesFormatter

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.Logging
                     formatDelimiterIndex = formatDelimiterIndex < 0 ? closeBraceIndex : formatDelimiterIndex + openBraceIndex;
 
                     vsb.Append(format.AsSpan(scanIndex, openBraceIndex - scanIndex + 1));
-                    vsb.Append(_valueNames.Count.ToString());
+                    vsb.Append(_valueNames.Count.ToString(CultureInfo.InvariantCulture));
                     _valueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
                     vsb.Append(format.AsSpan(formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1));
 
@@ -270,7 +270,10 @@ namespace Microsoft.Extensions.Logging
                         vsb.Append(", ");
                     }
 
-                    vsb.Append(e != null ? e.ToString() : NullValue);
+                    vsb.Append(
+                        e is IFormattable f ? f.ToString(null, CultureInfo.InvariantCulture) :
+                        e is not null ? e.ToString() :
+                        NullValue);
                     first = false;
                 }
                 stringValue = vsb.ToString();

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerExtensionsTest.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
+using System.Tests;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
@@ -139,31 +139,22 @@ namespace Microsoft.Extensions.Logging.Test
         public void FormatMessage_UsesInvariantCulture()
         {
             // Arrange
+            using ThreadCultureChange _ = new("fr-FR");
             var sink = new TestSink();
             var logger = SetUp(sink);
 
-            CultureInfo existing = CultureInfo.CurrentCulture;
-            try
-            {
-                CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            logger.Log(LogLevel.Trace, "{0}", new object[] { 1.23 });
+            logger.Log(LogLevel.Information, "{0}", new object[] { new object[] { 1.23f } });
 
-                logger.Log(LogLevel.Trace, "{0}", new object[] { 1.23 });
-                logger.Log(LogLevel.Information, "{0}", new object[] { new object[] { 1.23f } });
+            Assert.Equal(2, sink.Writes.Count());
 
-                Assert.Equal(2, sink.Writes.Count());
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal("1.23", trace.State?.ToString());
 
-                Assert.True(sink.Writes.TryTake(out var trace));
-                Assert.Equal(LogLevel.Trace, trace.LogLevel);
-                Assert.Equal("1.23", trace.State?.ToString());
-
-                Assert.True(sink.Writes.TryTake(out var info));
-                Assert.Equal(LogLevel.Information, info.LogLevel);
-                Assert.Equal("1.23", info.State?.ToString());
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = existing;
-            }
+            Assert.True(sink.Writes.TryTake(out var info));
+            Assert.Equal(LogLevel.Information, info.LogLevel);
+            Assert.Equal("1.23", info.State?.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/116979