### PR TITLE
Make dn_simdhash OOM safe

### DIFF
--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -9,52 +9,8 @@
 #include "datastructs.h"
 #include "enum_class_flags.h"
 #include <new>
-
-#include "../../native/containers/dn-simdhash.h"
-#include "../../native/containers/dn-simdhash-specializations.h"
-#include "../../native/containers/dn-simdhash-utils.h"
-
-class dn_simdhash_ptr_ptr_holder
-{
-    dn_simdhash_ptr_ptr_t *Value;
-public:
-    dn_simdhash_ptr_ptr_holder() :
-        Value(nullptr)
-    {
-    }
-
-    dn_simdhash_ptr_ptr_t* GetValue()
-    {
-        if (!Value)
-            Value = dn_simdhash_ptr_ptr_new(0, nullptr);
-        return Value;
-    }
-
-    dn_simdhash_ptr_ptr_holder(const dn_simdhash_ptr_ptr_holder&) = delete;
-    dn_simdhash_ptr_ptr_holder& operator=(const dn_simdhash_ptr_ptr_holder&) = delete;
-    dn_simdhash_ptr_ptr_holder(dn_simdhash_ptr_ptr_holder&& other)
-    {
-        Value = other.Value;
-        other.Value = nullptr;
-    }
-    dn_simdhash_ptr_ptr_holder& operator=(dn_simdhash_ptr_ptr_holder&& other)
-    {
-        if (this != &other)
-        {
-            if (Value != nullptr)
-                dn_simdhash_free(Value);
-            Value = other.Value;
-            other.Value = nullptr;
-        }
-        return *this;
-    }
-
-    ~dn_simdhash_ptr_ptr_holder()
-    {
-        if (Value != nullptr)
-            dn_simdhash_free(Value);
-    }
-};
+#include "failures.h"
+#include "simdhash.h"
 
 struct InterpException
 {
@@ -66,16 +22,6 @@ struct InterpException
     const char* const m_message;
     const CorJitResult m_result;
 };
-
-#if defined(__GNUC__) || defined(__clang__)
-#define INTERPRETER_NORETURN    __attribute__((noreturn))
-#else
-#define INTERPRETER_NORETURN    __declspec(noreturn)
-#endif
-
-INTERPRETER_NORETURN void NO_WAY(const char* message);
-INTERPRETER_NORETURN void BADCODE(const char* message);
-INTERPRETER_NORETURN void NOMEM();
 
 class InterpCompiler;
 
@@ -540,17 +486,11 @@ private:
     dn_simdhash_ptr_ptr_holder m_pointerToNameMap;
     bool PointerInNameMap(void* ptr)
     {
-        if (dn_simdhash_ptr_ptr_try_get_value(m_pointerToNameMap.GetValue(), ptr, NULL))
-        {
-            return true;
-        }
-        return false;
+        return dn_simdhash_ptr_ptr_try_get_value(m_pointerToNameMap.GetValue(), ptr, NULL) != 0;
     }
     void AddPointerToNameMap(void* ptr, const char* name)
     {
-        dn_simdhash_add_result addResult = dn_simdhash_ptr_ptr_try_add(m_pointerToNameMap.GetValue(), ptr, (void*)name);
-        if (addResult < 0)
-            NOMEM();
+        assertNoError(dn_simdhash_ptr_ptr_try_add(m_pointerToNameMap.GetValue(), ptr, (void*)name));
     }
     void PrintNameInPointerMap(void* ptr);
 #endif
@@ -867,13 +807,9 @@ int32_t InterpDataItemIndexMap::GetDataItemIndexForT(const T& lookup)
     VarSizedDataWithPayload<T>* pLookup = new(hashItemPayload) VarSizedDataWithPayload<T>();
     memcpy(&pLookup->payload, &lookup, sizeof(T));
 
