### PR TITLE
[HTTP Telemetry] Prioritize Host header when emitting `server.address`

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -64,6 +64,7 @@
     <Compile Include="System\Net\Http\HttpIOException.cs" />
     <Compile Include="System\Net\Http\HttpRuleParser.cs" />
     <Compile Include="System\Net\Http\HttpTelemetry.cs" />
+    <Compile Include="System\Net\Http\HttpUtilities.cs" />
     <Compile Include="System\Net\Http\HttpVersionPolicy.cs" />
     <Compile Include="System\Net\Http\MessageProcessingHandler.cs" />
     <Compile Include="System\Net\Http\MultipartContent.cs" />
@@ -209,7 +210,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpContentStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpContentWriteStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpKeepAlivePingPolicy.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpUtilities.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpUtilities.SocketsHttpHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\IHttpTrace.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\IMultiWebProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\MultiProxy.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -45,8 +45,6 @@ namespace System.Net.Http
                 }
                 _propagatorFields = fieldDescriptors.ToArray();
             }
-
-            _proxy = proxy;
         }
 
         private static bool IsEnabled()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -21,14 +21,16 @@ namespace System.Net.Http
         private readonly HttpMessageHandler _innerHandler;
         private readonly DistributedContextPropagator _propagator;
         private readonly HeaderDescriptor[]? _propagatorFields;
+        private readonly IWebProxy? _proxy;
 
-        public DiagnosticsHandler(HttpMessageHandler innerHandler, DistributedContextPropagator propagator, bool autoRedirect = false)
+        public DiagnosticsHandler(HttpMessageHandler innerHandler, DistributedContextPropagator propagator, IWebProxy? proxy, bool autoRedirect = false)
         {
             Debug.Assert(GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation);
             Debug.Assert(innerHandler is not null && propagator is not null);
 
             _innerHandler = innerHandler;
             _propagator = propagator;
+            _proxy = proxy;
 
             // Prepare HeaderDescriptors for fields we need to clear when following redirects
             if (autoRedirect && _propagator.Fields is IReadOnlyCollection<string> fields && fields.Count > 0)
@@ -43,6 +45,8 @@ namespace System.Net.Http
                 }
                 _propagatorFields = fieldDescriptors.ToArray();
             }
+
+            _proxy = proxy;
         }
 
         private static bool IsEnabled()
@@ -125,7 +129,7 @@ namespace System.Net.Http
 
                     if (request.RequestUri is Uri requestUri && requestUri.IsAbsoluteUri)
                     {
-                        activity.SetTag("server.address", requestUri.Host);
+                        activity.SetTag("server.address", DiagnosticsHelper.GetServerAddress(request, _proxy));
                         activity.SetTag("server.port", requestUri.Port);
                         activity.SetTag("url.full", UriRedactionHelper.GetRedactedUriString(requestUri));
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHelper.cs
@@ -46,7 +46,7 @@ namespace System.Net.Http
                 return HttpUtilities.ParseHostNameFromHeader(hostHeader);
             }
 
-            return request.RequestUri.Host;
+            return request.RequestUri.IdnHost;
         }
 
         public static bool TryGetErrorType(HttpResponseMessage? response, Exception? exception, out string? errorType)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHelper.cs
@@ -35,6 +35,20 @@ namespace System.Net.Http
             _ => httpVersion.ToString()
         };
 
