### PR TITLE
Add support for some more simd folding to improve the new IndexOf and related helpers

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -32529,45 +32529,6 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
     }
 #endif // FEATURE_MASKED_HW_INTRINSICS && TARGET_XARCH
 
-    switch (ni)
-    {
-        // There's certain IR simplifications that are possible and which
-        // unblock other constant folding, so do those early here.
-
-#if defined(TARGET_XARCH)
-        case NI_AVX_Compare:
-        case NI_AVX_CompareScalar:
-        case NI_AVX512_CompareMask:
-        {
-            assert(tree->GetOperandCount() == 3);
-
-            if (!op3->IsCnsIntOrI())
-            {
-                break;
-            }
-
-            FloatComparisonMode mode = static_cast<FloatComparisonMode>(op3->AsIntConCommon()->IntegralValue());
-            NamedIntrinsic      id = HWIntrinsicInfo::lookupIdForFloatComparisonMode(ni, mode, simdBaseType, simdSize);
-
-            if (id == ni)
-            {
-                break;
-            }
-
-            tree->ResetHWIntrinsicId(id, op1, op2);
-            DEBUG_DESTROY_NODE(op3);
-
-            tree->SetMorphed(this);
-            return gtFoldExprHWIntrinsic(tree);
-        }
-#endif // TARGET_XARCH
-
-        default:
-        {
-            break;
-        }
-    }
-
     GenTree* cnsNode   = nullptr;
     GenTree* otherNode = nullptr;
 
@@ -32576,12 +32537,23 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
         cnsNode   = op1;
         otherNode = op2;
     }
-    else if ((op2 != nullptr) && op2->OperIsConst())
+    else if (op2 != nullptr)
     {
-        cnsNode   = op2;
-        otherNode = op1;
+        if (op2->OperIsConst())
+        {
+            cnsNode   = op2;
+            otherNode = op1;
+        }
+        else if (op3 != nullptr)
+        {
+            if (op3->OperIsConst())
+            {
+                cnsNode = op3;
+            }
+        }
     }
