### PR TITLE
Fix diagnostic for calls on marshalled delegates

### DIFF
--- a/src/coreclr/vm/amd64/UMThunkStub.asm
+++ b/src/coreclr/vm/amd64/UMThunkStub.asm
@@ -8,7 +8,7 @@ extern TheUMEntryPrestubWorker:proc
 extern UMEntryPrestubUnwindFrameChainHandler:proc
 
 ;
-; METHODDESC_REGISTER: UMEntryThunk*
+; METHODDESC_REGISTER: UMEntryThunkData*
 ;
 NESTED_ENTRY TheUMEntryPrestub, _TEXT, UMEntryPrestubUnwindFrameChainHandler
 

--- a/src/coreclr/vm/amd64/umthunkstub.S
+++ b/src/coreclr/vm/amd64/umthunkstub.S
@@ -6,7 +6,7 @@
 #include "asmconstants.h"
 
 //
-// METHODDESC_REGISTER: UMEntryThunk*
+// METHODDESC_REGISTER: UMEntryThunkData*
 //
 NESTED_ENTRY TheUMEntryPrestub, _TEXT, UnhandledExceptionHandlerUnix
     PUSH_ARGUMENT_REGISTERS

--- a/src/coreclr/vm/arm/asmhelpers.S
+++ b/src/coreclr/vm/arm/asmhelpers.S
@@ -136,7 +136,7 @@ CallDescrWorkerInternalReturnAddressOffset:
 // ------------------------------------------------------------------
 
 //
-// r12 = UMEntryThunk*
+// r12 = UMEntryThunkData*
 //
         NESTED_ENTRY TheUMEntryPrestub,_TEXT,NoHandler
 

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -95,7 +95,7 @@ LEAF_ENTRY  JIT_WriteBarrier_Callable, _TEXT
 LEAF_END JIT_WriteBarrier_Callable, _TEXT
 
 //
-// x12 = UMEntryThunk*
+// x12 = UMEntryThunkData*
 //
 NESTED_ENTRY TheUMEntryPrestub, _TEXT, UnhandledExceptionHandlerUnix
 

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -429,7 +429,7 @@ COMToCLRDispatchHelper_RegSetup
 #endif ; FEATURE_COMINTEROP
 
 ;
-; x12 = UMEntryThunk*
+; x12 = UMEntryThunkData*
 ;
     NESTED_ENTRY TheUMEntryPrestub,,UMEntryPrestubUnwindFrameChainHandler
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3388,14 +3388,14 @@ void Module::FixupVTables()
                     LOG((LF_INTEROP, LL_INFO10, "[0x%p] <-- VTable  thunk for \"%s\" (pMD = 0x%p)\n",
                         (UINT_PTR)&(pPointers[iMethod]), pMD->m_pszDebugMethodName, pMD));
 
-                    UMEntryThunk *pUMEntryThunk = UMEntryThunk::CreateUMEntryThunk();
+                    UMEntryThunkData *pUMEntryThunkData = UMEntryThunkData::CreateUMEntryThunk();
 
                     UMThunkMarshInfo *pUMThunkMarshInfo = (UMThunkMarshInfo*)(void*)(SystemDomain::GetGlobalLoaderAllocator()->GetLowFrequencyHeap()->AllocAlignedMem(sizeof(UMThunkMarshInfo), CODE_SIZE_ALIGN));
 
                     pUMThunkMarshInfo->LoadTimeInit(pMD);
-                    pUMEntryThunk->LoadTimeInit((PCODE)0, NULL, pUMThunkMarshInfo, pMD);
+                    pUMEntryThunkData->LoadTimeInit((PCODE)0, NULL, pUMThunkMarshInfo, pMD);
 
-                    SetTargetForVTableEntry(hInstThis, (BYTE **)&pPointers[iMethod], (BYTE *)pUMEntryThunk->GetCode());
+                    SetTargetForVTableEntry(hInstThis, (BYTE **)&pPointers[iMethod], (BYTE *)pUMEntryThunkData->GetCode());
 
                     pData->MarkMethodFixedUp(iFixup, iMethod);
                 }

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -372,12 +372,6 @@ struct VASigCookieBlock
     VASigCookie          m_cookies[kVASigCookieBlockSize];
 };
 
