### PR TITLE
Remove Uri length limits

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -2334,7 +2334,10 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task LargeUriAndHeaders_Works()
         {
-            int length = IsWinHttpHandler ? 65_000 : 10_000_000;
+            int length =
+                IsWinHttpHandler ? 65_000 :
+                PlatformDetection.IsBrowser ? 4_000 :
+                10_000_000;
 
             string longPath = "/" + new string('X', length);
             string longHeaderName = new string('Y', length);

--- a/src/libraries/Common/tests/System/Net/Http/QPackTestDecoder.cs
+++ b/src/libraries/Common/tests/System/Net/Http/QPackTestDecoder.cs
@@ -92,15 +92,15 @@ namespace System.Net.Test.Common
 
             ulong extra = 0;
             int length = 1;
-            ulong b;
+            byte b;
 
             do
             {
                 // https://http2.github.io/http2-spec/compression.html#integer.representation
                 // HPack encodes integers from the least significant byte to the most.
                 // Every 7-bits of the next byte is shifted by (7 * index) and added to the result.
-                b = (ulong)headerBlock[length++];
-                extra = checked(b << (7 * (length - 2))) | extra;
+                b = headerBlock[length++];
+                extra = checked((ulong)(b & 0x7F) << (7 * (length - 2))) | extra;
             }
             while ((b & 0b10000000) != 0);
 

--- a/src/libraries/System.Private.Uri/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Uri/src/Resources/Strings.resx
@@ -168,9 +168,6 @@
   <data name="net_uri_PortOutOfRange" xml:space="preserve">
     <value>A derived type '{0}' has reported an invalid value for the Uri port '{1}'.</value>
   </data>
-  <data name="net_uri_SizeLimit" xml:space="preserve">
-    <value>Invalid URI: The Uri string is too long.</value>
-  </data>
   <data name="net_uri_UserDrivenParsing" xml:space="preserve">
     <value>A derived type '{0}' is responsible for parsing this Uri instance. The base implementation must not be used.</value>
   </data>

--- a/src/libraries/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IriHelper.cs
@@ -88,6 +88,8 @@ namespace System
         //
         internal static unsafe string EscapeUnescapeIri(char* pInput, int start, int end, UriComponents component)
         {
+            Debug.Assert(end >= 0 && start >= 0 && start <= end);
+
             int size = end - start;
             var dest = size <= Uri.StackallocThreshold
                 ? new ValueStringBuilder(stackalloc char[Uri.StackallocThreshold])

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -9,7 +9,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
@@ -17,7 +16,7 @@ using System.Threading;
 namespace System
 {
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    [TypeForwardedFrom("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial class Uri : ISpanFormattable, IEquatable<Uri>, ISerializable
     {
         public static readonly string UriSchemeFile = UriParser.FileUri.SchemeName;
@@ -38,10 +37,9 @@ namespace System
         public static readonly string UriSchemeNetPipe = UriParser.NetPipeUri.SchemeName;
         public static readonly string SchemeDelimiter = "://";
 
-        internal const int StackallocThreshold = 512;
+        private const int SchemeLengthLimit = 1024;
 
-        internal const int c_MaxUriBufferSize = 0xFFF0;
-        private const int c_MaxUriSchemeName = 1024;
+        internal const int StackallocThreshold = 512;
 
         // untouched user string unless string has unicode chars and iriparsing is enabled
         // or idn is on and we have unicode host or idn host
@@ -60,86 +58,136 @@ namespace System
         [Flags]
         internal enum Flags : ulong
         {
-            Zero = 0x00000000,
+            Zero = 0,
 
-            SchemeNotCanonical = 0x1,
-            UserNotCanonical = 0x2,
-            HostNotCanonical = 0x4,
-            PortNotCanonical = 0x8,
-            PathNotCanonical = 0x10,
-            QueryNotCanonical = 0x20,
-            FragmentNotCanonical = 0x40,
-            CannotDisplayCanonical = 0x7F,
+            SchemeNotCanonical = 1UL << 0,
+            UserNotCanonical = 1UL << 1,
+            HostNotCanonical = 1UL << 2,
+            PortNotCanonical = 1UL << 3,
+            PathNotCanonical = 1UL << 4,
+            QueryNotCanonical = 1UL << 5,
+            FragmentNotCanonical = 1UL << 6,
+            CannotDisplayCanonical = SchemeNotCanonical | UserNotCanonical | HostNotCanonical | PortNotCanonical | PathNotCanonical | QueryNotCanonical | FragmentNotCanonical,
 
-            E_UserNotCanonical = 0x80,
-            E_HostNotCanonical = 0x100,
-            E_PortNotCanonical = 0x200,
-            E_PathNotCanonical = 0x400,
-            E_QueryNotCanonical = 0x800,
-            E_FragmentNotCanonical = 0x1000,
-            E_CannotDisplayCanonical = 0x1F80,
+            E_UserNotCanonical = 1UL << 7,
+            E_HostNotCanonical = 1UL << 8,
+            E_PortNotCanonical = 1UL << 9,
+            E_PathNotCanonical = 1UL << 10,
+            E_QueryNotCanonical = 1UL << 11,
+            E_FragmentNotCanonical = 1UL << 12,
+            E_CannotDisplayCanonical = E_UserNotCanonical | E_HostNotCanonical | E_PortNotCanonical | E_PathNotCanonical | E_QueryNotCanonical | E_FragmentNotCanonical,
 
+            ShouldBeCompressed = 1UL << 13,
+            FirstSlashAbsent = 1UL << 14,
+            BackslashInPath = 1UL << 15,
 
-            ShouldBeCompressed = 0x2000,
-            FirstSlashAbsent = 0x4000,
-            BackslashInPath = 0x8000,
+            IndexMask = 0xFFFFFFFF, // 32 bits
 
-            IndexMask = 0x0000FFFF,
-            HostTypeMask = 0x00070000,
-            HostNotParsed = 0x00000000,
-            IPv6HostType = 0x00010000,
-            IPv4HostType = 0x00020000,
-            DnsHostType = 0x00030000,
-            UncHostType = 0x00040000,
-            BasicHostType = 0x00050000,
-            UnusedHostType = 0x00060000,
-            UnknownHostType = 0x00070000,
+            HostTypeMask = 7 * (1UL << 32),
+            HostNotParsed = 0,
+            IPv6HostType = 1 * (1UL << 32),
+            IPv4HostType = 2 * (1UL << 32),
+            DnsHostType = 3 * (1UL << 32),
+            UncHostType = 4 * (1UL << 32),
+            BasicHostType = 5 * (1UL << 32),
+            UnusedHostType = 6 * (1UL << 32),
+            UnknownHostType = 7 * (1UL << 32),
 
-            UserEscaped = 0x00080000,
-            AuthorityFound = 0x00100000,
-            HasUserInfo = 0x00200000,
-            LoopbackHost = 0x00400000,
-            NotDefaultPort = 0x00800000,
+            UserEscaped = 1UL << 35,
+            AuthorityFound = 1UL << 36,
+            HasUserInfo = 1UL << 37,
+            LoopbackHost = 1UL << 38,
+            NotDefaultPort = 1UL << 39,
 
-            UserDrivenParsing = 0x01000000,
-            CanonicalDnsHost = 0x02000000,
-            ErrorOrParsingRecursion = 0x04000000,   // Used to signal a default parser error and also to confirm Port
+            UserDrivenParsing = 1UL << 40,
+            CanonicalDnsHost = 1UL << 41,
+            ErrorOrParsingRecursion = 1UL << 42,    // Used to signal a default parser error and also to confirm Port
                                                     // and Host values in case of a custom user Parser
-            DosPath = 0x08000000,
-            UncPath = 0x10000000,
-            ImplicitFile = 0x20000000,
-            MinimalUriInfoSet = 0x40000000,
-            AllUriInfoSet = unchecked(0x80000000),
-            IdnHost = 0x100000000,
-            HasUnicode = 0x200000000,
+            DosPath = 1UL << 43,
+            UncPath = 1UL << 44,
+            ImplicitFile = 1UL << 45,
+            MinimalUriInfoSet = 1UL << 46,
+            AllUriInfoSet = 1UL << 47,
+            IdnHost = 1UL << 48,
+            HasUnicode = 1UL << 49,
+
             // Is this component Iri canonical
-            UserIriCanonical = 0x8000000000,
-            PathIriCanonical = 0x10000000000,
-            QueryIriCanonical = 0x20000000000,
-            FragmentIriCanonical = 0x40000000000,
-            IriCanonical = 0x78000000000,
-            UnixPath = 0x100000000000,
+            UserIriCanonical = 1UL << 50,
+            PathIriCanonical = 1UL << 51,
+            QueryIriCanonical = 1UL << 52,
+            FragmentIriCanonical = 1UL << 53,
+            IriCanonical = UserIriCanonical | PathIriCanonical | QueryIriCanonical | FragmentIriCanonical,
+            UnixPath = 1UL << 54,
 
             /// <summary>
             /// Disables any validation/normalization past the authority. Fragments will always be empty. GetComponents will throw for Path/Query.
             /// </summary>
-            DisablePathAndQueryCanonicalization = 0x200000000000,
+            DisablePathAndQueryCanonicalization = 1UL << 55,
 
             /// <summary>
             /// Used to ensure that InitializeAndValidate is only called once per Uri instance and only from an override of InitializeAndValidate
             /// </summary>
-            CustomParser_ParseMinimalAlreadyCalled = 0x4000000000000000,
+            CustomParser_ParseMinimalAlreadyCalled = 1UL << 56,
 
             /// <summary>
             /// Used for asserting that certain methods are only called from the constructor to validate thread-safety assumptions
             /// </summary>
-            Debug_LeftConstructor = 0x8000000000000000
+            Debug_LeftConstructor = 1UL << 57
         }
 
         [Conditional("DEBUG")]
         private void DebugSetLeftCtor()
         {
             _flags |= Flags.Debug_LeftConstructor;
+
+            AssertInvariants();
+        }
+
+        [Conditional("DEBUG")]
+        private void AssertInvariants()
+        {
+            Debug.Assert(InFact(Flags.MinimalUriInfoSet) == (_info is not null));
+
+            if (_info is UriInfo info)
+            {
+                Debug.Assert(IsAbsoluteUri);
+
+                Offset offset = info.Offset;
+
+                Debug.Assert(offset.Scheme >= 0);
+                Debug.Assert(offset.User >= 0 && offset.User >= offset.Scheme);
+                Debug.Assert(offset.Host >= 0 && offset.Host >= offset.User);
+                Debug.Assert(offset.Path >= 0);
+                Debug.Assert(offset.End >= 0 && offset.End >= offset.Path);
+
+                if (InFact(Flags.AllUriInfoSet))
+                {
+                    Debug.Assert(offset.Path >= offset.Host);
+                    Debug.Assert(offset.Query >= 0 && offset.Query >= offset.Path);
+                    Debug.Assert(offset.Fragment >= 0 && offset.Fragment >= offset.Query);
+                    Debug.Assert(offset.End >= offset.Fragment && offset.End <= _string.Length);
+                }
+                else
+                {
+                    // If we have non-ASCII, we're about to continue with ParseRemaining.
+                    // Between CreateUriInfo and the rest of ParseRemaining, the Path offset is pointing into the original string,
+                    // while the Host offset is poining into the new _string. As such the Host offset may temporarily be > Path.
+                    if (!InFact(Flags.HasUnicode))
+                    {
+                        Debug.Assert(offset.Path >= offset.Host);
+                    }
+
+                    Debug.Assert(offset.Query == 0);
+                    Debug.Assert(offset.Fragment == 0);
+                }
+            }
+            else
+            {
+                if (IsAbsoluteUri && IriParsing)
+                {
+                    Debug.Assert(Ascii.IsValid(_string));
+                }
+            }
         }
 
         [Conditional("DEBUG")]
@@ -175,17 +223,16 @@ namespace System
             }
         };
 
-        [StructLayout(LayoutKind.Sequential, Pack = 1)]
         private struct Offset
         {
-            public ushort Scheme;
-            public ushort User;
-            public ushort Host;
+            public int Scheme;
+            public int User;
+            public int Host;
             public ushort PortValue;
-            public ushort Path;
-            public ushort Query;
-            public ushort Fragment;
-            public ushort End;
+            public int Path;
+            public int Query;
+            public int Fragment;
+            public int End;
         };
 
         private sealed class MoreInfo
@@ -323,6 +370,7 @@ namespace System
             if ((cF & Flags.MinimalUriInfoSet) == 0)
             {
                 CreateUriInfo(cF);
+                AssertInvariants();
             }
             Debug.Assert(_info != null && (_flags & Flags.MinimalUriInfoSet) != 0);
             return _info;
@@ -333,6 +381,7 @@ namespace System
             if ((_flags & Flags.AllUriInfoSet) == 0)
             {
                 ParseRemaining();
+                AssertInvariants();
             }
         }
 
@@ -664,8 +713,6 @@ namespace System
                 // Fatal
                 case ParsingError.SchemeLimit:
                     return new UriFormatException(SR.net_uri_SchemeLimit);
-                case ParsingError.SizeLimit:
-                    return new UriFormatException(SR.net_uri_SizeLimit);
                 case ParsingError.MustRootedPath:
                     return new UriFormatException(SR.net_uri_MustRootedPath);
                 // Derived class controllable
@@ -1019,7 +1066,7 @@ namespace System
                 }
 
 
-                ushort pathStart = (ushort)count; //save for optional Compress() call
+                int pathStart = count; // save for optional Compress() call
 
                 UnescapeMode mode = (InFact(Flags.PathNotCanonical) && !IsImplicitFile)
                     ? (UnescapeMode.Unescape | UnescapeMode.UnescapeAll) : UnescapeMode.CopyOnly;
@@ -1263,7 +1310,7 @@ namespace System
         //
         public static UriHostNameType CheckHostName(string? name)
         {
-            if (string.IsNullOrEmpty(name) || name.Length > short.MaxValue)
+            if (string.IsNullOrEmpty(name))
             {
                 return UriHostNameType.Unknown;
             }
@@ -1911,9 +1958,6 @@ namespace System
             if (length == 0)
                 return ParsingError.EmptyUriString;
 
-            if (length >= c_MaxUriBufferSize)
-                return ParsingError.SizeLimit;
-
             // Fast path for valid http(s) schemes with no leading whitespace that are expected to be very common.
             if (uriString.StartsWith("https:", StringComparison.OrdinalIgnoreCase))
             {
@@ -2213,7 +2257,7 @@ namespace System
             UriInfo info = new UriInfo();
 
             // This will be revisited in ParseRemaining but for now just have it at least _string.Length
-            info.Offset.End = (ushort)_string.Length;
+            info.Offset.End = _string.Length;
 
             if (UserDrivenParsing)
                 goto Done;
@@ -2284,7 +2328,7 @@ namespace System
                 )
             {
                 //there is no Authority component defined
-                info.Offset.User = (ushort)(cF & Flags.IndexMask);
+                info.Offset.User = (int)(cF & Flags.IndexMask);
                 info.Offset.Host = info.Offset.User;
                 info.Offset.Path = info.Offset.User;
                 cF &= ~Flags.IndexMask;
@@ -2295,13 +2339,13 @@ namespace System
                 goto Done;
             }
 
-            info.Offset.User = (ushort)idx;
+            info.Offset.User = idx;
 
             //Basic Host Type does not have userinfo and port
             if (HostType == Flags.BasicHostType)
             {
-                info.Offset.Host = (ushort)idx;
-                info.Offset.Path = (ushort)(cF & Flags.IndexMask);
+                info.Offset.Host = idx;
+                info.Offset.Path = (int)(cF & Flags.IndexMask);
                 cF &= ~Flags.IndexMask;
                 goto Done;
             }
@@ -2314,15 +2358,14 @@ namespace System
                     ++idx;
                 }
                 ++idx;
-                info.Offset.Host = (ushort)idx;
+                info.Offset.Host = idx;
             }
             else
             {
-                info.Offset.Host = (ushort)idx;
+                info.Offset.Host = idx;
             }
 
             //Now reload the end of the parsed host
-
             idx = (int)(cF & Flags.IndexMask);
 
             //From now on we do not need IndexMask bits, and reuse the space for X_NotCanonical flags
@@ -2336,7 +2379,7 @@ namespace System
             }
 
             //Guessing this is a path start
