### PR TITLE
Add support for statics access from shared generic code, as well as precise-init static class construction

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1240,11 +1240,9 @@ InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
     m_compScopeHnd = methodInfo->scope;
     m_compHnd = compHnd;
     m_methodInfo = methodInfo;
-
-#ifdef DEBUG
-
     m_classHnd   = compHnd->getMethodClass(m_methodHnd);
 
+#ifdef DEBUG
     m_methodName = ::PrintMethodName(compHnd, m_classHnd, m_methodHnd, &m_methodInfo->args,
                             /* includeAssembly */ false,
                             /* includeClass */ true,

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3079,7 +3079,7 @@ void InterpCompiler::EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORI
         case CORINFO_FIELD_STATIC_ADDRESS:
         case CORINFO_FIELD_STATIC_RVA_ADDRESS:
         {
-            if (pFieldInfo->fieldFlags |= CORINFO_FLG_FIELD_INITCLASS)
+            if ((pFieldInfo->fieldFlags & CORINFO_FLG_FIELD_INITCLASS) != 0)
             {
                 CORINFO_GENERICHANDLE_RESULT embedInfo;
                 m_compHnd->embedGenericHandle(pResolvedToken, true, m_methodInfo->ftn, &embedInfo);

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2329,7 +2329,7 @@ void InterpCompiler::EmitPushHelperCall_2(const CorInfoHelpFunc ftn, const CORIN
 
     if (handleData.argType == HelperArgType::GenericResolution)
     {
-        AddIns(INTOP_CALL_HELPER_P_GP);
+        AddIns(INTOP_CALL_HELPER_P_GS);
         m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(ftn);
         m_pLastNewIns->data[1] = handleData.dataItemIndex;
 
@@ -2338,7 +2338,7 @@ void InterpCompiler::EmitPushHelperCall_2(const CorInfoHelpFunc ftn, const CORIN
     }
     else
     {
-        AddIns(INTOP_CALL_HELPER_P_PP);
+        AddIns(INTOP_CALL_HELPER_P_PS);
         m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(ftn);
         m_pLastNewIns->data[1] = handleData.dataItemIndex;
 
@@ -2383,7 +2383,7 @@ void InterpCompiler::EmitPushUnboxAnyNullable(const CORINFO_GENERICHANDLE_RESULT
 
     if (handleData.argType == HelperArgType::GenericResolution)
     {
-        AddIns(INTOP_CALL_HELPER_V_AGP);
+        AddIns(INTOP_CALL_HELPER_V_AGS);
         m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(CORINFO_HELP_UNBOX_NULLABLE);
         m_pLastNewIns->data[1] = handleData.dataItemIndex;
         
@@ -2392,7 +2392,7 @@ void InterpCompiler::EmitPushUnboxAnyNullable(const CORINFO_GENERICHANDLE_RESULT
     }
     else
     {
-        AddIns(INTOP_CALL_HELPER_V_APP);
+        AddIns(INTOP_CALL_HELPER_V_APS);
         m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(CORINFO_HELP_UNBOX_NULLABLE);
         m_pLastNewIns->data[1] = handleData.dataItemIndex;
 
@@ -3079,6 +3079,13 @@ void InterpCompiler::EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORI
         case CORINFO_FIELD_STATIC_ADDRESS:
         case CORINFO_FIELD_STATIC_RVA_ADDRESS:
         {
+            if (pFieldInfo->fieldFlags |= CORINFO_FLG_FIELD_INITCLASS)
+            {
+                CORINFO_GENERICHANDLE_RESULT embedInfo;
+                m_compHnd->embedGenericHandle(pResolvedToken, true, m_methodInfo->ftn, &embedInfo);
+                EmitPushHelperCall(CORINFO_HELP_INITCLASS, embedInfo, StackTypeI, NULL);
+                m_pStackPointer--; // The InitClass helper doesn't actually return anything, so we pop the stack
+            }
             // const field address
             assert(pFieldInfo->fieldLookup.accessType == IAT_VALUE);
             AddIns(INTOP_LDPTR);
@@ -3107,6 +3114,17 @@ void InterpCompiler::EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORI
                 case CORINFO_HELP_GETDYNAMIC_NONGCTHREADSTATIC_BASE:
                     helperArg = (void*)m_compHnd->getClassThreadStaticDynamicInfo(pResolvedToken->hClass);
                     break;
+                case CORINFO_HELP_GETDYNAMIC_GCSTATIC_BASE:
+                case CORINFO_HELP_GETDYNAMIC_NONGCSTATIC_BASE:
+                case CORINFO_HELP_GETPINNED_GCSTATIC_BASE:
+                case CORINFO_HELP_GETPINNED_NONGCSTATIC_BASE:
+                case CORINFO_HELP_GETDYNAMIC_GCSTATIC_BASE_NOCTOR:
+                case CORINFO_HELP_GETDYNAMIC_NONGCSTATIC_BASE_NOCTOR:
+                case CORINFO_HELP_GETPINNED_GCSTATIC_BASE_NOCTOR:
+                case CORINFO_HELP_GETPINNED_NONGCSTATIC_BASE_NOCTOR:
+                    helperArg = (void*)m_compHnd->getClassStaticDynamicInfo(pResolvedToken->hClass);
+                    break;
+
                 default:
                     // TODO
                     assert(0);
@@ -3130,11 +3148,9 @@ void InterpCompiler::EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORI
         }
         case CORINFO_FIELD_STATIC_GENERICS_STATIC_HELPER:
         {
-            AddIns(INTOP_CALL_HELPER_P_P);
-            m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(pFieldInfo->helper);
-            m_pLastNewIns->data[1] = GetDataItemIndex(pResolvedToken->tokenContext);
-            PushInterpType(InterpTypeByRef, NULL);
-            m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+            CORINFO_GENERICHANDLE_RESULT embedInfo;
+            m_compHnd->embedGenericHandle(pResolvedToken, true, m_methodInfo->ftn, &embedInfo);
+            EmitPushHelperCall(pFieldInfo->helper, embedInfo, StackTypeByRef, NULL);
 
             // Add field offset
             m_pStackPointer--;
@@ -3298,6 +3314,73 @@ void InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
     // Safepoint at each method entry. This could be done as part of a call, rather than
     // adding an opcode.
     AddIns(INTOP_SAFEPOINT);
+
+    CorInfoInitClassResult initOnFunctionStart = m_compHnd->initClass(NULL, NULL, METHOD_BEING_COMPILED_CONTEXT());
+    if ((initOnFunctionStart & CORINFO_INITCLASS_USE_HELPER) == CORINFO_INITCLASS_USE_HELPER)
+    {
+        // This happens if the method is on a type which is not beforefieldinit,
+        // and the type is not initialized at the start of the method.
+
+        CORINFO_LOOKUP_KIND kind;
+        m_compHnd->getLocationOfThisType(m_methodHnd, &kind);
+
+        if (!kind.needsRuntimeLookup)
+        {
+            AddIns(INTOP_CALL_HELPER_P_P);
+            m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(CORINFO_HELP_INITCLASS);
+            m_pLastNewIns->data[1] = GetDataItemIndex(m_classHnd);
+            PushInterpType(InterpTypeI, NULL);
+            m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+            m_pStackPointer--;
+        }
+        else
+        {
+            switch (kind.runtimeLookupKind)
+            {
+            case CORINFO_LOOKUP_CLASSPARAM:
+                AddIns(INTOP_CALL_HELPER_P_S);
+                m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(CORINFO_HELP_INITCLASS);
+                m_pLastNewIns->SetSVar(getParamArgIndex());
+                PushInterpType(InterpTypeI, NULL);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                m_pStackPointer--;
+                break;
+            case CORINFO_LOOKUP_THISOBJ:
+            {
+                AddIns(INTOP_LDIND_I);
+                m_pLastNewIns->data[0] = 0; // The offset is 0 for the this pointer
+                m_pLastNewIns->SetSVar(getParamArgIndex());
+                PushInterpType(InterpTypeI, NULL);
+                int thisObjMethodTablePtrVar = m_pStackPointer[-1].var;
+                m_pLastNewIns->SetDVar(thisObjMethodTablePtrVar);
+                m_pStackPointer--;
+
+                AddIns(INTOP_CALL_HELPER_P_SP);
+                m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(CORINFO_HELP_INITINSTCLASS);
+                m_pLastNewIns->data[1] = GetDataItemIndex(m_methodHnd);
+                m_pLastNewIns->SetSVar(thisObjMethodTablePtrVar);
+                PushInterpType(InterpTypeI, NULL);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                m_pStackPointer--;
+                break;
+            }
+            case CORINFO_LOOKUP_METHODPARAM:
+            {
+                AddIns(INTOP_CALL_HELPER_P_PS);
+                m_pLastNewIns->data[0] = GetDataItemIndexForHelperFtn(CORINFO_HELP_INITINSTCLASS);
+                m_pLastNewIns->data[1] = GetDataItemIndex(0);
+                m_pLastNewIns->SetSVar(getParamArgIndex());
+                PushInterpType(InterpTypeI, NULL);
+                m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+                m_pStackPointer--;
+                break;
+            }
+            default:
+                assert(0);
+                break;
+            }
+        }
+    }
 
     linkBBlocks = true;
     needsRetryEmit = false;
@@ -5924,6 +6007,11 @@ void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int3
             CORINFO_CLASS_HANDLE ch = (CORINFO_CLASS_HANDLE)((size_t)m_dataItems.Get(*pData));
             printf(" ");
             PrintClassName(ch);
+            break;
+        }
+        case InterpOpHelperFtnNoArgs:
+        {
+            PrintHelperFtn((void*)GetDataItemAtIndex(pData[0]));
             break;
         }
         case InterpOpHelperFtn:

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -528,8 +528,8 @@ private:
 #endif // DEBUG
     }
 
-#ifdef DEBUG
     CORINFO_CLASS_HANDLE m_classHnd;
+    #ifdef DEBUG
     TArray<char> m_methodName;
     bool m_verbose = false;
 

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -345,19 +345,21 @@ OPDEF(INTOP_NEWOBJ_VT, "newobj.vt", 5, 1, 1, InterpOpMethodHandle)
 
 // Call a helper function with a signature of PointerSizedDest helper(TypeOrGenericArg))
 OPDEF(INTOP_CALL_HELPER_P_P, "call.helper.p.p", 4, 1, 0, InterpOpHelperFtn)
-OPDEF(INTOP_CALL_HELPER_P_PP, "call.helper.p.pp", 5, 1, 1, InterpOpHelperFtn)
+OPDEF(INTOP_CALL_HELPER_P_G, "call.helper.p.g", 5, 1, 1, InterpOpGenericHelperFtn)
+OPDEF(INTOP_CALL_HELPER_P_S, "call.helper.p.s", 4, 1, 1, InterpOpHelperFtnNoArgs)
 
 // Call a helper function with a signature of PointerSizedDest helper(TypeOrGenericArg, SVar))
-OPDEF(INTOP_CALL_HELPER_P_G, "call.helper.p.g", 5, 1, 1, InterpOpGenericHelperFtn)
-OPDEF(INTOP_CALL_HELPER_P_GP, "call.helper.p.gp", 6, 1, 2, InterpOpGenericHelperFtn)
+OPDEF(INTOP_CALL_HELPER_P_PS, "call.helper.p.ps", 5, 1, 1, InterpOpHelperFtn)
+OPDEF(INTOP_CALL_HELPER_P_GS, "call.helper.p.gs", 6, 1, 2, InterpOpGenericHelperFtn)
+OPDEF(INTOP_CALL_HELPER_P_SP, "call.helper.p.sp", 5, 1, 1, InterpOpHelperFtn)
 
 // Call a helper function with a signature of PointerSizedDest helper(TypeOrGenericArg, AddrOfSVar))
 OPDEF(INTOP_CALL_HELPER_P_PA, "call.helper.p.pa", 5, 1, 1, InterpOpHelperFtn)
 OPDEF(INTOP_CALL_HELPER_P_GA, "call.helper.p.ga", 6, 1, 2, InterpOpGenericHelperFtn)
 
 // Call a helper function with a signature of void helper(AddrOfDVar, TypeOrGenericArg, SVar))
-OPDEF(INTOP_CALL_HELPER_V_APP, "call.helper.v.app", 5, 1, 1, InterpOpHelperFtn)
-OPDEF(INTOP_CALL_HELPER_V_AGP, "call.helper.v.agp", 6, 1, 2, InterpOpGenericHelperFtn)
+OPDEF(INTOP_CALL_HELPER_V_APS, "call.helper.v.aps", 5, 1, 1, InterpOpHelperFtn)
+OPDEF(INTOP_CALL_HELPER_V_AGS, "call.helper.v.ags", 6, 1, 2, InterpOpGenericHelperFtn)
 
 OPDEF(INTOP_GENERICLOOKUP, "generic", 4, 1, 1, InterpOpGenericLookup)
 

--- a/src/coreclr/interpreter/intops.h
+++ b/src/coreclr/interpreter/intops.h
@@ -26,6 +26,7 @@ typedef enum
     InterpOpGenericHelperFtn,
     InterpOpLdPtr,
     InterpOpHelperFtn,
+    InterpOpHelperFtnNoArgs,
     InterpOpPointerHelperFtn,
     InterpOpPointerInt,
     InterpOpGenericLookupInt,

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1592,12 +1592,33 @@ MAIN_LOOP:
                     ip += 4;
                     break;
                 }
-                case INTOP_CALL_HELPER_P_PP:
+
+                case INTOP_CALL_HELPER_P_S:
+                {
+                    HELPER_FTN_P_P helperFtn = GetPossiblyIndirectHelper<HELPER_FTN_P_P>(pMethod->pDataItems[ip[2]]);
+                    void* helperArg = LOCAL_VAR(ip[3], void*);
+
+                    LOCAL_VAR(ip[1], void*) = helperFtn(helperArg);
+                    ip += 4;
+                    break;
+                }
+
+                case INTOP_CALL_HELPER_P_PS:
                 {
                     HELPER_FTN_P_PP helperFtn = GetPossiblyIndirectHelper<HELPER_FTN_P_PP>(pMethod->pDataItems[ip[3]]);
                     void* helperArg = pMethod->pDataItems[ip[4]];
 
                     LOCAL_VAR(ip[1], void*) = helperFtn(helperArg, LOCAL_VAR(ip[2], void*));
+                    ip += 5;
+                    break;
+                }
+
+                case INTOP_CALL_HELPER_P_SP:
+                {
+                    HELPER_FTN_P_PP helperFtn = GetPossiblyIndirectHelper<HELPER_FTN_P_PP>(pMethod->pDataItems[ip[3]]);
+                    void* helperArg = pMethod->pDataItems[ip[4]];
+
+                    LOCAL_VAR(ip[1], void*) = helperFtn(LOCAL_VAR(ip[2], void*), helperArg);
                     ip += 5;
                     break;
                 }
@@ -1614,7 +1635,7 @@ MAIN_LOOP:
                     break;
                 }
 
-                case INTOP_CALL_HELPER_P_GP:
+                case INTOP_CALL_HELPER_P_GS:
                 {
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
                     void* helperArg = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
@@ -1646,7 +1667,7 @@ MAIN_LOOP:
                     break;
                 }
 
-                case INTOP_CALL_HELPER_V_AGP:
+                case INTOP_CALL_HELPER_V_AGS:
                 {
                     InterpGenericLookup *pLookup = (InterpGenericLookup*)&pMethod->pDataItems[ip[5]];
                     void* helperArg = DoGenericLookup(LOCAL_VAR(ip[2], void*), pLookup);
@@ -1657,7 +1678,7 @@ MAIN_LOOP:
                     break;
                 }
 
-                case INTOP_CALL_HELPER_V_APP:
+                case INTOP_CALL_HELPER_V_APS:
                 {
                     HELPER_FTN_V_PPP helperFtn = GetPossiblyIndirectHelper<HELPER_FTN_V_PPP>(pMethod->pDataItems[ip[3]]);
                     void* helperArg = pMethod->pDataItems[ip[4]];

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -885,6 +885,10 @@ public class InterpreterTest
         if (!TestStaticVirtualGeneric_CodePointerCase())
             Environment.FailFast(null);
 
+        Console.WriteLine("TestPreciseInitCctors");
+        if (!TestPreciseInitCctors())
+            Environment.FailFast(null);
+
 	Console.WriteLine("Empty string length: {0}", string.Empty.Length);
 
 	Console.WriteLine("BitConverter.IsLittleEndian: {0}", BitConverter.IsLittleEndian);
@@ -1938,8 +1942,26 @@ public class InterpreterTest
         public T Value;
     }
 
+    public static int preciseInitCctorsRun = 0;
+
+    class MyPreciseInitClass<T>
+    {
+        static MyPreciseInitClass()
+        {
+            preciseInitCctorsRun++;
+        }
+
+        public static void TriggerCctorClass()
+        {
+        }
+
+        public static void TriggerCctorMethod<U>()
+        {}
+    }
+
     class MyClass<T>
     {
+        static Type staticVarType = typeof(MyClass<T>);
         public Type GetTypeOf()
         {
             return typeof(MyClass<T>);
@@ -1948,6 +1970,61 @@ public class InterpreterTest
         {
             return typeof(MyClass<T>);
         }
+
+        public static Type GetTypeThroughStaticVar()
+        {
+            return staticVarType;
+        }
+    }
+
+    public static bool TestPreciseInitCctors()
+    {
+        if (preciseInitCctorsRun != 0)
+        {
+            Console.WriteLine("preciseInitCctorsRun should be 0, but is {0}", preciseInitCctorsRun);
+            return false;
+        }
+        MyPreciseInitClass<int>.TriggerCctorClass();
+        if (preciseInitCctorsRun != 1)
+        {
+            Console.WriteLine("preciseInitCctorsRun should be 1, but is {0}", preciseInitCctorsRun);
+            return false;
+        }
+        MyPreciseInitClass<short>.TriggerCctorMethod<int>();
+        if (preciseInitCctorsRun != 2)
+        {
+            Console.WriteLine("TriggerCctorClass should return 2, but did not");
+            return false;
+        }
+
+        object o = new MyPreciseInitClass<double>();
+        if (preciseInitCctorsRun != 3)
+        {
+            Console.WriteLine("TriggerCctorClass should return 3, but did not");
+            return false;
+        }
+
+        MyPreciseInitClass<object>.TriggerCctorClass();
+        if (preciseInitCctorsRun != 4)
+        {
+            Console.WriteLine("preciseInitCctorsRun should be 4 but is {0}", preciseInitCctorsRun);
+            return false;
+        }
+        MyPreciseInitClass<string>.TriggerCctorMethod<object>();
+        if (preciseInitCctorsRun != 5)
+        {
+            Console.WriteLine("TriggerCctorClass should return 5, but did not");
+            return false;
+        }
+
+        o = new MyPreciseInitClass<Type>();
+        if (preciseInitCctorsRun != 6)
+        {
+            Console.WriteLine("TriggerCctorClass should return 6, but did not");
+            return false;
+        }
+
+        return true;
     }
 
     public static bool TestSharedGenerics()
@@ -2101,12 +2178,16 @@ public class InterpreterTest
             return false;
         }
 
-        MyClass<string > mcString = new MyClass<string>();
+        MyClass<string> mcString = new MyClass<string>();
         if (mcString.GetTypeOf() != typeof(MyClass<string>))
         {
             return false;
         }
         if (MyClass<object>.GetTypeOfStatic() != typeof(MyClass<object>))
+        {
+            return false;
+        }
+        if (MyClass<object>.GetTypeThroughStaticVar() != typeof(MyClass<object>))
         {
             return false;
         }

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -1993,14 +1993,14 @@ public class InterpreterTest
         MyPreciseInitClass<short>.TriggerCctorMethod<int>();
         if (preciseInitCctorsRun != 2)
         {
-            Console.WriteLine("TriggerCctorClass should return 2, but did not");
+            Console.WriteLine("TriggerCctorClass should return 2, but is {0}", preciseInitCctorsRun);
             return false;
         }
 
         object o = new MyPreciseInitClass<double>();
         if (preciseInitCctorsRun != 3)
         {
-            Console.WriteLine("TriggerCctorClass should return 3, but did not");
+            Console.WriteLine("TriggerCctorClass should return 3, but is {0}", preciseInitCctorsRun);
             return false;
         }
 
@@ -2013,14 +2013,14 @@ public class InterpreterTest
         MyPreciseInitClass<string>.TriggerCctorMethod<object>();
         if (preciseInitCctorsRun != 5)
         {
-            Console.WriteLine("TriggerCctorClass should return 5, but did not");
+            Console.WriteLine("TriggerCctorClass should return 5, but is {0}", preciseInitCctorsRun);
             return false;
         }
 
         o = new MyPreciseInitClass<Type>();
         if (preciseInitCctorsRun != 6)
         {
-            Console.WriteLine("TriggerCctorClass should return 6, but did not");
+            Console.WriteLine("TriggerCctorClass should return 6,  but is {0}", preciseInitCctorsRun);
             return false;
         }
 


### PR DESCRIPTION
- There is another renaming of the helpers call opcodes to allow distinguishing between whether or not the arg is supplied via svar or dataindex.
- More tests to cover these scenarios
- This should finish up the support for shared generics