### PR TITLE
JIT: Rename `BasicBlock` edge ref methods

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1916,7 +1916,7 @@ void AsyncTransformation::CreateResumptionSwitch()
                 checkILOffsetBB->bbNum);
 
         // Redirect newEntryBB -> onContinuationBB into newEntryBB -> checkILOffsetBB -> onContinuationBB
-        m_comp->fgRedirectEdge(newEntryBB->GetTrueEdgeRef(), checkILOffsetBB);
+        m_comp->fgRedirectEdge(newEntryBB->TrueEdgeRef(), checkILOffsetBB);
         newEntryBB->GetTrueEdge()->setLikelihood(0);
         checkILOffsetBB->inheritWeightPercentage(newEntryBB, 0);
 
@@ -1966,7 +1966,7 @@ void AsyncTransformation::CreateResumptionSwitch()
         BasicBlock* checkILOffsetBB    = m_comp->fgNewBBbefore(BBJ_COND, onContinuationBB, true);
 
         // Switch newEntryBB -> onContinuationBB into newEntryBB -> checkILOffsetBB
-        m_comp->fgRedirectEdge(newEntryBB->GetTrueEdgeRef(), checkILOffsetBB);
+        m_comp->fgRedirectEdge(newEntryBB->TrueEdgeRef(), checkILOffsetBB);
         newEntryBB->GetTrueEdge()->setLikelihood(0);
         checkILOffsetBB->inheritWeightPercentage(newEntryBB, 0);
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -861,7 +861,7 @@ public:
         return bbTargetEdge;
     }
 
-    FlowEdge*& GetTargetEdgeRef()
+    FlowEdge*& TargetEdgeRef()
     {
         assert(HasInitializedTarget());
         assert(bbTargetEdge->getSourceBlock() == this);
@@ -896,7 +896,7 @@ public:
         return bbTrueEdge;
     }
 
-    FlowEdge*& GetTrueEdgeRef()
+    FlowEdge*& TrueEdgeRef()
     {
         assert(KindIs(BBJ_COND));
         assert(bbTrueEdge != nullptr);
@@ -938,7 +938,7 @@ public:
         return bbFalseEdge;
     }
 
