### PR TITLE
JIT: Unify block successor iteration logic

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -580,13 +580,10 @@ unsigned BasicBlock::dspPreds() const
 //------------------------------------------------------------------------
 // dspSuccs: Display the basic block successors.
 //
-// Arguments:
-//    compiler - compiler instance; passed to NumSucc(Compiler*) -- see that function for implications.
-//
-void BasicBlock::dspSuccs(Compiler* compiler)
+void BasicBlock::dspSuccs() const
 {
     bool first = true;
-    for (const BasicBlock* const succ : Succs(compiler))
+    for (const BasicBlock* const succ : Succs())
     {
         printf("%s" FMT_BB, first ? "" : ",", succ->bbNum);
         first = false;
@@ -734,10 +731,7 @@ void BasicBlock::dspKind() const
     }
 }
 
-void BasicBlock::dspBlockHeader(Compiler* compiler,
-                                bool      showKind /*= true*/,
-                                bool      showFlags /*= false*/,
-                                bool      showPreds /*= true*/)
+void BasicBlock::dspBlockHeader(bool showKind /*= true*/, bool showFlags /*= false*/, bool showPreds /*= true*/) const
 {
     printf("%s ", dspToString());
     dspBlockILRange();
@@ -750,7 +744,7 @@ void BasicBlock::dspBlockHeader(Compiler* compiler,
         printf(", preds={");
         dspPreds();
         printf("} succs={");
-        dspSuccs(compiler);
+        dspSuccs();
         printf("}");
     }
     if (showFlags)
@@ -1120,7 +1114,7 @@ unsigned BasicBlock::NumSucc() const
             return bbEhfTargets->GetSuccCount();
 
         case BBJ_SWITCH:
-            return bbSwtTargets->GetCaseCount();
+            return bbSwtTargets->GetSuccCount();
 
         default:
             unreached();
@@ -1128,7 +1122,7 @@ unsigned BasicBlock::NumSucc() const
 }
 
 //------------------------------------------------------------------------
-// GetSucc: Returns the requested successor edge. See the declaration comment for details.
+// GetSuccEdge: Returns the requested successor edge. See the declaration comment for details.
 //
 // Arguments:
 //    i - index of successor to return. 0 <= i <= NumSucc().
@@ -1165,7 +1159,7 @@ FlowEdge* BasicBlock::GetSuccEdge(unsigned i) const
             return bbEhfTargets->GetSucc(i);
 
         case BBJ_SWITCH:
-            return bbSwtTargets->GetCase(i);
+            return bbSwtTargets->GetSucc(i);
 
         default:
             unreached();
