### PR TITLE
Revert "Exit with quick_exit when using debug UCRT (#109006)"

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include <stdint.h>
-#include <stdlib.h>
 
 //
 // This is the mechanism whereby multiple linked modules contribute their global data for initialization at
@@ -223,12 +222,7 @@ int main(int argc, char* argv[])
     if (initval != 0)
         return initval;
 
-#if defined(DEBUG) && defined(_WIN32)
-    // quick_exit works around Debug UCRT shutdown issues: https://github.com/dotnet/runtime/issues/108640
-    quick_exit(__managed__Main(argc, argv));
-#else
     return __managed__Main(argc, argv);
-#endif
 }
 
 #ifdef HAS_ADDRESS_SANITIZER

--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -222,7 +222,14 @@ int main(int argc, char* argv[])
     if (initval != 0)
         return initval;
 
+#if defined(DEBUG) && defined(_WIN32)
+    // work around Debug UCRT shutdown issues: https://github.com/dotnet/runtime/issues/108640
+    int exitCode = __managed__Main(argc, argv);
+    _cexit();
+    ExitProcess(exitCode);
+#else
     return __managed__Main(argc, argv);
+#endif
 }
 
 #ifdef HAS_ADDRESS_SANITIZER

--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -3,6 +3,11 @@
 
 #include <stdint.h>
 
+#if defined(DEBUG) && defined(_WIN32)
+#include <process.h>
+#include <windows.h>
+#endif
+
 //
 // This is the mechanism whereby multiple linked modules contribute their global data for initialization at
 // startup of the application.

--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -111,16 +111,16 @@ void* PalGetModuleHandleFromPointer(void* pointer);
 #if defined(HOST_X86) && defined(HOST_WINDOWS)
 #define STRINGIFY(s) #s
 #define MANAGED_RUNTIME_EXPORT_ALTNAME(_method) STRINGIFY(/alternatename:_##_method=_method)
+#define MANAGED_RUNTIME_EXPORT_CALLCONV __cdecl
 #define MANAGED_RUNTIME_EXPORT(_name) \
     __pragma(comment (linker, MANAGED_RUNTIME_EXPORT_ALTNAME(_name))) \
-    extern "C" void __cdecl _name();
+    extern "C" void MANAGED_RUNTIME_EXPORT_CALLCONV _name();
 #define MANAGED_RUNTIME_EXPORT_NAME(_name) _name
-#define CDECL __cdecl
 #else
+#define MANAGED_RUNTIME_EXPORT_CALLCONV
 #define MANAGED_RUNTIME_EXPORT(_name) \
     extern "C" void _name();
 #define MANAGED_RUNTIME_EXPORT_NAME(_name) _name
-#define CDECL
 #endif
 
 MANAGED_RUNTIME_EXPORT(GetRuntimeException)
@@ -138,7 +138,7 @@ MANAGED_RUNTIME_EXPORT(ObjectiveCMarshalGetOnEnteredFinalizerQueueCallback)
 MANAGED_RUNTIME_EXPORT(ObjectiveCMarshalGetUnhandledExceptionPropagationHandler)
 #endif
 
-typedef void (CDECL *pfn)();
+typedef void (MANAGED_RUNTIME_EXPORT_CALLCONV *pfn)();
 
 static const pfn c_classlibFunctions[] = {
     &MANAGED_RUNTIME_EXPORT_NAME(GetRuntimeException),
@@ -218,7 +218,7 @@ static int InitializeRuntime()
 #ifndef NATIVEAOT_DLL
 
 #if defined(_WIN32)
-int CDECL wmain(int argc, wchar_t* argv[])
+int __cdecl wmain(int argc, wchar_t* argv[])
 #else
 int main(int argc, char* argv[])
 #endif

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -350,10 +350,6 @@ extern "C" bool RhInitialize(bool isDll)
 #endif
 
 #if defined(HOST_WINDOWS) || defined(FEATURE_PERFTRACING)
-#if defined(DEBUG) && defined(HOST_WINDOWS)
-    // quick_exit works around Debug UCRT shutdown issues: https://github.com/dotnet/runtime/issues/108640
-    at_quick_exit(&OnProcessExit);
-#endif
     atexit(&OnProcessExit);
 #endif
 


### PR DESCRIPTION
This reverts commit e1d7398072966e20b01d2e3bd4af724f82a98f04.

The fix didn't work around the problem after all. A CI run from a couple days ago still hits the CRT shutdown bug. Crashdump still at:

```
runfo get-helix-payload -j 608a7b9d-68cc-46d0-9d48-dd5571a3c251 -w System.Xml.Linq.xNodeBuilder.Tests -o c:\helix\608a7b9d-68cc-46d0-9d48-dd5571a3c251\System.Xml.Linq.xNodeBuilder.Tests\
```

We should ideally address this at the xunit single file runner level, but I (or Copilot) cannot find a way to get xunit infrastructure to wait for its background threads to finish.

The problem is that we still have an xunit background thread message bus collector delegator sink proxy factory factory doing some work at the time the main thread is already done. I tried disposing things, and adding more waits, and I'm just giving up, the thread is still there.

We could add a 500 ms wait at the end of single file runner Main and see if that works, I guess.

Cc @dotnet/ilc-contrib 