### PR TITLE
Specialize __GetFieldHelper per generic instantiation

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+
 using ILCompiler;
+
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -105,7 +107,7 @@ namespace Internal.IL.Stubs
                 getFieldStream.EmitLabel(label);
                 getFieldStream.EmitLdArg(2);
 
-                // We need something we can instantiate EETypePtrOf over. Also, the classlib
+                // We need something we can instantiate MethodTable.Of over. Also, the classlib
                 // code doesn't handle pointers.
                 TypeDesc boxableFieldType = field.FieldType;
                 if (boxableFieldType.IsPointer || boxableFieldType.IsFunctionPointer)
@@ -123,7 +125,7 @@ namespace Internal.IL.Stubs
                     boxableFieldType = Context.GetWellKnownType(WellKnownType.Object);
 
                 // If this is an enum, it's okay to Equals/GetHashCode the underlying type.
-                // Don't unnecessarily create an MethodTable for the enum.
+                // Don't unnecessarily create a MethodTable for the enum.
                 if (fieldTypeForOptimizationChecks.IsEnum)
                     boxableFieldType = fieldTypeForOptimizationChecks.UnderlyingType;
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
@@ -113,7 +113,7 @@ namespace Internal.IL.Stubs
 
                 // We're trying to do some optimizations below that can benefit from knowing the concrete
                 // type after substitutions.
