### PR TITLE
Arm64 SVE: Force tests to always run with hwintrinsics enabled

### DIFF
--- a/src/tests/JIT/opt/SVE/ConstantMasks.csproj
+++ b/src/tests/JIT/opt/SVE/ConstantMasks.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs">
-      <HasDisasmCheck Condition="'$(DOTNET_EnableHWIntrinsic)' != '0' and '$(DOTNET_EnableArm64Sve)' != '0'">true</HasDisasmCheck>
+      <HasDisasmCheck>true</HasDisasmCheck>
     </Compile>
 
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />

--- a/src/tests/JIT/opt/SVE/ConstantMasksOp2Fixed.csproj
+++ b/src/tests/JIT/opt/SVE/ConstantMasksOp2Fixed.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs">
-      <HasDisasmCheck Condition="'$(DOTNET_EnableHWIntrinsic)' != '0' and '$(DOTNET_EnableArm64Sve)' != '0'">true</HasDisasmCheck>
+      <HasDisasmCheck>true</HasDisasmCheck>
     </Compile>
 
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />

--- a/src/tests/JIT/opt/SVE/Directory.Build.props
+++ b/src/tests/JIT/opt/SVE/Directory.Build.props
@@ -5,4 +5,7 @@
     <NoWarn>$(NoWarn);SYSLIB5003</NoWarn>
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm64' or '$(TargetOS)' == 'osx' or '$(RuntimeFlavor)' == 'mono'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
+  <ItemGroup>
+      <CLRTestEnvironmentVariable Include="DOTNET_EnableHWIntrinsic" Value="1" />
+  </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/SVE/EmbeddedLoads.csproj
+++ b/src/tests/JIT/opt/SVE/EmbeddedLoads.csproj
@@ -15,6 +15,5 @@
 
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
     <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
-    <CLRTestEnvironmentVariable Include="DOTNET_EnableHWIntrinsic" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/SVE/PredicateInstructions.csproj
+++ b/src/tests/JIT/opt/SVE/PredicateInstructions.csproj
@@ -11,6 +11,5 @@
     </Compile>
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
     <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
-    <CLRTestEnvironmentVariable Include="DOTNET_EnableHWIntrinsic" Value="1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #116905