### PR TITLE
Improve method body interning and deduplication logic

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/MethodReadOnlyDataNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/MethodReadOnlyDataNode.cs
@@ -18,6 +18,12 @@ namespace ILCompiler.DependencyAnalysis
             _owningMethod = owningMethod;
         }
 
+        public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
+        {
+            IMethodNode owningBody = factory.MethodEntrypoint(_owningMethod);
+            return factory.ObjectInterner.GetDeduplicatedSymbol(factory, owningBody) != owningBody;
+        }
+
         public override ObjectNodeSection GetSection(NodeFactory factory) => ObjectNodeSection.ReadOnlyDataSection;
         public override bool StaticDependenciesAreComputed => _data != null;
 

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/MethodReadOnlyDataNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/MethodReadOnlyDataNode.cs
@@ -18,11 +18,13 @@ namespace ILCompiler.DependencyAnalysis
             _owningMethod = owningMethod;
         }
 
+#if !READYTORUN
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {
             IMethodNode owningBody = factory.MethodEntrypoint(_owningMethod);
             return factory.ObjectInterner.GetDeduplicatedSymbol(factory, owningBody) != owningBody;
         }
+#endif
 
         public override ObjectNodeSection GetSection(NodeFactory factory) => ObjectNodeSection.ReadOnlyDataSection;
         public override bool StaticDependenciesAreComputed => _data != null;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
@@ -25,30 +25,37 @@ namespace ILCompiler
             if (_symbolRemapping != null)
                 return;
 
-            var symbolRemapping = new Dictionary<ISymbolNode, ISymbolNode>();
-            var methodHash = new HashSet<MethodInternKey>(new MethodInternComparer(factory));
+            Dictionary<ISymbolNode, ISymbolNode> previousSymbolRemapping;
+            Dictionary<ISymbolNode, ISymbolNode> symbolRemapping = null;
 
-            foreach (IMethodBodyNode body in factory.MetadataManager.GetCompiledMethodBodies())
+            do
             {
-                // We don't track special unboxing thunks as virtual method use related so ignore them
-                if (body is ISpecialUnboxThunkNode unboxThunk && unboxThunk.IsSpecialUnboxingThunk)
-                    continue;
+                previousSymbolRemapping = symbolRemapping;
+                var methodHash = new HashSet<MethodInternKey>(new MethodInternComparer(factory, previousSymbolRemapping));
+                symbolRemapping = new Dictionary<ISymbolNode, ISymbolNode>();
 
-                // Bodies that are visible from outside should not be folded because we don't know
-                // if they're address taken.
-                if (factory.GetSymbolAlternateName(body, out _) != null)
-                    continue;
+                foreach (IMethodBodyNode body in factory.MetadataManager.GetCompiledMethodBodies())
+                {
+                    // We don't track special unboxing thunks as virtual method use related so ignore them
+                    if (body is ISpecialUnboxThunkNode unboxThunk && unboxThunk.IsSpecialUnboxingThunk)
+                        continue;
 
-                var key = new MethodInternKey(body, factory);
-                if (methodHash.TryGetValue(key, out MethodInternKey found))
-                {
-                    symbolRemapping.Add(body, found.Method);
+                    // Bodies that are visible from outside should not be folded because we don't know
+                    // if they're address taken.
+                    if (factory.GetSymbolAlternateName(body, out _) != null)
+                        continue;
+
+                    var key = new MethodInternKey(body, factory);
+                    if (methodHash.TryGetValue(key, out MethodInternKey found))
+                    {
+                        symbolRemapping.Add(body, found.Method);
+                    }
+                    else
+                    {
+                        methodHash.Add(key);
+                    }
                 }
-                else
-                {
-                    methodHash.Add(key);
-                }
-            }
+            } while (previousSymbolRemapping == null || previousSymbolRemapping.Count < symbolRemapping.Count);
 
             _symbolRemapping = symbolRemapping;
         }
