### PR TITLE
Move IPv6 ScopeId storage slot out of common path in Uri

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -156,12 +156,7 @@ namespace System
             public string? IdnHost;
             public string? PathAndQuery;
 
-            /// <summary>
-            /// Only IP v6 may need this
-            /// </summary>
-            public string? ScopeId;
-
-            private MoreInfo? _moreInfo;
+            public MoreInfo? _moreInfo;
             public MoreInfo MoreInfo
             {
                 get
@@ -195,6 +190,11 @@ namespace System
             public string? Fragment;
             public string? AbsoluteUri;
             public string? RemoteUrl;
+
+            /// <summary>
+            /// Only IP v6 may need this
+            /// </summary>
+            public string? ScopeId;
         };
 
         private void InterlockedSetFlags(Flags flags)
@@ -1184,8 +1184,8 @@ namespace System
                     }
                     else if (hostType == Flags.IPv6HostType)
                     {
-                        host = _info.ScopeId != null ?
-                            string.Concat(host.AsSpan(1, host.Length - 2), _info.ScopeId) :
+                        host = _info._moreInfo?.ScopeId is string scopeId ?
+                            string.Concat(host.AsSpan(1, host.Length - 2), scopeId) :
                             host.Substring(1, host.Length - 2);
                     }
                     // Validate that this basic host qualifies as Dns safe,
@@ -2433,8 +2433,9 @@ namespace System
                     }
                 }
             }
+
             Flags flags = _flags;
-            string host = CreateHostStringHelper(_string, _info.Offset.Host, _info.Offset.Path, ref flags, ref _info.ScopeId);
+            string host = CreateHostStringHelper(_string, _info.Offset.Host, _info.Offset.Path, ref flags, _info);
 
             // now check on canonical host representation
             if (host.Length != 0)
@@ -2482,7 +2483,7 @@ namespace System
                 else if (NotAny(Flags.CanonicalDnsHost))
                 {
                     // Check to see if we can take the canonical host string out of _string
-                    if (_info.ScopeId is not null)
+                    if (_info._moreInfo?.ScopeId is not null)
                     {
                         // IPv6 ScopeId is included when serializing a Uri
                         flags |= (Flags.HostNotCanonical | Flags.E_HostNotCanonical);
@@ -2506,7 +2507,7 @@ namespace System
             InterlockedSetFlags(flags);
         }
 
-        private static string CreateHostStringHelper(string str, int idx, int end, ref Flags flags, ref string? scopeId)
+        private static string CreateHostStringHelper(string str, int idx, int end, ref Flags flags, UriInfo info)
         {
             bool loopback = false;
             string host;
@@ -2519,7 +2520,11 @@ namespace System
                 case Flags.IPv6HostType:
                     // The helper will return [...] string that is not suited for Dns.Resolve()
                     host = IPv6AddressHelper.ParseCanonicalName(str.AsSpan(idx), ref loopback, out ReadOnlySpan<char> scopeIdSpan);
-                    scopeId = scopeIdSpan.IsEmpty ? null : new string(scopeIdSpan);
+
+                    if (!scopeIdSpan.IsEmpty)
+                    {
+                        info.MoreInfo.ScopeId = new string(scopeIdSpan);
+                    }
                     break;
 
                 case Flags.IPv4HostType:
@@ -2603,7 +2608,8 @@ namespace System
                 }
                 else
                 {
-                    host = CreateHostStringHelper(host, 0, host.Length, ref flags, ref _info.ScopeId);
+                    host = CreateHostStringHelper(host, 0, host.Length, ref flags, _info);
+
                     for (int i = 0; i < host.Length; ++i)
                     {
                         if ((_info.Offset.Host + i) >= _info.Offset.End || host[i] != _string[_info.Offset.Host + i])
@@ -2880,10 +2886,10 @@ namespace System
                     hostBuilder.Dispose();
 
                     // A fix up only for SerializationInfo and IpV6 host with a scopeID
-                    if ((parts & UriComponents.SerializationInfoString) != 0 && HostType == Flags.IPv6HostType && _info.ScopeId != null)
+                    if ((parts & UriComponents.SerializationInfoString) != 0 && HostType == Flags.IPv6HostType && _info._moreInfo?.ScopeId is string scopeId)
                     {
                         dest.Length--;
-                        dest.Append(_info.ScopeId);
+                        dest.Append(scopeId);
                         dest.Append(']');
                     }
                 }


### PR DESCRIPTION
Moves the `ScopeId` field from `UriInfo` to `UriInfo.MoreInfo` under the assumption that scopes are much rared compared to DNS / IPv4 / regular IPv6 hosts.
Saves 8 bytes for those common cases.

| Method      | Toolchain | Mean     | Error   | Ratio | Allocated | Alloc Ratio |
|------------ |---------- |---------:|--------:|------:|----------:|------------:|
| Dns         | main      | 136.6 ns | 0.90 ns |  1.00 |     168 B |        1.00 |
| Dns         | pr        | 131.3 ns | 0.67 ns |  0.96 |     160 B |        0.95 |
|             |           |          |         |       |           |             |
| IPv4        | main      | 180.0 ns | 1.97 ns |  1.00 |     176 B |        1.00 |
| IPv4        | pr        | 174.4 ns | 0.87 ns |  0.97 |     168 B |        0.95 |
|             |           |          |         |       |           |             |
| IPv6        | main      | 163.5 ns | 2.21 ns |  1.00 |     168 B |        1.00 |
| IPv6        | pr        | 155.7 ns | 0.46 ns |  0.95 |     160 B |        0.95 |
|             |           |          |         |       |           |             |
| WithScopeId | main      | 266.7 ns | 0.86 ns |  1.00 |     376 B |        1.00 |
| WithScopeId | pr        | 283.4 ns | 3.00 ns |  1.06 |     432 B |        1.15 |

```c#
[MemoryDiagnoser(false)]
public class UriBench
{
    [Benchmark]
    public string Dns() => new Uri("http://host/").Host;

    [Benchmark]
    public string IPv4() => new Uri("http://127.0.0.1/").Host;

    [Benchmark]
    public string IPv6() => new Uri("http://[::]/").Host;

    [Benchmark]
    public string WithScopeId() => new Uri("http://[::%42]/").Host;
}
```