### PR TITLE
Optimize Queue<T>.Enumerator

### DIFF
--- a/src/libraries/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
@@ -51,7 +51,7 @@ namespace System.Collections.Tests
         protected override void CopyTo(IEnumerable<T> enumerable, T[] array, int index) => ((Queue<T>)enumerable).CopyTo(array, index);
         protected override bool Remove(IEnumerable<T> enumerable) => ((Queue<T>)enumerable).TryDequeue(out _);
         protected override bool Enumerator_Empty_UsesSingletonInstance => true;
-        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
         protected override bool Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException => false;
         protected override Type IGenericSharedAPI_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 

--- a/src/libraries/System.Collections/tests/Generic/Queue/Queue.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Queue/Queue.Tests.cs
@@ -27,7 +27,7 @@ namespace System.Collections.Tests
             return new Queue<string>();
         }
 
-        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throw => true;
 
         protected override Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
@@ -426,10 +426,10 @@ namespace System.Collections.Generic
             private int _i;
             private T? _currentElement;
 
-            internal Enumerator(Queue<T> q)
+            internal Enumerator(Queue<T> queue)
             {
-                _queue = q;
-                _version = q._version;
+                _queue = queue;
+                _version = queue._version;
                 _i = -1;
                 _currentElement = default;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs
@@ -421,90 +421,76 @@ namespace System.Collections.Generic
         public struct Enumerator : IEnumerator<T>,
             IEnumerator
         {
-            private readonly Queue<T> _q;
+            private readonly Queue<T> _queue;
             private readonly int _version;
-            private int _index;   // -1 = not started, -2 = ended/disposed
+            private int _i;
             private T? _currentElement;
 
             internal Enumerator(Queue<T> q)
             {
-                _q = q;
+                _queue = q;
                 _version = q._version;
-                _index = -1;
+                _i = -1;
                 _currentElement = default;
             }
 
             public void Dispose()
             {
-                _index = -2;
+                _i = -2;
                 _currentElement = default;
             }
 
             public bool MoveNext()
             {
-                if (_version != _q._version) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
-
-                if (_index == -2)
-                    return false;
-
-                _index++;
-
-                if (_index == _q._size)
+                if (_version != _queue._version)
                 {
-                    // We've run past the last element
-                    _index = -2;
-                    _currentElement = default;
-                    return false;
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                 }
 
-                // Cache some fields in locals to decrease code size
-                T[] array = _q._array;
-                uint capacity = (uint)array.Length;
+                Queue<T> q = _queue;
+                int size = q._size;
 
-                // _index represents the 0-based index into the queue, however the queue
-                // doesn't have to start from 0 and it may not even be stored contiguously in memory.
-
-                uint arrayIndex = (uint)(_q._head + _index); // this is the actual index into the queue's backing array
-                if (arrayIndex >= capacity)
+                int offset = _i + 1;
+                if ((uint)offset < (uint)size)
                 {
-                    // NOTE: Originally we were using the modulo operator here, however
-                    // on Intel processors it has a very high instruction latency which
-                    // was slowing down the loop quite a bit.
-                    // Replacing it with simple comparison/subtraction operations sped up
-                    // the average foreach loop by 2x.
+                    _i = offset;
 
-                    arrayIndex -= capacity; // wrap around if needed
+                    T[] array = q._array;
+                    int index = q._head + offset;
+                    if ((uint)index < (uint)array.Length)
+                    {
+                        _currentElement = array[index];
+                    }
+                    else
+                    {
+                        // The index has wrapped around the end of the array. Shift the index and then
+                        // get the current element. It is tempting to dedup this dereferencing with that
+                        // in the if block above, but the if block above avoids a bounds check for the
+                        // accesses that are in that portion, whereas these still incur it.
+                        index -= array.Length;
+                        _currentElement = array[index];
+                    }
+
+                    return true;
                 }
 
-                _currentElement = array[arrayIndex];
-                return true;
+                _i = -2;
+                _currentElement = default;
+                return false;
             }
 
-            public T Current
-            {
-                get
-                {
-                    if (_index < 0)
-                        ThrowEnumerationNotStartedOrEnded();
-                    return _currentElement!;
-                }
-            }
+            public T Current => _currentElement!;
 
-            private void ThrowEnumerationNotStartedOrEnded()
-            {
-                Debug.Assert(_index == -1 || _index == -2);
-                throw new InvalidOperationException(_index == -1 ? SR.InvalidOperation_EnumNotStarted : SR.InvalidOperation_EnumEnded);
-            }
-
-            object? IEnumerator.Current
-            {
-                get { return Current; }
-            }
+            object? IEnumerator.Current => Current;
 
             void IEnumerator.Reset()
             {
-                if (_version != _q._version) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
-                _index = -1;
+                if (_version != _queue._version)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                }
+
+                _i = -1;
                 _currentElement = default;
             }
         }


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/pull/117328