@@ -96,15 +103,16 @@ namespace ILCompiler
         private sealed class MethodInternComparer : IEqualityComparer<MethodInternKey>
         {
             private readonly NodeFactory _factory;
+            private readonly Dictionary<ISymbolNode, ISymbolNode> _interner;
 
-            public MethodInternComparer(NodeFactory factory)
-                => (_factory) = (factory);
+            public MethodInternComparer(NodeFactory factory, Dictionary<ISymbolNode, ISymbolNode> interner)
+                => (_factory, _interner) = (factory, interner);
 
             public int GetHashCode(MethodInternKey key) => key.HashCode;
 
             private static bool AreSame(ReadOnlySpan<byte> o1, ReadOnlySpan<byte> o2) => o1.SequenceEqual(o2);
 
-            private static bool AreSame(ObjectNode.ObjectData o1, ObjectNode.ObjectData o2)
+            private bool AreSame(ObjectNode.ObjectData o1, ObjectNode.ObjectData o2)
             {
                 if (AreSame(o1.Data, o2.Data) && o1.Relocs.Length == o2.Relocs.Length)
                 {
@@ -113,11 +121,29 @@ namespace ILCompiler
                         ref Relocation r1 = ref o1.Relocs[i];
                         ref Relocation r2 = ref o2.Relocs[i];
                         if (r1.RelocType != r2.RelocType
-                            || r1.Offset != r2.Offset
-                            // TODO: should be comparing target after folding to catch more sameness
-                            || r1.Target != r2.Target)
+                            || r1.Offset != r2.Offset)
                         {
                             return false;
+                        }
+
+                        if (r1.Target != r2.Target)
+                        {
+                            if (r1.Target is MethodReadOnlyDataNode rodata1
+                                && r2.Target is MethodReadOnlyDataNode rodata2
+                                && AreSame(rodata1.GetData(_factory, relocsOnly: false), rodata2.GetData(_factory, relocsOnly: false)))
+                            {
+                                // We can consider same MethodReadOnlyDataNode the same.
+                            }
+                            else if (_interner != null &&
+                                ((_interner.TryGetValue(r1.Target, out ISymbolNode t1) && r2.Target == t1)
+                                || (_interner.TryGetValue(r2.Target, out ISymbolNode t2) && r1.Target == t2)))
+                            {
+                                // These got already interned
+                            }
+                            else
+                            {
+                                return false;
+                            }
                         }
                     }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
@@ -25,14 +25,17 @@ namespace ILCompiler
             if (_symbolRemapping != null)
                 return;
 
+            HashSet<MethodInternKey> previousMethodHash;
+            HashSet<MethodInternKey> methodHash = null;
             Dictionary<ISymbolNode, ISymbolNode> previousSymbolRemapping;
             Dictionary<ISymbolNode, ISymbolNode> symbolRemapping = null;
 
             do
             {
+                previousMethodHash = methodHash;
                 previousSymbolRemapping = symbolRemapping;
-                var methodHash = new HashSet<MethodInternKey>(new MethodInternComparer(factory, previousSymbolRemapping));
-                symbolRemapping = new Dictionary<ISymbolNode, ISymbolNode>();
+                methodHash = new HashSet<MethodInternKey>(previousMethodHash?.Count ?? 0, new MethodInternComparer(factory, previousSymbolRemapping));
+                symbolRemapping = new Dictionary<ISymbolNode, ISymbolNode>(previousSymbolRemapping?.Count ?? 0);
 
                 foreach (IMethodBodyNode body in factory.MetadataManager.GetCompiledMethodBodies())
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
@@ -35,7 +35,7 @@ namespace ILCompiler
                 previousMethodHash = methodHash;
                 previousSymbolRemapping = symbolRemapping;
                 methodHash = new HashSet<MethodInternKey>(previousMethodHash?.Count ?? 0, new MethodInternComparer(factory, previousSymbolRemapping));
-                symbolRemapping = new Dictionary<ISymbolNode, ISymbolNode>(previousSymbolRemapping?.Count ?? 0);
+                symbolRemapping = new Dictionary<ISymbolNode, ISymbolNode>((int)(1.05 * (previousSymbolRemapping?.Count ?? 0)));
 
                 foreach (IMethodBodyNode body in factory.MetadataManager.GetCompiledMethodBodies())
                 {


### PR DESCRIPTION
* Enhanced ObjectDataInterner to perform multiple iterations of interning.
* Consider two same `MethodReadOnlyDataNode` the same.

Cc @dotnet/ilc-contrib 