### PR TITLE
Report folded method bodies in the MSTAT file

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/IObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/IObjectDumper.cs
@@ -8,5 +8,6 @@ namespace ILCompiler.DependencyAnalysis
     public interface IObjectDumper
     {
         void DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData);
+        void ReportFoldedNode(NodeFactory factory, ObjectNode originalNode, ISymbolNode targetNode);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
@@ -25,7 +25,7 @@ namespace ILCompiler
     public class MstatObjectDumper : ObjectDumper
     {
         private const int VersionMajor = 2;
-        private const int VersionMinor = 1;
+        private const int VersionMinor = 2;
 
         private readonly string _fileName;
         private readonly MstatEmitter _emitter;
@@ -40,6 +40,7 @@ namespace ILCompiler
         private List<(MethodDesc Method, string MangledName, int Size, int GcInfoSize)> _methods = new();
         private Dictionary<MethodDesc, int> _methodEhInfo = new();
         private Dictionary<string, int> _blobs = new();
+        private Dictionary<MethodDesc, List<(MethodDesc Method, int MangledName)>> _deduplicatedBodies = new();
 
         public MstatObjectDumper(string fileName, TypeSystemContext context)
         {
@@ -106,6 +107,17 @@ namespace ILCompiler
             }
         }
 
+        public override void ReportFoldedNode(NodeFactory factory, ObjectNode originalNode, ISymbolNode targetNode)
+        {
+            if (originalNode is IMethodBodyNode originalBody && targetNode is IMethodBodyNode targetBody)
+            {
+                if (!_deduplicatedBodies.TryGetValue(originalBody.Method, out List<(MethodDesc, int)> targetBodies))
+                    _deduplicatedBodies.Add(originalBody.Method, targetBodies = new List<(MethodDesc, int)>());
+
+                targetBodies.Add((targetBody.Method, AppendMangledName(targetBody.GetName(factory))));
+            }
+        }
+
         private void DumpFrozenRegion(NodeFactory factory)
         {
             Debug.Assert(_frozenObjects.Offset == 0);
@@ -168,12 +180,27 @@ namespace ILCompiler
                 blobs.LoadConstantI4(b.Value);
             }
 
+            var deduplicatedMethods = new InstructionEncoder(new BlobBuilder());
+            foreach (var d in _deduplicatedBodies)
+            {
+                deduplicatedMethods.OpCode(ILOpCode.Ldtoken);
+                deduplicatedMethods.Token(_emitter.EmitMetadataHandleForTypeSystemEntity(d.Key));
+                deduplicatedMethods.LoadConstantI4(d.Value.Count);
+                foreach (var o in d.Value)
+                {
+                    deduplicatedMethods.OpCode(ILOpCode.Ldtoken);
+                    deduplicatedMethods.Token(_emitter.EmitMetadataHandleForTypeSystemEntity(o.Method));
+                    deduplicatedMethods.LoadConstantI4(o.MangledName);
+                }
+            }
+
             _emitter.AddGlobalMethod("Methods", methods, 0);
             _emitter.AddGlobalMethod("Types", _types, 0);
             _emitter.AddGlobalMethod("Blobs", blobs, 0);
             _emitter.AddGlobalMethod("RvaFields", _fieldRvas, 0);
             _emitter.AddGlobalMethod("FrozenObjects", _frozenObjects, 0);
             _emitter.AddGlobalMethod("ManifestResources", _manifestResources, 0);
+            _emitter.AddGlobalMethod("DeduplicatedMethods", deduplicatedMethods, 0);
 
             _emitter.AddPESection(".names", _mangledNames);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDumper.cs
@@ -16,6 +16,8 @@ namespace ILCompiler
         void IObjectDumper.DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData) => DumpObjectNode(factory, node, objectData);
         protected abstract void DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData);
 
+        public virtual void ReportFoldedNode(NodeFactory factory, ObjectNode originalNode, ISymbolNode targetNode) { }
+
         protected static string GetObjectNodeName(ObjectNode node)
         {
             string name = node.GetType().Name;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
@@ -385,8 +385,12 @@ namespace ILCompiler.ObjectWriter
                     continue;
 
                 ISymbolNode symbolNode = node as ISymbolNode;
-                if (_nodeFactory.ObjectInterner.GetDeduplicatedSymbol(_nodeFactory, symbolNode) != symbolNode)
+                ISymbolNode deduplicatedSymbolNode = _nodeFactory.ObjectInterner.GetDeduplicatedSymbol(_nodeFactory, symbolNode);
+                if (deduplicatedSymbolNode != symbolNode)
+                {
+                    dumper?.ReportFoldedNode(_nodeFactory, node, deduplicatedSymbolNode);
                     continue;
+                }
 
                 ObjectData nodeContents = node.GetData(_nodeFactory);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReachabilityInstrumentationProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReachabilityInstrumentationProvider.cs
@@ -218,7 +218,7 @@ namespace ILCompiler
                 bool IDependencyNode<NodeFactory>.StaticDependenciesAreComputed => true;
                 bool IDependencyNode.Marked => true;
 
-                public string GetName(NodeFactory context) => _name;
+                string IDependencyNode<NodeFactory>.GetName(NodeFactory context) => _name;
                 void ISymbolNode.AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb) => sb.Append(_name);
                 IEnumerable<CombinedDependencyListEntry> IDependencyNode<NodeFactory>.GetConditionalStaticDependencies(NodeFactory context) => throw new NotImplementedException();
                 IEnumerable<DependencyListEntry> IDependencyNode<NodeFactory>.GetStaticDependencies(NodeFactory context) => null;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReachabilityInstrumentationProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReachabilityInstrumentationProvider.cs
@@ -218,6 +218,7 @@ namespace ILCompiler
                 bool IDependencyNode<NodeFactory>.StaticDependenciesAreComputed => true;
                 bool IDependencyNode.Marked => true;
 
+                public string GetName(NodeFactory context) => _name;
                 void ISymbolNode.AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb) => sb.Append(_name);
                 IEnumerable<CombinedDependencyListEntry> IDependencyNode<NodeFactory>.GetConditionalStaticDependencies(NodeFactory context) => throw new NotImplementedException();
                 IEnumerable<DependencyListEntry> IDependencyNode<NodeFactory>.GetStaticDependencies(NodeFactory context) => null;

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyNodeCore.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyNodeCore.cs
@@ -147,6 +147,8 @@ namespace ILCompiler.DependencyAnalysisFramework
         // Force all non-abstract nodes to provide a name
         protected abstract string GetName(DependencyContextType context);
 
+        string IDependencyNode<DependencyContextType>.GetName(DependencyContextType context) => GetName(context);
+
         // We would prefer GetName to be "protected internal", but that will break people who want to source
         // include the dependency analysis framework. When nobody does that, maybe we can get rid of this method.
         internal string GetNameInternal(DependencyContextType context)

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/IDependencyNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/IDependencyNode.cs
@@ -40,5 +40,7 @@ namespace ILCompiler.DependencyAnalysisFramework
         IEnumerable<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> GetConditionalStaticDependencies(DependencyContextType context);
 
         IEnumerable<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<DependencyContextType>> markedNodes, int firstNode, DependencyContextType context);
+
+        string GetName(DependencyContextType context);
     }
 }


### PR DESCRIPTION
So that we have this for statistics or visualizations when needed.

Cc @dotnet/ilc-contrib 