### PR TITLE
[Testing interpreter pipeline doesn't trigger for PRs automatically]

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -30,7 +30,7 @@ namespace System.Threading
 
         // The semaphore count, initialized in the constructor to the initial value, every release call increments it
         // and every wait call decrements it as long as its value is positive otherwise the wait will block.
-        // Its value must be between the maximum semaphore value and zero
+        // Its value must be between the maximum semaphore value and zero.
         private volatile int m_currentCount;
 
         // The maximum semaphore value, it is initialized to Int.MaxValue if the client didn't specify it. it is used


### PR DESCRIPTION
Just testing https://github.com/dotnet/runtime/pull/117254 doesn't trigger the interpreter pipeline as it did after the first merge.