### PR TITLE
Allow caching IDynamicInterfaceCastable results

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
@@ -29,17 +29,7 @@ namespace System.Runtime
             IntPtr pTargetCode = RhResolveDispatchWorker(pObject, (void*)pCell, ref cellInfo);
             if (pTargetCode != IntPtr.Zero)
             {
-                // We don't update the dispatch cell cache if this is IDynamicInterfaceCastable because this
-                // scenario is by-design dynamic. There is no guarantee that another instance with the same MethodTable
-                // as the one we just resolved would do the resolution the same way. We will need to ask again.
-                if (!pObject.GetMethodTable()->IsIDynamicInterfaceCastable)
-                {
-                    return InternalCalls.RhpUpdateDispatchCellCache(pCell, pTargetCode, pObject.GetMethodTable(), ref cellInfo);
-                }
-                else
-                {
-                    return pTargetCode;
-                }
+                return InternalCalls.RhpUpdateDispatchCellCache(pCell, pTargetCode, pObject.GetMethodTable(), ref cellInfo);
             }
 
             // "Valid method implementation was not found."

--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -371,7 +371,7 @@ namespace IDynamicInterfaceCastableTests
 
             Console.WriteLine(" -- Validate method call");
             Assert.Same(castableObj, testObj.ReturnThis());
-            Assert.Equal(typeof(DynamicInterfaceCastable), testObj.GetMyType());
+            Assert.Equal(typeof(DynamicInterfaceCastable_ValidateBasicInterface), testObj.GetMyType());
 
             Console.WriteLine(" -- Validate method call which calls methods using 'this'");
             Assert.Equal(DynamicInterfaceCastable.ImplementedMethodReturnValue, testObj.CallImplemented(ImplementationToCall.Class));

