### PR TITLE
[mono][interp] Always sign extend small integers to native integer when returning to compiled code

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -985,6 +985,48 @@ stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 	}
 }
 
+static void
+stackval_to_data_sign_ext (MonoType *type, stackval *val, void *data, gboolean pinvoke)
+{
+	switch (type->type) {
+		case MONO_TYPE_I1: {
+			mono_i *p = (mono_i*)data;
+			*p = (mono_i)((gint8)val->data.i);
+			break;
+		}
+		case MONO_TYPE_U1: {
+			mono_u *p = (mono_u*)data;
+			*p = (mono_u)((guint8)val->data.i);
+			break;
+		}
+		case MONO_TYPE_I2: {
+			mono_i *p = (mono_i*)data;
+			*p = (mono_i)((gint16)val->data.i);
+			break;
+		}
+		case MONO_TYPE_U2: {
+			mono_u *p = (mono_u*)data;
+			*p = (mono_u)((guint16)val->data.i);
+			break;
+		}
+#if SIZEOF_VOID_P == 8
+		case MONO_TYPE_I4: {
+			mono_i *p = (mono_i*)data;
+			*p = (mono_i)(val->data.i);
+			break;
+		}
+		case MONO_TYPE_U4: {
+			mono_u *p = (mono_u*)data;
+			*p = (mono_u)((guint32)val->data.i);
+			break;
+		}
+#endif
+		default:
+			stackval_to_data (type, val, data, pinvoke);
+			break;
+	}
+}
+
 typedef struct {
 	MonoException *ex;
 	MonoContext *ctx;
@@ -1651,7 +1693,7 @@ interp_frame_arg_to_data (MonoInterpFrameHandle frame, MonoMethodSignature *sig,
 
 	// If index == -1, we finished executing an InterpFrame and the result is at retval.
 	if (index == -1)
-		stackval_to_data (sig->ret, iframe->retval, data, sig->pinvoke && !sig->marshalling_disabled);
+		stackval_to_data_sign_ext (sig->ret, iframe->retval, data, sig->pinvoke && !sig->marshalling_disabled);
 	else if (sig->hasthis && index == 0)
 		*(gpointer*)data = iframe->stack->data.p;
 	else
@@ -2354,7 +2396,7 @@ interp_entry (InterpEntryData *data)
 	// The return value is at the bottom of the stack, after the locals space
 	type = rmethod->rtype;
 	if (type->type != MONO_TYPE_VOID)
-		stackval_to_data (type, frame.stack, data->res, FALSE);
+		stackval_to_data_sign_ext (type, frame.stack, data->res, FALSE);
 }
 
 static void


### PR DESCRIPTION
On amd64 it seems our jit expects i4 return to be sign extended to the full 64bit register. On arm64 apple, unlike arm64 linux, callers of methods returning i1,u1,i2 or u2 are expecting a value sign extended to i4. In order to prevent any potential issues around this area, this commit takes on a conservative approach and sign extends every time, since there is no real cost to it.

stackval_to_data_sign_ext is called either with a data pointer from a CallContext register or the address of a native int local variable in the `mini_get_interp_in_wrapper`. This means that it should always be safe to write the full value.

Fixes https://github.com/dotnet/runtime/issues/115859
Fixes https://github.com/dotnet/runtime/issues/110649

More general alternative to https://github.com/dotnet/runtime/pull/117306