### PR TITLE
Properly dispose intermediate certificates in SslStream

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -153,7 +153,7 @@ namespace System.Net.Security
                     bool ocspFetch = false;
                     _ = AppContext.TryGetSwitch(EnableOcspStaplingContextSwitchName, out ocspFetch);
                     // given cert is X509Certificate2 with key. We can use it directly.
-                    SetCertificateContextFromCert(certificateWithKey);
+                    SetCertificateContextFromCert(certificateWithKey, !ocspFetch);
                 }
                 else
                 {
@@ -195,9 +195,11 @@ namespace System.Net.Security
             return protocols;
         }
 
-        internal void SetCertificateContextFromCert(X509Certificate2 certificate)
+        internal void SetCertificateContextFromCert(X509Certificate2 certificate, bool? noOcspFetch = null)
         {
-            CertificateContext = SslStreamCertificateContext.Create(certificate);
+            Debug.Assert(CertificateContext == null, "CertificateContext should be null when setting it from certificate");
+
+            CertificateContext = SslStreamCertificateContext.Create(certificate, null, offline: false, null, noOcspFetch ?? true);
             OwnsCertificateContext = true;
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -237,12 +237,7 @@ namespace System.Net.Security
         {
             if (OwnsCertificateContext && CertificateContext != null)
             {
-                // TargetCertificate is owned by the user, but we have created the cert context
-                // which looked up intermediate certificates and only we have reference to them.
-                foreach (X509Certificate2 cert in CertificateContext.IntermediateCertificates)
-                {
-                    cert.Dispose();
-                }
+                CertificateContext.ReleaseResources();
             }
 
 #if TARGET_ANDROID

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -197,8 +197,6 @@ namespace System.Net.Security
 
         internal void SetCertificateContextFromCert(X509Certificate2 certificate, bool? noOcspFetch = null)
         {
-            Debug.Assert(CertificateContext == null, "CertificateContext should be null when setting it from certificate");
-
             CertificateContext = SslStreamCertificateContext.Create(certificate, null, offline: false, null, noOcspFetch ?? true);
             OwnsCertificateContext = true;
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -9,7 +9,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net.Security
 {
-    internal sealed class SslAuthenticationOptions
+    internal sealed class SslAuthenticationOptions : IDisposable
     {
         private const string EnableOcspStaplingContextSwitchName = "System.Net.Security.EnableServerOcspStaplingFromOnlyCertificateOnLinux";
 
@@ -153,7 +153,7 @@ namespace System.Net.Security
                     bool ocspFetch = false;
                     _ = AppContext.TryGetSwitch(EnableOcspStaplingContextSwitchName, out ocspFetch);
                     // given cert is X509Certificate2 with key. We can use it directly.
-                    CertificateContext = SslStreamCertificateContext.Create(certificateWithKey, additionalCertificates: null, offline: false, trust: null, noOcspFetch: !ocspFetch);
+                    SetCertificateContextFromCert(certificateWithKey);
                 }
                 else
                 {
@@ -165,7 +165,7 @@ namespace System.Net.Security
                         throw new AuthenticationException(SR.net_ssl_io_no_server_cert);
                     }
 
-                    CertificateContext = SslStreamCertificateContext.Create(certificateWithKey);
+                    SetCertificateContextFromCert(certificateWithKey);
                 }
             }
 
@@ -195,13 +195,22 @@ namespace System.Net.Security
             return protocols;
         }
 
+        internal void SetCertificateContextFromCert(X509Certificate2 certificate)
+        {
+            CertificateContext = SslStreamCertificateContext.Create(certificate);
+            OwnsCertificateContext = true;
+        }
+
         internal bool AllowRenegotiation { get; set; }
         internal string TargetHost { get; set; }
         internal X509CertificateCollection? ClientCertificates { get; set; }
         internal List<SslApplicationProtocol>? ApplicationProtocols { get; set; }
         internal bool IsServer { get; set; }
         internal bool IsClient => !IsServer;
-        internal SslStreamCertificateContext? CertificateContext { get; set; }
+        internal SslStreamCertificateContext? CertificateContext { get; private set; }
+        // If true, the certificate context was created by the SslStream and
+        // certificates inside should be disposed when no longer needed.
+        internal bool OwnsCertificateContext { get; private set; }
         internal SslProtocols EnabledSslProtocols { get; set; }
         internal X509RevocationMode CertificateRevocationCheckMode { get; set; }
         internal EncryptionPolicy EncryptionPolicy { get; set; }
@@ -221,5 +230,22 @@ namespace System.Net.Security
 #if TARGET_ANDROID
         internal SslStream.JavaProxy? SslStreamProxy { get; set; }
 #endif
+
+        public void Dispose()
+        {
+            if (OwnsCertificateContext && CertificateContext != null)
+            {
+                // TargetCertificate is owned by the user, but we have created the cert context
+                // which looked up intermediate certificates and only we have reference to them.
+                foreach (X509Certificate2 cert in CertificateContext.IntermediateCertificates)
+                {
+                    cert.Dispose();
+                }
+            }
+
+#if TARGET_ANDROID
+            SslStreamProxy?.Dispose();
+#endif
+        }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -417,7 +417,7 @@ namespace System.Net.Security
             return uriString;
         }
 
-        private partial void ReleasePlatformSpecificResources()
+        partial void ReleasePlatformSpecificResources()
         {
             Debug.Assert(_staplingForbidden, "Shouldn't release resources while OCSP stapling may be happening on the background.");
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -416,5 +416,19 @@ namespace System.Net.Security
 
             return uriString;
         }
