### PR TITLE
Tar: fix handing of null terminated fields.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -205,4 +205,7 @@
   <data name="TarStreamSeekabilityUnsupportedCombination" xml:space="preserve">
     <value>Cannot write the unseekable data stream of entry '{0}' into an unseekable archive stream.</value>
   </data>
+  <data name="ExtHeaderInvalidRecords" xml:space="preserve">
+    <value>The extended header contains invalid records.</value>
+  </data>
 </root>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
@@ -64,14 +64,26 @@ namespace System.Formats.Tar
 
         public override bool CanWrite => false;
 
-        internal long Remaining => _endInSuperStream - _positionInSuperStream;
+        private long Remaining => _endInSuperStream - _positionInSuperStream;
 
         private int LimitByRemaining(int bufferSize) => (int)Math.Min(Remaining, bufferSize);
 
-        internal void SetReachedEnd()
+        internal ValueTask AdvanceToEndAsync(CancellationToken cancellationToken)
         {
-            _positionInSuperStream = _endInSuperStream;
             _hasReachedEnd = true;
+
+            long remaining = Remaining;
+            _positionInSuperStream = _endInSuperStream;
+            return TarHelpers.AdvanceStreamAsync(_superStream, remaining, cancellationToken);
+        }
+
+        internal void AdvanceToEnd()
+        {
+            _hasReachedEnd = true;
+
+            long remaining = Remaining;
+            _positionInSuperStream = _endInSuperStream;
+            TarHelpers.AdvanceStream(_superStream, remaining);
         }
 
         protected void ThrowIfDisposed()

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
@@ -64,23 +64,14 @@ namespace System.Formats.Tar
 
         public override bool CanWrite => false;
 
-        internal bool HasReachedEnd
+        internal long Remaining => _endInSuperStream - _positionInSuperStream;
+
+        private int LimitByRemaining(int bufferSize) => Math.Min(bufferSize, (int)Math.Min(Remaining, int.MaxValue));
+
+        internal void SetReachedEnd()
         {
-            get
-            {
-                if (!_hasReachedEnd && _positionInSuperStream > _endInSuperStream)
-                {
-                    _hasReachedEnd = true;
-                }
-                return _hasReachedEnd;
-            }
-            set
-            {
-                if (value) // Don't allow revert to false
-                {
-                    _hasReachedEnd = true;
-                }
-            }
+            _positionInSuperStream = _endInSuperStream;
+            _hasReachedEnd = true;
         }
 
         protected void ThrowIfDisposed()
@@ -90,7 +81,7 @@ namespace System.Formats.Tar
 
         private void ThrowIfBeyondEndOfStream()
         {
-            if (HasReachedEnd)
+            if (_hasReachedEnd)
             {
                 throw new EndOfStreamException();
             }
@@ -107,21 +98,12 @@ namespace System.Formats.Tar
             ThrowIfDisposed();
             ThrowIfBeyondEndOfStream();
 
-            // parameter validation sent to _superStream.Read
-            int origCount = destination.Length;
-            int count = destination.Length;
+            destination = destination[..LimitByRemaining(destination.Length)];
 
-            if (_positionInSuperStream + count > _endInSuperStream)
-            {
-                count = (int)(_endInSuperStream - _positionInSuperStream);
-            }
-
-            Debug.Assert(count >= 0);
-            Debug.Assert(count <= origCount);
-
-            int ret = _superStream.Read(destination.Slice(0, count));
+            int ret = _superStream.Read(destination);
 
             _positionInSuperStream += ret;
+
             return ret;
         }
 
@@ -158,14 +140,12 @@ namespace System.Formats.Tar
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (_positionInSuperStream > _endInSuperStream - buffer.Length)
-            {
-                buffer = buffer.Slice(0, (int)(_endInSuperStream - _positionInSuperStream));
-            }
+            buffer = buffer[..LimitByRemaining(buffer.Length)];
 
             int ret = await _superStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
 
             _positionInSuperStream += ret;
+
             return ret;
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
@@ -66,7 +66,7 @@ namespace System.Formats.Tar
 
         internal long Remaining => _endInSuperStream - _positionInSuperStream;
 
-        private int LimitByRemaining(int bufferSize) => Math.Min(bufferSize, (int)Math.Min(Remaining, int.MaxValue));
+        private int LimitByRemaining(int bufferSize) => (int)Math.Min(Remaining, bufferSize);
 
         internal void SetReachedEnd()
         {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -221,12 +221,7 @@ namespace System.Formats.Tar
                     return;
                 }
 
-                long remaining = dataStream.Remaining;
-                dataStream.SetReachedEnd();
-                if (remaining > 0)
-                {
-                    TarHelpers.AdvanceStream(_archiveStream, remaining);
-                }
+                dataStream.AdvanceToEnd();
 
                 TarHelpers.SkipBlockAlignmentPadding(_archiveStream, _previouslyReadEntry._header._size);
             }
@@ -259,12 +254,7 @@ namespace System.Formats.Tar
                     return;
                 }
 
-                long remaining = dataStream.Remaining;
-                dataStream.SetReachedEnd();
-                if (remaining > 0)
-                {
-                    await TarHelpers.AdvanceStreamAsync(_archiveStream, remaining, cancellationToken).ConfigureAwait(false);
-                }
+                await dataStream.AdvanceToEndAsync(cancellationToken).ConfigureAwait(false);
 
                 await TarHelpers.SkipBlockAlignmentPaddingAsync(_archiveStream, _previouslyReadEntry._header._size, cancellationToken).ConfigureAwait(false);
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -221,17 +221,13 @@ namespace System.Formats.Tar
                     return;
                 }
 
