### PR TITLE
ILCompiler.Reflection.ReadyToRun encapsulate image state

### DIFF
--- a/src/coreclr/.nuget/ILCompiler.Reflection.ReadyToRun.Experimental/ILCompiler.Reflection.ReadyToRun.Experimental.pkgproj
+++ b/src/coreclr/.nuget/ILCompiler.Reflection.ReadyToRun.Experimental/ILCompiler.Reflection.ReadyToRun.Experimental.pkgproj
@@ -12,11 +12,11 @@
 
   <ItemGroup>
     <PackageFile Include="$(RuntimeBinDir)ILCompiler.Reflection.ReadyToRun.dll">
-       <TargetPath>\lib\netstandard2.0\</TargetPath>
+       <TargetPath>\lib\$(NetCoreAppMinimum)\</TargetPath>
     </PackageFile>
     <Dependency Include="System.Reflection.Metadata">
        <Version>$(SystemReflectionMetadataVersion)</Version>
-       <TargetFramework>netstandard2.0</TargetFramework>
+       <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
        <Exclude>Build,Analyzers</Exclude>
     </Dependency>
   </ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -87,7 +87,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/gcinfodecoder.cpp">GcInfoDecoder::GcInfoDecoder</a>
         /// </summary>
-        public GcInfo(byte[] image, int offset, Machine machine, ushort majorVersion, ushort minorVersion)
+        public GcInfo(NativeReader imageReader, int offset, Machine machine, ushort majorVersion, ushort minorVersion)
         {
             Offset = offset;
             Version = ReadyToRunVersionToGcInfoVersion(majorVersion, minorVersion);
@@ -106,98 +106,98 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
 
             int bitOffset = offset * 8;
 
-            ParseHeaderFlags(image, ref bitOffset);
+            ParseHeaderFlags(imageReader, ref bitOffset);
 
             if (Version >= MIN_GCINFO_VERSION_WITH_RETURN_KIND && Version <= MAX_GCINFO_VERSION_WITH_RETURN_KIND) // IsReturnKindAvailable
             {
                 int returnKindBits = (_slimHeader) ? _gcInfoTypes.SIZE_OF_RETURN_KIND_SLIM : _gcInfoTypes.SIZE_OF_RETURN_KIND_FAT;
-                ReturnKind = (ReturnKinds)NativeReader.ReadBits(image, returnKindBits, ref bitOffset);
+                ReturnKind = (ReturnKinds)imageReader.ReadBits(returnKindBits, ref bitOffset);
             }
 
-            CodeLength = _gcInfoTypes.DenormalizeCodeLength((int)NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.CODE_LENGTH_ENCBASE, ref bitOffset));
+            CodeLength = _gcInfoTypes.DenormalizeCodeLength((int)imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.CODE_LENGTH_ENCBASE, ref bitOffset));
 
             if (_hasGSCookie)
             {
-                uint normPrologSize = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.NORM_PROLOG_SIZE_ENCBASE, ref bitOffset) + 1;
-                uint normEpilogSize = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.NORM_EPILOG_SIZE_ENCBASE, ref bitOffset);
+                uint normPrologSize = imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.NORM_PROLOG_SIZE_ENCBASE, ref bitOffset) + 1;
+                uint normEpilogSize = imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.NORM_EPILOG_SIZE_ENCBASE, ref bitOffset);
 
                 ValidRangeStart = _gcInfoTypes.DenormalizeCodeOffset(normPrologSize);
                 ValidRangeEnd = (uint)CodeLength - _gcInfoTypes.DenormalizeCodeOffset(normEpilogSize);
             }
             else if (_hasSecurityObject || _hasGenericsInstContext)
             {
-                uint normValidRangeStart = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.NORM_PROLOG_SIZE_ENCBASE, ref bitOffset) + 1;
+                uint normValidRangeStart = imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.NORM_PROLOG_SIZE_ENCBASE, ref bitOffset) + 1;
                 ValidRangeStart = _gcInfoTypes.DenormalizeCodeOffset(normValidRangeStart);
                 ValidRangeEnd = ValidRangeStart + 1;
             }
 
             if (_hasSecurityObject)
             {
-                SecurityObjectStackSlot = _gcInfoTypes.DenormalizeStackSlot(NativeReader.DecodeVarLengthSigned(image, _gcInfoTypes.SECURITY_OBJECT_STACK_SLOT_ENCBASE, ref bitOffset));
+                SecurityObjectStackSlot = _gcInfoTypes.DenormalizeStackSlot(imageReader.DecodeVarLengthSigned(_gcInfoTypes.SECURITY_OBJECT_STACK_SLOT_ENCBASE, ref bitOffset));
             }
 
             if (_hasGSCookie)
             {
-                GSCookieStackSlot = _gcInfoTypes.DenormalizeStackSlot(NativeReader.DecodeVarLengthSigned(image, _gcInfoTypes.GS_COOKIE_STACK_SLOT_ENCBASE, ref bitOffset));
+                GSCookieStackSlot = _gcInfoTypes.DenormalizeStackSlot(imageReader.DecodeVarLengthSigned(_gcInfoTypes.GS_COOKIE_STACK_SLOT_ENCBASE, ref bitOffset));
             }
 
             if (_hasPSPSym)
             {
-                PSPSymStackSlot = _gcInfoTypes.DenormalizeStackSlot(NativeReader.DecodeVarLengthSigned(image, _gcInfoTypes.PSP_SYM_STACK_SLOT_ENCBASE, ref bitOffset));
+                PSPSymStackSlot = _gcInfoTypes.DenormalizeStackSlot(imageReader.DecodeVarLengthSigned(_gcInfoTypes.PSP_SYM_STACK_SLOT_ENCBASE, ref bitOffset));
             }
 
             if (_hasGenericsInstContext)
             {
-                GenericsInstContextStackSlot = _gcInfoTypes.DenormalizeStackSlot(NativeReader.DecodeVarLengthSigned(image, _gcInfoTypes.GENERICS_INST_CONTEXT_STACK_SLOT_ENCBASE, ref bitOffset));
+                GenericsInstContextStackSlot = _gcInfoTypes.DenormalizeStackSlot(imageReader.DecodeVarLengthSigned(_gcInfoTypes.GENERICS_INST_CONTEXT_STACK_SLOT_ENCBASE, ref bitOffset));
             }
 
             if (_hasStackBaseRegister && !_slimHeader)
             {
-                StackBaseRegister = _gcInfoTypes.DenormalizeStackBaseRegister(NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.STACK_BASE_REGISTER_ENCBASE, ref bitOffset));
+                StackBaseRegister = _gcInfoTypes.DenormalizeStackBaseRegister(imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.STACK_BASE_REGISTER_ENCBASE, ref bitOffset));
             }
 
             if (_hasSizeOfEditAndContinuePreservedArea)
             {
-                SizeOfEditAndContinuePreservedArea = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.SIZE_OF_EDIT_AND_CONTINUE_PRESERVED_AREA_ENCBASE, ref bitOffset);
+                SizeOfEditAndContinuePreservedArea = imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.SIZE_OF_EDIT_AND_CONTINUE_PRESERVED_AREA_ENCBASE, ref bitOffset);
             }
 
             if (_hasReversePInvokeFrame)
             {
-                ReversePInvokeFrameStackSlot = NativeReader.DecodeVarLengthSigned(image, _gcInfoTypes.REVERSE_PINVOKE_FRAME_ENCBASE, ref bitOffset);
+                ReversePInvokeFrameStackSlot = imageReader.DecodeVarLengthSigned(_gcInfoTypes.REVERSE_PINVOKE_FRAME_ENCBASE, ref bitOffset);
             }
 
             // FIXED_STACK_PARAMETER_SCRATCH_AREA (this macro is always defined in _gcInfoTypes.h)
             if (!_slimHeader)
             {
-                SizeOfStackOutgoingAndScratchArea = _gcInfoTypes.DenormalizeSizeOfStackArea(NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.SIZE_OF_STACK_AREA_ENCBASE, ref bitOffset));
+                SizeOfStackOutgoingAndScratchArea = _gcInfoTypes.DenormalizeSizeOfStackArea(imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.SIZE_OF_STACK_AREA_ENCBASE, ref bitOffset));
             }
 
             // PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED (this macro is always defined in _gcInfoTypes.h)
-            NumSafePoints = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.NUM_SAFE_POINTS_ENCBASE, ref bitOffset);
+            NumSafePoints = imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.NUM_SAFE_POINTS_ENCBASE, ref bitOffset);
 
             if (!_slimHeader)
             {
-                NumInterruptibleRanges = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.NUM_INTERRUPTIBLE_RANGES_ENCBASE, ref bitOffset);
+                NumInterruptibleRanges = imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.NUM_INTERRUPTIBLE_RANGES_ENCBASE, ref bitOffset);
             }
 
             // PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED (this macro is always defined in _gcInfoTypes.h)
-            SafePointOffsets = EnumerateSafePoints(image, ref bitOffset);
+            SafePointOffsets = EnumerateSafePoints(imageReader, ref bitOffset);
 
-            InterruptibleRanges = EnumerateInterruptibleRanges(image, _gcInfoTypes.INTERRUPTIBLE_RANGE_DELTA1_ENCBASE, _gcInfoTypes.INTERRUPTIBLE_RANGE_DELTA2_ENCBASE, ref bitOffset);
+            InterruptibleRanges = EnumerateInterruptibleRanges(imageReader, _gcInfoTypes.INTERRUPTIBLE_RANGE_DELTA1_ENCBASE, _gcInfoTypes.INTERRUPTIBLE_RANGE_DELTA2_ENCBASE, ref bitOffset);
 
-            SlotTable = new GcSlotTable(image, machine, _gcInfoTypes, ref bitOffset);
+            SlotTable = new GcSlotTable(imageReader, machine, _gcInfoTypes, ref bitOffset);
 
             if (SlotTable.NumSlots > 0)
             {
                 if (NumSafePoints > 0)
                 {
                     // Partially interruptible code
-                    LiveSlotsAtSafepoints = GetLiveSlotsAtSafepoints(image, ref bitOffset);
+                    LiveSlotsAtSafepoints = GetLiveSlotsAtSafepoints(imageReader, ref bitOffset);
                 }
                 else
                 {
                     // Fully interruptible code
-                    Transitions = GetTransitions(image, ref bitOffset);
+                    Transitions = GetTransitions(imageReader, ref bitOffset);
                 }
             }
 
@@ -326,18 +326,18 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/gcinfodecoder.cpp">GcInfoDecoder::GcInfoDecoder</a>
         /// </summary>
