### PR TITLE
Avoid duplicate messages in Console logging with Json formatter

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Extensions.Logging
 {
     /// <summary>
     /// LogValues to enable formatting options supported by <see cref="string.Format(IFormatProvider, string, object?)"/>.
-    /// This also enables using {NamedformatItem} in the format string.
+    /// This also enables using {NamedFormatItem} in the format string.
     /// </summary>
-    internal readonly struct FormattedLogValues : IReadOnlyList<KeyValuePair<string, object?>>
+    internal struct FormattedLogValues : IReadOnlyList<KeyValuePair<string, object?>>
     {
         internal const int MaxCachedFormatters = 1024;
         private const string NullFormat = "[null]";
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Logging
         private readonly LogValuesFormatter? _formatter;
         private readonly object?[]? _values;
         private readonly string _originalMessage;
-        private readonly string? _cachedToString;
+        private string? _cachedToString;
 
         // for testing purposes
         internal LogValuesFormatter? Formatter => _formatter;
@@ -106,14 +106,7 @@ namespace Microsoft.Extensions.Logging
                 return _originalMessage;
             }
 
-            if (_cachedToString is null)
-            {
-                // caching the formatted string to avoid repeated formatting and allocations.
-                // FormattedLogValues is readonly struct, use Unsafe.AsRef to mutate the cached string.
-                Unsafe.AsRef(in _cachedToString) = _formatter.Format(_values);
-            }
-
-            return _cachedToString!;
+            return _cachedToString ??= _formatter.Format(_values);
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -81,14 +81,20 @@ namespace Microsoft.Extensions.Logging.Console
                     if (hasState)
                     {
                         writer.WriteStartObject(nameof(LogEntry<object>.State));
-                        writer.WriteString("Message", stateMessage);
-                        if (stateProperties != null)
+
+                        // In many cases the message and stateMessage will be the same, so we only write the message if it differs from the stateMessage.
+                        // This helps reducing the size of the log entry.
+                        if (!string.Equals(message, stateMessage))
                         {
-                            foreach (KeyValuePair<string, object?> item in stateProperties)
-                            {
-                                WriteItem(writer, item);
-                            }
+                            writer.WriteString("Message", stateMessage);
                         }
+                        if (stateProperties != null)
+                            {
+                                foreach (KeyValuePair<string, object?> item in stateProperties)
+                                {
+                                    WriteItem(writer, item);
+                                }
+                            }
                         writer.WriteEndObject();
                     }
                     WriteScopeInformation(writer, scopeProvider);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
@@ -104,12 +104,12 @@ namespace Microsoft.Extensions.Logging.Console.Test
             Assert.Equal(3, sink.Writes.Count);
             Assert.Equal(
                 "{\"EventId\":0,\"LogLevel\":\"Critical\",\"Category\":\"test\",\"Message\":\"[null]\""
-                + ",\"State\":{\"Message\":\"[null]\",\"{OriginalFormat}\":\"[null]\"}}"
+                + ",\"State\":{\"{OriginalFormat}\":\"[null]\"}}"
                 + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg)));
             Assert.Equal(
                 "{\"EventId\":0,\"LogLevel\":\"Critical\",\"Category\":\"test\",\"Message\":\"[null]\""
-                + ",\"State\":{\"Message\":\"[null]\",\"{OriginalFormat}\":\"[null]\"}}"
+                + ",\"State\":{\"{OriginalFormat}\":\"[null]\"}}"
                 + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(1 * t.WritesPerMsg, t.WritesPerMsg)));
 
@@ -117,7 +117,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 "{\"EventId\":0,\"LogLevel\":\"Critical\",\"Category\":\"test\""
                 + ",\"Message\":\"[null]\""
                 + ",\"Exception\":\"System.InvalidOperationException: Invalid value\""
-                + ",\"State\":{\"Message\":\"[null]\",\"{OriginalFormat}\":\"[null]\"}}"
+                + ",\"State\":{\"{OriginalFormat}\":\"[null]\"}}"
                 + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(2 * t.WritesPerMsg, t.WritesPerMsg)));
         }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 "{\"EventId\":0,\"LogLevel\":\"Information\",\"Category\":\"test\""
                 + ",\"Message\":\"exception message with stacktrace\""
                 + ",\"Exception\":\"System.InvalidOperationException: Invalid value\""