-//
-// A Module is the primary unit of code packaging in the runtime.  It
-// corresponds mostly to an OS executable image, although other kinds
-// of modules exist.
-//
-class UMEntryThunk;
 
 // Hashtable of absolute addresses of IL blobs for dynamics, keyed by token
 

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -1328,12 +1328,12 @@ LPVOID COMDelegate::ConvertToCallback(OBJECTREF pDelegateObj)
     }
     else
     {
-        UMEntryThunk*   pUMEntryThunk   = NULL;
-        SyncBlock*      pSyncBlock      = pDelegate->GetSyncBlock();
+        UMEntryThunkData*   pUMEntryThunk   = NULL;
+        SyncBlock*          pSyncBlock      = pDelegate->GetSyncBlock();
 
         InteropSyncBlockInfo* pInteropInfo = pSyncBlock->GetInteropInfo();
 
-        pUMEntryThunk = (UMEntryThunk*)pInteropInfo->GetUMEntryThunk();
+        pUMEntryThunk = pInteropInfo->GetUMEntryThunk();
 
         if (!pUMEntryThunk)
         {
@@ -1360,8 +1360,8 @@ LPVOID COMDelegate::ConvertToCallback(OBJECTREF pDelegateObj)
             _ASSERTE(pUMThunkMarshInfo != NULL);
             _ASSERTE(pUMThunkMarshInfo == pClass->m_pUMThunkMarshInfo);
 
-            pUMEntryThunk = UMEntryThunk::CreateUMEntryThunk();
-            Holder<UMEntryThunk *, DoNothing, UMEntryThunk::FreeUMEntryThunk> umHolder;
+            pUMEntryThunk = UMEntryThunkData::CreateUMEntryThunk();
+            Holder<UMEntryThunkData *, DoNothing, UMEntryThunkData::FreeUMEntryThunk> umHolder;
             umHolder.Assign(pUMEntryThunk);
 
             // multicast. go thru Invoke
@@ -1379,7 +1379,7 @@ LPVOID COMDelegate::ConvertToCallback(OBJECTREF pDelegateObj)
 
             if (!pInteropInfo->SetUMEntryThunk(pUMEntryThunk))
             {
-                pUMEntryThunk = (UMEntryThunk*)pInteropInfo->GetUMEntryThunk();
+                pUMEntryThunk = pInteropInfo->GetUMEntryThunk();
             }
             else
             {
@@ -1387,7 +1387,7 @@ LPVOID COMDelegate::ConvertToCallback(OBJECTREF pDelegateObj)
             }
 
             _ASSERTE(pUMEntryThunk != NULL);
-            _ASSERTE(pUMEntryThunk == (UMEntryThunk*)pInteropInfo->GetUMEntryThunk());
+            _ASSERTE(pUMEntryThunk == pInteropInfo->GetUMEntryThunk());
 
         }
         pCode = (PCODE)pUMEntryThunk->GetCode();
@@ -1432,7 +1432,7 @@ OBJECTREF COMDelegate::ConvertToDelegate(LPVOID pCallback, MethodTable* pMT)
     // Otherwise, we'll treat this as an unmanaged callsite.
     // Make sure that the pointer doesn't have the value of 1 which is our hash table deleted item marker.
     OBJECTHANDLE DelegateHnd = (pUMEntryThunk != NULL)
-        ? pUMEntryThunk->GetObjectHandle()
+        ? pUMEntryThunk->GetData()->GetObjectHandle()
         : (OBJECTHANDLE)NULL;
 
     if (DelegateHnd != (OBJECTHANDLE)NULL)

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -755,7 +755,7 @@ HRESULT CorHost2::CreateDelegate(
         }
         else
         {
-            UMEntryThunk* pUMEntryThunk = pMD->GetLoaderAllocator()->GetUMEntryThunkCache()->GetUMEntryThunk(pMD);
+            UMEntryThunkData* pUMEntryThunk = pMD->GetLoaderAllocator()->GetUMEntryThunkCache()->GetUMEntryThunk(pMD);
             *fnPtr = (INT_PTR)pUMEntryThunk->GetCode();
         }
     }

--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -267,7 +267,7 @@ UMEntryThunkData* UMEntryThunkData::CreateUMEntryThunk()
         pData = (UMEntryThunkData *)pamTracker->Track(pLoaderAllocator->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(UMEntryThunkData))));
         UMEntryThunk* pThunk = (UMEntryThunk*)pamTracker->Track(pLoaderAllocator->GetNewStubPrecodeHeap()->AllocStub());
 #ifdef FEATURE_PERFMAP
