### PR TITLE
[H/3] Fix disposing of buffers in parallel with running tasks

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -26,7 +26,9 @@ namespace System.Net.Http
         private Http3Connection _connection;
         private long _streamId = -1; // A stream does not have an ID until the first I/O against it. This gets set almost immediately following construction.
         private readonly QuicStream _stream;
+        private volatile bool _concurrentWrite;
         private ArrayBuffer _sendBuffer;
+        private volatile bool _concurrentRead;
         private ArrayBuffer _recvBuffer;
         private TaskCompletionSource<bool>? _expect100ContinueCompletionSource; // True indicates we should send content (e.g. received 100 Continue).
         private bool _disposed;
@@ -130,8 +132,18 @@ namespace System.Net.Http
         {
             _connection.RemoveStream(_stream);
 
-            _sendBuffer.Dispose();
-            _recvBuffer.Dispose();
+            // If the request sending was offloaded to be done concurrently and not awaited within SendAsync (by calling connection.LogException),
+            // the _sendBuffer disposal is the responsibility of that offloaded task to prevent returning buffer to the pool while it still might be accessed by the task.
+            if (!_concurrentWrite)
+            {
+                _sendBuffer.Dispose();
+            }
+            // If the response receiving was offloaded to be done concurrently and not awaited within SendAsync (by calling connection.LogException),
+            // the _recvBuffer disposal is the responsibility of that offloaded task to prevent returning buffer to the pool while it still might be accessed by the task.
+            if (!_concurrentRead)
+            {
+                _recvBuffer.Dispose();
+            }
         }
 
         public void GoAway()
@@ -199,6 +211,7 @@ namespace System.Net.Http
                         // Exceptions will be bubbled up from sendRequestTask here,
                         // which means the result of readResponseTask won't be observed directly:
                         // Do a background await to log any exceptions.
+                        _concurrentRead = true;
                         _connection.LogExceptions(readResponseTask);
                         throw;
                     }
@@ -207,6 +220,7 @@ namespace System.Net.Http
                 {
                     // Duplex is being used, so we can't wait for content to finish sending.
                     // Do a background await to log any exceptions.
+                    _concurrentWrite = true;
                     _connection.LogExceptions(sendRequestTask);
                 }
 
@@ -225,12 +239,6 @@ namespace System.Net.Http
                     catch (QuicException qex) when (qex.QuicError == QuicError.StreamAborted && qex.ApplicationErrorCode == (long)Http3ErrorCode.NoError)
                     {
                         // The server doesn't need the whole request to respond so it's aborting its reading side gracefully, see https://datatracker.ietf.org/doc/html/rfc9114#section-4.1-15.
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // If the request got cancelled before WritesClosed completed, avoid leaking an unobserved task exception.
-                        _connection.LogExceptions(writesClosed);
-                        throw;
                     }
                 }
 
@@ -387,32 +395,44 @@ namespace System.Net.Http
         /// </summary>
         private async Task ReadResponseAsync(CancellationToken cancellationToken)
         {
-            if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStart();
-
-            Debug.Assert(_response == null);
-            do
+            try
             {
-                _headerState = HeaderState.StatusHeader;
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStart();
 
-                (Http3FrameType? frameType, long payloadLength) = await ReadFrameEnvelopeAsync(cancellationToken).ConfigureAwait(false);
-
-                if (frameType != Http3FrameType.Headers)
+                Debug.Assert(_response == null);
+                do
                 {
-                    if (NetEventSource.Log.IsEnabled())
+                    _headerState = HeaderState.StatusHeader;
+
+                    (Http3FrameType? frameType, long payloadLength) = await ReadFrameEnvelopeAsync(cancellationToken).ConfigureAwait(false);
+
+                    if (frameType != Http3FrameType.Headers)
                     {
-                        Trace($"Expected HEADERS as first response frame; received {frameType}.");
+                        if (NetEventSource.Log.IsEnabled())
+                        {
+                            Trace($"Expected HEADERS as first response frame; received {frameType}.");
+                        }
+                        throw new HttpIOException(HttpRequestError.InvalidResponse, SR.net_http_invalid_response);
                     }
-                    throw new HttpIOException(HttpRequestError.InvalidResponse, SR.net_http_invalid_response);
+
+                    await ReadHeadersAsync(payloadLength, cancellationToken).ConfigureAwait(false);
+                    Debug.Assert(_response != null);
                 }
+                while ((int)_response.StatusCode < 200);
 
-                await ReadHeadersAsync(payloadLength, cancellationToken).ConfigureAwait(false);
-                Debug.Assert(_response != null);
+                _headerState = HeaderState.TrailingHeaders;
+
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)_response.StatusCode);
             }
