### PR TITLE
Address COM interop case involving legacy `wCode` usage.

### DIFF
--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ExcepInfo.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ExcepInfo.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
         }
 #endif
 
-        private static string ConvertAndFreeBstr(ref IntPtr bstr)
+        private static string? ConvertAndFreeBstr(ref IntPtr bstr)
         {
             if (bstr == IntPtr.Zero)
             {
@@ -55,11 +55,22 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             wReserved = -1; // to ensure that the method gets called only once
 #endif
 
+            // If the scode is non-zero, we use the wCode. The wCode is a legacy of
+            // 16-bit Windows error codes. This means it will never be an error
+            // scode (HRESULT, < 0) and we will get a null exception.
             int errorCode = (scode != 0) ? scode : wCode;
-            Exception exception = Marshal.GetExceptionForHR(errorCode);
+            Exception? exception = Marshal.GetExceptionForHR(errorCode);
 
-            string message = ConvertAndFreeBstr(ref bstrDescription);
-            if (message != null)
+            // If the error code doesn't resolve to an exception, we create a
+            // generic COMException with the error code and no message.
+            if (exception is null)
+            {
+                // If we don't recognize the error code, create a generic COMException.
+                exception = new COMException(null, errorCode);
+            }
+
+            string? message = ConvertAndFreeBstr(ref bstrDescription);
+            if (message is not null)
             {
                 // If we have a custom message, create a new Exception object with the message set correctly.
                 // We need to create a new object because "exception.Message" is a read-only property.
@@ -71,7 +82,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                 {
                     Type exceptionType = exception.GetType();
                     ConstructorInfo ctor = exceptionType.GetConstructor(new Type[] { typeof(string) });
-                    if (ctor != null)
+                    if (ctor is not null)
                     {
                         exception = (Exception)ctor.Invoke(new object[] { message });
                     }
@@ -80,8 +91,8 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
             exception.Source = ConvertAndFreeBstr(ref bstrSource);
 
-            string helpLink = ConvertAndFreeBstr(ref bstrHelpFile);
-            if (helpLink != null && dwHelpContext != 0)
+            string? helpLink = ConvertAndFreeBstr(ref bstrHelpFile);
+            if (helpLink is not null && dwHelpContext != 0)
             {
                 helpLink += "#" + dwHelpContext;
             }

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ExcepInfo.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ExcepInfo.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             wReserved = -1; // to ensure that the method gets called only once
 #endif
 
-            // If the scode is non-zero, we use the wCode. The wCode is a legacy of
+            // If the scode is zero, we use the wCode. The wCode is a legacy of
             // 16-bit Windows error codes. This means it will never be an error
             // scode (HRESULT, < 0) and we will get a null exception.
             int errorCode = (scode != 0) ? scode : wCode;

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ExcepInfo.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ExcepInfo.cs
@@ -59,15 +59,10 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             // 16-bit Windows error codes. This means it will never be an error
             // scode (HRESULT, < 0) and we will get a null exception.
             int errorCode = (scode != 0) ? scode : wCode;
-            Exception? exception = Marshal.GetExceptionForHR(errorCode);
 
             // If the error code doesn't resolve to an exception, we create a
             // generic COMException with the error code and no message.
-            if (exception is null)
-            {
-                // If we don't recognize the error code, create a generic COMException.
-                exception = new COMException(null, errorCode);
-            }
+            Exception exception = Marshal.GetExceptionForHR(errorCode) ?? new COMException(null, errorCode);
 
             string? message = ConvertAndFreeBstr(ref bstrDescription);
             if (message is not null)

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -108,7 +108,7 @@ namespace NetClient
 
         static int GetErrorCodeFromHResult(int hresult)
         {
-            // https://msdn.microsoft.com/en-us/library/cc231198.aspx
+            // https://msdn.microsoft.com/library/cc231198.aspx
             return hresult & 0xffff;
         }
 
@@ -116,7 +116,7 @@ namespace NetClient
         {
             var dispatchTesting = (DispatchTesting)new DispatchTestingClass();
 
-            int errorCode = 127;
+            int errorCode = 1127;
             string resultString = errorCode.ToString("x");
             try
             {
@@ -127,6 +127,19 @@ namespace NetClient
             catch (COMException e)
             {
                 Assert.Equal(GetErrorCodeFromHResult(e.HResult), errorCode);
+                Assert.Equal(e.Message, resultString);
+            }
+
+            try
+            {
+                Console.WriteLine($"Calling {nameof(DispatchTesting.TriggerException)} with {nameof(IDispatchTesting_Exception.DispLegacy)} {errorCode}...");
+                dispatchTesting.TriggerException(IDispatchTesting_Exception.DispLegacy, errorCode);
+                Assert.Fail("DISP exception not thrown properly");
+            }
+            catch (COMException e)
+            {
+                Assert.Equal(e.ErrorCode, errorCode); // The legacy DISP exception returns the error code unmodified.
+                Assert.Equal(e.HResult, errorCode);
                 Assert.Equal(e.Message, resultString);
             }
 

--- a/src/tests/Interop/COM/NETServer/DispatchTesting.cs
+++ b/src/tests/Interop/COM/NETServer/DispatchTesting.cs
@@ -55,6 +55,7 @@ public class DispatchTesting : Server.Contract.IDispatchTesting
         switch (excep)
         {
         case IDispatchTesting_Exception.Disp:
+        case IDispatchTesting_Exception.DispLegacy:
             throw new Exception();
         case IDispatchTesting_Exception.HResult:
         case IDispatchTesting_Exception.Int:

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -237,7 +237,8 @@ namespace Server.Contract
 
     public enum IDispatchTesting_Exception
     {
-        Disp,
+        Disp,       // scode
+        DispLegacy, // wCode
         HResult,
         Int,
     }

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
@@ -413,7 +413,8 @@ IErrorMarshalTesting : IUnknown
 
 enum IDispatchTesting_Exception
 {
-    IDispatchTesting_Exception_Disp,
+    IDispatchTesting_Exception_Disp,        // scode
+    IDispatchTesting_Exception_Disp_Legacy, // wCode
     IDispatchTesting_Exception_HResult,
     IDispatchTesting_Exception_Int,
 };


### PR DESCRIPTION
The `wCode` field in the [`EXCEPINFO`](https://learn.microsoft.com/windows/win32/api/oaidl/ns-oaidl-excepinfo) is a 16-bit signed integer. This is a legacy field for 16-bit Windows, but is still used in many COM servers. The current implementation assumed it would result in an `Exception` using [`Marshal.GetExceptionForHR()`](https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getexceptionforhr), but converting a `short` to an `int`, will rarely result in a negative value which means `null` will almost always be returned. This change checks if the exception is `null` and if so, creates a simple `COMException` with the error code.

Fixes #117568