### PR TITLE
Change Key on MLDsaCng to GetKey method

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
@@ -95,15 +95,20 @@ namespace System.Security.Cryptography
             }
         }
 
-        public partial CngKey Key
+        public partial CngKey GetKey()
         {
-            get
-            {
-                ThrowIfDisposed();
+            ThrowIfDisposed();
 
-                return _key;
-            }
+#if SYSTEM_SECURITY_CRYPTOGRAPHY
+            return CngHelpers.Duplicate(_key.HandleNoDuplicate, _key.IsEphemeral);
+#else
+#pragma warning disable CA1416 // only supported on: 'windows'
+            return _key.Duplicate();
+#pragma warning restore CA1416 // only supported on: 'windows'
+#endif
         }
+
+        internal CngKey KeyNoDuplicate => _key;
 
         /// <inheritdoc/>
         protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) =>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.cs
@@ -63,18 +63,15 @@ namespace System.Security.Cryptography
         private static partial MLDsaAlgorithm AlgorithmFromHandle(CngKey key, out CngKey duplicateKey);
 
         /// <summary>
-        ///   Gets the key that will be used by the <see cref="MLDsaCng"/> object for any cryptographic operation that it performs.
+        ///   Gets a new <see cref="CngKey" /> representing the key used by the current instance.
         /// </summary>
-        /// <value>
-        ///   The key that will be used by the <see cref="MLDsaCng"/> object for any cryptographic operation that it performs.
-        /// </value>
         /// <exception cref="ObjectDisposedException">
         ///   This instance has been disposed.
         /// </exception>
         /// <remarks>
-        ///   This <see cref="CngKey"/> object is not the same as the one passed to the <see cref="MLDsaCng"/> constructor,
+        ///   This <see cref="CngKey"/> object is not the same as the one passed to <see cref="MLDsaCng(CngKey)"/>,
         ///   if that constructor was used. However, it will point to the same CNG key.
         /// </remarks>
-        public partial CngKey Key { get; }
+        public partial CngKey GetKey();
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaCngTests.Windows.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaCngTests.Windows.cs
@@ -234,5 +234,27 @@ namespace System.Security.Cryptography.Tests
                 key.Delete();
             }
         }
+
+        [Fact]
+        public static void MLDsaCng_GetKey()
+        {
+            CngProperty parameterSet = MLDsaTestHelpers.GetCngProperty(MLDsaAlgorithm.MLDsa65);
+            CngKeyCreationParameters creationParams = new();
+            creationParams.Parameters.Add(parameterSet);
+
+            using CngKey key = CngKey.Create(CngAlgorithm.MLDsa, keyName: null, creationParams);
+
+            using (MLDsaCng mlDsaKey = new(key))
+            using (CngKey getKey1 = mlDsaKey.GetKey())
+            {
+                using (CngKey getKey2 = mlDsaKey.GetKey())
+                {
+                    Assert.NotSame(key, getKey1);
+                    Assert.NotSame(getKey1, getKey2);
+                }
+
+                Assert.Equal(key.Algorithm, getKey1.Algorithm); // Assert.NoThrow on getKey1.Algorithm
+            }
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -2002,11 +2002,11 @@ namespace System.Security.Cryptography
     {
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public MLDsaCng(System.Security.Cryptography.CngKey key) : base (default(System.Security.Cryptography.MLDsaAlgorithm)) { }
-        public System.Security.Cryptography.CngKey Key { get { throw null; } }
         protected override void Dispose(bool disposing) { }
         protected override void ExportMLDsaPrivateSeedCore(System.Span<byte> destination) { }
         protected override void ExportMLDsaPublicKeyCore(System.Span<byte> destination) { }
         protected override void ExportMLDsaSecretKeyCore(System.Span<byte> destination) { }
+        public System.Security.Cryptography.CngKey GetKey() { throw null; }
         protected override void SignDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.Span<byte> destination) { }
         protected override void SignPreHashCore(System.ReadOnlySpan<byte> hash, System.ReadOnlySpan<byte> context, string hashAlgorithmOid, System.Span<byte> destination) { }
         protected override bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten) { throw null; }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
@@ -396,32 +396,32 @@ namespace System.Security.Cryptography
         private static partial MLDsaAlgorithm AlgorithmFromHandle(CngKey key, out CngKey duplicateKey) =>
             throw new PlatformNotSupportedException();
 
-        public partial CngKey Key =>
-            throw new PlatformNotSupportedException();
+        public partial CngKey GetKey() =>
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
 
         protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) =>
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
 
         protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) =>
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
 
         protected override void ExportMLDsaSecretKeyCore(Span<byte> destination) =>
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
 
         protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) =>
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
 
         protected override void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination) =>
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
 
         protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) =>
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
 
         protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) =>
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
 
         protected override bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature) =>
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
     }
 
     public sealed partial class MLKemCng : MLKem

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
@@ -196,7 +196,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             if (privateKey is MLDsaCng mldsaCng)
             {
-                CngKey key = mldsaCng.Key;
+                CngKey key = mldsaCng.KeyNoDuplicate;
 
                 ICertificatePal? clone = CopyWithPersistedCngKey(key);
 
@@ -223,7 +223,7 @@ namespace System.Security.Cryptography.X509Certificates
             using (PinAndClear.Track(exportedPkcs8))
             using (MLDsaCng clonedKey = MLDsaCng.ImportPkcs8PrivateKey(exportedPkcs8, out _))
             {
-                CngKey clonedCngKey = clonedKey.Key;
+                CngKey clonedCngKey = clonedKey.KeyNoDuplicate;
 
                 if (clonedCngKey.AlgorithmGroup != CngAlgorithmGroup.MLDsa)
                 {


### PR DESCRIPTION
As we did for MLKemCng, this changes the `CngKey Key` property to `CngKey GetKey()` method that returns a duplicated handle.