### PR TITLE
Do not generate __GetFieldHelper for ValueTuple

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
@@ -102,6 +102,10 @@ namespace ILCompiler
             if (IsAsyncStateMachineType(valueType))
                 return false;
 
+            // ValueTuples override Equals/GetHashCode and don't have a `base.GetHashCode` call. So avoid the infrastructure.
+            if (valueType.Module == SystemModule && valueType.Name.StartsWith("ValueTuple`", StringComparison.OrdinalIgnoreCase) && valueType.Namespace == "System")
+                return false;
+
             return !_typeStateHashtable.GetOrCreateValue(valueType).CanCompareValueTypeBits;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
@@ -103,7 +103,7 @@ namespace ILCompiler
                 return false;
 
             // ValueTuples override Equals/GetHashCode and don't have a `base.GetHashCode` call. So avoid the infrastructure.
-            if (valueType.Module == SystemModule && valueType.Name.StartsWith("ValueTuple`", StringComparison.OrdinalIgnoreCase) && valueType.Namespace == "System")
+            if (valueType.Module == SystemModule && valueType.Name.StartsWith("ValueTuple`", StringComparison.Ordinal) && valueType.Namespace == "System")
                 return false;
 
             return !_typeStateHashtable.GetOrCreateValue(valueType).CanCompareValueTypeBits;


### PR DESCRIPTION
Noticed a couple of these in a log.

Cc @dotnet/ilc-contrib 