### PR TITLE
JIT: Fix isEmbeddedMaskingCompatible logic

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -20712,7 +20712,7 @@ bool GenTree::isEmbeddedMaskingCompatible(Compiler* comp, unsigned tgtMaskSize, 
         return false;
     }
 
-    if (comp->canUseEmbeddedMasking())
+    if (!comp->canUseEmbeddedMasking())
     {
         return false;
     }
@@ -20871,7 +20871,7 @@ bool GenTree::isEmbeddedMaskingCompatible(Compiler* comp, unsigned tgtMaskSize, 
     unsigned maskSize = maskBaseSize * (genTypeSize(simdType) / 16);
     assert(maskSize != 0);
 
-    return maskSize != tgtMaskSize;
+    return maskSize == tgtMaskSize;
 }
 #endif // TARGET_XARCH
 


### PR DESCRIPTION
This was blocking containment of embedded masking compatible instructions under BlendVariableMask