### PR TITLE
Improve constant value analysis for method IL

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -675,56 +675,107 @@ namespace ILCompiler
                 || method.IsNoOptimization
                 || _nestedILProvider.GetMethodIL(method) is not MethodIL methodIL)
             {
-                constant = 0;
-                return false;
+                return Fail(out constant);
             }
 
-            var reader = new ILReader(methodIL.GetILBytes());
-            var opcode = reader.ReadILOpcode();
-            switch (opcode)
-            {
-                case ILOpcode.ldc_i4: constant = (int)reader.ReadILUInt32(); break;
-                case ILOpcode.ldc_i4_s: constant = (sbyte)reader.ReadILByte(); break;
-                case >= ILOpcode.ldc_i4_0 and <= ILOpcode.ldc_i4_8: constant = opcode - ILOpcode.ldc_i4_0; break;
-                case ILOpcode.ldc_i4_m1: constant = -1; break;
+            Stack<int?> stack = new Stack<int?>(methodIL.MaxStack);
 
-                case ILOpcode.call:
+            int instructionCounter = 0;
+
+            var reader = new ILReader(methodIL.GetILBytes());
+            while (reader.HasNext && instructionCounter++ < 1000)
+            {
+                var opcode = reader.ReadILOpcode();
+                switch (opcode)
                 {
-                    MethodDesc callee = (MethodDesc)methodIL.GetObject(reader.ReadILToken());
-                    if (reader.ReadILOpcode() != ILOpcode.ret)
+                    case ILOpcode.ldc_i4: stack.Push((int)reader.ReadILUInt32()); break;
+                    case ILOpcode.ldc_i4_s: stack.Push((sbyte)reader.ReadILByte()); break;
+                    case >= ILOpcode.ldc_i4_0 and <= ILOpcode.ldc_i4_8: stack.Push(opcode - ILOpcode.ldc_i4_0); break;
+                    case ILOpcode.ldc_i4_m1: stack.Push(-1); break;
+
+                    case ILOpcode.ldsfld:
                     {
-                        constant = 0;
-                        return false;
+                        reader.ReadILToken();
+                        stack.Push(null);
+                        break;
                     }
 
-                    BodySubstitution substitution = _substitutionProvider.GetSubstitution(method);
-                    if (substitution != null && substitution.Value is int c)
+                    case ILOpcode.brtrue:
+                    case ILOpcode.brtrue_s:
+                    case ILOpcode.brfalse:
+                    case ILOpcode.brfalse_s:
                     {
-                        constant = c;
+                        if (!stack.TryPop(out int? val) || !val.HasValue)
+                            return Fail(out constant);
+
+                        bool taken = (opcode is ILOpcode.brtrue or ILOpcode.brtrue_s && val.Value != 0)
+                            || (opcode is ILOpcode.brfalse or ILOpcode.brfalse_s && val.Value == 0);
+
+                        int destOffset = reader.ReadBranchDestination(opcode);
+                        if (taken)
+                            reader.Seek(destOffset);
+                        break;
+                    }
+
+                    case ILOpcode.br:
+                    case ILOpcode.br_s:
+                        reader.Seek(reader.ReadBranchDestination(opcode)); break;
+
+                    // Callvirt could trigger a NullRef. We ignore that here. It is fine because we only need to know
+                    // what the method would return if it didn't throw. If it throws, it doesn't matter because
+                    // we do not eliminate the call to it, only the basic block conditioned on the call return value.
+                    case ILOpcode.callvirt:
+                    case ILOpcode.call:
+                    {
+                        MethodDesc callee = (MethodDesc)methodIL.GetObject(reader.ReadILToken());
+                        if (opcode == ILOpcode.callvirt && method.IsVirtual)
+                            return Fail(out constant);
+
+                        for (int i = 0; i < callee.Signature.Length + (callee.Signature.IsStatic ? 0 : 1); i++)
+                            if (!stack.TryPop(out _))
+                                return Fail(out constant);
+
+                        BodySubstitution substitution = _substitutionProvider.GetSubstitution(callee);
+                        if (substitution != null && substitution.Value is int c)
+                        {
+                            constant = c;
+                        }
+                        else if (level > 4
+                            || !TryGetMethodConstantValue(callee, out constant, level + 1))
+                        {
+                            return Fail(out constant);
+                        }
+
+                        stack.Push(constant);
+                        break;
+                    }
+
+                    case ILOpcode.ret:
+                    {
+                        Debug.Assert(stack.Count == 1);
+                        if (stack.Count == 0)
+                            return Fail(out constant);
+
+                        int? ret = stack.Pop();
+                        if (!ret.HasValue)
+                            return Fail(out constant);
+
+                        constant = ret.Value;
                         return true;
                     }
 
-                    if (level > 4)
-                    {
-                        constant = 0;
-                        return false;
-                    }
-
-                    return TryGetMethodConstantValue(callee, out constant, level + 1);
+                    default:
+                        return Fail(out constant);
                 }
-
-                default:
-                    constant = 0;
-                    return false;
             }
 
-            if (reader.ReadILOpcode() != ILOpcode.ret)
+            return Fail(out constant);
+
+            static bool Fail(out int constant)
             {
                 constant = 0;
                 return false;
             }
-
-            return true;
         }
 
         private bool TryGetConstantArgument(MethodIL methodIL, byte[] body, OpcodeFlags[] flags, int offset, int argIndex, out int constant)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -673,7 +673,8 @@ namespace ILCompiler
                 || method.IsIntrinsic
                 || method.IsNoInlining
                 || method.IsNoOptimization
