### PR TITLE
Fix ExecutionManager::GetCodeMethodDesc for interpreter

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -5088,17 +5088,6 @@ MethodDesc * ExecutionManager::GetCodeMethodDesc(PCODE currentPC)
     }
     CONTRACTL_END
 
-#ifdef FEATURE_INTERPRETER
-    // For interpreted methods, the currentPC can point to the InterpreterPrecode. So we need to get the MethodDesc from it,
-    // the EECodeInfo works only for the actual IR bytecode.
-    PTR_Precode pPrecode = Precode::GetPrecodeFromEntryPoint(currentPC);
-    if (pPrecode != NULL && pPrecode->GetType() == InterpreterPrecode::Type)
-    {
-        // If we are in an interpreter precode, we get the MethodDesc from the precode
-        return pPrecode->GetMethodDesc();
-    }
-#endif // FEATURE_INTERPRETER
-
     EECodeInfo codeInfo(currentPC);
     if (!codeInfo.IsValid())
         return NULL;
@@ -6407,7 +6396,7 @@ size_t ReadyToRunJitManager::WalkILOffsets(
     BoundsType boundsType,
     void* pContext,
     size_t (* pfnWalkILOffsets)(ICorDebugInfo::OffsetMapping *pOffsetMapping, void *pContext))
-{
+{   
     CONTRACTL {
         THROWS;       // on OOM.
         GC_NOTRIGGER; // getting vars shouldn't trigger

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -5088,6 +5088,17 @@ MethodDesc * ExecutionManager::GetCodeMethodDesc(PCODE currentPC)
     }
     CONTRACTL_END
 
+#ifdef FEATURE_INTERPRETER
+    // For interpreted methods, the currentPC can point to the InterpreterPrecode. So we need to get the MethodDesc from it,
+    // the EECodeInfo works only for the actual IR bytecode.
+    PTR_Precode pPrecode = Precode::GetPrecodeFromEntryPoint(currentPC);
+    if (pPrecode != NULL && pPrecode->GetType() == InterpreterPrecode::Type)
+    {
+        // If we are in an interpreter precode, we get the MethodDesc from the precode
+        return pPrecode->GetMethodDesc();
+    }
+#endif // FEATURE_INTERPRETER
+
     EECodeInfo codeInfo(currentPC);
     if (!codeInfo.IsValid())
         return NULL;
@@ -6396,7 +6407,7 @@ size_t ReadyToRunJitManager::WalkILOffsets(
     BoundsType boundsType,
     void* pContext,
     size_t (* pfnWalkILOffsets)(ICorDebugInfo::OffsetMapping *pOffsetMapping, void *pContext))
-{   
+{
     CONTRACTL {
         THROWS;       // on OOM.
         GC_NOTRIGGER; // getting vars shouldn't trigger

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -10,6 +10,7 @@
 
 #include "common.h"
 #include "dllimportcallback.h"
+#include "../interpreter/interpretershared.h"
 
 #ifdef FEATURE_PERFMAP
 #include "perfmap.h"
@@ -158,7 +159,7 @@ MethodDesc* Precode::GetMethodDesc(BOOL fSpeculative /*= FALSE*/)
         break;
 #ifdef FEATURE_INTERPRETER
     case PRECODE_INTERPRETER:
-        return NULL;
+        pMD = AsInterpreterPrecode()->GetMethodDesc();
         break;
 #endif // FEATURE_INTERPRETER
 
@@ -179,6 +180,16 @@ MethodDesc* Precode::GetMethodDesc(BOOL fSpeculative /*= FALSE*/)
     // Once we headers factoring of headers cleaned up, we should be able to get rid of it.
     return (PTR_MethodDesc)pMD;
 }
+
+#ifdef FEATURE_INTERPRETER
+TADDR InterpreterPrecode::GetMethodDesc()
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+
+    InterpByteCodeStart* pInterpreterCode = dac_cast<PTR_InterpByteCodeStart>(GetData()->ByteCodeAddr);
+    return (TADDR)pInterpreterCode->Method->methodHnd;
+}
+#endif // FEATURE_INTERPRETER
 
 BOOL Precode::IsPointingToPrestub(PCODE target)
 {

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -335,7 +335,12 @@ struct InterpreterPrecode
         LIMITED_METHOD_CONTRACT;
         return (InterpreterPrecode*)PCODEToPINSTR(entryPoint);
     }
+
+    TADDR GetMethodDesc();
 };
+
+typedef DPTR(InterpreterPrecode) PTR_InterpreterPrecode;
+
 #endif // FEATURE_INTERPRETER
 
 #ifdef HAS_FIXUP_PRECODE
@@ -592,6 +597,16 @@ private:
         return dac_cast<PTR_ThisPtrRetBufPrecode>(this);
     }
 #endif // HAS_THISPTR_RETBUF_PRECODE
+
+#ifdef FEATURE_INTERPRETER
+    InterpreterPrecode* AsInterpreterPrecode()
+    {
+        LIMITED_METHOD_CONTRACT;
+        SUPPORTS_DAC;
+
+        return dac_cast<PTR_InterpreterPrecode>(this);
+    }
+#endif // FEATURE_INTERPRETER
 
     TADDR GetStart()
     {


### PR DESCRIPTION
The `ExecutionManager::GetCodeMethodDesc` expects that the address passed to it is an address of actual JIT/AOT or interpreter generated code. However, it is sometimes passed an address of the interpreter precode, e.g. in the case when called by the
`MethodTable::GetMethodDescForSlotAddress`. The VTable slots need to point to the interpreter stub so that these methods can be called by virtual calls from native code.

This issue occurs in several methods on the .NET runtime startup path when running interpreted.

This change adds a check for the interpreter precode to the `ExecutionManager::GetCodeMethodDesc` and extracts the `MethodDesc` from the interpreter data in case it is passed the precode address.