-            while ((int)_response.StatusCode < 200);
-
-            _headerState = HeaderState.TrailingHeaders;
-
-            if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)_response.StatusCode);
+            finally
+            {
+                // Note that we might still observe false here even if we're responsible for the _recvBuffer disposal.
+                // But in that case, we just don't return the rented buffer to the pool, which is lesser evil than writing to returned one.
+                if (_concurrentRead)
+                {
+                    _recvBuffer.Dispose();
+                }
+            }
         }
 
         private async Task SendContentAsync(HttpContent content, CancellationToken cancellationToken)
@@ -491,6 +511,12 @@ namespace System.Net.Http
             }
             finally
             {
+                // Note that we might still observe false here even if we're responsible for the _sendBuffer disposal.
+                // But in that case, we just don't return the rented buffer to the pool, which is lesser evil than writing to returned one.
+                if (_concurrentWrite)
+                {
+                    _sendBuffer.Dispose();
+                }
                 _requestSendCompleted = true;
                 RemoveFromConnectionIfDone();
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -133,13 +133,13 @@ namespace System.Net.Http
             _connection.RemoveStream(_stream);
 
             // If the request sending was offloaded to be done concurrently and not awaited within SendAsync (by calling connection.LogException),
-            // the _sendBuffer disposal is the responsibility of that offloaded task to prevent returning buffer to the pool while it still might be accessed by the task.
+            // the _sendBuffer disposal is the responsibility of that offloaded task to prevent returning the buffer to the pool while it still might be in use.
             if (!_concurrentWrite)
             {
                 _sendBuffer.Dispose();
             }
             // If the response receiving was offloaded to be done concurrently and not awaited within SendAsync (by calling connection.LogException),
-            // the _recvBuffer disposal is the responsibility of that offloaded task to prevent returning buffer to the pool while it still might be accessed by the task.
+            // the _recvBuffer disposal is the responsibility of that offloaded task to prevent returning the buffer to the pool while it still might be in use.
             if (!_concurrentRead)
             {
                 _recvBuffer.Dispose();


### PR DESCRIPTION
There are 2 cases when we decide to not to wait for HTTP request / response sending / receiving:
- sending request content stream in duplex streaming:
https://github.com/dotnet/runtime/blob/b8f9b99a01c078a5e14d75ef7db72d7516284c0c/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs#L210
- reading response headers in case request sending failed
https://github.com/dotnet/runtime/blob/b8f9b99a01c078a5e14d75ef7db72d7516284c0c/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs#L202

As a result, `Http3RequestStream.Dispose` might be called in parallel (in case of an error, e.g. cancellation), disposing `_recvBuffer` / `_sendBuffer` and thus returning their underlying byte array into the shared pool. In the worst case scenario, these tasks could potentially write into byte array thet's been already returned to the pool.

**So this change, moves the responsibility to dispose the buffers to the non-awaited tasks in case they are send to `LogException`.** Note that this fixes the parallel usage of the buffer, but might not return the buffers to the pool in all cases (timing dependent). Which seems to me like a reasonable trade-off.

Tested by running stress with `-cancelRate 1` for an hour, no assert hit (previously it would get hit within few minutes).

Also removing observation of `WritesClosed` exception which is no necessary since #114226

Fixes #93713