-        private void ParseHeaderFlags(byte[] image, ref int bitOffset)
+        private void ParseHeaderFlags(NativeReader imageReader, ref int bitOffset)
         {
             GcInfoHeaderFlags headerFlags;
-            _slimHeader = (NativeReader.ReadBits(image, 1, ref bitOffset) == 0);
+            _slimHeader = (imageReader.ReadBits(1, ref bitOffset) == 0);
             if (_slimHeader)
             {
-                headerFlags = NativeReader.ReadBits(image, 1, ref bitOffset) == 1 ? GcInfoHeaderFlags.GC_INFO_HAS_STACK_BASE_REGISTER : 0;
+                headerFlags = imageReader.ReadBits(1, ref bitOffset) == 1 ? GcInfoHeaderFlags.GC_INFO_HAS_STACK_BASE_REGISTER : 0;
             }
             else
             {
                 int numFlagBits = (int)((Version == 1) ? GcInfoHeaderFlags.GC_INFO_FLAGS_BIT_SIZE_VERSION_1 : GcInfoHeaderFlags.GC_INFO_FLAGS_BIT_SIZE);
-                headerFlags = (GcInfoHeaderFlags)NativeReader.ReadBits(image, numFlagBits, ref bitOffset);
+                headerFlags = (GcInfoHeaderFlags)imageReader.ReadBits(numFlagBits, ref bitOffset);
             }
 
             _hasSecurityObject = (headerFlags & GcInfoHeaderFlags.GC_INFO_HAS_SECURITY_OBJECT) != 0;
@@ -353,13 +353,13 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
             _wantsReportOnlyLeaf = ((headerFlags & GcInfoHeaderFlags.GC_INFO_WANTS_REPORT_ONLY_LEAF) != 0);
         }
 