-        PerfMap::LogStubs(__FUNCTION__, "UMEntryThunk", (PCODE)p, sizeof(UMEntryThunk), PerfMapStubType::IndividualWithinBlock);
+        PerfMap::LogStubs(__FUNCTION__, "UMEntryThunk", (PCODE)pThunk, sizeof(UMEntryThunk), PerfMapStubType::IndividualWithinBlock);
 #endif
         pData->m_pUMEntryThunk = pThunk;
         pThunk->Init(pThunk, dac_cast<TADDR>(pData), NULL, dac_cast<TADDR>(PRECODE_UMENTRY_THUNK));

--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -227,7 +227,7 @@ PCODE TheUMEntryPrestubWorker(UMEntryThunkData * pUMEntryThunkData)
         ReversePInvokeBadTransition();
 
     if (pUMEntryThunkData->IsCollectedDelegate())
-        CallbackOnCollectedDelegate(pUMEntryThunkData)
+        CallbackOnCollectedDelegate(pUMEntryThunkData);
 
     INSTALL_MANAGED_EXCEPTION_DISPATCHER;
     // this method is called by stubs which are called by managed code,

--- a/src/coreclr/vm/dllimportcallback.h
+++ b/src/coreclr/vm/dllimportcallback.h
@@ -154,6 +154,7 @@ class UMEntryThunkData
 
     // Object handle holding "this" reference. May be a strong or weak handle.
     // Field is NULL for a static method.
+    // Field is (OBJECHANDLE)-1 for collected delegates
     OBJECTHANDLE            m_pObjectHandle;
 
     union
@@ -290,6 +291,13 @@ public:
         RETURN m_pObjectHandle;
     }
 
+    bool IsCollectedDelegate() const
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_pObjectHandle == (OBJECTHANDLE)-1;
+    }
+
     UMThunkMarshInfo* GetUMThunkMarshInfo() const
     {
         CONTRACT (UMThunkMarshInfo*)
@@ -335,8 +343,6 @@ public:
 
         RETURN m_pMD;
     }
-
-    static VOID __fastcall ReportViolation(UMEntryThunkData* pEntryThunkData);
 };
 
 // Cache to hold UMEntryThunk/UMThunkMarshInfo instances associated with MethodDescs.

--- a/src/coreclr/vm/dllimportcallback.h
+++ b/src/coreclr/vm/dllimportcallback.h
@@ -113,38 +113,7 @@ private:
     Signature         m_sig;
 };
 
-struct UMEntryThunkData
-{
-    friend class NDirectStubLinker;
-
-    // The start of the managed code.
-    // if m_pObjectHandle is non-NULL, this field is still set to help with diagnostic of call on collected delegate crashes
-    // but it may not have the correct value.
-    PCODE                   m_pManagedTarget;
-
-    // This is used for profiling.
-    PTR_MethodDesc          m_pMD;
-
-    // Object handle holding "this" reference. May be a strong or weak handle.
-    // Field is NULL for a static method.
-    OBJECTHANDLE            m_pObjectHandle;
-
-    union
-    {
-        // Pointer to the shared structure containing everything else
-        PTR_UMThunkMarshInfo    m_pUMThunkMarshInfo;
-        // Pointer to the next UMEntryThunk in the free list. Used when it is freed.
-        UMEntryThunk *m_pNextFreeThunk;
-    };
-
-    PTR_UMEntryThunk m_pUMEntryThunk;
-
-#ifdef _DEBUG
-    DWORD                   m_state;        // the initialization state
-#endif
-};
-
-typedef DPTR(struct UMEntryThunkData) PTR_UMEntryThunkData;
+typedef DPTR(class UMEntryThunkData) PTR_UMEntryThunkData;
 
 //----------------------------------------------------------------------
 // This structure contains the minimal information required to
