### PR TITLE
Track assignment to property backing field

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -131,7 +131,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
         public abstract TValue GetFieldTargetValue(IFieldReferenceOperation fieldReference, in TContext context);
 
-        public abstract TValue GetPropertyTargetValue(IPropertyReferenceOperation propertyReference, in TContext context);
+        public abstract TValue GetBackingFieldTargetValue(IPropertyReferenceOperation propertyReference, in TContext context);
 
         public abstract TValue GetParameterTargetValue(IParameterSymbol parameter);
 
@@ -286,7 +286,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                         // the case where there is no set method.
 
                         var current = state.Current;
-                        TValue targetValue = GetPropertyTargetValue(propertyRef, in current.Context);
+                        TValue targetValue = GetBackingFieldTargetValue(propertyRef, in current.Context);
                         HandleAssignment(value, targetValue, operation, in current.Context);
                         return value;
                     }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -129,7 +129,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             IOperation branchValueOperation,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state);
 
-        public abstract TValue GetFieldTargetValue(IFieldSymbol field, IFieldReferenceOperation fieldReferenceOperation, in TContext context);
+        public abstract TValue GetFieldTargetValue(IFieldReferenceOperation fieldReference, in TContext context);
+
+        public abstract TValue GetPropertyTargetValue(IPropertyReferenceOperation propertyReference, in TContext context);
 
         public abstract TValue GetParameterTargetValue(IParameterSymbol parameter);
 
@@ -247,7 +249,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     var current = state.Current;
                     TValue targetValue = targetOperation switch
                     {
-                        IFieldReferenceOperation fieldRef => GetFieldTargetValue(fieldRef.Field, fieldRef, in current.Context),
+                        IFieldReferenceOperation fieldRef => GetFieldTargetValue(fieldRef, in current.Context),
                         IParameterReferenceOperation parameterRef => GetParameterTargetValue(parameterRef.Parameter),
                         _ => throw new InvalidOperationException()
                     };
@@ -266,19 +268,28 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     TValue instanceValue = Visit(propertyRef.Instance, state);
                     TValue value = Visit(operation.Value, state);
                     IMethodSymbol? setMethod = propertyRef.Property.GetSetMethod();
-                    if (setMethod == null)
+
+                    if (setMethod == null ||
+                        (OwningSymbol is IPropertySymbol && (ControlFlowGraph.OriginalOperation is not IAttributeOperation)))
                     {
+                        // This can be a write to a byref return of a property getter.
+                        // Skip for now: https://github.com/dotnet/linker/issues/2158
+                        if (propertyRef.Property.RefKind is not RefKind.None)
+                            break;
+
                         // This can happen in a constructor - there it is possible to assign to a property
                         // without a setter. This turns into an assignment to the compiler-generated backing field.
-                        // To match the linker, this should warn about the compiler-generated backing field.
-                        // For now, just don't warn. https://github.com/dotnet/runtime/issues/93277
-                        break;
+                        // Handle this similarly to field assignments.
+
+                        // Even if the property has a set method, if the assignment takes place in a property initializer,
+                        // the write becomes a direct write to the underlying field. This should be treated the same as
+                        // the case where there is no set method.
+
+                        var current = state.Current;
+                        TValue targetValue = GetPropertyTargetValue(propertyRef, in current.Context);
+                        HandleAssignment(value, targetValue, operation, in current.Context);
+                        return value;
                     }
