### PR TITLE
Avoid some substring allocations during Uri host normalization

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -4015,11 +4015,9 @@ namespace System
                     if (hasUnicode)
                     {
                         // Normalize any other host or do idn
-                        string user = new string(pString, startInput, end - startInput);
-
                         try
                         {
-                            newHost += user.Normalize(NormalizationForm.FormC);
+                            newHost = UriHelper.NormalizeAndConcat(newHost, new ReadOnlySpan<char>(pString + startInput, end - startInput));
                         }
                         catch (ArgumentException)
                         {
@@ -4061,10 +4059,9 @@ namespace System
                         if (hasUnicode)
                         {
                             // Normalize any other host
-                            string user = new string(pString, startOtherHost, end - startOtherHost);
                             try
                             {
-                                newHost += user.Normalize(NormalizationForm.FormC);
+                                newHost = UriHelper.NormalizeAndConcat(newHost, new ReadOnlySpan<char>(pString + startOtherHost, end - startOtherHost));
                             }
                             catch (ArgumentException)
                             {
@@ -4095,10 +4092,16 @@ namespace System
 
             if (hasUnicode)
             {
-                string temp = UriHelper.StripBidiControlCharacters(new ReadOnlySpan<char>(pString + start, end - start));
+                ReadOnlySpan<char> host = new ReadOnlySpan<char>(pString + start, end - start);
+
+                if (UriHelper.StripBidiControlCharacters(host, out string? stripped))
+                {
+                    host = stripped;
+                }
+
                 try
                 {
-                    newHost += temp.Normalize(NormalizationForm.FormC);
+                    newHost = UriHelper.NormalizeAndConcat(newHost, host);
                 }
                 catch (ArgumentException)
                 {

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -17,6 +18,21 @@ namespace System
                 int charsWritten = span.ToLowerInvariant(buffer);
                 Debug.Assert(charsWritten == buffer.Length);
             });
+        }
+
+        public static string NormalizeAndConcat(string? start, ReadOnlySpan<char> toNormalize)
+        {
+            var vsb = new ValueStringBuilder(stackalloc char[Uri.StackallocThreshold]);
+
+            int charsWritten;
+            while (!toNormalize.TryNormalize(vsb.RawChars, out charsWritten, NormalizationForm.FormC))
+            {
+                vsb.EnsureCapacity(vsb.Length + 1);
+            }
+
+            string result = string.Concat(start, vsb.RawChars.Slice(0, charsWritten));
+            vsb.Dispose();
+            return result;
         }
 
         // http://host/Path/Path/File?Query is the base of
@@ -591,10 +607,20 @@ namespace System
             char.IsBetween(ch, '\u200E', '\u202E') && !char.IsBetween(ch, '\u2010', '\u2029');
 
         // Strip Bidirectional control characters from this string
-        internal static string StripBidiControlCharacters(ReadOnlySpan<char> strToClean, string? backingString = null)
+        public static string StripBidiControlCharacters(ReadOnlySpan<char> strToClean, string? backingString = null)
         {
             Debug.Assert(backingString is null || strToClean.Length == backingString.Length);
 
+            if (StripBidiControlCharacters(strToClean, out string? stripped))
+            {
+                return stripped;
+            }
+
+            return backingString ?? strToClean.ToString();
+        }
+
+        public static bool StripBidiControlCharacters(ReadOnlySpan<char> strToClean, [NotNullWhen(true)] out string? stripped)
+        {
             int charsToRemove = 0;
 
             int indexOfPossibleCharToRemove = strToClean.IndexOfAnyInRange('\u200E', '\u202E');
@@ -613,10 +639,11 @@ namespace System
             if (charsToRemove == 0)
             {
                 // Hot path
-                return backingString ?? new string(strToClean);
+                stripped = null;
+                return false;
             }
 
-            return string.Create(strToClean.Length - charsToRemove, strToClean, static (buffer, strToClean) =>
+            stripped = string.Create(strToClean.Length - charsToRemove, strToClean, static (buffer, strToClean) =>
             {
                 int destIndex = 0;
                 foreach (char c in strToClean)
@@ -628,6 +655,7 @@ namespace System
                 }
                 Debug.Assert(buffer.Length == destIndex);
             });
+            return true;
         }
     }
 }

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -27,7 +27,7 @@ namespace System
             int charsWritten;
             while (!toNormalize.TryNormalize(vsb.RawChars, out charsWritten, NormalizationForm.FormC))
             {
-                vsb.EnsureCapacity(vsb.Length + 1);
+                vsb.EnsureCapacity(vsb.Capacity + 1);
             }
 
             string result = string.Concat(start, vsb.RawChars.Slice(0, charsWritten));


### PR DESCRIPTION
Avoids 1 or 2 temporary string allocations - the argument to `Normalize` and (sometimes) its result.
Only applies to Uris with non-ASCII values.

| Method | Toolchain  | Mean     | Error   | Ratio | Allocated | Alloc Ratio |
|------- |----------- |---------:|--------:|------:|----------:|------------:|
| NewUri | main       | 397.0 ns | 1.59 ns |  1.00 |     440 B |        1.00 |
| NewUri | pr         | 377.6 ns | 1.60 ns |  0.95 |     368 B |        0.84 |

```c#
[MemoryDiagnoser(false)]
public class UriBench
{
    [Benchmark]
    public Uri NewUri() => new("http://some.host.with.ümlauts/");
}
```