### PR TITLE
[Android] Reenable SocketsHttpHandlerTest.LargeHeaders_TrickledOverTime_ProcessedEfficiently on 64-bit Android

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1702,11 +1702,16 @@ namespace System.Net.Http.Functional.Tests
 
         private delegate int StreamReadSpanDelegate(Span<byte> buffer);
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(TripleBoolValues))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/77474", TestPlatforms.Android)]
         public async Task LargeHeaders_TrickledOverTime_ProcessedEfficiently(bool trailingHeaders, bool async, bool lineFolds)
         {
+            if (PlatformDetection.IsAndroid && !(PlatformDetection.IsArm64Process || PlatformDetection.IsX64Process))
+            {
+                // https://github.com/dotnet/runtime/issues/77474
+                throw new SkipTestException("This test is runs out of memory on 32-bit Android devices");
+            }
+
             Memory<byte> responsePrefix = Encoding.ASCII.GetBytes(trailingHeaders
                 ? "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\nLong-Header: "
                 : "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nLong-Header: ");

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1706,7 +1706,7 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(TripleBoolValues))]
         public async Task LargeHeaders_TrickledOverTime_ProcessedEfficiently(bool trailingHeaders, bool async, bool lineFolds)
         {
-            if (PlatformDetection.IsAndroid && !(PlatformDetection.IsArm64Process || PlatformDetection.IsX64Process))
+            if (PlatformDetection.IsAndroid && PlatformDetection.Is32BitProcess)
             {
                 // https://github.com/dotnet/runtime/issues/77474
                 throw new SkipTestException("This test runs out of memory on 32-bit Android devices");

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1709,7 +1709,7 @@ namespace System.Net.Http.Functional.Tests
             if (PlatformDetection.IsAndroid && !(PlatformDetection.IsArm64Process || PlatformDetection.IsX64Process))
             {
                 // https://github.com/dotnet/runtime/issues/77474
-                throw new SkipTestException("This test is runs out of memory on 32-bit Android devices");
+                throw new SkipTestException("This test runs out of memory on 32-bit Android devices");
             }
 
             Memory<byte> responsePrefix = Encoding.ASCII.GetBytes(trailingHeaders


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/77474

The test is known to run out of memory on 32-bit Android. We should still run the test on 64-bit Android which most commonly used by end customers.