### PR TITLE
Fix illumos compile error in coreclr/vm/appdomain.hpp

### DIFF
--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -927,7 +927,7 @@ CDAC_GLOBAL_STRING(RID, RID_STRING)
 CDAC_GLOBAL(GCInfoVersion, uint32, GCINFO_VERSION)
 
 CDAC_GLOBAL_POINTER(AppDomain, &AppDomain::m_pTheAppDomain)
-CDAC_GLOBAL_POINTER(SystemDomain, cdac_data<SystemDomain>::SystemDomain)
+CDAC_GLOBAL_POINTER(SystemDomain, cdac_data<SystemDomain>::SystemDomainPtr)
 CDAC_GLOBAL_POINTER(ThreadStore, &ThreadStore::s_pThreadStore)
 CDAC_GLOBAL_POINTER(FinalizerThread, &::g_pFinalizerThread)
 CDAC_GLOBAL_POINTER(GCThread, &::g_pSuspensionThread)

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -1937,7 +1937,7 @@ public:
 template<>
 struct cdac_data<SystemDomain>
 {
-    static constexpr PTR_SystemDomain* SystemDomain = &SystemDomain::m_pSystemDomain;
+    static constexpr PTR_SystemDomain* SystemDomainPtr = &SystemDomain::m_pSystemDomain;
 };
 #endif // DACCESS_COMPILE
 


### PR DESCRIPTION
Using gcc 13.3 configured as a cross-compiler:
```
$ /crossrootfs/x64/bin/x86_64-illumos-gcc --version
x86_64-illumos-gcc (GCC) 13.3.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
``` 
There are `Wchanges-meaning` errors in src/coreclr/vm/appdomain.hpp
```
src/coreclr/vm/appdomain.hpp:1934:40: error: declaration of 'constexpr SystemDomain** const cdac_data<SystemDomain>::SystemDomain' changes meaning of 'SystemDomain' [-Wchanges-meaning]
   1934 |     static constexpr PTR_SystemDomain* SystemDomain = &SystemDomain::m_pSystemDomain;
        |                                        ^~~~~~~~~~~~
  src/coreclr/vm/appdomain.hpp:1934:56: note: used here to mean 'class SystemDomain'
   1934 |     static constexpr PTR_SystemDomain* SystemDomain = &SystemDomain::m_pSystemDomain;
        |                                                        ^~~~~~~~~~~~
  src/coreclr/vm/appdomain.hpp:1629:7: note: declared here
   1629 | class SystemDomain final
        |       ^~~~~~~~~~~~
```
What I read about `Wchanges-meaning` errors recommends renaming one of the things in conflict to avoid the problem, which is what this change does.  Is this OK?
I'm not sure about this fix, but it let things build for me.

FWIW, the change here is similar to how other problems were fixed in  3099f31cc7dda1a70318c9ee1aefebee7ad588e2