### PR TITLE
JIT: Mark throw blocks with heuristic-derived weights as rarely run during morph

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -183,6 +183,12 @@ void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
     // Update jump kind after the scrub.
     block->SetKindAndTargetEdge(BBJ_THROW);
     block->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
+
+    // Heuristic: Throw blocks without profile-derived weights are presumed to be rare.
+    if (!block->hasProfileWeight())
+    {
+        block->bbSetRunRarely();
+    }
 }
 
 /*****************************************************************************


### PR DESCRIPTION
Fixes #117577 ([comment](https://github.com/dotnet/runtime/issues/117577#issuecomment-3074182097)).