-                TypeDesc fieldTypeForOptimizationChecks = boxableFieldType.IsSignatureVariable && contextMethod != null
+                TypeDesc fieldTypeForOptimizationChecks = boxableFieldType.IsSignatureVariable
                     ? boxableFieldType.InstantiateSignature(contextMethod.OwningType.Instantiation, default)
                     : boxableFieldType;
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-
+using ILCompiler;
 using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace Internal.IL.Stubs
 {
@@ -12,12 +14,12 @@ namespace Internal.IL.Stubs
     /// into all value types that cannot have their Equals(object) and GetHashCode() methods operate on individual
     /// bytes. The purpose of the override is to provide access to the value types' fields and their types.
     /// </summary>
-    public sealed partial class ValueTypeGetFieldHelperMethodOverride : ILStubMethod
+    public sealed partial class ValueTypeGetFieldHelperMethodOverride : SpecializableILStubMethod
     {
-        private DefType _owningType;
+        private MetadataType _owningType;
         private MethodSignature _signature;
 
-        internal ValueTypeGetFieldHelperMethodOverride(DefType owningType)
+        internal ValueTypeGetFieldHelperMethodOverride(MetadataType owningType)
         {
             _owningType = owningType;
         }
@@ -57,21 +59,29 @@ namespace Internal.IL.Stubs
 
         public override MethodIL EmitIL()
         {
-            TypeDesc owningType = _owningType.InstantiateAsOpen();
+            return EmitILCommon(null);
+        }
+
+        public override MethodIL EmitIL(MethodDesc specializedMethod)
+        {
+            Debug.Assert(specializedMethod.GetTypicalMethodDefinition() == this);
+            return new InstantiatedMethodIL(specializedMethod, EmitILCommon(specializedMethod));
+        }
+
+        private MethodIL EmitILCommon(MethodDesc contextMethod)
+        {
+            var owningType = (MetadataType)_owningType.InstantiateAsOpen();
 
             ILEmitter emitter = new ILEmitter();
 
-            if (_owningType is MetadataType mdType)
+            // Types marked as InlineArray aren't supported by
+            // the built-in Equals() or GetHashCode().
+            if (owningType.IsInlineArray)
             {
-                // Types marked as InlineArray aren't supported by
-                // the built-in Equals() or GetHashCode().
-                if (mdType.IsInlineArray)
-                {
-                    var stream = emitter.NewCodeStream();
-                    MethodDesc thrower = Context.GetHelperEntryPoint("ThrowHelpers", "ThrowNotSupportedInlineArrayEqualsGetHashCode");
-                    stream.EmitCallThrowHelper(emitter, thrower);
-                    return emitter.Link(this);
-                }
+                var stream = emitter.NewCodeStream();
+                MethodDesc thrower = Context.GetHelperEntryPoint("ThrowHelpers", "ThrowNotSupportedInlineArrayEqualsGetHashCode");
+                stream.EmitCallThrowHelper(emitter, thrower);
+                return emitter.Link(this);
             }
 
             TypeDesc methodTableType = Context.SystemModule.GetKnownType("Internal.Runtime", "MethodTable");
@@ -101,14 +111,21 @@ namespace Internal.IL.Stubs
                 if (boxableFieldType.IsPointer || boxableFieldType.IsFunctionPointer)
                     boxableFieldType = Context.GetWellKnownType(WellKnownType.IntPtr);
 
+                // We're trying to do some optimizations below that can benefit from knowing the concrete
+                // type after substitutions.
+                TypeDesc fieldTypeForOptimizationChecks = boxableFieldType.IsSignatureVariable && contextMethod != null
+                    ? boxableFieldType.InstantiateSignature(contextMethod.OwningType.Instantiation, default)
+                    : boxableFieldType;
+
                 // The fact that the type is a reference type is sufficient for the callers.
-                // Don't unnecessarily create an MethodTable for the field type.
-                if (!boxableFieldType.IsSignatureVariable && !boxableFieldType.IsValueType)
+                // Don't unnecessarily create a MethodTable for the field type.
+                if (!fieldTypeForOptimizationChecks.IsValueType)
                     boxableFieldType = Context.GetWellKnownType(WellKnownType.Object);
 
                 // If this is an enum, it's okay to Equals/GetHashCode the underlying type.
                 // Don't unnecessarily create an MethodTable for the enum.
-                boxableFieldType = boxableFieldType.UnderlyingType;
+                if (fieldTypeForOptimizationChecks.IsEnum)
+                    boxableFieldType = fieldTypeForOptimizationChecks.UnderlyingType;
 
                 MethodDesc mtOfFieldMethod = methodTableOfMethod.MakeInstantiatedMethod(boxableFieldType);
                 getFieldStream.Emit(ILOpcode.call, emitter.NewToken(mtOfFieldMethod));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
@@ -16,14 +16,14 @@ namespace ILCompiler
         private MethodDesc _objectEqualsMethod;
         private MetadataType _iAsyncStateMachineType;
 
-        private sealed class ValueTypeMethodHashtable : LockFreeReaderHashtable<DefType, MethodDesc>
+        private sealed class ValueTypeMethodHashtable : LockFreeReaderHashtable<MetadataType, MethodDesc>
         {
-            protected override int GetKeyHashCode(DefType key) => key.GetHashCode();
+            protected override int GetKeyHashCode(MetadataType key) => key.GetHashCode();
             protected override int GetValueHashCode(MethodDesc value) => value.OwningType.GetHashCode();
-            protected override bool CompareKeyToValue(DefType key, MethodDesc value) => key == value.OwningType;
+            protected override bool CompareKeyToValue(MetadataType key, MethodDesc value) => key == value.OwningType;
             protected override bool CompareValueToValue(MethodDesc v1, MethodDesc v2) => v1.OwningType == v2.OwningType;
 
-            protected override MethodDesc CreateValueFromKey(DefType key)
+            protected override MethodDesc CreateValueFromKey(MetadataType key)
             {
                 return new ValueTypeGetFieldHelperMethodOverride(key);
             }
@@ -37,7 +37,7 @@ namespace ILCompiler
 
             if (RequiresValueTypeGetFieldHelperMethod((MetadataType)valueTypeDefinition))
             {
-                MethodDesc getFieldHelperMethod = _valueTypeMethodHashtable.GetOrCreateValue((DefType)valueTypeDefinition);
+                MethodDesc getFieldHelperMethod = _valueTypeMethodHashtable.GetOrCreateValue((MetadataType)valueTypeDefinition);
 
                 if (valueType != valueTypeDefinition)
                 {
@@ -60,7 +60,7 @@ namespace ILCompiler
 
             if (RequiresAttributeGetFieldHelperMethod(attributeTypeDefinition))
             {
-                MethodDesc getFieldHelperMethod = _valueTypeMethodHashtable.GetOrCreateValue((DefType)attributeTypeDefinition);
+                MethodDesc getFieldHelperMethod = _valueTypeMethodHashtable.GetOrCreateValue((MetadataType)attributeTypeDefinition);
 
                 if (attributeType != attributeTypeDefinition)
                 {


### PR DESCRIPTION
We have an optimization that tries to avoid bringing in constructed `MethodTable` for struct fields that are reference types. However, if the type of the field is T on a generic type, we had to be conservative because we didn't know if it was a valuetype or not. Use `SpecializableILStubMethod` instead of `ILStubMethod` so we know.

Cc @dotnet/ilc-contrib 