-        private List<SafePointOffset> EnumerateSafePoints(byte[] image, ref int bitOffset)
+        private List<SafePointOffset> EnumerateSafePoints(NativeReader imageReader, ref int bitOffset)
         {
             List<SafePointOffset> safePoints = new List<SafePointOffset>();
             uint numBitsPerOffset = GcInfoTypes.CeilOfLog2((int)_gcInfoTypes.NormalizeCodeOffset((uint)CodeLength));
             for (int i = 0; i < NumSafePoints; i++)
             {
-                uint normOffset = (uint)NativeReader.ReadBits(image, (int)numBitsPerOffset, ref bitOffset);
+                uint normOffset = (uint)imageReader.ReadBits((int)numBitsPerOffset, ref bitOffset);
                 safePoints.Add(new SafePointOffset(i, _gcInfoTypes.DenormalizeCodeOffset(normOffset)));
             }
             return safePoints;
@@ -368,15 +368,15 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         /// <summary>
         /// based on beginning of <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/gcinfodecoder.cpp">GcInfoDecoder::EnumerateLiveSlots</a>
         /// </summary>
-        private List<InterruptibleRange> EnumerateInterruptibleRanges(byte[] image, int interruptibleRangeDelta1EncBase, int interruptibleRangeDelta2EncBase, ref int bitOffset)
+        private List<InterruptibleRange> EnumerateInterruptibleRanges(NativeReader imageReader, int interruptibleRangeDelta1EncBase, int interruptibleRangeDelta2EncBase, ref int bitOffset)
         {
             List<InterruptibleRange> ranges = new List<InterruptibleRange>();
             uint normLastinterruptibleRangeStopOffset = 0;
 
             for (uint i = 0; i < NumInterruptibleRanges; i++)
             {
-                uint normStartDelta = NativeReader.DecodeVarLengthUnsigned(image, interruptibleRangeDelta1EncBase, ref bitOffset);
-                uint normStopDelta = NativeReader.DecodeVarLengthUnsigned(image, interruptibleRangeDelta2EncBase, ref bitOffset) + 1;
+                uint normStartDelta = imageReader.DecodeVarLengthUnsigned(interruptibleRangeDelta1EncBase, ref bitOffset);
+                uint normStopDelta = imageReader.DecodeVarLengthUnsigned(interruptibleRangeDelta2EncBase, ref bitOffset) + 1;
 
                 uint normRangeStartOffset = normLastinterruptibleRangeStopOffset + normStartDelta;
                 uint normRangeStopOffset = normRangeStartOffset + normStopDelta;
@@ -411,7 +411,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
             return 4;
         }
 
-        private List<List<BaseGcSlot>> GetLiveSlotsAtSafepoints(byte[] image, ref int bitOffset)
+        private List<List<BaseGcSlot>> GetLiveSlotsAtSafepoints(NativeReader imageReader, ref int bitOffset)
         {
             // For each safe point, enumerates a list of GC slots that are alive at that point
             var result = new List<List<BaseGcSlot>>();
@@ -423,9 +423,9 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
             uint numBitsPerOffset = 0;
             // Duplicate the encoder's heuristic to determine if we have indirect live
             // slot table (similar to the chunk pointers)
-            if (NativeReader.ReadBits(image, 1, ref bitOffset) != 0)
+            if (imageReader.ReadBits(1, ref bitOffset) != 0)
             {
-                numBitsPerOffset = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.POINTER_SIZE_ENCBASE, ref bitOffset) + 1;
+                numBitsPerOffset = imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.POINTER_SIZE_ENCBASE, ref bitOffset) + 1;
                 Debug.Assert(numBitsPerOffset != 0);
             }
 
@@ -441,20 +441,20 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 {
                     bitOffset += (int)(numBitsPerOffset * safePointIndex);
 
-                    uint liveStatesOffset = (uint)NativeReader.ReadBits(image, (int)numBitsPerOffset, ref bitOffset);
+                    uint liveStatesOffset = (uint)imageReader.ReadBits((int)numBitsPerOffset, ref bitOffset);
                     uint liveStatesStart = (uint)((offsetTablePos + NumSafePoints * numBitsPerOffset + 7) & (~7));
                     bitOffset = (int)(liveStatesStart + liveStatesOffset);
-                    if (NativeReader.ReadBits(image, 1, ref bitOffset) != 0)
+                    if (imageReader.ReadBits(1, ref bitOffset) != 0)
                     {
                         // RLE encoded
-                        bool skip = NativeReader.ReadBits(image, 1, ref bitOffset) == 0;
+                        bool skip = imageReader.ReadBits(1, ref bitOffset) == 0;
                         bool report = true;
-                        uint readSlots = NativeReader.DecodeVarLengthUnsigned(image,
+                        uint readSlots = imageReader.DecodeVarLengthUnsigned(
                             skip ? _gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE : _gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref bitOffset);
                         skip = !skip;
                         while (readSlots < numSlots)
                         {
-                            uint cnt = NativeReader.DecodeVarLengthUnsigned(image,
+                            uint cnt = imageReader.DecodeVarLengthUnsigned(
                                 skip ? _gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE : _gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref bitOffset) + 1;
                             if (report)
                             {
@@ -492,7 +492,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
 
                 for (uint slotIndex = 0; slotIndex < numSlots; slotIndex++)
                 {
-                    bool isLive = NativeReader.ReadBits(image, 1, ref bitOffset) != 0;
+                    bool isLive = imageReader.ReadBits(1, ref bitOffset) != 0;
                     if (isLive)
                     {
                         int trackedSlotIndex = 0;
@@ -520,7 +520,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         /// <summary>
         /// based on end of <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/gcinfodecoder.cpp">GcInfoDecoder::EnumerateLiveSlots and GcInfoEncoder::Build</a>
         /// </summary>
-        private Dictionary<int, List<BaseGcTransition>> GetTransitions(byte[] image, ref int bitOffset)
+        private Dictionary<int, List<BaseGcTransition>> GetTransitions(NativeReader imageReader, ref int bitOffset)
         {
             int totalInterruptibleLength = 0;
             if (NumInterruptibleRanges == 0)
@@ -532,7 +532,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 foreach (InterruptibleRange range in InterruptibleRanges)
                 {
                     uint normStart = _gcInfoTypes.NormalizeCodeOffset(range.StartOffset);
-                    uint normStop  = _gcInfoTypes.NormalizeCodeOffset(range.StopOffset);
+                    uint normStop = _gcInfoTypes.NormalizeCodeOffset(range.StopOffset);
                     totalInterruptibleLength += (int)(normStop - normStart);
                 }
             }
@@ -541,7 +541,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 return new Dictionary<int, List<BaseGcTransition>>();
 
             int numChunks = (totalInterruptibleLength + _gcInfoTypes.NUM_NORM_CODE_OFFSETS_PER_CHUNK - 1) / _gcInfoTypes.NUM_NORM_CODE_OFFSETS_PER_CHUNK;
-            int numBitsPerPointer = (int)NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.POINTER_SIZE_ENCBASE, ref bitOffset);
+            int numBitsPerPointer = (int)imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.POINTER_SIZE_ENCBASE, ref bitOffset);
             if (numBitsPerPointer == 0)
             {
                 return new Dictionary<int, List<BaseGcTransition>>();
@@ -551,7 +551,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
             int[] chunkPointers = new int[numChunks];
             for (int i = 0; i < numChunks; i++)
             {
-                chunkPointers[i] = NativeReader.ReadBits(image, numBitsPerPointer, ref bitOffset);
+                chunkPointers[i] = imageReader.ReadBits(numBitsPerPointer, ref bitOffset);
             }
 
             // Offset to m_Info2 containing all the info on register liveness, which starts at the next byte
@@ -572,16 +572,16 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
 
                 int couldBeLiveOffset = bitOffset; // points to the couldBeLive bit array (array of bits indicating the slot changed state in the chunk)
                 int slotId = 0;
-                bool fSimple = (NativeReader.ReadBits(image, 1, ref couldBeLiveOffset) == 0);
+                bool fSimple = (imageReader.ReadBits(1, ref couldBeLiveOffset) == 0);
                 bool fSkipFirst = false;
                 int couldBeLiveCnt = 0;
                 if (!fSimple)
                 {
-                    fSkipFirst = (NativeReader.ReadBits(image, 1, ref couldBeLiveOffset) == 0);
+                    fSkipFirst = (imageReader.ReadBits(1, ref couldBeLiveOffset) == 0);
                     slotId = -1;
                 }
 
-                uint numCouldBeLiveSlots = GetNumCouldBeLiveSlots(image, ref bitOffset); // count the number of set bits in the couldBeLive array
+                uint numCouldBeLiveSlots = GetNumCouldBeLiveSlots(imageReader, ref bitOffset); // count the number of set bits in the couldBeLive array
 
                 int finalStateOffset = bitOffset; // points to the finalState bit array (array of bits indicating if the slot is live at the end of the chunk)
                 bitOffset += (int)numCouldBeLiveSlots; // points to the array of code offsets
@@ -590,16 +590,16 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 for (int i = 0; i < numCouldBeLiveSlots; i++)
                 {
                     // get the index of the next couldBeLive slot
-                    slotId = GetNextSlotId(image, fSimple, fSkipFirst, slotId, ref couldBeLiveCnt, ref couldBeLiveOffset);
+                    slotId = GetNextSlotId(imageReader, fSimple, fSkipFirst, slotId, ref couldBeLiveCnt, ref couldBeLiveOffset);
 
                     // set the liveAtEnd for the slot at slotId
                     bool isLive = !liveAtEnd[slotId];
-                    liveAtEnd[slotId] = (NativeReader.ReadBits(image, 1, ref finalStateOffset) != 0);
+                    liveAtEnd[slotId] = (imageReader.ReadBits(1, ref finalStateOffset) != 0);
 
                     // Read all the code offsets where the slot at slotId changed state
-                    while (NativeReader.ReadBits(image, 1, ref bitOffset) != 0)
+                    while (imageReader.ReadBits(1, ref bitOffset) != 0)
                     {
-                        int transitionOffset = NativeReader.ReadBits(image, _gcInfoTypes.NUM_NORM_CODE_OFFSETS_PER_CHUNK_LOG2, ref bitOffset) + normChunkBaseCodeOffset;
+                        int transitionOffset = imageReader.ReadBits(_gcInfoTypes.NUM_NORM_CODE_OFFSETS_PER_CHUNK_LOG2, ref bitOffset) + normChunkBaseCodeOffset;
                         transitions.Add(new GcTransition(transitionOffset, slotId, isLive, currentChunk, SlotTable, _machine));
                         isLive = !isLive;
                     }
@@ -612,20 +612,20 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
             return UpdateTransitionCodeOffset(transitions);
         }
 
-        private uint GetNumCouldBeLiveSlots(byte[] image, ref int bitOffset)
+        private uint GetNumCouldBeLiveSlots(NativeReader imageReader, ref int bitOffset)
         {
             uint numCouldBeLiveSlots = 0;
             uint numTracked = SlotTable.NumTracked;
-            if (NativeReader.ReadBits(image, 1, ref bitOffset) != 0)
+            if (imageReader.ReadBits(1, ref bitOffset) != 0)
             {
                 // RLE encoded
-                bool fSkip = (NativeReader.ReadBits(image, 1, ref bitOffset) == 0);
+                bool fSkip = (imageReader.ReadBits(1, ref bitOffset) == 0);
                 bool fReport = true;
-                uint readSlots = NativeReader.DecodeVarLengthUnsigned(image, fSkip ? _gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE : _gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref bitOffset);
+                uint readSlots = imageReader.DecodeVarLengthUnsigned(fSkip ? _gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE : _gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref bitOffset);
                 fSkip = !fSkip;
                 while (readSlots < numTracked)
                 {
-                    uint cnt = NativeReader.DecodeVarLengthUnsigned(image, fSkip ? _gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE : _gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref bitOffset) + 1;
+                    uint cnt = imageReader.DecodeVarLengthUnsigned(fSkip ? _gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE : _gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref bitOffset) + 1;
                     if (fReport)
                     {
                         numCouldBeLiveSlots += cnt;
@@ -644,7 +644,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                     if ((slot.Flags & GcSlotFlags.GC_SLOT_UNTRACKED) != 0)
                         break;
 
-                    if (NativeReader.ReadBits(image, 1, ref bitOffset) != 0)
+                    if (imageReader.ReadBits(1, ref bitOffset) != 0)
                         numCouldBeLiveSlots++;
                 }
             }
@@ -652,12 +652,12 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
             return numCouldBeLiveSlots;
         }
 
-        private int GetNextSlotId(byte[] image, bool fSimple, bool fSkipFirst, int slotId, ref int couldBeLiveCnt, ref int couldBeLiveOffset)
+        private int GetNextSlotId(NativeReader imageReader, bool fSimple, bool fSkipFirst, int slotId, ref int couldBeLiveCnt, ref int couldBeLiveOffset)
         {
             if (fSimple)
             {
                 // Get the slotId by iterating through the couldBeLive bit array. The slotId is the index of the next set bit
-                while (NativeReader.ReadBits(image, 1, ref couldBeLiveOffset) == 0)
+                while (imageReader.ReadBits(1, ref couldBeLiveOffset) == 0)
                     slotId++;
             }
             else if (couldBeLiveCnt > 0)
@@ -668,15 +668,15 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
             // We need to find a new run
             else if (fSkipFirst)
             {
-                int tmp = (int)NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE, ref couldBeLiveOffset) + 1;
+                int tmp = (int)imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE, ref couldBeLiveOffset) + 1;
                 slotId += tmp;
-                couldBeLiveCnt = (int)NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref couldBeLiveOffset);
+                couldBeLiveCnt = (int)imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref couldBeLiveOffset);
             }
             else
             {
-                int tmp = (int)NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref couldBeLiveOffset) + 1;
+                int tmp = (int)imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.LIVESTATE_RLE_RUN_ENCBASE, ref couldBeLiveOffset) + 1;
                 slotId += tmp;
-                couldBeLiveCnt = (int)NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE, ref couldBeLiveOffset);
+                couldBeLiveCnt = (int)imageReader.DecodeVarLengthUnsigned(_gcInfoTypes.LIVESTATE_RLE_SKIP_ENCBASE, ref couldBeLiveOffset);
             }
             return slotId;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm/UnwindInfo.cs
@@ -75,11 +75,11 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm
 
         public UnwindInfo() { }
 
-        public UnwindInfo(byte[] image, int offset)
+        public UnwindInfo(NativeReader imageReader, int offset)
         {
             uint startOffset = (uint)offset;
 
-            int dw = NativeReader.ReadInt32(image, ref offset);
+            int dw = imageReader.ReadInt32(ref offset);
             CodeWords = ExtractBits(dw, 28, 4);
             EpilogCount = ExtractBits(dw, 23, 5);
             FBit = ExtractBits(dw, 22, 1);
@@ -92,7 +92,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm
             {
                 // We have an extension word specifying a larger number of Code Words or Epilog Counts
                 // than can be specified in the header word.
-                dw = NativeReader.ReadInt32(image, ref offset);
+                dw = imageReader.ReadInt32(ref offset);
                 ExtendedCodeWords = ExtractBits(dw, 16, 8);
                 ExtendedEpilogCount = ExtractBits(dw, 0, 16);
             }
@@ -106,7 +106,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm
                 {
                     for (int scope = 0; scope < EpilogCount; scope++)
                     {
-                        dw = NativeReader.ReadInt32(image, ref offset);
+                        dw = imageReader.ReadInt32(ref offset);
                         Epilogs[scope] = new Epilog(scope, dw, startOffset);
                         epilogStartAt[Epilogs[scope].EpilogStartIndex] = true; // an epilog starts at this offset in the unwind codes
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm64/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm64/UnwindInfo.cs
@@ -75,11 +75,11 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm64
 
         public UnwindInfo() { }
 
-        public UnwindInfo(byte[] image, int offset)
+        public UnwindInfo(NativeReader imageReader, int offset)
         {
             uint startOffset = (uint)offset;
 
-            int dw = NativeReader.ReadInt32(image, ref offset);
+            int dw = imageReader.ReadInt32(ref offset);
             CodeWords = ExtractBits(dw, 27, 5);
             EpilogCount = ExtractBits(dw, 22, 5);
             EBit = ExtractBits(dw, 21, 1);
@@ -91,7 +91,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm64
             {
                 // We have an extension word specifying a larger number of Code Words or Epilog Counts
                 // than can be specified in the header word.
-                dw = NativeReader.ReadInt32(image, ref offset);
+                dw = imageReader.ReadInt32(ref offset);
                 ExtendedCodeWords = ExtractBits(dw, 16, 8);
                 ExtendedEpilogCount = ExtractBits(dw, 0, 16);
             }
@@ -105,7 +105,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm64
                 {
                     for (int scope = 0; scope < EpilogCount; scope++)
                     {
-                        dw = NativeReader.ReadInt32(image, ref offset);
+                        dw = imageReader.ReadInt32(ref offset);
                         Epilogs[scope] = new Epilog(scope, dw, startOffset);
                         epilogStartAt[Epilogs[scope].EpilogStartIndex] = true; // an epilog starts at this offset in the unwind codes
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
@@ -7,8 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyKey>Open</AssemblyKey>
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>
-    <!-- ILSpy requires this assembly to target netstandard2.0 -->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
     <CLSCompliant>false</CLSCompliant>
     <NoWarn>$(NoWarn);8002;NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
@@ -16,11 +15,6 @@
     <Platforms>AnyCPU;x64</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <RunAnalyzers>false</RunAnalyzers>
-    <!--
-      The SDK warns if a project targets a framework that doesn't support trimming and IsTrimmable is true.
-      We set IsTrimmable higher up in the Directory.Build.props files, so we reset it to false here.
-    -->
-    <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/InliningInfoSection.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/InliningInfoSection.cs
@@ -24,14 +24,14 @@ namespace ILCompiler.Reflection.ReadyToRun
             StringBuilder sb = new StringBuilder();
 
             int iiOffset = _startOffset;
-            int sizeOfInlineIndex = NativeReader.ReadInt32(_r2r.Image, ref iiOffset);
+            int sizeOfInlineIndex = _r2r.ImageReader.ReadInt32(ref iiOffset);
             int inlineIndexEndOffset = iiOffset + sizeOfInlineIndex;
             while (iiOffset < inlineIndexEndOffset)
             {
-                int inlineeRid = NativeReader.ReadInt32(_r2r.Image, ref iiOffset);
-                int inlinersOffset = NativeReader.ReadInt32(_r2r.Image, ref iiOffset);
+                int inlineeRid = _r2r.ImageReader.ReadInt32(ref iiOffset);
+                int inlinersOffset = _r2r.ImageReader.ReadInt32(ref iiOffset);
                 sb.AppendLine($"Inliners for inlinee {RidToMethodDef(inlineeRid):X8}:");
-                var inlinersReader = new NibbleReader(_r2r.Image, inlineIndexEndOffset + inlinersOffset);
+                var inlinersReader = new NibbleReader(_r2r.ImageReader, inlineIndexEndOffset + inlinersOffset);
                 uint sameModuleCount = inlinersReader.ReadUInt();
 
                 int baseRid = 0;

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/InliningInfoSection2.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/InliningInfoSection2.cs
@@ -23,8 +23,8 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             StringBuilder sb = new StringBuilder();
 
-            NativeParser parser = new NativeParser(_r2r.Image, (uint)_startOffset);
-            NativeHashtable hashtable = new NativeHashtable(_r2r.Image, parser, (uint)_endOffset);
+            NativeParser parser = new NativeParser(_r2r.ImageReader, (uint)_startOffset);
+            NativeHashtable hashtable = new NativeHashtable(_r2r.ImageReader, parser, (uint)_endOffset);
 
             var enumerator = hashtable.EnumerateAllEntries();
 

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/LoongArch64/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/LoongArch64/UnwindInfo.cs
@@ -75,11 +75,11 @@ namespace ILCompiler.Reflection.ReadyToRun.LoongArch64
 
         public UnwindInfo() { }
 
-        public UnwindInfo(byte[] image, int offset)
+        public UnwindInfo(NativeReader imageReader, int offset)
         {
             uint startOffset = (uint)offset;
 
-            int dw = NativeReader.ReadInt32(image, ref offset);
+            int dw = imageReader.ReadInt32(ref offset);
             CodeWords = ExtractBits(dw, 27, 5);
             EpilogCount = ExtractBits(dw, 22, 5);
             EBit = ExtractBits(dw, 21, 1);
@@ -91,7 +91,7 @@ namespace ILCompiler.Reflection.ReadyToRun.LoongArch64
             {
                 // We have an extension word specifying a larger number of Code Words or Epilog Counts
                 // than can be specified in the header word.
-                dw = NativeReader.ReadInt32(image, ref offset);
+                dw = imageReader.ReadInt32(ref offset);
                 ExtendedCodeWords = ExtractBits(dw, 16, 8);
                 ExtendedEpilogCount = ExtractBits(dw, 0, 16);
             }
@@ -105,7 +105,7 @@ namespace ILCompiler.Reflection.ReadyToRun.LoongArch64
                 {
                     for (int scope = 0; scope < EpilogCount; scope++)
                     {
-                        dw = NativeReader.ReadInt32(image, ref offset);
+                        dw = imageReader.ReadInt32(ref offset);
                         Epilogs[scope] = new Epilog(scope, dw, startOffset);
                         epilogStartAt[Epilogs[scope].EpilogStartIndex] = true; // an epilog starts at this offset in the unwind codes
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeArray.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeArray.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using System.Text;
 
 namespace ILCompiler.Reflection.ReadyToRun
@@ -10,20 +11,21 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// </summary>
     public class NativeArray
     {
-        // TODO (refactoring) - all these Native* class should be private
         private const int _blockSize = 16;
+
+        private NativeReader _reader;
         private uint _baseOffset;
         private uint _nElements;
         private byte _entryIndexSize;
-        private byte[] _image;
 
-        public NativeArray(byte[] image, uint offset)
+        public NativeArray(NativeReader reader, uint offset)
         {
+            _reader = reader;
+
             uint val = 0;
-            _baseOffset = NativeReader.DecodeUnsigned(image, offset, ref val);
+            _baseOffset = _reader.DecodeUnsigned(offset, ref val);
             _nElements = (val >> 2);
             _entryIndexSize = (byte)(val & 3);
-            _image = image;
         }
 
         public uint GetCount()
@@ -40,7 +42,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             for (uint i = 0; i < _nElements; i++)
             {
                 int val = 0;
-                if (TryGetAt(_image, i, ref val))
+                if (TryGetAt(i, ref val))
                 {
                     sb.AppendLine($"{i}: {val}");
                 }
@@ -49,7 +51,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             return sb.ToString();
         }
 
-        public bool TryGetAt(byte[] image, uint index, ref int pOffset)
+        public bool TryGetAt(uint index, ref int pOffset)
         {
             if (index >= _nElements)
                 return false;
@@ -58,24 +60,24 @@ namespace ILCompiler.Reflection.ReadyToRun
             if (_entryIndexSize == 0)
             {
                 int i = (int)(_baseOffset + (index / _blockSize));
-                offset = NativeReader.ReadByte(image, ref i);
+                offset = _reader.ReadByte(ref i);
             }
             else if (_entryIndexSize == 1)
             {
                 int i = (int)(_baseOffset + 2 * (index / _blockSize));
-                offset = NativeReader.ReadUInt16(image, ref i);
+                offset = _reader.ReadUInt16(ref i);
             }
             else
             {
                 int i = (int)(_baseOffset + 4 * (index / _blockSize));
-                offset = NativeReader.ReadUInt32(image, ref i);
+                offset = _reader.ReadUInt32(ref i);
             }
             offset += _baseOffset;
 
             for (uint bit = _blockSize >> 1; bit > 0; bit >>= 1)
             {
                 uint val = 0;
-                uint offset2 = NativeReader.DecodeUnsigned(image, offset, ref val);
+                uint offset2 = _reader.DecodeUnsigned(offset, ref val);
                 if ((index & bit) != 0)
                 {
                     if ((val & 2) != 0)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeReader.cs
@@ -9,7 +9,6 @@ using System.Text;
 
 namespace ILCompiler.Reflection.ReadyToRun
 {
-
     public class NativeReader(Stream backingStream, bool littleEndian = true)
     {
         private const int BITS_PER_BYTE = 8;
@@ -18,11 +17,22 @@ namespace ILCompiler.Reflection.ReadyToRun
         private readonly Stream _backingStream = backingStream;
         private readonly bool _littleEndian = littleEndian;
 
+        /// <summary>
+        /// Reads a byte from the image at the specified index
+        /// </summary>
         public int this[int index]
         {
             get => ReadByte(ref index);
         }
 
+        /// <summary>
+        /// Reads a span of bytes from the image at the specified start index
+        /// </summary>
+        /// <param name="start">Starting index of the value</param>
+        /// <param name="buffer">Span to be filled with the read bytes</param>
+        /// <remarks>
+        /// The <paramref name="start"/> gets incremented by the size of the buffer
+        /// </remarks>
         public void ReadSpanAt(ref int start, Span<byte> buffer)
         {
             if (start < 0 || start + buffer.Length > _backingStream.Length)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeReader.cs
@@ -2,122 +2,127 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace ILCompiler.Reflection.ReadyToRun
 {
-    public class NativeReader
+
+    public class NativeReader(Stream backingStream, bool littleEndian = true)
     {
-        // TODO (refactoring) - all these Native* class should be private
         private const int BITS_PER_BYTE = 8;
         private const int BITS_PER_SIZE_T = 32;
+
+        private readonly Stream _backingStream = backingStream;
+        private readonly bool _littleEndian = littleEndian;
+
+        public int this[int index]
+        {
+            get => ReadByte(ref index);
+        }
+
+        public void ReadSpanAt(ref int start, Span<byte> buffer)
+        {
+            if (start < 0 || start + buffer.Length > _backingStream.Length)
+                throw new ArgumentOutOfRangeException(nameof(start), "Start index is out of bounds");
+
+            _backingStream.Seek(start, SeekOrigin.Begin);
+            _backingStream.Read(buffer);
+            start += buffer.Length;
+        }
 
         /// <summary>
         /// Extracts a 64bit value from the image byte array
         /// </summary>
-        /// <param name="image">PE image</param>
         /// <param name="start">Starting index of the value</param>
         /// <remarks>
         /// The <paramref name="start"/> gets incremented by the size of the value
         /// </remarks>
-        public static long ReadInt64(byte[] image, ref int start)
+        public long ReadInt64(ref int start)
         {
-            int size = sizeof(long);
-            byte[] bytes = new byte[size];
-            Array.Copy(image, start, bytes, 0, size);
-            start += size;
-            return BitConverter.ToInt64(bytes, 0);
+            Span<byte> bytes = stackalloc byte[sizeof(long)];
+            ReadSpanAt(ref start, bytes);
+            return _littleEndian ? BinaryPrimitives.ReadInt64LittleEndian(bytes) : BinaryPrimitives.ReadInt64BigEndian(bytes);
         }
 
         // <summary>
         /// Extracts a 32bit value from the image byte array
         /// </summary>
-        /// <param name="image">PE image</param>
         /// <param name="start">Starting index of the value</param>
         /// <remarks>
         /// The <paramref name="start"/> gets incremented by the size of the value
         /// </remarks>
-        public static int ReadInt32(byte[] image, ref int start)
+        public int ReadInt32(ref int start)
         {
-            int size = sizeof(int);
-            byte[] bytes = new byte[size];
-            Array.Copy(image, start, bytes, 0, size);
-            start += size;
-            return BitConverter.ToInt32(bytes, 0);
+            Span<byte> bytes = stackalloc byte[sizeof(int)];
+            ReadSpanAt(ref start, bytes);
+            return _littleEndian ? BinaryPrimitives.ReadInt32LittleEndian(bytes) : BinaryPrimitives.ReadInt32BigEndian(bytes);
         }
 
         // <summary>
         /// Extracts an unsigned 32bit value from the image byte array
         /// </summary>
-        /// <param name="image">PE image</param>
         /// <param name="start">Starting index of the value</param>
         /// <remarks>
         /// The <paramref name="start"/> gets incremented by the size of the value
         /// </remarks>
-        public static uint ReadUInt32(byte[] image, ref int start)
+        public uint ReadUInt32(ref int start)
         {
-            int size = sizeof(int);
-            byte[] bytes = new byte[size];
-            Array.Copy(image, start, bytes, 0, size);
-            start += size;
-            return (uint)BitConverter.ToInt32(bytes, 0);
+            Span<byte> bytes = stackalloc byte[sizeof(uint)];
+            ReadSpanAt(ref start, bytes);
+            return _littleEndian ? BinaryPrimitives.ReadUInt32LittleEndian(bytes) : BinaryPrimitives.ReadUInt32BigEndian(bytes);
         }
 
         // <summary>
         /// Extracts an unsigned 16bit value from the image byte array
         /// </summary>
-        /// <param name="image">PE image</param>
         /// <param name="start">Starting index of the value</param>
         /// <remarks>
         /// The <paramref name="start"/> gets incremented by the size of the value
         /// </remarks>
-        public static ushort ReadUInt16(byte[] image, ref int start)
+        public ushort ReadUInt16(ref int start)
         {
-            int size = sizeof(short);
-            byte[] bytes = new byte[size];
-            Array.Copy(image, start, bytes, 0, size);
-            start += size;
-            return (ushort)BitConverter.ToInt16(bytes, 0);
+            Span<byte> bytes = stackalloc byte[sizeof(ushort)];
+            ReadSpanAt(ref start, bytes);
+            return _littleEndian ? BinaryPrimitives.ReadUInt16LittleEndian(bytes) : BinaryPrimitives.ReadUInt16BigEndian(bytes);
         }
 
         // <summary>
         /// Extracts byte from the image byte array
         /// </summary>
-        /// <param name="image">PE image</param>
         /// <param name="start">Start index of the value</param>
         /// <remarks>
         /// The <paramref name="start"/> gets incremented by the size of the value
         /// </remarks>
-        public static byte ReadByte(byte[] image, ref int start)
+        public byte ReadByte(ref int start)
         {
-            byte val = image[start];
-            start += sizeof(byte);
-            return val;
+            Span<byte> bytes = stackalloc byte[sizeof(byte)];
+            ReadSpanAt(ref start, bytes);
+            return bytes[0];
         }
 
         // <summary>
         /// Extracts bits from the image byte array
         /// </summary>
-        /// <param name="image">PE image</param>
         /// <param name="numBits">Number of bits to read</param>
         /// <param name="bitOffset">Start bit of the value</param>
         /// <remarks>
         /// The <paramref name="bitOffset"/> gets incremented by <paramref name="numBits">
         /// </remarks>
-        public static int ReadBits(byte[] image, int numBits, ref int bitOffset)
+        public int ReadBits(int numBits, ref int bitOffset)
         {
             int start = bitOffset / BITS_PER_BYTE;
             int bits = bitOffset % BITS_PER_BYTE;
-            int val = image[start] >> bits;
+            int val = ReadByte(ref start) >> bits;
             bits += numBits;
             while (bits > BITS_PER_BYTE)
             {
-                start++;
                 bits -= BITS_PER_BYTE;
                 if (bits > 0)
                 {
-                    int extraBits = image[start] << (numBits - bits);
+                    int extraBits = ReadByte(ref start) << (numBits - bits);
                     val ^= extraBits;
                 }
             }
@@ -130,19 +135,18 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// Decode variable length numbers
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfodecoder.h">src\inc\gcinfodecoder.h</a> DecodeVarLengthUnsigned
         /// </summary>
-        /// <param name="image">PE image</param>
         /// <param name="len">Number of bits to read</param>
         /// <param name="bitOffset">Start bit of the value</param>
         /// <remarks>
         /// The <paramref name="bitOffset"/> gets incremented by the size of the value
         /// </remarks>
-        public static uint DecodeVarLengthUnsigned(byte[] image, int len, ref int bitOffset)
+        public uint DecodeVarLengthUnsigned(int len, ref int bitOffset)
         {
             uint numEncodings = (uint)(1 << len);
             uint result = 0;
             for (int shift = 0; ; shift += len)
             {
-                uint currentChunk = (uint)ReadBits(image, len + 1, ref bitOffset);
+                uint currentChunk = (uint)ReadBits(len + 1, ref bitOffset);
                 result |= (currentChunk & (numEncodings - 1)) << shift;
                 if ((currentChunk & numEncodings) == 0)
                 {
@@ -155,13 +159,13 @@ namespace ILCompiler.Reflection.ReadyToRun
         // <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfodecoder.h">src\inc\gcinfodecoder.h</a> DecodeVarLengthSigned
         /// </summary>
-        public static int DecodeVarLengthSigned(byte[] image, int len, ref int bitOffset)
+        public int DecodeVarLengthSigned(int len, ref int bitOffset)
         {
             int numEncodings = (1 << len);
             int result = 0;
             for (int shift = 0; ; shift += len)
             {
-                int currentChunk = ReadBits(image, len + 1, ref bitOffset);
+                int currentChunk = ReadBits(len + 1, ref bitOffset);
                 result |= (currentChunk & (numEncodings - 1)) << shift;
                 if ((currentChunk & numEncodings) == 0)
                 {
@@ -177,13 +181,13 @@ namespace ILCompiler.Reflection.ReadyToRun
         // <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/nativeformatreader.h">src\vm\nativeformatreader.h</a> DecodeUnsigned
         /// </summary>
-        public static uint DecodeUnsigned(byte[] image, uint offset, ref uint pValue)
+        public uint DecodeUnsigned(uint offset, ref uint pValue)
         {
-            if (offset >= image.Length)
+            if (offset >= _backingStream.Length)
                 throw new System.BadImageFormatException("offset out of bounds");
 
             int off = (int)offset;
-            uint val = ReadByte(image, ref off);
+            uint val = ReadByte(ref off);
 
             if ((val & 1) == 0)
             {
@@ -192,37 +196,37 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
             else if ((val & 2) == 0)
             {
-                if (offset + 1 >= image.Length)
+                if (offset + 1 >= _backingStream.Length)
                     throw new System.BadImageFormatException("offset out of bounds");
 
                 pValue = (val >> 2) |
-                      ((uint)ReadByte(image, ref off) << 6);
+                        ((uint)ReadByte(ref off) << 6);
                 offset += 2;
             }
             else if ((val & 4) == 0)
             {
-                if (offset + 2 >= image.Length)
+                if (offset + 2 >= _backingStream.Length)
                     throw new System.BadImageFormatException("offset out of bounds");
 
                 pValue = (val >> 3) |
-                      ((uint)ReadByte(image, ref off) << 5) |
-                      ((uint)ReadByte(image, ref off) << 13);
+                        ((uint)ReadByte(ref off) << 5) |
+                        ((uint)ReadByte(ref off) << 13);
                 offset += 3;
             }
             else if ((val & 8) == 0)
             {
-                if (offset + 3 >= image.Length)
+                if (offset + 3 >= _backingStream.Length)
                     throw new System.BadImageFormatException("offset out of bounds");
 
                 pValue = (val >> 4) |
-                      ((uint)ReadByte(image, ref off) << 4) |
-                      ((uint)ReadByte(image, ref off) << 12) |
-                      ((uint)ReadByte(image, ref off) << 20);
+                        ((uint)ReadByte(ref off) << 4) |
+                        ((uint)ReadByte(ref off) << 12) |
+                        ((uint)ReadByte(ref off) << 20);
                 offset += 4;
             }
             else if ((val & 16) == 0)
             {
-                pValue = ReadUInt32(image, ref off);
+                pValue = ReadUInt32(ref off);
                 offset += 5;
             }
             else
@@ -236,13 +240,13 @@ namespace ILCompiler.Reflection.ReadyToRun
         // <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/nativeformatreader.h">src\vm\nativeformatreader.h</a> DecodeSigned
         /// </summary>
-        public static uint DecodeSigned(byte[] image, uint offset, ref int pValue)
+        public uint DecodeSigned(uint offset, ref int pValue)
         {
-            if (offset >= image.Length)
+            if (offset >= _backingStream.Length)
                 throw new System.BadImageFormatException("offset out of bounds");
 
             int off = (int)offset;
-            int val = ReadByte(image, ref off);
+            int val = ReadByte(ref off);
 
             if ((val & 1) == 0)
             {
@@ -251,37 +255,37 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
             else if ((val & 2) == 0)
             {
-                if (offset + 1 >= image.Length)
+                if (offset + 1 >= _backingStream.Length)
                     throw new System.BadImageFormatException("offset out of bounds");
 
                 pValue = (val >> 2) |
-                      (ReadByte(image, ref off) << 6);
+                        (ReadByte(ref off) << 6);
                 offset += 2;
             }
             else if ((val & 4) == 0)
             {
-                if (offset + 2 >= image.Length)
+                if (offset + 2 >= _backingStream.Length)
                     throw new System.BadImageFormatException("offset out of bounds");
 
                 pValue = (val >> 3) |
-                      (ReadByte(image, ref off) << 5) |
-                      (ReadByte(image, ref off) << 13);
+                        (ReadByte(ref off) << 5) |
+                        (ReadByte(ref off) << 13);
                 offset += 3;
             }
             else if ((val & 8) == 0)
             {
-                if (offset + 3 >= image.Length)
+                if (offset + 3 >= _backingStream.Length)
                     throw new System.BadImageFormatException("offset out of bounds");
 
                 pValue = (val >> 4) |
-                      (ReadByte(image, ref off) << 4) |
-                      (ReadByte(image, ref off) << 12) |
-                      (ReadByte(image, ref off) << 20);
+                        (ReadByte(ref off) << 4) |
+                        (ReadByte(ref off) << 12) |
+                        (ReadByte(ref off) << 20);
                 offset += 4;
             }
             else if ((val & 16) == 0)
             {
-                pValue = ReadInt32(image, ref off);
+                pValue = ReadInt32(ref off);
                 offset += 5;
             }
             else
@@ -295,10 +299,10 @@ namespace ILCompiler.Reflection.ReadyToRun
         // <summary>
         /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/debug/daccess/nidump.cpp">src\debug\daccess\nidump.cpp</a> DacSigUncompressData and DacSigUncompressBigData
         /// </summary>
-        public static uint ReadCompressedData(byte[] image, ref int start)
+        public uint ReadCompressedData(ref int start)
         {
             int off = start;
-            uint data = ReadUInt32(image, ref off);
+            uint data = ReadUInt32(ref off);
             if ((data & 0x80) == 0x00)
             {
                 start++;
@@ -306,15 +310,15 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
             if ((data & 0xC0) == 0x80)  // 10?? ????
             {
-                data = (uint)((ReadByte(image, ref start) & 0x3f) << 8);
-                data |= ReadByte(image, ref start);
+                data = (uint)((ReadByte(ref start) & 0x3f) << 8);
+                data |= ReadByte(ref start);
             }
             else // 110? ????
             {
-                data = (uint)(ReadByte(image, ref start) & 0x1f) << 24;
-                data |= (uint)ReadByte(image, ref start) << 16;
-                data |= (uint)ReadByte(image, ref start) << 8;
-                data |= ReadByte(image, ref start);
+                data = (uint)(ReadByte(ref start) & 0x1f) << 24;
+                data |= (uint)ReadByte(ref start) << 16;
+                data |= (uint)ReadByte(ref start) << 8;
+                data |= ReadByte(ref start);
             }
             return data;
         }
@@ -322,15 +326,15 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeUnsigned
         /// </summary>
-        public static uint DecodeUnsignedGc(byte[] image, ref int start)
+        public uint DecodeUnsignedGc(ref int start)
         {
             int size = 1;
-            byte data = image[start++];
+            byte data = ReadByte(ref start);
             uint value = (uint)data & 0x7f;
             while ((data & 0x80) != 0)
             {
                 size++;
-                data = image[start++];
+                data = ReadByte(ref start);
                 value <<= 7;
                 value += (uint)data & 0x7f;
             }
@@ -340,16 +344,16 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeSigned
         /// </summary>
-        public static int DecodeSignedGc(byte[] image, ref int start)
+        public int DecodeSignedGc(ref int start)
         {
             int size = 1;
-            byte data  = image[start++];
+            byte data = ReadByte(ref start);
             byte first = data;
             int value = data & 0x3f;
             while ((data & 0x80) != 0)
             {
                 size++;
-                data = image[start++];
+                data = ReadByte(ref start);
                 value <<= 7;
                 value += data & 0x7f;
             }
@@ -362,9 +366,9 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeUDelta
         /// </summary>
-        public static uint DecodeUDelta(byte[] image, ref int start, uint lastValue)
+        public uint DecodeUDelta(ref int start, uint lastValue)
         {
-            uint delta = DecodeUnsignedGc(image, ref start);
+            uint delta = DecodeUnsignedGc(ref start);
             return lastValue + delta;
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NibbleReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NibbleReader.cs
@@ -16,9 +16,9 @@ namespace ILCompiler.Reflection.ReadyToRun
         private const byte NoNextNibble = 0xFF;
 
         /// <summary>
-        /// Byte array representing the PE file.
+        /// NativeReader representing the PE file.
         /// </summary>
-        private byte[] _image;
+        private NativeReader _imageReader;
 
         /// <summary>
         /// Offset within the image.
@@ -30,9 +30,9 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         private byte _nextNibble;
 
-        public NibbleReader(byte[] image, int offset)
+        public NibbleReader(NativeReader imageReader, int offset)
         {
-            _image = image;
+            _imageReader = imageReader;
             _offset = offset;
             _nextNibble = NoNextNibble;
         }
@@ -47,7 +47,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
             else
             {
-                _nextNibble = _image[_offset++];
+                _nextNibble = _imageReader.ReadByte(ref _offset);
                 result = (byte)(_nextNibble & 0x0F);
                 _nextNibble >>= 4;
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
@@ -132,7 +132,6 @@ namespace ILCompiler.Reflection.ReadyToRun
             byte[] signature = new byte[sizeof(uint) - 1]; // -1 removes the null character at the end of the cstring
             imageReader.ReadSpanAt(ref curOffset, signature);
             curOffset = startOffset;
-            Array.Copy(Array.Empty<int>(), curOffset, signature, 0, sizeof(uint) - 1);
             SignatureString = Encoding.UTF8.GetString(signature);
             Signature = imageReader.ReadUInt32(ref curOffset);
             if (Signature != READYTORUN_SIGNATURE)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
@@ -22,16 +22,12 @@ namespace ILCompiler.Reflection.ReadyToRun
         public readonly int AssemblyHeaderRVA;
         public readonly int AssemblyHeaderSize;
 
-        public ComponentAssembly(byte[] image, ref int curOffset)
+        public ComponentAssembly(NativeReader imageReader, ref int curOffset)
         {
-            CorHeaderRVA = BitConverter.ToInt32(image, curOffset);
-            curOffset += sizeof(int);
-            CorHeaderSize = BitConverter.ToInt32(image, curOffset);
-            curOffset += sizeof(int);
-            AssemblyHeaderRVA = BitConverter.ToInt32(image, curOffset);
-            curOffset += sizeof(int);
-            AssemblyHeaderSize = BitConverter.ToInt32(image, curOffset);
-            curOffset += sizeof(int);
+            CorHeaderRVA = imageReader.ReadInt32(ref curOffset);
+            CorHeaderSize = imageReader.ReadInt32(ref curOffset);
+            AssemblyHeaderRVA = imageReader.ReadInt32(ref curOffset);
+            AssemblyHeaderSize = imageReader.ReadInt32(ref curOffset);
         }
     }
 
@@ -55,32 +51,32 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
         }
 
-        public ReadyToRunCoreHeader(byte[] image, ref int curOffset)
+        public ReadyToRunCoreHeader(NativeReader imageReader, ref int curOffset)
         {
-            ParseCoreHeader(image, ref curOffset);
+            ParseCoreHeader(imageReader, ref curOffset);
         }
 
         /// <summary>
         /// Parse core header fields common to global R2R file header and per assembly headers in composite R2R images.
         /// </summary>
-        /// <param name="image">PE image</param>
+        /// <param name="imageReader">PE Image reader</param>
         /// <param name="curOffset">Index in the image byte array to the start of the ReadyToRun core header</param>
-        public void ParseCoreHeader(byte[] image, ref int curOffset)
+        public void ParseCoreHeader(NativeReader imageReader, ref int curOffset)
         {
-            Flags = NativeReader.ReadUInt32(image, ref curOffset);
-            int nSections = NativeReader.ReadInt32(image, ref curOffset);
+            Flags = imageReader.ReadUInt32(ref curOffset);
+            int nSections = imageReader.ReadInt32(ref curOffset);
             Sections = new Dictionary<ReadyToRunSectionType, ReadyToRunSection>();
 
             for (int i = 0; i < nSections; i++)
             {
-                int type = NativeReader.ReadInt32(image, ref curOffset);
+                int type = imageReader.ReadInt32(ref curOffset);
                 var sectionType = (ReadyToRunSectionType)type;
                 if (!Enum.IsDefined(typeof(ReadyToRunSectionType), type))
                 {
                     throw new BadImageFormatException("Warning: Invalid ReadyToRun section type");
                 }
-                int sectionStartRva = NativeReader.ReadInt32(image, ref curOffset);
-                int sectionLength = NativeReader.ReadInt32(image, ref curOffset);
+                int sectionStartRva = imageReader.ReadInt32(ref curOffset);
+                int sectionLength = imageReader.ReadInt32(ref curOffset);
                 Sections[sectionType] = new ReadyToRunSection(sectionType, sectionStartRva, sectionLength);
             }
         }
@@ -124,28 +120,30 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// Initializes the fields of the R2RHeader
         /// </summary>
-        /// <param name="image">PE image</param>
+        /// <param name="imageReader">PE Image reader</param>
         /// <param name="rva">Relative virtual address of the ReadyToRun header</param>
         /// <param name="curOffset">Index in the image byte array to the start of the ReadyToRun header</param>
         /// <exception cref="BadImageFormatException">The signature must be 0x00525452</exception>
-        public ReadyToRunHeader(byte[] image, int rva, int curOffset)
+        public ReadyToRunHeader(NativeReader imageReader, int rva, int curOffset)
         {
             RelativeVirtualAddress = rva;
             int startOffset = curOffset;
 
             byte[] signature = new byte[sizeof(uint) - 1]; // -1 removes the null character at the end of the cstring
-            Array.Copy(image, curOffset, signature, 0, sizeof(uint) - 1);
+            imageReader.ReadSpanAt(ref curOffset, signature);
+            curOffset = startOffset;
+            Array.Copy(Array.Empty<int>(), curOffset, signature, 0, sizeof(uint) - 1);
             SignatureString = Encoding.UTF8.GetString(signature);
-            Signature = NativeReader.ReadUInt32(image, ref curOffset);
+            Signature = imageReader.ReadUInt32(ref curOffset);
             if (Signature != READYTORUN_SIGNATURE)
             {
                 throw new System.BadImageFormatException("Incorrect R2R header signature: " + SignatureString);
             }
 
-            MajorVersion = NativeReader.ReadUInt16(image, ref curOffset);
-            MinorVersion = NativeReader.ReadUInt16(image, ref curOffset);
+            MajorVersion = imageReader.ReadUInt16(ref curOffset);
+            MinorVersion = imageReader.ReadUInt16(ref curOffset);
 
-            ParseCoreHeader(image, ref curOffset);
+            ParseCoreHeader(imageReader, ref curOffset);
 
             Size = curOffset - startOffset;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/RiscV64/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/RiscV64/UnwindInfo.cs
@@ -75,11 +75,11 @@ namespace ILCompiler.Reflection.ReadyToRun.RiscV64
 
         public UnwindInfo() { }
 
-        public UnwindInfo(byte[] image, int offset)
+        public UnwindInfo(NativeReader imageReader, int offset)
         {
             uint startOffset = (uint)offset;
 
-            int dw = NativeReader.ReadInt32(image, ref offset);
+            int dw = imageReader.ReadInt32(ref offset);
             CodeWords = ExtractBits(dw, 27, 5);
             EpilogCount = ExtractBits(dw, 22, 5);
             EBit = ExtractBits(dw, 21, 1);
@@ -91,7 +91,7 @@ namespace ILCompiler.Reflection.ReadyToRun.RiscV64
             {
                 // We have an extension word specifying a larger number of Code Words or Epilog Counts
                 // than can be specified in the header word.
-                dw = NativeReader.ReadInt32(image, ref offset);
+                dw = imageReader.ReadInt32(ref offset);
                 ExtendedCodeWords = ExtractBits(dw, 16, 8);
                 ExtendedEpilogCount = ExtractBits(dw, 0, 16);
             }
@@ -105,7 +105,7 @@ namespace ILCompiler.Reflection.ReadyToRun.RiscV64
                 {
                     for (int scope = 0; scope < EpilogCount; scope++)
                     {
-                        dw = NativeReader.ReadInt32(image, ref offset);
+                        dw = imageReader.ReadInt32(ref offset);
                         Epilogs[scope] = new Epilog(scope, dw, startOffset);
                         epilogStartAt[Epilogs[scope].EpilogStartIndex] = true; // an epilog starts at this offset in the unwind codes
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
@@ -21,30 +21,30 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
-        public GcInfo(byte[] image, int offset)
+        public GcInfo(NativeReader imageReader, int offset)
         {
             Offset = offset;
 
-            CodeLength = (int)NativeReader.DecodeUnsignedGc(image, ref offset);
+            CodeLength = (int)imageReader.DecodeUnsignedGc(ref offset);
 
-            Header = InfoHdrDecoder.DecodeHeader(image, ref offset, CodeLength);
+            Header = InfoHdrDecoder.DecodeHeader(imageReader, ref offset, CodeLength);
 
-            NoGCRegions = new NoGcRegionTable(image, Header, ref offset);
+            NoGCRegions = new NoGcRegionTable(imageReader, Header, ref offset);
 
-            SlotTable = new GcSlotTable(image, Header, ref offset);
+            SlotTable = new GcSlotTable(imageReader, Header, ref offset);
 
             Transitions = new Dictionary<int, List<BaseGcTransition>>();
             if (Header.Interruptible)
             {
-                GetTransitionsFullyInterruptible(image, ref offset);
+                GetTransitionsFullyInterruptible(imageReader, ref offset);
             }
             else if (Header.EbpFrame)
             {
-                GetTransitionsEbpFrame(image, ref offset);
+                GetTransitionsEbpFrame(imageReader, ref offset);
             }
             else
             {
-                GetTransitionsNoEbp(image, ref offset);
+                GetTransitionsNoEbp(imageReader, ref offset);
             }
 
             Size = offset - Offset;
@@ -79,7 +79,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             Transitions[transition.CodeOffset].Add(transition);
         }
 
-        private void ArgEncoding(byte[] image, ref uint isPop, ref uint argOffs, ref uint argCnt, ref uint curOffs, ref bool isThis, ref bool iptr)
+        private void ArgEncoding(NativeReader imageReader, ref uint isPop, ref uint argOffs, ref uint argCnt, ref uint curOffs, ref bool isThis, ref bool iptr)
         {
             if (isPop != 0)
             {
@@ -101,7 +101,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
-        private void GetTransitionsFullyInterruptible(byte[] image, ref int offset)
+        private void GetTransitionsFullyInterruptible(NativeReader imageReader, ref int offset)
         {
             uint argCnt = 0;
             bool isThis = false;
@@ -112,7 +112,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             {
                 uint isPop;
                 uint argOffs;
-                uint val = image[offset++];
+                uint val = imageReader.ReadByte(ref offset);
 
                 if ((val & 0x80) == 0)
                 {
@@ -143,7 +143,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                     curOffs += (val & 0x07);
                     isPop = (val & 0x40);
 
-                    ArgEncoding(image, ref isPop, ref argOffs, ref argCnt, ref curOffs, ref isThis, ref iptr);
+                    ArgEncoding(imageReader, ref isPop, ref argOffs, ref argCnt, ref curOffs, ref isThis, ref iptr);
 
                     continue;
                 }
@@ -177,21 +177,21 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                         iptr = true;
                         break;
                     case 0xB8:
-                        val = NativeReader.DecodeUnsignedGc(image, ref offset);
+                        val = imageReader.DecodeUnsignedGc(ref offset);
                         curOffs += val;
                         break;
                     case 0xF8:
                     case 0xFC:
                         isPop = val & 0x04;
-                        argOffs = NativeReader.DecodeUnsignedGc(image, ref offset);
-                        ArgEncoding(image, ref isPop, ref argOffs, ref argCnt, ref curOffs, ref isThis, ref iptr);
+                        argOffs = imageReader.DecodeUnsignedGc(ref offset);
+                        ArgEncoding(imageReader, ref isPop, ref argOffs, ref argCnt, ref curOffs, ref isThis, ref iptr);
                         break;
                     case 0xFD:
-                        argOffs = NativeReader.DecodeUnsignedGc(image, ref offset);
+                        argOffs = imageReader.DecodeUnsignedGc(ref offset);
                         AddNewTransition(new GcTransitionPointer((int)curOffs, argOffs, argCnt, Action.KILL, Header.EbpFrame));
                         break;
                     case 0xF9:
-                        argOffs = NativeReader.DecodeUnsignedGc(image, ref offset);
+                        argOffs = imageReader.DecodeUnsignedGc(ref offset);
                         argCnt += argOffs;
                         break;
                     default:
@@ -203,7 +203,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
-        private void GetTransitionsEbpFrame(byte[] image, ref int offset)
+        private void GetTransitionsEbpFrame(NativeReader imageReader, ref int offset)
         {
             while (true)
             {
@@ -218,7 +218,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                 uint curOffs = 0;
 
                 // Get the next byte and check for a 'special' entry
-                uint encType = image[offset++];
+                uint encType = imageReader.ReadByte(ref offset);
                 GcTransitionCall transition = null;
 
                 switch (encType)
@@ -259,50 +259,50 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                         {
                             // A small call entry
                             curOffs += (val & 0x7F);
-                            val = image[offset++];
+                            val = imageReader.ReadByte(ref offset);
                             regMask = val >> 5;
                             argMask = val & 0x1F;
                         }
                         break;
 
                     case 0xFD:  // medium encoding
-                        argMask = image[offset++];
-                        val = image[offset++];
+                        argMask = imageReader.ReadByte(ref offset);
+                        val = imageReader.ReadByte(ref offset);
                         argMask |= (val & 0xF0) << 4;
-                        nxt = image[offset++];
+                        nxt = imageReader.ReadByte(ref offset);
                         curOffs += (val & 0x0F) + ((nxt & 0x1F) << 4);
                         regMask = nxt >> 5;                   // EBX,ESI,EDI
                         break;
 
                     case 0xF9:  // medium encoding with byrefs
-                        curOffs += image[offset++];
-                        val = image[offset++];
+                        curOffs += imageReader.ReadByte(ref offset);
+                        val = imageReader.ReadByte(ref offset);
                         argMask = val & 0x1F;
                         regMask = val >> 5;
-                        val = image[offset++];
+                        val = imageReader.ReadByte(ref offset);
                         byrefArgMask = val & 0x1F;
                         byrefRegMask = val >> 5;
                         break;
                     case 0xFE:  // large encoding
                     case 0xFA:  // large encoding with byrefs
-                        val = image[offset++];
+                        val = imageReader.ReadByte(ref offset);
                         regMask = val & 0x7;
                         byrefRegMask = val >> 4;
 
-                        curOffs += NativeReader.ReadUInt32(image, ref offset);
-                        argMask = NativeReader.ReadUInt32(image, ref offset);
+                        curOffs += imageReader.ReadUInt32(ref offset);
+                        argMask = imageReader.ReadUInt32(ref offset);
                         if (encType == 0xFA) // read byrefArgMask
                         {
-                            byrefArgMask = NativeReader.ReadUInt32(image, ref offset);
+                            byrefArgMask = imageReader.ReadUInt32(ref offset);
                         }
                         break;
                     case 0xFB:  // huge encoding
-                        val = image[offset++];
+                        val = imageReader.ReadByte(ref offset);
                         regMask = val & 0x7;
                         byrefRegMask = val >> 4;
-                        curOffs = NativeReader.ReadUInt32(image, ref offset);
-                        argCnt = NativeReader.ReadUInt32(image, ref offset);
-                        argTabSize = NativeReader.ReadUInt32(image, ref offset);
+                        curOffs = imageReader.ReadUInt32(ref offset);
+                        argCnt = imageReader.ReadUInt32(ref offset);
+                        argTabSize = imageReader.ReadUInt32(ref offset);
                         argOffset = offset;
                         offset += (int)argTabSize;
                         break;
@@ -326,7 +326,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                 {
                     do
                     {
-                        val = NativeReader.DecodeUnsignedGc(image, ref argOffset);
+                        val = imageReader.DecodeUnsignedGc(ref argOffset);
 
                         uint stkOffs = val & ~byref_OFFSET_FLAG;
                         uint lowBit = val & byref_OFFSET_FLAG;
@@ -346,7 +346,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
-        private void SaveCallTransition(byte[] image, ref int offset, uint val, uint curOffs, uint callRegMask, bool callPndTab, uint callPndTabCnt, uint callPndMask, uint lastSkip, ref uint imask)
+        private void SaveCallTransition(NativeReader imageReader, ref int offset, uint val, uint curOffs, uint callRegMask, bool callPndTab, uint callPndTabCnt, uint callPndMask, uint lastSkip, ref uint imask)
         {
             uint iregMask, iargMask;
             iregMask = imask & 0xF;
@@ -359,7 +359,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             {
                 for (int i = 0; i < callPndTabCnt; i++)
                 {
-                    uint pndOffs = NativeReader.DecodeUnsignedGc(image, ref offset);
+                    uint pndOffs = imageReader.DecodeUnsignedGc(ref offset);
 
                     uint stkOffs = val & ~byref_OFFSET_FLAG;
                     uint lowBit = val & byref_OFFSET_FLAG;
@@ -377,7 +377,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             imask = lastSkip = 0;
         }
 
-        private void GetTransitionsNoEbp(byte[] image, ref int offset)
+        private void GetTransitionsNoEbp(NativeReader imageReader, ref int offset)
         {
             uint curOffs = 0;
             uint lastSkip = 0;
@@ -385,7 +385,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
             for (; ; )
             {
-                uint val = image[offset++];
+                uint val = imageReader.ReadByte(ref offset);
 
                 if ((val & 0x80) == 0)
                 {
@@ -400,7 +400,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                         else
                         {
                             // push    00100000 [pushCount]     ESP push multiple items
-                            uint pushCount = NativeReader.DecodeUnsignedGc(image, ref offset);
+                            uint pushCount = imageReader.DecodeUnsignedGc(ref offset);
                             AddNewTransition(new GcTransitionRegister((int)curOffs, Registers.ESP, Action.PUSH, false, false, (int)pushCount));
                         }
                     }
@@ -414,7 +414,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                             //
                             // skip    01000000 [Delta]  Skip arbitrary sized delta
                             //
-                            skip = NativeReader.DecodeUnsignedGc(image, ref offset);
+                            skip = imageReader.DecodeUnsignedGc(ref offset);
                             curOffs += skip;
                             lastSkip = skip;
                         }
@@ -450,7 +450,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                             //
                             CallPattern.DecodeCallPattern((val & 0x7f), out callArgCnt, out callRegMask, out callPndMask, out lastSkip);
                             curOffs += lastSkip;
-                            SaveCallTransition(image, ref offset, val, curOffs, callRegMask, callPndTab, callPndTabCnt, callPndMask, lastSkip, ref imask);
+                            SaveCallTransition(imageReader, ref offset, val, curOffs, callRegMask, callPndTab, callPndTabCnt, callPndMask, lastSkip, ref imask);
                             break;
 
                         case 5:
@@ -459,12 +459,12 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                             //                        ArgMask=MMM Delta=commonDelta[DD]
                             //
                             callRegMask = val & 0xf;    // EBP,EBX,ESI,EDI
-                            val = image[offset++];
+                            val = imageReader.ReadByte(ref offset);
                             callPndMask = (val & 0x7);
                             callArgCnt = (val >> 3) & 0x7;
                             lastSkip = CallPattern.callCommonDelta[val >> 6];
                             curOffs += lastSkip;
-                            SaveCallTransition(image, ref offset, val, curOffs, callRegMask, callPndTab, callPndTabCnt, callPndMask, lastSkip, ref imask);
+                            SaveCallTransition(imageReader, ref offset, val, curOffs, callRegMask, callPndTab, callPndTabCnt, callPndMask, lastSkip, ref imask);
                             break;
                         case 6:
                             //
@@ -472,16 +472,16 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                             //                          Call ArgCnt,RegMask=RRR,ArgMask
                             //
                             callRegMask = val & 0xf;    // EBP,EBX,ESI,EDI
-                            callArgCnt = NativeReader.DecodeUnsignedGc(image, ref offset);
-                            callPndMask = NativeReader.DecodeUnsignedGc(image, ref offset);
-                            SaveCallTransition(image, ref offset, val, curOffs, callRegMask, callPndTab, callPndTabCnt, callPndMask, lastSkip, ref imask);
+                            callArgCnt = imageReader.DecodeUnsignedGc(ref offset);
+                            callPndMask = imageReader.DecodeUnsignedGc(ref offset);
+                            SaveCallTransition(imageReader, ref offset, val, curOffs, callRegMask, callPndTab, callPndTabCnt, callPndMask, lastSkip, ref imask);
                             break;
                         case 7:
                             switch (val & 0x0C)
                             {
                                 case 0x00:
                                     //  iptr 11110000 [IPtrMask] Arbitrary Interior Pointer Mask
-                                    imask = NativeReader.DecodeUnsignedGc(image, ref offset);
+                                    imask = imageReader.DecodeUnsignedGc(ref offset);
                                     AddNewTransition(new IPtrMask((int)curOffs, imask));
                                     break;
 
@@ -490,16 +490,16 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                                     break;
 
                                 case 0x08:
-                                    val = image[offset++];
+                                    val = imageReader.ReadByte(ref offset);
                                     callRegMask = val & 0xF;
                                     imask = val >> 4;
-                                    lastSkip = NativeReader.ReadUInt32(image, ref offset);
+                                    lastSkip = imageReader.ReadUInt32(ref offset);
                                     curOffs += lastSkip;
-                                    callArgCnt = NativeReader.ReadUInt32(image, ref offset);
-                                    callPndTabCnt = NativeReader.ReadUInt32(image, ref offset);
-                                    callPndTabSize = NativeReader.ReadUInt32(image, ref offset);
+                                    callArgCnt = imageReader.ReadUInt32(ref offset);
+                                    callPndTabCnt = imageReader.ReadUInt32(ref offset);
+                                    callPndTabSize = imageReader.ReadUInt32(ref offset);
                                     callPndTab = true;
-                                    SaveCallTransition(image, ref offset, val, curOffs, callRegMask, callPndTab, callPndTabCnt, callPndMask, lastSkip, ref imask);
+                                    SaveCallTransition(imageReader, ref offset, val, curOffs, callRegMask, callPndTab, callPndTabCnt, callPndMask, lastSkip, ref imask);
                                     break;
                                 case 0x0C:
                                     return;

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcSlotTable.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcSlotTable.cs
@@ -98,12 +98,12 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
         public GcSlotTable() { }
 
-        public GcSlotTable(byte[] image, InfoHdrSmall header, ref int offset)
+        public GcSlotTable(NativeReader imageReader, InfoHdrSmall header, ref int offset)
         {
             GcSlots = new List<GcSlot>();
 
-            DecodeUntracked(image, header, ref offset);
-            DecodeFrameVariableLifetimeTable(image, header, ref offset);
+            DecodeUntracked(imageReader, header, ref offset);
+            DecodeFrameVariableLifetimeTable(imageReader, header, ref offset);
         }
 
         public override string ToString()
@@ -124,7 +124,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
-        private void DecodeUntracked(byte[] image, InfoHdrSmall header, ref int offset)
+        private void DecodeUntracked(NativeReader imageReader, InfoHdrSmall header, ref int offset)
         {
             uint calleeSavedRegs = 0;
             if (header.DoubleAlign)
@@ -144,7 +144,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
                 char reg = header.EbpFrame ? 'B' : 'S';
 
-                stkOffsDelta = NativeReader.DecodeSignedGc(image, ref offset);
+                stkOffsDelta = imageReader.DecodeSignedGc(ref offset);
                 int stkOffs = lastStkOffs - stkOffsDelta;
                 lastStkOffs = stkOffs;
 
@@ -165,15 +165,15 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         /// <summary>
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
-        private void DecodeFrameVariableLifetimeTable(byte[] image, InfoHdrSmall header, ref int offset)
+        private void DecodeFrameVariableLifetimeTable(NativeReader imageReader, InfoHdrSmall header, ref int offset)
         {
             uint count = header.VarPtrTableSize;
             uint curOffs = 0;
             while (count-- > 0)
             {
-                uint varOffs = NativeReader.DecodeUnsignedGc(image, ref offset);
-                uint begOffs = NativeReader.DecodeUDelta(image, ref offset, curOffs);
-                uint endOffs = NativeReader.DecodeUDelta(image, ref offset, begOffs);
+                uint varOffs = imageReader.DecodeUnsignedGc(ref offset);
+                uint begOffs = imageReader.DecodeUDelta(ref offset, curOffs);
+                uint endOffs = imageReader.DecodeUDelta(ref offset, begOffs);
 
 
                 uint lowBits = varOffs & 0x3;

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
@@ -158,7 +158,8 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         }
     };
 
-    public class InfoHdrDecoder {
+    public class InfoHdrDecoder
+    {
 
         private const uint HAS_VARPTR = 0xFFFFFFFF;
         private const uint HAS_UNTRACKED = 0xFFFFFFFF;
@@ -181,14 +182,14 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         /// Initialize the GcInfo header
         /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> DecodeHeader and <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpInfoHdr</a>
         /// </summary>
-        public static InfoHdrSmall DecodeHeader(byte[] image, ref int offset, int codeLength)
+        public static InfoHdrSmall DecodeHeader(NativeReader imageReader, ref int offset, int codeLength)
         {
-            byte nextByte = image[offset++];
+            byte nextByte = imageReader.ReadByte(ref offset);
             byte encoding = (byte)(nextByte & 0x7f);
             InfoHdrSmall header = GetInfoHdr(encoding);
             while ((nextByte & (uint)InfoHdrAdjustConstants.MORE_BYTES_TO_FOLLOW) != 0)
             {
-                nextByte = image[offset++];
+                nextByte = imageReader.ReadByte(ref offset);
                 encoding = (byte)(nextByte & (uint)InfoHdrAdjustConstants.ADJ_ENCODING_MAX);
 
                 if (encoding < (uint)InfoHdrAdjust.NEXT_FOUR_START)
@@ -284,7 +285,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
                                 break;
 
                             case (byte)InfoHdrAdjust.NEXT_OPCODE:
-                                nextByte = image[offset++];
+                                nextByte = imageReader.ReadByte(ref offset);
                                 encoding = (byte)(nextByte & (int)InfoHdrAdjustConstants.ADJ_ENCODING_MAX);
                                 // encoding here always corresponds to codes in InfoHdrAdjust2 set
                                 if (encoding <= (int)InfoHdrAdjustConstants.SET_RET_KIND_MAX)
@@ -347,29 +348,29 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
             if (header.UntrackedCnt == HAS_UNTRACKED)
             {
                 header.HasArgTabOffset = true;
-                header.UntrackedCnt = NativeReader.DecodeUnsignedGc(image, ref offset);
+                header.UntrackedCnt = imageReader.DecodeUnsignedGc(ref offset);
             }
             if (header.VarPtrTableSize == HAS_VARPTR)
             {
                 header.HasArgTabOffset = true;
-                header.VarPtrTableSize = NativeReader.DecodeUnsignedGc(image, ref offset);
+                header.VarPtrTableSize = imageReader.DecodeUnsignedGc(ref offset);
             }
             if (header.GsCookieOffset == HAS_GS_COOKIE_OFFSET)
             {
-                header.GsCookieOffset = NativeReader.DecodeUnsignedGc(image, ref offset);
+                header.GsCookieOffset = imageReader.DecodeUnsignedGc(ref offset);
             }
             if (header.SyncStartOffset == HAS_SYNC_OFFSET)
             {
-                header.SyncStartOffset = NativeReader.DecodeUnsignedGc(image, ref offset);
-                header.SyncEndOffset = NativeReader.DecodeUnsignedGc(image, ref offset);
+                header.SyncStartOffset = imageReader.DecodeUnsignedGc(ref offset);
+                header.SyncEndOffset = imageReader.DecodeUnsignedGc(ref offset);
             }
             if (header.RevPInvokeOffset == HAS_REV_PINVOKE_FRAME_OFFSET)
             {
-                header.RevPInvokeOffset = NativeReader.DecodeUnsignedGc(image, ref offset);
+                header.RevPInvokeOffset = imageReader.DecodeUnsignedGc(ref offset);
             }
             if (header.NoGCRegionCnt == HAS_NOGCREGIONS)
             {
-                header.NoGCRegionCnt = NativeReader.DecodeUnsignedGc(image, ref offset);
+                header.NoGCRegionCnt = imageReader.DecodeUnsignedGc(ref offset);
             }
 
             header.Epilogs = new List<int>();
@@ -379,7 +380,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
                 for (int i = 0; i < header.EpilogCount; i++)
                 {
-                    offs = NativeReader.DecodeUDelta(image, ref offset, offs);
+                    offs = imageReader.DecodeUDelta(ref offset, offs);
                     header.Epilogs.Add((int)offs);
                 }
             }
@@ -391,7 +392,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
             if (header.HasArgTabOffset)
             {
-                header.ArgTabOffset = NativeReader.DecodeUnsignedGc(image, ref offset);
+                header.ArgTabOffset = imageReader.DecodeUnsignedGc(ref offset);
             }
 
             return header;

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/NoGcRegionTable.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/NoGcRegionTable.cs
@@ -23,7 +23,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
             public override string ToString()
             {
-                return $"            [{Offset:04X}-{Offset+Size:04X})\n";
+                return $"            [{Offset:04X}-{Offset + Size:04X})\n";
             }
         }
 
@@ -31,15 +31,15 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
         public NoGcRegionTable() { }
 
-        public NoGcRegionTable(byte[] image, InfoHdrSmall header, ref int offset)
+        public NoGcRegionTable(NativeReader imageReader, InfoHdrSmall header, ref int offset)
         {
             Regions = new List<NoGcRegion>((int)header.NoGCRegionCnt);
 
             uint count = header.NoGCRegionCnt;
             while (count-- > 0)
             {
-                uint regionOffset = NativeReader.DecodeUnsignedGc(image, ref offset);
-                uint regionSize = NativeReader.DecodeUnsignedGc(image, ref offset);
+                uint regionOffset = imageReader.DecodeUnsignedGc(ref offset);
+                uint regionSize = imageReader.DecodeUnsignedGc(ref offset);
                 Regions.Add(new NoGcRegion(regionOffset, regionSize));
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/UnwindInfo.cs
@@ -14,10 +14,10 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
         public UnwindInfo() { }
 
-        public UnwindInfo(byte[] image, int offset)
+        public UnwindInfo(NativeReader imageReader, int offset)
         {
             int startOffset = offset;
-            FunctionLength = NativeReader.DecodeUnsignedGc(image, ref offset);
+            FunctionLength = imageReader.DecodeUnsignedGc(ref offset);
             Size = offset - startOffset;
         }
 


### PR DESCRIPTION
Using `NativeReader` instead of a raw `byte[]` will allow cDAC to utilize existing R2R parsing tools in this package. This change also adds some support for reading both LE/BE images. However this isn't fully implemented. 

Modifies package to target netcore rather than netstandard.