### PR TITLE
Allow trimming out HTTP3 support

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Versioning;
 
 namespace System.Net.Http
 {
@@ -38,12 +39,16 @@ namespace System.Net.Http
                 "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2SUPPORT",
                 true);
 
-            // Default to allowing HTTP/3, but enable that to be overridden by an
+            // Default to allowing HTTP/3 on platforms where we have QUIC, but enable that to be overridden by an
             // AppContext switch, or by an environment variable being set to false/0.
+            [SupportedOSPlatformGuard("linux")]
+            [SupportedOSPlatformGuard("macOS")]
+            [SupportedOSPlatformGuard("windows")]
+            [FeatureSwitchDefinition("System.Net.SocketsHttpHandler.Http3Support")]
             public static bool AllowHttp3 { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
                 "System.Net.SocketsHttpHandler.Http3Support",
                 "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT",
-                true);
+                (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS());
 
             // Switch to disable the HTTP/2 dynamic window scaling algorithm. Enabled by default.
             public static bool DisableDynamicHttp2WindowSizing { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
@@ -40,6 +40,7 @@ namespace System.Net.Http
 
             // Default to allowing HTTP/3, but enable that to be overridden by an
             // AppContext switch, or by an environment variable being set to false/0.
+            [FeatureSwitchDefinition("System.Net.SocketsHttpHandler.Http3Support")]
             public static bool AllowHttp3 { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
                 "System.Net.SocketsHttpHandler.Http3Support",
                 "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT",

--- a/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
@@ -40,7 +40,6 @@ namespace System.Net.Http
 
             // Default to allowing HTTP/3, but enable that to be overridden by an
             // AppContext switch, or by an environment variable being set to false/0.
-            [FeatureSwitchDefinition("System.Net.SocketsHttpHandler.Http3Support")]
             public static bool AllowHttp3 { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
                 "System.Net.SocketsHttpHandler.Http3Support",
                 "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT",

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -25,12 +25,6 @@ namespace System.Net.Http
         /// <summary>The time, in milliseconds, that an authority should remain in <see cref="_altSvcBlocklist"/>.</summary>
         private const int AltSvcBlocklistTimeoutInMilliseconds = 10 * 60 * 1000;
 
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("windows")]
-        [FeatureSwitchDefinition("System.Net.SocketsHttpHandler.Http3Support")]
-        internal static bool IsHttp3Supported => RuntimeSettingParser.QueryRuntimeSettingSwitch("System.Net.SocketsHttpHandler.Http3Support", (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS());
-
         /// <summary>List of available HTTP/3 connections stored in the pool.</summary>
         private List<Http3Connection>? _availableHttp3Connections;
         /// <summary>The number of HTTP/3 connections associated with the pool, including in use, available, and pending.</summary>
@@ -68,7 +62,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private async ValueTask<HttpResponseMessage?> TrySendUsingHttp3Async(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            Debug.Assert(IsHttp3Supported);
+            Debug.Assert(GlobalHttpSettings.SocketsHttpHandler.AllowHttp3);
 
             Debug.Assert(_kind == HttpConnectionKind.Https);
             Debug.Assert(_http3Enabled);
@@ -136,7 +130,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private bool TryGetPooledHttp3Connection(HttpRequestMessage request, [NotNullWhen(true)] out Http3Connection? connection, [NotNullWhen(false)] out HttpConnectionWaiter<Http3Connection?>? waiter, out bool streamAvailable)
         {
-            Debug.Assert(IsHttp3Supported);
+            Debug.Assert(GlobalHttpSettings.SocketsHttpHandler.AllowHttp3);
 
             // Look for a usable connection.
             while (true)
@@ -211,7 +205,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private void CheckForHttp3ConnectionInjection()
         {
-            Debug.Assert(IsHttp3Supported);
+            Debug.Assert(GlobalHttpSettings.SocketsHttpHandler.AllowHttp3);
 
             Debug.Assert(HasSyncObjLock);
 
@@ -250,7 +244,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private async Task InjectNewHttp3ConnectionAsync(RequestQueue<Http3Connection?>.QueueItem queueItem)
         {
-            Debug.Assert(IsHttp3Supported);
+            Debug.Assert(GlobalHttpSettings.SocketsHttpHandler.AllowHttp3);
 
             if (NetEventSource.Log.IsEnabled()) Trace("Creating new HTTP/3 connection for pool.");
 
@@ -333,7 +327,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private void HandleHttp3ConnectionFailure(HttpConnectionWaiter<Http3Connection?> requestWaiter, Exception? e)
         {
-            Debug.Assert(IsHttp3Supported);
+            Debug.Assert(GlobalHttpSettings.SocketsHttpHandler.AllowHttp3);
 
             if (NetEventSource.Log.IsEnabled()) Trace($"HTTP3 connection failed: {e}");
 
@@ -364,7 +358,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private void ReturnHttp3Connection(Http3Connection connection, bool isNewConnection, HttpConnectionWaiter<Http3Connection?>? initialRequestWaiter = null)
         {
-            Debug.Assert(IsHttp3Supported);
+            Debug.Assert(GlobalHttpSettings.SocketsHttpHandler.AllowHttp3);
 
             if (NetEventSource.Log.IsEnabled()) connection.Trace($"{nameof(isNewConnection)}={isNewConnection}");
 
@@ -486,7 +480,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private void DisableHttp3Connection(Http3Connection connection)
         {
-            Debug.Assert(IsHttp3Supported);
+            Debug.Assert(GlobalHttpSettings.SocketsHttpHandler.AllowHttp3);
 
             if (NetEventSource.Log.IsEnabled()) connection.Trace("");
 
@@ -529,7 +523,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         public void InvalidateHttp3Connection(Http3Connection connection, bool dispose = true)
         {
-            Debug.Assert(IsHttp3Supported);
+            Debug.Assert(GlobalHttpSettings.SocketsHttpHandler.AllowHttp3);
 
             if (NetEventSource.Log.IsEnabled()) connection.Trace("");
 
@@ -565,7 +559,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private static int ScavengeHttp3ConnectionList(List<Http3Connection> list, ref List<HttpConnectionBase>? toDispose, long nowTicks, TimeSpan pooledConnectionLifetime, TimeSpan pooledConnectionIdleTimeout)
         {
-            Debug.Assert(IsHttp3Supported);
+            Debug.Assert(GlobalHttpSettings.SocketsHttpHandler.AllowHttp3);
 
             int freeIndex = 0;
             while (freeIndex < list.Count && list[freeIndex].IsUsable(nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout))

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -28,7 +28,8 @@ namespace System.Net.Http
         [SupportedOSPlatformGuard("linux")]
         [SupportedOSPlatformGuard("macOS")]
         [SupportedOSPlatformGuard("windows")]
-        internal static bool IsHttp3Supported() => (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+        [FeatureSwitchDefinition("System.Net.SocketsHttpHandler.Http3Support")]
+        internal static bool IsHttp3Supported => RuntimeSettingParser.QueryRuntimeSettingSwitch("System.Net.SocketsHttpHandler.Http3Support", (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS());
 
         /// <summary>List of available HTTP/3 connections stored in the pool.</summary>
         private List<Http3Connection>? _availableHttp3Connections;
@@ -67,7 +68,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private async ValueTask<HttpResponseMessage?> TrySendUsingHttp3Async(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            Debug.Assert(IsHttp3Supported());
+            Debug.Assert(IsHttp3Supported);
 
             Debug.Assert(_kind == HttpConnectionKind.Https);
             Debug.Assert(_http3Enabled);
@@ -135,7 +136,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private bool TryGetPooledHttp3Connection(HttpRequestMessage request, [NotNullWhen(true)] out Http3Connection? connection, [NotNullWhen(false)] out HttpConnectionWaiter<Http3Connection?>? waiter, out bool streamAvailable)
         {
-            Debug.Assert(IsHttp3Supported());
+            Debug.Assert(IsHttp3Supported);
 
             // Look for a usable connection.
             while (true)
@@ -210,7 +211,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private void CheckForHttp3ConnectionInjection()
         {
-            Debug.Assert(IsHttp3Supported());
+            Debug.Assert(IsHttp3Supported);
 
             Debug.Assert(HasSyncObjLock);
 
@@ -249,7 +250,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private async Task InjectNewHttp3ConnectionAsync(RequestQueue<Http3Connection?>.QueueItem queueItem)
         {
-            Debug.Assert(IsHttp3Supported());
+            Debug.Assert(IsHttp3Supported);
 
             if (NetEventSource.Log.IsEnabled()) Trace("Creating new HTTP/3 connection for pool.");
 
@@ -332,7 +333,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private void HandleHttp3ConnectionFailure(HttpConnectionWaiter<Http3Connection?> requestWaiter, Exception? e)
         {
-            Debug.Assert(IsHttp3Supported());
+            Debug.Assert(IsHttp3Supported);
 
             if (NetEventSource.Log.IsEnabled()) Trace($"HTTP3 connection failed: {e}");
 
@@ -363,7 +364,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private void ReturnHttp3Connection(Http3Connection connection, bool isNewConnection, HttpConnectionWaiter<Http3Connection?>? initialRequestWaiter = null)
         {
-            Debug.Assert(IsHttp3Supported());
+            Debug.Assert(IsHttp3Supported);
 
             if (NetEventSource.Log.IsEnabled()) connection.Trace($"{nameof(isNewConnection)}={isNewConnection}");
 
@@ -485,7 +486,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private void DisableHttp3Connection(Http3Connection connection)
         {
-            Debug.Assert(IsHttp3Supported());
+            Debug.Assert(IsHttp3Supported);
 
             if (NetEventSource.Log.IsEnabled()) connection.Trace("");
 
@@ -528,7 +529,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         public void InvalidateHttp3Connection(Http3Connection connection, bool dispose = true)
         {
-            Debug.Assert(IsHttp3Supported());
+            Debug.Assert(IsHttp3Supported);
 
             if (NetEventSource.Log.IsEnabled()) connection.Trace("");
 
@@ -564,7 +565,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private static int ScavengeHttp3ConnectionList(List<Http3Connection> list, ref List<HttpConnectionBase>? toDispose, long nowTicks, TimeSpan pooledConnectionLifetime, TimeSpan pooledConnectionIdleTimeout)
         {
-            Debug.Assert(IsHttp3Supported());
+            Debug.Assert(IsHttp3Supported);
 
             int freeIndex = 0;
             while (freeIndex < list.Count && list[freeIndex].IsUsable(nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout))

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -85,7 +85,7 @@ namespace System.Net.Http
 
             _http2Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version20;
 
-            if (IsHttp3Supported)
+            if (GlobalHttpSettings.SocketsHttpHandler.AllowHttp3)
             {
                 _http3Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version30;
             }
@@ -227,7 +227,7 @@ namespace System.Net.Http
                     _http2EncodedAuthorityHostHeader = HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingToAllocatedArray(H2StaticTable.Authority, hostHeader);
                 }
 
-                if (IsHttp3Supported && _http3Enabled)
+                if (GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _http3Enabled)
                 {
                     _http3EncodedAuthorityHostHeader = QPackEncoder.EncodeLiteralHeaderFieldWithStaticNameReferenceToArray(H3StaticTable.Authority, hostHeader);
                 }
@@ -244,7 +244,7 @@ namespace System.Net.Http
             {
                 _http2RequestQueue = new RequestQueue<Http2Connection?>();
             }
-            if (IsHttp3Supported && _http3Enabled)
+            if (GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _http3Enabled)
             {
                 _http3RequestQueue = new RequestQueue<Http3Connection?>();
             }
@@ -400,7 +400,7 @@ namespace System.Net.Http
                     HttpResponseMessage? response = null;
 
                     // Use HTTP/3 if possible.
-                    if (IsHttp3Supported && // guard to enable trimming HTTP/3 support
+                    if (GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && // guard to enable trimming HTTP/3 support
                         _http3Enabled &&
                         (request.Version.Major >= 3 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)) &&
                         !request.IsExtendedConnectRequest)
@@ -913,7 +913,7 @@ namespace System.Net.Http
                     _availableHttp2Connections.Clear();
                 }
 
-                if (IsHttp3Supported && _availableHttp3Connections is not null)
+                if (GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _availableHttp3Connections is not null)
                 {
                     toDispose ??= new();
                     toDispose.AddRange(_availableHttp3Connections);
@@ -989,7 +989,7 @@ namespace System.Net.Http
                     // Note: Http11 connections will decrement the _associatedHttp11ConnectionCount when disposed.
                     // Http2 connections will not, hence the difference in handing _associatedHttp2ConnectionCount.
                 }
-                if (IsHttp3Supported && _availableHttp3Connections is not null)
+                if (GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _availableHttp3Connections is not null)
                 {
                     int removed = ScavengeHttp3ConnectionList(_availableHttp3Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
                     _associatedHttp3ConnectionCount -= removed;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -227,7 +227,7 @@ namespace System.Net.Http
                     _http2EncodedAuthorityHostHeader = HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingToAllocatedArray(H2StaticTable.Authority, hostHeader);
                 }
 
-                if (IsHttp3Supported() && _http3Enabled)
+                if (IsHttp3Supported() && GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _http3Enabled)
                 {
                     _http3EncodedAuthorityHostHeader = QPackEncoder.EncodeLiteralHeaderFieldWithStaticNameReferenceToArray(H3StaticTable.Authority, hostHeader);
                 }
@@ -244,7 +244,7 @@ namespace System.Net.Http
             {
                 _http2RequestQueue = new RequestQueue<Http2Connection?>();
             }
-            if (IsHttp3Supported() && _http3Enabled)
+            if (IsHttp3Supported() && GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _http3Enabled)
             {
                 _http3RequestQueue = new RequestQueue<Http3Connection?>();
             }
@@ -401,6 +401,7 @@ namespace System.Net.Http
 
                     // Use HTTP/3 if possible.
                     if (IsHttp3Supported() && // guard to enable trimming HTTP/3 support
+                        GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && // guard to enable trimming HTTP/3 support
                         _http3Enabled &&
                         (request.Version.Major >= 3 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)) &&
                         !request.IsExtendedConnectRequest)
@@ -913,7 +914,7 @@ namespace System.Net.Http
                     _availableHttp2Connections.Clear();
                 }
 
-                if (IsHttp3Supported() && _availableHttp3Connections is not null)
+                if (IsHttp3Supported() && GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _availableHttp3Connections is not null)
                 {
                     toDispose ??= new();
                     toDispose.AddRange(_availableHttp3Connections);
@@ -989,7 +990,7 @@ namespace System.Net.Http
                     // Note: Http11 connections will decrement the _associatedHttp11ConnectionCount when disposed.
                     // Http2 connections will not, hence the difference in handing _associatedHttp2ConnectionCount.
                 }
-                if (IsHttp3Supported() && _availableHttp3Connections is not null)
+                if (IsHttp3Supported() && GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _availableHttp3Connections is not null)
                 {
                     int removed = ScavengeHttp3ConnectionList(_availableHttp3Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
                     _associatedHttp3ConnectionCount -= removed;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -85,7 +85,7 @@ namespace System.Net.Http
 
             _http2Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version20;
 
-            if (IsHttp3Supported())
+            if (IsHttp3Supported)
             {
                 _http3Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version30;
             }
@@ -227,7 +227,7 @@ namespace System.Net.Http
                     _http2EncodedAuthorityHostHeader = HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingToAllocatedArray(H2StaticTable.Authority, hostHeader);
                 }
 
-                if (IsHttp3Supported() && GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _http3Enabled)
+                if (IsHttp3Supported && _http3Enabled)
                 {
                     _http3EncodedAuthorityHostHeader = QPackEncoder.EncodeLiteralHeaderFieldWithStaticNameReferenceToArray(H3StaticTable.Authority, hostHeader);
                 }
@@ -244,7 +244,7 @@ namespace System.Net.Http
             {
                 _http2RequestQueue = new RequestQueue<Http2Connection?>();
             }
-            if (IsHttp3Supported() && GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _http3Enabled)
+            if (IsHttp3Supported && _http3Enabled)
             {
                 _http3RequestQueue = new RequestQueue<Http3Connection?>();
             }
@@ -400,8 +400,7 @@ namespace System.Net.Http
                     HttpResponseMessage? response = null;
 
                     // Use HTTP/3 if possible.
-                    if (IsHttp3Supported() && // guard to enable trimming HTTP/3 support
-                        GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && // guard to enable trimming HTTP/3 support
+                    if (IsHttp3Supported && // guard to enable trimming HTTP/3 support
                         _http3Enabled &&
                         (request.Version.Major >= 3 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)) &&
                         !request.IsExtendedConnectRequest)
@@ -914,7 +913,7 @@ namespace System.Net.Http
                     _availableHttp2Connections.Clear();
                 }
 
-                if (IsHttp3Supported() && GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _availableHttp3Connections is not null)
+                if (IsHttp3Supported && _availableHttp3Connections is not null)
                 {
                     toDispose ??= new();
                     toDispose.AddRange(_availableHttp3Connections);
@@ -990,7 +989,7 @@ namespace System.Net.Http
                     // Note: Http11 connections will decrement the _associatedHttp11ConnectionCount when disposed.
                     // Http2 connections will not, hence the difference in handing _associatedHttp2ConnectionCount.
                 }
-                if (IsHttp3Supported() && GlobalHttpSettings.SocketsHttpHandler.AllowHttp3 && _availableHttp3Connections is not null)
+                if (IsHttp3Supported && _availableHttp3Connections is not null)
                 {
                     int removed = ScavengeHttp3ConnectionList(_availableHttp3Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
                     _associatedHttp3ConnectionCount -= removed;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RuntimeSettingParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RuntimeSettingParser.cs
@@ -15,6 +15,7 @@ namespace System.Net.Http
             bool value;
 
             // First check for the AppContext switch, giving it priority over the environment variable.
+            // This being first is important for correctness of all callers marked [FeatureSwitchDefinition].
             if (AppContext.TryGetSwitch(appCtxSettingName, out value))
             {
                 return value;

--- a/src/libraries/System.Net.Http/tests/TrimmingTests/QuicTrimmedTest.cs
+++ b/src/libraries/System.Net.Http/tests/TrimmingTests/QuicTrimmedTest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.IO;
 using System.Reflection;

--- a/src/libraries/System.Net.Http/tests/TrimmingTests/QuicTrimmedTest.cs
+++ b/src/libraries/System.Net.Http/tests/TrimmingTests/QuicTrimmedTest.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Net;
+using System.Net.Http;
+
+try
+{
+    _ = new HttpClient().GetStringAsync("https://bing.com").Result;
+}
+catch { }
+
+try
+{
+    var a = Assembly.Load("System.Net.Quic");
+    bool hasTypes = false;
+    foreach (var t in a.GetTypes())
+    {
+        Console.WriteLine(t);
+        hasTypes = true;
+    }
+
+    if (!hasTypes)
+        return 100;
+}
+catch (FileNotFoundException)
+{
+    return 100;
+}
+
+return -1;

--- a/src/libraries/System.Net.Http/tests/TrimmingTests/System.Net.Http.TrimmingTests.proj
+++ b/src/libraries/System.Net.Http/tests/TrimmingTests/System.Net.Http.TrimmingTests.proj
@@ -9,6 +9,9 @@
     <TestConsoleAppSourceFiles Include="DiagnosticsHandlerTrimmedTest.cs">
       <DisabledFeatureSwitches>System.Net.Http.EnableActivityPropagation</DisabledFeatureSwitches>
     </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="QuicTrimmedTest.cs">
+      <DisabledFeatureSwitches>System.Net.SocketsHttpHandler.Http3Support</DisabledFeatureSwitches>
+    </TestConsoleAppSourceFiles>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />


### PR DESCRIPTION
Fixes #77420.

This is a meaningful saving to leave on the table. For following app:

```csharp
Console.WriteLine(new HttpClient().GetStringAsync("https://bing.com").Result);
```

PublishAot without this switch: 4.91 MB
PublishAot with this switch: 4.14 MB

We might even go as far as disabling HTTP3 on native AOT by default since #73290 reached the dreaded Future milestone and as far as I understand HTTP3 doesn't actually work without extra gestures anyway.