--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -213,7 +213,7 @@ namespace IDynamicInterfaceCastableTests
     {
         private Dictionary<Type, Type> interfaceToImplMap;
 
-        public DynamicInterfaceCastable(Dictionary<Type, Type> interfaceToImplMap)
+        protected DynamicInterfaceCastable(Dictionary<Type, Type> interfaceToImplMap)
         {
             this.interfaceToImplMap = interfaceToImplMap;
         }
@@ -347,14 +347,20 @@ namespace IDynamicInterfaceCastableTests
     [ActiveIssue("https://github.com/dotnet/runtime/issues/55742", TestRuntimes.Mono)]
     public class Program
     {
+        class DynamicInterfaceCastable_ValidateBasicInterface : DynamicInterfaceCastable
+        {
+            public DynamicInterfaceCastable_ValidateBasicInterface()
+                : base(new Dictionary<Type, Type> {
+                    { typeof(ITest), typeof(ITestImpl) }
+                }) { }
+        }
+
         [Fact]
         public static void ValidateBasicInterface()
         {
             Console.WriteLine($"Running {nameof(ValidateBasicInterface)}");
 
-            object castableObj = new DynamicInterfaceCastable(new Dictionary<Type, Type> {
-                { typeof(ITest), typeof(ITestImpl) }
-            });
+            object castableObj = new DynamicInterfaceCastable_ValidateBasicInterface();
 
             Console.WriteLine(" -- Validate cast");
 
@@ -379,16 +385,22 @@ namespace IDynamicInterfaceCastableTests
             Assert.Same(castableObj, func());
         }
 
+        class DynamicInterfaceCastable_ValidateGenericInterface : DynamicInterfaceCastable
+        {
+            public DynamicInterfaceCastable_ValidateGenericInterface()
+                : base(new Dictionary<Type, Type> {
+                    { typeof(ITestGeneric<int, int>), typeof(ITestGenericIntImpl) },
+                    { typeof(ITestGeneric<string, string>), typeof(ITestGenericImpl<string, string>) },
+                    { typeof(ITestGeneric<string, object>), typeof(ITestGenericImpl<object, string>) },
+                }) { }
+        }
+
         [Fact]
         public static void ValidateGenericInterface()
         {
             Console.WriteLine($"Running {nameof(ValidateGenericInterface)}");
 
-            object castableObj = new DynamicInterfaceCastable(new Dictionary<Type, Type> {
-                { typeof(ITestGeneric<int, int>), typeof(ITestGenericIntImpl) },
-                { typeof(ITestGeneric<string, string>), typeof(ITestGenericImpl<string, string>) },
-                { typeof(ITestGeneric<string, object>), typeof(ITestGenericImpl<object, string>) },
-            });
+            object castableObj = new DynamicInterfaceCastable_ValidateGenericInterface();
 
             Console.WriteLine(" -- Validate cast");
 
@@ -442,15 +454,21 @@ namespace IDynamicInterfaceCastableTests
             Assert.Equal(expectedStr, funcVar(expectedStr));
         }
 
+        class DynamicInterfaceCastable_ValidateOverriddenInterface : DynamicInterfaceCastable
+        {
+            public DynamicInterfaceCastable_ValidateOverriddenInterface()
+                : base(new Dictionary<Type, Type> {
+                    { typeof(ITest), typeof(IOverrideTestImpl) },
+                    { typeof(IOverrideTest), typeof(IOverrideTestImpl) },
+                }) { }
+        }
+
         [Fact]
         public static void ValidateOverriddenInterface()
         {
             Console.WriteLine($"Running {nameof(ValidateOverriddenInterface)}");
 
-            object castableObj = new DynamicInterfaceCastable(new Dictionary<Type, Type> {
-                { typeof(ITest), typeof(IOverrideTestImpl) },
-                { typeof(IOverrideTest), typeof(IOverrideTestImpl) },
-            });
+            object castableObj = new DynamicInterfaceCastable_ValidateOverriddenInterface();
 
             Console.WriteLine(" -- Validate cast");
 
@@ -476,14 +494,20 @@ namespace IDynamicInterfaceCastableTests
             Assert.Equal(IOverrideTestImpl.GetMyTypeReturnValue, funcGetType());
         }
 
+        class DynamicInterfaceCastable_ValidateNotImplemented : DynamicInterfaceCastable
+        {
+            public DynamicInterfaceCastable_ValidateNotImplemented()
+                : base(new Dictionary<Type, Type> {
+                    { typeof(ITest), typeof(ITestImpl) }
+                }) { }
+        }
+
         [Fact]
         public static void ValidateNotImplemented()
         {
             Console.WriteLine($"Running {nameof(ValidateNotImplemented)}");
 
-            object castableObj = new DynamicInterfaceCastable(new Dictionary<Type, Type> {
-                { typeof(ITest), typeof(ITestImpl) }
-            });
+            object castableObj = new DynamicInterfaceCastable_ValidateNotImplemented();
 
             Assert.False(castableObj is INotImplemented, $"Should not be castable to {nameof(INotImplemented)} via is");
             Assert.Null(castableObj as INotImplemented);
@@ -491,15 +515,21 @@ namespace IDynamicInterfaceCastableTests
             Assert.Equal(string.Format(DynamicInterfaceCastableException.ErrorFormat, typeof(INotImplemented)), ex.Message);
         }
 
+        class DynamicInterfaceCastable_ValidateDirectlyImplemented : DynamicInterfaceCastable
+        {
+            public DynamicInterfaceCastable_ValidateDirectlyImplemented()
+                : base(new Dictionary<Type, Type> {
+                    { typeof(ITest), typeof(ITestImpl) },
+                    { typeof(IDirectlyImplemented), typeof(IDirectlyImplementedImpl) },
+                }) { }
+        }
+
         [Fact]
         public static void ValidateDirectlyImplemented()
         {
             Console.WriteLine($"Running {nameof(ValidateDirectlyImplemented)}");
 
-            object castableObj = new DynamicInterfaceCastable(new Dictionary<Type, Type> {
-                { typeof(ITest), typeof(ITestImpl) },
-                { typeof(IDirectlyImplemented), typeof(IDirectlyImplementedImpl) },
-            });
+            object castableObj = new DynamicInterfaceCastable_ValidateDirectlyImplemented();
 
             Console.WriteLine(" -- Validate cast");
             Assert.True(castableObj is IDirectlyImplemented, $"Should be castable to {nameof(IDirectlyImplemented)} via is");


### PR DESCRIPTION
Resolves #107999.

The caching on CoreCLR VM side is [wild](https://github.com/dotnet/runtime/issues/107999#issuecomment-3072051079). The native AOT cache is per-callsite. So we will have observable differences in how the cache works. I assume anyone who comes to us with "My `Gizmo` doesn't work for more than one type" where `Gizmo` is defined as:

```csharp
class Gizmo : IDynamicInterfaceCastable
{
    public Type InterfaceType { get; init; }
    public Type ImplType { get; init; }

    public RuntimeTypeHandle GetInterfaceImplementation(RuntimeTypeHandle interfaceType)
        => interfaceType.Equals(InterfaceType.TypeHandle) ? ImplType.TypeHandle : throw new Exception();
    public bool IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
        => interfaceType.Equals(InterfaceType.TypeHandle) ? true : (throwIfNotImplemented ? throw new InvalidCastException() : false);
}
```

will be sent away, although I can't find docs that we could point them to saying this is illegal. The CoreCLR VM implementation that sends things through a cache doesn't seem to allow that, and neither will native AOT.

Cc @dotnet/ilc-contrib @AaronRobinsonMSFT @jkoritzinsky 