### PR TITLE
Fix dispose pattern in PQC types

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
@@ -359,8 +359,13 @@ namespace System.Security.Cryptography
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
-            _key.Dispose();
-            _key = null!;
+            if (disposing)
+            {
+                _key.Dispose();
+                _key = null!;
+            }
+
+            base.Dispose(disposing);
         }
 
         private void ExportKey(

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
@@ -153,8 +153,13 @@ namespace System.Security.Cryptography
 
         protected override void Dispose(bool disposing)
         {
-            _key?.Dispose();
-            _key = null!;
+            if (disposing)
+            {
+                _key?.Dispose();
+                _key = null!;
+            }
+
+            base.Dispose(disposing);
         }
 
         private void ExportKey(string keyBlobType, int expectedKeySize, Span<byte> destination)

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
@@ -218,7 +218,7 @@ namespace System.Security.Cryptography
         {
             if (disposing)
             {
-                _key.Dispose();
+                _key?.Dispose();
                 _key = null!;
             }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
@@ -221,6 +221,8 @@ namespace System.Security.Cryptography
                 _key.Dispose();
                 _key = null!;
             }
+
+            base.Dispose(disposing);
         }
 
         private void ExportKey(KeyBlobMagicNumber kind, Span<byte> destination)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLDsaOpenSsl.OpenSsl.cs
@@ -60,12 +60,12 @@ namespace System.Security.Cryptography
         /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 _key.Dispose();
             }
+
+            base.Dispose(disposing);
         }
 
         /// <inheritdoc />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemImplementation.OpenSsl.cs
@@ -64,12 +64,12 @@ namespace System.Security.Cryptography
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 _key.Dispose();
             }
+
+            base.Dispose(disposing);
         }
 
         internal SafeEvpPKeyHandle DuplicateHandle() =>  _key.DuplicateHandle();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MLKemOpenSsl.OpenSsl.cs
@@ -59,12 +59,12 @@ namespace System.Security.Cryptography
         /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 _key.Dispose();
             }
+
+            base.Dispose(disposing);
         }
 
         /// <inheritdoc />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaImplementation.OpenSsl.cs
@@ -50,6 +50,8 @@ namespace System.Security.Cryptography
                 _key?.Dispose();
                 _key = null!;
             }
+
+            base.Dispose(disposing);
         }
 
         internal static partial SlhDsaImplementation GenerateKeyCore(SlhDsaAlgorithm algorithm)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaOpenSsl.OpenSsl.cs
@@ -72,12 +72,12 @@ namespace System.Security.Cryptography
         /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 _key.Dispose();
             }
+
+            base.Dispose(disposing);
         }
 
         protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) =>


### PR DESCRIPTION
I don't think we have been following the dispose pattern correctly for a few of the PQC implementations. We should only call managed dispose methods if `disposing` is true.

Technically we should also be calling the base implementation, even though they do nothing right now.

This makes the dispose pattern usage more consistent with other cryptographic algorithms.