### PR TITLE
Avoid wrapping in SortedDictionary enumeration as enumerable

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -245,7 +245,7 @@ namespace System.Collections.Generic
 
         IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() =>
             Count == 0 ? EnumerableHelpers.GetEmptyEnumerator<KeyValuePair<TKey, TValue>>() :
-            GetEnumerator();
+            _set.GetEnumerator();
 
         public bool Remove(TKey key)
         {
@@ -465,10 +465,8 @@ namespace System.Collections.Generic
                     {
                         return new DictionaryEntry(Current.Key, Current.Value);
                     }
-                    else
-                    {
-                        return new KeyValuePair<TKey, TValue>(Current.Key, Current.Value);
-                    }
+
+                    return Current;
                 }
             }
 


### PR DESCRIPTION
SortedDictionary's struct enumerator wraps an underlying TreeSet's enumerator. But when the SortedDictionary is enumerated via is `IEnumerable<T>` implementation, rather than boxing and returning the SortedDictionary's enumerator, we can skip that layer and instead directly use the TreeSet's.

(Changing this does mean if someone got an enumerator from the `IEnumerable<>` and then tried to cast it back to the strongly-typed Enumerator, that would now fail. But that falls into undefined behavior territory.)

| Method | Toolchain         | Mean     | Ratio |
|------- |------------------ |---------:|------:|
| Sum    | \main\corerun.exe | 979.6 ns |  1.00 |
| Sum    | \pr\corerun.exe   | 870.3 ns |  0.89 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Collections.Generic;

BenchmarkSwitcher.FromAssembly(typeof(Bench).Assembly).Run(args);

public class Bench
{
    private IEnumerable<KeyValuePair<int, int>> _e = new SortedDictionary<int, int>(Enumerable.Range(0, 100).Select(i => (i, i)).ToDictionary());

    [Benchmark]
    public int Sum()
    {
        int sum = 0;
        foreach (var entry in _e) sum += entry.Value;
        return sum;
    }
}
```