### PR TITLE
Extend allowed SemaphoreSlim wait TimeSpan values to match Timer and other APIs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3411,7 +3411,7 @@
     <value>The timeout must represent a value between -1 and Int32.MaxValue, inclusive.</value>
   </data>
   <data name="SemaphoreSlim_Wait_TimeSpanTimeoutWrong" xml:space="preserve">
-    <value>The timeout must be greater than or equal to -1.</value>
+    <value>The value needs to translate in milliseconds to -1 (signifying an infinite timeout), or be non-negative.</value>
   </data>
   <data name="Serialization_BadParameterInfo" xml:space="preserve">
     <value>Non existent ParameterInfo. Position bigger than member's parameters length.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3411,7 +3411,7 @@
     <value>The timeout must represent a value between -1 and Int32.MaxValue, inclusive.</value>
   </data>
   <data name="SemaphoreSlim_Wait_TimeSpanTimeoutWrong" xml:space="preserve">
-    <value>The timeout must represent a value between -1 and Timer.MaxSupportedTimeout, inclusive.</value>
+    <value>The timeout must represent a value between -1 and the maximum allowed timer duration.</value>
   </data>
   <data name="Serialization_BadParameterInfo" xml:space="preserve">
     <value>Non existent ParameterInfo. Position bigger than member's parameters length.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3410,6 +3410,9 @@
   <data name="SemaphoreSlim_Wait_TimeoutWrong" xml:space="preserve">
     <value>The timeout must represent a value between -1 and Int32.MaxValue, inclusive.</value>
   </data>
+  <data name="SemaphoreSlim_Wait_TimeSpanTimeoutWrong" xml:space="preserve">
+    <value>The timeout must represent a value between -1 and Timer.MaxSupportedTimeout, inclusive.</value>
+  </data>
   <data name="Serialization_BadParameterInfo" xml:space="preserve">
     <value>Non existent ParameterInfo. Position bigger than member's parameters length.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3411,7 +3411,7 @@
     <value>The timeout must represent a value between -1 and Int32.MaxValue, inclusive.</value>
   </data>
   <data name="SemaphoreSlim_Wait_TimeSpanTimeoutWrong" xml:space="preserve">
-    <value>The timeout must represent a value between -1 and the maximum allowed timer duration.</value>
+    <value>The timeout must be greater than or equal to -1.</value>
   </data>
   <data name="Serialization_BadParameterInfo" xml:space="preserve">
     <value>Non existent ParameterInfo. Position bigger than member's parameters length.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -508,7 +508,7 @@ namespace System.Threading
 
 
                 // We spin briefly before falling back to allocating and/or waiting on a true event.
-                uint startTime = 0;
+                long startTime = 0;
                 bool bNeedTimeoutAdjustment = false;
                 int realMillisecondsTimeout = millisecondsTimeout; // this will be adjusted if necessary.
 
@@ -520,7 +520,7 @@ namespace System.Threading
                     // period of time.  The timeout adjustments only take effect when and if we actually
                     // decide to block in the kernel below.
 
-                    startTime = (uint)Environment.TickCount;
+                    startTime = Environment.TickCount64;
                     bNeedTimeoutAdjustment = true;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs
@@ -520,7 +520,7 @@ namespace System.Threading
                     // period of time.  The timeout adjustments only take effect when and if we actually
                     // decide to block in the kernel below.
 
-                    startTime = TimeoutHelper.GetTime();
+                    startTime = (uint)Environment.TickCount;
                     bNeedTimeoutAdjustment = true;
                 }
 
@@ -558,7 +558,8 @@ namespace System.Threading
                             // update timeout (delays in wait commencement are due to spinning and/or spurious wakeups from other waits being canceled)
                             if (bNeedTimeoutAdjustment)
                             {
-                                realMillisecondsTimeout = TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout);
+                                // TimeoutHelper.UpdateTimeOut returns a long but the value is capped as millisecondsTimeout is an int.
+                                realMillisecondsTimeout = (int)TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout);
                                 if (realMillisecondsTimeout <= 0)
                                     return false;
                             }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -757,7 +757,9 @@ namespace System.Threading
             Debug.Assert(asyncWaiter is not null, "Waiter should have been constructed");
             Debug.Assert(Monitor.IsEntered(m_lockObjAndDisposed), "Requires the lock be held");
 
