### PR TITLE
[clr-interpreter] Followon changes from PR #116990

### DIFF
--- a/src/native/containers/dn-simdhash-specialization-declarations.h
+++ b/src/native/containers/dn-simdhash-specialization-declarations.h
@@ -58,9 +58,11 @@ DN_SIMDHASH_TRY_ADD (DN_SIMDHASH_T_PTR hash, DN_SIMDHASH_KEY_T key, DN_SIMDHASH_
 uint8_t
 DN_SIMDHASH_TRY_ADD_WITH_HASH (DN_SIMDHASH_T_PTR hash, DN_SIMDHASH_KEY_T key, uint32_t key_hash, DN_SIMDHASH_VALUE_T value);
 
+// result is an optional parameter that will be set to the value of the item if it was found.
 uint8_t
 DN_SIMDHASH_TRY_GET_VALUE (DN_SIMDHASH_T_PTR hash, DN_SIMDHASH_KEY_T key, DN_SIMDHASH_VALUE_T *result);
 
+// result is an optional parameter that will be set to the value of the item if it was found.
 uint8_t
 DN_SIMDHASH_TRY_GET_VALUE_WITH_HASH (DN_SIMDHASH_T_PTR hash, DN_SIMDHASH_KEY_T key, uint32_t key_hash, DN_SIMDHASH_VALUE_T *result);
 


### PR DESCRIPTION
- use static_asserts where possible
- remove the mess of casts and temp variables around helper function opcodes
- Remove the DO_GENERIC_LOOKUP macro since it wasn't doing much of use anymore
- Use the simdhash apis a little better