### PR TITLE
Remove pinning from frozen objects (strings, arrays, ..)

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1084,7 +1084,18 @@ public:
 
     bool IsNotGcDef() const
     {
-        return IsIntegralConst(0) || OperIs(GT_LCL_ADDR);
+        if (IsIntegralConst(0) || OperIs(GT_LCL_ADDR))
+        {
+            return true;
+        }
+
+        // Any NonGC object or NonGC object + any offset.
+        if (IsIconHandle(GTF_ICON_OBJ_HDL) || OperIs(GT_ADD) && gtGetOp1()->IsIconHandle(GTF_ICON_OBJ_HDL))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     // LIR flags

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1090,7 +1090,7 @@ public:
         }
 
         // Any NonGC object or NonGC object + any offset.
-        if (IsIconHandle(GTF_ICON_OBJ_HDL) || OperIs(GT_ADD) && gtGetOp1()->IsIconHandle(GTF_ICON_OBJ_HDL))
+        if (IsIconHandle(GTF_ICON_OBJ_HDL) || (OperIs(GT_ADD) && gtGetOp1()->IsIconHandle(GTF_ICON_OBJ_HDL)))
         {
             return true;
         }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13855,17 +13855,14 @@ unsigned Compiler::impInlineFetchLocal(unsigned lclNum DEBUGARG(const char* reas
 //
 GenTree* Compiler::impInlineFetchArg(InlArgInfo& argInfo, const InlLclVarInfo& lclInfo)
 {
-    GenTree* argNode = argInfo.arg->GetNode();
-    assert(!argNode->OperIs(GT_RET_EXPR));
-
     // Cache the relevant arg and lcl info for this argument.
     // We will modify argInfo but not lclVarInfo.
+    const bool      argCanBeModified = argInfo.argHasLdargaOp || argInfo.argHasStargOp;
+    const var_types lclTyp           = lclInfo.lclTypeInfo;
+    GenTree*        op1              = nullptr;
 
-    // Ignore Ldarga on CNS_STR, string literals can't be modified anyway (UB).
-    // We may ignore Starg as well, but then JIT might run into asserts on bad IL that modifies string literals.
-    const bool argCanBeModified = (!argNode->OperIs(GT_CNS_STR) && argInfo.argHasLdargaOp) || argInfo.argHasStargOp;
-    const var_types lclTyp      = lclInfo.lclTypeInfo;
-    GenTree*        op1         = nullptr;
+    GenTree* argNode = argInfo.arg->GetNode();
+    assert(!argNode->OperIs(GT_RET_EXPR));
 
     // For TYP_REF args, if the argNode doesn't have any class information
     // we will lose some type info if we directly substitute it.


### PR DESCRIPTION
Ignore pinning on top of NonGC objects (string literals, static readonly arrays, etc.).

```cs
void Test() => Foo("Test");

unsafe void Foo(string s)
{
    fixed (char* p = s)
        Console.WriteLine(p[2]);
}
```
codegen diff:
```diff
; Method Program:Test():this (FullOpts)
       sub      rsp, 40
-      mov      rcx, 0x274803D568C
-      mov      bword ptr [rsp+0x20], rcx
-      mov      rcx, bword ptr [rsp+0x20]
-      movzx    rcx, word  ptr [rcx+0x04]
+      mov      ecx, 115 ;; 's'
       call     [System.Console:WriteLine(char)]
+      nop
-      xor      eax, eax
-      mov      bword ptr [rsp+0x20], rax
       add      rsp, 40
       ret      
-; Total bytes of code: 46
+; Total bytes of code: 21
```

[spmi diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1086598&view=ms.vss-build-web.run-extensions-tab)