### PR TITLE
Fix side-effect extraction in optVNBasedFoldConstExpr

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3045,7 +3045,7 @@ GenTree* Compiler::optVNBasedFoldConstExpr(BasicBlock* block, GenTree* parent, G
 
         // Were able to optimize.
         conValTree->gtVNPair = vnPair;
-        return gtWrapWithSideEffects(conValTree, tree, GTF_ALL_EFFECT);
+        return gtWrapWithSideEffects(conValTree, tree, GTF_SIDE_EFFECT);
     }
     else
     {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3045,7 +3045,7 @@ GenTree* Compiler::optVNBasedFoldConstExpr(BasicBlock* block, GenTree* parent, G
 
         // Were able to optimize.
         conValTree->gtVNPair = vnPair;
-        return gtWrapWithSideEffects(conValTree, tree, GTF_SIDE_EFFECT);
+        return gtWrapWithSideEffects(conValTree, tree, GTF_ALL_EFFECT);
     }
     else
     {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3045,7 +3045,7 @@ GenTree* Compiler::optVNBasedFoldConstExpr(BasicBlock* block, GenTree* parent, G
 
         // Were able to optimize.
         conValTree->gtVNPair = vnPair;
-        return gtWrapWithSideEffects(conValTree, tree, GTF_SIDE_EFFECT, true);
+        return gtWrapWithSideEffects(conValTree, tree, GTF_SIDE_EFFECT);
     }
     else
     {
@@ -5486,14 +5486,6 @@ GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, Stat
                 assert((stmt->GetRootNode() == tree) && (stmt->GetRootNodePointer() == useEdge));
                 stmt->SetRootNode(newTree);
             }
-
-            // We only need to ensure that the gtNext field is set as it is used to traverse
-            // to the next node in the tree. We will re-morph this entire statement in
-            // optAssertionPropMain(). It will reset the gtPrev and gtNext links for all nodes.
-            newTree->gtNext = tree->gtNext;
-
-            // Old tree should not be referenced anymore.
-            DEBUG_DESTROY_NODE(tree);
         }
     }
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -10515,7 +10515,7 @@ var_types Compiler::gtTypeForNullCheck(GenTree* tree)
 //
 void Compiler::gtChangeOperToNullCheck(GenTree* tree, BasicBlock* block)
 {
-    assert(tree->OperIs(GT_IND, GT_BLK));
+    assert(tree->OperIs(GT_IND, GT_BLK, GT_ARR_LENGTH));
     tree->ChangeOper(GT_NULLCHECK);
     tree->ChangeType(gtTypeForNullCheck(tree));
     tree->SetIndirExceptionFlags(this);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1716,8 +1716,8 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             if (switchTree->gtFlags & GTF_SIDE_EFFECT)
             {
                 /* Extract the side effects from the conditional */
+                compCurBB            = block;
                 GenTree* sideEffList = nullptr;
-
                 gtExtractSideEffList(switchTree, &sideEffList);
 
                 if (sideEffList == nullptr)
@@ -2414,13 +2414,12 @@ void Compiler::fgRemoveConditionalJump(BasicBlock* block)
         if (cond->gtFlags & GTF_SIDE_EFFECT)
         {
             /* Extract the side effects from the conditional */
+            compCurBB            = block;
             GenTree* sideEffList = nullptr;
-
             gtExtractSideEffList(cond, &sideEffList);
 
             if (sideEffList == nullptr)
             {
-                compCurBB = block;
                 fgRemoveStmt(block, condStmt);
             }
             else
@@ -2444,8 +2443,6 @@ void Compiler::fgRemoveConditionalJump(BasicBlock* block)
 
                 if (fgNodeThreading == NodeThreading::AllTrees)
                 {
-                    compCurBB = block;
-
                     /* Update ordering, costs, FP levels, etc. */
                     gtSetStmtInfo(condStmt);
 
@@ -2456,7 +2453,6 @@ void Compiler::fgRemoveConditionalJump(BasicBlock* block)
         }
         else
         {
-            compCurBB = block;
             /* conditional has NO side effect - remove it */
             fgRemoveStmt(block, condStmt);
         }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17370,9 +17370,9 @@ void Compiler::gtExtractSideEffList(GenTree*     expr,
 
             if (m_compiler->gtNodeHasSideEffects(node, m_flags))
             {
-                if (node->OperIsBlk() && !node->OperIsStoreBlk())
+                if (node->OperIs(GT_ARR_LENGTH) || (node->OperIsBlk() && !node->OperIsStoreBlk()))
                 {
-                    JITDUMP("Replace an unused BLK node [%06d] with a NULLCHECK\n", dspTreeID(node));
+                    JITDUMP("Replace an unused node [%06d] with a NULLCHECK\n", dspTreeID(node));
                     m_compiler->gtChangeOperToNullCheck(node, m_compiler->compCurBB);
                 }
 


### PR DESCRIPTION
VN-based constant propagation used to incorrectly handle side-effects - it used to pass "ignoreTrue = true" to `gtWrapWithSideEffects`. This could led to replacing `IND(node)` with a constant while ignoring the GTF_EXCEPT on the IND node itself (it's precisely what I've hit in https://github.com/dotnet/runtime/pull/117583). Looks like most regressions from this change were caused by GT_ARR_LENGTH node so I made a small optimization in `gtExtractSideEffList` to fold unused GT_ARR_LENGTH into GT_NULLCHECK to mitigate some regressions.
