### PR TITLE
Fix a few runtime async stub issues

### DIFF
--- a/src/coreclr/vm/asyncthunks.cpp
+++ b/src/coreclr/vm/asyncthunks.cpp
@@ -448,13 +448,17 @@ void MethodDesc::EmitAsyncMethodThunk(MethodDesc* pAsyncOtherVariant, MetaSig& m
         MethodTable* pMTTaskOpen = CoreLibBinder::GetClass(CLASS__TASK_1);
         pMTTask = ClassLoader::LoadGenericInstantiationThrowing(pMTTaskOpen->GetModule(), pMTTaskOpen->GetCl(), Instantiation(&thLogicalRetType, 1)).GetMethodTable();
         MethodTable* pMTTaskAwaiterOpen = CoreLibBinder::GetClass(CLASS__TASK_AWAITER_1);
+
         thTaskAwaiter = ClassLoader::LoadGenericInstantiationThrowing(pMTTaskAwaiterOpen->GetModule(), pMTTaskAwaiterOpen->GetCl(), Instantiation(&thLogicalRetType, 1));
+
         mdGetAwaiter = CoreLibBinder::GetMethod(METHOD__TASK_1__GET_AWAITER);
-        mdGetAwaiter = pMTTask->GetParallelMethodDesc(mdGetAwaiter);
+        mdGetAwaiter = MethodDesc::FindOrCreateAssociatedMethodDesc(mdGetAwaiter, pMTTask, FALSE, Instantiation(), FALSE);
+
         mdIsCompleted = CoreLibBinder::GetMethod(METHOD__TASK_AWAITER_1__GET_ISCOMPLETED);
-        mdIsCompleted = thTaskAwaiter.GetMethodTable()->GetParallelMethodDesc(mdIsCompleted);
+        mdIsCompleted = MethodDesc::FindOrCreateAssociatedMethodDesc(mdIsCompleted, thTaskAwaiter.GetMethodTable(), FALSE, Instantiation(), FALSE);
+
         mdGetResult = CoreLibBinder::GetMethod(METHOD__TASK_AWAITER_1__GET_RESULT);
-        mdGetResult = thTaskAwaiter.GetMethodTable()->GetParallelMethodDesc(mdGetResult);
+        mdGetResult = MethodDesc::FindOrCreateAssociatedMethodDesc(mdGetResult, thTaskAwaiter.GetMethodTable(), FALSE, Instantiation(), FALSE);
     }
 
     DWORD localArg = 0;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14457,7 +14457,6 @@ static Signature BuildResumptionStubCalliSignature(MetaSig& msig, MethodTable* m
 
     auto appendTypeHandle = [](SigBuilder& sigBuilder, TypeHandle th)
     {
-        _ASSERTE(!th.IsByRef());
         CorElementType ty = th.GetSignatureCorElementType();
         if (CorTypeInfo::IsObjRef(ty))
         {

--- a/src/tests/async/byref-param/byref-param.cs
+++ b/src/tests/async/byref-param/byref-param.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2ByrefParam
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return Test().GetAwaiter().GetResult();
+    }
+
+    private static async Task<int> Test()
+    {
+        return await HasByrefParam(out int val) + val;
+    }
+
+    private static Task<int> HasByrefParam(out int foo)
+    {
+        foo = 47;
+        return Task.FromResult(53);
+    }
+}

--- a/src/tests/async/byref-param/byref-param.csproj
+++ b/src/tests/async/byref-param/byref-param.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/async/shared-generic/shared-generic.cs
+++ b/src/tests/async/shared-generic/shared-generic.cs
@@ -79,6 +79,31 @@ public class Async2SharedGeneric
         Assert.Equal(value, await GenericClass<T>.StaticReturnClassTypeAsync1(value));
         Assert.Equal(value, await GenericClass<T>.StaticReturnMethodTypeAsync1<T>(value));
     }
+
+    [Fact]
+    public static void TestInterface()
+    {
+        TestInterfaceAsync(new JsonDeserializer<ArrayReader>()).GetAwaiter().GetResult();
+    }
+
+    private static async Task TestInterfaceAsync(ITypeDeserializer deserializer)
+    {
+        Assert.Equal("abc", await deserializer.ReadString());
+    }
+
+    private struct ArrayReader
+    {
+    }
+
+    private interface ITypeDeserializer
+    {
+        Task<string> ReadString();
+    }
+
+    private class JsonDeserializer<TReader> : ITypeDeserializer
+    {
+        Task<string> ITypeDeserializer.ReadString() => Task.FromResult("abc");
+    }
 }
 
 public class GenericClass<T>


### PR DESCRIPTION
- Allow byref parameters when creating stubs (e.g. when calling [this](https://github.com/agocke/async-bench/blob/72b94f6869acd7b3260f3974a532d9282c1fe658/serde-task/src/serde/json/JsonDeserializer.Type.cs#L13) function from a runtime async function)
- Find `MethodDesc`s in right `MethodTable` used for tokens when creating stubs. Particularly we were using `TaskAwaiter<__Canon>.GetResult` for some tokens where we should have used non-shared instantiations (like on TaskAwaiter<string>`).