@@ -1184,137 +1178,6 @@ FlowEdge* BasicBlock::GetSuccEdge(unsigned i) const
 BasicBlock* BasicBlock::GetSucc(unsigned i) const
 {
     return GetSuccEdge(i)->getDestinationBlock();
-}
-
-//------------------------------------------------------------------------
-// NumSucc: Returns the count of block successors. See the declaration comment for details.
-//
-// Arguments:
-//    comp - Compiler instance
-//
-// Return Value:
-//    Count of block successors.
-//
-unsigned BasicBlock::NumSucc(Compiler* comp)
-{
-    assert(comp != nullptr);
-
-    switch (bbKind)
-    {
-        case BBJ_THROW:
-        case BBJ_RETURN:
-        case BBJ_EHFAULTRET:
-            return 0;
-
-        case BBJ_EHFINALLYRET:
-            // We may call this method before we realize we have invalid IL. Tolerate.
-            //
-            if (!hasHndIndex())
-            {
-                return 0;
-            }
-
-            // We may call this before we've computed the BBJ_EHFINALLYRET successors in the importer. Tolerate.
-            //
-            if (bbEhfTargets == nullptr)
-            {
-                return 0;
-            }
-
-            return bbEhfTargets->GetSuccCount();
-
-        case BBJ_CALLFINALLY:
-        case BBJ_CALLFINALLYRET:
-        case BBJ_ALWAYS:
-        case BBJ_EHCATCHRET:
-        case BBJ_EHFILTERRET:
-        case BBJ_LEAVE:
-            return 1;
-
-        case BBJ_COND:
-            if (bbTrueEdge == bbFalseEdge)
-            {
-                return 1;
-            }
-            else
-            {
-                return 2;
-            }
-
-        case BBJ_SWITCH:
-            return bbSwtTargets->GetSuccCount();
-
-        default:
-            unreached();
-    }
-}
-
-//------------------------------------------------------------------------
-// GetSucc: Returns the requested successor edge. See the declaration comment for details.
-//
-// Arguments:
-//    i - index of successor to return. 0 <= i <= NumSucc(comp).
-//    comp - Compiler instance
-//
-// Return Value:
-//    Requested successor edge
-//
-FlowEdge* BasicBlock::GetSuccEdge(unsigned i, Compiler* comp)
-{
-    assert(comp != nullptr);
-
-    assert(i < NumSucc(comp)); // Index bounds check.
-    switch (bbKind)
-    {
-        case BBJ_EHFILTERRET:
-            // Handler is the (sole) normal successor of the filter.
-            assert(comp->fgFirstBlockOfHandler(this) == GetTarget());
-            return GetTargetEdge();
-
-        case BBJ_EHFINALLYRET:
-            assert(bbEhfTargets != nullptr);
-            return bbEhfTargets->GetSucc(i);
-
-        case BBJ_CALLFINALLY:
-        case BBJ_CALLFINALLYRET:
-        case BBJ_ALWAYS:
-        case BBJ_EHCATCHRET:
-        case BBJ_LEAVE:
-            return GetTargetEdge();
-
-        case BBJ_COND:
-            if (i == 0)
-            {
-                return GetFalseEdge();
-            }
-            else
-            {
-                assert(i == 1);
-                assert(bbTrueEdge != bbFalseEdge);
-                return GetTrueEdge();
-            }
-
-        case BBJ_SWITCH:
-            return bbSwtTargets->GetSucc(i);
-
-        default:
-            unreached();
-    }
-}
-
-//------------------------------------------------------------------------
-// GetSucc: Returns the requested block successor. See the declaration comment for details.
-//
-// Arguments:
-//    i - index of successor to return. 0 <= i <= NumSucc(comp).
-//    comp - Compiler instance
-//
-// Return Value:
-//    Requested successor block
-//
-BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler* comp)
-{
-    return GetSuccEdge(i, comp)->getDestinationBlock();
 }
 
 void BasicBlock::InitVarSets(Compiler* comp)

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1067,41 +1067,6 @@ Statement* BasicBlock::FirstNonPhiDefOrCatchArgStore() const
 }
 
 //------------------------------------------------------------------------
-// bbFallsThrough: Check if inserting a BasicBlock after this one will alter
-// the flowgraph.
-//
-// Returns:
-//    True if so.
-//
-bool BasicBlock::bbFallsThrough() const
-{
-    switch (bbKind)
-    {
-        case BBJ_THROW:
-        case BBJ_EHFINALLYRET:
-        case BBJ_EHFAULTRET:
-        case BBJ_EHFILTERRET:
-        case BBJ_EHCATCHRET:
-        case BBJ_RETURN:
-        case BBJ_ALWAYS:
-        case BBJ_CALLFINALLYRET:
-        case BBJ_LEAVE:
-        case BBJ_SWITCH:
-            return false;
-
-        case BBJ_COND:
-            return true;
-
-        case BBJ_CALLFINALLY:
-            return !HasFlag(BBF_RETLESS_CALL);
-
-        default:
-            assert(!"Unknown bbKind in bbFallsThrough()");
-            return true;
-    }
-}
-
-//------------------------------------------------------------------------
 // NumSucc: Returns the count of block successors. See the declaration comment for details.
 //
 // Arguments:

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1895,7 +1895,7 @@ public:
     private:
         // For one or two successors, pre-compute and stash the successors inline, in m_succs[], so we don't
         // need to call a function or execute another `switch` to get them. Also, pre-compute the begin and end