-            info.Offset.Path = (ushort)idx;
+            info.Offset.Path = idx;
 
             // parse Port if any. The new spec allows a port after ':' to be empty (assuming default?)
             bool notEmpty = false;
@@ -2346,7 +2389,7 @@ namespace System
             // points to _originalUnicodeString and not _string
 
             if ((cF & Flags.HasUnicode) != 0)
-                info.Offset.End = (ushort)_originalUnicodeString.Length;
+                info.Offset.End = _originalUnicodeString.Length;
 
             if (idx < info.Offset.End)
             {
@@ -2389,7 +2432,7 @@ namespace System
                             //not follow to canonical rules
                             cF |= (Flags.PortNotCanonical | Flags.E_PortNotCanonical);
                         }
-                        info.Offset.Path = (ushort)idx;
+                        info.Offset.Path = idx;
                     }
                 }
             }
@@ -2578,9 +2621,6 @@ namespace System
             // ATTN: Check on whether recursion has not happened
             if (_info.Host is null)
             {
-                if (host.Length >= c_MaxUriBufferSize)
-                    throw GetException(ParsingError.SizeLimit)!;
-
                 ParsingError err = ParsingError.None;
                 Flags flags = _flags & ~Flags.HostTypeMask;
 
@@ -2769,6 +2809,8 @@ namespace System
 
         private ReadOnlySpan<char> RecreateParts(scoped ref ValueStringBuilder dest, string str, UriComponents parts, ushort nonCanonical, UriFormat formatAs)
         {
+            Debug.Assert(InFact(Flags.AllUriInfoSet));
+
             //Scheme and slashes
             if ((parts & UriComponents.Scheme) != 0)
             {
@@ -3299,11 +3341,11 @@ namespace System
                     }
 
                     _info.Offset.Scheme = 0;
-                    _info.Offset.User = (ushort)_string.Length;
-                    _info.Offset.Host = (ushort)_string.Length;
+                    _info.Offset.User = _string.Length;
+                    _info.Offset.Host = _string.Length;
                 }
 
-                _info.Offset.Path = (ushort)_string.Length;
+                _info.Offset.Path = _string.Length;
                 idx = _info.Offset.Path;
             }
 
