### PR TITLE
JIT: Allow compaction of blocks with switch predecessors

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -838,17 +838,6 @@ bool Compiler::fgCanCompactBlock(BasicBlock* block)
         return false;
     }
 
-    // If there is a switch predecessor don't bother because we'd have to update the uniquesuccs as well
-    // (if they are valid).
-    //
-    for (BasicBlock* const predBlock : target->PredBlocks())
-    {
-        if (predBlock->KindIs(BBJ_SWITCH))
-        {
-            return false;
-        }
-    }
-
     return true;
 }
 


### PR DESCRIPTION
Now that switch successor edge redirection is trivial, we can compact blocks with switch predecessors without worrying about invalidating the entire switch successor map.