### PR TITLE
Seal NullLogger

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
         public Microsoft.Extensions.Logging.LogLevel LogLevel { get { throw null; } }
         public TState State { get { throw null; } }
     }
-    public partial class NullLogger : Microsoft.Extensions.Logging.ILogger
+    public sealed partial class NullLogger : Microsoft.Extensions.Logging.ILogger
     {
         internal NullLogger() { }
         public static Microsoft.Extensions.Logging.Abstractions.NullLogger Instance { get { throw null; } }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/NullLogger.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Logging.Abstractions
     /// <summary>
     /// Minimalistic logger that does nothing.
     /// </summary>
-    public class NullLogger : ILogger
+    public sealed class NullLogger : ILogger
     {
         /// <summary>
         /// Returns the shared instance of <see cref="NullLogger"/>.


### PR DESCRIPTION
Sealing it makes type checks against it cheaper. Some libraries special-case ILogger instances that are NullLogger in order to avoid some logging-related overheads.

While normally sealing a previously shipped public type would be a breaking change, NullLogger's only constructor is private, so types can't currently derive from it.