### PR TITLE
Resolve missing `Assert.IsType` method in RuntimeBinder tests

### DIFF
--- a/src/libraries/Microsoft.CSharp/tests/ILLink.Descriptors.xml
+++ b/src/libraries/Microsoft.CSharp/tests/ILLink.Descriptors.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="xunit.assert">
+    <type fullname="Xunit.Assert">
+      <method name="IsType" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -11,6 +11,7 @@
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and ('$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi')">true</DebuggerSupport>
   </PropertyGroup>
   <ItemGroup>
+    <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.xml" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
     <Compile Include="AccessTests.cs" />
     <Compile Include="ArrayHandling.cs" />


### PR DESCRIPTION
Resolves #117565 I have not looked into what caused it to start failing recently.