### PR TITLE
ML-KEM: MLKemCng and CNG properties

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDecapsulateEncapsulate.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDecapsulateEncapsulate.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class NCrypt
+    {
+        [LibraryImport(Libraries.NCrypt)]
+        private static unsafe partial ErrorCode NCryptDecapsulate(
+            SafeNCryptKeyHandle hKey,
+            byte* pbCipherText,
+            uint cbCipherText,
+            byte* pbSecretKey,
+            uint cbSecretKey,
+            out uint pcbSecretKey,
+            uint dwFlags);
+
+        [LibraryImport(Libraries.NCrypt)]
+        private static unsafe partial ErrorCode NCryptEncapsulate(
+            SafeNCryptKeyHandle hKey,
+            byte* pbSecretKey,
+            uint cbSecretKey,
+            out uint pcbSecretKey,
+            byte* pbCipherText,
+            uint cbCipherText,
+            out uint pcbCipherText,
+            uint dwFlags);
+
+        internal static unsafe uint NCryptDecapsulate(
+            SafeNCryptKeyHandle hKey,
+            ReadOnlySpan<byte> cipherText,
+            Span<byte> secretKey,
+            uint dwFlags)
+        {
+            fixed (byte* pCiphertext = cipherText)
+            fixed (byte* pSecretKey = secretKey)
+            {
+                ErrorCode error = NCryptDecapsulate(
+                    hKey,
+                    pCiphertext,
+                    (uint)cipherText.Length,
+                    pSecretKey,
+                    (uint)secretKey.Length,
+                    out uint pcbSecretKey,
+                    dwFlags);
+
+                if (error != ErrorCode.ERROR_SUCCESS)
+                {
+                    throw error.ToCryptographicException();
+                }
+
+                return pcbSecretKey;
+            }
+        }
+
+        internal static unsafe void NCryptEncapsulate(
+            SafeNCryptKeyHandle hKey,
+            Span<byte> secretKey,
+            Span<byte> cipherText,
+            out uint pcbSecretKey,
+            out uint pcbCipherText,
+            uint dwFlags)
+        {
+            fixed (byte* pSecretKey = secretKey)
+            fixed (byte* pCipherText = cipherText)
+            {
+                ErrorCode error = NCryptEncapsulate(
+                    hKey,
+                    pSecretKey,
+                    (uint)secretKey.Length,
+                    out pcbSecretKey,
+                    pCipherText,
+                    (uint)cipherText.Length,
+                    out pcbCipherText,
+                    dwFlags);
+
+                if (error != ErrorCode.ERROR_SUCCESS)
+                {
+                    throw error.ToCryptographicException();
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.Windows.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using KeyBlobMagicNumber = Interop.BCrypt.KeyBlobMagicNumber;
+using BCRYPT_MLKEM_KEY_BLOB = Interop.BCrypt.BCRYPT_MLKEM_KEY_BLOB;
+
+namespace System.Security.Cryptography
+{
+    public abstract partial class MLKem
+    {
+        // This takes ownership of exported and clears it when done.
+        private protected unsafe void ReadCngMLKemBlob(
+            KeyBlobMagicNumber kind,
+            ReadOnlySpan<byte> exportedSpan,
+            Span<byte> destination)
+        {
+            fixed (byte* pExportedSpan = exportedSpan)
+            {
+                BCRYPT_MLKEM_KEY_BLOB* blob = (BCRYPT_MLKEM_KEY_BLOB*)pExportedSpan;
+
+                if (blob->dwMagic != kind)
+                {
+                    Debug.Fail("dwMagic is not expected value");
+                    throw new CryptographicException();
+                }
+
+                int blobHeaderSize = Marshal.SizeOf<BCRYPT_MLKEM_KEY_BLOB>();
+                int keySize = checked((int)blob->cbKey);
+
+                if (keySize != destination.Length)
+                {
+                    throw new CryptographicException(SR.Cryptography_NotValidPublicOrPrivateKey);
+                }
+
+                int paramSetSize = checked((int)blob->cbParameterSet);
+                ReadOnlySpan<char> paramSetWithNull = new(pExportedSpan + blobHeaderSize, paramSetSize / sizeof(char));
+                ReadOnlySpan<char> paramSet = paramSetWithNull[0..^1];
+                ReadOnlySpan<char> expectedParamSet = PqcBlobHelpers.GetMLKemParameterSet(Algorithm);
+
+                if (!paramSet.SequenceEqual(expectedParamSet) || paramSetWithNull[^1] != '\0')
+                {
+                    throw new CryptographicException(SR.Cryptography_NotValidPublicOrPrivateKey);
+                }
+
+                exportedSpan.Slice(blobHeaderSize + paramSetSize, keySize).CopyTo(destination);
+            }
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.Windows.cs
@@ -11,7 +11,6 @@ namespace System.Security.Cryptography
 {
     public abstract partial class MLKem
     {
-        // This takes ownership of exported and clears it when done.
         private protected unsafe void ReadCngMLKemBlob(
             KeyBlobMagicNumber kind,
             ReadOnlySpan<byte> exportedSpan,

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography
     ///   </para>
     /// </remarks>
     [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
-    public abstract class MLKem : IDisposable
+    public abstract partial class MLKem : IDisposable
     {
         private static readonly string[] s_knownOids = [Oids.MlKem512, Oids.MlKem768, Oids.MlKem1024];
 

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Formats.Asn1;
+using System.Security.Cryptography.Asn1;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class MLKemCng : MLKem
+    {
+        private const string NCRYPT_MLKEM_PARAMETER_SET_512 = PqcBlobHelpers.BCRYPT_MLKEM_PARAMETER_SET_512;
+        private const string NCRYPT_MLKEM_PARAMETER_SET_768 = PqcBlobHelpers.BCRYPT_MLKEM_PARAMETER_SET_768;
+        private const string NCRYPT_MLKEM_PARAMETER_SET_1024 = PqcBlobHelpers.BCRYPT_MLKEM_PARAMETER_SET_1024;
+
+        internal MLKemCng(CngKey key, bool transferOwnership)
+            : base(AlgorithmFromHandleNoDuplicate(key))
+        {
+            Debug.Assert(key is not null);
+            Debug.Assert(key.AlgorithmGroup == CngAlgorithmGroup.MLKem);
+            Debug.Assert(transferOwnership);
+
+            _key = key;
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static partial MLKemAlgorithm AlgorithmFromHandle(CngKey key, out CngKey duplicateKey)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            ThrowIfNotSupported();
+
+            if (key.AlgorithmGroup != CngAlgorithmGroup.MLDsa)
+            {
+                throw new ArgumentException(SR.Cryptography_ArgMLKemRequiresMLKemKey, nameof(key));
+            }
+
+            MLKemAlgorithm algorithm = AlgorithmFromHandleImpl(key);
+
+#if SYSTEM_SECURITY_CRYPTOGRAPHY
+            duplicateKey = CngHelpers.Duplicate(key.HandleNoDuplicate, key.IsEphemeral);
+#else
+            duplicateKey = key.Duplicate();
+#endif
+
+            return algorithm;
+        }
+
+        private static MLKemAlgorithm AlgorithmFromHandleNoDuplicate(CngKey key)
+        {
+            if (key.AlgorithmGroup != CngAlgorithmGroup.MLKem)
+            {
+                throw new CryptographicException(SR.Cryptography_ArgMLDsaRequiresMLDsaKey);
+            }
+
+            Debug.Assert(key is not null);
+
+            return AlgorithmFromHandleImpl(key);
+        }
+
+        private static MLKemAlgorithm AlgorithmFromHandleImpl(CngKey key)
+        {
+            string? parameterSet =
+#if SYSTEM_SECURITY_CRYPTOGRAPHY
+                key.HandleNoDuplicate.GetPropertyAsString(KeyPropertyName.ParameterSetName, CngPropertyOptions.None);
+#else
+                key.GetPropertyAsString(KeyPropertyName.ParameterSetName, CngPropertyOptions.None);
+#endif
+
+            return parameterSet switch
+            {
+                NCRYPT_MLKEM_PARAMETER_SET_512 => MLKemAlgorithm.MLKem512,
+                NCRYPT_MLKEM_PARAMETER_SET_768 => MLKemAlgorithm.MLKem768,
+                NCRYPT_MLKEM_PARAMETER_SET_1024 => MLKemAlgorithm.MLKem1024,
+                _ => throw DebugFailAndGetException(parameterSet),
+            };
+
+            static Exception DebugFailAndGetException(string? parameterSet)
+            {
+                Debug.Fail($"Unexpected parameter set '{parameterSet}'.");
+                return new CryptographicException();
+            }
+        }
+
+        public partial CngKey Key
+        {
+            get
+            {
+                ThrowIfDisposed();
+
+                return _key;
+            }
+        }
+
+        protected override void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
+        protected override void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
+        protected override void ExportPrivateSeedCore(Span<byte> destination)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
+        protected override void ExportDecapsulationKeyCore(Span<byte> destination)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
+        protected override void ExportEncapsulationKeyCore(Span<byte> destination)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
@@ -213,6 +213,16 @@ namespace System.Security.Cryptography
             }
         }
 
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _key.Dispose();
+                _key = null!;
+            }
+        }
+
         private void ExportKey(KeyBlobMagicNumber kind, Span<byte> destination)
         {
             Debug.Assert(kind is KeyBlobMagicNumber.BCRYPT_MLKEM_PUBLIC_MAGIC or

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace System.Security.Cryptography
+{
+    /// <summary>
+    ///   Provides a Cryptography Next Generation (CNG) implementation of the Module-Lattice-Based Key-Encapsulation
+    ///   Mechanism (ML-KEM).
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This algorithm is specified by FIPS-203.
+    ///   </para>
+    ///   <para>
+    ///     Developers are encouraged to program against the <see cref="MLKem" /> base class,
+    ///     rather than any specific derived class.
+    ///     The derived classes are intended for interop with the underlying system
+    ///     cryptographic libraries.
+    ///   </para>
+    /// </remarks>
+    [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+    public sealed partial class MLKemCng : MLKem
+    {
+        private CngKey _key;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="MLKemCng"/> class by using the specified <see cref="CngKey"/>.
+        /// </summary>
+        /// <param name="key">
+        ///   The key that will be used as input to the cryptographic operations performed by the current object.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="key"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="key"/> does not specify a Module-Lattice-Based Key-Encapsulation Mechanism (ML-KEM)
+        ///   algorithm group.
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   Cryptography Next Generation (CNG) classes are not supported on this system.
+        /// </exception>
+        [SupportedOSPlatform("windows")]
+        public MLKemCng(CngKey key) : base(AlgorithmFromHandleWithPlatformCheck(key, out CngKey duplicateKey))
+        {
+            _key = duplicateKey;
+        }
+
+        private static MLKemAlgorithm AlgorithmFromHandleWithPlatformCheck(CngKey key, out CngKey duplicateKey)
+        {
+#if !NETFRAMEWORK
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException();
+            }
+#endif
+
+            return AlgorithmFromHandle(key, out duplicateKey);
+        }
+
+        private static partial MLKemAlgorithm AlgorithmFromHandle(CngKey key, out CngKey duplicateKey);
+
+        /// <summary>
+        ///   Gets the key that will be used by the <see cref="MLKemCng"/> object for any cryptographic operation that it performs.
+        /// </summary>
+        /// <value>
+        ///   The key that will be used by the <see cref="MLKemCng"/> object for any cryptographic operation that it performs.
+        /// </value>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <remarks>
+        ///   This <see cref="CngKey"/> object is not the same as the one passed to the <see cref="MLKemCng"/> constructor,
+        ///   if that constructor was used. However, it will point to the same CNG key.
+        /// </remarks>
+        public partial CngKey Key { get; }
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/PqcBlobHelpers.MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/PqcBlobHelpers.MLKem.cs
@@ -4,7 +4,9 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
+using BCRYPT_MLKEM_KEY_BLOB = Interop.BCrypt.BCRYPT_MLKEM_KEY_BLOB;
 using KeyBlobMagicNumber = Interop.BCrypt.KeyBlobMagicNumber;
 using KeyBlobType = Interop.BCrypt.KeyBlobType;
 
@@ -49,6 +51,72 @@ namespace System.Security.Cryptography
             {
                 Debug.Fail($"Unknown blob type '{other}'.");
                 return new CryptographicException();
+            }
+        }
+
+        internal delegate TReturn EncodeMLKemBlobCallback<TState, TReturn>(
+            TState state,
+            string blobKind,
+            ReadOnlySpan<byte> blob);
+
+        internal static TReturn EncodeMLKemBlob<TState, TReturn>(
+            KeyBlobMagicNumber kind,
+            MLKemAlgorithm algorithm,
+            ReadOnlySpan<byte> key,
+            TState state,
+            EncodeMLKemBlobCallback<TState, TReturn> callback)
+        {
+            checked
+            {
+                // ML-KEM 1024 seeds are 86 byte blobs. Round it off to 128.
+                // Other keys like encapsulation or decapsulation keys will never fit in a stack buffer, so don't
+                // try to accommodate them.
+                const int MaxKeyStackSize = 128;
+                string parameterSet = GetMLKemParameterSet(algorithm);
+                int blobHeaderSize = Marshal.SizeOf<BCRYPT_MLKEM_KEY_BLOB>();
+                int parameterSetMarshalLength = (parameterSet.Length + 1) * 2;
+                int blobSize =
+                    blobHeaderSize +
+                    parameterSetMarshalLength +
+                    key.Length;
+
+                byte[]? rented = null;
+                Span<byte> buffer = (uint)blobSize <= MaxKeyStackSize ?
+                    stackalloc byte[MaxKeyStackSize] :
+                    (rented = CryptoPool.Rent(blobSize));
+
+                try
+                {
+                    buffer.Clear();
+
+                    unsafe
+                    {
+                        fixed (byte* pBuffer = buffer)
+                        {
+                            BCRYPT_MLKEM_KEY_BLOB* blob = (BCRYPT_MLKEM_KEY_BLOB*)pBuffer;
+                            blob->dwMagic = kind;
+                            blob->cbParameterSet = (uint)parameterSetMarshalLength;
+                            blob->cbKey = (uint)key.Length;
+                        }
+                    }
+
+                    // This won't write the null byte, but we zeroed the whole buffer earlier.
+                    Encoding.Unicode.GetBytes(parameterSet, buffer.Slice(blobHeaderSize));
+                    key.CopyTo(buffer.Slice(blobHeaderSize + parameterSetMarshalLength));
+                    string blobKind = MLKemBlobMagicToBlobType(kind);
+                    return callback(state, blobKind, buffer.Slice(0, blobSize));
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(buffer.Slice(0, blobSize));
+
+                    if (rented is not null)
+                    {
+                        // buffer is a slice of rented which was zeroed, since it needs to be zeroed regardless of being
+                        // a rent or a stack buffer.
+                        CryptoPool.Return(rented, 0);
+                    }
+                }
             }
         }
     }

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemBaseTests.cs
@@ -48,8 +48,8 @@ namespace System.Security.Cryptography.Tests
         {
             using MLKem kem = ImportDecapsulationKey(MLKemAlgorithm.MLKem512, MLKemTestData.MLKem512DecapsulationKey);
 
-            Assert.Throws<CryptographicException>(() => kem.ExportPrivateSeed());
-            Assert.Throws<CryptographicException>(() => kem.ExportPrivateSeed(
+            Assert.ThrowsAny<CryptographicException>(() => kem.ExportPrivateSeed());
+            Assert.ThrowsAny<CryptographicException>(() => kem.ExportPrivateSeed(
                 new byte[MLKemAlgorithm.MLKem512.PrivateSeedSizeInBytes]));
         }
 
@@ -344,7 +344,7 @@ namespace System.Security.Cryptography.Tests
                 using MLKem imported = MLKem.ImportPkcs8PrivateKey(pkcs8);
                 Assert.Equal(MLKemAlgorithm.MLKem512, imported.Algorithm);
 
-                Assert.Throws<CryptographicException>(() => kem.ExportPrivateSeed());
+                Assert.ThrowsAny<CryptographicException>(() => kem.ExportPrivateSeed());
                 AssertExtensions.SequenceEqual(MLKemTestData.MLKem512DecapsulationKey, kem.ExportDecapsulationKey());
             });
         }

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.NotSupported.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.NotSupported.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+#if NET || NETSTANDARD2_1_OR_GREATER
+    [PlatformSpecific(~TestPlatforms.Windows)]
+    public sealed class MLKemCngNotSupportedTests
+    {
+        [Fact]
+        public static void MLKemCng_NotSupportedOnNonWindowsPlatforms()
+        {
+            // We cannot actually construct a CngKey on non-Windows platforms, so this cheats by just instantiating
+            // a bogus object. We don't need the object to do anything. We shouldn't touch it before the platform check.
+            CngKey key = (CngKey)RuntimeHelpers.GetUninitializedObject(typeof(CngKey));
+            Assert.Throws<PlatformNotSupportedException>(() => key);
+        }
+    }
+#endif
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.NotSupported.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.NotSupported.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography.Tests
             // We cannot actually construct a CngKey on non-Windows platforms, so this cheats by just instantiating
             // a bogus object. We don't need the object to do anything. We shouldn't touch it before the platform check.
             CngKey key = (CngKey)RuntimeHelpers.GetUninitializedObject(typeof(CngKey));
-            Assert.Throws<PlatformNotSupportedException>(() => key);
+            Assert.Throws<PlatformNotSupportedException>(() => new MLKemCng(key));
         }
     }
 #endif

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.Windows.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.Windows.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+using Xunit;
+using Xunit.Sdk;
+
+using KeyBlobMagicNumber = Interop.BCrypt.KeyBlobMagicNumber;
+
+namespace System.Security.Cryptography.Tests
+{
+    [ConditionalClass(typeof(MLKem), nameof(MLKem.IsSupported))]
+    public sealed class MLKemCngTests : MLKemBaseTests
+    {
+        public override MLKem GenerateKey(MLKemAlgorithm algorithm)
+        {
+            CngProperty parameterSet = GetCngProperty(algorithm);
+
+            CngKeyCreationParameters creationParams = new();
+            creationParams.Parameters.Add(parameterSet);
+            creationParams.ExportPolicy = CngExportPolicies.AllowExport | CngExportPolicies.AllowPlaintextExport;
+
+            using (CngKey key = CngKey.Create(CngAlgorithm.MLKem, keyName: null, creationParams))
+            {
+                return new MLKemCng(key);
+            }
+        }
+
+        public override MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, ReadOnlySpan<byte> seed)
+        {
+            using (CngKey key = ImportMLKemKey(KeyBlobMagicNumber.BCRYPT_MLKEM_PRIVATE_SEED_MAGIC, algorithm, seed))
+            {
+                return new MLKemCng(key);
+            }
+        }
+
+        public override MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
+        {
+            using (CngKey key = ImportMLKemKey(KeyBlobMagicNumber.BCRYPT_MLKEM_PRIVATE_MAGIC, algorithm, source))
+            {
+                return new MLKemCng(key);
+            }
+        }
+
+        public override MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
+        {
+            using (CngKey key = ImportMLKemKey(KeyBlobMagicNumber.BCRYPT_MLKEM_PUBLIC_MAGIC, algorithm, source))
+            {
+                return new MLKemCng(key);
+            }
+        }
+
+        private static CngProperty GetCngProperty(MLKemAlgorithm algorithm)
+        {
+            string cngParameterSet;
+
+            if (algorithm == MLKemAlgorithm.MLKem512)
+            {
+                cngParameterSet = "512\0";
+            }
+            else if (algorithm == MLKemAlgorithm.MLKem768)
+            {
+                cngParameterSet = "768\0";
+            }
+            else if (algorithm == MLKemAlgorithm.MLKem1024)
+            {
+                cngParameterSet = "1024\0";
+            }
+            else
+            {
+                throw new XunitException($"Unknown MLKemAlgorithm '{algorithm}'.");
+            }
+
+            byte[] byteValue = Encoding.Unicode.GetBytes(cngParameterSet);
+            return new CngProperty("ParameterSetName", byteValue, CngPropertyOptions.None);
+        }
+
+        private static CngKey ImportMLKemKey(KeyBlobMagicNumber kind, MLKemAlgorithm algorithm, ReadOnlySpan<byte> key)
+        {
+            return PqcBlobHelpers.EncodeMLKemBlob(
+                kind,
+                algorithm,
+                key,
+                (object)null,
+                static (_, blobKind, blob) =>
+                {
+                    if (blobKind == CngKeyBlobFormat.MLKemPublicBlob.Format)
+                    {
+                        return CngKey.Import(blob.ToArray(), CngKeyBlobFormat.MLKemPublicBlob);
+                    }
+                    else
+                    {
+                        CngProperty blobProperty = new CngProperty(
+                            blobKind,
+                            blob.ToArray(),
+                            CngPropertyOptions.None);
+
+                        CngKeyCreationParameters creationParams = new();
+                        creationParams.ExportPolicy = CngExportPolicies.AllowExport | CngExportPolicies.AllowPlaintextExport;
+                        creationParams.Parameters.Add(blobProperty);
+                        return CngKey.Create(CngAlgorithm.MLKem, keyName: null, creationParams);
+                    }
+                });
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.Windows.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.Windows.cs
@@ -11,17 +11,64 @@ using KeyBlobMagicNumber = Interop.BCrypt.KeyBlobMagicNumber;
 namespace System.Security.Cryptography.Tests
 {
     [ConditionalClass(typeof(MLKem), nameof(MLKem.IsSupported))]
-    public sealed class MLKemCngTests : MLKemBaseTests
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public sealed class MLKemCngPlaintextExportableTests : MLKemCngTests
     {
+        protected override CngExportPolicies ExportPolicies => CngExportPolicies.AllowExport | CngExportPolicies.AllowPlaintextExport;
+    }
+
+    // ML-KEM as of Windows build 27881 does not have PKCS#8 exports, so we cannot implement encrypted exports.
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/116304")]
+    [ConditionalClass(typeof(MLKem), nameof(MLKem.IsSupported))]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public sealed class MLKemCngExportableTests : MLKemCngTests
+    {
+        protected override CngExportPolicies ExportPolicies => CngExportPolicies.AllowExport;
+    }
+
+    [ConditionalClass(typeof(MLKem), nameof(MLKem.IsSupported))]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public static class MLKemCngNonExportableTests
+    {
+        [Theory]
+        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
+        public static void MLKemCng_NonExportable_ExportPrivateSeedThrows(MLKemAlgorithm algorithm)
+        {
+            using CngKey key = MLKemCngTests.GenerateCngKey(algorithm, CngExportPolicies.None);
+            using MLKemCng kem = new MLKemCng(key);
+            Assert.Throws<CryptographicException>(() => kem.ExportPrivateSeed());
+        }
+
+        [Theory]
+        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
+        public static void MLKemCng_NonExportable_ExportDecapsulationKeyThrows(MLKemAlgorithm algorithm)
+        {
+            using CngKey key = MLKemCngTests.GenerateCngKey(algorithm, CngExportPolicies.None);
+            using MLKemCng kem = new MLKemCng(key);
+            Assert.Throws<CryptographicException>(() => kem.ExportDecapsulationKey());
+        }
+
+        [Fact]
+        public static void MLKemCng_NonExportable_ExportEncapsulationKeyAlwaysWorks()
+        {
+            using CngKey key = MLKemCngTests.ImportPrivateSeed(
+                MLKemAlgorithm.MLKem512,
+                MLKemTestData.MLKem512PrivateSeed,
+                CngExportPolicies.None);
+
+            using MLKemCng kem = new MLKemCng(key);
+            byte[] exportedKey = kem.ExportEncapsulationKey();
+            AssertExtensions.SequenceEqual(MLKemTestData.MLKem512EncapsulationKey, exportedKey);
+        }
+    }
+
+    public abstract class MLKemCngTests : MLKemBaseTests
+    {
+        protected abstract CngExportPolicies ExportPolicies { get; }
+
         public override MLKem GenerateKey(MLKemAlgorithm algorithm)
         {
-            CngProperty parameterSet = GetCngProperty(algorithm);
-
-            CngKeyCreationParameters creationParams = new();
-            creationParams.Parameters.Add(parameterSet);
-            creationParams.ExportPolicy = CngExportPolicies.AllowExport | CngExportPolicies.AllowPlaintextExport;
-
-            using (CngKey key = CngKey.Create(CngAlgorithm.MLKem, keyName: null, creationParams))
+            using (CngKey key = GenerateCngKey(algorithm, ExportPolicies))
             {
                 return new MLKemCng(key);
             }
@@ -29,7 +76,7 @@ namespace System.Security.Cryptography.Tests
 
         public override MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, ReadOnlySpan<byte> seed)
         {
-            using (CngKey key = ImportMLKemKey(KeyBlobMagicNumber.BCRYPT_MLKEM_PRIVATE_SEED_MAGIC, algorithm, seed))
+            using (CngKey key = ImportPrivateSeed(algorithm, seed, ExportPolicies))
             {
                 return new MLKemCng(key);
             }
@@ -37,7 +84,7 @@ namespace System.Security.Cryptography.Tests
 
         public override MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            using (CngKey key = ImportMLKemKey(KeyBlobMagicNumber.BCRYPT_MLKEM_PRIVATE_MAGIC, algorithm, source))
+            using (CngKey key = ImportMLKemKey(KeyBlobMagicNumber.BCRYPT_MLKEM_PRIVATE_MAGIC, algorithm, source, ExportPolicies))
             {
                 return new MLKemCng(key);
             }
@@ -45,10 +92,53 @@ namespace System.Security.Cryptography.Tests
 
         public override MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            using (CngKey key = ImportMLKemKey(KeyBlobMagicNumber.BCRYPT_MLKEM_PUBLIC_MAGIC, algorithm, source))
+            using (CngKey key = ImportMLKemKey(KeyBlobMagicNumber.BCRYPT_MLKEM_PUBLIC_MAGIC, algorithm, source, ExportPolicies))
             {
                 return new MLKemCng(key);
             }
+        }
+
+        internal static CngKey GenerateCngKey(MLKemAlgorithm algorithm, CngExportPolicies exportPolicies)
+        {
+            CngProperty parameterSet = GetCngProperty(algorithm);
+
+            CngKeyCreationParameters creationParameters = new();
+            creationParameters.Parameters.Add(parameterSet);
+            creationParameters.ExportPolicy = exportPolicies;
+
+            return CngKey.Create(CngAlgorithm.MLKem, keyName: null, creationParameters);
+        }
+
+        internal static CngKey ImportPrivateSeed(
+            MLKemAlgorithm algorithm,
+            ReadOnlySpan<byte> seed,
+            CngExportPolicies exportPolicies)
+        {
+            return ImportMLKemKey(KeyBlobMagicNumber.BCRYPT_MLKEM_PRIVATE_SEED_MAGIC, algorithm, seed, exportPolicies);
+        }
+
+        [Fact]
+        public void MLKemCng_Ctor_ArgValidation()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("key", static () => new MLKemCng(null));
+        }
+
+        [Fact]
+        public void MLKemCng_Ctor_KeyWrongAlgorithm()
+        {
+            using CngKey rsaKey = CngKey.Create(CngAlgorithm.Rsa, keyName: null);
+            AssertExtensions.Throws<ArgumentException>("key", () => new MLKemCng(rsaKey));
+        }
+
+        [Theory]
+        [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
+        public void MLKemCng_Key(MLKemAlgorithm algorithm)
+        {
+            using CngKey key = GenerateCngKey(algorithm, ExportPolicies);
+            using MLKemCng mlKemKey = new(key);
+
+            Assert.NotSame(key, mlKemKey.Key);
+            Assert.Same(mlKemKey.Key, mlKemKey.Key);
         }
 
         private static CngProperty GetCngProperty(MLKemAlgorithm algorithm)
@@ -76,14 +166,18 @@ namespace System.Security.Cryptography.Tests
             return new CngProperty("ParameterSetName", byteValue, CngPropertyOptions.None);
         }
 
-        private static CngKey ImportMLKemKey(KeyBlobMagicNumber kind, MLKemAlgorithm algorithm, ReadOnlySpan<byte> key)
+        private static CngKey ImportMLKemKey(
+            KeyBlobMagicNumber kind,
+            MLKemAlgorithm algorithm,
+            ReadOnlySpan<byte> key,
+            CngExportPolicies exportPolicies)
         {
             return PqcBlobHelpers.EncodeMLKemBlob(
                 kind,
                 algorithm,
                 key,
                 (object)null,
-                static (_, blobKind, blob) =>
+                (_, blobKind, blob) =>
                 {
                     if (blobKind == CngKeyBlobFormat.MLKemPublicBlob.Format)
                     {
@@ -96,10 +190,10 @@ namespace System.Security.Cryptography.Tests
                             blob.ToArray(),
                             CngPropertyOptions.None);
 
-                        CngKeyCreationParameters creationParams = new();
-                        creationParams.ExportPolicy = CngExportPolicies.AllowExport | CngExportPolicies.AllowPlaintextExport;
-                        creationParams.Parameters.Add(blobProperty);
-                        return CngKey.Create(CngAlgorithm.MLKem, keyName: null, creationParams);
+                        CngKeyCreationParameters creationParameters = new();
+                        creationParameters.ExportPolicy = exportPolicies;
+                        creationParameters.Parameters.Add(blobProperty);
+                        return CngKey.Create(CngAlgorithm.MLKem, keyName: null, creationParameters);
                     }
                 });
         }

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.Forwards.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.Forwards.cs
@@ -17,6 +17,7 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLDsaCng))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLKem))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLKemAlgorithm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLKemCng))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SlhDsa))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SlhDsaAlgorithm))]
 #endif

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
@@ -387,7 +387,7 @@
              Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKem.cs"
              Link="Common\System\Security\Cryptography\MLKem.cs" />
-<Compile Include="$(CommonPath)System\Security\Cryptography\MLKem.Windows.cs"
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLKem.Windows.cs"
              Link="Common\System\Security\Cryptography\MLKem.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemAlgorithm.cs"
              Link="Common\System\Security\Cryptography\MLKemAlgorithm.cs" />
@@ -442,6 +442,10 @@
              Link="Common\System\Security\Cryptography\MLDsaCng.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.CreateCng.cs"
              Link="Common\System\Security\Cryptography\MLDsaImplementation.CreateCng.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemCng.cs"
+             Link="Common\System\Security\Cryptography\MLKemCng.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemCng.Windows.cs"
+             Link="Common\System\Security\Cryptography\MLKemCng.Windows.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptGenRandom.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptGenRandom.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.AsymmetricPaddingMode.cs"
@@ -452,6 +456,8 @@
              Link="Common\Interop\Windows\NCrypt\Interop.Keys.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptBuffer.cs"
              Link="Common\Interop\Windows\NCrypt\Interop.NCryptBuffer.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptDecapsulateEncapsulate.cs"
+             Link="Common\Internal\Windows\NCrypt\Interop.NCryptDecapsulateEncapsulate.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.Properties.cs"
              Link="Common\Interop\Windows\NCrypt\Interop.Properties.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.SignVerify.cs"

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
@@ -364,7 +364,7 @@
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Cng.cs"
              Link="Common\Interop\Windows\BCrypt\Cng.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs"
-             Link="Common\Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs" /> 
+             Link="Common\Interop\Windows\BCrypt\Interop.AsymmetricEncryption.Types.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDecapsulateEncapsulate.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptDecapsulateEncapsulate.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptExportKey.cs"
@@ -387,6 +387,8 @@
              Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKem.cs"
              Link="Common\System\Security\Cryptography\MLKem.cs" />
+<Compile Include="$(CommonPath)System\Security\Cryptography\MLKem.Windows.cs"
+             Link="Common\System\Security\Cryptography\MLKem.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemAlgorithm.cs"
              Link="Common\System\Security\Cryptography\MLKemAlgorithm.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.Windows.cs"

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
@@ -177,6 +177,9 @@
   <data name="Cryptography_KemNoDecapsulationKey" xml:space="preserve">
     <value>The current instance does not contain a decapsulation key.</value>
   </data>
+  <data name="Cryptography_KeyNotExtractable" xml:space="preserve">
+    <value>The key does not permit being exported.</value>
+  </data>
   <data name="Cryptography_KeyWrongSizeForAlgorithm" xml:space="preserve">
     <value>The specified key is not the correct size for the indicated algorithm.</value>
   </data>

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Resources/Strings.resx
@@ -141,6 +141,9 @@
   <data name="Cryptography_ArgMLDsaRequiresMLDsaKey" xml:space="preserve">
     <value>Keys used with the MLDsaCng algorithm must have an algorithm group of MLDsa.</value>
   </data>
+  <data name="Cryptography_ArgMLKemRequiresMLKemKey" xml:space="preserve">
+    <value>Keys used with the MLKemCng algorithm must have an algorithm group of MLKem.</value>
+  </data>
   <data name="Cryptography_AuthTagMismatch" xml:space="preserve">
     <value>The computed authentication tag did not match the input authentication tag.</value>
   </data>

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/CngIdentifierExtensions.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/CngIdentifierExtensions.cs
@@ -6,33 +6,53 @@ namespace System.Security.Cryptography
     internal static class CngAlgorithmExtensions
     {
         private static CngAlgorithm? _mlDsaCngAlgorithm;
+        private static CngAlgorithm? _mlKemCngAlgorithm;
 
-        extension (CngAlgorithm)
+        extension(CngAlgorithm)
         {
             internal static CngAlgorithm MLDsa =>
                 _mlDsaCngAlgorithm ??= new CngAlgorithm("ML-DSA");  // BCRYPT_MLDSA_ALGORITHM
+
+            internal static CngAlgorithm MLKem =>
+                _mlKemCngAlgorithm ??= new CngAlgorithm("ML-KEM");  // BCRYPT_MLKEM_ALGORITHM
         }
     }
 
     internal static class CngAlgorithmGroupExtensions
     {
         private static CngAlgorithmGroup? _mlDsaCngAlgorithmGroup;
+        private static CngAlgorithmGroup? _mlKemCngAlgorithmGroup;
 
-        extension (CngAlgorithmGroup)
+        extension(CngAlgorithmGroup)
         {
             internal static CngAlgorithmGroup MLDsa =>
                 _mlDsaCngAlgorithmGroup ??= new CngAlgorithmGroup("MLDSA"); // NCRYPT_MLDSA_ALGORITHM_GROUP
+
+            internal static CngAlgorithmGroup MLKem =>
+                _mlKemCngAlgorithmGroup ??= new CngAlgorithmGroup("MLKEM"); // NCRYPT_MLKEM_ALGORITHM_GROUP
         }
     }
 
     internal static class CngKeyBlobFormatExtensions
     {
+        private static CngKeyBlobFormat? _mlKemPublicBlob;
+        private static CngKeyBlobFormat? _mlKemPrivateBlob;
+        private static CngKeyBlobFormat? _mlKemPrivateSeedBlob;
         private static CngKeyBlobFormat? _pqDsaPublicBlob;
         private static CngKeyBlobFormat? _pqDsaPrivateBlob;
         private static CngKeyBlobFormat? _pqDsaPrivateSeedBlob;
 
-        extension (CngKeyBlobFormat)
+        extension(CngKeyBlobFormat)
         {
+            internal static CngKeyBlobFormat MLKemPublicBlob =>
+                _mlKemPublicBlob ??= new CngKeyBlobFormat("MLKEMPUBLICBLOB"); // BCRYPT_MLKEM_PUBLIC_BLOB
+
+            internal static CngKeyBlobFormat MLKemPrivateBlob =>
+                _mlKemPrivateBlob ??= new CngKeyBlobFormat("MLKEMPRIVATEBLOB"); // BCRYPT_MLKEM_PRIVATE_BLOB
+
+            internal static CngKeyBlobFormat MLKemPrivateSeedBlob =>
+                _mlKemPrivateSeedBlob ??= new CngKeyBlobFormat("MLKEMPRIVATESEEDBLOB"); // BCRYPT_MLKEM_PRIVATE_SEED_BLOB
+
             internal static CngKeyBlobFormat PQDsaPublicBlob =>
                 _pqDsaPublicBlob ??= new CngKeyBlobFormat("PQDSAPUBLICBLOB"); // BCRYPT_PQDSA_PUBLIC_BLOB
 

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/NetStandardShims.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/NetStandardShims.cs
@@ -24,9 +24,6 @@ namespace System.Security.Cryptography
 
         internal static unsafe int GetBytes(this Encoding encoding, string str, Span<byte> destination)
         {
-            if (str is null)
-                throw new ArgumentNullException(nameof(str));
-
             return GetBytes(encoding, str.AsSpan(), destination);
         }
 

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/NetStandardShims.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/NetStandardShims.cs
@@ -22,6 +22,14 @@ namespace System.Security.Cryptography
             }
         }
 
+        internal static unsafe int GetBytes(this Encoding encoding, string str, Span<byte> destination)
+        {
+            if (str is null)
+                throw new ArgumentNullException(nameof(str));
+
+            return GetBytes(encoding, str.AsSpan(), destination);
+        }
+
         internal static unsafe int GetBytes(this Encoding encoding, ReadOnlySpan<char> str, Span<byte> destination)
         {
             if (str.IsEmpty)

--- a/src/libraries/Microsoft.Bcl.Cryptography/tests/Microsoft.Bcl.Cryptography.Tests.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/tests/Microsoft.Bcl.Cryptography.Tests.csproj
@@ -136,10 +136,16 @@
              Link="CommonTest\System\Security\Cryptography\MLKemKeyTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\MLKemNotSupportedTests.cs"
              Link="CommonTest\System\Security\Cryptography\MLKemNotSupportedTests.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\MLKemCngTests.Windows.cs"
+             Link="CommonTest\System\Security\Cryptography\MLKemCngTests.Windows.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\MLKemCngTests.NotSupported.cs"
+             Link="CommonTest\System\Security\Cryptography\MLKemCngTests.NotSupported.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PbeParametersTests.cs"
              Link="CommonTest\System\Security\Cryptography\PbeParametersTests.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.cs"
              Link="Common\System\Security\Cryptography\PqcBlobHelpers.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.MLKem.cs"
+             Link="Common\System\Security\Cryptography\PqcBlobHelpers.MLKem.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\SP800108HmacCounterKdfTests.ArgValidation.cs"
              Link="CommonTest\System\Security\Cryptography\SP800108HmacCounterKdfTests.ArgValidation.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\SP800108HmacCounterKdfTests.Functional.cs"
@@ -213,6 +219,8 @@
              Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
     <Compile Include="$(LibrariesProjectRoot)\Microsoft.Bcl.Cryptography\src\System\Security\Cryptography\PemEncoding.cs"
              Link="System\Security\Cryptography\PemEncoding.cs" />
+    <Compile Include="$(LibrariesProjectRoot)\Microsoft.Bcl.Cryptography\src\System\Security\Cryptography\NetStandardShims.cs"
+             Link="System\Security\Cryptography\NetStandardShims.cs" />
     <Compile Include="PemEncodingTests.cs" />
     <Compile Include="PemEncodingFindTests.cs" />
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -323,6 +323,8 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.CngAlgorithm MD5 { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public static System.Security.Cryptography.CngAlgorithm MLDsa { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+        public static System.Security.Cryptography.CngAlgorithm MLKem { get { throw null; } }
         public static System.Security.Cryptography.CngAlgorithm Rsa { get { throw null; } }
         public static System.Security.Cryptography.CngAlgorithm Sha1 { get { throw null; } }
         public static System.Security.Cryptography.CngAlgorithm Sha256 { get { throw null; } }
@@ -345,6 +347,8 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.CngAlgorithmGroup ECDsa { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public static System.Security.Cryptography.CngAlgorithmGroup MLDsa { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+        public static System.Security.Cryptography.CngAlgorithmGroup MLKem { get { throw null; } }
         public static System.Security.Cryptography.CngAlgorithmGroup Rsa { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Security.Cryptography.CngAlgorithmGroup? other) { throw null; }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -424,6 +424,12 @@ namespace System.Security.Cryptography
         public string Format { get { throw null; } }
         public static System.Security.Cryptography.CngKeyBlobFormat GenericPrivateBlob { get { throw null; } }
         public static System.Security.Cryptography.CngKeyBlobFormat GenericPublicBlob { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+        public static System.Security.Cryptography.CngKeyBlobFormat MLKemPrivateBlob { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+        public static System.Security.Cryptography.CngKeyBlobFormat MLKemPrivateSeedBlob { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+        public static System.Security.Cryptography.CngKeyBlobFormat MLKemPublicBlob { get { throw null; } }
         public static System.Security.Cryptography.CngKeyBlobFormat OpaqueTransportBlob { get { throw null; } }
         public static System.Security.Cryptography.CngKeyBlobFormat Pkcs8PrivateBlob { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -1994,6 +1994,19 @@ namespace System.Security.Cryptography
         public override string ToString() { throw null; }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class MLKemCng : System.Security.Cryptography.MLKem
+    {
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
+        public MLKemCng(System.Security.Cryptography.CngKey key) : base (default(System.Security.Cryptography.MLKemAlgorithm)) { }
+        public System.Security.Cryptography.CngKey Key { get { throw null; } }
+        protected override void DecapsulateCore(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret) { }
+        protected override void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret) { }
+        protected override void ExportDecapsulationKeyCore(System.Span<byte> destination) { }
+        protected override void ExportEncapsulationKeyCore(System.Span<byte> destination) { }
+        protected override void ExportPrivateSeedCore(System.Span<byte> destination) { }
+        protected override bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
     public sealed partial class MLKemOpenSsl : System.Security.Cryptography.MLKem
     {
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("android")]

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -243,6 +243,9 @@
   <data name="Cryptography_ArgMLDsaRequiresMLDsaKey" xml:space="preserve">
     <value>Keys used with the MLDsaCng algorithm must have an algorithm group of MLDsa.</value>
   </data>
+  <data name="Cryptography_ArgMLKemRequiresMLKemKey" xml:space="preserve">
+    <value>Keys used with the MLKemCng algorithm must have an algorithm group of MLKem.</value>
+  </data>
   <data name="Cryptography_ArgRSARequiresRSAKey" xml:space="preserve">
     <value>Keys used with the RSACng algorithm must have an algorithm group of RSA.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -416,6 +416,8 @@
             Link="Common\System\Security\Cryptography\MLKem.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemAlgorithm.cs"
             Link="Common\System\Security\Cryptography\MLKemAlgorithm.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemCng.cs"
+             Link="Common\System\Security\Cryptography\MLKemCng.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemPkcs8.cs"
             Link="Common\System\Security\Cryptography\MLKemPkcs8.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.cs"
@@ -1784,6 +1786,8 @@
              Link="Common\Interop\Windows\NCrypt\Interop.Keys.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptBuffer.cs"
              Link="Common\Internal\Windows\NCrypt\Interop.NCryptBuffer.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptDecapsulateEncapsulate.cs"
+             Link="Common\Internal\Windows\NCrypt\Interop.NCryptDecapsulateEncapsulate.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptDeriveKeyMaterial.cs"
              Link="Common\Internal\Windows\NCrypt\Interop.NCryptDeriveKeyMaterial.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\NCrypt\Interop.NCryptDeriveSecretAgreement.cs"
@@ -1864,8 +1868,6 @@
              Link="Common\System\Security\Cryptography\MLDsaImplementation.CreateCng.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKem.Windows.cs"
              Link="Common\System\Security\Cryptography\MLKem.Windows.cs" />
-    <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemCng.cs"
-             Link="Common\System\Security\Cryptography\MLKemCng.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemCng.Windows.cs"
              Link="Common\System\Security\Cryptography\MLKemCng.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemImplementation.cs"

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -1862,6 +1862,12 @@
              Link="Common\System\Security\Cryptography\MLDsaImplementation.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.CreateCng.cs"
              Link="Common\System\Security\Cryptography\MLDsaImplementation.CreateCng.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLKem.Windows.cs"
+             Link="Common\System\Security\Cryptography\MLKem.Windows.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemCng.cs"
+             Link="Common\System\Security\Cryptography\MLKemCng.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemCng.Windows.cs"
+             Link="Common\System\Security\Cryptography\MLKemCng.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemImplementation.cs"
              Link="Common\System\Security\Cryptography\MLKemImplementation.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLKemImplementation.Windows.cs"

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
@@ -411,4 +411,50 @@ namespace System.Security.Cryptography
         protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) =>
             throw new PlatformNotSupportedException();
     }
+
+    public sealed partial class MLKemCng : MLKem
+    {
+        private static partial MLKemAlgorithm AlgorithmFromHandle(CngKey key, out CngKey duplicateKey)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
+        }
+
+        public partial CngKey Key
+        {
+            get
+            {
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
+            }
+        }
+
+        protected override void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
+        }
+
+        protected override void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
+        }
+
+        protected override void ExportPrivateSeedCore(Span<byte> destination)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
+        }
+
+        protected override void ExportDecapsulationKeyCore(Span<byte> destination)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
+        }
+
+        protected override void ExportEncapsulationKeyCore(Span<byte> destination)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
+        }
+
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
+        }
+    }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngAlgorithm.cs
@@ -201,6 +201,17 @@ namespace System.Security.Cryptography
         public static CngAlgorithm MLDsa =>
             field ??= new CngAlgorithm("ML-DSA"); // BCRYPT_MLDSA_ALGORITHM
 
+        /// <summary>
+        ///   Gets a new <see cref="CngAlgorithm"/> object that specifies the Module-Lattice-Based Key-Encapsulation
+        ///   Mechanism (ML-KEM).
+        /// </summary>
+        /// <value>
+        ///   A new <see cref="CngAlgorithm"/> object that specifies the Module-Lattice-Based Key-Encapsulation
+        ///   Mechanism (ML-KEM).
+        /// </value>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public static CngAlgorithm MLKem => field ??= new CngAlgorithm("ML-KEM"); // BCRYPT_MLKEM_ALGORITHM
+
         private static CngAlgorithm? s_ecdh;
         private static CngAlgorithm? s_ecdhp256;
         private static CngAlgorithm? s_ecdhp384;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngAlgorithmGroup.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngAlgorithmGroup.cs
@@ -130,6 +130,17 @@ namespace System.Security.Cryptography
         public static CngAlgorithmGroup MLDsa =>
             field ??= new CngAlgorithmGroup("MLDSA"); // NCRYPT_MLDSA_ALGORITHM_GROUP
 
+        /// <summary>
+        ///   Gets a <see cref="CngAlgorithmGroup" /> object that specifies the Module-Lattice-Based Key-Encapsulation
+        ///   Mechanism (ML-KEM) family of algorithms.
+        /// </summary>
+        /// <value>
+        ///   An object that specifies the ML-KEM family of algorithms.
+        /// </value>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public static CngAlgorithmGroup MLKem =>
+            field ??= new CngAlgorithmGroup("MLKEM"); // NCRYPT_MLKEM_ALGORITHM_GROUP
+
         private static CngAlgorithmGroup? s_dh;
         private static CngAlgorithmGroup? s_dsa;
         private static CngAlgorithmGroup? s_ecdh;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKeyBlobFormat.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKeyBlobFormat.cs
@@ -146,6 +146,48 @@ namespace System.Security.Cryptography
         public static CngKeyBlobFormat PQDsaPrivateSeedBlob =>
             field ??= new CngKeyBlobFormat("PQDSAPRIVATESEEDBLOB"); // BCRYPT_PQDSA_PRIVATE_SEED_BLOB
 
+        /// <summary>
+        ///   Gets a <see cref="CngKeyBlobFormat"/> object that specifies a Module-Lattice-Based Key-Encapsulation
+        ///   Mechanism (ML-KEM) public key BLOB.
+        /// </summary>
+        /// <value>
+        ///   A <see cref="CngKeyBlobFormat"/> object that specifies a Module-Lattice-Based Key-Encapsulation
+        ///   Mechanism (ML-KEM) public key BLOB.
+        /// </value>
+        /// <remarks>
+        ///   The value identified by this blob format is &quot;MLKEMPUBLICBLOB&quot;.
+        /// </remarks>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public static CngKeyBlobFormat MLKemPublicBlob => field ??= new CngKeyBlobFormat("MLKEMPUBLICBLOB");
+
+        /// <summary>
+        ///   Gets a <see cref="CngKeyBlobFormat"/> object that specifies a Module-Lattice-Based Key-Encapsulation
+        ///   Mechanism (ML-KEM) private key BLOB.
+        /// </summary>
+        /// <value>
+        ///   A <see cref="CngKeyBlobFormat"/> object that specifies a Module-Lattice-Based Key-Encapsulation
+        ///   Mechanism (ML-KEM) private key BLOB.
+        /// </value>
+        /// <remarks>
+        ///   The value identified by this blob format is &quot;MLKEMPRIVATEBLOB&quot;.
+        /// </remarks>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public static CngKeyBlobFormat MLKemPrivateBlob => field ??= new CngKeyBlobFormat("MLKEMPRIVATEBLOB");
+
+        /// <summary>
+        ///   Gets a <see cref="CngKeyBlobFormat"/> object that specifies a Module-Lattice-Based Key-Encapsulation
+        ///   Mechanism (ML-KEM) private seed BLOB.
+        /// </summary>
+        /// <value>
+        ///   A <see cref="CngKeyBlobFormat"/> object that specifies a Module-Lattice-Based Key-Encapsulation
+        ///   Mechanism (ML-KEM) private seed BLOB.
+        /// </value>
+        /// <remarks>
+        ///   The value identified by this blob format is &quot;MLKEMPRIVATESEEDBLOB&quot;.
+        /// </remarks>
+        [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+        public static CngKeyBlobFormat MLKemPrivateSeedBlob => field ??= new CngKeyBlobFormat("MLKEMPRIVATESEEDBLOB");
+
         public static CngKeyBlobFormat OpaqueTransportBlob
         {
             get

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -789,8 +789,12 @@
              Link="Common\Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaCngTests.Windows.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaCngTests.Windows.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\MLKemCngTests.Windows.cs"
+             Link="CommonTest\System\Security\Cryptography\MLKemCngTests.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.cs"
              Link="Common\System\Security\Cryptography\PqcBlobHelpers.cs" />
+<Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.MLKem.cs"
+             Link="Common\System\Security\Cryptography\PqcBlobHelpers.MLKem.cs" />
 
     <Compile Include="MLKemOpenSslTests.NotSupported.cs" />
     <Compile Include="SlhDsaOpenSslConstructionTests.NotSupported.cs" />

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -793,7 +793,7 @@
              Link="CommonTest\System\Security\Cryptography\MLKemCngTests.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.cs"
              Link="Common\System\Security\Cryptography\PqcBlobHelpers.cs" />
-<Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.MLKem.cs"
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PqcBlobHelpers.MLKem.cs"
              Link="Common\System\Security\Cryptography\PqcBlobHelpers.MLKem.cs" />
 
     <Compile Include="MLKemOpenSslTests.NotSupported.cs" />

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -473,6 +473,8 @@
              Link="CommonTest\System\Security\Cryptography\CngKeyWrapper.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs"
              Link="CommonTest\System\Security\Cryptography\CryptoUtils.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\MLKemCngTests.NotSupported.cs"
+             Link="CommonTest\System\Security\Cryptography\MLKemCngTests.NotSupported.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\OpenSslNamedKeys.Helpers.cs"
              Link="CommonTest\System\Security\Cryptography\OpenSslNamedKeys.Helpers.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"


### PR DESCRIPTION
This pull request adds primitive functionality for `MLKemCng` in System.Security.Cryptography and Microsoft.Bcl.Cryptography.

Only basic encapsulation, decapsulation, and key operations are supported. Windows' ML-KEM "ncrypt" functionality is incomplete.

* X.509 / PKCS#12 support for ML-KEM certificates is missing.
* `NCryptExportKey` cannot perform a PKCS#8 export of an ML-KEM key handle. This means that we cannot perform encrypted exports. So key export functionality is currently limited to plaintext-exportable CNG keys.

    The managed PKCS#8 encoder that is used for MLKemImplementation is used by MLKemCng, for now, since we are able to export the blobs. As Windows' implementation progresses 

Contributes to #116304 