### PR TITLE
Fix GetName on TypeMetadataNode

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -172,7 +172,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName(NodeFactory factory)
         {
-            return "Reflectable type: " + _type.ToString();
+            return "Type metadata: " + _type.ToString();
         }
 
         protected override void OnMarked(NodeFactory factory)


### PR DESCRIPTION
`MethodMetadataNode` says "Method metadata", `FieldMetadataNode` says "Field metadata". `TypeMetadataNode` should say "Type metadata".

"Reflectable type" is same string as the one used on `ReflectedTypeNode`, causing extra confusion.

Cc @dotnet/ilc-contrib 