### PR TITLE
Optimize Stack<T>'s enumerator

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -360,67 +360,50 @@ namespace System.Collections.Generic
             {
                 _stack = stack;
                 _version = stack._version;
-                _index = -2;
+                _index = stack.Count;
                 _currentElement = default;
             }
 
-            public void Dispose()
-            {
-                _index = -1;
-            }
+            public void Dispose() => _index = -1;
 
             public bool MoveNext()
             {
-                bool retval;
-                if (_version != _stack._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
-                if (_index == -2)
-                {  // First call to enumerator.
-                    _index = _stack._size - 1;
-                    retval = (_index >= 0);
-                    if (retval)
-                        _currentElement = _stack._array[_index];
-                    return retval;
-                }
-                if (_index == -1)
-                {  // End of enumeration.
-                    return false;
-                }
-
-                retval = (--_index >= 0);
-                if (retval)
-                    _currentElement = _stack._array[_index];
-                else
-                    _currentElement = default;
-                return retval;
-            }
-
-            public T Current
-            {
-                get
+                if (_version != _stack._version)
                 {
-                    if (_index < 0)
-                        ThrowEnumerationNotStartedOrEnded();
-                    return _currentElement!;
+                    ThrowInvalidVersion();
                 }
+
+                T[] array = _stack._array;
+                int index = _index - 1;
+                if ((uint)index < (uint)array.Length)
+                {
+                    Debug.Assert(index < _stack.Count);
+                    _currentElement = array[index];
+                    _index = index;
+                    return true;
+                }
+
+                _currentElement = default;
+                _index = -1;
+                return false;
             }
 
-            private void ThrowEnumerationNotStartedOrEnded()
-            {
-                Debug.Assert(_index == -1 || _index == -2);
-                throw new InvalidOperationException(_index == -2 ? SR.InvalidOperation_EnumNotStarted : SR.InvalidOperation_EnumEnded);
-            }
+            public T Current => _currentElement!;
 
-            object? System.Collections.IEnumerator.Current
-            {
-                get { return Current; }
-            }
+            object? System.Collections.IEnumerator.Current => Current;
 
             void IEnumerator.Reset()
             {
-                if (_version != _stack._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
-                _index = -2;
+                if (_version != _stack._version)
+                {
+                    ThrowInvalidVersion();
+                }
+
+                _index = _stack.Count;
                 _currentElement = default;
             }
+
+            private static void ThrowInvalidVersion() => throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
         }
     }
 }

--- a/src/libraries/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -53,7 +53,7 @@ namespace System.Collections.Tests
         protected override bool Contains(IEnumerable<T> enumerable, T value) => ((Stack<T>)enumerable).Contains(value);
         protected override void CopyTo(IEnumerable<T> enumerable, T[] array, int index) => ((Stack<T>)enumerable).CopyTo(array, index);
         protected override bool Remove(IEnumerable<T> enumerable) { ((Stack<T>)enumerable).Pop(); return true; }
-        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
 
         #endregion
 

--- a/src/libraries/System.Collections/tests/Generic/Stack/Stack.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Stack/Stack.Tests.cs
@@ -24,7 +24,7 @@ namespace System.Collections.Tests
         }
 
         protected override bool Enumerator_Empty_UsesSingletonInstance => true;
-        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throw => true;
         protected override bool Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException => false;
 
         protected override Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);


### PR DESCRIPTION
There's a non-trivial amount of unnecessary overhead/complexity in `Stack<T>`'s enumerator. This streamlines it.

(It does also change the undefined behavior of using Current erroneously. We can put back most of its current semantics if we really care. This change puts it on a plan closer to `List<T>`.)

| Method            | Toolchain         | Mean      | Error    | StdDev   | Ratio | Allocated | Alloc Ratio |
|------------------ |------------------ |----------:|---------:|---------:|------:|----------:|------------:|
| IntsEnumerable    | \main\corerun.exe | 232.50 ns | 1.022 ns | 0.956 ns |  1.00 |      40 B |        1.00 |
| IntsEnumerable    | \pr\corerun.exe   |  57.13 ns | 0.401 ns | 0.356 ns |  0.25 |         - |        0.00 |
|                   |                   |           |          |          |       |           |             |
| IntsStack         | \main\corerun.exe | 220.76 ns | 1.008 ns | 0.943 ns |  1.00 |         - |          NA |
| IntsStack         | \pr\corerun.exe   |  54.96 ns | 0.377 ns | 0.335 ns |  0.25 |         - |          NA |
|                   |                   |           |          |          |       |           |             |
| StringsEnumerable | \main\corerun.exe | 345.99 ns | 1.714 ns | 1.604 ns |  1.00 |      40 B |        1.00 |
| StringsEnumerable | \pr\corerun.exe   |  67.93 ns | 0.639 ns | 0.598 ns |  0.20 |         - |        0.00 |
|                   |                   |           |          |          |       |           |             |
| StringsStack      | \main\corerun.exe | 243.20 ns | 1.808 ns | 1.603 ns |  1.00 |         - |          NA |
| StringsStack      | \pr\corerun.exe   |  55.86 ns | 0.603 ns | 0.534 ns |  0.23 |         - |          NA |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Bench).Assembly).Run(args);

[MemoryDiagnoser(false)]
public class Bench
{
    const int Length = 100;

    private IEnumerable<int> _intsEnumerable = new Stack<int>(Enumerable.Range(0, Length));
    private Stack<int> _intsStack = new Stack<int>(Enumerable.Range(0, Length));
    private IEnumerable<string> _stringsEnumerable = new Stack<string>(Enumerable.Range(0, Length).Select(i => i.ToString()));
    private Stack<string> _stringsStack = new Stack<string>(Enumerable.Range(0, Length).Select(i => i.ToString()));

    [Benchmark]
    public int IntsEnumerable()
    {
        int sum = 0;
        foreach (var i in _intsEnumerable) sum += i;
        return sum;
    }

    [Benchmark]
    public int IntsStack()
    {
        int sum = 0;
        foreach (var i in _intsStack) sum += i;
        return sum;
    }

    [Benchmark]
    public int StringsEnumerable()
    {
        int sum = 0;
        foreach (var s in _stringsEnumerable) sum += s.Length;
        return sum;
    }

    [Benchmark]
    public int StringsStack()
    {
        int sum = 0;
        foreach (var s in _stringsStack) sum += s.Length;
        return sum;
    }
}
```