### PR TITLE
Revert "Replace `CordbProcess::GetSharedDomain` with `GetAppDomain`"

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -4856,12 +4856,14 @@ VMPTR_OBJECTHANDLE DacDbiInterfaceImpl::GetCurrentCustomDebuggerNotification(VMP
     return vmObjHandle;
 }
 
-// Return the current appdomain.
-VMPTR_AppDomain DacDbiInterfaceImpl::GetCurrentAppDomain()
+// Return the current appdomain the specified thread is in.
+VMPTR_AppDomain DacDbiInterfaceImpl::GetCurrentAppDomain(VMPTR_Thread vmThread)
 {
     DD_ENTER_MAY_THROW;
 
+    Thread *    pThread    = vmThread.GetDacPtr();
     AppDomain * pAppDomain = AppDomain::GetCurrentDomain();
+
     VMPTR_AppDomain vmAppDomain = VMPTR_AppDomain::NullPtr();
     vmAppDomain.SetDacTargetPtr(PTR_HOST_TO_TADDR(pAppDomain));
     return vmAppDomain;

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -822,8 +822,9 @@ public:
     // (or a dump was generated while in this callback)
     VMPTR_OBJECTHANDLE GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread);
 
-    // Return the current appdomain
-    VMPTR_AppDomain GetCurrentAppDomain();
+
+    // Return the current appdomain the specified thread is in.
+    VMPTR_AppDomain GetCurrentAppDomain(VMPTR_Thread vmThread);
 
     // Given an assembly ref token and metadata scope (via the DomainAssembly), resolve the assembly.
     VMPTR_DomainAssembly ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef);

--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -65,12 +65,12 @@ CordbModule::CordbModule(
         pProcess->GetDAC()->GetDomainAssemblyData(vmDomainAssembly, &dfInfo); // throws
 
         m_pAppDomain = pProcess->LookupOrCreateAppDomain(dfInfo.vmAppDomain);
-        _ASSERTE(m_pAppDomain == pProcess->GetAppDomain());
         m_pAssembly  = m_pAppDomain->LookupOrCreateAssembly(dfInfo.vmDomainAssembly);
     }
     else
     {
-        m_pAppDomain = pProcess->GetAppDomain();
+        // Not yet implemented
+        m_pAppDomain = pProcess->GetSharedAppDomain();
         m_pAssembly = m_pAppDomain->LookupOrCreateAssembly(modInfo.vmAssembly);
     }
 #ifdef _DEBUG

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -2530,7 +2530,8 @@ public:
                                          // them as special cases.
     CordbSafeHashTable<CordbType>        m_sharedtypes;
 
-    CordbAssembly * CacheAssembly(VMPTR_Assembly vmAssembly, VMPTR_DomainAssembly);
+    CordbAssembly * CacheAssembly(VMPTR_DomainAssembly vmDomainAssembly);
+    CordbAssembly * CacheAssembly(VMPTR_Assembly vmAssembly);
 
 
     // Cache of modules in this appdomain. In the VM, modules live in an assembly.
@@ -2542,7 +2543,7 @@ public:
     CordbSafeHashTable<CordbModule>      m_modules;
 private:
     // Cache of assemblies in this appdomain.
-    // This is indexed by VMPTR_Assembly.
+    // This is indexed by VMPTR_DomainAssembly, which has appdomain affinity.
     // This is populated by code:CordbAppDomain::LookupOrCreateAssembly (which may be invoked
     // anytime the RS gets hold of a VMPTR), and are removed at the unload event.
     CordbSafeHashTable<CordbAssembly>    m_assemblies;
@@ -3688,8 +3689,8 @@ public:
     // Lookup or create an appdomain.
     CordbAppDomain * LookupOrCreateAppDomain(VMPTR_AppDomain vmAppDomain);
 
-    // Get the app domain.
-    CordbAppDomain * GetAppDomain();
+    // Get the shared app domain.
+    CordbAppDomain * GetSharedAppDomain();
 
     // Get metadata dispenser.
     IMetaDataDispenserEx * GetDispenser();