@@ -3331,9 +3373,9 @@ namespace System
                     }
                 }
 
-                _info.Offset.Query = (ushort)idx;
-                _info.Offset.Fragment = (ushort)str.Length; // There is no fragment in DisablePathAndQueryCanonicalization mode
-                _info.Offset.End = (ushort)str.Length;
+                _info.Offset.Query = idx;
+                _info.Offset.Fragment = str.Length; // There is no fragment in DisablePathAndQueryCanonicalization mode
+                _info.Offset.End = str.Length;
 
                 goto Done;
             }
@@ -3374,12 +3416,6 @@ namespace System
                 }
 
                 _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Path);
-
-                if (_string.Length > ushort.MaxValue)
-                {
-                    UriFormatException e = GetException(ParsingError.SizeLimit)!;
-                    throw e;
-                }
 
                 length = _string.Length;
                 // We need to be sure that there isn't a '?' separated from the path by spaces.
@@ -3511,12 +3547,6 @@ namespace System
 
                     _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Query);
 
-                    if (_string.Length > ushort.MaxValue)
-                    {
-                        UriFormatException e = GetException(ParsingError.SizeLimit)!;
-                        throw e;
-                    }
-
                     length = _string.Length;
                     // We need to be sure that there isn't a '#' separated from the query by spaces.
                     if (_string == _originalUnicodeString)
