### PR TITLE
Ensure profiler test output is flushed

### DIFF
--- a/src/tests/profiler/native/transitions/transitions.cpp
+++ b/src/tests/profiler/native/transitions/transitions.cpp
@@ -60,7 +60,7 @@ HRESULT Transitions::Shutdown()
         printf("Test failed _failures=%d _pinvoke=%s _reversePinvoke=%s\n",
                 _failures.load(), boolFmt(successPinvoke), boolFmt(successReversePinvoke));
     }
-
+    fflush(stdout);
     return S_OK;
 }
 


### PR DESCRIPTION
This might fix issue #114608

These tests redirect profilee output to a parent which can cause it to get buffered. Given that the last line of output is missing but the Profiler.dll!Profiler::Shutdown message emitted just before is present it seems more likely that this is a buffering issue rather than a process crash in that small window. Notably, every other profiler Shutdown() method includes this fflush() call but it was missing for the transitions profiler.