### PR TITLE
[NET] Fix calling non-validating ctor

### DIFF
--- a/src/libraries/System.Net.Primitives/src/System/Net/IPNetwork.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPNetwork.cs
@@ -57,13 +57,6 @@ namespace System.Net
             static void ThrowArgumentOutOfRangeException() => throw new ArgumentOutOfRangeException(nameof(prefixLength));
         }
 
-        // Non-validating ctor
-        private IPNetwork(IPAddress baseAddress, int prefixLength, bool _)
-        {
-            _baseAddress = baseAddress;
-            PrefixLength = prefixLength;
-        }
-
         /// <summary>
         /// Determines whether a given <see cref="IPAddress"/> is part of the network.
         /// </summary>
@@ -196,7 +189,7 @@ namespace System.Net
                     prefixLength <= GetMaxPrefixLength(address))
                 {
                     Debug.Assert(prefixLength >= 0); // Parsing with NumberStyles.None should ensure that prefixLength is always non-negative.
-                    result = new IPNetwork(address, prefixLength, false);
+                    result = new IPNetwork(address, prefixLength);
                     return true;
                 }
             }
@@ -224,7 +217,7 @@ namespace System.Net
                     prefixLength <= GetMaxPrefixLength(address))
                 {
                     Debug.Assert(prefixLength >= 0); // Parsing with NumberStyles.None should ensure that prefixLength is always non-negative.
-                    result = new IPNetwork(address, prefixLength, false);
+                    result = new IPNetwork(address, prefixLength);
                     return true;
                 }
             }

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPNetworkTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPNetworkTest.cs
@@ -83,10 +83,11 @@ namespace System.Net.Primitives.Functional.Tests
             string[] splitInput = input.Split('/');
             IPAddress address = IPAddress.Parse(splitInput[0]);
             int prefixLength = int.Parse(splitInput[1]);
+            IPAddress baseAddress = GetBaseAddress(address, prefixLength);
 
             IPNetwork network = new IPNetwork(address, prefixLength);
 
-            Assert.Equal(GetBaseAddress(address, prefixLength), network.BaseAddress);
+            Assert.Equal(baseAddress, network.BaseAddress);
             Assert.Equal(prefixLength, network.PrefixLength);
         }
 
@@ -155,8 +156,19 @@ namespace System.Net.Primitives.Functional.Tests
             var stringParsedNetwork = IPNetwork.Parse(input);
             var utf8ParsedNetwork = IPNetwork.Parse(utf8Bytes);
 
-            Assert.Equal(input, stringParsedNetwork.ToString());
-            Assert.Equal(input, utf8ParsedNetwork.ToString());
+            string[] splitInput = input.Split('/');
+            IPAddress address = IPAddress.Parse(splitInput[0]);
+            int prefixLength = int.Parse(splitInput[1]);
+            IPAddress baseAddress = GetBaseAddress(address, prefixLength);
+            string expectedString = $"{baseAddress}/{prefixLength}";
+
+            Assert.Equal(GetBaseAddress(address, prefixLength), stringParsedNetwork.BaseAddress);
+            Assert.Equal(prefixLength, stringParsedNetwork.PrefixLength);
+            Assert.Equal(expectedString, stringParsedNetwork.ToString());
+
+            Assert.Equal(GetBaseAddress(address, prefixLength), utf8ParsedNetwork.BaseAddress);
+            Assert.Equal(prefixLength, utf8ParsedNetwork.PrefixLength);
+            Assert.Equal(expectedString, utf8ParsedNetwork.ToString());
         }
 
         [Theory]
@@ -165,11 +177,21 @@ namespace System.Net.Primitives.Functional.Tests
         {
             byte[] utf8Bytes = Encoding.UTF8.GetBytes(input);
 
-            Assert.True(IPNetwork.TryParse(input, out IPNetwork network));
-            Assert.Equal(input, network.ToString());
+            string[] splitInput = input.Split('/');
+            IPAddress address = IPAddress.Parse(splitInput[0]);
+            int prefixLength = int.Parse(splitInput[1]);
+            IPAddress baseAddress = GetBaseAddress(address, prefixLength);
+            string expectedString = $"{baseAddress}/{prefixLength}";
 
-            Assert.True(IPNetwork.TryParse(utf8Bytes, out network));
-            Assert.Equal(input, network.ToString());
+            Assert.True(IPNetwork.TryParse(input, out IPNetwork stringParsedNetwork));
+            Assert.Equal(GetBaseAddress(address, prefixLength), stringParsedNetwork.BaseAddress);
+            Assert.Equal(prefixLength, stringParsedNetwork.PrefixLength);
+            Assert.Equal(expectedString, stringParsedNetwork.ToString());
+
+            Assert.True(IPNetwork.TryParse(utf8Bytes, out IPNetwork utf8ParsedNetwork));
+            Assert.Equal(GetBaseAddress(address, prefixLength), utf8ParsedNetwork.BaseAddress);
+            Assert.Equal(prefixLength, utf8ParsedNetwork.PrefixLength);
+            Assert.Equal(expectedString, utf8ParsedNetwork.ToString());
         }
 
         [Fact]

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPNetworkTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPNetworkTest.cs
@@ -76,19 +76,26 @@ namespace System.Net.Primitives.Functional.Tests
                 _ => throw new ArgumentOutOfRangeException($"Unexpected address family {address.AddressFamily} of {address}.")
             };
 