@@ -3526,7 +3556,7 @@ namespace System
                 }
             }
 
-            _info.Offset.Query = (ushort)idx;
+            _info.Offset.Query = idx;
 
             fixed (char* str = _string)
             {
@@ -3568,19 +3598,13 @@ namespace System
 
                     _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Fragment);
 
-                    if (_string.Length > ushort.MaxValue)
-                    {
-                        UriFormatException e = GetException(ParsingError.SizeLimit)!;
-                        throw e;
-                    }
-
                     length = _string.Length;
                     // we don't need to check _originalUnicodeString == _string because # is last part
                     GetLengthWithoutTrailingSpaces(_string, ref length, idx);
                 }
             }
 
-            _info.Offset.Fragment = (ushort)idx;
+            _info.Offset.Fragment = idx;
 
             fixed (char* str = _string)
             {
@@ -3607,7 +3631,7 @@ namespace System
                     }
                 }
             }
-            _info.Offset.End = (ushort)idx;
+            _info.Offset.End = idx;
 
         Done:
             cF |= Flags.AllUriInfoSet;
@@ -3768,7 +3792,7 @@ namespace System
                 return null;
             }
 
-            if (scheme.Length > c_MaxUriSchemeName)
+            if (scheme.Length > SchemeLengthLimit)
             {
                 error = ParsingError.SchemeLimit;
                 return null;
@@ -3844,12 +3868,6 @@ namespace System
                         {
                             // Normalize user info
                             newHost += IriHelper.EscapeUnescapeIri(pString, startInput, start + 1, UriComponents.UserInfo);
-
-                            if (newHost.Length > ushort.MaxValue)
-                            {
-                                err = ParsingError.SizeLimit;
-                                return idx;
-                            }
                         }
                         ++start;
                         ch = pString[start];
@@ -3881,6 +3899,8 @@ namespace System
             else if (((syntaxFlags & UriSyntaxFlags.AllowDnsHost) != 0) && !IriParsingStatic(syntax) &&
                 DomainNameHelper.IsValid(new ReadOnlySpan<char>(pString + start, end - start), iri: false, StaticNotAny(flags, Flags.ImplicitFile), out int domainNameLength))
             {
+                Debug.Assert(!hasUnicode);
+
                 end = start + domainNameLength;
 
                 // comes here if there are only ascii chars in host with original parsing and no Iri

--- a/src/libraries/System.Private.Uri/src/System/UriEnumTypes.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriEnumTypes.cs
@@ -64,7 +64,7 @@ namespace System
         BadScheme,
         BadAuthority,
         EmptyUriString,
-        LastRelativeUriOkErrIndex,
+        LastErrorOkayForRelativeUris,
 
         // All higher error values are fatal, indicating that neither an absolute or relative
         // Uri could be generated.

--- a/src/libraries/System.Private.Uri/src/System/UriEnumTypes.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriEnumTypes.cs
@@ -57,29 +57,28 @@ namespace System
     internal enum ParsingError
     {
         // looks good
-        None = 0,
+        None,
 
         // These first errors indicate that the Uri cannot be absolute, but may be relative.
-        BadFormat = 1,
-        BadScheme = 2,
-        BadAuthority = 3,
-        EmptyUriString = 4,
-        LastRelativeUriOkErrIndex = 4,
+        BadFormat,
+        BadScheme,
+        BadAuthority,
+        EmptyUriString,
+        LastRelativeUriOkErrIndex,
 
         // All higher error values are fatal, indicating that neither an absolute or relative
         // Uri could be generated.
-        SchemeLimit = 5,
-        SizeLimit = 6,
-        MustRootedPath = 7,
+        SchemeLimit,
+        MustRootedPath,
 
         // derived class controlled
-        BadHostName = 8,
-        NonEmptyHost = 9, // unix only
-        BadPort = 10,
-        BadAuthorityTerminator = 11,
+        BadHostName,
+        NonEmptyHost, // unix only
+        BadPort,
+        BadAuthorityTerminator,
 
         // The user requested only a relative Uri, but an absolute Uri was parsed.
-        CannotCreateRelative = 12
+        CannotCreateRelative
     }
 
     [Flags]

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -80,7 +80,7 @@ namespace System
                     }
                 }
             }