-        // points of the iteration, for use by BBArrayIterator. `m_begin` and `m_end` will either point at
+        // points of the iteration, for use by the iterator. `m_begin` and `m_end` will either point at
         // `m_succs` or at the switch table successor array.
         FlowEdge*        m_succs[2];
         FlowEdge* const* m_begin;

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1732,8 +1732,6 @@ public:
     static size_t s_Count;
 #endif // MEASURE_BLOCK_SIZE
 
-    bool bbFallsThrough() const;
-
 #ifdef DEBUG
     unsigned        bbTgtStkDepth; // Native stack depth on entry (for throw-blocks)
     static unsigned s_nMaxTrees;   // The max # of tree nodes in any BB

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -174,7 +174,7 @@ void CodeGen::genCodeForBBlist()
         if (compiler->verbose)
         {
             printf("\n=============== Generating ");
-            block->dspBlockHeader(compiler, true, true);
+            block->dspBlockHeader(true, true);
             compiler->fgDispBBLiveness(block);
         }
 #endif // DEBUG

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9242,7 +9242,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *      cVars,       dVars          : Display the local variable table (call lvaTableDump()).
  *      cVarsFinal,  dVarsFinal     : Display the local variable table (call lvaTableDump(FINAL_FRAME_LAYOUT)).
  *      cBlockPreds, dBlockPreds    : Display a block's predecessors (call block->dspPreds()).
- *      cBlockSuccs, dBlockSuccs    : Display a block's successors (call block->dspSuccs(compiler)).
+ *      cBlockSuccs, dBlockSuccs    : Display a block's successors (call block->dspSuccs()).
  *      cReach,      dReach         : Display all block reachability (call BlockReachabilitySets::Dump).
  *      cDoms,       dDoms          : Display all block dominators (call FlowGraphDominatorTree::Dump).
  *      cLiveness,   dLiveness      : Display per-block variable liveness (call fgDispBBLiveness()).
@@ -9536,7 +9536,7 @@ JITDBGAPI void __cdecl cBlockSuccs(Compiler* comp, BasicBlock* block)
 {
     static unsigned sequenceNumber = 0; // separate calls with a number to indicate this function has been called
     printf("===================================================================== *BlockSuccs %u\n", sequenceNumber++);
-    block->dspSuccs(comp);
+    block->dspSuccs();
 }
 
 JITDBGAPI void __cdecl cReach(Compiler* comp)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -162,7 +162,7 @@ void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
     // Scrub this block from the pred lists of any successors
     bool profileInconsistent = false;
 
