### PR TITLE
JIT: Remove overzealous fake-splitting assert for x86 unwind info

### DIFF
--- a/src/coreclr/jit/unwindx86.cpp
+++ b/src/coreclr/jit/unwindx86.cpp
@@ -119,13 +119,8 @@ void Compiler::unwindReserveFunc(FuncInfoDsc* func)
 
     if (fgFirstColdBlock != nullptr)
     {
-#ifdef DEBUG
-        if (JitConfig.JitFakeProcedureSplitting())
-        {
-            assert(func->funKind == FUNC_ROOT); // No splitting of funclets.
-        }
-        else
-#endif // DEBUG
+        // If fake-splitting, treat all unwind info as hot.
+        INDEBUG(if (!JitConfig.JitFakeProcedureSplitting()))
         {
             unwindReserveFuncHelper(func, false);
         }


### PR DESCRIPTION
This assert was hit by [Antigen](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1081296&view=ms.vss-build-web.run-extensions-tab) recently. If we are doing fake hot/cold splitting, the JIT should tell the VM to reserve just one unwind info for the main function entry, regardless of whether it is split. However, we still need to reserve unwind infos for the funclets. Thus, this assert doesn't make sense.