-                    // Even if the property has a set method, if the assignment takes place in a property initializer,
-                    // the write becomes a direct write to the underlying field. This should be treated the same as
-                    // the case where there is no set method.
-                    if (OwningSymbol is IPropertySymbol && (ControlFlowGraph.OriginalOperation is not IAttributeOperation))
-                        break;
 
                     // Property may be an indexer, in which case there will be one or more index arguments followed by a value argument
                     ImmutableArray<TValue>.Builder arguments = ImmutableArray.CreateBuilder<TValue>();

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FieldValue.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FieldValue.cs
@@ -12,13 +12,23 @@ namespace ILLink.Shared.TrimAnalysis
     internal partial record FieldValue
     {
         public FieldValue(IFieldSymbol fieldSymbol)
+            : this(fieldSymbol, fieldSymbol.Type, FlowAnnotations.GetFieldAnnotation(fieldSymbol))
         {
-            FieldSymbol = fieldSymbol;
-            StaticType = new(fieldSymbol.Type);
-            DynamicallyAccessedMemberTypes = FlowAnnotations.GetFieldAnnotation(fieldSymbol);
         }
 
-        public readonly IFieldSymbol FieldSymbol;
+        public FieldValue(IPropertySymbol propertySymbol)
+            : this(propertySymbol, propertySymbol.Type, FlowAnnotations.GetFieldAnnotation(propertySymbol))
+        {
+        }
+
+        private FieldValue(ISymbol fieldSymbol, ITypeSymbol fieldType, DynamicallyAccessedMemberTypes annotations)
+        {
+            FieldSymbol = fieldSymbol;
+            StaticType = new(fieldType);
+            DynamicallyAccessedMemberTypes = annotations;
+        }
+
+        public readonly ISymbol FieldSymbol;
 
         public override DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes { get; }
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FieldValue.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FieldValue.cs
@@ -17,7 +17,7 @@ namespace ILLink.Shared.TrimAnalysis
         }
 
         public FieldValue(IPropertySymbol propertySymbol)
-            : this(propertySymbol, propertySymbol.Type, FlowAnnotations.GetFieldAnnotation(propertySymbol))
+            : this(propertySymbol, propertySymbol.Type, FlowAnnotations.GetBackingFieldAnnotation(propertySymbol))
         {
         }
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
@@ -120,7 +120,7 @@ namespace ILLink.Shared.TrimAnalysis
             return field.GetDynamicallyAccessedMemberTypes();
         }
 
-        internal static DynamicallyAccessedMemberTypes GetFieldAnnotation(IPropertySymbol property)
+        internal static DynamicallyAccessedMemberTypes GetBackingFieldAnnotation(IPropertySymbol property)
         {
             if (!property.OriginalDefinition.Type.IsTypeInterestingForDataflow(isByRef: false))
                 return DynamicallyAccessedMemberTypes.None;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
@@ -120,6 +120,14 @@ namespace ILLink.Shared.TrimAnalysis
             return field.GetDynamicallyAccessedMemberTypes();
         }
 
+        internal static DynamicallyAccessedMemberTypes GetFieldAnnotation(IPropertySymbol property)
+        {
+            if (!property.OriginalDefinition.Type.IsTypeInterestingForDataflow(isByRef: false))
+                return DynamicallyAccessedMemberTypes.None;
+
+            return property.GetDynamicallyAccessedMemberTypes();
+        }
+
         internal static DynamicallyAccessedMemberTypes GetTypeAnnotations(INamedTypeSymbol type)
         {
             DynamicallyAccessedMemberTypes typeAnnotation = type.GetDynamicallyAccessedMemberTypes();

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
@@ -33,6 +33,11 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             ProcessGenericArgumentDataFlow(location, field.ContainingType, reportDiagnostic);
         }
 
