### PR TITLE
Fix a typo in GC comment

### DIFF
--- a/src/coreclr/vm/gcstress.h
+++ b/src/coreclr/vm/gcstress.h
@@ -15,7 +15,7 @@
 //
 //  GCStress<> template classes with its IsEnabled() & MaybeTrigger members.
 //
-//  Use GCStress<> to abstract away the GC stress related decissions. The
+//  Use GCStress<> to abstract away the GC stress related decisions. The
 //  template definitions will resolve to nothing when STRESS_HEAP is not
 //  defined, and will inline the function body at the call site otherwise.
 //


### PR DESCRIPTION
Fix a typo in comments.

@clamp03 @tomeksowi @SkyShield, @credo-quia-absurdum
part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung