### PR TITLE
Have forward sub search more than just the next statement

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6897,7 +6897,7 @@ private:
 
     PhaseStatus fgForwardSub();
     bool fgForwardSubBlock(BasicBlock* block);
-    bool fgForwardSubStatement(Statement* statement);
+    bool fgForwardSubStatement(Statement* stmt, Statement* lastStmt);
     bool fgForwardSubHasStoreInterference(Statement* defStmt, Statement* nextStmt, GenTree* nextStmtUse);
     void fgForwardSubUpdateLiveness(GenTree* newSubListFirst, GenTree* newSubListLast);
 

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -3035,7 +3035,7 @@ PhaseStatus Promotion::Run()
             if (replacer.MayHaveForwardSubOpportunity())
             {
                 JITDUMP("Invoking forward sub due to a potential opportunity\n");
-                while ((stmt != bb->firstStmt()) && m_compiler->fgForwardSubStatement(stmt->GetPrevStmt()))
+                while ((stmt != bb->firstStmt()) && m_compiler->fgForwardSubStatement(stmt->GetPrevStmt(), stmt))
                 {
                     m_compiler->fgRemoveStmt(bb, stmt->GetPrevStmt());
                 }


### PR DESCRIPTION
We get cases like the following semi-regularly when struct returns are involved. Effectively we have several inlined returns that all could be forward substituted, but where they end up blocking eachother just due to other inlined returns being in between.

To solve this issue, we instead search further than just the next statement in the basic block.

> [!NOTE]
> This is an early basic draft to get throughput and codegen numbers. It is likely that the current PR is too permissive and will need to be restricted to only look farther for simple trees (like constants) and/or to restrict the number of statements it looks forward to something reasonable (like 10-16 statements).

```
***** BB01 [0000]
STMT00008 ( INL01 @ 0x000[E-] ... ??? ) <- INLRT @ 0x000[E-]
               [000049] DA---------                         *  STORE_LCL_VAR simd16 V03 tmp2         
               [000047] -----------                         \--*  CNS_VEC   simd16<0x3f800000, 0x00000000, 0x00000000, 0x00000000>

***** BB01 [0000]
STMT00010 ( INL01 @ ??? ... ??? ) <- INLRT @ 0x000[E-]
               [000067] DA---------                         *  STORE_LCL_VAR simd16 V04 tmp3         
               [000065] -----------                         \--*  CNS_VEC   simd16<0x00000000, 0x3f800000, 0x00000000, 0x00000000>

***** BB01 [0000]
STMT00012 ( INL01 @ ??? ... ??? ) <- INLRT @ 0x000[E-]
               [000085] DA---------                         *  STORE_LCL_VAR simd16 V05 tmp4         
               [000083] -----------                         \--*  CNS_VEC   simd16<0x00000000, 0x00000000, 0x3f800000, 0x00000000>

***** BB01 [0000]
STMT00013 ( INL01 @ ??? ... ??? ) <- INLRT @ 0x000[E-]
               [000103] DA---------                         *  STORE_LCL_VAR simd16 V06 tmp5         
               [000101] -----------                         \--*  CNS_VEC   simd16<0x00000000, 0x00000000, 0x00000000, 0x3f800000>

***** BB01 [0000]
STMT00019 ( INL10 @ 0x000[E-] ... ??? ) <- INL01 @ ??? <- INLRT @ 0x000[E-]
               [000106] -----------                         *  NOP       void  

***** BB01 [0000]
STMT00025 ( INL11 @ 0x000[E-] ... ??? ) <- INL10 @ 0x007[E-] <- INL01 @ ??? <- INLRT @ 0x000[E-]
               [000123] UA---------                         *  STORE_LCL_FLD simd16 V07 tmp6         [+0]
               [000018] -----------                         \--*  LCL_VAR   simd16 V03 tmp2          (last use)

***** BB01 [0000]
STMT00027 ( INL13 @ 0x000[E-] ... ??? ) <- INL10 @ 0x00F[E-] <- INL01 @ ??? <- INLRT @ 0x000[E-]
               [000131] UA---------                         *  STORE_LCL_FLD simd16 V07 tmp6         [+16]
               [000023] -----------                         \--*  LCL_VAR   simd16 V04 tmp3          (last use)

***** BB01 [0000]
STMT00029 ( INL15 @ 0x000[E-] ... ??? ) <- INL10 @ 0x017[E-] <- INL01 @ ??? <- INLRT @ 0x000[E-]
               [000139] UA---------                         *  STORE_LCL_FLD simd16 V07 tmp6         [+32]
               [000028] -----------                         \--*  LCL_VAR   simd16 V05 tmp4          (last use)

***** BB01 [0000]
STMT00031 ( INL17 @ 0x000[E-] ... ??? ) <- INL10 @ 0x01F[E-] <- INL01 @ ??? <- INLRT @ 0x000[E-]
               [000147] UA---------                         *  STORE_LCL_FLD simd16 V07 tmp6         [+48]
               [000033] -----------                         \--*  LCL_VAR   simd16 V06 tmp5          (last use)
```