### PR TITLE
Increase cost of ARR_LENGTH node to match IND(ADD(..,CNS))

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5501,9 +5501,9 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 case GT_MDARR_LOWER_BOUND:
                     level++;
 
-                    // Array meta-data access should be the same as an indirection, which has a costEx of IND_COST_EX.
-                    costEx = IND_COST_EX - 1;
-                    costSz = 2;
+                    // Array meta-data access should be the same as an IND(ADD(ADDR, SMALL_CNS)).
+                    costEx = IND_COST_EX + 1;
+                    costSz = 2 * 2;
                     break;
 
                 case GT_BLK:


### PR DESCRIPTION
ARR_LENGTH was (2,2) while IND(ADD(addr, 8)) is (4,4) while both are effectively the same.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1091782&view=ms.vss-build-web.run-extensions-tab) - seems to be a big PerfScore improvement. Surprisingly, it's also a size improvement on arm64.