### PR TITLE
Move MethodContextReader to use the minipal mutex

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.cpp
@@ -417,7 +417,7 @@ bool MethodContextReader::hasTOC()
 
 bool MethodContextReader::isValid()
 {
-    return this->fileHandle != INVALID_HANDLE_VALUE && this->mutex != INVALID_HANDLE_VALUE;
+    return this->fileHandle != INVALID_HANDLE_VALUE;
 }
 
 // Return a measure of "progress" through the method contexts, as follows:

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.h
@@ -10,6 +10,7 @@
 
 #include "methodcontext.h"
 #include "tocfile.h"
+#include <minipal/mutex.h>
 
 struct MethodContextBuffer
 {
@@ -56,7 +57,7 @@ private:
     int curMCIndex;
 
     // The synchronization mutex
-    HANDLE mutex;
+    minipal_mutex mutex;
     bool   AcquireLock();
     void   ReleaseLock();
 


### PR DESCRIPTION
Removes one of the few remaining usages of the Win32 PAL Mutex in native code.