-    dn_simdhash_add_result addResult = dn_simdhash_ght_try_insert(
+    assertAddedNew(dn_simdhash_ght_try_insert(
         hash, (void*)pLookup, (void*)(size_t)dataItemIndex, DN_SIMDHASH_INSERT_MODE_ENSURE_UNIQUE
-    );
-    if (addResult == DN_SIMDHASH_OUT_OF_MEMORY)
-        NOMEM();
-    else if (addResult != DN_SIMDHASH_ADD_INSERTED)
-        assert(!"Internal error in dn_simdhash");
+    ));
 
     return dataItemIndex;
 }

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -490,7 +490,7 @@ private:
     }
     void AddPointerToNameMap(void* ptr, const char* name)
     {
-        assertNoError(dn_simdhash_ptr_ptr_try_add(m_pointerToNameMap.GetValue(), ptr, (void*)name));
+        checkNoError(dn_simdhash_ptr_ptr_try_add(m_pointerToNameMap.GetValue(), ptr, (void*)name));
     }
     void PrintNameInPointerMap(void* ptr);
 #endif
@@ -807,7 +807,7 @@ int32_t InterpDataItemIndexMap::GetDataItemIndexForT(const T& lookup)
     VarSizedDataWithPayload<T>* pLookup = new(hashItemPayload) VarSizedDataWithPayload<T>();
     memcpy(&pLookup->payload, &lookup, sizeof(T));
 
