### PR TITLE
Fixed instance where invalid was spelled invalod

### DIFF
--- a/src/libraries/System.Linq/tests/MinTests.cs
+++ b/src/libraries/System.Linq/tests/MinTests.cs
@@ -853,7 +853,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void Min_Bool_EmptySource_ThrowsInvalodOperationException()
+        public void Min_Bool_EmptySource_ThrowsInvalidOperationException()
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<bool>().Min());
             Assert.Throws<InvalidOperationException>(() => ForceNotCollection(Enumerable.Empty<bool>()).Min());


### PR DESCRIPTION
There was an instance where "invalid" was spelled as "invalod" - I fixed it.