### PR TITLE
ML-KEM: Change Key property to GetKey method

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.Windows.cs
@@ -86,14 +86,17 @@ namespace System.Security.Cryptography
             }
         }
 
-        public partial CngKey Key
+        public partial CngKey GetKey()
         {
-            get
-            {
-                ThrowIfDisposed();
+            ThrowIfDisposed();
 
-                return _key;
-            }
+#if SYSTEM_SECURITY_CRYPTOGRAPHY
+            return CngHelpers.Duplicate(_key.HandleNoDuplicate, _key.IsEphemeral);
+#else
+#pragma warning disable CA1416 // only supported on: 'windows'
+            return _key.Duplicate();
+#pragma warning restore CA1416 // only supported on: 'windows'
+#endif
         }
 
         /// <inheritdoc/>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKemCng.cs
@@ -64,18 +64,15 @@ namespace System.Security.Cryptography
         private static partial MLKemAlgorithm AlgorithmFromHandle(CngKey key, out CngKey duplicateKey);
 
         /// <summary>
-        ///   Gets the key that will be used by the <see cref="MLKemCng"/> object for any cryptographic operation that it performs.
+        ///   Gets a new <see cref="CngKey" /> representing the key used by the current instance.
         /// </summary>
-        /// <value>
-        ///   The key that will be used by the <see cref="MLKemCng"/> object for any cryptographic operation that it performs.
-        /// </value>
         /// <exception cref="ObjectDisposedException">
         ///   This instance has been disposed.
         /// </exception>
         /// <remarks>
-        ///   This <see cref="CngKey"/> object is not the same as the one passed to the <see cref="MLKemCng"/> constructor,
+        ///   This <see cref="CngKey"/> object is not the same as the one passed to <see cref="MLKemCng(CngKey)"/>,
         ///   if that constructor was used. However, it will point to the same CNG key.
         /// </remarks>
-        public partial CngKey Key { get; }
+        public partial CngKey GetKey();
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.Windows.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.Windows.cs
@@ -81,16 +81,24 @@ namespace System.Security.Cryptography.Tests
 
         [Theory]
         [MemberData(nameof(MLKemTestData.MLKemAlgorithms), MemberType = typeof(MLKemTestData))]
-        public static void MLKemCng_Key(MLKemAlgorithm algorithm)
+        public static void MLKemCng_GetKey(MLKemAlgorithm algorithm)
         {
             using CngKey key = MLKemCngTests.GenerateCngKey(
                 algorithm,
                 CngExportPolicies.AllowExport | CngExportPolicies.AllowPlaintextExport);
 
-            using MLKemCng mlKemKey = new(key);
+            using (MLKemCng mlKemKey = new(key))
+            using (CngKey getKey1 = mlKemKey.GetKey())
+            {
+                using (CngKey getKey2 = mlKemKey.GetKey())
+                {
 
-            Assert.NotSame(key, mlKemKey.Key);
-            Assert.Same(mlKemKey.Key, mlKemKey.Key);
+                    Assert.NotSame(key, getKey1);
+                    Assert.NotSame(getKey1, getKey2);
+                }
+
+                Assert.Equal(key.Algorithm, getKey1.Algorithm); // Assert.NoThrow on getKey1.Algorithm
+            }
         }
     }
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.Windows.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.Windows.cs
@@ -92,7 +92,6 @@ namespace System.Security.Cryptography.Tests
             {
                 using (CngKey getKey2 = mlKemKey.GetKey())
                 {
-
                     Assert.NotSame(key, getKey1);
                     Assert.NotSame(getKey1, getKey2);
                 }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -2099,12 +2099,13 @@ namespace System.Security.Cryptography
     {
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public MLKemCng(System.Security.Cryptography.CngKey key) : base (default(System.Security.Cryptography.MLKemAlgorithm)) { }
-        public System.Security.Cryptography.CngKey Key { get { throw null; } }
         protected override void DecapsulateCore(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret) { }
+        protected override void Dispose(bool disposing) { }
         protected override void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret) { }
         protected override void ExportDecapsulationKeyCore(System.Span<byte> destination) { }
         protected override void ExportEncapsulationKeyCore(System.Span<byte> destination) { }
         protected override void ExportPrivateSeedCore(System.Span<byte> destination) { }
+        public System.Security.Cryptography.CngKey GetKey() { throw null; }
         protected override bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
@@ -425,12 +425,9 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
         }
 
-        public partial CngKey Key
+        public partial CngKey GetKey()
         {
-            get
-            {
-                throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
-            }
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
         }
 
         protected override void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret)


### PR DESCRIPTION
Reacts to API review changes in #117091. The `Key` property was changed to a `GetKey` method that returns a duplicate handle of the `CngKey`.

Closes #117091