| Method            | Toolchain         | Wraps | Length | Mean       | Ratio | Allocated |
|------------------ |------------------ |------ |------- |-----------:|------:|----------:|
| IntsEnumerable    | \main\corerun.exe | False | 3      |  18.187 ns |  1.00 |         - |
| IntsEnumerable    | \pr\corerun.exe   | False | 3      |   4.249 ns |  0.23 |         - |
|                   |                   |       |        |            |       |           |
| IntsQueue         | \main\corerun.exe | False | 3      |   9.710 ns |  1.00 |         - |
| IntsQueue         | \pr\corerun.exe   | False | 3      |   3.933 ns |  0.41 |         - |
|                   |                   |       |        |            |       |           |
| StringsEnumerable | \main\corerun.exe | False | 3      |  19.448 ns |  1.00 |         - |
| StringsEnumerable | \pr\corerun.exe   | False | 3      |   4.574 ns |  0.24 |         - |
|                   |                   |       |        |            |       |           |
| StringsQueue      | \main\corerun.exe | False | 3      |   9.564 ns |  1.00 |         - |
| StringsQueue      | \pr\corerun.exe   | False | 3      |   3.026 ns |  0.32 |         - |
|                   |                   |       |        |            |       |           |
| IntsEnumerable    | \main\corerun.exe | False | 100    | 212.356 ns |  1.00 |      40 B |
| IntsEnumerable    | \pr\corerun.exe   | False | 100    | 119.884 ns |  0.56 |         - |
|                   |                   |       |        |            |       |           |
| IntsQueue         | \main\corerun.exe | False | 100    | 260.983 ns |  1.00 |         - |
| IntsQueue         | \pr\corerun.exe   | False | 100    |  76.163 ns |  0.29 |         - |
|                   |                   |       |        |            |       |           |
| StringsEnumerable | \main\corerun.exe | False | 100    | 363.271 ns |  1.00 |      40 B |
| StringsEnumerable | \pr\corerun.exe   | False | 100    | 126.384 ns |  0.35 |         - |
|                   |                   |       |        |            |       |           |
| StringsQueue      | \main\corerun.exe | False | 100    | 250.484 ns |  1.00 |         - |
| StringsQueue      | \pr\corerun.exe   | False | 100    |  76.951 ns |  0.31 |         - |
|                   |                   |       |        |            |       |           |
| IntsEnumerable    | \main\corerun.exe | True  | 3      |  16.776 ns |  1.00 |      40 B |
| IntsEnumerable    | \pr\corerun.exe   | True  | 3      |   5.312 ns |  0.32 |         - |
|                   |                   |       |        |            |       |           |
| IntsQueue         | \main\corerun.exe | True  | 3      |   9.567 ns |  1.00 |         - |
| IntsQueue         | \pr\corerun.exe   | True  | 3      |   2.911 ns |  0.30 |         - |
|                   |                   |       |        |            |       |           |
| StringsEnumerable | \main\corerun.exe | True  | 3      |  20.782 ns |  1.00 |         - |
| StringsEnumerable | \pr\corerun.exe   | True  | 3      |   3.919 ns |  0.19 |         - |
|                   |                   |       |        |            |       |           |
| StringsQueue      | \main\corerun.exe | True  | 3      |  14.296 ns |  1.00 |         - |
| StringsQueue      | \pr\corerun.exe   | True  | 3      |   3.835 ns |  0.27 |         - |
|                   |                   |       |        |            |       |           |
| IntsEnumerable    | \main\corerun.exe | True  | 100    | 271.858 ns |  1.00 |      40 B |
| IntsEnumerable    | \pr\corerun.exe   | True  | 100    |  99.918 ns |  0.37 |         - |
|                   |                   |       |        |            |       |           |
| IntsQueue         | \main\corerun.exe | True  | 100    | 245.360 ns |  1.00 |         - |
| IntsQueue         | \pr\corerun.exe   | True  | 100    |  82.029 ns |  0.33 |         - |
|                   |                   |       |        |            |       |           |
| StringsEnumerable | \main\corerun.exe | True  | 100    | 361.511 ns |  1.00 |      40 B |
| StringsEnumerable | \pr\corerun.exe   | True  | 100    | 101.535 ns |  0.28 |         - |
|                   |                   |       |        |            |       |           |
| StringsQueue      | \main\corerun.exe | True  | 100    | 253.267 ns |  1.00 |         - |
| StringsQueue      | \pr\corerun.exe   | True  | 100    |  83.072 ns |  0.33 |         - |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Bench).Assembly).Run(args);

[MemoryDiagnoser(false)]
public class Bench
{
    private IEnumerable<int> _intsEnumerable;
    private Queue<int> _intsQueue;
    private IEnumerable<string> _stringsEnumerable;
    private Queue<string> _stringsQueue;

    [Params(false, true)]
    public bool Wraps { get; set; }

    [Params(3, 100)]
    public int Length { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        _intsQueue = new Queue<int>(Length);
        _stringsQueue = new Queue<string>(Length);

        for (int i = 0; i < Length; i++)
        {
            _intsQueue.Enqueue(i);
            _stringsQueue.Enqueue(i.ToString());
        }

        if (Wraps)
        {
            for (int i = 0; i < Length - 1; i++)
            {
                _intsQueue.Dequeue();
                _intsQueue.Enqueue(i + Length);

                _stringsQueue.Dequeue();
                _stringsQueue.Enqueue((i + Length).ToString());
            }
        }

        _intsEnumerable = _intsQueue;
        _stringsEnumerable = _stringsQueue;
    }

    [Benchmark]
    public int IntsEnumerable()
    {
        int sum = 0;
        foreach (var i in _intsEnumerable) sum += i;
        return sum;
    }

    [Benchmark]
    public int IntsQueue()
    {
        int sum = 0;
        foreach (var i in _intsQueue) sum += i;
        return sum;
    }

    [Benchmark]
    public int StringsEnumerable()
    {
        int sum = 0;
        foreach (var s in _stringsEnumerable) sum += s.Length;
        return sum;
    }

    [Benchmark]
    public int StringsQueue()
    {
        int sum = 0;
        foreach (var s in _stringsQueue) sum += s.Length;
        return sum;
    }
}
```