@@ -3698,7 +3699,7 @@ public:
     // the jit attach.
     HRESULT GetAttachStateFlags(CLR_DEBUGGING_PROCESS_FLAGS *pFlags);
 
-    HRESULT GetTypeForObject(CORDB_ADDRESS obj, CordbType **ppType, CordbAppDomain **pAppDomain = NULL);
+    HRESULT GetTypeForObject(CORDB_ADDRESS obj, CordbAppDomain* pAppDomainOverride, CordbType **ppType, CordbAppDomain **pAppDomain = NULL);
 
     WriteableMetadataUpdateMode GetWriteableMetadataUpdateMode() { return m_writableMetadataUpdateMode; }
 private:
@@ -3728,6 +3729,7 @@ private:
     void ProcessContinuedLogMessage (DebuggerIPCEvent *event);
 
     void CloseIPCHandles();
+    void UpdateThreadsForAdUnload( CordbAppDomain* pAppDomain );
 
 #ifdef FEATURE_INTEROP_DEBUGGING
     // Each win32 debug event needs to be triaged to get a Reaction.
@@ -3900,6 +3902,8 @@ public:
 
     CordbSafeHashTable<CordbAppDomain>        m_appDomains;
 
+    CordbAppDomain * m_sharedAppDomain;
+
     // Since a stepper can begin in one appdomain, and complete in another,
     // we put the hashtable here, rather than on specific appdomains.
     CordbSafeHashTable<CordbStepper>          m_steppers;
@@ -4052,6 +4056,8 @@ public:
 
     HANDLE GetHelperThreadHandle() { return m_hHelperThread; }
 
+    CordbAppDomain* GetDefaultAppDomain() { return m_pDefaultAppDomain; }
+
 #ifdef FEATURE_INTEROP_DEBUGGING
     // Lookup if there's a native BP at the given address. Return NULL not found.
     NativePatch * GetNativePatch(const void * pAddress);
@@ -4068,6 +4074,11 @@ private:
     DebuggerIPCEventType  m_dispatchedEvent;   // what event are we currently dispatching?
 
     RSLock            m_StopGoLock;
+
+    // Each process has exactly one Default AppDomain
+    // @dbgtodo  appdomain : We should try and simplify things by removing this.
+    // At the moment it's necessary for CordbProcess::UpdateThreadsForAdUnload.
+    CordbAppDomain*     m_pDefaultAppDomain;    // owned by m_appDomains
 
 #ifdef FEATURE_INTEROP_DEBUGGING
     // Helpers
@@ -4153,7 +4164,7 @@ private:
     // controls how metadata updated in the target is handled
     WriteableMetadataUpdateMode m_writableMetadataUpdateMode;
 
-    COM_METHOD GetObjectInternal(CORDB_ADDRESS addr, ICorDebugObjectValue **pObject);
+    COM_METHOD GetObjectInternal(CORDB_ADDRESS addr, CordbAppDomain* pAppDomainOverride, ICorDebugObjectValue **pObject);
 
 #ifdef OUT_OF_PROCESS_SETTHREADCONTEXT
     CUnmanagedThreadHashTableImpl m_unmanagedThreadHashTable;

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -1212,17 +1212,20 @@ public:
 
 
     //
-    // Return the current appdomain.
+    // Return the current appdomain the specified thread is in.
+    //
+    // Arguments:
+    //    vmThread - the specified thread
     //
     // Return Value:
-    //    the current appdomain
+    //    the current appdomain of the specified thread
     //
     // Notes:
     //    This function throws if the current appdomain is NULL for whatever reason.
     //
 
     virtual
-    VMPTR_AppDomain GetCurrentAppDomain() = 0;
+    VMPTR_AppDomain GetCurrentAppDomain(VMPTR_Thread vmThread) = 0;
 
 
     //


### PR DESCRIPTION
Reverts dotnet/runtime#117037 This breaks debugging basics.

Notably, enumerating the list of assemblies results in an infinite loop as it builds more and more CorDbAssembly objects.