-            await ((Task)asyncWaiter.WaitAsync(TimeSpan.FromMilliseconds(millisecondsTimeout), cancellationToken)).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            await ((Task)asyncWaiter.WaitAsync(
+                TimeSpan.FromMilliseconds(millisecondsTimeout == Timeout.UnsignedInfinite ? (long)Timeout.Infinite : (long)millisecondsTimeout),
+                cancellationToken)).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 
             if (cancellationToken.IsCancellationRequested)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -312,6 +312,17 @@ namespace System.Threading
             return Wait(millisecondsTimeout == Timeout.Infinite ? Timeout.UnsignedInfinite : (uint)millisecondsTimeout, cancellationToken);
         }
 
+        /// <summary>
+        /// Blocks the current thread until it can enter the <see cref="SemaphoreSlim"/>,
+        /// using a 32-bit unsigned integer to measure the time interval,
+        /// while observing a <see cref="CancellationToken"/>.
+        /// </summary>
+        /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see cref="Timeout.UnsignedInfinite"/> to
+        /// wait indefinitely.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
+        /// <returns>true if the current thread successfully entered the <see cref="SemaphoreSlim"/>; otherwise, false.</returns>
+        /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was canceled.</exception>
+        [UnsupportedOSPlatform("browser")]
         private bool Wait(uint millisecondsTimeout, CancellationToken cancellationToken)
         {
             CheckDispose();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -658,6 +658,21 @@ namespace System.Threading
             return WaitAsync(millisecondsTimeout == Timeout.Infinite ? Timeout.UnsignedInfinite : (uint)millisecondsTimeout, cancellationToken);
         }
 
+        /// <summary>
+        /// Asynchronously waits to enter the <see cref="SemaphoreSlim"/>,
+        /// using a 32-bit unsigned integer to measure the time interval,
+        /// while observing a <see cref="CancellationToken"/>.
+        /// </summary>
+        /// <param name="millisecondsTimeout">
+        /// The number of milliseconds to wait, or <see cref="Timeout.UnsignedInfinite"/> to wait indefinitely.
+        /// </param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
+        /// <returns>
+        /// A task that will complete with a result of true if the current thread successfully entered
+        /// the <see cref="SemaphoreSlim"/>, otherwise with a result of false.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">The current instance has already been
+        /// disposed.</exception>
         private Task<bool> WaitAsync(uint millisecondsTimeout, CancellationToken cancellationToken)
         {
             CheckDispose();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -338,10 +338,10 @@ namespace System.Threading
                 return false;
             }
 
-            uint startTime = 0;
+            long startTime = 0;
             if (millisecondsTimeout != Timeout.UnsignedInfinite && millisecondsTimeout > 0)
             {
-                startTime = TimeoutHelper.GetTime();
+                startTime = TimeoutHelper.GetTime64();
             }
 
             bool waitSuccessful = false;
@@ -465,7 +465,7 @@ namespace System.Threading
         /// <param name="cancellationToken">The CancellationToken to observe.</param>
         /// <returns>true if the monitor received a signal, false if the timeout expired</returns>
         [UnsupportedOSPlatform("browser")]
-        private bool WaitUntilCountOrTimeout(uint millisecondsTimeout, uint startTime, CancellationToken cancellationToken)
+        private bool WaitUntilCountOrTimeout(uint millisecondsTimeout, long startTime, CancellationToken cancellationToken)
         {
 #if TARGET_WASI
             if (OperatingSystem.IsWasi()) throw new PlatformNotSupportedException(); // TODO remove with https://github.com/dotnet/runtime/pull/107185
@@ -483,7 +483,7 @@ namespace System.Threading
                 bool timeoutIsCapped = false;
                 if (millisecondsTimeout != Timeout.UnsignedInfinite)
                 {
-                    uint remainingWaitMilliseconds = TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout);
+                    long remainingWaitMilliseconds = TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout);
                     if (remainingWaitMilliseconds <= 0)
                     {
                         // The thread has expires its timeout

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -262,7 +262,7 @@ namespace System.Threading
             }
 
             // Call wait with the timeout milliseconds
-            return Wait(totalMilliseconds == timeout.Infinite ? Timeout.UnsignedInfinite : (uint)totalMilliseconds, cancellationToken);
+            return Wait(totalMilliseconds == Timeout.Infinite ? Timeout.UnsignedInfinite : (uint)totalMilliseconds, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -224,7 +224,7 @@ namespace System.Threading
             if (totalMilliseconds < -1 || totalMilliseconds > Timer.MaxSupportedTimeout)
             {
                 throw new ArgumentOutOfRangeException(
-                    nameof(timeout), timeout, SR.SemaphoreSlim_Wait_TimeoutWrong);
+                    nameof(timeout), timeout, SR.SemaphoreSlim_Wait_TimeSpanTimeoutWrong);
             }
 
             // Call wait with the timeout milliseconds
