### PR TITLE
Fix WebSocket test causing assert

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
@@ -244,7 +244,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on this platform")]
         public async Task ConnectAsync_Http11WithRequestVersionOrHigher_Loopback_Success()
         {


### PR DESCRIPTION
Fixes `ConnectAsync_Http11WithRequestVersionOrHigher_Loopback_Success` that used `UseSsl=true` without checking for `PlatformDetection.SupportsAlpn`

Fixes #117293