+        public static void ProcessGenericArgumentDataFlow(Location location, IPropertySymbol property, Action<Diagnostic> reportDiagnostic)
+        {
+            ProcessGenericArgumentDataFlow(location, property.ContainingType, reportDiagnostic);
+        }
+
         private static void ProcessGenericArgumentDataFlow(
             Location location,
             ImmutableArray<ITypeSymbol> typeArguments,
@@ -100,6 +105,11 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
         public static bool RequiresGenericArgumentDataFlow(IFieldSymbol field)
         {
             return RequiresGenericArgumentDataFlow(field.ContainingType);
+        }
+
+        public static bool RequiresGenericArgumentDataFlow(IPropertySymbol property)
+        {
+            return RequiresGenericArgumentDataFlow(property.ContainingType);
         }
 
         private static bool RequiresGenericArgumentDataFlow(ImmutableArray<ITypeParameterSymbol> typeParameters)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisBackingFieldAccessPattern.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisBackingFieldAccessPattern.cs
@@ -8,14 +8,14 @@ using ILLink.RoslynAnalyzer.DataFlow;
 
 namespace ILLink.RoslynAnalyzer.TrimAnalysis
 {
-    internal readonly record struct TrimAnalysisPropertyAccessPattern
+    internal readonly record struct TrimAnalysisBackingFieldAccessPattern
     {
         public IPropertySymbol Property { get; init; }
         public IPropertyReferenceOperation Operation { get; init; }
         public ISymbol OwningSymbol { get; init; }
         public FeatureContext FeatureContext { get; init; }
 
-        public TrimAnalysisPropertyAccessPattern(
+        public TrimAnalysisBackingFieldAccessPattern(
             IPropertySymbol property,
             IPropertyReferenceOperation operation,
             ISymbol owningSymbol,
@@ -27,15 +27,15 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             FeatureContext = featureContext;
         }
 
-        public TrimAnalysisPropertyAccessPattern Merge(
+        public TrimAnalysisBackingFieldAccessPattern Merge(
             FeatureContextLattice featureContextLattice,
-            TrimAnalysisPropertyAccessPattern other)
+            TrimAnalysisBackingFieldAccessPattern other)
         {
             Debug.Assert(SymbolEqualityComparer.Default.Equals(Property, other.Property));
             Debug.Assert(Operation == other.Operation);
             Debug.Assert(SymbolEqualityComparer.Default.Equals(OwningSymbol, other.OwningSymbol));
 
-            return new TrimAnalysisPropertyAccessPattern(
+            return new TrimAnalysisBackingFieldAccessPattern(
                 Property,
                 Operation,
                 OwningSymbol,

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisBackingFieldAccessPattern.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisBackingFieldAccessPattern.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Diagnostics;
 using ILLink.Shared.TrimAnalysis;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPatternStore.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPatternStore.cs
@@ -14,7 +14,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
     {
         private readonly Dictionary<IOperation, TrimAnalysisAssignmentPattern> AssignmentPatterns;
         private readonly Dictionary<IOperation, TrimAnalysisFieldAccessPattern> FieldAccessPatterns;
-        private readonly Dictionary<IOperation, TrimAnalysisPropertyAccessPattern> PropertyAccessPatterns;
+        private readonly Dictionary<IOperation, TrimAnalysisBackingFieldAccessPattern> BackingFieldAccessPatterns;
         private readonly Dictionary<IOperation, TrimAnalysisGenericInstantiationPattern> GenericInstantiationPatterns;
         private readonly Dictionary<IOperation, TrimAnalysisMethodCallPattern> MethodCallPatterns;
         private readonly Dictionary<IOperation, TrimAnalysisReflectionAccessPattern> ReflectionAccessPatterns;
@@ -28,7 +28,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
         {
             AssignmentPatterns = new Dictionary<IOperation, TrimAnalysisAssignmentPattern>();
             FieldAccessPatterns = new Dictionary<IOperation, TrimAnalysisFieldAccessPattern>();
-            PropertyAccessPatterns = new Dictionary<IOperation, TrimAnalysisPropertyAccessPattern>();
+            BackingFieldAccessPatterns = new Dictionary<IOperation, TrimAnalysisBackingFieldAccessPattern>();
             GenericInstantiationPatterns = new Dictionary<IOperation, TrimAnalysisGenericInstantiationPattern>();
             MethodCallPatterns = new Dictionary<IOperation, TrimAnalysisMethodCallPattern>();
             ReflectionAccessPatterns = new Dictionary<IOperation, TrimAnalysisReflectionAccessPattern>();
@@ -37,15 +37,15 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             FeatureContextLattice = featureContextLattice;
         }
 
-        public void Add(TrimAnalysisPropertyAccessPattern pattern)
+        public void Add(TrimAnalysisBackingFieldAccessPattern pattern)
         {
-            if (!PropertyAccessPatterns.TryGetValue(pattern.Operation, out var existingPattern))
+            if (!BackingFieldAccessPatterns.TryGetValue(pattern.Operation, out var existingPattern))
             {
-                PropertyAccessPatterns.Add(pattern.Operation, pattern);
+                BackingFieldAccessPatterns.Add(pattern.Operation, pattern);
                 return;
             }
 
-            PropertyAccessPatterns[pattern.Operation] = pattern.Merge(FeatureContextLattice, existingPattern);
+            BackingFieldAccessPatterns[pattern.Operation] = pattern.Merge(FeatureContextLattice, existingPattern);
         }
 
         public void Add(TrimAnalysisAssignmentPattern trimAnalysisPattern)
@@ -130,8 +130,8 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             foreach (var fieldAccessPattern in FieldAccessPatterns.Values)
                 fieldAccessPattern.ReportDiagnostics(context, reportDiagnostic);
 
-            foreach (var propertyAccessPattern in PropertyAccessPatterns.Values)
-                propertyAccessPattern.ReportDiagnostics(context, reportDiagnostic);
+            foreach (var backingFieldAccessPattern in BackingFieldAccessPatterns.Values)
+                backingFieldAccessPattern.ReportDiagnostics(context, reportDiagnostic);
 
             foreach (var genericInstantiationPattern in GenericInstantiationPatterns.Values)
                 genericInstantiationPattern.ReportDiagnostics(context, reportDiagnostic);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPropertyAccessPattern.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisPropertyAccessPattern.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Diagnostics;
+using ILLink.Shared.TrimAnalysis;
+using ILLink.Shared.DataFlow;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+using ILLink.RoslynAnalyzer.DataFlow;
+
+namespace ILLink.RoslynAnalyzer.TrimAnalysis
+{
+    internal readonly record struct TrimAnalysisPropertyAccessPattern
+    {
+        public IPropertySymbol Property { get; init; }
+        public IPropertyReferenceOperation Operation { get; init; }
+        public ISymbol OwningSymbol { get; init; }
+        public FeatureContext FeatureContext { get; init; }
+
+        public TrimAnalysisPropertyAccessPattern(
+            IPropertySymbol property,
+            IPropertyReferenceOperation operation,
+            ISymbol owningSymbol,
+            FeatureContext featureContext)
+        {
+            Property = property;
+            Operation = operation;
+            OwningSymbol = owningSymbol;
+            FeatureContext = featureContext;
+        }
+
+        public TrimAnalysisPropertyAccessPattern Merge(
+            FeatureContextLattice featureContextLattice,
+            TrimAnalysisPropertyAccessPattern other)
+        {
+            Debug.Assert(SymbolEqualityComparer.Default.Equals(Property, other.Property));
+            Debug.Assert(Operation == other.Operation);
+            Debug.Assert(SymbolEqualityComparer.Default.Equals(OwningSymbol, other.OwningSymbol));
+
+            return new TrimAnalysisPropertyAccessPattern(
+                Property,
+                Operation,
+                OwningSymbol,
+                featureContextLattice.Meet(FeatureContext, other.FeatureContext));
+        }
+
+        public void ReportDiagnostics(DataFlowAnalyzerContext context, Action<Diagnostic> reportDiagnostic)
+        {
+            DiagnosticContext diagnosticContext = new(Operation.Syntax.GetLocation(), reportDiagnostic);
+            foreach (var requiresAnalyzer in context.EnabledRequiresAnalyzers)
+                requiresAnalyzer.CheckAndCreateRequiresDiagnostic(Operation, Property, OwningSymbol, context, FeatureContext, in diagnosticContext);
+        }
+    }
+}

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -176,7 +176,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
                 return constValue;
 
             var current = state.Current;
-            return GetFieldTargetValue(fieldRef.Field, fieldRef, in current.Context);
+            return GetFieldTargetValue(fieldRef, in current.Context);
         }
 
         public override MultiValue VisitTypeOf(ITypeOfOperation typeOfOperation, StateValue state)
@@ -224,16 +224,32 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
         // - method calls
         // - value returned from a method
 
-        public override MultiValue GetFieldTargetValue(IFieldSymbol field, IFieldReferenceOperation fieldReferenceOperation, in FeatureContext featureContext)
+        public override MultiValue GetFieldTargetValue(IFieldReferenceOperation fieldReference, in FeatureContext featureContext)
         {
+            var field = fieldReference.Field;
+
             TrimAnalysisPatterns.Add(
-                new TrimAnalysisFieldAccessPattern(field, fieldReferenceOperation, OwningSymbol, featureContext)
+                new TrimAnalysisFieldAccessPattern(field, fieldReference, OwningSymbol, featureContext)
             );
 
-            ProcessGenericArgumentDataFlow(field, fieldReferenceOperation, featureContext);
+            ProcessGenericArgumentDataFlow(field, fieldReference, featureContext);
 
             return new FieldValue(field);
         }
+
+        public override MultiValue GetPropertyTargetValue(IPropertyReferenceOperation propertyReference, in FeatureContext featureContext)
+        {
+            var property = propertyReference.Property;
+
+            TrimAnalysisPatterns.Add(
+                new TrimAnalysisPropertyAccessPattern(propertyReference.Property, propertyReference, OwningSymbol, featureContext)
+            );
+
+            ProcessGenericArgumentDataFlow(property, propertyReference, featureContext);
+
+            return new FieldValue(property);
+        }
+
 
         public override MultiValue GetParameterTargetValue(IParameterSymbol parameter)
             => new MethodParameterValue(parameter);
@@ -447,6 +463,21 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             {
                 TrimAnalysisPatterns.Add(new TrimAnalysisGenericInstantiationPattern(
                     field,
+                    operation,
+                    OwningSymbol,
+                    featureContext));
+            }
+        }
+
+        private void ProcessGenericArgumentDataFlow(IPropertySymbol property, IOperation operation, in FeatureContext featureContext)
+        {
+            if (!property.IsStatic)
+                return;
+
+            if (GenericArgumentDataFlow.RequiresGenericArgumentDataFlow(property))
+            {
+                TrimAnalysisPatterns.Add(new TrimAnalysisGenericInstantiationPattern(
+                    property,
                     operation,
                     OwningSymbol,
                     featureContext));

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -237,12 +237,12 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             return new FieldValue(field);
         }
 
-        public override MultiValue GetPropertyTargetValue(IPropertyReferenceOperation propertyReference, in FeatureContext featureContext)
+        public override MultiValue GetBackingFieldTargetValue(IPropertyReferenceOperation propertyReference, in FeatureContext featureContext)
         {
             var property = propertyReference.Property;
 
             TrimAnalysisPatterns.Add(
-                new TrimAnalysisPropertyAccessPattern(propertyReference.Property, propertyReference, OwningSymbol, featureContext)
+                new TrimAnalysisBackingFieldAccessPattern(propertyReference.Property, propertyReference, OwningSymbol, featureContext)
             );
 
             ProcessGenericArgumentDataFlow(property, propertyReference, featureContext);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
@@ -39,11 +39,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
             Type annotatedField = GetUnknown();
 
-            [ExpectedWarning("IL2074", nameof(GetUnknown), nameof(AnnotatedProperty), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/93277", CompilerGeneratedCode = true)]
+            [ExpectedWarning("IL2074", nameof(GetUnknown), nameof(AnnotatedProperty), CompilerGeneratedCode = true)]
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
             Type AnnotatedProperty { get; } = GetUnknown();
 
-            [ExpectedWarning("IL2074", nameof(GetUnknown), nameof(AnnotatedPropertyWithSetter), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/93277", CompilerGeneratedCode = true)]
+            [ExpectedWarning("IL2074", nameof(GetUnknown), nameof(AnnotatedPropertyWithSetter), CompilerGeneratedCode = true)]
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
             Type AnnotatedPropertyWithSetter { get; set; } = GetUnknown();
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -489,8 +489,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
             public Type GetOnlyProperty { get; }
 
-            // Analyzer doesn't warn about compiler-generated backing field of property: https://github.com/dotnet/runtime/issues/93277
-            [ExpectedWarning("IL2074", nameof(WriteToGetOnlyProperty), nameof(GetUnknownType), Tool.Trimmer | Tool.NativeAot, "")]
+            [ExpectedWarning("IL2074", nameof(WriteToGetOnlyProperty), nameof(GetUnknownType))]
             public WriteToGetOnlyProperty()
             {
                 GetOnlyProperty = GetUnknownType();
@@ -568,9 +567,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
             Type GetOnlyProperty { get; }
 
-            // Analyzer doesn't warn about compiler-generated backing field of property: https://github.com/dotnet/runtime/issues/93277
-            [ExpectedWarning("IL2074", nameof(WriteCapturedGetOnlyProperty), nameof(GetUnknownType), Tool.Trimmer | Tool.NativeAot, "")]
-            [ExpectedWarning("IL2074", nameof(WriteCapturedGetOnlyProperty), nameof(GetTypeWithPublicConstructors), Tool.Trimmer | Tool.NativeAot, "")]
+            [ExpectedWarning("IL2074", nameof(WriteCapturedGetOnlyProperty), nameof(GetUnknownType))]
+            [ExpectedWarning("IL2074", nameof(WriteCapturedGetOnlyProperty), nameof(GetTypeWithPublicConstructors))]
             public WriteCapturedGetOnlyProperty()
             {
                 GetOnlyProperty = GetUnknownType() ?? GetTypeWithPublicConstructors();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/93277.

This detects the case where a write to a property actually becomes a write to the compiler-generated backing field. It follows the same logic and produces the same warning as field access, matching ILLink/ILC.