### PR TITLE
Don't use whole program analysis results when array covariance is involved

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -39,9 +40,21 @@ namespace ILCompiler
         private readonly TypeWithRepeatedFieldsFieldLayoutAlgorithm _typeWithRepeatedFieldsFieldLayoutAlgorithm;
 
         private TypeDesc[] _arrayOfTInterfaces;
+        private TypeDesc[] _arrayEnumeratorOfTInterfaces;
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
         private MetadataType _arrayOfTType;
         private MetadataType _attributeType;
+
+        private MetadataType _systemArrayOfTEnumeratorType;
+        public MetadataType ArrayOfTEnumeratorType
+        {
+            get
+            {
+                // This type is optional, but it's fine for this cache to be ineffective if that happens.
+                // Those scenarios are rare and typically deal with small compilations.
+                return _systemArrayOfTEnumeratorType ??= SystemModule.GetType("System", "SZGenericArrayEnumerator`1", throwIfNotFound: false);
+            }
+        }
 
         public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode, DelegateFeature delegateFeatures,
             int genericCycleDepthCutoff = DefaultGenericCycleDepthCutoff,
@@ -60,6 +73,28 @@ namespace ILCompiler
             _genericCycleDetector = new LazyGenericsSupport.GenericCycleDetector(genericCycleDepthCutoff, genericCycleBreadthCutoff);
 
             GenericsConfig = new SharedGenericsConfiguration();
