### PR TITLE
Convert CoreCLR classic debug logging to use the minipal mutex

### DIFF
--- a/src/coreclr/utilcode/log.cpp
+++ b/src/coreclr/utilcode/log.cpp
@@ -156,7 +156,7 @@ VOID EnterLogLock()
     // rather hard to care about this, as we LOG all over the place.
     CONTRACT_VIOLATION(TakesLockViolation);
 
-    if(LogFileMutex != nullptr)
+    if (LogFileMutex != nullptr)
     {
         minipal_mutex_enter(LogFileMutex);
     }
@@ -167,7 +167,7 @@ VOID LeaveLogLock()
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
 
-    if(LogFileMutex != nullptr)
+    if (LogFileMutex != nullptr)
     {
         minipal_mutex_leave(LogFileMutex);
     }

--- a/src/coreclr/utilcode/log.cpp
+++ b/src/coreclr/utilcode/log.cpp
@@ -33,7 +33,7 @@
 static          DWORD        LogFlags                    = 0;
 static          CQuickWSTR   szLogFileName;
 static          HANDLE       LogFileHandle               = INVALID_HANDLE_VALUE;
-static volatile HANDLE       LogFileMutex                = 0;
+static minipal_mutex* volatile LogFileMutex              = nullptr;
 static          DWORD        LogFacilityMask             = LF_ALL;
 static          DWORD        LogFacilityMask2            = 0;
 static          DWORD        LogVMLevel                  = LL_INFO100;
@@ -156,11 +156,9 @@ VOID EnterLogLock()
     // rather hard to care about this, as we LOG all over the place.
     CONTRACT_VIOLATION(TakesLockViolation);
 
-    if(LogFileMutex != 0)
+    if(LogFileMutex != nullptr)
     {
-        DWORD status;
-        status = WaitForSingleObjectEx(LogFileMutex, INFINITE, FALSE);
-        _ASSERTE(WAIT_OBJECT_0 == status);
+        minipal_mutex_enter(LogFileMutex);
     }
 }
 
@@ -169,11 +167,9 @@ VOID LeaveLogLock()
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
 
-    if(LogFileMutex != 0)
+    if(LogFileMutex != nullptr)
     {
-        BOOL success;
-        success = ReleaseMutex(LogFileMutex);
-        _ASSERTE(success);
+        minipal_mutex_leave(LogFileMutex);
     }
 }
 
@@ -185,11 +181,14 @@ VOID InitializeLogging()
     if (bLoggingInitialized)
         return;
 
-    HANDLE mutex = CreateMutex(NULL, FALSE, NULL);
-    _ASSERTE(mutex != 0);
-    if (InterlockedCompareExchangeT(&LogFileMutex, mutex, 0) != 0)
+    minipal_mutex* mutex = new minipal_mutex;
+    bool success = minipal_mutex_init(mutex);
+    _ASSERTE(success);
+
+    if (InterlockedCompareExchangeT(&LogFileMutex, mutex, nullptr) != nullptr)
     {
-        CloseHandle(mutex);
+        minipal_mutex_destroy(mutex);
+        delete mutex;
     }
 
     EnterLogLock();


### PR DESCRIPTION
Removes another usage of the CoreCLR Win32 PAL Mutex