### PR TITLE
[HTTP] Fix new diagnostic test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -861,14 +861,7 @@ namespace System.Net.Http.Functional.Tests
                             uri = new Uri($"{uri.Scheme}://localhost:{uri.Port}");
                         }
 
-                        // We are not using Assert.ThrowsAsync<TaskCanceledException>(...); in case we get an incorrect exception, we want to fully propagate it into the test logs.
-                        try
-                        {
-                            await GetAsync(useVersion, testAsync, uri, cts.Token);
-                        }
-                        catch (TaskCanceledException)
-                        {
-                        }
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => GetAsync(useVersion, testAsync, uri, cts.Token));
 
                         Assert.NotNull(activity);
                         Assert.Equal(ActivityStatusCode.Error, activity.Status);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -861,8 +861,7 @@ namespace System.Net.Http.Functional.Tests
                             uri = new Uri($"{uri.Scheme}://localhost:{uri.Port}");
                         }
 
-                        // We are not using Assert.ThrowsAsync<TaskCanceledException>(...).
-                        // In case we get an incorrect exception, we want to fully propagate it into the test logs.
+                        // We are not using Assert.ThrowsAsync<TaskCanceledException>(...); in case we get an incorrect exception, we want to fully propagate it into the test logs.
                         try
                         {
                             await GetAsync(useVersion, testAsync, uri, cts.Token);
@@ -873,13 +872,13 @@ namespace System.Net.Http.Functional.Tests
 
                         Assert.NotNull(activity);
                         Assert.Equal(ActivityStatusCode.Error, activity.Status);
-                        ActivityAssert.HasTag(activity, "error.type", typeof(TaskCanceledException).FullName);
+                        ActivityAssert.HasTag(activity, "error.type", (string errorType) => errorType == typeof(TaskCanceledException).FullName || errorType == typeof(OperationCanceledException).FullName);
                         ActivityEvent evt = activity.Events.Single(e => e.Name == "exception");
                         Dictionary<string, object?> tags = evt.Tags.ToDictionary(t => t.Key, t => t.Value);
                         Assert.Contains("exception.type", tags.Keys);
                         Assert.Contains("exception.message", tags.Keys);
                         Assert.Contains("exception.stacktrace", tags.Keys);
-                        Assert.Equal(typeof(TaskCanceledException).FullName, tags["exception.type"]);
+                        Assert.True((string)tags["exception.type"] == typeof(TaskCanceledException).FullName || (string)tags["exception.type"] == typeof(TaskCanceledException).FullName);
                     },
                     async server =>
                     {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -871,7 +871,7 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Contains("exception.type", tags.Keys);
                         Assert.Contains("exception.message", tags.Keys);
                         Assert.Contains("exception.stacktrace", tags.Keys);
-                        Assert.True((string)tags["exception.type"] == typeof(TaskCanceledException).FullName || (string)tags["exception.type"] == typeof(TaskCanceledException).FullName);
+                        Assert.True((string)tags["exception.type"] == typeof(TaskCanceledException).FullName || (string)tags["exception.type"] == typeof(OperationCanceledException).FullName);
                     },
                     async server =>
                     {


### PR DESCRIPTION
Fixes #117161

Depending on the timing of the cancellation, the exception type can be either `OperationCanceledException` or `TaskCanceledExcption`, we need to allow both. The PR also refactors the assertions outside of the `ActivityListener` callback, so we get better error messages if something fails in the future. (This test has been recently added in #116269.)