### PR TITLE
Allow SVE mask patterns to be empty

### DIFF
--- a/src/coreclr/jit/simd.h
+++ b/src/coreclr/jit/simd.h
@@ -1740,7 +1740,6 @@ bool EvaluateSimdPatternToMask(simdmask_t* result, SveMaskPattern pattern)
             return false;
     }
     assert(finalOne <= count);
-    assert(finalOne > 0);
 
     // Write finalOne number of bits
     for (uint32_t i = 0; i < finalOne; i++)
@@ -1834,7 +1833,6 @@ bool EvaluateSimdPatternToVector(simd_t* result, SveMaskPattern pattern)
             return false;
     }
     assert(finalOne <= count);
-    assert(finalOne > 0);
 
     // Write finalOne number of entries
     for (uint32_t i = 0; i < count; i++)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116888/Runtime_116888.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116888/Runtime_116888.cs
@@ -48,7 +48,10 @@ public class TestClass
     [Fact]
     public static void TestEntryPoint()
     {
-        new TestClass().Method0();
+        if (Sve.IsSupported)
+        {
+            new TestClass().Method0();
+        }
         return;
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116888/Runtime_116888.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116888/Runtime_116888.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Found by Antigen
+// Reduced from 342.86 KB to 1.33 KB.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+using System.Numerics;
+using Xunit;
+
+public class TestClass
+{
+    public struct S1
+    {
+    }
+    public struct S2
+    {
+    }
+    static Vector<ulong> s_v_ulong_45 = Vector<ulong>.AllBitsSet;
+    static S1 s_s1_51 = new S1();
+    S1 s1_101 = new S1();
+    S2 s2_102 = new S2();
+    private static List<string> toPrint = new List<string>();
+    public S2 Method14(ref S1 p_s1_448, S2 p_s2_449, out S2 p_s2_450, S1 p_s1_451, out S1 p_s1_452, Vector<ulong> p_v_ulong_453, out S1 p_s1_454)
+    {
+        unchecked
+        {
+            return s2_102;
+        }
+    }
+
+    private void Method0()
+    {
+        unchecked
+        {
+            S1 s1_2842 = new S1();
+            S2 s2_2843 = new S2();
+            s2_2843 = Method14(ref s_s1_51, s2_102, out s2_102, s1_101, out s_s1_51, Sve.CreateTrueMaskUInt64(SveMaskPattern.LargestMultipleOf4) + s_v_ulong_45 + s_v_ulong_45- s_v_ulong_45 * s_v_ulong_45, out s1_2842);
+            return;
+        }
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        new TestClass().Method0();
+        return;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116888/Runtime_116888.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116888/Runtime_116888.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <NoWarn>$(NoWarn);SYSLIB5003</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #116888

When evaluating an SVE mask pattern, it's possible that the resulting predicate will be all false. For example, when using LargestMultipleOf4 on a vector with only 2 elements.