### PR TITLE
[PERF] Removed building of musl artifacts from performance related pipelines

### DIFF
--- a/eng/pipelines/performance/perf-build.yml
+++ b/eng/pipelines/performance/perf-build.yml
@@ -14,10 +14,6 @@ parameters:
   displayName: Build Coreclr Arm64 Windows
   type: boolean
   default: true
-- name: coreclr_muslx64_linux
-  displayName: Build Coreclr Musl x64 Linux
-  type: boolean
-  default: true
 - name: coreclr_x64_linux
   displayName: Build Coreclr x64 Linux
   type: boolean
@@ -110,8 +106,6 @@ extends:
                 - coreclr_arm64_linux
               - ${{ if eq(parameters.coreclr_arm64_windows, true) }}:
                 - coreclr_arm64_windows
-              - ${{ if eq(parameters.coreclr_muslx64_linux, true) }}:
-                - coreclr_muslx64_linux
               - ${{ if eq(parameters.coreclr_x64_linux, true) }}:
                 - coreclr_x64_linux
               - ${{ if eq(parameters.coreclr_x64_windows, true) }}:
@@ -152,8 +146,6 @@ extends:
               - coreclr_arm64_linux
             - ${{ if eq(parameters.coreclr_arm64_windows, true) }}:
               - coreclr_arm64_windows
-            - ${{ if eq(parameters.coreclr_muslx64_linux, true) }}:
-              - coreclr_muslx64_linux
             - ${{ if eq(parameters.coreclr_x64_linux, true) }}:
               - coreclr_x64_linux
             - ${{ if eq(parameters.coreclr_x64_windows, true) }}:
@@ -182,7 +174,7 @@ extends:
               - nativeAot_arm64_ios
           ${{ if parameters.mauiFramework }}:
             mauiFramework: ${{ parameters.mauiFramework }}
-            
+
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.Reason'], 'IndividualCI'), parameters.runPrivateJobs)) }}:
       - stage: UploadArtifacts
         displayName: 'Upload Artifacts'
@@ -200,8 +192,6 @@ extends:
                 - coreclr_arm64_linux
               - ${{ if eq(parameters.coreclr_arm64_windows, true) }}:
                 - coreclr_arm64_windows
-              - ${{ if eq(parameters.coreclr_muslx64_linux, true) }}:
-                - coreclr_muslx64_linux
               - ${{ if eq(parameters.coreclr_x64_linux, true) }}:
                 - coreclr_x64_linux
               - ${{ if eq(parameters.coreclr_x64_windows, true) }}:

--- a/eng/pipelines/performance/templates/perf-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-build-jobs.yml
@@ -8,7 +8,6 @@ jobs:
       linux_x64: true
       windows_x64: true
       windows_x86: true
-      linux_musl_x64: true
       android_arm64: true
 
   # build mono for AOT

--- a/eng/pipelines/performance/templates/perf-coreclr-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-coreclr-build-jobs.yml
@@ -1,6 +1,5 @@
 parameters:
     linux_x64: false
-    linux_musl_x64: false
     linux_arm64: false
     windows_x64: false
     windows_x86: false
@@ -8,7 +7,7 @@ parameters:
     android_arm64: false
 
 jobs:
-  - ${{ if or(eq(parameters.linux_x64, true), eq(parameters.windows_x64, true), eq(parameters.windows_x86, true), eq(parameters.linux_musl_x64, true), eq(parameters.linux_arm64, true), eq(parameters.windows_arm64, true)) }}:
+  - ${{ if or(eq(parameters.linux_x64, true), eq(parameters.windows_x64, true), eq(parameters.windows_x86, true), eq(parameters.linux_arm64, true), eq(parameters.windows_arm64, true)) }}:
     # build coreclr and libraries
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
@@ -21,8 +20,6 @@ jobs:
           - windows_x64
         - ${{ if eq(parameters.windows_x86, true) }}:
           - windows_x86
-        - ${{ if eq(parameters.linux_musl_x64, true) }}:
-          - linux_musl_x64
         - ${{ if eq(parameters.linux_arm64, true) }}:
           - linux_arm64
         - ${{ if eq(parameters.windows_arm64, true) }}:


### PR DESCRIPTION
Removed building of musl artifacts from performance related pipelines as we no longer have alpine machines to run them for.

To be merged with: https://github.com/dotnet/performance/pull/4886