### PR TITLE
Maintain DAC field offsets in EECodeGenManager

### DIFF
--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -1980,9 +1980,7 @@ private:
     // must hold critical section to access this structure.
     CUnorderedArray<DomainCodeHeapList*, 5> m_DomainCodeHeaps;
     CUnorderedArray<DomainCodeHeapList*, 5> m_DynamicDomainCodeHeaps;
-#ifndef DACCESS_COMPILE
     CUnorderedArray<LoaderAllocator*, 4> m_delayUnload;
-#endif // !DACCESS_COMPILE
 
 protected:
     Crst m_CodeHeapLock;


### PR DESCRIPTION
PR #116354 added a field to EECodeGenManager which was enabled in the runtime but #ifdef'd out in the DAC. This caused the `m_storeRichDebugInfo` field to become uninitialized in the DAC build, resulting in random crashes while debugging. 