-                + ",\"State\":{\"Message\":\"exception message with stacktrace\",\"0\":\"stacktrace\",\"{OriginalFormat}\":\"exception message with {0}\"}"
+                + ",\"State\":{\"0\":\"stacktrace\",\"{OriginalFormat}\":\"exception message with {0}\"}"
                 + ",\"Scopes\":[]"
                 + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg)));
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 "{\"EventId\":0,\"LogLevel\":\"Information\",\"Category\":\"test\""
                 + ",\"Message\":\"exception message\""
                 + ",\"Exception\":\"System.InvalidOperationException: Invalid value\""
-                + ",\"State\":{\"Message\":\"exception message\"}"
+                + ",\"State\":{}"
                 + ",\"Scopes\":[]"
                 + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(1 * t.WritesPerMsg, t.WritesPerMsg)));
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 "{\"EventId\":0,\"LogLevel\":\"Information\",\"Category\":\"test\""
                 + ",\"Message\":\"exception message\""
                 + ",\"Exception\":\"System.InvalidOperationException: Invalid value\""
-                + ",\"State\":{\"Message\":\"exception message\"}"
+                + ",\"State\":{}"
                 + ",\"Scopes\":[{\"Message\":\"scope1 123\",\"name1\":123,\"{OriginalFormat}\":\"scope1 {name1}\"},{\"Message\":\"scope2 456 789\",\"name1\":456,\"name2\":789,\"{OriginalFormat}\":\"scope2 {name1} {name2}\"}]"
                 + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(2 * t.WritesPerMsg, t.WritesPerMsg)));
@@ -203,7 +203,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             Assert.Equal(
                 "{\"EventId\":0,\"LogLevel\":\"Information\",\"Category\":\"test\""
                 + ",\"Message\":\"exception message\""
-                + ",\"State\":{\"Message\":\"exception message\"}"
+                + ",\"State\":{}"
                 + ",\"Scopes\":[{\"Message\":\"scope1 123\",\"name1\":123,\"{OriginalFormat}\":\"scope1 {name1}\"},{\"Message\":\"scope2 456 789\",\"name1\":456,\"name2\":789,\"{OriginalFormat}\":\"scope2 {name1} {name2}\"}]"
                 + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg)));
@@ -238,7 +238,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             Assert.Equal(
                 "{\"EventId\":0,\"LogLevel\":\"Information\",\"Category\":\"test\""
                 + ",\"Message\":\"1\""
-                + ",\"State\":{\"Message\":\"1\",\"LogEntryNumber\":1,\"{OriginalFormat}\":\"{LogEntryNumber}\"}"
+                + ",\"State\":{\"LogEntryNumber\":1,\"{OriginalFormat}\":\"{LogEntryNumber}\"}"
                 + ",\"Scopes\":[{\"Message\":\"2\",\"Number\":2,\"{OriginalFormat}\":\"{Number}\"},{\"Message\":\"3\",\"AnotherNumber\":3,\"{OriginalFormat}\":\"{AnotherNumber}\"}]"
                 + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg)));


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/104409

When logging to the console using the JSON formatter, the log message often appears redundantly—once as the top-level `Message`, again inside the `State` object, and a third time as the original format string. This commonly occurs in typical usage patterns like `logger.LogInformation(...)`.

This duplication:

* Increases log size
* Causes confusion due to repeated content
* Adds unnecessary overhead by formatting the same message multiple times

### Example

```csharp
logger.LogInformation("This is an information message.");
```

Current output:

```json
{
  "EventId": 0,
  "LogLevel": "Information",
  "Category": "Program",
  "Message": "This is an information message.",
  "State": {
    "Message": "This is an information message.",
    "{OriginalFormat}": "This is an information message."
  }
}
```

### After the change

```json
{
  "EventId": 0,
  "LogLevel": "Information",
  "Category": "Program",
  "Message": "This is an information message.",
  "State": {
    "{OriginalFormat}": "This is an information message."
  }
}
```

In addition to removing the redundant `Message` field from `State`, I've optimized `FormattedLogValues.ToString()` to avoid reformatting the message multiple times. This method is frequently called more than once in common scenarios (e.g., `LogInformation`), resulting in wasted processing. The optimization ensures formatting occurs only once.

Finally, I plan to file a breaking change issue, as this adjustment may affect consumers who rely on the exact shape of the JSON output for parsing or processing.