-    FlowEdge*& GetFalseEdgeRef()
+    FlowEdge*& FalseEdgeRef()
     {
         assert(KindIs(BBJ_COND));
         assert(bbFalseEdge != nullptr);

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -492,18 +492,18 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* oldTarget, Bas
         case BBJ_EHFILTERRET:
         case BBJ_LEAVE: // This function can be called before import, so we still have BBJ_LEAVE
             assert(block->TargetIs(oldTarget));
-            fgRedirectEdge(block->GetTargetEdgeRef(), newTarget);
+            fgRedirectEdge(block->TargetEdgeRef(), newTarget);
             break;
 
         case BBJ_COND:
             if (block->TrueTargetIs(oldTarget))
             {
-                fgRedirectEdge(block->GetTrueEdgeRef(), newTarget);
+                fgRedirectEdge(block->TrueEdgeRef(), newTarget);
             }
             else
             {
                 assert(block->FalseTargetIs(oldTarget));
-                fgRedirectEdge(block->GetFalseEdgeRef(), newTarget);
+                fgRedirectEdge(block->FalseEdgeRef(), newTarget);
             }
 
             if (block->TrueEdgeIs(block->GetFalseEdge()))
@@ -4118,7 +4118,7 @@ void Compiler::fgFixEntryFlowForOSR()
     fgCreateNewInitBB();
     assert(fgFirstBB->KindIs(BBJ_ALWAYS));
 
-    fgRedirectEdge(fgFirstBB->GetTargetEdgeRef(), fgOSREntryBB);
+    fgRedirectEdge(fgFirstBB->TargetEdgeRef(), fgOSREntryBB);
 
     fgFirstBB->bbWeight = fgCalledCount;
     fgFirstBB->CopyFlags(fgEntryBB, BBF_PROF_WEIGHT);

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -171,7 +171,7 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
                     fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
                     // Ref count updates.
-                    fgRedirectEdge(currentBlock->GetTargetEdgeRef(), postTryFinallyBlock);
+                    fgRedirectEdge(currentBlock->TargetEdgeRef(), postTryFinallyBlock);
                     currentBlock->SetKind(BBJ_ALWAYS);
                     currentBlock->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
 
@@ -1565,7 +1565,7 @@ PhaseStatus Compiler::fgCloneFinally()
                     fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
                     // Ref count updates.
-                    fgRedirectEdge(currentBlock->GetTargetEdgeRef(), firstCloneBlock);
+                    fgRedirectEdge(currentBlock->TargetEdgeRef(), firstCloneBlock);
 
                     // This call returns to the expected spot, so retarget it to branch to the clone.
                     currentBlock->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
@@ -2197,7 +2197,7 @@ bool Compiler::fgRetargetBranchesToCanonicalCallFinally(BasicBlock*      block,
             canonicalCallFinally->bbNum);
 
     assert(callFinally->bbRefs > 0);
-    fgRedirectEdge(block->GetTargetEdgeRef(), canonicalCallFinally);
+    fgRedirectEdge(block->TargetEdgeRef(), canonicalCallFinally);
 
     // Update profile counts
     //

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1852,7 +1852,7 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
         // Insert inlinee's blocks into inliner's block list.
         assert(topBlock->KindIs(BBJ_ALWAYS));
         assert(topBlock->TargetIs(bottomBlock));
-        fgRedirectEdge(topBlock->GetTargetEdgeRef(), InlineeCompiler->fgFirstBB);
+        fgRedirectEdge(topBlock->TargetEdgeRef(), InlineeCompiler->fgFirstBB);
 
         topBlock->SetNext(InlineeCompiler->fgFirstBB);
         InlineeCompiler->fgLastBB->SetNext(bottomBlock);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -720,7 +720,7 @@ PhaseStatus Compiler::fgPostImportationCleanup()
 
                 if (entryJumpTarget != osrEntry)
                 {
-                    fgRedirectEdge(fgFirstBB->GetTargetEdgeRef(), entryJumpTarget);
+                    fgRedirectEdge(fgFirstBB->TargetEdgeRef(), entryJumpTarget);
 
                     JITDUMP("OSR: redirecting flow from method entry " FMT_BB " to OSR entry " FMT_BB
                             " via step blocks.\n",
@@ -1355,7 +1355,7 @@ bool Compiler::fgOptimizeBranchToEmptyUnconditional(BasicBlock* block, BasicBloc
             case BBJ_CALLFINALLYRET:
             {
                 removedWeight = block->bbWeight;
-                fgRedirectEdge(block->GetTargetEdgeRef(), bDest->GetTarget());
+                fgRedirectEdge(block->TargetEdgeRef(), bDest->GetTarget());
                 break;
             }
 
@@ -1364,13 +1364,13 @@ bool Compiler::fgOptimizeBranchToEmptyUnconditional(BasicBlock* block, BasicBloc
                 {
                     assert(!block->FalseTargetIs(bDest));
                     removedWeight = block->GetTrueEdge()->getLikelyWeight();
-                    fgRedirectEdge(block->GetTrueEdgeRef(), bDest->GetTarget());
+                    fgRedirectEdge(block->TrueEdgeRef(), bDest->GetTarget());
                 }
                 else
                 {
                     assert(block->FalseTargetIs(bDest));
                     removedWeight = block->GetFalseEdge()->getLikelyWeight();
-                    fgRedirectEdge(block->GetFalseEdgeRef(), bDest->GetTarget());
+                    fgRedirectEdge(block->FalseEdgeRef(), bDest->GetTarget());
                 }
                 break;
 
@@ -2256,7 +2256,7 @@ bool Compiler::fgOptimizeUncondBranchToSimpleCond(BasicBlock* block, BasicBlock*
     // Fix up block's flow.
     // Assume edge likelihoods transfer over.
     //
-    fgRedirectEdge(block->GetTargetEdgeRef(), target->GetTrueTarget());
+    fgRedirectEdge(block->TargetEdgeRef(), target->GetTrueTarget());
     block->GetTargetEdge()->setLikelihood(target->GetTrueEdge()->getLikelihood());
     block->GetTargetEdge()->setHeuristicBased(target->GetTrueEdge()->isHeuristicBased());
 
@@ -2751,7 +2751,7 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
     FlowEdge* const falseEdge = bDest->GetFalseEdge();
     FlowEdge* const trueEdge  = bDest->GetTrueEdge();
 
-    fgRedirectEdge(bJump->GetTargetEdgeRef(), falseTarget);
+    fgRedirectEdge(bJump->TargetEdgeRef(), falseTarget);
     bJump->GetTargetEdge()->setLikelihood(falseEdge->getLikelihood());
     bJump->GetTargetEdge()->setHeuristicBased(falseEdge->isHeuristicBased());
 
@@ -4611,8 +4611,8 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication /* = false */, bool isPh
 
                         // Rewire flow from block
                         //
-                        std::swap(block->GetTrueEdgeRef(), block->GetFalseEdgeRef());
-                        fgRedirectEdge(block->GetTrueEdgeRef(), bNext->GetTarget());
+                        std::swap(block->TrueEdgeRef(), block->FalseEdgeRef());
+                        fgRedirectEdge(block->TrueEdgeRef(), bNext->GetTarget());
 
                         // bNext no longer flows to target
                         //
@@ -5320,7 +5320,7 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
                 if (commSucc != nullptr)
                 {
                     assert(predBlock->KindIs(BBJ_ALWAYS));
-                    fgRedirectEdge(predBlock->GetTargetEdgeRef(), crossJumpTarget);
+                    fgRedirectEdge(predBlock->TargetEdgeRef(), crossJumpTarget);
                 }
                 else
                 {

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2997,7 +2997,7 @@ void Compiler::fgInsertFuncletPrologBlock(BasicBlock* block)
                 case BBJ_CALLFINALLY:
                 {
                     noway_assert(predBlock->TargetIs(block));
-                    fgRedirectEdge(predBlock->GetTargetEdgeRef(), newHead);
+                    fgRedirectEdge(predBlock->TargetEdgeRef(), newHead);
                     incomingWeight += predBlock->bbWeight;
                     break;
                 }

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -386,7 +386,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     if (needsSizeCheck)
     {
         // sizeCheckBb is the first block after prevBb
-        fgRedirectEdge(prevBb->GetTargetEdgeRef(), sizeCheckBb);
+        fgRedirectEdge(prevBb->TargetEdgeRef(), sizeCheckBb);
 
         // sizeCheckBb flows into nullcheckBb in case if the size check passes
         {
@@ -404,7 +404,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     else
     {
         // nullcheckBb is the first block after prevBb
-        fgRedirectEdge(prevBb->GetTargetEdgeRef(), nullcheckBb);
+        fgRedirectEdge(prevBb->TargetEdgeRef(), nullcheckBb);
 
         // No size check, nullcheckBb jumps to fast path
         // fallbackBb is only reachable from nullcheckBb (jump destination)
@@ -746,7 +746,7 @@ bool Compiler::fgExpandThreadLocalAccessForCallNativeAOT(BasicBlock** pBlock, St
     // fallback will just execute first time
     fallbackBb->inheritWeightPercentage(tlsRootNullCondBB, 0);
 
-    fgRedirectEdge(prevBb->GetTargetEdgeRef(), tlsRootNullCondBB);
+    fgRedirectEdge(prevBb->TargetEdgeRef(), tlsRootNullCondBB);
 
     // All blocks are expected to be in the same EH region
     assert(BasicBlock::sameEHRegion(prevBb, block));
@@ -1033,7 +1033,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
         tlsBaseComputeBB->SetTargetEdge(newEdge);
 
         assert(prevBb->KindIs(BBJ_ALWAYS));
-        fgRedirectEdge(prevBb->GetTargetEdgeRef(), tlsBaseComputeBB);
+        fgRedirectEdge(prevBb->TargetEdgeRef(), tlsBaseComputeBB);
 
         // Inherit the weights
         block->inheritWeight(prevBb);
@@ -1142,7 +1142,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
         // Update preds in all new blocks
         //
         assert(prevBb->KindIs(BBJ_ALWAYS));
-        fgRedirectEdge(prevBb->GetTargetEdgeRef(), maxThreadStaticBlocksCondBB);
+        fgRedirectEdge(prevBb->TargetEdgeRef(), maxThreadStaticBlocksCondBB);
 
         {
             FlowEdge* const trueEdge  = fgAddRefPred(fallbackBb, maxThreadStaticBlocksCondBB);
@@ -1518,7 +1518,7 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
     //
 
     // Redirect prevBb from block to isInitedBb
-    fgRedirectEdge(prevBb->GetTargetEdgeRef(), isInitedBb);
+    fgRedirectEdge(prevBb->TargetEdgeRef(), isInitedBb);
     assert(prevBb->JumpsToNext());
 
     {
@@ -1845,7 +1845,7 @@ bool Compiler::fgVNBasedIntrinsicExpansionForCall_ReadUtf8(BasicBlock** pBlock, 
     // Update preds in all new blocks
     //
     // Redirect prevBb to lengthCheckBb
-    fgRedirectEdge(prevBb->GetTargetEdgeRef(), lengthCheckBb);
+    fgRedirectEdge(prevBb->TargetEdgeRef(), lengthCheckBb);
     lengthCheckBb->inheritWeight(prevBb);
     assert(prevBb->JumpsToNext());
 
@@ -2600,7 +2600,7 @@ bool Compiler::fgLateCastExpansionForCall(BasicBlock** pBlock, Statement* stmt, 
         }
     }
 
-    fgRedirectEdge(firstBb->GetTargetEdgeRef(), nullcheckBb);
+    fgRedirectEdge(firstBb->TargetEdgeRef(), nullcheckBb);
 
     //
     // Re-distribute weights and set edge likelihoods.

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4695,7 +4695,7 @@ void Compiler::impImportLeaveEHRegions(BasicBlock* block)
 
                 // callBlock calls the finally handler
                 assert(callBlock->HasInitializedTarget());
-                fgRedirectEdge(callBlock->GetTargetEdgeRef(), HBtab->ebdHndBeg);
+                fgRedirectEdge(callBlock->TargetEdgeRef(), HBtab->ebdHndBeg);
                 callBlock->SetKind(BBJ_CALLFINALLY);
 
                 if (endCatches)
@@ -4990,7 +4990,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 assert((step == block) || !step->HasInitializedTarget());
                 if (step == block)
                 {
-                    fgRedirectEdge(step->GetTargetEdgeRef(), exitBlock);
+                    fgRedirectEdge(step->TargetEdgeRef(), exitBlock);
                 }
                 else
                 {
@@ -5037,7 +5037,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 // the new BBJ_CALLFINALLY is in a different EH region, thus it can't just replace the BBJ_LEAVE,
                 // which might be in the middle of the "try". In most cases, the BBJ_ALWAYS will jump to the
                 // next block, and flow optimizations will remove it.
-                fgRedirectEdge(block->GetTargetEdgeRef(), callBlock);
+                fgRedirectEdge(block->TargetEdgeRef(), callBlock);
                 block->SetKind(BBJ_ALWAYS);
 
                 // The new block will inherit this block's weight.
@@ -5063,7 +5063,7 @@ void Compiler::impImportLeave(BasicBlock* block)
 
                 // callBlock calls the finally handler
                 assert(callBlock->HasInitializedTarget());
-                fgRedirectEdge(callBlock->GetTargetEdgeRef(), HBtab->ebdHndBeg);
+                fgRedirectEdge(callBlock->TargetEdgeRef(), HBtab->ebdHndBeg);
                 callBlock->SetKind(BBJ_CALLFINALLY);
 
 #ifdef DEBUG
@@ -5104,7 +5104,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                     BasicBlock* step2 = fgNewBBinRegion(BBJ_ALWAYS, XTnum + 1, 0, step);
                     if (step == block)
                     {
-                        fgRedirectEdge(step->GetTargetEdgeRef(), step2);
+                        fgRedirectEdge(step->TargetEdgeRef(), step2);
                     }
                     else
                     {
@@ -5154,7 +5154,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 callBlock = fgNewBBinRegion(BBJ_CALLFINALLY, callFinallyTryIndex, callFinallyHndIndex, step);
                 if (step == block)
                 {
-                    fgRedirectEdge(step->GetTargetEdgeRef(), callBlock);
+                    fgRedirectEdge(step->TargetEdgeRef(), callBlock);
                 }
                 else
                 {
@@ -5264,7 +5264,7 @@ void Compiler::impImportLeave(BasicBlock* block)
 
                 if (step == block)
                 {
-                    fgRedirectEdge(step->GetTargetEdgeRef(), catchStep);
+                    fgRedirectEdge(step->TargetEdgeRef(), catchStep);
                 }
                 else
                 {
@@ -5322,7 +5322,7 @@ void Compiler::impImportLeave(BasicBlock* block)
         // leaveTarget is the ultimate destination of the LEAVE
         if (step == block)
         {
-            fgRedirectEdge(step->GetTargetEdgeRef(), leaveTarget);
+            fgRedirectEdge(step->TargetEdgeRef(), leaveTarget);
         }
         else
         {
@@ -5415,7 +5415,7 @@ void Compiler::impResetLeaveBlock(BasicBlock* block, unsigned jmpAddr)
 
     fgInitBBLookup();
 
-    fgRedirectEdge(block->GetTargetEdgeRef(), fgLookupBB(jmpAddr));
+    fgRedirectEdge(block->TargetEdgeRef(), fgLookupBB(jmpAddr));
     block->SetKind(BBJ_LEAVE);
 
     // We will leave the BBJ_ALWAYS block we introduced. When it's reimported

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -1305,7 +1305,7 @@ private:
             // Rewire the cold block to jump to the else block,
             // not fall through to the check block.
             //
-            compiler->fgRedirectEdge(coldBlock->GetTargetEdgeRef(), elseBlock);
+            compiler->fgRedirectEdge(coldBlock->TargetEdgeRef(), elseBlock);
 
             // Update the profile data
             //

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -4494,7 +4494,7 @@ void Compiler::fgExtendEHRegionBefore(BasicBlock* block)
                 }
 #endif
                 // Change the target for bFilterLast from the old first 'block' to the new first 'bPrev'
-                fgRedirectEdge(bFilterLast->GetTargetEdgeRef(), bPrev);
+                fgRedirectEdge(bFilterLast->TargetEdgeRef(), bPrev);
             }
         }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14519,7 +14519,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
     BasicBlock* elseBlock = fgNewBBafter(BBJ_ALWAYS, condBlock, true);
 
     // Update flowgraph
-    fgRedirectEdge(block->GetTargetEdgeRef(), condBlock);
+    fgRedirectEdge(block->TargetEdgeRef(), condBlock);
     condBlock->SetTargetEdge(fgAddRefPred(elseBlock, condBlock));
     elseBlock->SetTargetEdge(fgAddRefPred(remainderBlock, elseBlock));
 

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -4535,7 +4535,7 @@ void ObjectAllocator::CloneAndSpecialize(CloneInfo* info)
     BasicBlock*       firstClonedBlock = nullptr;
     bool const        firstFound       = map.Lookup(firstBlock, &firstClonedBlock);
     assert(firstFound);
-    comp->fgRedirectEdge(info->m_allocBlock->GetTargetEdgeRef(), firstClonedBlock);
+    comp->fgRedirectEdge(info->m_allocBlock->TargetEdgeRef(), firstClonedBlock);
 
     // If we are subsequently going to do the "empty collection static enumerator" opt,
     // then our profile is now consistent.

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1239,7 +1239,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
             // We will now reach via B1 true.
             // Modify flow for true side of B1
             //
-            m_comp->fgRedirectEdge(m_b1->GetTrueEdgeRef(), m_b2->GetTrueTarget());
+            m_comp->fgRedirectEdge(m_b1->TrueEdgeRef(), m_b2->GetTrueTarget());
             origB1TrueEdge->setHeuristicBased(origB2TrueEdge->isHeuristicBased());
 
             newB1TrueLikelihood =

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1681,7 +1681,7 @@ void Compiler::optRedirectPrevUnrollIteration(FlowGraphNaturalLoop* loop, BasicB
         }
 
         // Redirect exit edge from previous iteration to new entry.
-        fgRedirectEdge(prevTestBlock->GetTrueEdgeRef(), target);
+        fgRedirectEdge(prevTestBlock->TrueEdgeRef(), target);
         fgRemoveRefPred(prevTestBlock->GetFalseEdge());
         prevTestBlock->SetKindAndTargetEdge(BBJ_ALWAYS, prevTestBlock->GetTrueEdge());
 
@@ -2092,7 +2092,7 @@ bool Compiler::optTryInvertWhileLoop(FlowGraphNaturalLoop* loop)
     preheader->GetFalseEdge()->setLikelihood(condBlock->GetFalseEdge()->getLikelihood());
 
     // Redirect newPreheader from header to stayInLoopSucc
-    fgRedirectEdge(newPreheader->GetTargetEdgeRef(), stayInLoopSucc);
+    fgRedirectEdge(newPreheader->TargetEdgeRef(), stayInLoopSucc);
 
     // Duplicate all the code now
     for (int i = 0; i < duplicatedBlocks.Height(); i++)

--- a/src/coreclr/jit/rangecheckcloning.cpp
+++ b/src/coreclr/jit/rangecheckcloning.cpp
@@ -280,7 +280,7 @@ static BasicBlock* optRangeCheckCloning_DoClone(Compiler*             comp,
 
     // Wire up the edges
     //
-    comp->fgRedirectEdge(prevBb->GetTargetEdgeRef(), lowerBndBb);
+    comp->fgRedirectEdge(prevBb->TargetEdgeRef(), lowerBndBb);
     FlowEdge* fallbackToNextBb       = comp->fgAddRefPred(lastBb, fallbackBb);
     FlowEdge* lowerBndToUpperBndEdge = comp->fgAddRefPred(upperBndBb, lowerBndBb);
     FlowEdge* lowerBndToFallbackEdge = comp->fgAddRefPred(fallbackBb, lowerBndBb);


### PR DESCRIPTION
Follow-up to #116933 ([comment](https://github.com/dotnet/runtime/pull/116933#discussion_r2163302501)).

@jakobbotsch PTAL, thanks!