### PR TITLE
JIT: Tolerate underflow when reducing flow into ex-successor of folded condition

### DIFF
--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -5019,7 +5019,7 @@ void Compiler::fgRepairProfileCondToUncond(BasicBlock* block,
     //
     weight_t const weight = removedEdge->getLikelyWeight();
 
-    if (weight == 0.0)
+    if (weight == BB_ZERO_WEIGHT)
     {
         return;
     }
@@ -5056,30 +5056,28 @@ void Compiler::fgRepairProfileCondToUncond(BasicBlock* block,
 
     if (alternate->hasProfileWeight())
     {
-        weight_t const alternateNewWeight = alternate->bbWeight - weight;
-
-        // If profile weights are consistent, expect at worst a slight underflow.
-        //
-        const bool checkProfileConsistency = hasFlag(activePhaseChecks, PhaseChecks::CHECK_PROFILE);
-        if (checkProfileConsistency && fgPgoConsistent && (alternateNewWeight < 0.0))
-        {
-            assert(fgProfileWeightsEqual(alternateNewWeight, 0.0));
-        }
-        alternate->setBBProfileWeight(max(0.0, alternateNewWeight));
+        alternate->decreaseBBProfileWeight(weight);
     }
     else
     {
         missingProfileData = true;
     }
 
-    // Check for the special case where the block's postdominator
-    // is target's target (simple if/then/else/join).
+    // Check for the special cases where both successors are leaves,
+    // or the block's postdominator is target's target (simple if/then/else/join).
     //
     // TODO: try a bit harder to find a postdominator, if it's "nearby"
     //
-    if (!missingProfileData && target->KindIs(BBJ_ALWAYS))
+    if (!missingProfileData)
     {
-        repairWasComplete = alternate->KindIs(BBJ_ALWAYS) && (alternate->GetTarget() == target->GetTarget());
+        if ((target->NumSucc() == 0) && (alternate->NumSucc() == 0))
+        {
+            repairWasComplete = true;
+        }
+        else if (target->KindIs(BBJ_ALWAYS))
+        {
+            repairWasComplete = target->TargetIs(alternate->GetUniqueSucc());
+        }
     }
 
     if (missingProfileData)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12752,15 +12752,10 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
             block->SetKindAndTargetEdge(BBJ_ALWAYS, retainedEdge);
             fgRepairProfileCondToUncond(block, retainedEdge, removedEdge);
 
-#ifdef DEBUG
-            if (verbose)
-            {
-                printf("\nConditional folded at " FMT_BB "\n", block->bbNum);
-                printf(FMT_BB " becomes a %s", block->bbNum, "BBJ_ALWAYS");
-                printf(" to " FMT_BB, block->GetTarget()->bbNum);
-                printf("\n");
-            }
-#endif
+            JITDUMP("\nConditional folded at " FMT_BB "\n", block->bbNum);
+            JITDUMP(FMT_BB " becomes a %s", block->bbNum, "BBJ_ALWAYS");
+            JITDUMP(" to " FMT_BB, block->GetTarget()->bbNum);
+            JITDUMP("\n");
         }
     }
     else if (block->KindIs(BBJ_SWITCH))


### PR DESCRIPTION
Fixes #117371. Also makes the profile inconsistency detection slightly smarter by recognizing that changes to flow into zero-successor blocks don't affect global consistency.