### PR TITLE
Fix illumos compile error in coreclr/runtime/amd64/AllocFast.S

### DIFF
--- a/src/coreclr/runtime/amd64/AllocFast.S
+++ b/src/coreclr/runtime/amd64/AllocFast.S
@@ -233,8 +233,11 @@ LEAF_END RhpNewArrayFast, _TEXT
 LEAF_ENTRY RhpNewPtrArrayFast, _TEXT
 
         // Delegate overflow handling to the generic helper conservatively
+        // The constant 0x8000000 is (0x40000000 / sizeof(void*))
+        // Some assemblers don't like an expression here, so the
+        // constant expression is reduced to it's simple form.
 
-        cmp         rsi, (0x40000000 / 8) // sizeof(void*)
+        cmp         rsi, 0x8000000        // (0x40000000 / 8)
         jae         C_FUNC(RhpNewArrayFast)
 
         // In this case we know the element size is sizeof(void *), or 8 for x64


### PR DESCRIPTION
Using gcc 13.3 configured as a cross-compiler:
```
$ /crossrootfs/x64/bin/x86_64-illumos-gcc --version
x86_64-illumos-gcc (GCC) 13.3.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
``` 
And the GNU assembler that uses:
```
$ /crossrootfs/x64/bin/x86_64-illumos-as --version
GNU assembler (GNU Binutils) 2.42
Copyright (C) 2024 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or later.
This program has absolutely no warranty.
This assembler was configured for a target of `x86_64-sun-solaris2.11'.
```
There are compiler errors in src/coreclr/runtime/amd64/AllocFast.S
```
 coreclr/runtime/amd64/AllocFast.S: Assembler messages:
  coreclr/runtime/amd64/AllocFast.S:237: Error: missing ')'
```