### PR TITLE
[Android] InvariantGlobalization support for CoreCLR Android builds

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -234,10 +234,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\tests\System.Reflection.MetadataLoadContext.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Resources.ResourceManager.Tests\System.Resources.ResourceManager.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests\InvariantTimezone\System.Runtime.InvariantTimezone.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\System.Runtime.Loader.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Text.Encoding.Tests\System.Text.Encoding.Tests.csproj" />
     <!-- https://github.com/dotnet/runtime/issues/62547 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography\tests\System.Security.Cryptography.Tests.csproj" />
   </ItemGroup>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -231,7 +231,6 @@
 
   <ItemGroup Condition="'$(TargetOS)' == 'android' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(RunDisablediOSTests)' != 'true'">
     <!-- https://github.com/dotnet/runtime/issues/114951 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Globalization.Tests\Invariant\Invariant.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\tests\System.Reflection.MetadataLoadContext.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -234,7 +234,10 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\tests\System.Reflection.MetadataLoadContext.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Resources.ResourceManager.Tests\System.Resources.ResourceManager.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests\InvariantTimezone\System.Runtime.InvariantTimezone.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\System.Runtime.Loader.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Text.Encoding.Tests\System.Text.Encoding.Tests.csproj" />
     <!-- https://github.com/dotnet/runtime/issues/62547 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography\tests\System.Security.Cryptography.Tests.csproj" />
   </ItemGroup>

--- a/src/mono/msbuild/android/build/AndroidBuild.targets
+++ b/src/mono/msbuild/android/build/AndroidBuild.targets
@@ -251,6 +251,7 @@
         ForceAOT="$(RunAOTCompilation)"
         ForceFullAOT="$(ForceFullAOT)"
         ForceInterpreter="$(MonoForceInterpreter)"
+        InvariantGlobalization="$(InvariantGlobalization)"
         IsLibraryMode="$(_IsLibraryMode)"
         MainLibraryFileName="$(MainLibraryFileName)"
         RuntimeHeaders="@(RuntimeHeaders)"

--- a/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -108,6 +108,11 @@ public class AndroidAppBuilderTask : Task
 
     public bool ForceInterpreter { get; set; }
 
+    /// <summary>
+    /// Indicates whether we want to use invariant globalization mode.
+    /// </summary>
+    public bool InvariantGlobalization { get; set; }
+
     [Output]
     public string ApkBundlePath { get; set; } = ""!;
 

--- a/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -146,6 +146,7 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.NativeDependencies = NativeDependencies;
         apkBuilder.ExtraLinkerArguments = ExtraLinkerArguments;
         apkBuilder.RuntimeFlavor = RuntimeFlavor;
+        apkBuilder.InvariantGlobalization = InvariantGlobalization;
         (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(RuntimeIdentifier, MainLibraryFileName, RuntimeHeaders);
 
         return true;

--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -424,7 +424,6 @@ public partial class ApkBuilder
             envVariables += $"\t\tsetEnv(\"{name}\", \"{value}\");\n";
         }
 
-        // Set invariant globalization environment variable if enabled
         if (InvariantGlobalization)
         {
             envVariables += $"\t\tsetEnv(\"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT\", \"true\");\n";

--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -424,6 +424,12 @@ public partial class ApkBuilder
             envVariables += $"\t\tsetEnv(\"{name}\", \"{value}\");\n";
         }
 
+        // Set invariant globalization environment variable if enabled
+        if (InvariantGlobalization)
+        {
+            envVariables += $"\t\tsetEnv(\"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT\", \"true\");\n";
+        }
+
         string jniLibraryName = (IsLibraryMode) ? ProjectName! :
             (StaticLinkedRuntime && IsCoreCLR) ? "monodroid" : "System.Security.Cryptography.Native.Android";
         string monoRunner = Utils.GetEmbeddedResource("MonoRunner.java")

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
@@ -182,7 +182,7 @@ mono_droid_execute_assembly (const char* executable_path, void* coreclr_handle, 
     return rv;
 }
 
-#define PROPERTY_COUNT 3
+#define PROPERTY_COUNT 4
 
 static int
 mono_droid_runtime_init (const char* executable)

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
@@ -182,7 +182,7 @@ mono_droid_execute_assembly (const char* executable_path, void* coreclr_handle, 
     return rv;
 }
 
-#define PROPERTY_COUNT 4
+#define PROPERTY_COUNT 3
 
 static int
 mono_droid_runtime_init (const char* executable)
@@ -210,7 +210,6 @@ mono_droid_runtime_init (const char* executable)
     appctx_keys[0] = "RUNTIME_IDENTIFIER";
     appctx_keys[1] = "APP_CONTEXT_BASE_DIRECTORY";
     appctx_keys[2] = "HOST_RUNTIME_CONTRACT";
-    appctx_keys[3] = "System.Globalization.Invariant";
 
     const char* appctx_values[PROPERTY_COUNT];
     appctx_values[0] = ANDROID_RUNTIME_IDENTIFIER;
@@ -219,14 +218,6 @@ mono_droid_runtime_init (const char* executable)
     char contract_str[19]; // 0x + 16 hex digits + '\0'
     snprintf(contract_str, 19, "0x%zx", (size_t)(&g_host_contract));
     appctx_values[2] = contract_str;
-
-    const char* invariant_env = getenv("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
-    const char* invariant_value = "false"; // Default to false
-    if (invariant_env != NULL && (strcmp(invariant_env, "1") == 0 || strcmp(invariant_env, "true") == 0))
-    {
-        invariant_value = "true";
-    }
-    appctx_values[3] = invariant_value;
 
     LOG_INFO ("Calling coreclr_initialize");
     int rv = coreclr_initialize (

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
@@ -210,6 +210,7 @@ mono_droid_runtime_init (const char* executable)
     appctx_keys[0] = "RUNTIME_IDENTIFIER";
     appctx_keys[1] = "APP_CONTEXT_BASE_DIRECTORY";
     appctx_keys[2] = "HOST_RUNTIME_CONTRACT";
+    appctx_keys[3] = "System.Globalization.Invariant";
 
     const char* appctx_values[PROPERTY_COUNT];
     appctx_values[0] = ANDROID_RUNTIME_IDENTIFIER;
@@ -218,6 +219,14 @@ mono_droid_runtime_init (const char* executable)
     char contract_str[19]; // 0x + 16 hex digits + '\0'
     snprintf(contract_str, 19, "0x%zx", (size_t)(&g_host_contract));
     appctx_values[2] = contract_str;
+
+    const char* invariant_env = getenv("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
+    const char* invariant_value = "false"; // Default to false
+    if (invariant_env != NULL && (strcmp(invariant_env, "1") == 0 || strcmp(invariant_env, "true") == 0))
+    {
+        invariant_value = "true";
+    }
+    appctx_values[3] = invariant_value;
 
     LOG_INFO ("Calling coreclr_initialize");
     int rv = coreclr_initialize (

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -264,6 +264,7 @@
         AppDir="$(BuildDir)"
         DiagnosticPorts="$(DiagnosticPorts)"
         ForceInterpreter="$(MonoInterp)"
+        InvariantGlobalization="$(InvariantGlobalization)"
         RuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackDir)/native/include/mono-2.0"
         OutputDir="$(AppDir)"
         ProjectName="$(Category)"


### PR DESCRIPTION
## Description

Forward the `InvariantGlobalization` MSBuild property to the CoreCLR runtime for Android applications by connecting the existing infrastructure.

## Related issues

Fixes #117270 