@@ -258,7 +258,7 @@ namespace System.Threading
             if (totalMilliseconds < -1 || totalMilliseconds > Timer.MaxSupportedTimeout)
             {
                 throw new ArgumentOutOfRangeException(
-                    nameof(timeout), timeout, SR.SemaphoreSlim_Wait_TimeoutWrong);
+                    nameof(timeout), timeout, SR.SemaphoreSlim_Wait_TimeSpanTimeoutWrong);
             }
 
             // Call wait with the timeout milliseconds
@@ -611,7 +611,7 @@ namespace System.Threading
             if (totalMilliseconds < -1 || totalMilliseconds > Timer.MaxSupportedTimeout)
             {
                 throw new ArgumentOutOfRangeException(
-                    nameof(timeout), timeout, SR.SemaphoreSlim_Wait_TimeoutWrong);
+                    nameof(timeout), timeout, SR.SemaphoreSlim_Wait_TimeSpanTimeoutWrong);
             }
 
             // Call wait with the timeout milliseconds

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -653,7 +653,7 @@ namespace System.Threading
                     nameof(millisecondsTimeout), millisecondsTimeout, SR.SemaphoreSlim_Wait_TimeoutWrong);
             }
 
-            return WaitAsync(millisecondsTimeout, cancellationToken);
+            return WaitAsync((long)millisecondsTimeout, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SpinLock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SpinLock.cs
@@ -287,10 +287,10 @@ namespace System.Threading
                     nameof(millisecondsTimeout), millisecondsTimeout, SR.SpinLock_TryEnter_ArgumentOutOfRange);
             }
 
-            uint startTime = 0;
+            long startTime = 0;
             if (millisecondsTimeout != Timeout.Infinite && millisecondsTimeout != 0)
             {
-                startTime = (uint)Environment.TickCount;
+                startTime = Environment.TickCount64;
             }
 
             if (IsThreadOwnerTrackingEnabled)
@@ -404,7 +404,7 @@ namespace System.Threading
         /// <summary>
         /// ContinueTryEnter for the thread tracking mode enabled
         /// </summary>