@@ -157,30 +126,59 @@ typedef DPTR(struct UMEntryThunkData) PTR_UMEntryThunkData;
 //----------------------------------------------------------------------
 class UMEntryThunk : private StubPrecode
 {
-    friend class UMEntryThunkFreeList;
+    friend class UMEntryThunkData;
 
-private:
-#ifdef _DEBUG
-    enum
-    {
-        kLoadTimeInited = 0x4c554554,   //'LUET'
-        kRunTimeInited  = 0x52554554,   //'RUET'
-    };
-#endif
+    static const int Type = PRECODE_UMENTRY_THUNK;
 
+public:
     PTR_UMEntryThunkData GetData() const
     {
         LIMITED_METHOD_CONTRACT;
         
         return dac_cast<PTR_UMEntryThunkData>(GetSecretParam());
     }
+};
+
+class UMEntryThunkData
+{
+    friend class UMEntryThunkFreeList;
+    friend class NDirectStubLinker;
+
+    // The start of the managed code.
+    // if m_pObjectHandle is non-NULL, this field is still set to help with diagnostic of call on collected delegate crashes
+    // but it may not have the correct value.
+    PCODE                   m_pManagedTarget;
+
+    // This is used for debugging and profiling.
+    PTR_MethodDesc          m_pMD;
+
+    // Object handle holding "this" reference. May be a strong or weak handle.
+    // Field is NULL for a static method.
+    OBJECTHANDLE            m_pObjectHandle;
+
+    union
+    {
+        // Pointer to the shared structure containing everything else
+        PTR_UMThunkMarshInfo    m_pUMThunkMarshInfo;
+        // Pointer to the next UMEntryThunk in the free list. Used when it is freed.
+        UMEntryThunkData *m_pNextFreeThunk;
+    };
+
+    PTR_UMEntryThunk m_pUMEntryThunk;
+
+#ifdef _DEBUG
+    enum
+    {
+        kLoadTimeInited = 0x4c554554,   //'LUET'
+        kRunTimeInited  = 0x52554554,   //'RUET'
+    };
+
+    DWORD                   m_state;        // the initialization state
+#endif
 
 public:
-
-    static const int Type = PRECODE_UMENTRY_THUNK;
-
-    static UMEntryThunk* CreateUMEntryThunk();
-    static VOID FreeUMEntryThunk(UMEntryThunk* p);
+    static UMEntryThunkData* CreateUMEntryThunk();
+    static VOID FreeUMEntryThunk(UMEntryThunkData* p);
 
 #ifndef DACCESS_COMPILE
     VOID LoadTimeInit(PCODE                   pManagedTarget,
@@ -198,17 +196,16 @@ public:
         }
         CONTRACTL_END;
 
-        PTR_UMEntryThunkData data = GetData();
-        data->m_pManagedTarget = pManagedTarget;
-        data->m_pObjectHandle     = pObjectHandle;
-        data->m_pUMThunkMarshInfo = pUMThunkMarshInfo;
+        m_pManagedTarget = pManagedTarget;
+        m_pObjectHandle     = pObjectHandle;
+        m_pUMThunkMarshInfo = pUMThunkMarshInfo;
 
-        data->m_pMD = pMD;    // For debugging and profiling, so they can identify the target
+        m_pMD = pMD;
 
-        SetTargetUnconditional(TheUMThunkPreStub());
+        m_pUMEntryThunk->SetTargetUnconditional(TheUMThunkPreStub());
 
 #ifdef _DEBUG
-        data->m_state = kLoadTimeInited;
+        m_state = kLoadTimeInited;
 #endif
     }
 
@@ -218,20 +215,19 @@ public:
     {
         STANDARD_VM_CONTRACT;
 
-        PTR_UMEntryThunkData data = GetData();
         // Ensure method's module is activate in app domain
-        data->m_pMD->EnsureActive();
+        m_pMD->EnsureActive();
 
-        data->m_pUMThunkMarshInfo->RunTimeInit();
+        m_pUMThunkMarshInfo->RunTimeInit();
 
         // Ensure that we have either the managed target or the delegate.
-        if (data->m_pObjectHandle == NULL && data->m_pManagedTarget == (TADDR)0)
-            data->m_pManagedTarget = data->m_pMD->GetMultiCallableAddrOfCode();
+        if (m_pObjectHandle == NULL && m_pManagedTarget == (TADDR)0)
+            m_pManagedTarget = m_pMD->GetMultiCallableAddrOfCode();
 
-        SetTargetUnconditional(data->m_pUMThunkMarshInfo->GetExecStubEntryPoint());
+        m_pUMEntryThunk->SetTargetUnconditional(m_pUMThunkMarshInfo->GetExecStubEntryPoint());
 
 #ifdef _DEBUG
-        data->m_state = kRunTimeInited;
+        m_state = kRunTimeInited;
 #endif // _DEBUG
     }
 
@@ -242,7 +238,7 @@ public:
             THROWS;
             GC_TRIGGERS;
             MODE_ANY;
-            PRECONDITION(GetData()->m_state == kRunTimeInited || GetData()->m_state == kLoadTimeInited);
+            PRECONDITION(m_state == kRunTimeInited || m_state == kLoadTimeInited);
             POSTCONDITION(RETVAL != NULL);
         }
         CONTRACT_END;
@@ -254,7 +250,7 @@ public:
 
             DELEGATEREF orDelegate = (DELEGATEREF)ObjectFromHandle(hndDelegate);
             _ASSERTE(orDelegate != NULL);