-    for (BasicBlock* const succBlock : block->Succs(this))
+    for (BasicBlock* const succBlock : block->Succs())
     {
         FlowEdge* const succEdge = fgRemoveAllRefPreds(succBlock, block);
 
@@ -3359,7 +3359,7 @@ void Compiler::fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
 
         fgLastBB = curBBdesc;
 
-        DBEXEC(verbose, curBBdesc->dspBlockHeader(this, false, false, false));
+        DBEXEC(verbose, curBBdesc->dspBlockHeader(false, false, false));
 
         /* Remember where the next BB will start */
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2414,7 +2414,7 @@ void Compiler::fgDumpStmtTree(const BasicBlock* block, Statement* stmt)
 void Compiler::fgDumpBlock(BasicBlock* block)
 {
     printf("\n------------ ");
-    block->dspBlockHeader(this);
+    block->dspBlockHeader();
 
     if (fgSsaValid)
     {
@@ -2968,7 +2968,7 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
         maxBBNum = max(maxBBNum, block->bbNum);
 
         // Check that all the successors have the current traversal stamp.
-        for (BasicBlock* const succBlock : block->Succs(this))
+        for (BasicBlock* const succBlock : block->Succs())
         {
             assert(succBlock->bbTraversalStamp == curTraversalStamp);
         }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -491,9 +491,6 @@ PhaseStatus Compiler::fgPostImportationCleanup()
                         // this would be problematic as we don't have enough context to redirect
                         // all the incoming edges, but we know oldTryEntry is unreachable.
                         // So there are no incoming edges to worry about.
-                        //
-                        assert(!tryEntryPrev->bbFallsThrough());
-
                         // What follows is similar to fgNewBBInRegion, but we can't call that
                         // here as the oldTryEntry is no longer in the main bb list.
                         newTryEntry = BasicBlock::New(this);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -353,7 +353,7 @@ PhaseStatus Compiler::fgPostImportationCleanup()
                 // When we alter flow in the importer branch opts, we should be able to make
                 // suitable updates there for blocks that we plan to keep.
                 //
-                for (BasicBlock* succ : cur->Succs(this))
+                for (BasicBlock* succ : cur->Succs())
                 {
                     fgRemoveAllRefPreds(succ, cur);
                 }
@@ -1248,7 +1248,7 @@ void Compiler::fgUnreachableBlock(BasicBlock* block)
 
     // Update bbRefs and bbPreds for this block's successors
     bool profileInconsistent = false;
-    for (BasicBlock* const succBlock : block->Succs(this))
+    for (BasicBlock* const succBlock : block->Succs())
     {
         FlowEdge* const succEdge = fgRemoveAllRefPreds(succBlock, block);
 
@@ -3499,7 +3499,7 @@ void Compiler::ThreeOptLayout<hasEH>::AddNonFallthroughSuccs(unsigned blockPos)
     BasicBlock* const block = blockOrder[blockPos];
     BasicBlock* const next  = ((blockPos + 1) >= numCandidateBlocks) ? nullptr : blockOrder[blockPos + 1];
 
-    for (FlowEdge* const succEdge : block->SuccEdges(compiler))
+    for (FlowEdge* const succEdge : block->SuccEdges())
     {
         if (succEdge->getDestinationBlock() != next)
         {

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -1020,13 +1020,13 @@ void Compiler::WalkSpanningTree(SpanningTreeVisitor* visitor)
                 // things will just work for switches either way, but it
                 // might work a bit better using the root compiler.
                 //
-                const unsigned numSucc = block->NumSucc(this);
+                const unsigned numSucc = block->NumSucc();
 
                 if (numSucc == 1)
                 {
                     // Not a fork. Just visit the sole successor.
                     //
-                    BasicBlock* const target = block->GetSucc(0, this);
+                    BasicBlock* const target = block->GetSucc(0);
                     if (BitVecOps::IsMember(&traits, marked, target->bbID))
                     {
                         // We can't instrument in the call finally pair tail block
@@ -1061,7 +1061,7 @@ void Compiler::WalkSpanningTree(SpanningTreeVisitor* visitor)
 
                     for (unsigned i = 0; i < numSucc; i++)
                     {
-                        BasicBlock* const succ = block->GetSucc(i, this);
+                        BasicBlock* const succ = block->GetSucc(i);
                         scratch.Push(succ);
                     }
 
@@ -1483,7 +1483,7 @@ void EfficientEdgeCountInstrumentor::SplitCriticalEdges()
                     // See if the edge still exists.
                     //
                     bool found = false;
-                    for (BasicBlock* const succ : block->Succs(m_comp))
+                    for (BasicBlock* const succ : block->Succs())
                     {
                         if (target == succ)
                         {
@@ -3782,7 +3782,7 @@ void EfficientEdgeCountReconstructor::Propagate()
         assert(info->m_weightKnown);
         block->setBBProfileWeight(info->m_weight);
 
-        const unsigned nSucc = block->NumSucc(m_comp);
+        const unsigned nSucc = block->NumSucc();
         if (nSucc == 0)
         {
             // No edges to worry about.
@@ -3983,7 +3983,7 @@ void EfficientEdgeCountReconstructor::PropagateEdges(BasicBlock* block, BlockInf
 
         weight_t equalLikelihood = 1.0 / nSucc;
 
-        for (FlowEdge* const succEdge : block->SuccEdges(m_comp))
+        for (FlowEdge* const succEdge : block->SuccEdges())
         {
             BasicBlock* const succBlock = succEdge->getDestinationBlock();
             JITDUMP("Setting likelihood of " FMT_BB " -> " FMT_BB " to " FMT_WT " (heur)\n", block->bbNum,
@@ -4871,7 +4871,7 @@ bool Compiler::fgDebugCheckOutgoingProfileData(BasicBlock* block, ProfileChecks 
 
     // We want switch targets unified, but not EH edges.
     //
-    const unsigned numSuccs = block->NumSucc(this);
+    const unsigned numSuccs = block->NumSucc();
 
     if ((numSuccs > 0) && !block->KindIs(BBJ_EHFAULTRET, BBJ_EHFILTERRET))
     {
@@ -4883,7 +4883,7 @@ bool Compiler::fgDebugCheckOutgoingProfileData(BasicBlock* block, ProfileChecks 
         unsigned missingEdges      = 0;
         unsigned missingLikelihood = 0;
 
-        for (FlowEdge* succEdge : block->SuccEdges(this))
+        for (FlowEdge* succEdge : block->SuccEdges())
         {
             assert(succEdge != nullptr);
             BasicBlock* succBlock = succEdge->getDestinationBlock();
@@ -4935,7 +4935,7 @@ bool Compiler::fgDebugCheckOutgoingProfileData(BasicBlock* block, ProfileChecks 
 #ifdef DEBUG
                     if (verbose)
                     {
-                        for (const FlowEdge* succEdge : block->SuccEdges(this))
+                        for (const FlowEdge* succEdge : block->SuccEdges())
                         {
                             const BasicBlock* succBlock = succEdge->getDestinationBlock();
                             if (succEdge->hasLikelihood())

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -70,7 +70,7 @@
             bool anyPathThrows = false;
             bool allPathsThrow = true;
 
-            for (BasicBlock* const succBlock : block->Succs(compiler))
+            for (BasicBlock* const succBlock : block->Succs())
             {
                 if (BitVecOps::IsMember(&traits, willThrow, succBlock->bbPostorderNum))
                 {
@@ -525,7 +525,7 @@ void ProfileSynthesis::AssignLikelihoodSwitch(BasicBlock* block)
 {
     // Assume each switch case is equally probable
     //
-    const unsigned n = block->NumSucc();
+    const unsigned n = block->GetSwitchTargets()->GetCaseCount();
     assert(n != 0);
 
     // Check for divide by zero to avoid compiler warnings for Release builds (above assert is removed)
@@ -533,7 +533,7 @@ void ProfileSynthesis::AssignLikelihoodSwitch(BasicBlock* block)
 
     // Each unique edge gets some multiple of that basic probability
     //
-    for (FlowEdge* const succEdge : block->SuccEdges(m_comp))
+    for (FlowEdge* const succEdge : block->SuccEdges())
     {
         succEdge->setLikelihood(p * succEdge->getDupCount());
     }
@@ -558,7 +558,7 @@ weight_t ProfileSynthesis::SumOutgoingLikelihoods(BasicBlock* block, WeightVecto
         likelihoods->clear();
     }
 
-    for (FlowEdge* const succEdge : block->SuccEdges(m_comp))
+    for (FlowEdge* const succEdge : block->SuccEdges())
     {
         weight_t likelihood = succEdge->getLikelihood();
         if (likelihoods != nullptr)
@@ -739,7 +739,7 @@ void ProfileSynthesis::BlendLikelihoods()
                 JITDUMP("Blending likelihoods in " FMT_BB " with blend factor " FMT_WT " \n", block->bbNum,
                         m_blendFactor);
                 iter = likelihoods.begin();
-                for (FlowEdge* const succEdge : block->SuccEdges(m_comp))
+                for (FlowEdge* const succEdge : block->SuccEdges())
                 {
                     weight_t newLikelihood = succEdge->getLikelihood();
                     weight_t oldLikelihood = *iter;
@@ -767,7 +767,7 @@ void ProfileSynthesis::ClearLikelihoods()
 {
     for (BasicBlock* const block : m_comp->Blocks())
     {
-        for (FlowEdge* const succEdge : block->SuccEdges(m_comp))
+        for (FlowEdge* const succEdge : block->SuccEdges())
         {
             succEdge->clearLikelihood();
         }
@@ -785,7 +785,7 @@ void ProfileSynthesis::ReverseLikelihoods()
     WeightVector likelihoods(m_comp->getAllocator(CMK_Pgo));
     for (BasicBlock* const block : m_comp->Blocks())
     {
-        for (BasicBlock* const succ : block->Succs(m_comp))
+        for (BasicBlock* const succ : block->Succs())
         {
             weight_t sum = SumOutgoingLikelihoods(block, &likelihoods);
 
@@ -825,7 +825,7 @@ void ProfileSynthesis::RandomizeLikelihoods()
 
     for (BasicBlock* const block : m_comp->Blocks())
     {
-        unsigned const N = block->NumSucc(m_comp);
+        unsigned const N = block->NumSucc();
         likelihoods.clear();
         likelihoods.reserve(N);
 
@@ -842,7 +842,7 @@ void ProfileSynthesis::RandomizeLikelihoods()
         }
 
         i = 0;
-        for (FlowEdge* const succEdge : block->SuccEdges(m_comp))
+        for (FlowEdge* const succEdge : block->SuccEdges())
         {
             succEdge->setLikelihood(likelihoods[i++] / sum);
         }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1436,7 +1436,6 @@ void Compiler::fgAddSyncMethodEnterExit()
     // Create a block for the fault.
     // It gets an artificial ref count.
 
-    assert(!tryLastBB->bbFallsThrough());
     BasicBlock* faultBB = fgNewBBafter(BBJ_EHFAULTRET, tryLastBB, false);
 
     assert(tryLastBB->NextIs(faultBB));

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6182,7 +6182,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             //
                             if (!mustUseTargetPatchpoint)
                             {
-                                for (BasicBlock* const succBlock : block->Succs(this))
+                                for (BasicBlock* const succBlock : block->Succs())
                                 {
                                     if ((succBlock->bbNum <= block->bbNum) && (succBlock->bbRefs > 1))
                                     {
@@ -6203,7 +6203,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         // We wanted a source patchpoint, but could not have one.
                         // So, add patchpoints to the backedge targets.
                         //
-                        for (BasicBlock* const succBlock : block->Succs(this))
+                        for (BasicBlock* const succBlock : block->Succs())
                         {
                             if (succBlock->bbNum <= block->bbNum)
                             {
@@ -6355,7 +6355,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
             // Block will no longer flow to any of its successors.
             //
-            for (BasicBlock* const succ : block->Succs(this))
+            for (BasicBlock* const succ : block->Succs())
             {
                 // We may have degenerate flow, make sure to fully remove
                 fgRemoveAllRefPreds(succ, block);

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1101,7 +1101,7 @@ void LinearScan::setBlockSequence()
         {
             if (!hasUniquePred)
             {
-                if (predBlock->NumSucc(compiler) > 1)
+                if (predBlock->NumSucc() > 1)
                 {
                     blockInfo[block->bbNum].hasCriticalInEdge = true;
                     hasCriticalEdges                          = true;
@@ -1131,14 +1131,14 @@ void LinearScan::setBlockSequence()
 
         // First, update the NORMAL successors of the current block, adding them to the worklist
         // according to the desired order.  We will handle the EH successors below.
-        const unsigned numSuccs                = block->NumSucc(compiler);
+        const unsigned numSuccs                = block->NumSucc();
         bool           checkForCriticalOutEdge = (numSuccs > 1);
         if (!checkForCriticalOutEdge && block->KindIs(BBJ_SWITCH))
         {
             assert(!"Switch with single successor");
         }
 
-        for (BasicBlock* const succ : block->Succs(compiler))
+        for (BasicBlock* const succ : block->Succs())
         {
             if (checkForCriticalOutEdge && (succ->GetUniquePred(compiler) == nullptr))
             {
@@ -8953,7 +8953,7 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
 
     // Get the outVarToRegMap for this block
     VarToRegMap outVarToRegMap = getOutVarToRegMap(block->bbNum);
-    unsigned    succCount      = block->NumSucc(compiler);
+    unsigned    succCount      = block->NumSucc();
     assert(succCount > 1);
 
     // First, determine the live regs at the end of this block so that we know what regs are
@@ -9096,7 +9096,7 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
         regNumber sameToReg           = REG_NA;
         for (unsigned succIndex = 0; succIndex < succCount; succIndex++)
         {
-            BasicBlock* succBlock = block->GetSucc(succIndex, compiler);
+            BasicBlock* succBlock = block->GetSucc(succIndex);
             if (!VarSetOps::IsMember(compiler, succBlock->bbLiveIn, outResolutionSetVarIndex))
             {
                 maybeSameLivePaths = true;
@@ -9215,7 +9215,7 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
     {
         for (unsigned succIndex = 0; succIndex < succCount; succIndex++)
         {
-            BasicBlock* succBlock = block->GetSucc(succIndex, compiler);
+            BasicBlock* succBlock = block->GetSucc(succIndex);
 
             // Any "diffResolutionSet" resolution for a block with no other predecessors will be handled later
             // as split resolution.
@@ -9333,7 +9333,7 @@ void LinearScan::resolveEdges()
             continue;
         }
 
-        unsigned    succCount       = block->NumSucc(compiler);
+        unsigned    succCount       = block->NumSucc();
         BasicBlock* uniquePredBlock = block->GetUniquePred(compiler);
 
         // First, if this block has a single predecessor,
@@ -9366,7 +9366,7 @@ void LinearScan::resolveEdges()
 
         if (succCount == 1)
         {
-            BasicBlock* succBlock = block->GetSucc(0, compiler);
+            BasicBlock* succBlock = block->GetSucc(0);
             if (succBlock->GetUniquePred(compiler) == nullptr)
             {
                 VARSET_TP outResolutionSet(
@@ -10958,7 +10958,7 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
                             continueLoop = false;
                             break;
                         }
-                        block->dspBlockHeader(compiler);
+                        block->dspBlockHeader();
                         printedBlockHeader = true;
                         printf("=====\n");
                         break;
@@ -10975,7 +10975,7 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
         }
         else
         {
-            block->dspBlockHeader(compiler);
+            block->dspBlockHeader();
             printf("=====\n");
         }
         if (enregisterLocalVars && mode == LSRA_DUMP_POST && block != compiler->fgFirstBB &&

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2771,7 +2771,7 @@ void LinearScan::buildIntervals()
     // If the last block has successors, create a RefTypeBB to record
     // what's live
 
-    if (prevBlock->NumSucc(compiler) > 0)
+    if (prevBlock->NumSucc() > 0)
     {
         RefPosition* pos = newRefPosition((Interval*)nullptr, currentLoc, RefTypeBB, nullptr, RBM_NONE);
     }

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -3013,7 +3013,7 @@ PhaseStatus Promotion::Run()
         Statement* firstStmt = replacer.StartBlock(bb);
 
         JITDUMP("\nReplacing in ");
-        DBEXEC(m_compiler->verbose, bb->dspBlockHeader(m_compiler));
+        DBEXEC(m_compiler->verbose, bb->dspBlockHeader());
         JITDUMP("\n");
 
         for (Statement* stmt : StatementList(firstStmt))


### PR DESCRIPTION
Follow-up to #117423.
* Collapse `BBSuccList` and `BBSuccEdgeList` into one templatized type, where the template specifies the iterator kind
* Remove `BasicBlock::NumSucc(Compiler*)` et al
* Have `BasicBlock::NumSucc()` et al deal only with unique successors, now that they're always available
  * For the occasional case where we have a switch block, and we want to iterate its cases with duplicates, we don't rely on the general successor iteration pattern, anyway
* (unrelated) Remove `BasicBlock::bbFallsThrough`