-                if (!dataStream.HasReachedEnd)
+                long remaining = dataStream.Remaining;
+                dataStream.SetReachedEnd();
+                if (remaining > 0)
                 {
-                    // If the user did not advance the position, we need to make sure the position
-                    // pointer is located at the beginning of the next header.
-                    if (dataStream.Position < (_previouslyReadEntry._header._size - 1))
-                    {
-                        long bytesToSkip = _previouslyReadEntry._header._size - dataStream.Position;
-                        TarHelpers.AdvanceStream(_archiveStream, bytesToSkip);
-                        dataStream.HasReachedEnd = true; // Now the pointer is beyond the limit, so any read attempts should throw
-                    }
+                    TarHelpers.AdvanceStream(_archiveStream, remaining);
                 }
+
                 TarHelpers.SkipBlockAlignmentPadding(_archiveStream, _previouslyReadEntry._header._size);
             }
         }
@@ -263,17 +259,13 @@ namespace System.Formats.Tar
                     return;
                 }
 
-                if (!dataStream.HasReachedEnd)
+                long remaining = dataStream.Remaining;
+                dataStream.SetReachedEnd();
+                if (remaining > 0)
                 {
-                    // If the user did not advance the position, we need to make sure the position
-                    // pointer is located at the beginning of the next header.
-                    if (dataStream.Position < (_previouslyReadEntry._header._size - 1))
-                    {
-                        long bytesToSkip = _previouslyReadEntry._header._size - dataStream.Position;
-                        await TarHelpers.AdvanceStreamAsync(_archiveStream, bytesToSkip, cancellationToken).ConfigureAwait(false);
-                        dataStream.HasReachedEnd = true; // Now the pointer is beyond the limit, so any read attempts should throw
-                    }
+                    await TarHelpers.AdvanceStreamAsync(_archiveStream, remaining, cancellationToken).ConfigureAwait(false);
                 }
+
                 await TarHelpers.SkipBlockAlignmentPaddingAsync(_archiveStream, _previouslyReadEntry._header._size, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
@@ -262,7 +262,8 @@ namespace System.Formats.Tar.Tests
         [InlineData("gnu-multi-hdrs")] // Multiple consecutive GNU metadata entries
         [InlineData("neg-size")] // Garbage chars
         [InlineData("invalid-go17")] // Many octal fields are all zero chars
-        // [InlineData("issue11169")] // Checksum with null in the middle, https://github.com/dotnet/runtime/issues/117455
+        [InlineData("issue11169")] // Extended header uses spaces instead of newlines to separate records
+        [InlineData("pax-bad-hdr-file")] // Extended header record is not terminated by newline
         [InlineData("issue10968")] // Garbage chars
         public async Task Throw_ArchivesWithRandomCharsAsync(string testCaseName)
         {

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
@@ -261,7 +261,7 @@ namespace System.Formats.Tar.Tests
         [InlineData("gnu-multi-hdrs")] // Multiple consecutive GNU metadata entries
         [InlineData("neg-size")] // Garbage chars
         [InlineData("invalid-go17")] // Many octal fields are all zero chars
-        [InlineData("issue11169")] // Checksum with null in the middle
+        // [InlineData("issue11169")] // Checksum with null in the middle, https://github.com/dotnet/runtime/issues/117455
         [InlineData("issue10968")] // Garbage chars
         public async Task Throw_ArchivesWithRandomCharsAsync(string testCaseName)
         {

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -270,7 +270,8 @@ namespace System.Formats.Tar.Tests
         [InlineData("gnu-multi-hdrs")] // Multiple consecutive GNU metadata entries
         [InlineData("neg-size")] // Garbage chars
         [InlineData("invalid-go17")] // Many octal fields are all zero chars
-        // [InlineData("issue11169")] // Checksum with null in the middle, https://github.com/dotnet/runtime/issues/117455
+        [InlineData("issue11169")] // Extended header uses spaces instead of newlines to separate records
+        [InlineData("pax-bad-hdr-file")] // Extended header record is not terminated by newline
         [InlineData("issue10968")] // Garbage chars
         public void Throw_ArchivesWithRandomChars(string testCaseName)
         {

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -269,7 +269,7 @@ namespace System.Formats.Tar.Tests
         [InlineData("gnu-multi-hdrs")] // Multiple consecutive GNU metadata entries
         [InlineData("neg-size")] // Garbage chars
         [InlineData("invalid-go17")] // Many octal fields are all zero chars
-        [InlineData("issue11169")] // Checksum with null in the middle
+        // [InlineData("issue11169")] // Checksum with null in the middle, https://github.com/dotnet/runtime/issues/117455
         [InlineData("issue10968")] // Garbage chars
         public void Throw_ArchivesWithRandomChars(string testCaseName)
         {

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -137,7 +137,6 @@ namespace System.Formats.Tar.Tests
             "gnu",
             "hardlink",
             "nil-uid",
-            "pax-bad-hdr-file",
             "pax-bad-mtime-file",
             "pax-global-records",
             "pax-nul-path",


### PR DESCRIPTION
The current implementation is trimming spaces and nulls from the end.

Instead we need to find the terminating null from the start, and we shouldn't trim spaces at the end.

Fixes https://github.com/dotnet/runtime/issues/117331.

@ericstj @ViktorHofer ptal.

cc @bruce965