-    assertAddedNew(dn_simdhash_ght_try_insert(
+    checkAddedNew(dn_simdhash_ght_try_insert(
         hash, (void*)pLookup, (void*)(size_t)dataItemIndex, DN_SIMDHASH_INSERT_MODE_ENSURE_UNIQUE
     ));
 

--- a/src/coreclr/interpreter/failures.h
+++ b/src/coreclr/interpreter/failures.h
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef _FAILURES_H_
+#define _FAILURES_H_
+
+#if defined(__GNUC__) || defined(__clang__)
+#define INTERPRETER_NORETURN    __attribute__((noreturn))
+#else
+#define INTERPRETER_NORETURN    __declspec(noreturn)
+#endif
+
+INTERPRETER_NORETURN void NO_WAY(const char* message);
+INTERPRETER_NORETURN void BADCODE(const char* message);
+INTERPRETER_NORETURN void NOMEM();
+
+#endif

--- a/src/coreclr/interpreter/interpreter.h
+++ b/src/coreclr/interpreter/interpreter.h
@@ -25,8 +25,9 @@
 
 #define ALIGN_UP_TO(val,align) ((((size_t)val) + (size_t)((align) - 1)) & (~((size_t)(align - 1))))
 
-#ifdef DEBUG
 extern "C" void assertAbort(const char* why, const char* file, unsigned line);
+
+#ifdef DEBUG
 #undef assert
 #define assert(p) (void)((p) || (assertAbort(#p, __FILE__, __LINE__), 0))
 #endif // DEBUG

--- a/src/coreclr/interpreter/interpreter.h
+++ b/src/coreclr/interpreter/interpreter.h
@@ -25,9 +25,9 @@
 
 #define ALIGN_UP_TO(val,align) ((((size_t)val) + (size_t)((align) - 1)) & (~((size_t)(align - 1))))
 
+#ifdef DEBUG
 extern "C" void assertAbort(const char* why, const char* file, unsigned line);
 
-#ifdef DEBUG
 #undef assert
 #define assert(p) (void)((p) || (assertAbort(#p, __FILE__, __LINE__), 0))
 #endif // DEBUG

--- a/src/coreclr/interpreter/simdhash.h
+++ b/src/coreclr/interpreter/simdhash.h
@@ -52,21 +52,21 @@ public:
 };
 
 // Asserts that no error occurred during a simdhash add, but does not mind if no new item was inserted
-inline void assertNoError(dn_simdhash_add_result result)
+inline void checkNoError(dn_simdhash_add_result result)
 {
     if (result == DN_SIMDHASH_OUT_OF_MEMORY)
         NOMEM();
     else if (result < 0)
-        assert(!"Internal error in simdhash");
+        NO_WAY("Internal error in simdhash");
 }
 
 // Asserts that a new item was successfully inserted into the simdhash
-inline void assertAddedNew(dn_simdhash_add_result result)
+inline void checkAddedNew(dn_simdhash_add_result result)
 {
     if (result == DN_SIMDHASH_OUT_OF_MEMORY)
         NOMEM();
     else if (result != DN_SIMDHASH_ADD_INSERTED)
-        assert(!"Failed to add new item into simdhash");
+        NO_WAY("Failed to add new item into simdhash");
 }
 
 #endif // _SIMDHASH_H_

--- a/src/coreclr/interpreter/simdhash.h
+++ b/src/coreclr/interpreter/simdhash.h
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef _SIMDHASH_H_
+#define _SIMDHASH_H_
+
+#include "failures.h"
+#include "../../native/containers/dn-simdhash.h"
+#include "../../native/containers/dn-simdhash-specializations.h"
+#include "../../native/containers/dn-simdhash-utils.h"
+
+class dn_simdhash_ptr_ptr_holder
+{
+    dn_simdhash_ptr_ptr_t *Value;
+public:
+    dn_simdhash_ptr_ptr_holder() :
+        Value(nullptr)
+    {
+    }
+
+    dn_simdhash_ptr_ptr_t* GetValue()
+    {
+        if (!Value)
+            Value = dn_simdhash_ptr_ptr_new(0, nullptr);
+        return Value;
+    }
+
+    dn_simdhash_ptr_ptr_holder(const dn_simdhash_ptr_ptr_holder&) = delete;
+    dn_simdhash_ptr_ptr_holder& operator=(const dn_simdhash_ptr_ptr_holder&) = delete;
+    dn_simdhash_ptr_ptr_holder(dn_simdhash_ptr_ptr_holder&& other)
+    {
+        Value = other.Value;
+        other.Value = nullptr;
+    }
+    dn_simdhash_ptr_ptr_holder& operator=(dn_simdhash_ptr_ptr_holder&& other)
+    {
+        if (this != &other)
+        {
+            if (Value != nullptr)
+                dn_simdhash_free(Value);
+            Value = other.Value;
+            other.Value = nullptr;
+        }
+        return *this;
+    }
+
+    ~dn_simdhash_ptr_ptr_holder()
+    {
+        if (Value != nullptr)
+            dn_simdhash_free(Value);
+    }
+};
+
+// Asserts that no error occurred during a simdhash add, but does not mind if no new item was inserted
+inline void assertNoError(dn_simdhash_add_result result)
+{
+    if (result == DN_SIMDHASH_OUT_OF_MEMORY)
+        NOMEM();
+    else if (result < 0)
+        assert(!"Internal error in simdhash");
+}
+
+// Asserts that a new item was successfully inserted into the simdhash
+inline void assertAddedNew(dn_simdhash_add_result result)
+{
+    if (result == DN_SIMDHASH_OUT_OF_MEMORY)
+        NOMEM();
+    else if (result != DN_SIMDHASH_ADD_INSERTED)
+        assert(!"Failed to add new item into simdhash");
+}
+
+#endif // _SIMDHASH_H_

--- a/src/coreclr/interpreter/stackmap.cpp
+++ b/src/coreclr/interpreter/stackmap.cpp
@@ -6,11 +6,8 @@
 #include "interpreter.h"
 #include "stackmap.h"
 
-#include "../../native/containers/dn-simdhash.h"
-#include "../../native/containers/dn-simdhash-specializations.h"
-#include "../../native/containers/dn-simdhash-utils.h"
-
-extern "C" void assertAbort(const char* why, const char* file, unsigned line);
+#include "failures.h"
+#include "simdhash.h"
 
 void
 dn_simdhash_assert_fail (const char* file, int line, const char* condition) {
@@ -30,11 +27,7 @@ InterpreterStackMap* GetInterpreterStackMap(ICorJitInfo* jitInfo, CORINFO_CLASS_
     if (!dn_simdhash_ptr_ptr_try_get_value(t_sharedStackMapLookup, classHandle, (void **)&result))
     {
         result = new InterpreterStackMap(jitInfo, classHandle);
-        dn_simdhash_add_result addResult = dn_simdhash_ptr_ptr_try_add(t_sharedStackMapLookup, classHandle, result);
-        if (addResult == DN_SIMDHASH_OUT_OF_MEMORY)
-            NOMEM();
-        else
-            assert(addResult == DN_SIMDHASH_ADD_INSERTED);
+        assertAddedNew(dn_simdhash_ptr_ptr_try_add(t_sharedStackMapLookup, classHandle, result));
     }
     return result;
 }

--- a/src/coreclr/interpreter/stackmap.cpp
+++ b/src/coreclr/interpreter/stackmap.cpp
@@ -24,10 +24,17 @@ InterpreterStackMap* GetInterpreterStackMap(ICorJitInfo* jitInfo, CORINFO_CLASS_
     InterpreterStackMap* result = nullptr;
     if (!t_sharedStackMapLookup)
         t_sharedStackMapLookup = dn_simdhash_ptr_ptr_new(0, nullptr);
+    if (!t_sharedStackMapLookup)
+        NOMEM();
+
     if (!dn_simdhash_ptr_ptr_try_get_value(t_sharedStackMapLookup, classHandle, (void **)&result))
     {
         result = new InterpreterStackMap(jitInfo, classHandle);
-        dn_simdhash_ptr_ptr_try_add(t_sharedStackMapLookup, classHandle, result);
+        dn_simdhash_add_result addResult = dn_simdhash_ptr_ptr_try_add(t_sharedStackMapLookup, classHandle, result);
+        if (addResult == DN_SIMDHASH_OUT_OF_MEMORY)
+            NOMEM();
+        else
+            assert(addResult == DN_SIMDHASH_ADD_INSERTED);
     }
     return result;
 }

--- a/src/coreclr/interpreter/stackmap.cpp
+++ b/src/coreclr/interpreter/stackmap.cpp
@@ -11,7 +11,11 @@
 
 void
 dn_simdhash_assert_fail (const char* file, int line, const char* condition) {
+#if DEBUG
     assertAbort(condition, file, line);
+#else
+    NO_WAY(condition);
+#endif
 }
 
 thread_local dn_simdhash_ptr_ptr_t *t_sharedStackMapLookup = nullptr;
@@ -27,7 +31,7 @@ InterpreterStackMap* GetInterpreterStackMap(ICorJitInfo* jitInfo, CORINFO_CLASS_
     if (!dn_simdhash_ptr_ptr_try_get_value(t_sharedStackMapLookup, classHandle, (void **)&result))
     {
         result = new InterpreterStackMap(jitInfo, classHandle);
-        assertAddedNew(dn_simdhash_ptr_ptr_try_add(t_sharedStackMapLookup, classHandle, result));
+        checkAddedNew(dn_simdhash_ptr_ptr_try_add(t_sharedStackMapLookup, classHandle, result));
     }
     return result;
 }

--- a/src/native/containers/dn-simdhash-ght-compatible.h
+++ b/src/native/containers/dn-simdhash-ght-compatible.h
@@ -38,6 +38,13 @@ dn_simdhash_ght_get_value_or_default (
 	dn_simdhash_ght_t *hash, void * key
 );
 
+dn_simdhash_add_result
+dn_simdhash_ght_try_insert (
+	dn_simdhash_ght_t *hash,
+	void *key, void *value,
+	dn_simdhash_insert_mode mode
+);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/src/native/containers/dn-simdhash-specialization-declarations.h
+++ b/src/native/containers/dn-simdhash-specialization-declarations.h
@@ -52,10 +52,10 @@ DN_SIMDHASH_T_PTR
 DN_SIMDHASH_NEW (uint32_t capacity, dn_allocator_t *allocator);
 #endif
 
-uint8_t
+dn_simdhash_add_result
 DN_SIMDHASH_TRY_ADD (DN_SIMDHASH_T_PTR hash, DN_SIMDHASH_KEY_T key, DN_SIMDHASH_VALUE_T value);
 
-uint8_t
+dn_simdhash_add_result
 DN_SIMDHASH_TRY_ADD_WITH_HASH (DN_SIMDHASH_T_PTR hash, DN_SIMDHASH_KEY_T key, uint32_t key_hash, DN_SIMDHASH_VALUE_T value);
 
 // result is an optional parameter that will be set to the value of the item if it was found.

--- a/src/native/containers/dn-simdhash-specializations.h
+++ b/src/native/containers/dn-simdhash-specializations.h
@@ -61,7 +61,7 @@ typedef struct dn_simdhash_str_key dn_simdhash_str_key;
 
 
 typedef struct dn_ptrpair_t {
-    void *first, *second;
+	void *first, *second;
 } dn_ptrpair_t;
 
 #define DN_SIMDHASH_T dn_simdhash_ptrpair_ptr

--- a/src/native/containers/dn-simdhash-string-ptr.c
+++ b/src/native/containers/dn-simdhash-string-ptr.c
@@ -83,8 +83,8 @@ dn_simdhash_string_ptr_try_remove (dn_simdhash_string_ptr_t *hash, const char *k
 void
 dn_simdhash_string_ptr_foreach (dn_simdhash_string_ptr_t *hash, dn_simdhash_string_ptr_foreach_func func, void *user_data)
 {
-	assert(hash);
-	assert(func);
+	dn_simdhash_assert(hash);
+	dn_simdhash_assert(func);
 
 	dn_simdhash_buffers_t buffers = hash->buffers;
 	BEGIN_SCAN_PAIRS(buffers, key_address, value_address)

--- a/src/native/containers/simdhash-benchmark/run-benchmark.ps1
+++ b/src/native/containers/simdhash-benchmark/run-benchmark.ps1
@@ -1,2 +1,2 @@
-cl /GS- /O2 /std:c17 ./*.c ../dn-simdhash-u32-ptr.c ../dn-simdhash.c ../dn-vector.c ../dn-simdhash-string-ptr.c /DNO_CONFIG_H /DSIZEOF_VOID_P=8 /DNDEBUG /Fe:all-measurements.exe
+cl /GS- /O2 /std:c17 ./*.c ../dn-simdhash-u32-ptr.c ../dn-simdhash.c ../dn-vector.c ../dn-simdhash-string-ptr.c ../dn-simdhash-ght-compatible.c /DNO_CONFIG_H /DSIZEOF_VOID_P=8 /DNDEBUG /Fe:all-measurements.exe
 ./all-measurements.exe


### PR DESCRIPTION
Like its predecessor ghashtable, dn_simdhash was not written to handle malloc failures. Thanks to @davidwrighton for reminding me that this needed to be fixed.

Note that the 'ght compatible' version of simdhash asserts on malloc failure, since there's no way to retrofit it to allow the caller to do anything else - all the existing call sites in mono would become wrong if we did that.

The 'new' operation now returns NULL on malloc failure.
The add operations now return an enum where a positive value indicates success, a negative value indicates OOM, and a 0 indicates failure.
The ensure capacity operation now returns a success bool, where 0 means malloc failed and 1 means that the hash is big enough to hold the capacity you requested.

This PR also adds the new `dn_simdhash_ght_try_insert` API which allows you to sense OOM when using the ght compatible variant.