### PR TITLE
Fix Infinite loop on OdbcDataReader.internalGetString with UTF-8 text

### DIFF
--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcDataReader.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcDataReader.cs
@@ -1008,6 +1008,11 @@ namespace System.Data.Odbc
                             // followed by exception. I did not add it now to avoid breaking change
                             Debug.Assert(lengthOrIndicator >= 0 || lengthOrIndicator == ODBC32.SQL_NO_TOTAL, "unexpected lengthOrIndicator value");
 
+                            if (0 == lengthOrIndicator)
+                            {
+                                break;  // done
+                            }
+
                             if (ODBC32.SQL_NO_TOTAL != lengthOrIndicator)
                             {
                                 cbActual = Math.Min(lengthOrIndicator, cbMaxData);


### PR DESCRIPTION
Fix Infinite loop on OdbcDataReader.internalGetString with UTF-8 text.

When the lengthOrIndicator is 0 the loop should be broken.
This change fixes the issue #86490 