### PR TITLE
Add (commented) test case that crashes LibraryImportGenerator

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -57,6 +57,9 @@ namespace LibraryImportGenerator.UnitTests
             // Not LibraryImportAttribute
             yield return new object[] { ID(), CodeSnippets.UserDefinedPrefixedAttributes, Array.Empty<DiagnosticResult>() };
 
+            // Bug: crashes
+            // yield return new[] { ID(), CodeSnippets.ImproperCollectionWithMarshalUsingOnElements };
+
             // No explicit marshalling for char or string
             yield return new object[] { ID(), CodeSnippets.BasicParametersAndModifiers<char>(), new[]
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -57,7 +57,7 @@ namespace LibraryImportGenerator.UnitTests
             // Not LibraryImportAttribute
             yield return new object[] { ID(), CodeSnippets.UserDefinedPrefixedAttributes, Array.Empty<DiagnosticResult>() };
 
-            // Bug: crashes
+            // Bug: https://github.com/dotnet/runtime/issues/117448
             // yield return new[] { ID(), CodeSnippets.ImproperCollectionWithMarshalUsingOnElements };
 
             // No explicit marshalling for char or string


### PR DESCRIPTION
Ran into this while testing some some sample code. When a collection marshaller does not conform to the correct shape and an element marshaller is specified, we crash the generator with a NullRef.

Filed https://github.com/dotnet/runtime/issues/117448 to track this.