### PR TITLE
Fix BuildChainCustomTrustStore test

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -364,14 +364,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         chainTest.ChainPolicy.CustomTrustStore.Remove(rootCert);
                         chainTest.ChainPolicy.TrustMode = X509ChainTrustMode.System;
                         chainTest.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
-                        allowedFlags |= X509ChainStatusFlags.PartialChain;
+                        cahinTest.ChainPolicy.ExtraStore.Add(rootCert);
                         break;
                     default:
                         throw new InvalidDataException();
                 }
 
                 Assert.Equal(chainBuildsSuccessfully, chainTest.Build(endCert));
-                Assert.InRange(chainTest.ChainElements.Count, 2, 3);
+                Assert.Equal(3, chainTest.ChainElements.Count);
 
                 X509ChainStatusFlags actualFlags = chainTest.AllStatusFlags();
                 actualFlags &= ~allowedFlags;

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -363,6 +363,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         chainHolder.DisposeChainElements();
                         chainTest.ChainPolicy.CustomTrustStore.Remove(rootCert);
                         chainTest.ChainPolicy.TrustMode = X509ChainTrustMode.System;
+                        chainTest.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
                         allowedFlags |= X509ChainStatusFlags.PartialChain;
                         break;
                     default:
@@ -370,7 +371,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 }
 
                 Assert.Equal(chainBuildsSuccessfully, chainTest.Build(endCert));
-                Assert.Equal(3, chainTest.ChainElements.Count);
+                Assert.InRange(chainTest.ChainElements.Count, 2, 3);
 
                 X509ChainStatusFlags actualFlags = chainTest.AllStatusFlags();
                 actualFlags &= ~allowedFlags;

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -365,6 +365,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         chainTest.ChainPolicy.TrustMode = X509ChainTrustMode.System;
                         chainTest.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
                         chainTest.ChainPolicy.ExtraStore.Add(rootCert);
+                        allowedFlags |= X509ChainStatusFlags.UntrustedRoot;
                         break;
                     default:
                         throw new InvalidDataException();

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -344,6 +344,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chainTest.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
                 chainTest.ChainPolicy.ExtraStore.Add(issuerCert);
 
+                X509ChainStatusFlags allowedFlags = X509ChainStatusFlags.NoError;
+
                 switch (testArguments)
                 {
                     case BuildChainCustomTrustStoreTestArguments.TrustedIntermediateUntrustedRoot:
@@ -361,6 +363,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         chainHolder.DisposeChainElements();
                         chainTest.ChainPolicy.CustomTrustStore.Remove(rootCert);
                         chainTest.ChainPolicy.TrustMode = X509ChainTrustMode.System;
+                        allowedFlags |= X509ChainStatusFlags.PartialChain;
                         break;
                     default:
                         throw new InvalidDataException();
@@ -368,7 +371,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 Assert.Equal(chainBuildsSuccessfully, chainTest.Build(endCert));
                 Assert.Equal(3, chainTest.ChainElements.Count);
-                Assert.Equal(chainFlags, chainTest.AllStatusFlags());
+
+                X509ChainStatusFlags actualFlags = chainTest.AllStatusFlags();
+                actualFlags &= ~allowedFlags;
+
+                Assert.Equal(chainFlags, actualFlags);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -364,7 +364,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         chainTest.ChainPolicy.CustomTrustStore.Remove(rootCert);
                         chainTest.ChainPolicy.TrustMode = X509ChainTrustMode.System;
                         chainTest.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
-                        cahinTest.ChainPolicy.ExtraStore.Add(rootCert);
+                        chainTest.ChainPolicy.ExtraStore.Add(rootCert);
                         break;
                     default:
                         throw new InvalidDataException();


### PR DESCRIPTION
The test BuildChainCustomTrustStore started failing in Alpine 3.22.

This is failing because the root certificate of the chain, "C=IE, O=Baltimore, OU=CyberTrust, CN=Baltimore CyberTrust Root" expired May 12 23:59:00 2025. Since the root certificate is expired, it was completely removed from the trust store in an update to Alpine.

This unit test was relying on the certificate being in the system trust store, which is no longer true.

This pull request changes the "use the system trust store" case to permit an untrusted root. This is consistent with what we are doing in other tests that use this chain:

https://github.com/dotnet/runtime/blob/a436284d7f5aae74ab25867c6ded4c9e83ad2ecb/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs#L46-L49

Contributes to https://github.com/dotnet/runtime/issues/117723