### PR TITLE
Fix illumos compile errors in coreclr/tools/superpmi/mcs/verbmerge.cpp

### DIFF
--- a/src/coreclr/tools/superpmi/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/CMakeLists.txt
@@ -1,3 +1,6 @@
+include(configure.cmake)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 add_subdirectory(superpmi)
 add_subdirectory(mcs)
 add_subdirectory(superpmi-shim-collector)

--- a/src/coreclr/tools/superpmi/config.h.in
+++ b/src/coreclr/tools/superpmi/config.h.in
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
+#cmakedefine01 HAVE_DIRENT_D_TYPE
+
+#endif // __CONFIG_H__

--- a/src/coreclr/tools/superpmi/configure.cmake
+++ b/src/coreclr/tools/superpmi/configure.cmake
@@ -1,0 +1,7 @@
+include(CheckStructHasMember)
+
+check_struct_has_member ("struct dirent" d_type dirent.h HAVE_DIRENT_D_TYPE)
+
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+	${CMAKE_CURRENT_BINARY_DIR}/config.h)

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -6,12 +6,19 @@
 #include "simpletimer.h"
 #include "logging.h"
 #include "spmiutil.h"
+#include "config.h"
 #include <stdio.h>
 #ifdef TARGET_UNIX
 #include <sys/types.h>
 #include <dirent.h>
 #include <fnmatch.h>
-#endif
+#if !HAVE_DIRENT_D_TYPE
+#define DT_UNKNOWN 0
+#define DT_DIR 4
+#define DT_REG 8
+#define DT_LNK 10
+#endif // !HAVE_DIRENT_D_TYPE
+#endif // TARGET_UNIX
 
 #include <utility>
 
@@ -187,9 +194,9 @@ bool verbMerge::DirectoryFilterDirectories(FilterArgType* findData)
 #else // TARGET_WINDOWS
     if (findData->d_type == DT_DIR)
     {
-        if (strcmp(findData->d_name, ".") == 0)
+        if (u16_strcmp(findData->cFileName, W(".")) == 0)
             return false;
-        if (strcmp(findData->d_name, "..") == 0)
+        if (u16_strcmp(findData->cFileName, W("..")) == 0)
             return false;
 
         return true;
@@ -277,18 +284,58 @@ int verbMerge::FilterDirectory(LPCWSTR                      dir,
     DIR* pDir = opendir(dirUtf8.c_str());
     if (pDir != nullptr)
     {
-        errno = 0;
-        dirent *pEntry = readdir(pDir);
-        while (pEntry != nullptr)
+        while (true)
         {
-            if ((fnmatch(searchPatternUtf8.c_str(), pEntry->d_name, 0) == 0) && filter(pEntry))
+            dirent *pEntry;
+            int dirEntryType;
+
+            errno = 0;
+            pEntry = readdir(pDir);
+            if (pEntry == nullptr)
+                break;
+
+#if HAVE_DIRENT_D_TYPE
+            dirEntryType = pEntry->d_type;
+#else
+            dirEntryType = DT_UNKNOWN;
+#endif
+            // On some systems, dirent contains a d_type field, but note:
+            // some file systems MAY leave d_type == DT_UNKNOWN,
+            // expecting the consumer to stat the file. On systems
+            // without a d_type simply always stat the file.
+
+            if (dirEntryType == DT_UNKNOWN)
             {
-                FindData findData(pEntry->d_type, ConvertMultiByteToWideChar(pEntry->d_name));
+                struct stat sb;
+
+                if (fstatat(dirfd(pDir), pEntry->d_name, &sb, 0) == -1)
+                    continue;
+
+                if (S_ISDIR(sb.st_mode))
+                    dirEntryType = DT_DIR;
+                else if (S_ISREG(sb.st_mode))
+                    dirEntryType = DT_REG;
+                else if (S_ISLNK(sb.st_mode))
+                    dirEntryType = DT_LNK;
+                else
+                    dirEntryType = DT_UNKNOWN;
+
+            }
+
+            if (dirEntryType == DT_UNKNOWN)
+                continue;
+
+            if (fnmatch(searchPatternUtf8.c_str(), pEntry->d_name, 0) != 0)
+                continue;
+
+            // Call the filter with &FindData like the Windows code below.
+            FindData findData(dirEntryType, ConvertMultiByteToWideChar(pEntry->d_name));
+            if (filter(&findData))
+            {
+                // Prepend it to the list.
                 first = new findDataList(&findData, first);
                 ++elemCount;
             }
-            errno = 0;
-            pEntry = readdir(pDir);
         }
 
         if (errno != 0)

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.h
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.h
@@ -65,7 +65,7 @@ private:
 #ifdef TARGET_WINDOWS
     typedef _WIN32_FIND_DATAW FilterArgType;
 #else
-    typedef struct dirent FilterArgType;
+    typedef struct FindData FilterArgType;
 #endif
 
     typedef bool (*DirectoryFilterFunction_t)(FilterArgType*);


### PR DESCRIPTION
When cross-compiling for illumos, which has no "d_type" field in struct dirent:
```
  /runtime/src/coreclr/tools/superpmi/mcs/verbmerge.cpp: In static member function 'static bool verbMerge::DirectoryFilterDirectories(FilterArgType*)':
  /runtime/src/coreclr/tools/superpmi/mcs/verbmerge.cpp:188:19: error: 'verbMerge::FilterArgType' {aka 'struct dirent'} has no member named 'd_type'
    188 |     if (findData->d_type == DT_DIR)
        |                   ^~~~~~
```
and similar a few other places in this file

For the fix, do similarly as: src/native/corehost/hostmisc/pal.unix.cpp

Let FilterArgType use struct FindData to simplify filters.
Handle the possibility of finding d_type == DT_UNKOWN

This part is from @am11 (Thanks!)
Add HAVE_DIRENT_D_TYPE introspection