### PR TITLE
Include Pkcs (net10.0 & -windows) in aspnetcore transport pack

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -250,9 +250,9 @@
       <!-- Add ReferenceCopyLocalPaths for ProjectReferences which are flagged as Pack="true" into the package. -->
       <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('Pack', 'true'))" />
       <TfmSpecificPackageFile Include="@(_projectReferenceCopyLocalPaths)"
-                              PackagePath="$([MSBuild]::ValueOrDefault('%(ReferenceCopyLocalPaths.PackagePath)', '$(BuildOutputTargetFolder)\$(_referringTargetFramework)\'))" />
+                              PackagePath="$([MSBuild]::ValueOrDefault('%(ReferenceCopyLocalPaths.PackagePath)', '$(BuildOutputTargetFolder)/$(_referringTargetFramework)/'))" />
       <TfmSpecificDebugSymbolsFile Include="@(TfmSpecificPackageFile->WithMetadataValue('Extension', '.pdb'))"
-                                   TargetPath="/%(TfmSpecificPackageFile.PackagePath)/%(Filename)%(Extension)"
+                                   TargetPath="/%(TfmSpecificPackageFile.PackagePath)%(Filename)%(Extension)"
                                    TargetFramework="$(_referringTargetFramework)"
                                    Condition="'$(IncludeSymbols)' == 'true'" />
       <!-- Remove symbol from the non symbol package. -->

--- a/src/libraries/Microsoft.Internal.Runtime.AspNetCore.Transport/src/Microsoft.Internal.Runtime.AspNetCore.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.AspNetCore.Transport/src/Microsoft.Internal.Runtime.AspNetCore.Transport.proj
@@ -14,6 +14,7 @@
     <NoWarn>$(NoWarn);NU5131</NoWarn>
     <!-- Include the symbols in the non-symbols package so that they get redistributed into aspnetcore's shared framework. -->
     <IncludeSymbolsInPackage>true</IncludeSymbolsInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePkcsWindowsProjectReference</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +24,7 @@
                       PrivateAssets="all"
                       Private="true"
                       IncludeReferenceAssemblyInPackage="true" />
+
     <!-- These generators only provides an implementation targeting Roslyn 4.4 and upwards. -->
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration.Binder\gen\Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj"
                       ReferenceOutputAssembly="false"
@@ -33,6 +35,24 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Options\gen\Microsoft.Extensions.Options.SourceGeneration.csproj"
                       ReferenceOutputAssembly="false"
                       PackAsAnalyzer="true" />
+
+    <!-- Manually reference Pkcs to make sure that the $(NetCoreAppCurrent)-windows assembly gets included as well. -->
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj"
+                      PrivateAssets="all"
+                      SetTargetFramework="TargetFramework=$(NetCoreAppCurrent)-windows"
+                      OutputItemType="PkcsWindowsProjectReference" />
   </ItemGroup>
+
+  <Target Name="IncludePkcsWindowsProjectReference" DependsOnTargets="BuildOnlySettings;ResolveReferences">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(PkcsWindowsProjectReference)"
+                              PackagePath="/runtimes/win/lib/$(NetCoreAppCurrent)/" />
+      <_pkcsWindowsProjectReferenceAsPdb Include="$([System.IO.Path]::ChangeExtension('%(PkcsWindowsProjectReference.Identity)', '.pdb'))" />
+      <TfmSpecificDebugSymbolsFile Include="@(_pkcsWindowsProjectReferenceAsPdb)"
+                                   TargetPath="/runtimes/win/lib/$(NetCoreAppCurrent)/%(Filename)%(Extension)"
+                                   TargetFramework="$(NetCoreAppCurrent)" />
+    </ItemGroup>
+  </Target>
+
 
 </Project>

--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -224,6 +224,7 @@
       Microsoft.Extensions.Primitives;
       System.Diagnostics.EventLog;
       System.Formats.Cbor;
+      System.Security.Cryptography.Pkcs;
       System.Security.Cryptography.Xml;
       System.Threading.AccessControl;
       System.Threading.RateLimiting;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/117146

![image](https://github.com/user-attachments/assets/e4219ce4-c106-4562-b43d-b3d16ca4a17b)
