### PR TITLE
Add acquire barrier to populate bit reading

### DIFF
--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -3180,7 +3180,7 @@ public:
     BOOL IsPopulated()
     {
         LIMITED_METHOD_CONTRACT;
-        return (ndirect.m_wFlags & kNDirectPopulated) != 0;
+        return (VolatileLoad(&ndirect.m_wFlags) & kNDirectPopulated) != 0;
     }
 
     ULONG DefaultDllImportSearchPathsAttributeCachedValue()


### PR DESCRIPTION
The setting of the `NDirectMethodDesc::kNDirectPopulated` bit is done via an interlocked operation. This bit is used to indicate if the `NDirectMethodDesc` has been populated with the needed information to load the P/Invoke. The reading of this bit however was missing an acquire barrier and thus setting of fields between the check and set weren't being observed correctly.

Fixes #112565 

This should be considered to backport to .NET 9.0.