### PR TITLE
Handle calls to shared generic interfaces from shared generic code

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2890,7 +2890,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             break;
 
         case CORINFO_VIRTUALCALL_LDVIRTFTN:
-            if (callInfo.sig.sigInst.methInstCount != 0)
+            if ((callInfo.sig.sigInst.methInstCount != 0) || (m_compHnd->getClassAttribs(resolvedCallToken.hClass) & CORINFO_FLG_SHAREDINST))
             {
                 assert(extraParamArgLocation == INT_MAX);
                 // We should not have a type argument for the ldvirtftn path since we don't know

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -1885,13 +1885,18 @@ public class InterpreterTest
         return typeof(T);
     }
 
-    class GenericClass<T>
+    class GenericClass<T> : IGeneric<T>
     {
         public Type GetTypeOfTInstance()
         {
             return typeof(T);
         }
         public static Type GetTypeOfTStatic()
+        {
+            return typeof(T);
+        }
+
+        Type IGeneric<T>.Method()
         {
             return typeof(T);
         }
@@ -2135,6 +2140,11 @@ public class InterpreterTest
         return true;
     }
 
+    interface IGeneric<T>
+    {
+        Type Method();
+    }
+
     public static bool TestGenerics_CallsFrom<T>()
     {
         if (LoadType<T>() != typeof(T))
@@ -2144,6 +2154,9 @@ public class InterpreterTest
             return false;
 
         if (GenericClass<T>.GetTypeOfTStatic() != typeof(T))
+            return false;
+
+        if (((IGeneric<T>)new GenericClass<T>()).Method() != typeof(T))
             return false;
 
         return true;


### PR DESCRIPTION
- The implementation uses the true LDVIRTFTN path for this. Since it thunks to using function pointer the perf is likely not ideal, but we will need a new generic dictionary entry kind to make this simple, and I'd like to avoid making that change to unblock progress here
- This expensive path was probably fine for use with virtual generic methods, but regular interface dispatch shouldn't be this expensive, so we'll want to fix this later