-                || _nestedILProvider.GetMethodIL(method) is not MethodIL methodIL)
+                || _nestedILProvider.GetMethodIL(method) is not MethodIL methodIL
+                || methodIL.GetExceptionRegions().Length > 0)
             {
                 return Fail(out constant);
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -709,8 +709,8 @@ namespace ILCompiler
                         if (!stack.TryPop(out int? val) || !val.HasValue)
                             return Fail(out constant);
 
-                        bool taken = (opcode is ILOpcode.brtrue or ILOpcode.brtrue_s && val.Value != 0)
-                            || (opcode is ILOpcode.brfalse or ILOpcode.brfalse_s && val.Value == 0);
+                        bool taken = ((opcode is ILOpcode.brtrue or ILOpcode.brtrue_s) && val.Value != 0)
+                            || ((opcode is ILOpcode.brfalse or ILOpcode.brfalse_s) && val.Value == 0);
 
                         int destOffset = reader.ReadBranchDestination(opcode);
                         if (taken)
@@ -720,7 +720,8 @@ namespace ILCompiler
 
                     case ILOpcode.br:
                     case ILOpcode.br_s:
-                        reader.Seek(reader.ReadBranchDestination(opcode)); break;
+                        reader.Seek(reader.ReadBranchDestination(opcode));
+                        break;
 
                     // Callvirt could trigger a NullRef. We ignore that here. It is fine because we only need to know
                     // what the method would return if it didn't throw. If it throws, it doesn't matter because

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -728,7 +728,7 @@ namespace ILCompiler
                     case ILOpcode.call:
                     {
                         MethodDesc callee = (MethodDesc)methodIL.GetObject(reader.ReadILToken());
-                        if (opcode == ILOpcode.callvirt && method.IsVirtual)
+                        if (opcode == ILOpcode.callvirt && callee.IsVirtual)
                             return Fail(out constant);
 
                         for (int i = 0; i < callee.Signature.Length + (callee.Signature.IsStatic ? 0 : 1); i++)


### PR DESCRIPTION
Refactors `TryGetMethodConstantValue` to use a stack-based IL interpreter, enabling more robust constant folding and handling of more complex control flow and method calls. This addresses patterns that often show up around Metrics code (calling a helper that checks several diagnostic switches like `someLog.Log.IsSupported` and using it in an `if` check).

Cc @dotnet/ilc-contrib 