### PR TITLE
[H/3] Fix response header tests for H/3

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -73,7 +73,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(15)]
         public async Task LargeSingleHeader_ThrowsException(int maxResponseHeadersLength)
         {
-            var semaphore = new SemaphoreSlim(0);
+            var ce = new CountdownEvent(2);
             using HttpClientHandler handler = CreateHttpClientHandler();
             handler.MaxResponseHeadersLength = maxResponseHeadersLength;
 
@@ -86,7 +86,8 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
                 }
-                await semaphore.WaitAsync();
+                ce.Signal();
+                ce.Wait(TestHelper.PassingTestTimeout);
             },
             async server =>
             {
@@ -105,7 +106,8 @@ namespace System.Net.Http.Functional.Tests
 #endif
                 finally
                 {
-                    semaphore.Release();
+                    ce.Signal();
+                    ce.Wait(TestHelper.PassingTestTimeout);
                     await connection.DisposeAsync();
                 }
             });
@@ -119,7 +121,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(int.MaxValue / 800, 100 * 1024)] // Capped at int.MaxValue
         public async Task ThresholdExceeded_ThrowsException(int? maxResponseHeadersLength, int headersLengthEstimate)
         {
-            var semaphore = new SemaphoreSlim(0);
+            var ce = new CountdownEvent(2);
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 using HttpClientHandler handler = CreateHttpClientHandler();
@@ -143,7 +145,8 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
                     }
                 }
-                await semaphore.WaitAsync();
+                ce.Signal();
+                ce.Wait(TestHelper.PassingTestTimeout);
             },
             async server =>
             {
@@ -168,7 +171,8 @@ namespace System.Net.Http.Functional.Tests
 #endif
                 finally
                 {
-                    semaphore.Release();
+                    ce.Signal();
+                    ce.Wait(TestHelper.PassingTestTimeout);
                     await connection.DisposeAsync();
                 }
             });

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -73,7 +73,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(15)]
         public async Task LargeSingleHeader_ThrowsException(int maxResponseHeadersLength)
         {
-            var ce = new CountdownEvent(2);
+            using var ce = new CountdownEvent(2);
             using HttpClientHandler handler = CreateHttpClientHandler();
             handler.MaxResponseHeadersLength = maxResponseHeadersLength;
 
@@ -121,7 +121,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(int.MaxValue / 800, 100 * 1024)] // Capped at int.MaxValue
         public async Task ThresholdExceeded_ThrowsException(int? maxResponseHeadersLength, int headersLengthEstimate)
         {
-            var ce = new CountdownEvent(2);
+            using var ce = new CountdownEvent(2);
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 using HttpClientHandler handler = CreateHttpClientHandler();


### PR DESCRIPTION
This time server was the one closing the connection while the client is still waiting on stream abort:
```
System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_MaxResponseHeadersLength_Http3.ThresholdExceeded_ThrowsException(maxResponseHeadersLength: 2684354, headersLengthEstimate: 102400) [FAIL]
      System.Net.Http.HttpRequestException : An error occurred while sending the request.
      ---- System.Net.Http.HttpProtocolException : The HTTP/3 server closed the connection. HTTP/3 error code 'H3_NO_ERROR' (0x100). (HttpProtocolError)
      Stack Trace:
        /_/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs(321,0): at System.Net.Http.Http3RequestStream.SendAsync(CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs(398,0): at System.Net.Http.Http3RequestStream.SendAsync(CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs(339,0): at System.Net.Http.Http3Connection.SendAsync(HttpRequestMessage request, WaitForHttp3ConnectionActivity waitForConnectionActivity, Boolean streamAvailable, CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs(353,0): at System.Net.Http.Http3Connection.SendAsync(HttpRequestMessage request, WaitForHttp3ConnectionActivity waitForConnectionActivity, Boolean streamAvailable, CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs(107,0): at System.Net.Http.HttpConnectionPool.TrySendUsingHttp3Async(HttpRequestMessage request, CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs(419,0): at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs(29,0): at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs(629,0): at System.Net.Http.SocketsHttpHandler.<SendAsync>g__CreateHandlerAndSendAsync|115_0(HttpRequestMessage request, CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs(523,0): at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
        /_/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs(136,0): at System.Net.Http.Functional.Tests.HttpClientHandler_MaxResponseHeadersLength_Test.<>c__DisplayClass6_0.<<ThresholdExceeded_ThrowsException>b__0>d.MoveNext()
        --- End of stack trace from previous location ---
        /_/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs(120,0): at System.Threading.Tasks.TaskTimeoutExtensions.GetRealException(Task task)
        --- End of stack trace from previous location ---
        /_/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs(90,0): at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks)
        /_/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs(44,0): at System.Net.Test.Common.LoopbackServerFactory.<>c__DisplayClass6_0.<<CreateClientAndServerAsync>b__0>d.MoveNext()
        --- End of stack trace from previous location ---
        /_/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs(115,0): at System.Net.Test.Common.Http3LoopbackServerFactory.CreateServerAsync(Func`3 funcAsync, Int32 millisecondsTimeout, GenericLoopbackOptions options)
        /_/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs(123,0): at System.Net.Http.Functional.Tests.HttpClientHandler_MaxResponseHeadersLength_Test.ThresholdExceeded_ThrowsException(Nullable`1 maxResponseHeadersLength, Int32 headersLengthEstimate)
        --- End of stack trace from previous location ---
        ----- Inner Stack Trace -----
        
```

So wait with connection disposal on both sides.

Fixes #117484