### PR TITLE
Replace SecTrustEvaluate with SecTrustEvaluateWithError

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -53,15 +53,20 @@ int32_t AppleCryptoNative_X509ChainEvaluate(SecTrustRef chain,
         return -3;
     }
 
-    SecTrustResultType trustResult;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    *pOSStatus = SecTrustEvaluate(chain, &trustResult);
-#pragma clang diagnostic pop
+    // If the chain built successfully return 1. We pass in NULL for the CFError, since we don't care what it is. We use
+    // the SecTrustResultType for that.
+    if (SecTrustEvaluateWithError(chain, NULL))
+    {
+        *pOSStatus = noErr;
+        return 1;
+    }
 
-    // If any error is reported from the function or the trust result value indicates that
-    // otherwise was a failed chain build (vs an untrusted chain, etc) return failure and
-    // we'll throw in the managed layer.  (but if we hit the "or" the message is "No error")
+    SecTrustResultType trustResult;
+    *pOSStatus = SecTrustGetTrustResult(chain, &trustResult);
+
+    // If SecTrustGetTrustResult couldn't get the trust result, return an error.
+    // If the result is kSecTrustResultInvalid then that means you asked for the result before building a chain.
+    // This shouldn't happen but we shouldn't treat it as success, so it's also a fail.
     if (*pOSStatus != noErr || trustResult == kSecTrustResultInvalid)
     {
         return 0;


### PR DESCRIPTION
Since our iOS floor is now >= iOS 12, we can replace `SecTrustEvaluate` with `SecTrustEvaluateWithError`.

The other deprecated function uses can't easily be replaced yet (`SecTrustGetCertificateAtIndex` to `SecTrustCopyCertificateChain`) - those require the iOS floor to be iOS 15. So we would have to split the chain PAL which I don't think is worth it.