+        }
+
+        public bool IsArrayVariantCastable(TypeDesc type)
+        {
+            // Arrays and array enumerators have weird casting rules due to array covariance
+            // (string[] castable to object[], or int[] castable to uint[], or int[] castable
+            // to IList<SomeIntEnum>).
+
+            if (type.IsSzArray
+                || type.GetTypeDefinition() == ArrayOfTEnumeratorType
+                || IsGenericArrayInterfaceType(type)
+                || IsGenericArrayEnumeratorInterfaceType(type))
+            {
+                TypeDesc elementType = type.IsSzArray ? ((ArrayType)type).ElementType : type.Instantiation[0];
+                if (CastingHelper.IsArrayElementTypeCastableBySize(elementType) ||
+                    (elementType.IsDefType && !elementType.IsValueType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         protected override RuntimeInterfacesAlgorithm GetRuntimeInterfacesAlgorithmForNonPointerArrayType(ArrayType type)
@@ -124,6 +159,33 @@ namespace ILCompiler
             }
 
             return false;
+        }
+
+        public bool IsGenericArrayEnumeratorInterfaceType(TypeDesc type)
+        {
+            // Hardcode the fact that all generic interfaces on array enumerator have arity 1
+            if (!type.IsInterface || type.Instantiation.Length != 1)
+                return false;
+
+            if (_arrayEnumeratorOfTInterfaces == null)
+            {
+                DefType[] implementedInterfaces = ArrayOfTEnumeratorType?.ExplicitlyImplementedInterfaces;
+
+                ArrayBuilder<TypeDesc> definitions = default;
+                if (implementedInterfaces != null)
+                {
+                    foreach (DefType interfaceType in implementedInterfaces)
+                    {
+                        if (interfaceType.HasInstantiation)
+                            definitions.Add(interfaceType.GetTypeDefinition());
+                    }
+                }
+
+                Interlocked.CompareExchange(ref _arrayEnumeratorOfTInterfaces, definitions.ToArray(), null);
+            }
+
+            TypeDesc interfaceDefinition = type.GetTypeDefinition();
+            return Array.IndexOf(_arrayEnumeratorOfTInterfaces, interfaceDefinition) >= 0;
         }
 
         protected override IEnumerable<MethodDesc> GetAllMethods(TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
@@ -43,18 +43,8 @@ namespace ILCompiler
         private TypeDesc[] _arrayEnumeratorOfTInterfaces;
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
         private MetadataType _arrayOfTType;
+        private MetadataType _arrayOfTEnumeratorType;
         private MetadataType _attributeType;
-
-        private MetadataType _systemArrayOfTEnumeratorType;
-        public MetadataType ArrayOfTEnumeratorType
-        {
-            get
-            {
-                // This type is optional, but it's fine for this cache to be ineffective if that happens.
-                // Those scenarios are rare and typically deal with small compilations.
-                return _systemArrayOfTEnumeratorType ??= SystemModule.GetType("System", "SZGenericArrayEnumerator`1", throwIfNotFound: false);
-            }
-        }
 
         public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode, DelegateFeature delegateFeatures,
             int genericCycleDepthCutoff = DefaultGenericCycleDepthCutoff,
@@ -73,6 +63,16 @@ namespace ILCompiler
             _genericCycleDetector = new LazyGenericsSupport.GenericCycleDetector(genericCycleDepthCutoff, genericCycleBreadthCutoff);
 
             GenericsConfig = new SharedGenericsConfiguration();
+        }
+
+        public MetadataType ArrayOfTEnumeratorType
+        {
+            get
+            {
+                // This type is optional, but it's fine for this cache to be ineffective if that happens.
+                // Those scenarios are rare and typically deal with small compilations.
+                return _arrayOfTEnumeratorType ??= SystemModule.GetType("System", "SZGenericArrayEnumerator`1", throwIfNotFound: false);
+            }
         }
 
         public bool IsArrayVariantCastable(TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -758,7 +758,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             uint flags = EETypeBuilderHelpers.ComputeFlags(_type);
 
-            if (_type.GetTypeDefinition() == factory.ArrayOfTEnumeratorType)
+            if (_type.GetTypeDefinition() == factory.TypeSystemContext.ArrayOfTEnumeratorType)
             {
                 // Generic array enumerators use special variance rules recognized by the runtime
                 flags |= (uint)EETypeFlags.GenericVarianceFlag;
@@ -1148,7 +1148,7 @@ namespace ILCompiler.DependencyAnalysis
                 else
                 {
                     GenericVarianceDetails details;
-                    if (_type == factory.ArrayOfTEnumeratorType)
+                    if (_type == factory.TypeSystemContext.ArrayOfTEnumeratorType)
                     {
                         // Generic array enumerators use special variance rules recognized by the runtime
                         details = new GenericVarianceDetails(new[] { GenericVariance.ArrayCovariant });

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
             // Generic array enumerators use special variance rules recognized by the runtime
             // Runtime casting logic relies on all interface types implemented on arrays
             // to have the variant flag set.
-            if (_type == factory.ArrayOfTEnumeratorType || factory.TypeSystemContext.IsGenericArrayInterfaceType(_type))
+            if (_type == factory.TypeSystemContext.ArrayOfTEnumeratorType || factory.TypeSystemContext.IsGenericArrayInterfaceType(_type))
                 flags |= (uint)EETypeFlags.GenericVarianceFlag;
 
             if (_type.IsByRefLike)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -1257,17 +1257,6 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        private TypeDesc _systemArrayOfTEnumeratorType;
-        public TypeDesc ArrayOfTEnumeratorType
-        {
-            get
-            {
-                // This type is optional, but it's fine for this cache to be ineffective if that happens.
-                // Those scenarios are rare and typically deal with small compilations.
-                return _systemArrayOfTEnumeratorType ??= _context.SystemModule.GetType("System", "SZGenericArrayEnumerator`1", throwIfNotFound: false);
-            }
-        }
-
         private MethodDesc _instanceMethodRemovedHelper;
         public MethodDesc InstanceMethodRemovedHelper
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VariantInterfaceMethodUseNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VariantInterfaceMethodUseNode.cs
@@ -76,7 +76,7 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             if (!result &&
-                (providingType.IsArray || providingType.GetTypeDefinition() == factory.ArrayOfTEnumeratorType) &&
+                (providingType.IsArray || providingType.GetTypeDefinition() == factory.TypeSystemContext.ArrayOfTEnumeratorType) &&
                 implementedInterface.HasInstantiation)
             {
                 // We need to also do this for generic interfaces on arrays because they have a weird casting rule

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -1087,6 +1087,10 @@ namespace ILCompiler
             if (_devirtualizationManager.CanReferenceConstructedTypeOrCanonicalFormOfType(type.NormalizeInstantiation()))
                 return false;
 
+            // Above check took care of most variant scenarios but we still need to worry about array variance
+            if (((CompilerTypeSystemContext)type.Context).IsArrayVariantCastable(type))
+                return false;
+
             constant = 0;
 
             return true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -846,7 +846,10 @@ namespace Internal.IL
             {
                 TypeDesc isinstCheckType = (TypeDesc)_canonMethodIL.GetObject(_isInstCheckPatternAnalyzer.Token);
                 if (ConstructedEETypeNode.CreationAllowed(isinstCheckType)
-                    && !isinstCheckType.ConvertToCanonForm(CanonicalFormKind.Specific).IsCanonicalSubtype(CanonicalFormKind.Any))
+                    // Below makes sure we don't need to worry about variance
+                    && !isinstCheckType.ConvertToCanonForm(CanonicalFormKind.Specific).IsCanonicalSubtype(CanonicalFormKind.Any)
+                    // However, we still need to worry about variant-by-size casting with arrays
+                    && !_factory.TypeSystemContext.IsArrayVariantCastable(isinstCheckType))
                 {
                     condition = _factory.MaximallyConstructableType(isinstCheckType);
                 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2251,6 +2251,10 @@ namespace Internal.JitInterface
             if (!ConstructedEETypeNode.CreationAllowed(type))
                 return false;
 
+            // We don't track information that would allow us to deal with array variance
+            if (_compilation.TypeSystemContext.IsArrayVariantCastable(type))
+                return false;
+
             TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
 
             // If we don't have a constructed MethodTable for the exact type or for its template,


### PR DESCRIPTION
Array covariance makes things difficult to model, so just abort. We already had some abort logic but it wasn't sufficient and it wasn't in all the places where it was necessary.

Fixes #117249.

Cc @dotnet/ilc-contrib 