### PR TITLE
Add reference equality to unrolled string/span equality against constant strings

### DIFF
--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -507,6 +507,16 @@ GenTree* Compiler::impUtf16StringComparison(StringComparisonKind kind, CORINFO_S
                                                  strLenOffset + sizeof(int), cmpMode);
     if (unrolled != nullptr)
     {
+        // Wrap with the reference equality check for Equals.
+        // We believe it's less likely to be useful for StartsWith/EndsWith.
+        if (kind == StringComparisonKind::Equals)
+        {
+            GenTreeColon* refEqualityColon = gtNewColonNode(TYP_INT, gtNewTrue(), unrolled);
+            unrolled =
+                gtNewQmarkNode(TYP_INT, gtNewOperNode(GT_EQ, TYP_INT, gtCloneExpr(varStrLcl), gtCloneExpr(cnsStr)),
+                               refEqualityColon);
+        }
+
         impStoreToTemp(varStrTmp, varStr, CHECK_SPILL_NONE);
         if (unrolled->OperIs(GT_QMARK))
         {
@@ -673,6 +683,16 @@ GenTree* Compiler::impUtf16SpanComparison(StringComparisonKind kind, CORINFO_SIG
 
     if (unrolled != nullptr)
     {
+        // Wrap with the reference equality check for Equals.
+        // We believe it's less likely to be useful for StartsWith/EndsWith.
+        if (kind == StringComparisonKind::Equals)
+        {
+            GenTreeColon* refEqualityColon = gtNewColonNode(TYP_INT, gtNewTrue(), unrolled);
+            unrolled                       = gtNewQmarkNode(TYP_INT,
+                                                            gtNewOperNode(GT_EQ, TYP_INT, gtCloneExpr(spanReferenceFld), gtCloneExpr(cnsStr)),
+                                                            refEqualityColon);
+        }
+
         if (!spanObj->OperIs(GT_LCL_VAR))
         {
             impStoreToTemp(spanLclNum, spanObj, CHECK_SPILL_NONE);


### PR DESCRIPTION
Jit knows how to unroll `string.Equals`/`MemoryExtensions.SequenceEquals` when one of its args is a constant string. When it does so, it doesn't check for reference equality, which can lead to a regression compared to the non-unrolled behavior (can be quite significant). It's hard to say how often that happens on practice (we may involve Dynamic PGO for that, I might do that in a separate PR), but looks like the overhead from the reference check is not too bad. This issue led to terrible benchmark results for this benchmark: https://github.com/dotnet/runtime/pull/117427#issuecomment-3049687609 when that PR causes the unrolling to kick in and the previous fast path with reference equality was not presented in the codegen.

Example:
```cs
bool Test(string str)
{
    return str == "hello";
}
```
Asm diff: https://www.diffchecker.com/6ZrwEyJb/