-            _ASSERTE(GetData()->m_pMD->IsEEImpl());
+            _ASSERTE(m_pMD->IsEEImpl());
 
             // We have optimizations that skip the Invoke method and call directly the
             // delegate's target method. We need to return the target in that case,
@@ -263,14 +259,13 @@ public:
         }
         else
         {
-            PTR_UMEntryThunkData data = GetData();
-            if (data->m_pManagedTarget != (TADDR)0)
+            if (m_pManagedTarget != (TADDR)0)
             {
-                RETURN data->m_pManagedTarget;
+                RETURN m_pManagedTarget;
             }
             else
             {
-                RETURN data->m_pMD->GetMultiCallableAddrOfCode();
+                RETURN m_pMD->GetMultiCallableAddrOfCode();
             }
         }
     }
@@ -286,13 +281,13 @@ public:
             // If we OOM after we create the holder but
             // before we set the m_state we can have
             // m_state == 0 and m_pObjectHandle == NULL
-            PRECONDITION(GetData()->m_state == kRunTimeInited  ||
-                         GetData()->m_state == kLoadTimeInited ||
-                         GetData()->m_pObjectHandle == NULL);
+            PRECONDITION(m_state == kRunTimeInited  ||
+                         m_state == kLoadTimeInited ||
+                         m_pObjectHandle == NULL);
         }
         CONTRACT_END;
 
-        RETURN GetData()->m_pObjectHandle;
+        RETURN m_pObjectHandle;
     }
 
     UMThunkMarshInfo* GetUMThunkMarshInfo() const
@@ -303,14 +298,13 @@ public:
             GC_NOTRIGGER;
             MODE_ANY;
             SUPPORTS_DAC;
-            PRECONDITION(GetData()->m_state == kRunTimeInited || GetData()->m_state == kLoadTimeInited);
+            PRECONDITION(m_state == kRunTimeInited || m_state == kLoadTimeInited);
             POSTCONDITION(CheckPointer(RETVAL));
         }
         CONTRACT_END;
 
-        RETURN GetData()->m_pUMThunkMarshInfo;
+        RETURN m_pUMThunkMarshInfo;
     }
-
 
     PCODE GetCode() const
     {
@@ -319,12 +313,12 @@ public:
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
-            PRECONDITION(GetData()->m_state == kRunTimeInited || GetData()->m_state == kLoadTimeInited);
+            PRECONDITION(m_state == kRunTimeInited || m_state == kLoadTimeInited);
             POSTCONDITION(CheckPointer(dac_cast<BYTE*>(RETVAL), NULL_OK));
         }
         CONTRACT_END;
 
-        RETURN PINSTRToPCODE(dac_cast<TADDR>(this));
+        RETURN PINSTRToPCODE(dac_cast<TADDR>(m_pUMEntryThunk));
     }
 
     MethodDesc* GetMethod() const
@@ -334,12 +328,12 @@ public:
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
-            PRECONDITION(GetData()->m_state == kRunTimeInited || GetData()->m_state == kLoadTimeInited);
+            PRECONDITION(m_state == kRunTimeInited || m_state == kLoadTimeInited);
             POSTCONDITION(CheckPointer(RETVAL,NULL_OK));
         }
         CONTRACT_END;
 
-        RETURN GetData()->m_pMD;
+        RETURN m_pMD;
     }
 
     static VOID __fastcall ReportViolation(UMEntryThunkData* pEntryThunkData);
@@ -353,31 +347,16 @@ public:
     UMEntryThunkCache(AppDomain *pDomain);
     ~UMEntryThunkCache();
 
-    UMEntryThunk *GetUMEntryThunk(MethodDesc *pMD);
+    UMEntryThunkData *GetUMEntryThunk(MethodDesc *pMD);
 
 private:
-    struct CacheElement
-    {
-        CacheElement()
-        {
-            LIMITED_METHOD_CONTRACT;
-            m_pMD = NULL;
-            m_pThunk = NULL;
-        }
-
-        MethodDesc   *m_pMD;
-        UMEntryThunk *m_pThunk;
-    };
-
-    class ThunkSHashTraits : public NoRemoveSHashTraits< DefaultSHashTraits<CacheElement> >
+    class ThunkSHashTraits : public NoRemoveSHashTraits< DefaultSHashTraits<UMEntryThunkData *> >
     {
     public:
         typedef MethodDesc *key_t;
-        static key_t GetKey(element_t e)       { LIMITED_METHOD_CONTRACT; return e.m_pMD; }
+        static key_t GetKey(element_t e)       { LIMITED_METHOD_CONTRACT; return e->GetMethod(); }
         static BOOL Equals(key_t k1, key_t k2) { LIMITED_METHOD_CONTRACT; return (k1 == k2); }
         static count_t Hash(key_t k)           { LIMITED_METHOD_CONTRACT; return (count_t)(size_t)k; }
-        static const element_t Null()          { LIMITED_METHOD_CONTRACT; return CacheElement(); }
-        static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return (e.m_pMD == NULL); }
     };
 
     static void DestroyMarshInfo(UMThunkMarshInfo *pMarshInfo)
