### PR TITLE
Fix using right configuration provider order when getting configuration value

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -3007,5 +3007,36 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             Assert.Equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], instance.ByteArray3);
 #endif
         }
+
+        [Fact]
+        public void TestProvidersOrder()
+        {
+            string jsonConfig1 = @"
+            {
+                ""SimplePoco"": {
+                    ""A"": ""Provider1A"",
+                    ""B"": ""Provider1B"",
+                },
+            }";
+
+            // Missing B in the second provider should not override the value from the first provider.
+            string jsonConfig2 = @"
+            {
+                ""SimplePoco"": {
+                    ""A"": ""Provider2A"",
+                },
+            }";
+
+            var configuration = new ConfigurationBuilder()
+                        .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(jsonConfig1)))
+                        .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(jsonConfig2)))
+                        .Build().GetSection("SimplePoco");
+
+            SimplePoco? result = configuration.Get<SimplePoco>();
+
+            Assert.NotNull(result);
+            Assert.Equal("Provider2A", result.A); // Value should come from the last provider
+            Assert.Equal("Provider1B", result.B); // B should not be overridden by the second provider
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration/src/InternalConfigurationRootExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/InternalConfigurationRootExtensions.cs
@@ -42,8 +42,15 @@ namespace Microsoft.Extensions.Configuration
 
         internal static bool TryGetConfiguration(this IConfigurationRoot root, string key, out string? value)
         {
-            foreach (IConfigurationProvider provider in root.Providers)
+            // common cases Providers is IList<IConfigurationProvider> in ConfigurationRoot
+            IList<IConfigurationProvider> providers = root.Providers is IList<IConfigurationProvider> list
+                ? list
+                : root.Providers.ToList();
+
+            // ensure looping in the reverse order
+            for (int i = providers.Count - 1; i >= 0; i--)
             {
+                IConfigurationProvider provider = providers[i];
                 if (provider.TryGet(key, out value))
                 {
                     return true;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/117444
Fixes https://github.com/dotnet/runtime/issues/117445
Fixes https://github.com/dotnet/runtime/issues/117469

We recently made a change https://github.com/dotnet/runtime/pull/116677 to support null values in configuration. Initially, the code was performing the configuration value lookup in the order the providers are stored in the root configuration object. However, to align with standard behavior, the lookup should occur in reverse order, as that's how configuration resolution typically works.

I've manually verified the fix against all reported issues and added a test case to cover this previously missed scenario.