+
+        private partial void ReleasePlatformSpecificResources()
+        {
+            Debug.Assert(_staplingForbidden, "Shouldn't release resources while OCSP stapling may be happening on the background.");
+
+            CertificateHandle.Dispose();
+            KeyHandle.Dispose();
+            _rootCertificate?.Dispose();
+
+            foreach (X509Certificate2 cert in _privateIntermediateCertificates)
+            {
+                cert.Dispose();
+            }
+        }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
@@ -42,6 +42,8 @@ namespace System.Net.Security
                         count++;
                     }
 
+                    DisposeChainElements(chain);
+
                     // OS failed to build the chain but we have at least some intermediates.
                     // We will try to add them to "Intermediate Certification Authorities" store.
                     if (!osCanBuildChain)
@@ -92,6 +94,8 @@ namespace System.Net.Security
                                     }
                                 }
 
+                                DisposeChainElements(chain);
+
                                 if (!osCanBuildChain)
                                 {
                                     // Add also root to Intermediate CA store so OS can complete building chain.
@@ -121,6 +125,15 @@ namespace System.Net.Security
                     {
                         NetEventSource.Error(null, $"Failed to add certificate to store: {ex.Message}, certificate: {certificate}");
                     }
+                }
+            }
+
+            static void DisposeChainElements(X509Chain chain)
+            {
+                int elementsCount = chain.ChainElements.Count;
+                for (int i = 0; i < elementsCount; i++)
+                {
+                    chain.ChainElements[i].Certificate.Dispose();
                 }
             }
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -184,6 +184,6 @@ namespace System.Net.Security
             ReleasePlatformSpecificResources();
         }
 
-        private partial void ReleasePlatformSpecificResources();
+        partial void ReleasePlatformSpecificResources();
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -169,7 +169,15 @@ namespace System.Net.Security
 
         internal SslStreamCertificateContext Duplicate()
         {
-            return new SslStreamCertificateContext(new X509Certificate2(TargetCertificate), IntermediateCertificates, Trust);
+            // Create will internally clone any certificates that it will
+            // retain, so we don't have to duplicate any of the instances here
+            X509Certificate2Collection intermediates = new X509Certificate2Collection();
+            foreach (X509Certificate2 cert in IntermediateCertificates)
+            {
+                intermediates.Add(cert);
+            }
+
+            return Create(new X509Certificate2(TargetCertificate), intermediates, trust: Trust);
         }
 
         internal void ReleaseResources()

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -171,5 +171,19 @@ namespace System.Net.Security
         {
             return new SslStreamCertificateContext(new X509Certificate2(TargetCertificate), IntermediateCertificates, Trust);
         }
+
+        internal void ReleaseResources()
+        {
+            // TargetCertificate is owned by the user, but we have created the cert context
+            // which looked up intermediate certificates and only we have reference to them.
+            foreach (X509Certificate2 cert in IntermediateCertificates)
+            {
+                cert.Dispose();
+            }
+
+            ReleasePlatformSpecificResources();
+        }
+
+        private partial void ReleasePlatformSpecificResources();
     }
 }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
@@ -114,6 +114,10 @@ namespace System.Net.Security.Tests
                     Assert.False(server.IsMutuallyAuthenticated, "server.IsMutuallyAuthenticated");
                 }
             }
+
+            // Assert that the certificates are not being disposed
+            Assert.NotEqual(_clientCertificate.Handle, IntPtr.Zero);
+            Assert.NotEqual(_serverCertificate.Handle, IntPtr.Zero);
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
@@ -152,7 +156,8 @@ namespace System.Net.Security.Tests
                     // mutual authentication should only be set if server required client cert
                     Assert.Equal(expectMutualAuthentication, server.IsMutuallyAuthenticated);
                     Assert.Equal(expectMutualAuthentication, client.IsMutuallyAuthenticated);
-                };
+                }
+                ;
             }
         }
 
@@ -268,7 +273,8 @@ namespace System.Net.Security.Tests
                     {
                         Assert.Null(server.RemoteCertificate);
                     }
-                };
+                }
+                ;
             }
         }
 
@@ -322,7 +328,8 @@ namespace System.Net.Security.Tests
                     {
                         Assert.Null(server.RemoteCertificate);
                     }
-                };
+                }
+                ;
             }
         }
 
@@ -380,7 +387,8 @@ namespace System.Net.Security.Tests
                     {
                         Assert.Null(server.RemoteCertificate);
                     }
-                };
+                }
+                ;
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -807,6 +807,18 @@ namespace System.Net.Security.Tests
 
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
             }
+
+            // the ownership of the ExtraStore cert is not transferred to the
+            // SslStream, so we need to verify that the certs are still valid.
+            foreach (X509Certificate2 cert in clientOptions.CertificateChainPolicy.ExtraStore)
+            {
+                Assert.NotEqual(cert.Handle, IntPtr.Zero);
+            }
+
+            foreach (X509Certificate2 cert in clientOptions.CertificateChainPolicy.CustomTrustStore)
+            {
+                Assert.NotEqual(cert.Handle, IntPtr.Zero);
+            }
         }
 
         private async Task SslStream_ClientSendsChain_Core(SslClientAuthenticationOptions clientOptions, X509Certificate2Collection clientChain)


### PR DESCRIPTION
There are two instances where SslStream will abandon X509Certificate2 instances to finalizer to deal with:

- any intermediate certificates received from the peer over the wire (those which end up in ExtraStore on the X509ChainPolicy)
- any certificate handles that are created when internally creating the SslStreamCertificateContext (like intermediate cert handles), if we create the context internally, we can ensure proper cleanup when disposing SslStream.

As a result, HttpClient.GetAsync to a mTLS-enabled server does not produce any hanging cert handles (as per `DEBUG_SAFEX509HANDLE_FINALIZATION`-enabled logs)

SslStreamCertificateContext seems like it would benefit from IDisposeable, but it is too late for that in .NET 10.