### PR TITLE
Add InlinedCallFrame support for the interpreter take 2

### DIFF
--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -139,7 +139,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
     SyncRegDisplayToCurrentContext(pRD);
 
 #ifdef FEATURE_INTERPRETER
-    if (m_Next != FRAME_TOP && m_Next->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+    if ((m_Next != FRAME_TOP) && (m_Next->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame))
     {
         // If the next frame is an interpreter frame, we also need to set the first argument register to point to the interpreter frame.
         SetFirstArgReg(pRD->pCurrentContext, dac_cast<TADDR>(m_Next));

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -138,6 +138,14 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 
     SyncRegDisplayToCurrentContext(pRD);
 
+#ifdef FEATURE_INTERPRETER
+    if (m_Next != FRAME_TOP && m_Next->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+    {
+        // If the next frame is an interpreter frame, we also need to set the first argument register to point to the interpreter frame.
+        SetFirstArgReg(pRD->pCurrentContext, dac_cast<TADDR>(m_Next));
+    }
+#endif // FEATURE_INTERPRETER
+
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    InlinedCallFrame::UpdateRegDisplay_Impl(rip:%p, rsp:%p)\n", pRD->ControlPC, pRD->SP));
 }
 

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -319,7 +319,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
     pRD->pCurrentContextPointers->Fp = (DWORD64 *)&m_pCalleeSavedFP;
 
 #ifdef FEATURE_INTERPRETER
-    if (m_Next != FRAME_TOP && m_Next->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+    if ((m_Next != FRAME_TOP) && (m_Next->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame))
     {
         // If the next frame is an interpreter frame, we also need to set the first argument register to point to the interpreter frame.
         SetFirstArgReg(pRD->pCurrentContext, dac_cast<TADDR>(m_Next));

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -318,6 +318,14 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
     // Update the frame pointer in the current context.
     pRD->pCurrentContextPointers->Fp = (DWORD64 *)&m_pCalleeSavedFP;
 
+#ifdef FEATURE_INTERPRETER
+    if (m_Next != FRAME_TOP && m_Next->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+    {
+        // If the next frame is an interpreter frame, we also need to set the first argument register to point to the interpreter frame.
+        SetFirstArgReg(pRD->pCurrentContext, dac_cast<TADDR>(m_Next));
+    }
+#endif // FEATURE_INTERPRETER
+
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    InlinedCallFrame::UpdateRegDisplay_Impl(pc:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
     RETURN;

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2134,6 +2134,21 @@ typedef DPTR(class InlinedCallFrame) PTR_InlinedCallFrame;
 class InlinedCallFrame : public Frame
 {
 public:
+
+#ifndef DACCESS_COMPILE
+#ifdef FEATURE_INTERPRETER
+    InlinedCallFrame() : Frame(FrameIdentifier::InlinedCallFrame)
+    {
+        WRAPPER_NO_CONTRACT;
+        m_Datum = NULL;
+        m_pCallSiteSP = NULL;
+        m_pCallerReturnAddress = 0;
+        m_pCalleeSavedFP = 0;
+        m_pThread = NULL;
+    }
+#endif // FEATURE_INTERPRETER
+#endif // DACCESS_COMPILE
+
     MethodDesc *GetFunction_Impl()
     {
         WRAPPER_NO_CONTRACT;

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2845,16 +2845,16 @@ void StackFrameIterator::ProcessCurrentFrame(void)
 
             if (m_crawl.pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
             {
-                if (GetIP(pRD->pCurrentContext) != (TADDR)InterpreterFrame::DummyCallerIP)
+                if (GetIP(pRD->pCurrentContext) != (PCODE)InterpreterFrame::DummyCallerIP)
                 {
                     // We have hit the InterpreterFrame while we were not processing the interpreter frames.
                     // Switch to walking the underlying interpreted frames.
                     // Save the registers the interpreter frames walking reuses so that we can restore them
                     // after we are done with the interpreter frames.
-                    m_interpExecMethodIP = (TADDR)GetIP(pRD->pCurrentContext);
-                    m_interpExecMethodSP = (TADDR)GetSP(pRD->pCurrentContext);
-                    m_interpExecMethodFP = (TADDR)GetFP(pRD->pCurrentContext);
-                    m_interpExecMethodFirstArgReg = (TADDR)GetFirstArgReg(pRD->pCurrentContext);
+                    m_interpExecMethodIP = GetIP(pRD->pCurrentContext);
+                    m_interpExecMethodSP = GetSP(pRD->pCurrentContext);
+                    m_interpExecMethodFP = GetFP(pRD->pCurrentContext);
+                    m_interpExecMethodFirstArgReg = GetFirstArgReg(pRD->pCurrentContext);
 
                     ((PTR_InterpreterFrame)m_crawl.pFrame)->SetContextToInterpMethodContextFrame(pRD->pCurrentContext);
                     if (pRD->pCurrentContext->ContextFlags & CONTEXT_EXCEPTION_ACTIVE)
@@ -2877,15 +2877,16 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                     SyncRegDisplayToCurrentContext(pRD);
                 }
             }
-            else if (InlinedCallFrame::FrameHasActiveCall(m_crawl.pFrame) && m_crawl.pFrame->PtrNextFrame() != FRAME_TOP && m_crawl.pFrame->PtrNextFrame()->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+            else if (InlinedCallFrame::FrameHasActiveCall(m_crawl.pFrame) &&
+                     (m_crawl.pFrame->PtrNextFrame() != FRAME_TOP) &&
+                     (m_crawl.pFrame->PtrNextFrame()->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame))
             {
                 // There is an active inlined call frame and the next frame is the interpreter frame. This is a special case where we need to save the current context registers that the interpreter frames walking reuses.
-                m_interpExecMethodIP = (TADDR)GetIP(pRD->pCurrentContext);
-                m_interpExecMethodSP = (TADDR)GetSP(pRD->pCurrentContext);
-                m_interpExecMethodFP = (TADDR)GetFP(pRD->pCurrentContext);
-                m_interpExecMethodFirstArgReg = (TADDR)GetFirstArgReg(pRD->pCurrentContext);
+                m_interpExecMethodIP = GetIP(pRD->pCurrentContext);
+                m_interpExecMethodSP = GetSP(pRD->pCurrentContext);
+                m_interpExecMethodFP = GetFP(pRD->pCurrentContext);
+                m_interpExecMethodFirstArgReg = GetFirstArgReg(pRD->pCurrentContext);
             }
-
         }
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -1053,9 +1053,6 @@ void StackFrameIterator::CommonCtor(Thread * pThread, PTR_Frame pFrame, ULONG32 
     m_movedPastFirstExInfo = false;
     m_fFuncletNotSeen = false;
     m_fFoundFirstFunclet = false;
-#ifdef FEATURE_INTERPRETER
-    m_walkingInterpreterFrames = false;
-#endif
 #if defined(RECORD_RESUMABLE_FRAME_SP)
     m_pvResumableFrameTargetSP = NULL;
 #endif
@@ -2844,11 +2841,11 @@ void StackFrameIterator::ProcessCurrentFrame(void)
 #ifdef FEATURE_INTERPRETER
         if (!m_crawl.isFrameless)
         {
+            PREGDISPLAY pRD = m_crawl.GetRegisterSet();
+
             if (m_crawl.pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
             {
-                PREGDISPLAY pRD = m_crawl.GetRegisterSet();
-
-                if (!m_walkingInterpreterFrames)
+                if (GetIP(pRD->pCurrentContext) != (TADDR)InterpreterFrame::DummyCallerIP)
                 {
                     // We have hit the InterpreterFrame while we were not processing the interpreter frames.
                     // Switch to walking the underlying interpreted frames.
@@ -2868,12 +2865,10 @@ void StackFrameIterator::ProcessCurrentFrame(void)
 
                     SyncRegDisplayToCurrentContext(pRD);
                     ProcessIp(GetControlPC(pRD));
-                    m_walkingInterpreterFrames = m_crawl.isFrameless;
                 }
                 else
                 {
                     // We have finished walking the interpreted frames. Process the InterpreterFrame itself.
-                    m_walkingInterpreterFrames = false;
                     // Restore the registers to the values they had before we started walking the interpreter frames.
                     SetIP(pRD->pCurrentContext, m_interpExecMethodIP);
                     SetSP(pRD->pCurrentContext, m_interpExecMethodSP);
@@ -2882,6 +2877,15 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                     SyncRegDisplayToCurrentContext(pRD);
                 }
             }
+            else if (InlinedCallFrame::FrameHasActiveCall(m_crawl.pFrame) && m_crawl.pFrame->PtrNextFrame() != FRAME_TOP && m_crawl.pFrame->PtrNextFrame()->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+            {
+                // There is an active inlined call frame and the next frame is the interpreter frame. This is a special case where we need to save the current context registers that the interpreter frames walking reuses.
+                m_interpExecMethodIP = (TADDR)GetIP(pRD->pCurrentContext);
+                m_interpExecMethodSP = (TADDR)GetSP(pRD->pCurrentContext);
+                m_interpExecMethodFP = (TADDR)GetFP(pRD->pCurrentContext);
+                m_interpExecMethodFirstArgReg = (TADDR)GetFirstArgReg(pRD->pCurrentContext);
+            }
+
         }
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/stackwalk.h
+++ b/src/coreclr/vm/stackwalk.h
@@ -769,7 +769,6 @@ private:
     // Indicates that the stack walk has moved past a funclet
     bool          m_fFoundFirstFunclet;
 #ifdef FEATURE_INTERPRETER
-    bool          m_walkingInterpreterFrames;
     // Saved registers of the context of the InterpExecMethod. These registers are reused for interpreter frames,
     // but we need to restore the original values after we are done with all the interpreted frames belonging to
     // that InterpExecMethod.


### PR DESCRIPTION
This change adds support for using `InlinedCallFrame` in the interpreter. It adds a public constructor and also ensures that the stack walking works correctly. The stack walking is tricky, because the the runtime expects the `InlinedCallFrame` updates `REGDISPLAY` to point to managed code. In the interpreter case, that means the interpreted frames. But that changes how the stack walking enters the interpreted frames. 
Without the `InlinedCallFrame`, the stack walking sees that it would move to the `InterpreterFrame` and so sets the `REGDISPLAY` to the interpreted context and enumerates all the interpreted frames for the `InterpreterFrame`. Only after all the frames are enumerated, it moves to the `InterpretedFrame` itself and let's it update the `REGDISPLAY` to the caller of the interpreted code.
With the `InlinedCallFrame`, we move to the interpreted frames before we see the `InterpreterFrame`. So we need to ensure that when we are done with the interpreted frames and we move to the `InterpreterFrame`, we do the right thing without previously seeing the `InterpreterFrame`.

This is an example of how the `InlinedCallFrame` is going to be created around the pinvoke call (this explicitly calls a QCALL, the real pinvoke call would go through a call stub)

```c++
InlinedCallFrame inlinedCallFrame;
inlinedCallFrame.m_pCallerReturnAddress = (TADDR)ip;
inlinedCallFrame.m_pCallSiteSP = pFrame;
inlinedCallFrame.m_pCalleeSavedFP = (TADDR)stack;
inlinedCallFrame.m_pThread = GetThread();
inlinedCallFrame.m_Datum = NULL;
inlinedCallFrame.Push();
{ 
    GCX_PREEMP();
    GCInterface_Collect(-1, collection_blocking | collection_aggressive, false);
}
inlinedCallFrame.Pop();  
```