### PR TITLE
[NAOT] Only call IDIC methods (and ensure we have usable System.Type instances) for types that can have implementations

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -469,7 +469,7 @@ namespace System.Runtime
 
         private static unsafe bool IsInstanceOfInterfaceViaIDynamicInterfaceCastable(MethodTable* pTargetType, object obj, bool throwing)
         {
-            return ((IDynamicInterfaceCastable)obj).IsInterfaceImplemented(new RuntimeTypeHandle(pTargetType), throwing);
+            return IDynamicInterfaceCastable.IsInterfaceImplemented((IDynamicInterfaceCastable)obj, pTargetType, throwing);
         }
 
         internal static unsafe bool IsDerived(MethodTable* pDerivedType, MethodTable* pBaseType)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -34,7 +34,7 @@ namespace Internal.Reflection.Core.Execution
         //==============================================================================================
         // Reflection Mapping Tables
         //==============================================================================================
-        public abstract QTypeDefinition GetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle);
+        public abstract bool TryGetMetadataForNamedType(RuntimeTypeHandle runtimeTypeHandle, out QTypeDefinition qTypeDefinition);
         public abstract bool TryGetNamedTypeForMetadata(QTypeDefinition qTypeDefinition, out RuntimeTypeHandle runtimeTypeHandle);
 
         public abstract bool TryGetArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, out RuntimeTypeHandle arrayTypeHandle);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Helpers.cs
@@ -61,6 +61,13 @@ namespace System.Reflection.Runtime.General
             return null;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryGetRuntimeTypeInfo(this Type type, [NotNullWhen(true)] out RuntimeTypeInfo? info)
+        {
+            info = null;
+            return type is RuntimeType runtimeType && runtimeType.TryGetRuntimeTypeInfo(out info);
+        }
+
         public static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> enumeration)
         {
             return Array.AsReadOnly(enumeration.ToArray());

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/TypeUnifier.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/TypeUnifier.cs
@@ -71,6 +71,11 @@ namespace System.Reflection.Runtime.General
         {
             return Type.GetTypeFromHandle(typeHandle)!.ToRuntimeTypeInfo();
         }
+
+        public static bool TryGetRuntimeTypeInfoForRuntimeTypeHandle(this RuntimeTypeHandle typeHandle, [NotNullWhen(true)] out RuntimeTypeInfo? typeInfo)
+        {
+            return Type.GetTypeFromHandle(typeHandle)!.TryGetRuntimeTypeInfo(out typeInfo);
+        }
     }
 }
 

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
@@ -78,7 +78,9 @@ namespace Internal.Reflection.Execution
                 typeDefHandle = RuntimeAugments.GetGenericDefinition(typeHandle);
             }
 
-            QTypeDefinition qTypeDefinition = ReflectionExecution.ExecutionEnvironment.GetMetadataForNamedType(typeDefHandle);
+            QTypeDefinition qTypeDefinition;
+            if (!ReflectionExecution.ExecutionEnvironment.TryGetMetadataForNamedType(typeDefHandle, out qTypeDefinition))
+                throw new InvalidOperationException();
 
             if (qTypeDefinition.IsNativeFormatMetadataBased)
             {

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
@@ -69,7 +69,9 @@ namespace Internal.Reflection.Execution
             if (!qMethodDefinition.IsNativeFormatMetadataBased)
                 return false;
 
-            QTypeDefinition qTypeDefinition = ExecutionEnvironment.GetMetadataForNamedType(declaringTypeHandle);
+            QTypeDefinition qTypeDefinition;
+            if (!ExecutionEnvironment.TryGetMetadataForNamedType(declaringTypeHandle, out qTypeDefinition))
+                return false;
 
             Debug.Assert(qTypeDefinition.IsNativeFormatMetadataBased);
             Debug.Assert(qTypeDefinition.NativeFormatReader == qMethodDefinition.NativeFormatReader);

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/InteropServices/IDynamicInterfaceCastable.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/InteropServices/IDynamicInterfaceCastable.cs
@@ -7,7 +7,12 @@ namespace System.Runtime.InteropServices
 {
     public unsafe partial interface IDynamicInterfaceCastable
     {
-        internal static IntPtr GetDynamicInterfaceImplementation(object instance, MethodTable* interfaceType, ushort slot)
+        internal static bool IsInterfaceImplemented(IDynamicInterfaceCastable instance, MethodTable* interfaceType, bool throwing)
+        {
+            return false;
+        }
+
+        internal static IntPtr GetDynamicInterfaceImplementation(IDynamicInterfaceCastable instance, MethodTable* interfaceType, ushort slot)
         {
             RuntimeImports.RhpFallbackFailFast();
             return default;


### PR DESCRIPTION
Further scope down interface type dependencies added for IDIC to only be done for types that can actually successfully return an interface type from IDIC. Update the NAOT runtime to only pass down types that have metadata info to IDIC implementations and throw `InvalidCastException` for interfaces that don't (as they couldn't successfully return an implementation type anyway).

Opening as draft so we can see the size win for IDIC-using apps.