@@ -397,9 +376,5 @@ EXCEPTION_HANDLER_DECL(FastNExportExceptHandler);
 
 extern "C" void TheUMEntryPrestub(void);
 extern "C" PCODE TheUMEntryPrestubWorker(UMEntryThunkData * pUMEntryThunk);
-
-#ifdef _DEBUG
-void STDCALL LogUMTransition(UMEntryThunk* thunk);
-#endif
 
 #endif //__dllimportcallback_h__

--- a/src/coreclr/vm/i386/umthunkstub.S
+++ b/src/coreclr/vm/i386/umthunkstub.S
@@ -6,7 +6,7 @@
 #include "asmconstants.h"
 
 //
-// eax = UMEntryThunk*
+// eax = UMEntryThunkData*
 //
 NESTED_ENTRY TheUMEntryPrestub, _TEXT, UnhandledExceptionHandlerUnix
 #define STK_ALIGN_PADDING 8

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -2303,7 +2303,7 @@ EXCEPTION_HANDLER_DECL(FastNExportExceptHandler);
 #endif
 
 // This is a slower version of the reverse PInvoke enter function.
-NOINLINE static void JIT_ReversePInvokeEnterRare(ReversePInvokeFrame* frame, void* returnAddr, UMEntryThunk* pThunk = NULL)
+NOINLINE static void JIT_ReversePInvokeEnterRare(ReversePInvokeFrame* frame, void* returnAddr, UMEntryThunkData* pUMEntryThunkData = NULL)
 {
     _ASSERTE(frame != NULL);
 
@@ -2332,11 +2332,11 @@ NOINLINE static void JIT_ReversePInvokeEnterRare(ReversePInvokeFrame* frame, voi
     // Increment/DecrementTraceCallCount() will bump
     // g_TrapReturningThreads for us.
     if (CORDebuggerTraceCall())
-        g_pDebugInterface->TraceCall(pThunk ? (const BYTE*)pThunk->GetManagedTarget() : (const BYTE*)returnAddr);
+        g_pDebugInterface->TraceCall(pUMEntryThunkData ? (const BYTE*)pUMEntryThunkData->GetManagedTarget() : (const BYTE*)returnAddr);
 #endif // DEBUGGING_SUPPORTED
 }
 
-NOINLINE static void JIT_ReversePInvokeEnterRare2(ReversePInvokeFrame* frame, void* returnAddr, UMEntryThunk* pThunk = NULL)
+NOINLINE static void JIT_ReversePInvokeEnterRare2(ReversePInvokeFrame* frame, void* returnAddr, UMEntryThunkData* pUMEntryThunkData = NULL)
 {
     frame->currentThread->RareDisablePreemptiveGC();
 #ifdef DEBUGGING_SUPPORTED
@@ -2346,7 +2346,7 @@ NOINLINE static void JIT_ReversePInvokeEnterRare2(ReversePInvokeFrame* frame, vo
     // Increment/DecrementTraceCallCount() will bump
     // g_TrapReturningThreads for us.
     if (CORDebuggerTraceCall())
-        g_pDebugInterface->TraceCall(pThunk ? (const BYTE*)pThunk->GetManagedTarget() : (const BYTE*)returnAddr);
+        g_pDebugInterface->TraceCall(pUMEntryThunkData ? (const BYTE*)pUMEntryThunkData->GetManagedTarget() : (const BYTE*)returnAddr);
 #endif // DEBUGGING_SUPPORTED
 }
 
@@ -2355,16 +2355,14 @@ NOINLINE static void JIT_ReversePInvokeEnterRare2(ReversePInvokeFrame* frame, vo
 // We may not have a managed thread set up in JIT_ReversePInvokeEnter, and the GC mode may be incorrect.
 // On x86, SEH handlers are set up and torn down explicitly, so we avoid using dynamic contracts.
 // This method uses the correct calling convention and argument layout manually, without relying on standard macros or contracts.
-HCIMPL3_RAW(void, JIT_ReversePInvokeEnterTrackTransitions, ReversePInvokeFrame* frame, MethodDesc* pMD, void* secretArg)
+HCIMPL3_RAW(void, JIT_ReversePInvokeEnterTrackTransitions, ReversePInvokeFrame* frame, MethodDesc* pMD, UMEntryThunkData* pUMEntryThunkData)
 {
     _ASSERTE(frame != NULL && pMD != NULL);
-    _ASSERTE(!pMD->IsILStub() || secretArg != NULL);
+    _ASSERTE(!pMD->IsILStub() || pUMEntryThunkData != NULL);
 
-    UMEntryThunk* pEntryThunk = NULL;
-    if (secretArg != NULL)
+    if (pUMEntryThunkData != NULL)
     {
-        pEntryThunk = ((UMEntryThunkData*)secretArg)->m_pUMEntryThunk;
-        pMD = ((UMEntryThunkData*)secretArg)->m_pMD;
+        pMD = pUMEntryThunkData->GetMethod();
     }
     frame->pMD = pMD;
 
@@ -2390,14 +2388,14 @@ HCIMPL3_RAW(void, JIT_ReversePInvokeEnterTrackTransitions, ReversePInvokeFrame* 
         {
             // If we're in an IL stub, we want to trace the address of the target method,
             // not the next instruction in the stub.
-            JIT_ReversePInvokeEnterRare2(frame, _ReturnAddress(), pEntryThunk);
+            JIT_ReversePInvokeEnterRare2(frame, _ReturnAddress(), pUMEntryThunkData);
         }
     }
     else
     {
         // If we're in an IL stub, we want to trace the address of the target method,
         // not the next instruction in the stub.
-        JIT_ReversePInvokeEnterRare(frame, _ReturnAddress(), pEntryThunk);
+        JIT_ReversePInvokeEnterRare(frame, _ReturnAddress(), pUMEntryThunkData);
     }
 
 #if defined(TARGET_X86) && defined(TARGET_WINDOWS)

--- a/src/coreclr/vm/loongarch64/asmhelpers.S
+++ b/src/coreclr/vm/loongarch64/asmhelpers.S
@@ -469,7 +469,7 @@ NESTED_END StubDispatchFixupStub, _TEXT
 #endif
 
 //
-// $t2 = UMEntryThunk*
+// $t2 = UMEntryThunkData*
 //
 NESTED_ENTRY TheUMEntryPrestub, _TEXT, UnhandledExceptionHandlerUnix
 
@@ -631,11 +631,6 @@ NESTED_END ResolveWorkerChainLookupAsmStub, _TEXT
 //     |f13  |
 //     |f12  |
 //
-//#define UMThunkStub_Offset_t9    0x50
-#define UMThunkStub_Offset_Entry 0x58   // offset of saved UMEntryThunk *
-#define UMThunkStub_Offset_s0    0x60
-#define UMThunkStub_StackArgs    0x70   // Frame size.
-
 
 // ------------------------------------------------------------------
 // void ResolveWorkerAsmStub(args in regs $a0-$a7 & stack, t8:IndirectionCellAndFlags, $t2:DispatchToken)

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -1739,8 +1739,8 @@ BOOL ILStubManager::TraceManager(Thread *thread,
     {
         if (pStubMD->IsStatic())
         {
-            // This is reverse P/Invoke stub, the argument is UMEntryThunk
-            UMEntryThunk *pEntryThunk = (UMEntryThunk *)arg;
+            // This is reverse P/Invoke stub, the argument is UMEntryThunkData
+            UMEntryThunkData *pEntryThunk = (UMEntryThunkData*)arg;
             target = pEntryThunk->GetManagedTarget();
             LOG((LF_CORDB, LL_INFO10000, "ILSM::TraceManager: Reverse P/Invoke case 0x%p\n", target));
         }

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -78,15 +78,12 @@ void InteropSyncBlockInfo::FreeUMEntryThunk()
     }
     CONTRACTL_END
 
-    if (!g_fEEShutDown)
+    UMEntryThunkData *pUMEntryThunk = m_pUMEntryThunk;
+    if (pUMEntryThunk != NULL)
     {
-        void *pUMEntryThunk = GetUMEntryThunk();
-        if (pUMEntryThunk != NULL)
-        {
-            UMEntryThunk::FreeUMEntryThunk((UMEntryThunk *)pUMEntryThunk);
-        }
+        UMEntryThunkData::FreeUMEntryThunk(pUMEntryThunk);
+        m_pUMEntryThunk = NULL;
     }
-    m_pUMEntryThunk = NULL;
 }
 
 #ifdef FEATURE_COMINTEROP

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -602,6 +602,7 @@ public:
     }
 };
 
+class UMEntryThunkData;
 #ifdef FEATURE_COMINTEROP
 class ComCallWrapper;
 class ComClassFactory;
@@ -734,7 +735,7 @@ public:
 
 #if !defined(DACCESS_COMPILE)
     // set m_pUMEntryThunk if not already set - return true if not already set
-    bool SetUMEntryThunk(void* pUMEntryThunk)
+    bool SetUMEntryThunk(UMEntryThunkData* pUMEntryThunk)
     {
         WRAPPER_NO_CONTRACT;
         return (InterlockedCompareExchangeT(&m_pUMEntryThunk,
@@ -746,7 +747,7 @@ public:
 
 #endif // DACCESS_COMPILE
 
-    void* GetUMEntryThunk()
+    UMEntryThunkData* GetUMEntryThunk()
     {
         LIMITED_METHOD_CONTRACT;
         return m_pUMEntryThunk;
@@ -755,7 +756,7 @@ public:
 private:
     // If this is a delegate marshalled out to unmanaged code, this points
     // to the thunk generated for unmanaged code to call back on.
-    void*               m_pUMEntryThunk;
+    UMEntryThunkData*   m_pUMEntryThunk;
 
 #ifdef FEATURE_COMINTEROP
     // If this object is being exposed to COM, it will have an associated CCW object

--- a/src/tests/baseservices/exceptions/unhandled/collecteddelegate.cs
+++ b/src/tests/baseservices/exceptions/unhandled/collecteddelegate.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+unsafe
+{
+    IntPtr p = CreateCollectedDelegate("Hello");
+    GC.Collect();
+    GC.WaitForPendingFinalizers();
+    ((delegate* unmanaged<void>)p)();
+}
+
+[MethodImpl(MethodImplOptions.NoInlining)]
+static IntPtr CreateCollectedDelegate(string message)
+{
+    return Marshal.GetFunctionPointerForDelegate<Action>(() => Console.WriteLine(message));    
+}

--- a/src/tests/baseservices/exceptions/unhandled/collecteddelegate.cs
+++ b/src/tests/baseservices/exceptions/unhandled/collecteddelegate.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 

--- a/src/tests/baseservices/exceptions/unhandled/collecteddelegate.csproj
+++ b/src/tests/baseservices/exceptions/unhandled/collecteddelegate.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needs explicit Main to return the proper "unhandled exception" exit code -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="collecteddelegate.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -112,6 +112,13 @@ namespace TestUnhandledExceptionTester
                         throw new Exception("Missing Unhandled exception header");
                     }
                 }
+                else if (unhandledType == "collecteddelegate")
+                {
+                    if (lines[1] != "A callback was made on a garbage collected delegate of type 'System.Private.CoreLib!System.Action::Invoke'.")
+                    {
+                        throw new Exception("Missing collected delegate diagnostic");
+                    }
+                }
             }
 
             if (unhandledType == "main")
@@ -142,6 +149,8 @@ namespace TestUnhandledExceptionTester
             RunExternalProcess("foreign", "unhandled.dll");
             File.Delete(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "dependencytodelete.dll"));
             RunExternalProcess("missingdependency", "unhandledmissingdependency.dll");
+            if (!TestLibrary.Utilities.IsMonoRuntime && !TestLibrary.Utilities.IsNativeAot)
+                RunExternalProcess("collecteddelegate", "collecteddelegate.dll");
         }
     }
 }

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -60,6 +60,11 @@ namespace TestUnhandledExceptionTester
                     // Null reference exception code
                     expectedExitCode = unchecked((int)0xC0000005);
                 }
+                else if (unhandledType == "collecteddelegate")
+                {
+                    // Fail fast exit code
+                    expectedExitCode = unchecked((int)0x80131623);
+                }
                 else
                 {
                     expectedExitCode = unchecked((int)0xE0434352);

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.csproj
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.csproj
@@ -22,5 +22,10 @@
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </ProjectReference>
+    <ProjectReference Include="collecteddelegate.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Fix diagnostic for calls on marshalled delegates. It got broken by switch to precode thunks.
- Add test for diagnostic for calls on marshalled delegates.
- Pass UMEntryThunkData* around in the delegate marshaling code instead of UMEntryThunk*. This avoids constant back and forth hops between the two.
