### PR TITLE
Implement IMinMaxValue for CLong and CULong

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CLong.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CLong.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // We use our own aliases since they differ per platform
@@ -22,7 +23,7 @@ namespace System.Runtime.InteropServices
     /// </summary>
     [CLSCompliant(false)]
     [Intrinsic]
-    public readonly struct CLong : IEquatable<CLong>
+    public readonly struct CLong : IEquatable<CLong>, IMinMaxValue<CLong>
     {
         private readonly NativeType _value;
 
@@ -49,6 +50,24 @@ namespace System.Runtime.InteropServices
         /// The underlying integer value of this instance.
         /// </summary>
         public nint Value => _value;
+
+        /// <summary>
+        /// Represents the largest finite value of a CLong.
+        /// </summary>
+        public static CLong MaxValue
+        {
+            [NonVersionable]
+            get => new CLong(NativeType.MaxValue);
+        }
+
+        /// <summary>
+        /// Represents the smallest finite value of a CLong.
+        /// </summary>
+        public static CLong MinValue
+        {
+            [NonVersionable]
+            get => new CLong(NativeType.MinValue);
+        }
 
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified object.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CLong.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CLong.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 
 #pragma warning disable SA1121 // We use our own aliases since they differ per platform
 #if TARGET_WINDOWS

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CULong.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CULong.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // We use our own aliases since they differ per platform
@@ -22,7 +23,7 @@ namespace System.Runtime.InteropServices
     /// </summary>
     [CLSCompliant(false)]
     [Intrinsic]
-    public readonly struct CULong : IEquatable<CULong>
+    public readonly struct CULong : IEquatable<CULong>, IMinMaxValue<CULong>
     {
         private readonly NativeType _value;
 
@@ -49,6 +50,24 @@ namespace System.Runtime.InteropServices
         /// The underlying integer value of this instance.
         /// </summary>
         public nuint Value => _value;
+
+        /// <summary>
+        /// Represents the largest finite value of a CULong.
+        /// </summary>
+        public static CULong MaxValue
+        {
+            [NonVersionable]
+            get => new CULong(NativeType.MaxValue);
+        }
+
+        /// <summary>
+        /// Represents the smallest finite value of a CULong.
+        /// </summary>
+        public static CULong MinValue
+        {
+            [NonVersionable]
+            get => new CULong(NativeType.MinValue);
+        }
 
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified object.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CULong.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CULong.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 
 #pragma warning disable SA1121 // We use our own aliases since they differ per platform
 #if TARGET_WINDOWS

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -666,6 +666,8 @@ namespace System.Runtime.InteropServices
         public CLong(int value) { throw null; }
         public CLong(nint value) { throw null; }
         public nint Value { get { throw null; } }
+        public static System.Runtime.InteropServices.CLong MaxValue { get { throw null; } }
+        public static System.Runtime.InteropServices.CLong MinValue { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? o) { throw null; }
         public bool Equals(System.Runtime.InteropServices.CLong other) { throw null; }
         public override int GetHashCode() { throw null; }
@@ -813,6 +815,8 @@ namespace System.Runtime.InteropServices
         public CULong(uint value) { throw null; }
         public CULong(nuint value) { throw null; }
         public nuint Value { get { throw null; } }
+        public static System.Runtime.InteropServices.CULong MaxValue { get { throw null; } }
+        public static System.Runtime.InteropServices.CULong MinValue { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? o) { throw null; }
         public bool Equals(System.Runtime.InteropServices.CULong other) { throw null; }
         public override int GetHashCode() { throw null; }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CLongTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CLongTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -50,6 +51,36 @@ namespace System.Runtime.InteropServices.Tests
             nint largeValue = unchecked(((nint)int.MaxValue) + 1);
             CLong value = new CLong(largeValue);
             Assert.Equal(largeValue, value.Value);
+        }
+
+        [Fact]
+        public void MaxValue()
+        {
+            CLong result = CLong.MaxValue;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Equal(System.Int32.MaxValue, result.Value);
+            }
+            else
+            {
+                Assert.Equal(System.IntPtr.MaxValue, result.Value);
+            }
+        }
+
+        [Fact]
+        public void MinValue()
+        {
+            CLong result = CLong.MinValue;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Equal(System.Int32.MinValue, result.Value);
+            }
+            else
+            {
+                Assert.Equal(System.IntPtr.MinValue, result.Value);
+            }
         }
 
         public static IEnumerable<object[]> EqualsData()

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CULongTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CULongTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -50,6 +51,36 @@ namespace System.Runtime.InteropServices.Tests
             nuint largeValue = unchecked(((nuint)uint.MaxValue) + 1);
             CULong value = new CULong(largeValue);
             Assert.Equal(largeValue, value.Value);
+        }
+
+        [Fact]
+        public void MaxValue()
+        {
+            CLong result = CULong.MaxValue;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Equal(System.UInt32.MaxValue, result.Value);
+            }
+            else
+            {
+                Assert.Equal(System.UIntPtr.MaxValue, result.Value);
+            }
+        }
+
+        [Fact]
+        public void MinValue()
+        {
+            CLong result = CULong.MinValue;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Equal(System.UInt32.MinValue, result.Value);
+            }
+            else
+            {
+                Assert.Equal(System.UIntPtr.MinValue, result.Value);
+            }
         }
 
         public static IEnumerable<object[]> EqualsData()


### PR DESCRIPTION
# Description

Modified the following to implement System.Numerics.IMinMaxValue:
- System.Runtime.InteropServices.CLong
- System.Runtime.InteropServices.CULong

# Related issue

[Extend System.Runtime.InteropServices.CLong and CULong to match nfloat](https://github.com/dotnet/runtime/issues/68926)