-        private void ContinueTryEnterWithThreadTracking(int millisecondsTimeout, uint startTime, ref bool lockTaken)
+        private void ContinueTryEnterWithThreadTracking(int millisecondsTimeout, long startTime, ref bool lockTaken)
         {
             Debug.Assert(IsThreadOwnerTrackingEnabled);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SpinLock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SpinLock.cs
@@ -290,7 +290,7 @@ namespace System.Threading
             uint startTime = 0;
             if (millisecondsTimeout != Timeout.Infinite && millisecondsTimeout != 0)
             {
-                startTime = TimeoutHelper.GetTime();
+                startTime = (uint)Environment.TickCount;
             }
 
             if (IsThreadOwnerTrackingEnabled)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SpinWait.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SpinWait.cs
@@ -315,7 +315,7 @@ namespace System.Threading
             uint startTime = 0;
             if (millisecondsTimeout != 0 && millisecondsTimeout != Timeout.Infinite)
             {
-                startTime = TimeoutHelper.GetTime();
+                startTime = (uint)Environment.TickCount;
             }
             SpinWait spinner = default;
             while (!condition())
@@ -329,7 +329,7 @@ namespace System.Threading
 
                 if (millisecondsTimeout != Timeout.Infinite && spinner.NextSpinWillYield)
                 {
-                    if (millisecondsTimeout <= (TimeoutHelper.GetTime() - startTime))
+                    if (millisecondsTimeout <= (uint)Environment.TickCount - startTime)
                     {
                         return false;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimeoutHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimeoutHelper.cs
@@ -26,7 +26,7 @@ namespace System.Threading
         /// </summary>
         /// <param name="startTime"> The first time (in milliseconds) observed when the wait started</param>
         /// <param name="originalWaitMillisecondsTimeout">The original wait timeout in milliseconds</param>
-        /// <returns>The new wait time in milliseconds, or -1 if the time expired</returns>
+        /// <returns>The new wait time in milliseconds</returns>
         public static int UpdateTimeOut(uint startTime, int originalWaitMillisecondsTimeout)
         {
             // The function must be called in case the time out is not infinite
@@ -48,6 +48,27 @@ namespace System.Threading
             }
 
             return currentWaitTimeout;
+        }
+
+        /// <summary>
+        /// Helper function to measure and update the elapsed time
+        /// </summary>
+        /// <param name="startTime"> The first time (in milliseconds) observed when the wait started</param>
+        /// <param name="originalWaitMillisecondsTimeout">The original wait timeout in milliseconds</param>
+        /// <returns>The new wait time in milliseconds</returns>
+        public static uint UpdateTimeOut(uint startTime, uint originalWaitMillisecondsTimeout)
+        {
+            // The function must be called in case the time out is not infinite
+            Debug.Assert(originalWaitMillisecondsTimeout != Timeout.UnsignedInfinite);
+
+            uint elapsedMilliseconds = GetTime() - startTime;
+
+            if (originalWaitMillisecondsTimeout <= elapsedMilliseconds)
+            {
+                return 0;
+            }
+
+            return originalWaitMillisecondsTimeout - elapsedMilliseconds;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimeoutHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimeoutHelper.cs
@@ -22,6 +22,14 @@ namespace System.Threading
         }
 
         /// <summary>
+        /// Returns <see cref="Environment.TickCount64"/> as a start time in milliseconds.
+        /// </summary>
+        public static long GetTime64()
+        {
+            return Environment.TickCount64;
+        }
+
+        /// <summary>
         /// Helper function to measure and update the elapsed time
         /// </summary>
         /// <param name="startTime"> The first time (in milliseconds) observed when the wait started</param>
@@ -56,12 +64,12 @@ namespace System.Threading
         /// <param name="startTime"> The first time (in milliseconds) observed when the wait started</param>
         /// <param name="originalWaitMillisecondsTimeout">The original wait timeout in milliseconds</param>
         /// <returns>The new wait time in milliseconds</returns>
-        public static uint UpdateTimeOut(uint startTime, uint originalWaitMillisecondsTimeout)
+        public static long UpdateTimeOut(long startTime, uint originalWaitMillisecondsTimeout)
         {
             // The function must be called in case the time out is not infinite
             Debug.Assert(originalWaitMillisecondsTimeout != Timeout.UnsignedInfinite);
 
-            uint elapsedMilliseconds = GetTime() - startTime;
+            long elapsedMilliseconds = GetTime64() - startTime;
 
             if (originalWaitMillisecondsTimeout <= elapsedMilliseconds)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimeoutHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimeoutHelper.cs
@@ -6,77 +6,35 @@ using System.Diagnostics;
 namespace System.Threading
 {
     /// <summary>
-    /// A helper class to capture a start time using <see cref="Environment.TickCount"/> as a time in milliseconds.
-    /// Also updates a given timeout by subtracting the current time from the start time.
+    /// A helper class to update a given timeout by subtracting the current time from the start time.
     /// </summary>
     internal static class TimeoutHelper
     {
-        /// <summary>
-        /// Returns <see cref="Environment.TickCount"/> as a start time in milliseconds as a <see cref="uint"/>.
-        /// <see cref="Environment.TickCount"/> rolls over from positive to negative every ~25 days, then ~25 days to back to positive again.
-        /// <see cref="uint"/> is used to ignore the sign and double the range to 50 days.
-        /// </summary>
-        public static uint GetTime()
-        {
-            return (uint)Environment.TickCount;
-        }
-
-        /// <summary>
-        /// Returns <see cref="Environment.TickCount64"/> as a start time in milliseconds.
-        /// </summary>
-        public static long GetTime64()
-        {
-            return Environment.TickCount64;
-        }
-
         /// <summary>
         /// Helper function to measure and update the elapsed time
         /// </summary>
         /// <param name="startTime"> The first time (in milliseconds) observed when the wait started</param>
         /// <param name="originalWaitMillisecondsTimeout">The original wait timeout in milliseconds</param>
         /// <returns>The new wait time in milliseconds</returns>
-        public static int UpdateTimeOut(uint startTime, int originalWaitMillisecondsTimeout)
+        public static long UpdateTimeOut(long startTime, long originalWaitMillisecondsTimeout)
         {
             // The function must be called in case the time out is not infinite
             Debug.Assert(originalWaitMillisecondsTimeout != Timeout.Infinite);
 
-            uint elapsedMilliseconds = (GetTime() - startTime);
+            ulong elapsedMilliseconds = (ulong)(Environment.TickCount64 - startTime);
 
-            // Check the elapsed milliseconds is greater than max int because this property is uint
-            if (elapsedMilliseconds > int.MaxValue)
+            if (elapsedMilliseconds > long.MaxValue)
             {
                 return 0;
             }
 
-            // Subtract the elapsed time from the current wait time
-            int currentWaitTimeout = originalWaitMillisecondsTimeout - (int)elapsedMilliseconds;
+            long currentWaitTimeout = originalWaitMillisecondsTimeout - (long)elapsedMilliseconds;
             if (currentWaitTimeout <= 0)
             {
                 return 0;
             }
 
             return currentWaitTimeout;
-        }
-
-        /// <summary>
-        /// Helper function to measure and update the elapsed time
-        /// </summary>
-        /// <param name="startTime"> The first time (in milliseconds) observed when the wait started</param>
-        /// <param name="originalWaitMillisecondsTimeout">The original wait timeout in milliseconds</param>
-        /// <returns>The new wait time in milliseconds</returns>
-        public static long UpdateTimeOut(long startTime, uint originalWaitMillisecondsTimeout)
-        {
-            // The function must be called in case the time out is not infinite
-            Debug.Assert(originalWaitMillisecondsTimeout != Timeout.UnsignedInfinite);
-
-            long elapsedMilliseconds = GetTime64() - startTime;
-
-            if (originalWaitMillisecondsTimeout <= elapsedMilliseconds)
-            {
-                return 0;
-            }
-
-            return originalWaitMillisecondsTimeout - elapsedMilliseconds;
         }
     }
 }

--- a/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
@@ -14,6 +14,8 @@ namespace System.Threading.Tests
     /// </summary>
     public class SemaphoreSlimTests
     {
+        private const uint TimerMaxSupportedTimeout = 0xfffffffe;
+
         /// <summary>
         /// SemaphoreSlim public methods and properties to be tested
         /// </summary>
@@ -60,7 +62,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_Wait_Helper(10, 10, 10, true, null);
             RunSemaphoreSlimTest1_Wait_Helper(1, 10, 10, true, null);
             RunSemaphoreSlimTest1_Wait_Helper(0, 10, 10, false, null);
-            RunSemaphoreSlimTest1_Wait_Helper(1, 10, TimeSpan.FromMilliseconds(Timer.MaxSupportedTimeout), true, null);
+            RunSemaphoreSlimTest1_Wait_Helper(1, 10, TimeSpan.FromMilliseconds(TimerMaxSupportedTimeout), true, null);
         }
 
         [Fact]
@@ -69,7 +71,7 @@ namespace System.Threading.Tests
             // Invalid timeout
             RunSemaphoreSlimTest1_Wait_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_Wait_Helper
-               (10, 10, TimeSpan.FromMilliseconds(Timer.MaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
+               (10, 10, TimeSpan.FromMilliseconds(TimerMaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -88,7 +90,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, 10, true, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, 10, true, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(0, 10, 10, false, null);
-            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, TimeSpan.FromMilliseconds(Timer.MaxSupportedTimeout), true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, TimeSpan.FromMilliseconds(TimerMaxSupportedTimeout), true, null);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -98,7 +100,7 @@ namespace System.Threading.Tests
             // Invalid timeout
             RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_WaitAsync_Helper
-               (10, 10, TimeSpan.FromMilliseconds(Timer.MaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
+               (10, 10, TimeSpan.FromMilliseconds(TimerMaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_WaitAsync2();
         }
 

--- a/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
@@ -14,8 +14,6 @@ namespace System.Threading.Tests
     /// </summary>
     public class SemaphoreSlimTests
     {
-        private const uint TimerMaxSupportedTimeout = 0xfffffffe;
-
         /// <summary>
         /// SemaphoreSlim public methods and properties to be tested
         /// </summary>
@@ -62,7 +60,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_Wait_Helper(10, 10, 10, true, null);
             RunSemaphoreSlimTest1_Wait_Helper(1, 10, 10, true, null);
             RunSemaphoreSlimTest1_Wait_Helper(0, 10, 10, false, null);
-            RunSemaphoreSlimTest1_Wait_Helper(1, 10, TimeSpan.FromMilliseconds(TimerMaxSupportedTimeout), true, null);
+            RunSemaphoreSlimTest1_Wait_Helper(1, 10, TimeSpan.FromMilliseconds(uint.MaxValue), true, null);
         }
 
         [Fact]
@@ -70,8 +68,6 @@ namespace System.Threading.Tests
         {
             // Invalid timeout
             RunSemaphoreSlimTest1_Wait_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
-            RunSemaphoreSlimTest1_Wait_Helper
-               (10, 10, TimeSpan.FromMilliseconds(TimerMaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -90,7 +86,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, 10, true, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, 10, true, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(0, 10, 10, false, null);
-            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, TimeSpan.FromMilliseconds(TimerMaxSupportedTimeout), true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, TimeSpan.FromMilliseconds(uint.MaxValue), true, null);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -99,8 +95,6 @@ namespace System.Threading.Tests
         {
             // Invalid timeout
             RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
-            RunSemaphoreSlimTest1_WaitAsync_Helper
-               (10, 10, TimeSpan.FromMilliseconds(TimerMaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_WaitAsync2();
         }
 

--- a/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
@@ -87,6 +87,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, 10, true, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(0, 10, 10, false, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, TimeSpan.FromMilliseconds(uint.MaxValue), true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, TimeSpan.MaxValue, true, null);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]

--- a/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
@@ -60,7 +60,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_Wait_Helper(10, 10, 10, true, null);
             RunSemaphoreSlimTest1_Wait_Helper(1, 10, 10, true, null);
             RunSemaphoreSlimTest1_Wait_Helper(0, 10, 10, false, null);
-            RunSemaphoreSlimTest1_Wait_Helper(1, 10, new TimeSpan(0, 0, Timer.MaxSupportedTimeout), true, null);
+            RunSemaphoreSlimTest1_Wait_Helper(1, 10, TimeSpan.FromMilliseconds(Timer.MaxSupportedTimeout), true, null);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace System.Threading.Tests
             // Invalid timeout
             RunSemaphoreSlimTest1_Wait_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_Wait_Helper
-               (10, 10, new TimeSpan(0, 0, Timer.MaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
+               (10, 10, TimeSpan.FromMilliseconds(Timer.MaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -88,7 +88,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, 10, true, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, 10, true, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(0, 10, 10, false, null);
-            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, new TimeSpan(0, 0, Timer.MaxSupportedTimeout), true, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, TimeSpan.FromMilliseconds(Timer.MaxSupportedTimeout), true, null);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -98,7 +98,7 @@ namespace System.Threading.Tests
             // Invalid timeout
             RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_WaitAsync_Helper
-               (10, 10, new TimeSpan(0, 0, Timer.MaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
+               (10, 10, TimeSpan.FromMilliseconds(Timer.MaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_WaitAsync2();
         }
 

--- a/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
@@ -60,6 +60,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_Wait_Helper(10, 10, 10, true, null);
             RunSemaphoreSlimTest1_Wait_Helper(1, 10, 10, true, null);
             RunSemaphoreSlimTest1_Wait_Helper(0, 10, 10, false, null);
+            RunSemaphoreSlimTest1_Wait_Helper(1, 10, new TimeSpan(0, 0, Timer.MaxSupportedTimeout), true, null);
         }
 
         [Fact]
@@ -68,7 +69,7 @@ namespace System.Threading.Tests
             // Invalid timeout
             RunSemaphoreSlimTest1_Wait_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_Wait_Helper
-               (10, 10, new TimeSpan(0, 0, int.MaxValue), true, typeof(ArgumentOutOfRangeException));
+               (10, 10, new TimeSpan(0, 0, Timer.MaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -87,6 +88,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, 10, true, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, 10, true, null);
             RunSemaphoreSlimTest1_WaitAsync_Helper(0, 10, 10, false, null);
+            RunSemaphoreSlimTest1_WaitAsync_Helper(1, 10, new TimeSpan(0, 0, Timer.MaxSupportedTimeout), true, null);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
@@ -96,7 +98,7 @@ namespace System.Threading.Tests
             // Invalid timeout
             RunSemaphoreSlimTest1_WaitAsync_Helper(10, 10, -10, true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_WaitAsync_Helper
-               (10, 10, new TimeSpan(0, 0, int.MaxValue), true, typeof(ArgumentOutOfRangeException));
+               (10, 10, new TimeSpan(0, 0, Timer.MaxSupportedTimeout + 1), true, typeof(ArgumentOutOfRangeException));
             RunSemaphoreSlimTest1_WaitAsync2();
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/116877.

Allow SemaphoreSlim to accept a TimeSpan that goes all the way until UInt32.MaxValue - 1 milliseconds, matching the range that other APIs support.