### PR TITLE
JIT: Allow containment of CnsVec under GetElement node with non-const index

### DIFF
--- a/src/coreclr/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenxarch.cpp
@@ -2056,6 +2056,14 @@ void CodeGen::genBaseIntrinsic(GenTreeHWIntrinsic* node, insOpts instOptions)
                     }
                     baseReg = (isEBPbased) ? REG_EBP : REG_ESP;
                 }
+                else if (op1->IsCnsVec())
+                {
+                    CORINFO_FIELD_HANDLE hnd =
+                        GetEmitter()->emitSimdConst(&op1->AsVecCon()->gtSimdVal, emitTypeSize(op1));
+
+                    baseReg = internalRegisters.GetSingle(node);
+                    GetEmitter()->emitIns_R_C(INS_lea, emitTypeSize(TYP_I_IMPL), baseReg, hnd, 0, INS_OPTS_NONE);
+                }
                 else
                 {
                     // Require GT_IND addr to be not contained.

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -10121,7 +10121,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                                 MakeSrcContained(node, op2);
                             }
 
-                            if (IsContainableMemoryOp(op1) && IsSafeToContainMem(node, op1))
+                            if (op1->IsCnsVec() || (IsContainableMemoryOp(op1) && IsSafeToContainMem(node, op1)))
                             {
                                 MakeSrcContained(node, op1);
                             }

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -2304,11 +2304,16 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
 
                 if (!op2->OperIsConst() && !op1->isContained())
                 {
-                    // If the index is not a constant or op1 is in register,
+                    // If the index is not a constant and op1 is in register,
                     // we will use the SIMD temp location to store the vector.
 
                     var_types requiredSimdTempType = Compiler::getSIMDTypeForSize(intrinsicTree->GetSimdSize());
                     compiler->getSIMDInitTempVarNum(requiredSimdTempType);
+                }
+                else if (op1->IsCnsVec())
+                {
+                    // We need an int reg to load the address of the CnsVec data.
+                    buildInternalIntRegisterDefForNode(intrinsicTree);
                 }
                 break;
             }


### PR DESCRIPTION
This enables a pattern like `Vector128.GetElement(Vector128.Create(cns, cns, ...), noncns)` to emit a read directly into the data section instead of loading the CnsVec, spilling it to the stack, and indexing into it there.  

This is added primarily to support a cast implementation to come in another PR.

(peeled from #116805)