### PR TITLE
Fix NativeAOT COM custom query interface exception handling

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -329,7 +329,7 @@ namespace System.Runtime.InteropServices
                             }
                             catch (Exception ex)
                             {
-                                return ex.HResult;
+                                return Marshal.GetHRForException(ex);
                             }
                         }
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -314,15 +314,22 @@ namespace System.Runtime.InteropServices
                         }
                         else
                         {
-                            Guid riidLocal = riid;
-                            switch (customQueryInterface.GetInterface(ref riidLocal, out ppvObject))
+                            try
                             {
-                                case CustomQueryInterfaceResult.Handled:
-                                    return HResults.S_OK;
-                                case CustomQueryInterfaceResult.NotHandled:
-                                    break;
-                                case CustomQueryInterfaceResult.Failed:
-                                    return HResults.COR_E_INVALIDCAST;
+                                Guid riidLocal = riid;
+                                switch (customQueryInterface.GetInterface(ref riidLocal, out ppvObject))
+                                {
+                                    case CustomQueryInterfaceResult.Handled:
+                                        return HResults.S_OK;
+                                    case CustomQueryInterfaceResult.NotHandled:
+                                        break;
+                                    case CustomQueryInterfaceResult.Failed:
+                                        return HResults.COR_E_INVALIDCAST;
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                return ex.HResult;
                             }
                         }
                     }


### PR DESCRIPTION
After fixing a bug in the related stuff in coreclr, the regression test has revealed that the NativeAOT version has a similar issue. The exception stemming from the custom query interface are not caught and transformed to HRESULT, so they are reported as unhandled exceptions.

This change adds try / catch to catch the exception and translate it to HRESULT.

Close #117654