### PR TITLE
Do not assert IsSupported in DefaultValueAttribute ctor

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
@@ -39,7 +39,6 @@ namespace System.ComponentModel
             // The null check and try/catch here are because attributes should never throw exceptions.
             // We would fail to load an otherwise normal class.
 
-            Debug.Assert(IsSupported, "Runtime instantiation of this attribute is not allowed with trimming.");
             if (!IsSupported)
             {
                 _value = s_throwSentinel;


### PR DESCRIPTION
We have defined behaviors for this. We have tests that test the defined behaviors. I guess I'm the first person to run those tests with a Debug version of CoreLib and hit the assert. (Libraries testing typically uses Release runtime but the only time I build Release runtime is for perf testing.)