### PR TITLE
Ensure no-trim-aot-warning uses of types from signatures work

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Delegate.cs
@@ -389,6 +389,8 @@ namespace System
             Debug.Assert(delegateEEType != null);
             Debug.Assert(delegateEEType->IsCanonical);
 
+            RuntimeAugments.EnsureMethodTableSafeToAllocate(delegateEEType);
+
             Delegate del = (Delegate)(RuntimeImports.RhNewObject(delegateEEType));
 
             IntPtr objArrayThunk = del.GetThunk(Delegate.ObjectArrayThunk);
@@ -411,6 +413,8 @@ namespace System
         //
         internal static unsafe Delegate CreateDelegate(MethodTable* delegateEEType, IntPtr ldftnResult, object thisObject, bool isStatic, bool isOpen)
         {
+            RuntimeAugments.EnsureMethodTableSafeToAllocate(delegateEEType);
+
             Delegate del = (Delegate)RuntimeImports.RhNewObject(delegateEEType);
 
             // What? No constructor call? That's right, and it's not an oversight. All "construction" work happens in

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -99,12 +99,25 @@ namespace ILCompiler.DependencyAnalysis
             {
                 factory.TypeSystemContext.DetectGenericCycles(type, referent);
 
+                // If the user can legitimately get to a System.Type instance by inspecting the signature of the method,
+                // the user then might use these System.Type instances with APIs such as:
+                //
+                // * MethodInfo.CreateDelegate
+                // * RuntimeHelpers.Box
+                // * Array.CreateInstanceForArrayType
+                //
+                // All of these APIs are trim/AOT safe and allow creating new instances of the supplied Type.
+                // We need this to work.
+                // NOTE: We don't have to worry about RuntimeHelpers.GetUninitializedObject because that one is annotated
+                // as trim-unsafe.
+                bool isMaximallyConstructibleByPolicy = type.IsDelegate || type.IsValueType || type.IsSzArray;
+
                 // Reflection might need to create boxed instances of valuetypes as part of reflection invocation.
                 // Non-valuetypes are only needed for the purposes of casting/type checks.
                 // If this is a non-exact type, we need the type loader template to get the type handle.
                 if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
                     GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, type.NormalizeInstantiation());
-                else if (isOut && !type.IsGCPointer)
+                else if ((isOut && !type.IsGCPointer) || isMaximallyConstructibleByPolicy)
                     dependencies.Add(factory.MaximallyConstructableType(type.NormalizeInstantiation()), reason);
                 else
                     dependencies.Add(factory.NecessaryTypeSymbol(type.NormalizeInstantiation()), reason);

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -96,6 +96,7 @@ internal static class ReflectionTest
         TestEntryPoint.Run();
         TestGenericAttributesOnEnum.Run();
         TestLdtokenWithSignaturesDifferingInModifiers.Run();
+        TestActivatingThingsInSignature.Run();
 
         return 100;
     }
@@ -2917,6 +2918,33 @@ internal static class ReflectionTest
             if (cdecl.Compile()(null) != "Cdecl")
                 throw new Exception();
         }
+    }
+
+    class TestActivatingThingsInSignature
+    {
+        public static unsafe void Run()
+        {
+            var mi = typeof(TestActivatingThingsInSignature).GetMethod(nameof(MethodWithThingsInSignature));
+            var p = mi.GetParameters();
+
+            var d = typeof(TestActivatingThingsInSignature).GetMethod(nameof(Run)).CreateDelegate(p[0].ParameterType);
+            Console.WriteLine(d.ToString());
+
+            Span<byte> storage = stackalloc byte[sizeof(MyStruct)];
+            var s = RuntimeHelpers.Box(ref MemoryMarshal.GetReference(storage), p[1].ParameterType.TypeHandle);
+            Console.WriteLine(s.ToString());
+
+            var a = Array.CreateInstanceFromArrayType(p[2].ParameterType, 0);
+            Console.WriteLine(a.ToString());
+        }
+
+        public void MethodWithThingsInSignature(MyDelegate d, MyStruct s, MyArrayElementStruct[] a) { }
+
+        public delegate void MyDelegate();
+
+        public struct MyStruct;
+
+        public struct MyArrayElementStruct;
     }
 
     #region Helpers

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -97,6 +97,7 @@ internal static class ReflectionTest
         TestGenericAttributesOnEnum.Run();
         TestLdtokenWithSignaturesDifferingInModifiers.Run();
         TestActivatingThingsInSignature.Run();
+        TestDelegateInvokeFromEvent.Run();
 
         return 100;
     }
@@ -2945,6 +2946,23 @@ internal static class ReflectionTest
         public struct MyStruct;
 
         public struct MyArrayElementStruct;
+    }
+
+    class TestDelegateInvokeFromEvent
+    {
+        class MyClass
+        {
+            public event EventHandler<int> MyEvent;
+        }
+
+        static EventInfo s_eventInfo = typeof(MyClass).GetEvent("MyEvent");
+
+        public static unsafe void Run()
+        {
+            var invokeMethod = s_eventInfo.EventHandlerType.GetMethod("Invoke");
+            if (invokeMethod.Name != "Invoke")
+                throw new Exception();
+        }
     }
 
     #region Helpers

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -2952,7 +2952,7 @@ internal static class ReflectionTest
     {
         class MyClass
         {
-            public event EventHandler<int> MyEvent;
+            public event EventHandler<int> MyEvent { add { } remove { } }
         }
 
         static EventInfo s_eventInfo = typeof(MyClass).GetEvent("MyEvent");


### PR DESCRIPTION
I was helping a customer make a pattern trim safe and found a solution that has no warnings but still doesn't work due to this bug. I hit this with delegates, but it's also hittable with arrays and regrettably, structs.

This is a size regression. But correctness >> size.

Fixes #117200

Cc @dotnet/ilc-contrib 