### PR TITLE
[mono] Fix use of uninitialized variable

### DIFF
--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -183,6 +183,8 @@ mono_class_setup_interface_offsets_internal (MonoClass *klass, int cur_slot, int
 			interfaces_full [i] = inflated;
 			if (!bitmap_only)
 				interface_offsets_full [i] = gklass->interface_offsets_packed [i];
+			else
+				interface_offsets_full [i] = 0;
 
 			int count = mono_class_setup_count_virtual_methods (inflated);
 			if (count == -1) {


### PR DESCRIPTION
Unlikely for this to fix an issue, but should prevent false positives with valgrind. Use added in https://github.com/dotnet/runtime/pull/73786