-        [Theory]
-        [MemberData(nameof(ValidIPNetworkData))]
-        public void Constructor_Valid_Succeeds(string input)
+        private (IPAddress, IPAddress, int, string) ParseInput(string input)
         {
             string[] splitInput = input.Split('/');
             IPAddress address = IPAddress.Parse(splitInput[0]);
             int prefixLength = int.Parse(splitInput[1]);
             IPAddress baseAddress = GetBaseAddress(address, prefixLength);
+            return (address, baseAddress, prefixLength, $"{baseAddress}/{prefixLength}");
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidIPNetworkData))]
+        public void Constructor_Valid_Succeeds(string input)
+        {
+            var (address, baseAddress, prefixLength, toString) = ParseInput(input);
 
             IPNetwork network = new IPNetwork(address, prefixLength);
 
             Assert.Equal(baseAddress, network.BaseAddress);
             Assert.Equal(prefixLength, network.PrefixLength);
+            Assert.Equal(toString, network.ToString());
         }
 
         [Fact]
@@ -156,19 +163,15 @@ namespace System.Net.Primitives.Functional.Tests
             var stringParsedNetwork = IPNetwork.Parse(input);
             var utf8ParsedNetwork = IPNetwork.Parse(utf8Bytes);
 
-            string[] splitInput = input.Split('/');
-            IPAddress address = IPAddress.Parse(splitInput[0]);
-            int prefixLength = int.Parse(splitInput[1]);
-            IPAddress baseAddress = GetBaseAddress(address, prefixLength);
-            string expectedString = $"{baseAddress}/{prefixLength}";
+            var (_, baseAddress, prefixLength, toString) = ParseInput(input);
 
-            Assert.Equal(GetBaseAddress(address, prefixLength), stringParsedNetwork.BaseAddress);
+            Assert.Equal(baseAddress, stringParsedNetwork.BaseAddress);
             Assert.Equal(prefixLength, stringParsedNetwork.PrefixLength);
-            Assert.Equal(expectedString, stringParsedNetwork.ToString());
+            Assert.Equal(toString, stringParsedNetwork.ToString());
 
-            Assert.Equal(GetBaseAddress(address, prefixLength), utf8ParsedNetwork.BaseAddress);
+            Assert.Equal(baseAddress, utf8ParsedNetwork.BaseAddress);
             Assert.Equal(prefixLength, utf8ParsedNetwork.PrefixLength);
-            Assert.Equal(expectedString, utf8ParsedNetwork.ToString());
+            Assert.Equal(toString, utf8ParsedNetwork.ToString());
         }
 
         [Theory]
@@ -177,21 +180,17 @@ namespace System.Net.Primitives.Functional.Tests
         {
             byte[] utf8Bytes = Encoding.UTF8.GetBytes(input);
 
-            string[] splitInput = input.Split('/');
-            IPAddress address = IPAddress.Parse(splitInput[0]);
-            int prefixLength = int.Parse(splitInput[1]);
-            IPAddress baseAddress = GetBaseAddress(address, prefixLength);
-            string expectedString = $"{baseAddress}/{prefixLength}";
+            var (_, baseAddress, prefixLength, toString) = ParseInput(input);
 
             Assert.True(IPNetwork.TryParse(input, out IPNetwork stringParsedNetwork));
-            Assert.Equal(GetBaseAddress(address, prefixLength), stringParsedNetwork.BaseAddress);
+            Assert.Equal(baseAddress, stringParsedNetwork.BaseAddress);
             Assert.Equal(prefixLength, stringParsedNetwork.PrefixLength);
-            Assert.Equal(expectedString, stringParsedNetwork.ToString());
+            Assert.Equal(toString, stringParsedNetwork.ToString());
 
             Assert.True(IPNetwork.TryParse(utf8Bytes, out IPNetwork utf8ParsedNetwork));
-            Assert.Equal(GetBaseAddress(address, prefixLength), utf8ParsedNetwork.BaseAddress);
+            Assert.Equal(baseAddress, utf8ParsedNetwork.BaseAddress);
             Assert.Equal(prefixLength, utf8ParsedNetwork.PrefixLength);
-            Assert.Equal(expectedString, utf8ParsedNetwork.ToString());
+            Assert.Equal(toString, utf8ParsedNetwork.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
In #117367, I have overlooked existence of "non-validating" ctor, thinking all ctor calls went through the one I've changed.
Thankfully @skyoxZ noticed it in https://github.com/dotnet/runtime/pull/117367#discussion_r2192477638.

This fix addresses that and expands the tests to check the properties of parsed `IPNetwork`.

