### PR TITLE
Change unhandled exception detection

### DIFF
--- a/src/coreclr/vm/FrameTypes.h
+++ b/src/coreclr/vm/FrameTypes.h
@@ -37,6 +37,7 @@ FRAME_TYPE_NAME(DebuggerClassInitMarkFrame)
 FRAME_TYPE_NAME(DebuggerExitFrame)
 FRAME_TYPE_NAME(DebuggerU2MCatchHandlerFrame)
 FRAME_TYPE_NAME(ExceptionFilterFrame)
+FRAME_TYPE_NAME(UnhandledExceptionMarkerFrame)
 #ifdef FEATURE_INTERPRETER
 FRAME_TYPE_NAME(InterpreterFrame)
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -2168,7 +2168,7 @@ HRESULT DispatchInfo::InvokeMember(SimpleComCallWrapper *pSimpleWrap, DISPID id,
         // The sole purpose of having this frame is to tell the debugger that we have a catch handler here
         // which may swallow managed exceptions.  The debugger needs this in order to send a
         // CatchHandlerFound (CHF) notification.
-        DebuggerU2MCatchHandlerFrame catchFrame(true /* catchesAllExceptions */);
+        DebuggerU2MCatchHandlerFrame catchFrame;
 
         EX_TRY
         {

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -4013,16 +4013,17 @@ extern "C" CLR_BOOL QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollid
             // Check if there are any further managed frames on the stack or a catch for all exceptions in native code (marked by
             // DebuggerU2MCatchHandlerFrame with CatchesAllExceptions() returning true).
             // If not, the exception is unhandled.
-            bool isNotHandledByRuntime = 
-                (pFrame == FRAME_TOP) ||
-                (IsTopmostDebuggerU2MCatchHandlerFrame(pFrame) && !((DebuggerU2MCatchHandlerFrame*)pFrame)->CatchesAllExceptions())
+            bool reportUnhandledException = 
+                ((pFrame != FRAME_TOP) &&
+                (pFrame->GetFrameIdentifier() == FrameIdentifier::UnhandledExceptionMarkerFrame) &&
+                IsExceptionFromManagedCode(pTopExInfo->m_ptrs.ExceptionRecord))
 #ifdef HOST_UNIX
                 // Don't allow propagating exceptions from managed to non-runtime native code
                 || isPropagatingToExternalNativeCode
 #endif
                 ;
 
-            if (isNotHandledByRuntime && IsExceptionFromManagedCode(pTopExInfo->m_ptrs.ExceptionRecord))
+            if (reportUnhandledException)
             {
                 EH_LOG((LL_INFO100, "SfiNext (pass %d): no more managed frames on the stack, the exception is unhandled", pTopExInfo->m_passNumber));
                 if (pTopExInfo->m_passNumber == 1)

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -100,6 +100,9 @@
 //    +-DebuggerU2MCatchHandlerFrame - marker frame to indicate that native code is going to catch and
 //    |                                swallow a managed exception
 //    |
+//    +- UnhandledExceptionMarkerFrame - When exception handling passes through this frame,
+//    |                                  the exception is reported as unhandled.
+//    |
 #ifdef DEBUGGING_SUPPORTED
 //    +-FuncEvalFrame         - frame for debugger function evaluation
 #endif // DEBUGGING_SUPPORTED
@@ -2077,15 +2080,13 @@ class DebuggerU2MCatchHandlerFrame : public Frame
 {
 public:
 #ifndef DACCESS_COMPILE
-    DebuggerU2MCatchHandlerFrame(bool catchesAllExceptions) : Frame(FrameIdentifier::DebuggerU2MCatchHandlerFrame),
-                                                              m_catchesAllExceptions(catchesAllExceptions)
+    DebuggerU2MCatchHandlerFrame() : Frame(FrameIdentifier::DebuggerU2MCatchHandlerFrame)
     {
         WRAPPER_NO_CONTRACT;
         Frame::Push();
     }
 
-    DebuggerU2MCatchHandlerFrame(Thread * pThread, bool catchesAllExceptions) : Frame(FrameIdentifier::DebuggerU2MCatchHandlerFrame),
-                                                                                m_catchesAllExceptions(catchesAllExceptions)
+    DebuggerU2MCatchHandlerFrame(Thread * pThread) : Frame(FrameIdentifier::DebuggerU2MCatchHandlerFrame)
     {
         WRAPPER_NO_CONTRACT;
         Frame::Push(pThread);
@@ -2097,16 +2098,19 @@ public:
         LIMITED_METHOD_DAC_CONTRACT;
         return TT_U2M;
     }
+};
 
-    bool CatchesAllExceptions()
+typedef DPTR(class UnhandledExceptionMarkerFrame) PTR_UnhandledExceptionMarkerFrame;
+
+// When exception handling passes through this frame, the exception is reported as unhandled.
+class UnhandledExceptionMarkerFrame : public Frame
+{
+public:
+#ifndef DACCESS_COMPILE
+    UnhandledExceptionMarkerFrame() : Frame(FrameIdentifier::UnhandledExceptionMarkerFrame)
     {
-        LIMITED_METHOD_DAC_CONTRACT;
-        return m_catchesAllExceptions;
     }
-
-private:
-    // The catch handled marked by the DebuggerU2MCatchHandlerFrame catches all exceptions.
-    bool m_catchesAllExceptions;
+#endif
 };
 
 // Frame for the Reverse PInvoke (i.e. UnmanagedCallersOnlyAttribute).

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -355,18 +355,15 @@ namespace InteropLibImports
                 return TryInvokeICustomQueryInterfaceResult::FailedToInvoke;
         }
 
-        // Switch to Cooperative mode since object references
-        // are being manipulated and the catchFrame needs that so that it can push
-        // itself to the explicit frame stack.
-        GCX_COOP();
-        // Indicate to the debugger and exception handling that managed exceptions are being caught
-        // here.
-        DebuggerU2MCatchHandlerFrame catchFrame(true /* catchesAllExceptions */);
-
         HRESULT hr;
         auto result = TryInvokeICustomQueryInterfaceResult::FailedToInvoke;
         EX_TRY_THREAD(CURRENT_THREAD)
         {
+            // Switch to Cooperative mode since object references
+            // are being manipulated and the catchFrame needs that so that it can push
+            // itself to the explicit frame stack.
+            GCX_COOP();
+
             struct
             {
                 OBJECTREF objRef;
@@ -383,8 +380,6 @@ namespace InteropLibImports
             GCPROTECT_END();
         }
         EX_CATCH_HRESULT(hr);
-
-        catchFrame.Pop();
 
         // Assert valid value.
         _ASSERTE(TryInvokeICustomQueryInterfaceResult::Min <= result

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10512,12 +10512,8 @@ bool CEEInfo::runWithErrorTrap(void (*function)(void*), void* param)
 
     bool success = true;
 
-    GCX_COOP();
-    DebuggerU2MCatchHandlerFrame catchFrame(true /* catchesAllExceptions */);
-
     EX_TRY
     {
-        GCX_PREEMP();
         function(param);
     }
     EX_CATCH
@@ -10526,8 +10522,6 @@ bool CEEInfo::runWithErrorTrap(void (*function)(void*), void* param)
         RethrowTerminalExceptions();
     }
     EX_END_CATCH
-
-    catchFrame.Pop();
 
     return success;
 }

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7069,7 +7069,10 @@ static void ManagedThreadBase_DispatchOuter(ManagedThreadCallState *pCallState)
     // The sole purpose of having this frame is to tell the debugger that we have a catch handler here
     // which may swallow managed exceptions.  The debugger needs this in order to send a
     // CatchHandlerFound (CHF) notification.
-    DebuggerU2MCatchHandlerFrame catchFrame(false /* catchesAllExceptions */);
+    DebuggerU2MCatchHandlerFrame catchFrame(pThread);
+
+    UnhandledExceptionMarkerFrame unhandledExceptionMarkerFrame;
+    unhandledExceptionMarkerFrame.Push(pThread);
 
     TryParam param(pCallState);
     param.pFrame = &catchFrame;
@@ -7124,7 +7127,8 @@ static void ManagedThreadBase_DispatchOuter(ManagedThreadCallState *pCallState)
     }
     PAL_FINALLY
     {
-        catchFrame.Pop();
+        unhandledExceptionMarkerFrame.Pop(pThread);
+        catchFrame.Pop(pThread);
     }
     PAL_ENDTRY;
 }


### PR DESCRIPTION
Currently, the code detecting whether an exception should be propagated into native frames and not reported as unhandled relies on presence of the DebuggerU2MFrame with "CatchAllExceptions" set. Recent fixes due to this marking missing causing problems revealed that it would be actually better to do the detection in an inverse manner. That means always propagate the exception to native frames unless there is an explicit marker indicating that the exception needs to be reported as unhandled. Such a marker should only mark the main entry point for an application and a managed thread entry. All other places should just let the exception flow into the native code.

This change fixes it by creating a new kind of explicit frame to mark the code paths that should report unhandled exception. It also removes recent fixes in this area that are no longer needed.