### PR TITLE
Fix IP adjustment for interpreter EH

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7360,6 +7360,10 @@ VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFra
         }
         else
         {
+            if (pEntryFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+            {
+                ((InterpreterFrame*)pEntryFrame)->SetIsFaulting(true);
+            }
             DispatchManagedException(orThrowable);
         }
     }

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7360,10 +7360,12 @@ VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFra
         }
         else
         {
+#ifdef FEATURE_INTERPRETER
             if (pEntryFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
             {
                 ((InterpreterFrame*)pEntryFrame)->SetIsFaulting(true);
             }
+#endif // FEATURE_INTERPRETER
             DispatchManagedException(orThrowable);
         }
     }

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7361,7 +7361,7 @@ VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFra
         else
         {
 #ifdef FEATURE_INTERPRETER
-            if (pEntryFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+            if ((pEntryFrame != NULL) && (pEntryFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame))
             {
                 ((InterpreterFrame*)pEntryFrame)->SetIsFaulting(true);
             }

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7361,7 +7361,7 @@ VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFra
         else
         {
 #ifdef FEATURE_INTERPRETER
-            if ((pEntryFrame != NULL) && (pEntryFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame))
+            if ((pEntryFrame != FRAME_TOP) && (pEntryFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame))
             {
                 ((InterpreterFrame*)pEntryFrame)->SetIsFaulting(true);
             }

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1894,6 +1894,11 @@ void InterpreterFrame::SetContextToInterpMethodContextFrame(T_CONTEXT * pContext
     SetSP(pContext, dac_cast<TADDR>(pFrame));
     SetFP(pContext, (TADDR)pFrame->pStack);
     SetFirstArgReg(pContext, dac_cast<TADDR>(this));
+    pContext->ContextFlags = CONTEXT_FULL;
+    if (m_isFaulting)
+    {
+        pContext->ContextFlags |= CONTEXT_EXCEPTION_ACTIVE;
+    }
 }
 
 void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2417,7 +2417,8 @@ public:
 #ifndef DACCESS_COMPILE
     InterpreterFrame(TransitionBlock* pTransitionBlock, InterpMethodContextFrame* pContextFrame)
         : FramedMethodFrame(FrameIdentifier::InterpreterFrame, pTransitionBlock, NULL),
-        m_pTopInterpMethodContextFrame(pContextFrame)
+        m_pTopInterpMethodContextFrame(pContextFrame),
+        m_isFaulting(false)
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
         , m_SSP(0)
 #endif
@@ -2471,10 +2472,18 @@ public:
     }
 #endif // HOST_AMD64 && HOST_WINDOWS
 
+    void SetIsFaulting(bool isFaulting)
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_isFaulting = isFaulting;
+    }
+
 private:
     // The last known topmost interpreter frame in the InterpExecMethod belonging to
     // this InterpreterFrame.
     PTR_InterpMethodContextFrame m_pTopInterpMethodContextFrame;
+    // Set to true to indicate that the topmost interpreted frame has thrown an exception
+    bool m_isFaulting;
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
     // Saved SSP of the InterpExecMethod for resuming after catch into interpreter frames.
     TADDR m_SSP;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1737,12 +1737,14 @@ CALL_INTERP_METHOD:
                     {
                         throwable = LOCAL_VAR(ip[1], OBJECTREF);
                     }
+                    pInterpreterFrame->SetIsFaulting(true);
                     DispatchManagedException(throwable);
                     UNREACHABLE();
                     break;
                 }
                 case INTOP_RETHROW:
                 {
+                    pInterpreterFrame->SetIsFaulting(true);
                     DispatchRethrownManagedException();
                     UNREACHABLE();
                     break;
@@ -2220,6 +2222,8 @@ do {                                                                           \
         pMethod = pFrame->startIp->Method;
         assert(pMethod->CheckIntegrity());
         pThreadContext->pStackPointer = pFrame->pStack + pMethod->allocaSize;
+
+        pInterpreterFrame->SetIsFaulting(false);
         goto MAIN_LOOP;
     }
 

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2860,8 +2860,12 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                     m_interpExecMethodFirstArgReg = (TADDR)GetFirstArgReg(pRD->pCurrentContext);
 
                     ((PTR_InterpreterFrame)m_crawl.pFrame)->SetContextToInterpMethodContextFrame(pRD->pCurrentContext);
+                    if (pRD->pCurrentContext->ContextFlags & CONTEXT_EXCEPTION_ACTIVE)
+                    {
+                        m_crawl.isInterrupted = true;
+                        m_crawl.hasFaulted = true;
+                    }
 
-                    pRD->pCurrentContext->ContextFlags = CONTEXT_FULL;
                     SyncRegDisplayToCurrentContext(pRD);
                     ProcessIp(GetControlPC(pRD));
                     m_walkingInterpreterFrames = m_crawl.isFrameless;


### PR DESCRIPTION
The exception handling stack frame iterator adjusts IP it returns for all cases when the IP represents a return address. This is to make sure that if the last instruction in a try regios is a call, it is still covered by the try region (the return address would be right after it). For jit/aoted code, throwing a software exceptions results in a call. Only hardware exceptions like division by zero etc report the address of the failing instruction.
In the interpreter, when an exception is thrown, the IP address is always the address of the instruction that has triggered the exception. So we should not adjust the IP.
This change fixes that by marking exception throwing frame as "faulting", which ensures the adjustment doesn't occur. That information is recorded in the InterpreterFrame when an exception is thrown by the interpreter code and cleared when the execution resumes after catch.