-            else if (err > ParsingError.LastRelativeUriOkErrIndex)
+            else if (err > ParsingError.LastErrorOkayForRelativeUris)
             {
                 //This is a fatal error based solely on scheme name parsing
                 _string = null!; // make it be invalid Uri
@@ -104,7 +104,7 @@ namespace System
                 {
                     if ((err = PrivateParseMinimal()) != ParsingError.None)
                     {
-                        if (uriKind != UriKind.Absolute && err <= ParsingError.LastRelativeUriOkErrIndex)
+                        if (uriKind != UriKind.Absolute && err <= ParsingError.LastErrorOkayForRelativeUris)
                         {
                             // RFC 3986 Section 5.4.2 - http:(relativeUri) may be considered a valid relative Uri.
                             _syntax = null!; // convert to relative uri
@@ -153,7 +153,7 @@ namespace System
                     {
                         // Can we still take it as a relative Uri?
                         if (uriKind != UriKind.Absolute && err != ParsingError.None
-                            && err <= ParsingError.LastRelativeUriOkErrIndex)
+                            && err <= ParsingError.LastErrorOkayForRelativeUris)
                         {
                             _syntax = null!; // convert it to relative
                             e = null;
@@ -195,7 +195,7 @@ namespace System
             // If we encountered any parsing errors that indicate this may be a relative Uri,
             // and we'll allow relative Uri's, then create one.
             else if (err != ParsingError.None && uriKind != UriKind.Absolute
-                && err <= ParsingError.LastRelativeUriOkErrIndex)
+                && err <= ParsingError.LastErrorOkayForRelativeUris)
             {
                 e = null;
                 _flags &= (Flags.UserEscaped | Flags.HasUnicode); // the only flags that makes sense for a relative uri
@@ -768,7 +768,7 @@ namespace System
             if (err != ParsingError.None)
             {
                 // If it looks as a relative Uri, custom factory is ignored
-                if (uriKind != UriKind.Absolute && err <= ParsingError.LastRelativeUriOkErrIndex)
+                if (uriKind != UriKind.Absolute && err <= ParsingError.LastErrorOkayForRelativeUris)
                     return new Uri((flags & Flags.UserEscaped), null, uriString);
 
                 return null;

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -204,10 +204,6 @@ namespace System
                     // Iri'ze and then normalize relative uris
                     _string = EscapeUnescapeIri(_originalUnicodeString, 0, _originalUnicodeString.Length,
                                                 (UriComponents)0);
-                    if (_string.Length > ushort.MaxValue)
-                    {
-                        return;
-                    }
                 }
             }
             else

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriEscapingTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriEscapingTest.cs
@@ -303,9 +303,7 @@ namespace System.PrivateUri.Tests
         [Fact]
         public void UriEscapeUnescapeDataString_LongInputs()
         {
-            // Test the no-longer-existing "c_MaxUriBufferSize" limit of 0xFFF0,
-            // as well as lengths longer than the max Uri length of ushort.MaxValue.
-            foreach (int length in new[] { 1, 0xFFF0, 0xFFF1, ushort.MaxValue + 10 })
+            foreach (int length in new[] { 1, 64_000, 66_000, 1_000_000 })
             {
                 string unescaped = new string('s', length);
                 string escaped = unescaped;
@@ -411,9 +409,7 @@ namespace System.PrivateUri.Tests
 
         public static IEnumerable<object[]> UriEscapingUriString_Long_MemberData()
         {
-            // Test the no-longer-existing "c_MaxUriBufferSize" limit of 0xFFF0,
-            // as well as lengths longer than the max Uri length of ushort.MaxValue.
-            foreach (int length in new[] { 1, 0xFFF0, 0xFFF1, ushort.MaxValue + 10 })
+            foreach (int length in new[] { 1, 64_000, 66_000, 1_000_000 })
             {
                 yield return new object[] { new string('s', length), string.Concat(Enumerable.Repeat("s", length)) };
                 yield return new object[] { new string('<', length), string.Concat(Enumerable.Repeat("%3C", length)) };

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -979,8 +979,8 @@ namespace System.PrivateUri.Tests
         [ActiveIssue("Manual only. This test takes a few minutes to execute.")]
         public static async Task VeryLongInputs_ThrowOOM()
         {
-            // This string will expand 6x when escaped
-            string longString = string.Concat(Enumerable.Repeat("\uD83C\uDF49", 180_000_000));
+            // This string will expand 6x when escaped (12 = 6x growth * 2 chars in the string)
+            string longString = string.Concat(Enumerable.Repeat("\uD83C\uDF49", int.MaxValue / 12));
 
             Task userInfo = Task.Run(() => Test($"http://{longString}@host/path"));
             Task path = Task.Run(() => Test($"http://host/{longString}"));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Uri.CreateStringTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Uri.CreateStringTests.cs
@@ -11,7 +11,6 @@ namespace System.Tests
     public class UriCreateStringTests
     {
         private static readonly bool s_isWindowsSystem = PlatformDetection.IsWindows;
-        public static readonly string s_longString = new string('a', 65520 + 1);
 
         public static IEnumerable<object[]> OriginalString_AbsoluteUri_ToString_TestData()
         {
@@ -482,7 +481,7 @@ namespace System.Tests
             });
         }
 
-        public static IEnumerable<object[]> Path_Query_Fragment_TestData()
+        public static IEnumerable<object[]> Path_Query_Fragment_TestData_Core()
         {
             // Http
             yield return new object[] { "http://host", "/", "", "" };
@@ -802,6 +801,46 @@ namespace System.Tests
             yield return new object[] { "file://C:/abc/def/../ghi", "C:/abc/ghi", "", "" };
         }
 
+        public static IEnumerable<object[]> Path_Query_Fragment_TestData()
+        {
+            foreach (object[] data in Path_Query_Fragment_TestData_Core())
+            {
+                string uriString = (string)data[0];
+                string path = (string)data[1];
+                string query = (string)data[2];
+                string fragment = (string)data[3];
+
+                yield return new object[] { uriString, path, query, fragment };
+                yield return new object[] { new string(' ', 100_000) + uriString, path, query, fragment };
+
+                string longString = new string('^', 3);
+                string escaped = Uri.EscapeDataString(longString);
+
+                int fragmentOffset = uriString.IndexOf('#');
+
+                if (fragmentOffset >= 0)
+                {
+                    ReadOnlySpan<char> beforeFragment = uriString.AsSpan(0, fragmentOffset);
+                    ReadOnlySpan<char> sourceFragment = uriString.AsSpan(fragmentOffset + 1);
+                    yield return new object[] { $"{beforeFragment}#{longString}{sourceFragment}", path, query, $"#{escaped}{fragment.AsSpan(1)}" };
+                }
+
+                if (!string.IsNullOrEmpty(query) && uriString.IndexOf('?') is int queryOffset && queryOffset >= 0 && (fragmentOffset < 0 || fragmentOffset > queryOffset))
+                {
+                    ReadOnlySpan<char> beforeQuery = uriString.AsSpan(0, queryOffset);
+                    ReadOnlySpan<char> sourceQuery = uriString.AsSpan(queryOffset + 1);
+                    yield return new object[] { $"{beforeQuery}?{longString}{sourceQuery}", path, $"?{escaped}{query.AsSpan(1)}", fragment };
+                }
+
+                if (uriString.StartsWith("http://", StringComparison.OrdinalIgnoreCase) && !uriString.Contains('@'))
+                {
+                    ReadOnlySpan<char> remainder = uriString.AsSpan("http://".Length);
+
+                    yield return new object[] { $"http://{longString}@{remainder}", path, query, fragment };
+                }
+            }
+        }
+
         [Theory]
         [MemberData(nameof(Path_Query_Fragment_TestData))]
         public void Path_Query_Fragment(string uriString, string path, string query, string fragment)
@@ -1028,8 +1067,6 @@ namespace System.Tests
 
         public static IEnumerable<object[]> Create_String_Invalid_TestData()
         {
-            yield return new object[] { s_longString, UriKind.Absolute }; // UriString is longer than 66520 characters
-
             // Invalid scheme
             yield return new object[] { "", UriKind.Absolute };
             yield return new object[] { "  \t \r \n  \x0009 \x000A \x000D ", UriKind.Absolute };
@@ -1050,6 +1087,7 @@ namespace System.Tests
             yield return new object[] { "http~://domain.com", UriKind.Absolute };
             yield return new object[] { "http#://domain.com", UriKind.Absolute };
             yield return new object[] { new string('a', 1025) + "://domain.com", UriKind.Absolute }; // Scheme is longer than 1024 characters
+            yield return new object[] { new string('a', 100_000), UriKind.Absolute };
 
             // Invalid userinfo
             yield return new object[] { @"http://use\rinfo@host", UriKind.Absolute };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Uri.CreateStringTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Uri.CreateStringTests.cs
@@ -813,7 +813,7 @@ namespace System.Tests
                 yield return new object[] { uriString, path, query, fragment };
                 yield return new object[] { new string(' ', 100_000) + uriString, path, query, fragment };
 
-                string longString = new string('^', 3);
+                string longString = new string('^', 100_000);
                 string escaped = Uri.EscapeDataString(longString);
 
                 int fragmentOffset = uriString.IndexOf('#');

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Uri.CreateUriTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Uri.CreateUriTests.cs
@@ -101,8 +101,23 @@ namespace System.Tests
             yield return new object[] { "http://hostold/", "http://host/path/page", UriKind.Absolute, "http://host/path/page" };
         }
 
+        public static IEnumerable<object[]> Create_Uri_WithExtraWhiteSpace_TestData()
+        {
+            foreach (object[] testData in Create_Uri_TestData())
+            {
+                string uriString1 = (string)testData[0];
+                string uriString2 = (string)testData[1];
+                UriKind uriKind = (UriKind)testData[2];
+                string expectedUriString = (string)testData[3];
+
+                yield return new object[] { uriString1, uriString2, uriKind, expectedUriString };
+                yield return new object[] { $"{new string(' ', 100_000)}{uriString1}", uriString2, uriKind, expectedUriString };
+                yield return new object[] { uriString1, $"{new string(' ', 100_000)}{uriString2}", uriKind, expectedUriString };
+            }
+        }
+
         [Theory]
-        [MemberData(nameof(Create_Uri_TestData))]
+        [MemberData(nameof(Create_Uri_WithExtraWhiteSpace_TestData))]
         public void Create_Uri(string uriString1, string uriString2, UriKind uriKind, string expectedUriString)
         {
             Uri baseUri = new Uri(uriString1, UriKind.Absolute);

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Uri.MethodsTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Uri.MethodsTests.cs
@@ -443,7 +443,7 @@ namespace System.Tests
         public void EscapeUriString_Long_Success()
         {
             string s;
-            const int LongCount = 65520 + 1;
+            const int LongCount = 100_000;
 
             s = new string('a', LongCount);
             Assert.Equal(s, Uri.EscapeUriString(s));


### PR DESCRIPTION
Closes #96544

The current approach grows the `UriInfo` allocation by 16 bytes.
If we want to keep the 64 KB limit on the UserInfo/Host, we can rather easily cut that to just 8.

Gist:
- Removed explicit length checks
- Changed `UriInfo.Offset` fields from `ushort` to `int` and removed any remaining casts to `ushort` left after #32694
- Shuffled some of the internal `Uri.Flags` enum values around to make space for 32 bits (instead of 16) at the start since we store the index inside the flags before doing the full parse