-    else
+
+    if (cnsNode == nullptr)
     {
         // No constants, so nothing to fold
         return tree;
@@ -32589,11 +32561,8 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
 
     GenTree* resultNode = tree;
 
-    if (otherNode == nullptr)
+    if (opCount == 1)
     {
-        assert(op2 == nullptr);
-        assert(op3 == nullptr);
-
         if (oper != GT_NONE)
         {
             if (varTypeIsMask(retType))
@@ -32809,285 +32778,154 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
                     break;
                 }
 
-                default:
+#ifdef TARGET_ARM64
+                case NI_ArmBase_ReverseElementBits:
                 {
+                    assert(!varTypeIsSmall(retType) && !varTypeIsLong(retType));
+
+                    int32_t  value  = static_cast<int32_t>(cnsNode->AsIntConCommon()->IconValue());
+                    uint32_t result = BitOperations::ReverseBits(static_cast<uint32_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIconValue(static_cast<int32_t>(result));
+                    resultNode = cnsNode;
                     break;
                 }
-            }
-        }
-    }
-    else if (otherNode->OperIsConst())
-    {
-        if (oper != GT_NONE)
-        {
-            assert(op3 == nullptr);
 
-            if (varTypeIsMask(retType))
-            {
-                if (varTypeIsMask(cnsNode))
+                case NI_ArmBase_Arm64_ReverseElementBits:
                 {
-                    cnsNode->AsMskCon()->EvaluateBinaryInPlace(oper, isScalar, simdBaseType, simdSize,
-                                                               otherNode->AsMskCon());
+                    assert(varTypeIsLong(retType));
+
+                    int64_t  value  = cnsNode->AsIntConCommon()->IntegralValue();
+                    uint64_t result = BitOperations::ReverseBits(static_cast<uint64_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIntegralValue(static_cast<int64_t>(result));
+                    resultNode = cnsNode;
+                    break;
                 }
-                else
+#endif // TARGET_ARM64
+
+#ifdef TARGET_XARCH
+                case NI_AVX2_TrailingZeroCount:
                 {
-                    cnsNode->AsVecCon()->EvaluateBinaryInPlace(oper, isScalar, simdBaseType, otherNode->AsVecCon());
+                    assert(!varTypeIsSmall(retType) && !varTypeIsLong(retType));
+
+                    int32_t  value  = static_cast<int32_t>(cnsNode->AsIntConCommon()->IconValue());
+                    uint32_t result = BitOperations::TrailingZeroCount(static_cast<uint32_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIconValue(static_cast<int32_t>(result));
+                    resultNode = cnsNode;
+                    break;
                 }
-            }
-            else
-            {
-#if defined(TARGET_XARCH)
-                if ((oper == GT_LSH) || (oper == GT_RSH) || (oper == GT_RSZ))
+
+                case NI_AVX2_X64_TrailingZeroCount:
                 {
-                    if (otherNode->TypeIs(TYP_SIMD16))
+                    assert(varTypeIsLong(retType));
+
+                    int64_t  value  = cnsNode->AsIntConCommon()->IntegralValue();
+                    uint32_t result = BitOperations::TrailingZeroCount(static_cast<uint64_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIntegralValue(static_cast<int64_t>(result));
+                    resultNode = cnsNode;
+                    break;
+                }
+
+                case NI_SSE42_PopCount:
+                {
+                    assert(!varTypeIsSmall(retType) && !varTypeIsLong(retType));
+
+                    int32_t  value  = static_cast<int32_t>(cnsNode->AsIntConCommon()->IconValue());
+                    uint32_t result = BitOperations::PopCount(static_cast<uint32_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIconValue(static_cast<int32_t>(result));
+                    resultNode = cnsNode;
+                    break;
+                }
+
+                case NI_SSE42_X64_PopCount:
+                {
+                    assert(varTypeIsLong(retType));
+
+                    int64_t  value  = cnsNode->AsIntConCommon()->IntegralValue();
+                    uint32_t result = BitOperations::PopCount(static_cast<uint64_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIntegralValue(static_cast<int64_t>(result));
+                    resultNode = cnsNode;
+                    break;
+                }
+
+                case NI_X86Base_BitScanForward:
+                {
+                    assert(!varTypeIsSmall(retType) && !varTypeIsLong(retType));
+
+                    int32_t value = static_cast<int32_t>(cnsNode->AsIntConCommon()->IconValue());
+
+                    if (value == 0)
                     {
-                        if (!HWIntrinsicInfo::IsVariableShift(ni))
-                        {
-                            // The xarch shift instructions support taking the shift amount as
-                            // a simd16, in which case they take the shift amount from the lower
-                            // 64-bits.
-
-                            int64_t shiftAmount = otherNode->AsVecCon()->GetElementIntegral(TYP_LONG, 0);
-
-                            if (static_cast<uint64_t>(shiftAmount) >=
-                                (static_cast<uint64_t>(genTypeSize(simdBaseType)) * BITS_PER_BYTE))
-                            {
-                                // Set to -1 to indicate an explicit overshift
-                                shiftAmount = -1;
-                            }
-
-                            // Ensure we broadcast to the right vector size
-                            otherNode->gtType = retType;
-
-                            otherNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, shiftAmount);
-                        }
+                        // bsf is undefined for 0
+                        break;
                     }
+                    uint32_t result = BitOperations::BitScanForward(static_cast<uint32_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIconValue(static_cast<int32_t>(result));
+                    resultNode = cnsNode;
+                    break;
+                }
+
+                case NI_X86Base_X64_BitScanForward:
+                {
+                    assert(varTypeIsLong(retType));
+
+                    int64_t value = cnsNode->AsIntConCommon()->IntegralValue();
+
+                    if (value == 0)
+                    {
+                        // bsf is undefined for 0
+                        break;
+                    }
+                    uint32_t result = BitOperations::BitScanForward(static_cast<uint64_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIntegralValue(static_cast<int64_t>(result));
+                    resultNode = cnsNode;
+                    break;
+                }
+
+                case NI_X86Base_BitScanReverse:
+                {
+                    assert(!varTypeIsSmall(retType) && !varTypeIsLong(retType));
+
+                    int32_t value = static_cast<int32_t>(cnsNode->AsIntConCommon()->IconValue());
+
+                    if (value == 0)
+                    {
+                        // bsr is undefined for 0
+                        break;
+                    }
+                    uint32_t result = BitOperations::BitScanReverse(static_cast<uint32_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIconValue(static_cast<int32_t>(result));
+                    resultNode = cnsNode;
+                    break;
+                }
+
+                case NI_X86Base_X64_BitScanReverse:
+                {
+                    assert(varTypeIsLong(retType));
+
+                    int64_t value = cnsNode->AsIntConCommon()->IntegralValue();
+
+                    if (value == 0)
+                    {
+                        // bsr is undefined for 0
+                        break;
+                    }
+                    uint32_t result = BitOperations::BitScanReverse(static_cast<uint64_t>(value));
+
+                    cnsNode->AsIntConCommon()->SetIntegralValue(static_cast<int64_t>(result));
+                    resultNode = cnsNode;
+                    break;
                 }
 #endif // TARGET_XARCH
 
-                if (otherNode->IsIntegralConst())
-                {
-                    int64_t scalar = otherNode->AsIntConCommon()->IntegralValue();
-
-                    otherNode = gtNewVconNode(retType);
-                    otherNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, scalar);
-                }
-
-                cnsNode->AsVecCon()->EvaluateBinaryInPlace(oper, isScalar, simdBaseType, otherNode->AsVecCon());
-            }
-            resultNode = cnsNode;
-        }
-        else
-        {
-            switch (ni)
-            {
-                case NI_Vector128_GetElement:
-#ifdef TARGET_ARM64
-                case NI_Vector64_GetElement:
-#else
-                case NI_Vector256_GetElement:
-                case NI_Vector512_GetElement:
-#endif
-                {
-                    assert(op3 == nullptr);
-                    uint32_t index = static_cast<uint32_t>(otherNode->AsIntConCommon()->IconValue());
-
-                    if (index >= GenTreeVecCon::ElementCount(simdSize, simdBaseType))
-                    {
-                        // Nothing to fold for out of range indexes
-                        break;
-                    }
-
-                    var_types simdType = getSIMDTypeForSize(simdSize);
-
-                    if (varTypeIsFloating(retType))
-                    {
-                        double result = cnsNode->AsVecCon()->GetElementFloating(simdBaseType, index);
-
-                        resultNode = gtNewDconNode(result, retType);
-                    }
-                    else
-                    {
-                        assert(varTypeIsIntegral(retType));
-                        int64_t result = cnsNode->AsVecCon()->GetElementIntegral(simdBaseType, index);
-
-                        if (varTypeIsLong(retType))
-                        {
-                            resultNode = gtNewLconNode(result);
-                        }
-                        else
-                        {
-                            resultNode = gtNewIconNode(static_cast<int32_t>(result), retType);
-                        }
-                    }
-                    break;
-                }
-
-#ifdef TARGET_ARM64
-                case NI_AdvSimd_MultiplyByScalar:
-                case NI_AdvSimd_Arm64_MultiplyByScalar:
-                {
-                    assert(op3 == nullptr);
-
-                    // MultiplyByScalar takes a vector as the second operand but only utilizes element 0
-                    // We need to extract it and then functionally broadcast it up for the evaluation to
-                    // work as expected. Ensuring we broadcast up to the target vector size.
-
-                    otherNode->gtType = retType;
-
-                    if (varTypeIsFloating(simdBaseType))
-                    {
-                        double scalar = otherNode->AsVecCon()->ToScalarFloating(simdBaseType);
-                        otherNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, scalar);
-                    }
-                    else
-                    {
-                        assert(varTypeIsIntegral(simdBaseType));
-                        int64_t scalar = otherNode->AsVecCon()->ToScalarIntegral(simdBaseType);
-                        otherNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, scalar);
-                    }
-
-                    cnsNode->AsVecCon()->EvaluateBinaryInPlace(GT_MUL, isScalar, simdBaseType, otherNode->AsVecCon());
-                    resultNode = cnsNode;
-                    break;
-                }
-#endif
-
-                case NI_Vector128_WithElement:
-#ifdef TARGET_ARM64
-                case NI_Vector64_WithElement:
-#else
-                case NI_Vector256_WithElement:
-                case NI_Vector512_WithElement:
-#endif
-                {
-                    if (!op3->OperIsConst())
-                    {
-                        break;
-                    }
-
-                    uint32_t index = static_cast<uint32_t>(op2->AsIntConCommon()->IconValue());
-
-                    if (index >= GenTreeVecCon::ElementCount(simdSize, simdBaseType))
-                    {
-                        // Nothing to fold for out of range indexes
-                        break;
-                    }
-
-                    var_types simdType = getSIMDTypeForSize(simdSize);
-
-                    if (varTypeIsFloating(simdBaseType))
-                    {
-                        double value = op3->AsDblCon()->DconValue();
-                        cnsNode->AsVecCon()->SetElementFloating(simdBaseType, index, value);
-                        resultNode = cnsNode;
-                    }
-                    else
-                    {
-                        assert(varTypeIsIntegral(simdBaseType));
-                        int64_t value = op3->AsIntConCommon()->IntegralValue();
-                        cnsNode->AsVecCon()->SetElementIntegral(simdBaseType, index, value);
-                        resultNode = cnsNode;
-                    }
-                    break;
-                }
-
-#ifdef TARGET_ARM64
-                case NI_Vector128_WithLower:
-                {
-                    assert(retType == TYP_SIMD16);
-                    assert(cnsNode->TypeIs(TYP_SIMD16));
-                    assert(otherNode->TypeIs(TYP_SIMD8));
-                    cnsNode->AsVecCon()->gtSimd16Val.v64[0] = otherNode->AsVecCon()->gtSimd8Val;
-
-                    resultNode = cnsNode;
-                    break;
-                }
-#else
-                case NI_Vector256_WithLower:
-                {
-                    assert(retType == TYP_SIMD32);
-                    assert(cnsNode->TypeIs(TYP_SIMD32));
-                    assert(otherNode->TypeIs(TYP_SIMD16));
-                    cnsNode->AsVecCon()->gtSimd32Val.v128[0] = otherNode->AsVecCon()->gtSimd16Val;
-
-                    resultNode = cnsNode;
-                    break;
-                }
-
-                case NI_Vector512_WithLower:
-                {
-                    assert(retType == TYP_SIMD64);
-                    assert(cnsNode->TypeIs(TYP_SIMD64));
-                    assert(otherNode->TypeIs(TYP_SIMD32));
-                    cnsNode->AsVecCon()->gtSimd64Val.v256[0] = otherNode->AsVecCon()->gtSimd32Val;
-
-                    resultNode = cnsNode;
-                    break;
-                }
-#endif
-
-#ifdef TARGET_ARM64
-                case NI_Vector128_WithUpper:
-                {
-                    assert(retType == TYP_SIMD16);
-                    assert(cnsNode->TypeIs(TYP_SIMD16));
-                    assert(otherNode->TypeIs(TYP_SIMD8));
-                    cnsNode->AsVecCon()->gtSimd16Val.v64[1] = otherNode->AsVecCon()->gtSimd8Val;
-
-                    resultNode = cnsNode;
-                    break;
-                }
-#else
-                case NI_Vector256_WithUpper:
-                {
-                    assert(retType == TYP_SIMD32);
-                    assert(cnsNode->TypeIs(TYP_SIMD32));
-                    assert(otherNode->TypeIs(TYP_SIMD16));
-                    cnsNode->AsVecCon()->gtSimd32Val.v128[1] = otherNode->AsVecCon()->gtSimd16Val;
-
-                    resultNode = cnsNode;
-                    break;
-                }
-
-                case NI_Vector512_WithUpper:
-                {
-                    assert(retType == TYP_SIMD64);
-                    assert(cnsNode->TypeIs(TYP_SIMD64));
-                    assert(otherNode->TypeIs(TYP_SIMD32));
-                    cnsNode->AsVecCon()->gtSimd64Val.v256[1] = otherNode->AsVecCon()->gtSimd32Val;
-
-                    resultNode = cnsNode;
-                    break;
-                }
-#endif
-
-                case NI_Vector128_op_Equality:
-#if defined(TARGET_ARM64)
-                case NI_Vector64_op_Equality:
-#elif defined(TARGET_XARCH)
-                case NI_Vector256_op_Equality:
-                case NI_Vector512_op_Equality:
-#endif // !TARGET_ARM64 && !TARGET_XARCH
-                {
-                    cnsNode->AsVecCon()->EvaluateBinaryInPlace(GT_EQ, isScalar, simdBaseType, otherNode->AsVecCon());
-                    resultNode = gtNewIconNode(cnsNode->AsVecCon()->IsAllBitsSet() ? 1 : 0, retType);
-                    break;
-                }
-
-                case NI_Vector128_op_Inequality:
-#if defined(TARGET_ARM64)
-                case NI_Vector64_op_Inequality:
-#elif defined(TARGET_XARCH)
-                case NI_Vector256_op_Inequality:
-                case NI_Vector512_op_Inequality:
-#endif // !TARGET_ARM64 && !TARGET_XARCH
-                {
-                    cnsNode->AsVecCon()->EvaluateBinaryInPlace(GT_NE, isScalar, simdBaseType, otherNode->AsVecCon());
-                    resultNode = gtNewIconNode(cnsNode->AsVecCon()->IsZero() ? 0 : 1, retType);
-                    break;
-                }
-
                 default:
                 {
                     break;
@@ -33095,372 +32933,671 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
             }
         }
     }
-    else if (op3 == nullptr)
+    else if (opCount == 2)
     {
-        if (isScalar)
+        if (otherNode->OperIsConst())
         {
-            // We don't support folding for scalars when only one input is constant
-            // because it means one value is computed and the remaining values are
-            // either zeroed or preserved based on the underlying target architecture
-            oper = GT_NONE;
+            if (oper != GT_NONE)
+            {
+                if (varTypeIsMask(retType))
+                {
+                    if (varTypeIsMask(cnsNode))
+                    {
+                        cnsNode->AsMskCon()->EvaluateBinaryInPlace(oper, isScalar, simdBaseType, simdSize,
+                                                                   otherNode->AsMskCon());
+                    }
+                    else
+                    {
+                        cnsNode->AsVecCon()->EvaluateBinaryInPlace(oper, isScalar, simdBaseType, otherNode->AsVecCon());
+                    }
+                }
+                else
+                {
+#if defined(TARGET_XARCH)
+                    if ((oper == GT_LSH) || (oper == GT_RSH) || (oper == GT_RSZ))
+                    {
+                        if (otherNode->TypeIs(TYP_SIMD16))
+                        {
+                            if (!HWIntrinsicInfo::IsVariableShift(ni))
+                            {
+                                // The xarch shift instructions support taking the shift amount as
+                                // a simd16, in which case they take the shift amount from the lower
+                                // 64-bits.
+
+                                int64_t shiftAmount = otherNode->AsVecCon()->GetElementIntegral(TYP_LONG, 0);
+
+                                if (static_cast<uint64_t>(shiftAmount) >=
+                                    (static_cast<uint64_t>(genTypeSize(simdBaseType)) * BITS_PER_BYTE))
+                                {
+                                    // Set to -1 to indicate an explicit overshift
+                                    shiftAmount = -1;
+                                }
+
+                                // Ensure we broadcast to the right vector size
+                                otherNode->gtType = retType;
+
+                                otherNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, shiftAmount);
+                            }
+                        }
+                    }
+#endif // TARGET_XARCH
+
+                    if (otherNode->IsIntegralConst())
+                    {
+                        int64_t scalar = otherNode->AsIntConCommon()->IntegralValue();
+
+                        otherNode = gtNewVconNode(retType);
+                        otherNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, scalar);
+                    }
+
+                    cnsNode->AsVecCon()->EvaluateBinaryInPlace(oper, isScalar, simdBaseType, otherNode->AsVecCon());
+                }
+                resultNode = cnsNode;
+            }
+            else
+            {
+                switch (ni)
+                {
+                    case NI_Vector128_GetElement:
+#ifdef TARGET_ARM64
+                    case NI_Vector64_GetElement:
+#else
+                    case NI_Vector256_GetElement:
+                    case NI_Vector512_GetElement:
+#endif
+                    {
+                        uint32_t index = static_cast<uint32_t>(otherNode->AsIntConCommon()->IconValue());
+
+                        if (index >= GenTreeVecCon::ElementCount(simdSize, simdBaseType))
+                        {
+                            // Nothing to fold for out of range indexes
+                            break;
+                        }
+
+                        var_types simdType = getSIMDTypeForSize(simdSize);
+
+                        if (varTypeIsFloating(retType))
+                        {
+                            double result = cnsNode->AsVecCon()->GetElementFloating(simdBaseType, index);
+
+                            resultNode = gtNewDconNode(result, retType);
+                        }
+                        else
+                        {
+                            assert(varTypeIsIntegral(retType));
+                            int64_t result = cnsNode->AsVecCon()->GetElementIntegral(simdBaseType, index);
+
+                            if (varTypeIsLong(retType))
+                            {
+                                resultNode = gtNewLconNode(result);
+                            }
+                            else
+                            {
+                                resultNode = gtNewIconNode(static_cast<int32_t>(result), retType);
+                            }
+                        }
+                        break;
+                    }
+
+#ifdef TARGET_ARM64
+                    case NI_AdvSimd_MultiplyByScalar:
+                    case NI_AdvSimd_Arm64_MultiplyByScalar:
+                    {
+                        // MultiplyByScalar takes a vector as the second operand but only utilizes element 0
+                        // We need to extract it and then functionally broadcast it up for the evaluation to
+                        // work as expected. Ensuring we broadcast up to the target vector size.
+
+                        otherNode->gtType = retType;
+
+                        if (varTypeIsFloating(simdBaseType))
+                        {
+                            double scalar = otherNode->AsVecCon()->ToScalarFloating(simdBaseType);
+                            otherNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, scalar);
+                        }
+                        else
+                        {
+                            assert(varTypeIsIntegral(simdBaseType));
+                            int64_t scalar = otherNode->AsVecCon()->ToScalarIntegral(simdBaseType);
+                            otherNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, scalar);
+                        }
+
+                        cnsNode->AsVecCon()->EvaluateBinaryInPlace(GT_MUL, isScalar, simdBaseType,
+                                                                   otherNode->AsVecCon());
+                        resultNode = cnsNode;
+                        break;
+                    }
+#endif
+
+#ifdef TARGET_ARM64
+                    case NI_Vector128_WithLower:
+                    {
+                        assert(retType == TYP_SIMD16);
+                        assert(cnsNode->TypeIs(TYP_SIMD16));
+                        assert(otherNode->TypeIs(TYP_SIMD8));
+                        cnsNode->AsVecCon()->gtSimd16Val.v64[0] = otherNode->AsVecCon()->gtSimd8Val;
+
+                        resultNode = cnsNode;
+                        break;
+                    }
+#else
+                    case NI_Vector256_WithLower:
+                    {
+                        assert(retType == TYP_SIMD32);
+                        assert(cnsNode->TypeIs(TYP_SIMD32));
+                        assert(otherNode->TypeIs(TYP_SIMD16));
+                        cnsNode->AsVecCon()->gtSimd32Val.v128[0] = otherNode->AsVecCon()->gtSimd16Val;
+
+                        resultNode = cnsNode;
+                        break;
+                    }
+
+                    case NI_Vector512_WithLower:
+                    {
+                        assert(retType == TYP_SIMD64);
+                        assert(cnsNode->TypeIs(TYP_SIMD64));
+                        assert(otherNode->TypeIs(TYP_SIMD32));
+                        cnsNode->AsVecCon()->gtSimd64Val.v256[0] = otherNode->AsVecCon()->gtSimd32Val;
+
+                        resultNode = cnsNode;
+                        break;
+                    }
+#endif
+
+#ifdef TARGET_ARM64
+                    case NI_Vector128_WithUpper:
+                    {
+                        assert(retType == TYP_SIMD16);
+                        assert(cnsNode->TypeIs(TYP_SIMD16));
+                        assert(otherNode->TypeIs(TYP_SIMD8));
+                        cnsNode->AsVecCon()->gtSimd16Val.v64[1] = otherNode->AsVecCon()->gtSimd8Val;
+
+                        resultNode = cnsNode;
+                        break;
+                    }
+#else
+                    case NI_Vector256_WithUpper:
+                    {
+                        assert(retType == TYP_SIMD32);
+                        assert(cnsNode->TypeIs(TYP_SIMD32));
+                        assert(otherNode->TypeIs(TYP_SIMD16));
+                        cnsNode->AsVecCon()->gtSimd32Val.v128[1] = otherNode->AsVecCon()->gtSimd16Val;
+
+                        resultNode = cnsNode;
+                        break;
+                    }
+
+                    case NI_Vector512_WithUpper:
+                    {
+                        assert(retType == TYP_SIMD64);
+                        assert(cnsNode->TypeIs(TYP_SIMD64));
+                        assert(otherNode->TypeIs(TYP_SIMD32));
+                        cnsNode->AsVecCon()->gtSimd64Val.v256[1] = otherNode->AsVecCon()->gtSimd32Val;
+
+                        resultNode = cnsNode;
+                        break;
+                    }
+#endif
+
+                    case NI_Vector128_op_Equality:
+#if defined(TARGET_ARM64)
+                    case NI_Vector64_op_Equality:
+#elif defined(TARGET_XARCH)
+                    case NI_Vector256_op_Equality:
+                    case NI_Vector512_op_Equality:
+#endif // !TARGET_ARM64 && !TARGET_XARCH
+                    {
+                        cnsNode->AsVecCon()->EvaluateBinaryInPlace(GT_EQ, isScalar, simdBaseType,
+                                                                   otherNode->AsVecCon());
+                        resultNode = gtNewIconNode(cnsNode->AsVecCon()->IsAllBitsSet() ? 1 : 0, retType);
+                        break;
+                    }
+
+                    case NI_Vector128_op_Inequality:
+#if defined(TARGET_ARM64)
+                    case NI_Vector64_op_Inequality:
+#elif defined(TARGET_XARCH)
+                    case NI_Vector256_op_Inequality:
+                    case NI_Vector512_op_Inequality:
+#endif // !TARGET_ARM64 && !TARGET_XARCH
+                    {
+                        cnsNode->AsVecCon()->EvaluateBinaryInPlace(GT_NE, isScalar, simdBaseType,
+                                                                   otherNode->AsVecCon());
+                        resultNode = gtNewIconNode(cnsNode->AsVecCon()->IsZero() ? 0 : 1, retType);
+                        break;
+                    }
+
+                    default:
+                    {
+                        break;
+                    }
+                }
+            }
         }
-
-        // For mask nodes in particular, the foldings below are done under the presumption
-        // that we only produce something like `AddMask(op1, op2)` if op1 and op2 are compatible
-        // masks. On xarch, for example, this means that it'd be adding 8, 16, 32, or 64-bits
-        // together with the same size. We wouldn't ever encounter something like an 8 and 16 bit
-        // masks being added. This ensures that we don't end up with a case where folding would
-        // cause a different result to be produced, such as because the remaining upper bits are
-        // no longer zeroed.
-
-        switch (oper)
+        else
         {
-            case GT_ADD:
+            if (isScalar)
             {
-                if (varTypeIsMask(retType))
+                // We don't support folding for scalars when only one input is constant
+                // because it means one value is computed and the remaining values are
+                // either zeroed or preserved based on the underlying target architecture
+                oper = GT_NONE;
+            }
+
+            // For mask nodes in particular, the foldings below are done under the presumption
+            // that we only produce something like `AddMask(op1, op2)` if op1 and op2 are compatible
+            // masks. On xarch, for example, this means that it'd be adding 8, 16, 32, or 64-bits
+            // together with the same size. We wouldn't ever encounter something like an 8 and 16 bit
+            // masks being added. This ensures that we don't end up with a case where folding would
+            // cause a different result to be produced, such as because the remaining upper bits are
+            // no longer zeroed.
+
+            switch (oper)
+            {
+                case GT_ADD:
                 {
+                    if (varTypeIsMask(retType))
+                    {
+                        // Handle `x + 0 == x` and `0 + x == x`
+                        if (cnsNode->IsMaskZero())
+                        {
+                            resultNode = otherNode;
+                        }
+                        break;
+                    }
+
+                    if (varTypeIsFloating(simdBaseType))
+                    {
+                        // Handle `x + NaN == NaN` and `NaN + x == NaN`
+                        // This is safe for all floats since we do not fault for sNaN
+
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+
+                        // Handle `x + -0 == x` and `-0 + x == x`
+
+                        if (cnsNode->IsVectorNegativeZero(simdBaseType))
+                        {
+                            resultNode = otherNode;
+                            break;
+                        }
+
+                        // We cannot handle `x + 0 == x` or `0 + x == x` since `-0 + 0 == 0`
+                        break;
+                    }
+
                     // Handle `x + 0 == x` and `0 + x == x`
-                    if (cnsNode->IsMaskZero())
+                    if (cnsNode->IsVectorZero())
                     {
                         resultNode = otherNode;
                     }
                     break;
                 }
 
-                if (varTypeIsFloating(simdBaseType))
+                case GT_AND:
                 {
-                    // Handle `x + NaN == NaN` and `NaN + x == NaN`
-                    // This is safe for all floats since we do not fault for sNaN
-
-                    if (cnsNode->IsVectorNaN(simdBaseType))
+                    if (varTypeIsMask(retType))
                     {
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                        // Handle `x & 0 == 0` and `0 & x == 0`
+                        if (cnsNode->IsMaskZero())
+                        {
+                            resultNode = otherNode;
+                            break;
+                        }
+
+                        // Handle `x & AllBitsSet == x` and `AllBitsSet & x == x`
+                        if (cnsNode->IsMaskAllBitsSet())
+                        {
+                            resultNode = otherNode;
+                        }
                         break;
                     }
 
-                    // Handle `x + -0 == x` and `-0 + x == x`
-
-                    if (cnsNode->IsVectorNegativeZero(simdBaseType))
-                    {
-                        resultNode = otherNode;
-                        break;
-                    }
-
-                    // We cannot handle `x + 0 == x` or `0 + x == x` since `-0 + 0 == 0`
-                    break;
-                }
-
-                // Handle `x + 0 == x` and `0 + x == x`
-                if (cnsNode->IsVectorZero())
-                {
-                    resultNode = otherNode;
-                }
-                break;
-            }
-
-            case GT_AND:
-            {
-                if (varTypeIsMask(retType))
-                {
                     // Handle `x & 0 == 0` and `0 & x == 0`
-                    if (cnsNode->IsMaskZero())
-                    {
-                        resultNode = otherNode;
-                        break;
-                    }
-
-                    // Handle `x & AllBitsSet == x` and `AllBitsSet & x == x`
-                    if (cnsNode->IsMaskAllBitsSet())
-                    {
-                        resultNode = otherNode;
-                    }
-                    break;
-                }
-
-                // Handle `x & 0 == 0` and `0 & x == 0`
-                if (cnsNode->IsVectorZero())
-                {
-                    resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                    break;
-                }
-
-                // Handle `x & AllBitsSet == x` and `AllBitsSet & x == x`
-                if (cnsNode->IsVectorAllBitsSet())
-                {
-                    resultNode = otherNode;
-                }
-                break;
-            }
-
-            case GT_DIV:
-            {
-                assert(!varTypeIsMask(retType));
-
-                if (varTypeIsFloating(simdBaseType))
-                {
-                    // Handle `x / NaN == NaN` and `NaN / x == NaN`
-                    // This is safe for all floats since we do not fault for sNaN
-
-                    if (cnsNode->IsVectorNaN(simdBaseType))
-                    {
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-
-                // Handle `x / 1 == x`.
-                // This is safe for all floats since we do not fault for sNaN
-
-                if (cnsNode != op2)
-                {
-                    break;
-                }
-
-                if (!cnsNode->IsVectorBroadcast(simdBaseType))
-                {
-                    break;
-                }
-
-                if (cnsNode->AsVecCon()->IsScalarOne(simdBaseType))
-                {
-                    resultNode = otherNode;
-                }
-                break;
-            }
-
-            case GT_EQ:
-            {
-                if (varTypeIsFloating(simdBaseType))
-                {
-                    // Handle `(x == NaN) == false` and `(NaN == x) == false` for floating-point types
-                    if (cnsNode->IsVectorNaN(simdBaseType))
-                    {
-                        int64_t zero = 0;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-                break;
-            }
-
-            case GT_GT:
-            {
-                if (varTypeIsUnsigned(simdBaseType))
-                {
-                    // Handle `(0 > x) == false` for unsigned types.
-                    if ((cnsNode == op1) && cnsNode->IsVectorZero())
-                    {
-                        int64_t zero = 0;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-                else if (varTypeIsFloating(simdBaseType))
-                {
-                    // Handle `(x > NaN) == false` and `(NaN > x) == false` for floating-point types
-                    if (cnsNode->IsVectorNaN(simdBaseType))
-                    {
-                        int64_t zero = 0;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-                break;
-            }
-
-            case GT_GE:
-            {
-                if (varTypeIsUnsigned(simdBaseType))
-                {
-                    // Handle `x >= 0 == true` for unsigned types.
-                    if ((cnsNode == op2) && cnsNode->IsVectorZero())
-                    {
-                        int64_t allBitsSet = -1;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, allBitsSet);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-                else if (varTypeIsFloating(simdBaseType))
-                {
-                    // Handle `(x >= NaN) == false` and `(NaN >= x) == false` for floating-point types
-                    if (cnsNode->IsVectorNaN(simdBaseType))
-                    {
-                        int64_t zero = 0;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-                break;
-            }
-
-            case GT_LT:
-            {
-                if (varTypeIsUnsigned(simdBaseType))
-                {
-                    // Handle `x < 0 == false` for unsigned types.
-                    if ((cnsNode == op2) && cnsNode->IsVectorZero())
-                    {
-                        int64_t zero = 0;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-                else if (varTypeIsFloating(simdBaseType))
-                {
-                    // Handle `(x < NaN) == false` and `(NaN < x) == false` for floating-point types
-                    if (cnsNode->IsVectorNaN(simdBaseType))
-                    {
-                        int64_t zero = 0;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-                break;
-            }
-
-            case GT_LE:
-            {
-                if (varTypeIsUnsigned(simdBaseType))
-                {
-                    // Handle `0 <= x == true` for unsigned types.
-                    if ((cnsNode == op1) && cnsNode->IsVectorZero())
-                    {
-                        int64_t allBitsSet = -1;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, allBitsSet);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-                else if (varTypeIsFloating(simdBaseType))
-                {
-                    // Handle `(x <= NaN) == false` and `(NaN <= x) == false` for floating-point types
-                    if (cnsNode->IsVectorNaN(simdBaseType))
-                    {
-                        int64_t zero = 0;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
-                    }
-                }
-                break;
-            }
-
-            case GT_MUL:
-            {
-                assert(!varTypeIsMask(retType));
-
-                if (!varTypeIsFloating(simdBaseType))
-                {
-                    // Handle `x * 0 == 0` and `0 * x == 0`
-                    // Not safe for floating-point when x == -0.0, NaN, +Inf, -Inf
                     if (cnsNode->IsVectorZero())
                     {
                         resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
                         break;
                     }
-                }
-                else
-                {
-                    // Handle `x * NaN == NaN` and `NaN * x == NaN`
-                    // This is safe for all floats since we do not fault for sNaN
 
-                    if (cnsNode->IsVectorNaN(simdBaseType))
+                    // Handle `x & AllBitsSet == x` and `AllBitsSet & x == x`
+                    if (cnsNode->IsVectorAllBitsSet())
                     {
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
+                        resultNode = otherNode;
                     }
-
-                    // We cannot handle `x *  0 ==  0` or ` 0 * x ==  0` since `-0 *  0 == -0`
-                    // We cannot handle `x * -0 == -0` or `-0 * x == -0` since `-0 * -0 ==  0`
-                }
-
-                // Handle `x * 1 == x` and `1 * x == x`
-                // This is safe for all floats since we do not fault for sNaN
-
-                if (!cnsNode->IsVectorBroadcast(simdBaseType))
-                {
                     break;
                 }
 
-                if (cnsNode->AsVecCon()->IsScalarOne(simdBaseType))
+                case GT_DIV:
                 {
-                    resultNode = otherNode;
-                }
-                break;
-            }
+                    assert(!varTypeIsMask(retType));
 
-            case GT_NE:
-            {
-                if (varTypeIsFloating(simdBaseType))
-                {
-                    // Handle `(x != NaN) == true` and `(NaN != x) == true` for floating-point types
-                    if (cnsNode->IsVectorNaN(simdBaseType))
+                    if (varTypeIsFloating(simdBaseType))
                     {
-                        int64_t allBitsSet = -1;
-                        cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, allBitsSet);
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                        // Handle `x / NaN == NaN` and `NaN / x == NaN`
+                        // This is safe for all floats since we do not fault for sNaN
+
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+
+                    // Handle `x / 1 == x`.
+                    // This is safe for all floats since we do not fault for sNaN
+
+                    if (cnsNode != op2)
+                    {
                         break;
                     }
-                }
-                break;
-            }
 
-            case GT_OR:
-            {
-                if (varTypeIsMask(retType))
+                    if (!cnsNode->IsVectorBroadcast(simdBaseType))
+                    {
+                        break;
+                    }
+
+                    if (cnsNode->AsVecCon()->IsScalarOne(simdBaseType))
+                    {
+                        resultNode = otherNode;
+                    }
+                    break;
+                }
+
+                case GT_EQ:
                 {
+                    if (varTypeIsFloating(simdBaseType))
+                    {
+                        // Handle `(x == NaN) == false` and `(NaN == x) == false` for floating-point types
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            int64_t zero = 0;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    else if (otherNode->OperIsHWIntrinsic())
+                    {
+                        GenTreeHWIntrinsic* otherIntrinsic   = otherNode->AsHWIntrinsic();
+                        NamedIntrinsic      otherIntrinsicId = otherIntrinsic->GetHWIntrinsicId();
+
+                        if (HWIntrinsicInfo::ReturnsPerElementMask(otherIntrinsicId) &&
+                            (genTypeSize(simdBaseType) == genTypeSize(otherIntrinsic->GetSimdBaseType())))
+                        {
+                            // This optimization is only safe if we know the other node produces
+                            // AllBitsSet or Zero per element and if the outer comparison is the
+                            // same size as what the other node produces for its mask
+
+                            // Handle `(Mask == AllBitsSet) == Mask` and `(AllBitsSet == Mask) == Mask` for integrals
+                            if (cnsNode->IsVectorAllBitsSet())
+                            {
+                                resultNode = otherNode;
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+
+                case GT_GT:
+                {
+                    if (varTypeIsUnsigned(simdBaseType))
+                    {
+                        // Handle `(0 > x) == false` for unsigned types.
+                        if ((cnsNode == op1) && cnsNode->IsVectorZero())
+                        {
+                            int64_t zero = 0;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    else if (varTypeIsFloating(simdBaseType))
+                    {
+                        // Handle `(x > NaN) == false` and `(NaN > x) == false` for floating-point types
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            int64_t zero = 0;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                case GT_GE:
+                {
+                    if (varTypeIsUnsigned(simdBaseType))
+                    {
+                        // Handle `x >= 0 == true` for unsigned types.
+                        if ((cnsNode == op2) && cnsNode->IsVectorZero())
+                        {
+                            int64_t allBitsSet = -1;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, allBitsSet);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    else if (varTypeIsFloating(simdBaseType))
+                    {
+                        // Handle `(x >= NaN) == false` and `(NaN >= x) == false` for floating-point types
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            int64_t zero = 0;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                case GT_LT:
+                {
+                    if (varTypeIsUnsigned(simdBaseType))
+                    {
+                        // Handle `x < 0 == false` for unsigned types.
+                        if ((cnsNode == op2) && cnsNode->IsVectorZero())
+                        {
+                            int64_t zero = 0;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    else if (varTypeIsFloating(simdBaseType))
+                    {
+                        // Handle `(x < NaN) == false` and `(NaN < x) == false` for floating-point types
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            int64_t zero = 0;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                case GT_LE:
+                {
+                    if (varTypeIsUnsigned(simdBaseType))
+                    {
+                        // Handle `0 <= x == true` for unsigned types.
+                        if ((cnsNode == op1) && cnsNode->IsVectorZero())
+                        {
+                            int64_t allBitsSet = -1;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, allBitsSet);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    else if (varTypeIsFloating(simdBaseType))
+                    {
+                        // Handle `(x <= NaN) == false` and `(NaN <= x) == false` for floating-point types
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            int64_t zero = 0;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, zero);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                case GT_MUL:
+                {
+                    assert(!varTypeIsMask(retType));
+
+                    if (!varTypeIsFloating(simdBaseType))
+                    {
+                        // Handle `x * 0 == 0` and `0 * x == 0`
+                        // Not safe for floating-point when x == -0.0, NaN, +Inf, -Inf
+                        if (cnsNode->IsVectorZero())
+                        {
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        // Handle `x * NaN == NaN` and `NaN * x == NaN`
+                        // This is safe for all floats since we do not fault for sNaN
+
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+
+                        // We cannot handle `x *  0 ==  0` or ` 0 * x ==  0` since `-0 *  0 == -0`
+                        // We cannot handle `x * -0 == -0` or `-0 * x == -0` since `-0 * -0 ==  0`
+                    }
+
+                    // Handle `x * 1 == x` and `1 * x == x`
+                    // This is safe for all floats since we do not fault for sNaN
+
+                    if (!cnsNode->IsVectorBroadcast(simdBaseType))
+                    {
+                        break;
+                    }
+
+                    if (cnsNode->AsVecCon()->IsScalarOne(simdBaseType))
+                    {
+                        resultNode = otherNode;
+                    }
+                    break;
+                }
+
+                case GT_NE:
+                {
+                    if (varTypeIsFloating(simdBaseType))
+                    {
+                        // Handle `(x != NaN) == true` and `(NaN != x) == true` for floating-point types
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            int64_t allBitsSet = -1;
+                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(TYP_LONG, allBitsSet);
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+                    }
+                    else if (otherNode->OperIsHWIntrinsic())
+                    {
+                        GenTreeHWIntrinsic* otherIntrinsic   = otherNode->AsHWIntrinsic();
+                        NamedIntrinsic      otherIntrinsicId = otherIntrinsic->GetHWIntrinsicId();
+
+                        if (HWIntrinsicInfo::ReturnsPerElementMask(otherIntrinsicId) &&
+                            (genTypeSize(simdBaseType) == genTypeSize(otherIntrinsic->GetSimdBaseType())))
+                        {
+                            // This optimization is only safe if we know the other node produces
+                            // AllBitsSet or Zero per element and if the outer comparison is the
+                            // same size as what the other node produces for its mask
+
+                            // Handle `(Mask != Zero) == Mask` and `(Zero != Mask) == Mask` for integral types
+                            if (cnsNode->IsVectorZero())
+                            {
+                                resultNode = otherNode;
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+
+                case GT_OR:
+                {
+                    if (varTypeIsMask(retType))
+                    {
+                        // Handle `x | 0 == x` and `0 | x == x`
+                        if (cnsNode->IsMaskZero())
+                        {
+                            resultNode = otherNode;
+                            break;
+                        }
+
+                        // Handle `x | AllBitsSet == AllBitsSet` and `AllBitsSet | x == AllBitsSet`
+                        if (cnsNode->IsMaskAllBitsSet())
+                        {
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                        }
+                        break;
+                    }
+
                     // Handle `x | 0 == x` and `0 | x == x`
-                    if (cnsNode->IsMaskZero())
+                    if (cnsNode->IsVectorZero())
                     {
                         resultNode = otherNode;
                         break;
                     }
 
                     // Handle `x | AllBitsSet == AllBitsSet` and `AllBitsSet | x == AllBitsSet`
-                    if (cnsNode->IsMaskAllBitsSet())
+                    if (cnsNode->IsVectorAllBitsSet())
                     {
                         resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
                     }
                     break;
                 }
 
-                // Handle `x | 0 == x` and `0 | x == x`
-                if (cnsNode->IsVectorZero())
+                case GT_ROL:
+                case GT_ROR:
+                case GT_LSH:
+                case GT_RSH:
+                case GT_RSZ:
                 {
-                    resultNode = otherNode;
-                    break;
-                }
+                    // Handle `x rol 0 == x` and `0 rol x == 0`
+                    // Handle `x ror 0 == x` and `0 ror x == 0`
+                    // Handle `x <<  0 == x` and `0 <<  x == 0`
+                    // Handle `x >>  0 == x` and `0 >>  x == 0`
+                    // Handle `x >>> 0 == x` and `0 >>> x == 0`
 
-                // Handle `x | AllBitsSet == AllBitsSet` and `AllBitsSet | x == AllBitsSet`
-                if (cnsNode->IsVectorAllBitsSet())
-                {
-                    resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                }
-                break;
-            }
+                    if (varTypeIsMask(retType))
+                    {
+                        if (cnsNode->IsMaskZero())
+                        {
+                            if (cnsNode == op2)
+                            {
+                                resultNode = otherNode;
+                            }
+                            else
+                            {
+                                resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            }
+                        }
+                        else if (cnsNode->IsIntegralConst(0))
+                        {
+                            assert(cnsNode == op2);
+                            resultNode = otherNode;
+                        }
+                        break;
+                    }
 
-            case GT_ROL:
-            case GT_ROR:
-            case GT_LSH:
-            case GT_RSH:
-            case GT_RSZ:
-            {
-                // Handle `x rol 0 == x` and `0 rol x == 0`
-                // Handle `x ror 0 == x` and `0 ror x == 0`
-                // Handle `x <<  0 == x` and `0 <<  x == 0`
-                // Handle `x >>  0 == x` and `0 >>  x == 0`
-                // Handle `x >>> 0 == x` and `0 >>> x == 0`
-
-                if (varTypeIsMask(retType))
-                {
-                    if (cnsNode->IsMaskZero())
+                    if (cnsNode->IsVectorZero())
                     {
                         if (cnsNode == op2)
                         {
@@ -33479,207 +33616,190 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
                     break;
                 }
 
-                if (cnsNode->IsVectorZero())
+                case GT_SUB:
                 {
-                    if (cnsNode == op2)
-                    {
-                        resultNode = otherNode;
-                    }
-                    else
-                    {
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                    }
-                }
-                else if (cnsNode->IsIntegralConst(0))
-                {
-                    assert(cnsNode == op2);
-                    resultNode = otherNode;
-                }
-                break;
-            }
+                    assert(!varTypeIsMask(retType));
 
-            case GT_SUB:
-            {
-                assert(!varTypeIsMask(retType));
-
-                if (varTypeIsFloating(simdBaseType))
-                {
-                    // Handle `x - NaN == NaN` and `NaN - x == NaN`
-                    // This is safe for all floats since we do not fault for sNaN
-
-                    if (cnsNode->IsVectorNaN(simdBaseType))
+                    if (varTypeIsFloating(simdBaseType))
                     {
-                        resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                        break;
+                        // Handle `x - NaN == NaN` and `NaN - x == NaN`
+                        // This is safe for all floats since we do not fault for sNaN
+
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
+
+                        // We cannot handle `x - -0 == x` since `-0 - -0 == 0`
                     }
 
-                    // We cannot handle `x - -0 == x` since `-0 - -0 == 0`
-                }
-
-                // Handle `x - 0 == x`
-                if ((op2 == cnsNode) && cnsNode->IsVectorZero())
-                {
-                    resultNode = otherNode;
-                }
-                break;
-            }
-
-            case GT_XOR:
-            {
-                if (varTypeIsMask(retType))
-                {
-                    // Handle `x ^ 0 == x` and `0 ^ x == x`
-                    if (cnsNode->IsMaskZero())
+                    // Handle `x - 0 == x`
+                    if ((op2 == cnsNode) && cnsNode->IsVectorZero())
                     {
                         resultNode = otherNode;
                     }
                     break;
                 }
 
-                // Handle `x ^ 0 == x` and `0 ^ x == x`
-                if (cnsNode->IsVectorZero())
+                case GT_XOR:
                 {
-                    resultNode = otherNode;
+                    if (varTypeIsMask(retType))
+                    {
+                        // Handle `x ^ 0 == x` and `0 ^ x == x`
+                        if (cnsNode->IsMaskZero())
+                        {
+                            resultNode = otherNode;
+                        }
+                        break;
+                    }
+
+                    // Handle `x ^ 0 == x` and `0 ^ x == x`
+                    if (cnsNode->IsVectorZero())
+                    {
+                        resultNode = otherNode;
+                    }
+                    break;
                 }
-                break;
+
+                default:
+                {
+                    break;
+                }
             }
 
-            default:
+            switch (ni)
             {
-                break;
-            }
-        }
-
-        switch (ni)
-        {
 #ifdef TARGET_ARM64
-            case NI_Sve_ConvertVectorToMask:
-                resultNode = gtFoldExprConvertVecCnsToMask(tree, cnsNode->AsVecCon());
-                break;
+                case NI_Sve_ConvertVectorToMask:
+                    resultNode = gtFoldExprConvertVecCnsToMask(tree, cnsNode->AsVecCon());
+                    break;
 
-            case NI_AdvSimd_MultiplyByScalar:
-            case NI_AdvSimd_Arm64_MultiplyByScalar:
-            {
-                if (!varTypeIsFloating(simdBaseType))
+                case NI_AdvSimd_MultiplyByScalar:
+                case NI_AdvSimd_Arm64_MultiplyByScalar:
                 {
-                    // Handle `x * 0 == 0` and `0 * x == 0`
-                    // Not safe for floating-point when x == -0.0, NaN, +Inf, -Inf
-                    if (cnsNode == op1)
+                    if (!varTypeIsFloating(simdBaseType))
                     {
-                        if (cnsNode->IsVectorZero())
+                        // Handle `x * 0 == 0` and `0 * x == 0`
+                        // Not safe for floating-point when x == -0.0, NaN, +Inf, -Inf
+                        if (cnsNode == op1)
                         {
-                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                            break;
+                            if (cnsNode->IsVectorZero())
+                            {
+                                resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            assert(cnsNode == op2);
+
+                            if (cnsNode->AsVecCon()->IsScalarZero(simdBaseType))
+                            {
+                                int64_t val = 0;
+
+                                cnsNode->gtType = retType;
+                                cnsNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, val);
+
+                                resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                                break;
+                            }
                         }
                     }
                     else
                     {
-                        assert(cnsNode == op2);
+                        // Handle `x * NaN == NaN` and `NaN * x == NaN`
+                        // This is safe for all floats since we do not fault for sNaN
 
-                        if (cnsNode->AsVecCon()->IsScalarZero(simdBaseType))
+                        if (cnsNode == op1)
                         {
-                            int64_t val = 0;
-
-                            cnsNode->gtType = retType;
-                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, val);
-
-                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                            break;
+                            if (cnsNode->IsVectorNaN(simdBaseType))
+                            {
+                                resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                                break;
+                            }
                         }
-                    }
-                }
-                else
-                {
-                    // Handle `x * NaN == NaN` and `NaN * x == NaN`
-                    // This is safe for all floats since we do not fault for sNaN
+                        else
+                        {
+                            assert(cnsNode == op2);
+                            double val = cnsNode->AsVecCon()->GetElementFloating(simdBaseType, 0);
 
-                    if (cnsNode == op1)
+                            if (FloatingPointUtils::isNaN(val))
+                            {
+                                cnsNode->gtType = retType;
+                                cnsNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, val);
+
+                                resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
+                                break;
+                            }
+                        }
+
+                        // We cannot handle `x *  0 ==  0` or ` 0 * x ==  0` since `-0 *  0 == -0`
+                        // We cannot handle `x * -0 == -0` or `-0 * x == -0` since `-0 * -0 ==  0`
+                    }
+
+                    // Handle x * 1 => x, but only if the scalar RHS is <1, ...>.
+                    if ((cnsNode == op2) && cnsNode->AsVecCon()->IsScalarOne(simdBaseType))
                     {
-                        if (cnsNode->IsVectorNaN(simdBaseType))
-                        {
-                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                            break;
-                        }
+                        resultNode = otherNode;
                     }
-                    else
-                    {
-                        assert(cnsNode == op2);
-                        double val = cnsNode->AsVecCon()->GetElementFloating(simdBaseType, 0);
-
-                        if (FloatingPointUtils::isNaN(val))
-                        {
-                            cnsNode->gtType = retType;
-                            cnsNode->AsVecCon()->EvaluateBroadcastInPlace(simdBaseType, val);
-
-                            resultNode = gtWrapWithSideEffects(cnsNode, otherNode, GTF_ALL_EFFECT);
-                            break;
-                        }
-                    }
-
-                    // We cannot handle `x *  0 ==  0` or ` 0 * x ==  0` since `-0 *  0 == -0`
-                    // We cannot handle `x * -0 == -0` or `-0 * x == -0` since `-0 * -0 ==  0`
+                    break;
                 }
-
-                // Handle x * 1 => x, but only if the scalar RHS is <1, ...>.
-                if ((cnsNode == op2) && cnsNode->AsVecCon()->IsScalarOne(simdBaseType))
-                {
-                    resultNode = otherNode;
-                }
-                break;
-            }
 #endif
 
-            case NI_Vector128_op_Equality:
+                case NI_Vector128_op_Equality:
 #if defined(TARGET_ARM64)
-            case NI_Vector64_op_Equality:
+                case NI_Vector64_op_Equality:
 #elif defined(TARGET_XARCH)
-            case NI_Vector256_op_Equality:
-            case NI_Vector512_op_Equality:
+                case NI_Vector256_op_Equality:
+                case NI_Vector512_op_Equality:
 #endif // !TARGET_ARM64 && !TARGET_XARCH
-            {
-                if (varTypeIsFloating(simdBaseType))
                 {
-                    // Handle `(x == NaN) == false` and `(NaN == x) == false` for floating-point types
-                    if (cnsNode->IsVectorNaN(simdBaseType))
+                    if (varTypeIsFloating(simdBaseType))
                     {
-                        resultNode = gtNewIconNode(0, retType);
-                        resultNode = gtWrapWithSideEffects(resultNode, otherNode, GTF_ALL_EFFECT);
-                        break;
+                        // Handle `(x == NaN) == false` and `(NaN == x) == false` for floating-point types
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            resultNode = gtNewIconNode(0, retType);
+                            resultNode = gtWrapWithSideEffects(resultNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
                     }
+                    break;
                 }
-                break;
-            }
 
-            case NI_Vector128_op_Inequality:
+                case NI_Vector128_op_Inequality:
 #if defined(TARGET_ARM64)
-            case NI_Vector64_op_Inequality:
+                case NI_Vector64_op_Inequality:
 #elif defined(TARGET_XARCH)
-            case NI_Vector256_op_Inequality:
-            case NI_Vector512_op_Inequality:
+                case NI_Vector256_op_Inequality:
+                case NI_Vector512_op_Inequality:
 #endif // !TARGET_ARM64 && !TARGET_XARCH
-            {
-                if (varTypeIsFloating(simdBaseType))
                 {
-                    // Handle `(x != NaN) == true` and `(NaN != x) == true` for floating-point types
-                    if (cnsNode->IsVectorNaN(simdBaseType))
+                    if (varTypeIsFloating(simdBaseType))
                     {
-                        resultNode = gtNewIconNode(1, retType);
-                        resultNode = gtWrapWithSideEffects(resultNode, otherNode, GTF_ALL_EFFECT);
-                        break;
+                        // Handle `(x != NaN) == true` and `(NaN != x) == true` for floating-point types
+                        if (cnsNode->IsVectorNaN(simdBaseType))
+                        {
+                            resultNode = gtNewIconNode(1, retType);
+                            resultNode = gtWrapWithSideEffects(resultNode, otherNode, GTF_ALL_EFFECT);
+                            break;
+                        }
                     }
+                    break;
                 }
-                break;
-            }
 
-            default:
-            {
-                break;
+                default:
+                {
+                    break;
+                }
             }
         }
     }
-
-    if (op3 != nullptr)
+    else
     {
+        assert(opCount == 3);
+
         switch (ni)
         {
 #if defined(TARGET_XARCH)
@@ -33791,6 +33911,96 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
                 break;
             }
 #endif // TARGET_ARM64
+
+            case NI_Vector128_WithElement:
+#ifdef TARGET_ARM64
+            case NI_Vector64_WithElement:
+#else
+            case NI_Vector256_WithElement:
+            case NI_Vector512_WithElement:
+#endif
+            {
+                if ((cnsNode != op1) || !op3->OperIsConst())
+                {
+                    break;
+                }
+
+                uint32_t index = static_cast<uint32_t>(op2->AsIntConCommon()->IconValue());
+
+                if (index >= GenTreeVecCon::ElementCount(simdSize, simdBaseType))
+                {
+                    // Nothing to fold for out of range indexes
+                    break;
+                }
+
+                var_types simdType = getSIMDTypeForSize(simdSize);
+
+                if (varTypeIsFloating(simdBaseType))
+                {
+                    double value = op3->AsDblCon()->DconValue();
+                    cnsNode->AsVecCon()->SetElementFloating(simdBaseType, index, value);
+                    resultNode = cnsNode;
+                }
+                else
+                {
+                    assert(varTypeIsIntegral(simdBaseType));
+                    int64_t value = op3->AsIntConCommon()->IntegralValue();
+                    cnsNode->AsVecCon()->SetElementIntegral(simdBaseType, index, value);
+                    resultNode = cnsNode;
+                }
+                break;
+            }
+
+#if defined(TARGET_XARCH)
+            case NI_AVX_Compare:
+            case NI_AVX_CompareScalar:
+            case NI_AVX512_CompareMask:
+            {
+                if (!op3->IsCnsIntOrI())
+                {
+                    break;
+                }
+
+                FloatComparisonMode mode = static_cast<FloatComparisonMode>(op3->AsIntConCommon()->IntegralValue());
+                NamedIntrinsic      id   = ni;
+
+                switch (mode)
+                {
+                    case FloatComparisonMode::OrderedFalseNonSignaling:
+                    case FloatComparisonMode::OrderedFalseSignaling:
+                    {
+                        resultNode = gtNewZeroConNode(retType);
+                        resultNode = gtWrapWithSideEffects(resultNode, tree, GTF_ALL_EFFECT);
+                        break;
+                    }
+
+                    case FloatComparisonMode::UnorderedTrueNonSignaling:
+                    case FloatComparisonMode::UnorderedTrueSignaling:
+                    {
+                        resultNode = gtNewAllBitsSetConNode(retType);
+                        resultNode = gtWrapWithSideEffects(resultNode, tree, GTF_ALL_EFFECT);
+                        break;
+                    }
+
+                    default:
+                    {
+                        id = HWIntrinsicInfo::lookupIdForFloatComparisonMode(ni, mode, simdBaseType, simdSize);
+                        break;
+                    }
+                }
+
+                if (id == ni)
+                {
+                    break;
+                }
+
+                tree->ResetHWIntrinsicId(id, op1, op2);
+                DEBUG_DESTROY_NODE(op3);
+
+                tree->SetMorphed(this);
+                return gtFoldExprHWIntrinsic(tree);
+            }
+#endif // TARGET_XARCH
 
             default:
             {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11335,12 +11335,101 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
     if (tree->isCommutativeHWIntrinsic())
     {
         assert(tree->GetOperandCount() == 2);
+
         GenTree*& op1 = tree->Op(1);
+        GenTree*& op2 = tree->Op(2);
 
         if (op1->OperIsConst())
         {
             // Move constants from op1 to op2 for commutative operations
-            std::swap(op1, tree->Op(2));
+            std::swap(op1, op2);
+        }
+
+        if (((oper == GT_EQ) || (oper == GT_NE)) && op1->OperIsHWIntrinsic() && op2->IsCnsVec())
+        {
+            GenTreeHWIntrinsic* op1Intrinsic   = op1->AsHWIntrinsic();
+            NamedIntrinsic      op1IntrinsicId = op1Intrinsic->GetHWIntrinsicId();
+            var_types           op1Type        = op1Intrinsic->TypeGet();
+
+            if (HWIntrinsicInfo::ReturnsPerElementMask(op1IntrinsicId) &&
+                (genTypeSize(simdBaseType) == genTypeSize(op1Intrinsic->GetSimdBaseType())))
+            {
+                // This optimization is only safe if we know the other node produces
+                // AllBitsSet or Zero per element and if the outer comparison is the
+                // same size as what the other node produces for its mask
+
+                bool reverseCond = false;
+
+                if (oper == GT_EQ)
+                {
+                    // Handle `Mask == Zero` and `Zero == Mask` for integral types
+                    if (op2->IsVectorZero())
+                    {
+                        reverseCond = true;
+                    }
+                }
+                else if (oper == GT_NE)
+                {
+                    // Handle `Mask != AllBitsSet` and `AllBitsSet != Mask` for integral types
+                    if (op2->IsVectorAllBitsSet())
+                    {
+                        reverseCond = true;
+                    }
+                }
+
+                if (reverseCond)
+                {
+                    GenTree* newNode = nullptr;
+
+                    if (op1Intrinsic->OperIsConvertVectorToMask())
+                    {
+#if defined(TARGET_XARCH)
+                        op1 = op1Intrinsic->Op(1);
+#elif defined(TARGET_ARM64)
+                        op1 = op1Intrinsic->Op(2);
+                        DEBUG_DESTROY_NODE(op1Intrinsic->Op(1));
+#else
+#error Unsupported platform
+#endif // !TARGET_XARCH && !TARGET_ARM64
+
+                        op1Type = op1->TypeGet();
+                        DEBUG_DESTROY_NODE(op1Intrinsic);
+                    }
+
+                    if (op1Type == TYP_MASK)
+                    {
+#if defined(TARGET_XARCH)
+                        newNode = gtNewSimdHWIntrinsicNode(op1Type, op1, NI_AVX512_NotMask, simdBaseJitType, simdSize);
+#endif // TARGET_XARCH
+                    }
+                    else
+                    {
+                        newNode = gtNewSimdUnOpNode(GT_NOT, op1Type, op1, simdBaseJitType, simdSize);
+                    }
+
+                    if (newNode != nullptr)
+                    {
+                        DEBUG_DESTROY_NODE(op2);
+                        DEBUG_DESTROY_NODE(tree);
+
+                        if (op1Type != retType)
+                        {
+                            newNode = fgMorphHWIntrinsicRequired(newNode->AsHWIntrinsic());
+
+                            if (retType == TYP_MASK)
+                            {
+                                newNode = gtNewSimdCvtVectorToMaskNode(retType, newNode, simdBaseJitType, simdSize);
+                            }
+                            else
+                            {
+                                newNode = gtNewSimdCvtMaskToVectorNode(retType, newNode, simdBaseJitType, simdSize);
+                            }
+                        }
+
+                        return fgMorphHWIntrinsicRequired(newNode->AsHWIntrinsic());
+                    }
+                }
+            }
         }
     }
     else if (GenTree::OperIsCompare(oper))
@@ -11350,7 +11439,7 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
         GenTree* op1 = tree->Op(1);
         GenTree* op2 = tree->Op(2);
 
-        if (!isScalar && op1->IsCnsVec())
+        if (!isScalar && op1->OperIsConst())
         {
             // Move constant vectors from op1 to op2 for comparison operations
             // Noting that we can't handle scalar operations since they can copy upper bits from op1
@@ -11398,20 +11487,15 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
                     break;
                 }
 
-                FloatComparisonMode mode = static_cast<FloatComparisonMode>(op3->AsIntConCommon()->IntegralValue());
-
+                FloatComparisonMode mode    = static_cast<FloatComparisonMode>(op3->AsIntConCommon()->IntegralValue());
                 FloatComparisonMode newMode = mode;
 
                 switch (mode)
                 {
                     case FloatComparisonMode::UnorderedEqualNonSignaling:
-                    case FloatComparisonMode::OrderedFalseNonSignaling:
                     case FloatComparisonMode::OrderedNotEqualNonSignaling:
-                    case FloatComparisonMode::UnorderedTrueNonSignaling:
                     case FloatComparisonMode::UnorderedEqualSignaling:
-                    case FloatComparisonMode::OrderedFalseSignaling:
                     case FloatComparisonMode::OrderedNotEqualSignaling:
-                    case FloatComparisonMode::UnorderedTrueSignaling:
                     {
                         tree->Op(1) = op2;
                         tree->Op(2) = op1;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11405,6 +11405,10 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
                     else
                     {
                         newNode = gtNewSimdUnOpNode(GT_NOT, op1Type, op1, simdBaseJitType, simdSize);
+
+#if defined(TARGET_XARCH)
+                        newNode->AsHWIntrinsic()->Op(2)->SetMorphed(this);
+#endif // TARGET_XARCH
                     }
 
                     if (newNode != nullptr)
@@ -11439,7 +11443,7 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
         GenTree* op1 = tree->Op(1);
         GenTree* op2 = tree->Op(2);
 
-        if (!isScalar && op1->OperIsConst())
+        if (!isScalar && op1->IsCnsVec())
         {
             // Move constant vectors from op1 to op2 for comparison operations
             // Noting that we can't handle scalar operations since they can copy upper bits from op1

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8488,6 +8488,10 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(
 
             case GT_EQ:
             {
+                NamedIntrinsic argIntrinsicId;
+                unsigned       argSimdSize;
+                CorInfoType    argSimdBaseJitType;
+
                 if (varTypeIsFloating(baseType))
                 {
                     // Handle `(x == NaN) == false` and `(NaN == x) == false` for floating-point types
@@ -8496,6 +8500,30 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(
                     if (VNIsVectorNaN(simdType, baseType, cnsVN))
                     {
                         return VNZeroForType(type);
+                    }
+                }
+                else if (IsVNHWIntrinsicFunc(argVN, &argIntrinsicId, &argSimdSize, &argSimdBaseJitType))
+                {
+                    // This optimization is only safe if we know the other node produces
+                    // AllBitsSet or Zero per element and if the outer comparison is the
+                    // same size as what the other node produces for its mask
+
+                    if (!HWIntrinsicInfo::ReturnsPerElementMask(argIntrinsicId))
+                    {
+                        break;
+                    }
+
+                    if (genTypeSize(baseType) == genTypeSize(JitType2PreciseVarType(argSimdBaseJitType)))
+                    {
+                        break;
+                    }
+
+                    // Handle `(Mask == AllBitsSet) == Mask` and `(AllBitsSet == Mask) == Mask` for integral types
+                    ValueNum allBitsVN = VNAllBitsForType(type, simdSize);
+
+                    if (cnsVN == allBitsVN)
+                    {
+                        return argVN;
                     }
                 }
                 break;
@@ -8646,6 +8674,10 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(
             {
                 var_types simdType = Compiler::getSIMDTypeForSize(simdSize);
 
+                NamedIntrinsic argIntrinsicId;
+                unsigned       argSimdSize;
+                CorInfoType    argSimdBaseJitType;
+
                 if (varTypeIsFloating(baseType))
                 {
                     // Handle `(x != NaN) == true` and `(NaN != x) == true` for floating-point types
@@ -8653,6 +8685,30 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(
                     {
                         unsigned elementCount = simdSize / genTypeSize(baseType);
                         return VNAllBitsForType(type, elementCount);
+                    }
+                }
+                else if (IsVNHWIntrinsicFunc(argVN, &argIntrinsicId, &argSimdSize, &argSimdBaseJitType))
+                {
+                    // This optimization is only safe if we know the other node produces
+                    // AllBitsSet or Zero per element and if the outer comparison is the
+                    // same size as what the other node produces for its mask
+
+                    if (!HWIntrinsicInfo::ReturnsPerElementMask(argIntrinsicId))
+                    {
+                        break;
+                    }
+
+                    if (genTypeSize(baseType) != genTypeSize(JitType2PreciseVarType(argSimdBaseJitType)))
+                    {
+                        break;
+                    }
+
+                    // Handle `(Mask != Zero) == Mask` and `(Zero != Mask) == Mask` for integral types
+                    ValueNum zeroVN = VNZeroForType(type);
+
+                    if (cnsVN == zeroVN)
+                    {
+                        return argVN;
                     }
                 }
                 break;
@@ -9969,6 +10025,65 @@ bool ValueNumStore::IsVNBinFunc(ValueNum vn, VNFunc func, ValueNum* op1, ValueNu
         return true;
     }
     return false;
+}
+
+//----------------------------------------------------------------------------------
+// IsVNHWIntrinsicFunc: A specialized version of GetVNFunc that checks if the given ValueNum
+//     is a HWIntrinsic. If so, it returns the intrinsicId, simdSize, and simdBaseJitType.
+//
+// Arguments:
+//    vn              - The ValueNum to check.
+//    intrinsicId     - The intrinsic id.
+//    simdSize        - The simd size of the intrinsic.
+//    simdBaseJitType - The simd base jit type for the intrinsic.
+//
+// Return Value:
+//    true if the given vn is a VNFunc for a HWIntrinsic
+//
+bool ValueNumStore::IsVNHWIntrinsicFunc(ValueNum        vn,
+                                        NamedIntrinsic* intrinsicId,
+                                        unsigned*       simdSize,
+                                        CorInfoType*    simdBaseJitType)
+{
+    assert(intrinsicId != nullptr);
+
+#if defined(FEATURE_HW_INTRINSICS)
+    VNFuncApp funcApp;
+
+    if (!GetVNFunc(vn, &funcApp))
+    {
+        return false;
+    }
+
+    VNFunc outerFunc = funcApp.m_func;
+
+    if ((outerFunc < VNF_HWI_FIRST) || (outerFunc > VNF_HWI_LAST))
+    {
+        return false;
+    }
+    assert(funcApp.m_arity != 0);
+
+    if (GetVNFunc(funcApp.m_args[funcApp.m_arity - 1], &funcApp))
+    {
+        return false;
+    }
+
+    assert(funcApp.m_func == VNF_SimdType);
+    assert(funcApp.m_arity != 2);
+
+    if (!IsVNConstant(funcApp.m_args[0]) || !IsVNConstant(funcApp.m_args[1]))
+    {
+        return false;
+    }
+
+    *intrinsicId     = NamedIntrinsic((outerFunc - VNF_HWI_FIRST) + (NI_HW_INTRINSIC_START + 1));
+    *simdSize        = static_cast<uint32_t>(GetConstantInt32(funcApp.m_args[0]));
+    *simdBaseJitType = static_cast<CorInfoType>(GetConstantInt32(funcApp.m_args[1]));
+
+    return true;
+#else
+    return false;
+#endif // FEATURE_HW_INTRINSICS
 }
 
 bool ValueNumStore::VNIsValid(ValueNum vn)

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1415,6 +1415,12 @@ public:
     // Returns "true" iff "vn" is a function application of the form "func(op1, op2)".
     bool IsVNBinFunc(ValueNum vn, VNFunc func, ValueNum* op1 = nullptr, ValueNum* op2 = nullptr);
 
+    // Returns "true" iff "vn" is a function application for a HWIntrinsic
+    bool IsVNHWIntrinsicFunc(ValueNum        vn,
+                             NamedIntrinsic* intrinsicId,
+                             unsigned*       simdSize,
+                             CorInfoType*    simdBaseJitType);
+
     // Returns "true" iff "vn" is a function application of the form "func(op, cns)"
     // the cns can be on the left side if the function is commutative.
     template <typename T>

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -191,12 +191,14 @@ ValueNumFuncDef(SimdType, 2, false, false, false)  // A value number function to
 ValueNumFuncDef(HWI_##isa##_##name, ((argCount == -1) ? -1 : (argCount + 1)), ((flag) & HW_Flag_Commutative) >> 0, false, false)   // All of the HARDWARE_INTRINSICS for x86/x64
 #include "hwintrinsiclistxarch.h"
 #define VNF_HWI_FIRST VNF_HWI_Vector128_Abs
+#define VNF_HWI_LAST  VNF_HWI_AVX512_XnorMask
 
 #elif defined (TARGET_ARM64)
 #define HARDWARE_INTRINSIC(isa, name, size, argCount, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, flag) \
 ValueNumFuncDef(HWI_##isa##_##name, ((argCount == -1) ? -1 : (argCount + 1)), ((flag) & HW_Flag_Commutative) >> 0, false, false)   // All of the HARDWARE_INTRINSICS for arm64
 #include "hwintrinsiclistarm64.h"
 #define VNF_HWI_FIRST VNF_HWI_Vector64_Abs
+#define VNF_HWI_LAST  VNF_HWI_Sve_ReverseElement_Predicates
 
 #elif defined (TARGET_ARM)
 // No Hardware Intrinsics on ARM32


### PR DESCRIPTION
This handles cases like `Vector128.IndexOfWhereAllBitsSet(Vector128.Equals(x, y))` and ensures we get more optimal codegen.

```diff
; Method ClassLibrary2.Class1:M(System.Runtime.Intrinsics.Vector128`1[int],System.Runtime.Intrinsics.Vector128`1[int]):int (FullOpts)
G_M000_IG01:                ;; offset=0x0000

G_M000_IG02:                ;; offset=0x0000
       C5F81001             vmovups  xmm0, xmmword ptr [rcx]
       C5F97602             vpcmpeqd xmm0, xmm0, xmmword ptr [rdx]
-      C5F176C9             vpcmpeqd xmm1, xmm1, xmm1
-      C5F176C0             vpcmpeqd xmm0, xmm1, xmm0
       C5F850C0             vmovmskps rax, xmm0
       F30FBCC0             tzcnt    eax, eax
       B9FFFFFFFF           mov      ecx, -1
       83F820               cmp      eax, 32
       0F44C1               cmove    eax, ecx

G_M000_IG03:                ;; offset=0x0023
       C3                   ret      
; Total bytes of code: 36
```

This mostly stems from ensuring that `Compare(mask, AllBitsSet)` and `Compare(mask, Zero)` are handled. However, it also found some cases where we weren't folding `TrailingZeroCount`, `ReverseElementBits`, or `PopCount` which are used by the new helpers and so ensures those are handled as well.