### PR TITLE
Do not preserve enumerators in reflection

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection.Runtime.CustomAttributes
@@ -166,13 +167,13 @@ namespace System.Reflection.Runtime.CustomAttributes
             }
 
             // Handle the array case
-            if (value is IEnumerable enumerableValue && !(value is string))
+            if (value is Array arr)
             {
                 if (!argumentType.IsArray)
                     throw new BadImageFormatException();
                 Type reportedElementType = argumentType.GetElementType()!;
                 ArrayBuilder<CustomAttributeTypedArgument> elementTypedArguments = default;
-                foreach (object elementValue in enumerableValue)
+                foreach (object elementValue in arr)
                 {
                     CustomAttributeTypedArgument elementTypedArgument = WrapInCustomAttributeTypedArgument(elementValue, reportedElementType);
                     elementTypedArguments.Add(elementTypedArgument);
@@ -181,6 +182,7 @@ namespace System.Reflection.Runtime.CustomAttributes
             }
             else
             {
+                Debug.Assert(value is string or (not IEnumerable));
                 return new CustomAttributeTypedArgument(argumentType, value);
             }
         }


### PR DESCRIPTION
This single line will cause all enumerators to be preserved when reflection is used, for every generic instantiation of every collection type.

Although user application may still introduce this, at least it saves for simpler applications.