### PR TITLE
[Apple] Disable failing Apple mobile string tests

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
@@ -993,6 +993,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(NonRandomizedGetHashCode_EquivalentForStringAndSpan_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/116815", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void NonRandomizedGetHashCode_EquivalentForStringAndSpan(int charValueLimit, bool ignoreCase)
         {
             // This is testing internal API. If that API changes, this test will need to be updated.


### PR DESCRIPTION
## Description

This PR disable failing `StringTests.NonRandomizedGetHashCode_EquivalentForStringAndSpan` on Apple mobile platforms.

Contributes to https://github.com/dotnet/runtime/issues/116815