+        // Picks the value of the 'server.address' tag following rules specified in
+        // https://github.com/open-telemetry/semantic-conventions/blob/728e5d1/docs/http/http-spans.md#http-client-span
+        // When there is no proxy, we need to prioritize the contents of the Host header.
+        public static string GetServerAddress(HttpRequestMessage request, IWebProxy? proxy)
+        {
+            Debug.Assert(request.RequestUri is not null);
+            if ((proxy is null || proxy.IsBypassed(request.RequestUri)) && request.HasHeaders && request.Headers.Host is string hostHeader)
+            {
+                return HttpUtilities.ParseHostNameFromHeader(hostHeader);
+            }
+
+            return request.RequestUri.Host;
+        }
+
         public static bool TryGetErrorType(HttpResponseMessage? response, Exception? exception, out string? errorType)
         {
             if (response is not null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHelper.cs
@@ -38,6 +38,7 @@ namespace System.Net.Http
         // Picks the value of the 'server.address' tag following rules specified in
         // https://github.com/open-telemetry/semantic-conventions/blob/728e5d1/docs/http/http-spans.md#http-client-span
         // When there is no proxy, we need to prioritize the contents of the Host header.
+        // Note that this is a best-effort guess, e.g. we are not checking if proxy.GetProxy(uri) returns null.
         public static string GetServerAddress(HttpRequestMessage request, IWebProxy? proxy)
         {
             Debug.Assert(request.RequestUri is not null);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -43,7 +43,7 @@ namespace System.Net.Http
 
                         // MetricsHandler should be descendant of DiagnosticsHandler in the handler chain to make sure the 'http.request.duration'
                         // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
-                        // Since HttpClientHandler.Proxy is unsupported on many platforms, don't bother passing it.
+                        // Since HttpClientHandler.Proxy is unsupported on most platforms, don't bother passing it to telemetry handlers.
                         if (GlobalHttpSettings.MetricsHandler.IsGloballyEnabled)
                         {
                             handler = new MetricsHandler(handler, _nativeMeterFactory, proxy: null, out _);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -43,13 +43,14 @@ namespace System.Net.Http
 
                         // MetricsHandler should be descendant of DiagnosticsHandler in the handler chain to make sure the 'http.request.duration'
                         // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
+                        // Since HttpClientHandler.Proxy is unsupported on many platforms, don't bother passing it.
                         if (GlobalHttpSettings.MetricsHandler.IsGloballyEnabled)
                         {
-                            handler = new MetricsHandler(handler, _nativeMeterFactory, out _);
+                            handler = new MetricsHandler(handler, _nativeMeterFactory, proxy: null, out _);
                         }
                         if (GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation)
                         {
-                            handler = new DiagnosticsHandler(handler, DistributedContextPropagator.Current);
+                            handler = new DiagnosticsHandler(handler, DistributedContextPropagator.Current, proxy: null);
                         }
 
                         // Ensure a single handler is used for all requests.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -47,11 +47,11 @@ namespace System.Net.Http
                 // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
                 if (GlobalHttpSettings.MetricsHandler.IsGloballyEnabled)
                 {
-                    handler = new MetricsHandler(handler, _meterFactory, out _);
+                    handler = new MetricsHandler(handler, _meterFactory, proxy: null, out _);
                 }
                 if (GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation)
                 {
-                    handler = new DiagnosticsHandler(handler, DistributedContextPropagator.Current);
+                    handler = new DiagnosticsHandler(handler, DistributedContextPropagator.Current, proxy: null);
                 }
 
                 // Ensure a single handler is used for all requests.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -45,6 +45,7 @@ namespace System.Net.Http
 
                 // MetricsHandler should be descendant of DiagnosticsHandler in the handler chain to make sure the 'http.request.duration'
                 // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
+                // Since HttpClientHandler.Proxy is unsupported on most platforms, don't bother passing it to telemetry handlers.
                 if (GlobalHttpSettings.MetricsHandler.IsGloballyEnabled)
                 {
                     handler = new MetricsHandler(handler, _meterFactory, proxy: null, out _);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpUtilities.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpUtilities.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.Http
+{
+    internal static partial class HttpUtilities
+    {
+        public static string ParseHostNameFromHeader(string hostHeader)
+        {
+            // See if we need to trim off a port.
+            int colonPos = hostHeader.IndexOf(':');
+            if (colonPos >= 0)
+            {
+                // There is colon, which could either be a port separator or a separator in
+                // an IPv6 address.  See if this is an IPv6 address; if it's not, use everything
+                // before the colon as the host name, and if it is, use everything before the last
+                // colon iff the last colon is after the end of the IPv6 address (otherwise it's a
+                // part of the address).
+                int ipV6AddressEnd = hostHeader.IndexOf(']');
+                if (ipV6AddressEnd == -1)
+                {
+                    return hostHeader.Substring(0, colonPos);
+                }
+                else
+                {
+                    colonPos = hostHeader.LastIndexOf(':');
+                    if (colonPos > ipV6AddressEnd)
+                    {
+                        return hostHeader.Substring(0, colonPos);
+                    }
+                }
+            }
+
+            return hostHeader;
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/ConnectionSetupDistributedTracing.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/ConnectionSetupDistributedTracing.cs
@@ -12,7 +12,7 @@ namespace System.Net.Http
     {
         private static readonly ActivitySource s_connectionsActivitySource = new ActivitySource(DiagnosticsHandlerLoggingStrings.ConnectionsNamespace);
 
-        public static Activity? StartConnectionSetupActivity(bool isSecure, HttpAuthority authority)
+        public static Activity? StartConnectionSetupActivity(bool isSecure, string host, int port)
         {
             Activity? activity = null;
             if (s_connectionsActivitySource.HasListeners())
@@ -25,11 +25,11 @@ namespace System.Net.Http
 
             if (activity is not null)
             {
-                activity.DisplayName = $"HTTP connection_setup {authority.HostValue}:{authority.Port}";
+                activity.DisplayName = $"HTTP connection_setup {host}:{port}";
                 if (activity.IsAllDataRequested)
                 {
-                    activity.SetTag("server.address", authority.HostValue);
-                    activity.SetTag("server.port", authority.Port);
+                    activity.SetTag("server.address", host);
+                    activity.SetTag("server.port", port);
                     activity.SetTag("url.scheme", isSecure ? "https" : "http");
                 }
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/ConnectionSetupDistributedTracing.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/ConnectionSetupDistributedTracing.cs
@@ -12,7 +12,7 @@ namespace System.Net.Http
     {
         private static readonly ActivitySource s_connectionsActivitySource = new ActivitySource(DiagnosticsHandlerLoggingStrings.ConnectionsNamespace);
 
-        public static Activity? StartConnectionSetupActivity(bool isSecure, string host, int port)
+        public static Activity? StartConnectionSetupActivity(bool isSecure, string? serverAddress, int port)
         {
             Activity? activity = null;
             if (s_connectionsActivitySource.HasListeners())
@@ -25,10 +25,11 @@ namespace System.Net.Http
 
             if (activity is not null)
             {
-                activity.DisplayName = $"HTTP connection_setup {host}:{port}";
+                Debug.Assert(serverAddress is not null, "serverAddress should not be null when System.Net.Http.EnableActivityPropagation is true.");
+                activity.DisplayName = $"HTTP connection_setup {serverAddress}:{port}";
                 if (activity.IsAllDataRequested)
                 {
-                    activity.SetTag("server.address", host);
+                    activity.SetTag("server.address", serverAddress);
                     activity.SetTag("server.port", port);
                     activity.SetTag("url.scheme", isSecure ? "https" : "http");
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -263,7 +263,7 @@ namespace System.Net.Http
             {
                 if (TryGetHttp3Authority(queueItem.Request, out authority, out Exception? reasonException))
                 {
-                    connectionSetupActivity = ConnectionSetupDistributedTracing.StartConnectionSetupActivity(isSecure: true, authority);
+                    connectionSetupActivity = ConnectionSetupDistributedTracing.StartConnectionSetupActivity(isSecure: true, _telemetryServerAddress, authority.Port);
                     // If the authority was sent as an option through alt-svc then include alt-used header.
                     connection = new Http3Connection(this, authority, includeAltUsedHeader: _http3Authority == authority);
                     QuicConnection quicConnection = await ConnectHelper.ConnectQuicAsync(queueItem.Request, new DnsEndPoint(authority.IdnHost, authority.Port), _poolManager.Settings._pooledConnectionIdleTimeout, _sslOptionsHttp3!, connection.StreamCapacityCallback, cts.Token).ConfigureAwait(false);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -35,7 +35,7 @@ namespace System.Net.Http
         private readonly HttpConnectionPoolManager _poolManager;
         private readonly HttpConnectionKind _kind;
         private readonly Uri? _proxyUri;
-        private readonly string _telemetryServerAddress;
+        private readonly string? _telemetryServerAddress;
 
         /// <summary>The origin authority used to construct the <see cref="HttpConnectionPool"/>.</summary>
         private readonly HttpAuthority _originAuthority;
@@ -74,7 +74,7 @@ namespace System.Net.Http
         /// <param name="sslHostName">The SSL host with which this pool is associated.</param>
         /// <param name="proxyUri">The proxy this pool targets (optional).</param>
         /// <param name="telemetryServerAddress">The value of the 'server.address' tag to be emitted by Metrics and Distributed Tracing.</param>
-        public HttpConnectionPool(HttpConnectionPoolManager poolManager, HttpConnectionKind kind, string? host, int port, string? sslHostName, Uri? proxyUri, string telemetryServerAddress)
+        public HttpConnectionPool(HttpConnectionPoolManager poolManager, HttpConnectionKind kind, string? host, int port, string? sslHostName, Uri? proxyUri, string? telemetryServerAddress)
         {
             _poolManager = poolManager;
             _kind = kind;
@@ -282,7 +282,7 @@ namespace System.Net.Http
             return sslOptions;
         }
 
-        public string TelemetryServerAddress => _telemetryServerAddress;
+        public string? TelemetryServerAddress => _telemetryServerAddress;
         public HttpAuthority OriginAuthority => _originAuthority;
         public HttpConnectionSettings Settings => _poolManager.Settings;
         public HttpConnectionKind Kind => _kind;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -259,7 +259,6 @@ namespace System.Net.Http
             }
 
             if (NetEventSource.Log.IsEnabled()) Trace($"{this}");
-            _telemetryServerAddress = telemetryServerAddress;
         }
 
         private static SslClientAuthenticationOptions ConstructSslOptions(HttpConnectionPoolManager poolManager, string sslHostName)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -35,6 +35,7 @@ namespace System.Net.Http
         private readonly HttpConnectionPoolManager _poolManager;
         private readonly HttpConnectionKind _kind;
         private readonly Uri? _proxyUri;
+        private readonly string _telemetryServerAddress;
 
         /// <summary>The origin authority used to construct the <see cref="HttpConnectionPool"/>.</summary>
         private readonly HttpAuthority _originAuthority;
@@ -72,12 +73,14 @@ namespace System.Net.Http
         /// <param name="port">The port with which this pool is associated.</param>
         /// <param name="sslHostName">The SSL host with which this pool is associated.</param>
         /// <param name="proxyUri">The proxy this pool targets (optional).</param>
-        public HttpConnectionPool(HttpConnectionPoolManager poolManager, HttpConnectionKind kind, string? host, int port, string? sslHostName, Uri? proxyUri)
+        /// <param name="telemetryServerAddress">The value of the 'server.address' tag to be emitted by Metrics and Distributed Tracing.</param>
+        public HttpConnectionPool(HttpConnectionPoolManager poolManager, HttpConnectionKind kind, string? host, int port, string? sslHostName, Uri? proxyUri, string telemetryServerAddress)
         {
             _poolManager = poolManager;
             _kind = kind;
             _proxyUri = proxyUri;
             _maxHttp11Connections = Settings._maxConnectionsPerServer;
+            _telemetryServerAddress = telemetryServerAddress;
 
             // The only case where 'host' will not be set is if this is a Proxy connection pool.
             Debug.Assert(host is not null || (kind == HttpConnectionKind.Proxy && proxyUri is not null));
@@ -256,6 +259,7 @@ namespace System.Net.Http
             }
 
             if (NetEventSource.Log.IsEnabled()) Trace($"{this}");
+            _telemetryServerAddress = telemetryServerAddress;
         }
 
         private static SslClientAuthenticationOptions ConstructSslOptions(HttpConnectionPoolManager poolManager, string sslHostName)
@@ -279,6 +283,7 @@ namespace System.Net.Http
             return sslOptions;
         }
 
+        public string TelemetryServerAddress => _telemetryServerAddress;
         public HttpAuthority OriginAuthority => _originAuthority;
         public HttpConnectionSettings Settings => _poolManager.Settings;
         public HttpConnectionKind Kind => _kind;
@@ -557,7 +562,7 @@ namespace System.Net.Http
             Exception? exception = null;
             TransportContext? transportContext = null;
 
-            Activity? activity = ConnectionSetupDistributedTracing.StartConnectionSetupActivity(IsSecure, OriginAuthority);
+            Activity? activity = ConnectionSetupDistributedTracing.StartConnectionSetupActivity(IsSecure, _telemetryServerAddress, OriginAuthority.Port);
 
             try
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -69,6 +69,7 @@ namespace System.Net.Http
                         this is Http2Connection ? "2" :
                         "3";
 
+                    Debug.Assert(_pool.TelemetryServerAddress is not null, "TelemetryServerAddress should not be null when System.Diagnostics.Metrics.Meter.IsSupported is true.");
                     _connectionMetrics = new ConnectionMetrics(
                         metrics,
                         protocol,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -73,7 +73,7 @@ namespace System.Net.Http
                         metrics,
                         protocol,
                         _pool.IsSecure ? "https" : "http",
-                        _pool.OriginAuthority.HostValue,
+                        _pool.TelemetryServerAddress,
                         _pool.OriginAuthority.Port,
                         remoteEndPoint?.Address?.ToString());
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -311,14 +311,15 @@ namespace System.Net.Http
                 Uri? uri = request.RequestUri;
                 Debug.Assert(uri is not null);
 
-                if (key.ProxyUri is not null)
-                {
-                    return uri.IdnHost;
-                }
-
                 if (key.SslHostName is not null)
                 {
                     return key.SslHostName;
+                }
+
+                if (key.ProxyUri is not null && key.Kind == HttpConnectionKind.Proxy)
+                {
+                    // In case there is no tunnel, return the proxy address since the connection is shared.
+                    return key.ProxyUri.IdnHost;
                 }
 
                 string? hostHeader = request.Headers.Host;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -227,35 +227,6 @@ namespace System.Net.Http
         public HttpConnectionSettings Settings => _settings;
         public ICredentials? ProxyCredentials => _proxyCredentials;
 
-        private static string ParseHostNameFromHeader(string hostHeader)
-        {
-            // See if we need to trim off a port.
-            int colonPos = hostHeader.IndexOf(':');
-            if (colonPos >= 0)
-            {
-                // There is colon, which could either be a port separator or a separator in
-                // an IPv6 address.  See if this is an IPv6 address; if it's not, use everything
-                // before the colon as the host name, and if it is, use everything before the last
-                // colon iff the last colon is after the end of the IPv6 address (otherwise it's a
-                // part of the address).
-                int ipV6AddressEnd = hostHeader.IndexOf(']');
-                if (ipV6AddressEnd == -1)
-                {
-                    return hostHeader.Substring(0, colonPos);
-                }
-                else
-                {
-                    colonPos = hostHeader.LastIndexOf(':');
-                    if (colonPos > ipV6AddressEnd)
-                    {
-                        return hostHeader.Substring(0, colonPos);
-                    }
-                }
-            }
-
-            return hostHeader;
-        }
-
         private HttpConnectionKey GetConnectionKey(HttpRequestMessage request, Uri? proxyUri, bool isProxyConnect)
         {
             Uri? uri = request.RequestUri;
@@ -273,7 +244,7 @@ namespace System.Net.Http
                 string? hostHeader = request.Headers.Host;
                 if (hostHeader != null)
                 {
-                    sslHostName = ParseHostNameFromHeader(hostHeader);
+                    sslHostName = HttpUtilities.ParseHostNameFromHeader(hostHeader);
                 }
                 else
                 {
@@ -330,6 +301,28 @@ namespace System.Net.Http
             }
         }
 
+        // Picks the value of the 'server.address' tag following rules specified in
+        // https://github.com/open-telemetry/semantic-conventions/blob/728e5d1/docs/http/http-spans.md#http-client-span
+        // When there is no proxy, we need to prioritize the contents of the Host header.
+        private static string GetTelemetryServerAddress(HttpRequestMessage request, HttpConnectionKey key)
+        {
+            Uri? uri = request.RequestUri;
+            Debug.Assert(uri is not null);
+
+            if (key.ProxyUri is not null)
+            {
+                return uri.IdnHost;
+            }
+
+            if (key.SslHostName is not null)
+            {
+                return key.SslHostName;
+            }
+
+            string? hostHeader = request.Headers.Host;
+            return hostHeader is null ? uri.IdnHost : HttpUtilities.ParseHostNameFromHeader(hostHeader);
+        }
+
         public ValueTask<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, Uri? proxyUri, bool async, bool doRequestAuth, bool isProxyConnect, CancellationToken cancellationToken)
         {
             HttpConnectionKey key = GetConnectionKey(request, proxyUri, isProxyConnect);
@@ -337,7 +330,7 @@ namespace System.Net.Http
             HttpConnectionPool? pool;
             while (!_pools.TryGetValue(key, out pool))
             {
-                pool = new HttpConnectionPool(this, key.Kind, key.Host, key.Port, key.SslHostName, key.ProxyUri);
+                pool = new HttpConnectionPool(this, key.Kind, key.Host, key.Port, key.SslHostName, key.ProxyUri, GetTelemetryServerAddress(request, key));
 
                 if (_cleaningTimer == null)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpUtilities.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpUtilities.SocketsHttpHandler.cs
@@ -3,7 +3,7 @@
 
 namespace System.Net.Http
 {
-    internal static class HttpUtilities
+    internal static partial class HttpUtilities
     {
         internal static bool IsSupportedScheme(string scheme) =>
             IsSupportedNonSecureScheme(scheme) ||

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
@@ -46,7 +46,7 @@ namespace System.Net.Http.Metrics
                 });
 
                 tags.Add("url.scheme", pool.IsSecure ? "https" : "http");
-                tags.Add("server.address", pool.OriginAuthority.HostValue);
+                tags.Add("server.address", pool.TelemetryServerAddress);
 
                 if (!pool.IsDefaultPort)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
@@ -46,6 +46,8 @@ namespace System.Net.Http.Metrics
                 });
 
                 tags.Add("url.scheme", pool.IsSecure ? "https" : "http");
+
+                Debug.Assert(pool.TelemetryServerAddress is not null, "TelemetryServerAddress should not be null when System.Diagnostics.Metrics.Meter.IsSupported is true.");
                 tags.Add("server.address", pool.TelemetryServerAddress);
 
                 if (!pool.IsDefaultPort)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -527,14 +527,14 @@ namespace System.Net.Http
             // metric is recorded before stopping the request Activity. This is needed to make sure that our telemetry supports Exemplars.
             if (GlobalHttpSettings.MetricsHandler.IsGloballyEnabled)
             {
-                handler = new MetricsHandler(handler, settings._meterFactory, out Meter meter);
+                handler = new MetricsHandler(handler, settings._meterFactory, settings._proxy, out Meter meter);
                 settings._metrics = new SocketsHttpHandlerMetrics(meter);
             }
 
             // DiagnosticsHandler is inserted before RedirectHandler so that trace propagation is done on redirects as well
             if (GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation && settings._activityHeadersPropagator is DistributedContextPropagator propagator)
             {
-                handler = new DiagnosticsHandler(handler, propagator, settings._allowAutoRedirect);
+                handler = new DiagnosticsHandler(handler, propagator, settings._proxy, settings._allowAutoRedirect);
             }
 
             if (settings._allowAutoRedirect)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -1673,7 +1673,6 @@ namespace System.Net.Http.Functional.Tests
             if (UseVersion == HttpVersion30 && !useTls) return;
 
             await RemoteExecutor.Invoke(RunTest, UseVersion.ToString(), TestAsync.ToString(), useTls.ToString()).DisposeAsync();
-            //await RunTest(UseVersion.ToString(), TestAsync.ToString(), useTls.ToString());
             static async Task RunTest(string useVersion, string testAsync, string useTlsString)
             {
                 bool useTls = bool.Parse(useTlsString);
@@ -1702,16 +1701,11 @@ namespace System.Net.Http.Functional.Tests
 
                         await client.SendAsync(bool.Parse(testAsync), request);
 
-                        Activity requestActivity = requestRecorder.VerifyActivityRecordedOnce();
-                        ActivityAssert.HasTag(requestActivity, "server.address", hostName);
+                        Activity req = requestRecorder.VerifyActivityRecordedOnce();
+                        ActivityAssert.HasTag(req, "server.address", hostName);
 
-                        Activity connectionActivity = connectionSetupRecorder.VerifyActivityRecordedOnce();
-                        //Assert.Equal($"HTTP connection_setup {hostName}:{uri.Port}", conn.DisplayName);
-                        //ActivityAssert.HasTag(conn, "network.peer.address",
-                        //    (string a) => a == IPAddress.Loopback.ToString() ||
-                        //    a == IPAddress.Loopback.MapToIPv6().ToString() ||
-                        //    a == IPAddress.IPv6Loopback.ToString());
-                        //ActivityAssert.HasTag(conn, "server.address", hostName);
+                        Activity conn = connectionSetupRecorder.VerifyActivityRecordedOnce();
+                        ActivityAssert.HasTag(conn, "server.address", hostName);
                     },
                     async server =>
                     {
@@ -1724,7 +1718,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        public async Task UseIPAddressInUri_UseProxy_RecordsUriHostAsServerAddress()
+        public async Task UseIPAddressInTargetUri_UseProxy_RecordsUriHostAsServerAddress()
         {
             if (UseVersion != HttpVersion.Version11)
             {
@@ -1732,7 +1726,6 @@ namespace System.Net.Http.Functional.Tests
             }
 
             await RemoteExecutor.Invoke(RunTest, UseVersion.ToString(), TestAsync.ToString()).DisposeAsync();
-            //await RunTest(UseVersion.ToString(), TestAsync.ToString(), useTls.ToString());
             static async Task RunTest(string useVersion, string testAsync)
             {
                 const string IpString = "1.2.3.4";
@@ -1763,13 +1756,7 @@ namespace System.Net.Http.Functional.Tests
                         Activity req = requestRecorder.VerifyActivityRecordedOnce();
                         Activity conn = connectionSetupRecorder.VerifyActivityRecordedOnce();
                         ActivityAssert.HasTag(req, "server.address", IpString);
-
-                        //Assert.Equal($"HTTP connection_setup {hostName}:{uri.Port}", conn.DisplayName);
-                        //ActivityAssert.HasTag(conn, "network.peer.address",
-                        //    (string a) => a == IPAddress.Loopback.ToString() ||
-                        //    a == IPAddress.Loopback.MapToIPv6().ToString() ||
-                        //    a == IPAddress.IPv6Loopback.ToString());
-                        //ActivityAssert.HasTag(conn, "server.address", hostName);
+                        ActivityAssert.HasTag(conn, "server.address", IpString);
                     },
                     async server =>
                     {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -1211,7 +1211,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(typeof(SocketsHttpHandler), nameof(SocketsHttpHandler.IsSupported))]
-        public Task UseIPAddressInUri_Proxy_RecordsUriHostAsServerAddress()
+        public Task UseIPAddressInTargetUri_UseProxy_RecordsUriHostAsServerAddress()
         {
             const string IpString = "1.2.3.4";
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -77,6 +77,8 @@
              Link="ProductionCode\System\Net\Http\GlobalHttpSettings.cs"/>
     <Compile Include="..\..\src\System\Net\Http\HeaderEncodingSelector.cs"
              Link="ProductionCode\System\Net\Http\HeaderEncodingSelector.cs" />
+    <Compile Include="..\..\src\System\Net\Http\HttpUtilities.cs"
+             Link="ProductionCode\System\Net\Http\HttpUtilities.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\AltSvcHeaderParser.cs"
              Link="ProductionCode\System\Net\Http\Headers\AltSvcHeaderParser.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\AltSvcHeaderValue.cs"
@@ -241,8 +243,8 @@
              Link="ProductionCode\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Unix.cs" />
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs" Condition="'$(TargetPlatformIdentifier)' == 'windows'"
              Link="ProductionCode\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs" />
-    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpUtilities.cs"
-             Link="ProductionCode\System\Net\Http\SocketsHttpHandler\HttpUtilities.cs" />
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpUtilities.SocketsHttpHandler.cs"
+             Link="ProductionCode\System\Net\Http\SocketsHttpHandler\HttpUtilities.SocketsHttpHandler.cs" />
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs"
              Link="ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs" />
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" Condition=" '$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos'"


### PR DESCRIPTION
Fixes #117049

With the merge of https://github.com/open-telemetry/semantic-conventions/pull/2463, we are good to prioritize the contents of the `Host` header in cases no proxy is being used. The PR implements the change for both request and connection traces+metrics.

There is a non-negligible risk: actually, we do not and (with the current code structure) can not emit `network.peer.address` for request telemetry, meaning that with `http(s)://x.x.x.x/..` target Uri-s, IP information will be no longer present when a there is a Host header. I believe that most users would still prefer to see the contents of the Host header if there is a mismatch. Others can opt into connection metrics/traces where `network.peer.address` is available.