### PR TITLE
Mark GCBridge test as GC-stress incompatible

### DIFF
--- a/src/tests/Interop/GCBridge/BridgeTest.csproj
+++ b/src/tests/Interop/GCBridge/BridgeTest.csproj
@@ -3,6 +3,7 @@
     <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference, GC.WaitForPendingFinalizers -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableProjectBuild>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <!-- Support for native aot not yet implemented -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Other tests that rely on `GC.TryNoGCRegion` are already marked GC stress incompatible.

Fixes #117356