### PR TITLE
Fold ARR_LENGTH to CNS with live assertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4904,8 +4904,10 @@ GenTree* Compiler::optAssertionProp_ArrMetaData(ASSERT_VALARG_TP assertions, Gen
         while (iter.NextElem(&index))
         {
             AssertionDsc* curAssertion = optGetAssertion(GetAssertionIndex(index));
-            if (curAssertion->IsConstantInt32Assertion() && (curAssertion->op1.vn == vn))
+            if (curAssertion->IsConstantInt32Assertion() && (curAssertion->op1.vn == vn) &&
+                (curAssertion->assertionKind == OAK_EQUAL))
             {
+                assert(!curAssertion->op2.HasIconFlag());
                 return optAssertionProp_Update(gtNewIconNodeWithVN(this, curAssertion->op2.u1.iconVal, tree->TypeGet()),
                                                tree, stmt);
             }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8095,6 +8095,7 @@ public:
     GenTree* optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions, GenTreeOp* tree, Statement* stmt, BasicBlock* block);
     GenTree* optAssertionProp_Return(ASSERT_VALARG_TP assertions, GenTreeOp* ret, Statement* stmt);
     GenTree* optAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
+    GenTree* optAssertionProp_ArrMetaData(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
     GenTree* optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTreeCast* cast, Statement* stmt, BasicBlock* block);
     GenTree* optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call, Statement* stmt);
     GenTree* optAssertionProp_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt, BasicBlock* block);
@@ -8108,7 +8109,7 @@ public:
     GenTree* optAssertionProp_Update(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call);
     bool     optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
-    bool     optWriteBarrierAssertionProp_StoreInd(ASSERT_VALARG_TP assertions, GenTreeStoreInd* indir);
+    bool     optWriteBarrierAssertionProp_StoreInd(GenTreeStoreInd* indir);
 
     enum class AssertVisit
     {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7335,6 +7335,9 @@ bool GenTree::OperSupportsOrderingSideEffect() const
     {
         case GT_ARR_ADDR:
         case GT_BOUNDS_CHECK:
+        case GT_ARR_LENGTH:
+        case GT_MDARR_LENGTH:
+        case GT_MDARR_LOWER_BOUND:
         case GT_IND:
         case GT_BLK:
         case GT_STOREIND:


### PR DESCRIPTION
When we have "VN == CNS" assertion, we can replace `ARR_LENGTH` tree with that `CNS` if `ARR_LENTH` has that VN. Perhaps, we can replace other kinds of trees with CNS, but seems to be profitable only `ARR_LENGTH` now (there are lots of candidates for `IND` node as well, but with mixed diffs).


Normally, it's not needed when `ARR_LENGTH` is CSE'd so our existing logic knows how to do that replacement for LCL_VAR, but sometimes it's not CSE'd.