### PR TITLE
Make `append_path` in host utils a simple concatenation

### DIFF
--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -52,18 +52,21 @@ bool utils::ends_with(const pal::string_t& value, const pal::char_t* suffix, siz
 
 void append_path(pal::string_t* path1, const pal::char_t* path2)
 {
-    if (pal::is_path_rooted(path2))
+    if (pal::strlen(path2) == 0)
+        return;
+
+    if (path1->empty())
     {
         path1->assign(path2);
+        return;
     }
-    else
+
+    if (path1->back() != DIR_SEPARATOR && path2[0] != DIR_SEPARATOR)
     {
-        if (!path1->empty() && path1->back() != DIR_SEPARATOR)
-        {
-            path1->push_back(DIR_SEPARATOR);
-        }
-        path1->append(path2);
+        path1->push_back(DIR_SEPARATOR);
     }
+
+    path1->append(path2);
 }
 
 pal::string_t strip_executable_ext(const pal::string_t& filename)

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -76,7 +76,11 @@ pal::string_t get_directory(const pal::string_t& path);
 pal::string_t strip_file_ext(const pal::string_t& path);
 pal::string_t get_filename(const pal::string_t& path);
 pal::string_t get_filename_without_ext(const pal::string_t& path);
+
+// Concatenate path1 and path2 into path1, ensuring there is a directory separator.
+// This does not check for rooted paths or make any attempt to root the returned path.
 void append_path(pal::string_t* path1, const pal::char_t* path2);
+
 bool file_exists_in_dir(const pal::string_t& dir, const pal::char_t* file_name, pal::string_t* out_file_path);
 bool coreclr_exists_in_dir(const pal::string_t& candidate);
 void remove_trailing_dir_separator(pal::string_t* dir);


### PR DESCRIPTION
See https://github.com/dotnet/runtime/pull/116597#discussion_r2143783630

Make `append_path` a simple concatenation, similar to `Path.Join`. The existing behaviour around rooting is not what the usage actually needs/wants.

cc @dotnet/appmodel @AaronRobinsonMSFT 