### PR TITLE
Remove IsWatchOS checks for consistency

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/Interop.Odbc.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Odbc.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
     {
         internal static string GetNativeLibraryName()
         {
-            if (OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS())
+            if (OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
             {
                 return "libodbc.2.dylib";
             }

--- a/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
@@ -24,7 +24,7 @@ namespace System.IO
         {
             get
             {
-                return !(OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS());
+                return !(OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS());
             }
         }
     }

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -78,7 +78,7 @@ namespace System.Net.NetworkInformation.Tests
                 : Array.Empty<byte>();
 
         public static bool DoesNotUsePingUtility => OperatingSystem.IsWindows() ||
-                                OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsWatchOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() ||
+                                OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() ||
                                 Capability.CanUseRawSockets(TestSettings.GetLocalIPAddress().AddressFamily);
         public static bool UsesPingUtility => !DoesNotUsePingUtility;
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Interop/msquic.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Interop/msquic.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Quic
         [FieldOffset(0)]
         public QuicAddrFamilyAndLen FamilyLen;
 
-        public static bool SockaddrHasLength => OperatingSystem.IsFreeBSD() || OperatingSystem.IsIOS() || OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS();
+        public static bool SockaddrHasLength => OperatingSystem.IsFreeBSD() || OperatingSystem.IsIOS() || OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsTvOS();
 
         public int Family
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
@@ -39,7 +39,7 @@ namespace System.Globalization
             {
                 // These strings can't go into resources, because a resource lookup requires globalization, which requires ICU
                 if (OperatingSystem.IsBrowser() || OperatingSystem.IsWasi() || OperatingSystem.IsAndroid() ||
-                    OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS())
+                    OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
                 {
                     return "Unable to load required ICU Globalization data. Please see https://aka.ms/dotnet-missing-libicu for more information";
                 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/OperatingSystemTests.cs
@@ -198,7 +198,6 @@ namespace System.Tests
                 { "IsMacCatalyst", OperatingSystem.IsMacCatalyst() },
                 { "IsMacOS", OperatingSystem.IsMacOS() },
                 { "IsTvOS", OperatingSystem.IsTvOS() },
-                { "IsWatchOS", OperatingSystem.IsWatchOS() },
                 { "IsWindows", OperatingSystem.IsWindows() },
                 { "IsWasi", OperatingSystem.IsWasi() },
             };

--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -63,7 +63,7 @@ namespace TestLibrary
 
         // These platforms have not had their infrastructure updated to support native test assets.
         public static bool PlatformDoesNotSupportNativeTestAssets =>
-            OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS() || OperatingSystem.IsAndroid() || OperatingSystem.IsBrowser() || OperatingSystem.IsWasi();
-        public static bool IsAppleMobile => OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS() || OperatingSystem.IsMacCatalyst();
+            OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsAndroid() || OperatingSystem.IsBrowser() || OperatingSystem.IsWasi();
+        public static bool IsAppleMobile => OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsMacCatalyst();
     }
 }

--- a/src/tests/Common/XHarnessRunnerLibrary/RunnerEntryPoint.cs
+++ b/src/tests/Common/XHarnessRunnerLibrary/RunnerEntryPoint.cs
@@ -28,7 +28,7 @@ public static class RunnerEntryPoint
         {
             entryPoint = new AndroidEntryPoint(new SimpleDevice(assemblyName), runTestsCallback, assemblyName, filter, testExclusionTable);
         }
-        if (OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS())
+        if (OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
         {
             entryPoint = new AppleEntryPoint(new SimpleDevice(assemblyName), runTestsCallback, assemblyName, filter, testExclusionTable);
         }


### PR DESCRIPTION
## Description

Remove `OperatingSystem.IsWatchOS()` checks for consistency.

## Related issues

Fixes #92601