### PR TITLE
fix(marshal) Signed overflow check

### DIFF
--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -996,7 +996,7 @@ mono_string_builder_to_utf16_impl (MonoStringBuilderHandle sb, MonoError *error)
 			MONO_HANDLE_GET (chunkChars, chunk, chunkChars);
 			const int chunkOffset = MONO_HANDLE_GETVAL (chunk, chunkOffset);
 			g_assert (chunkOffset >= 0);
-			g_assertf ((chunkOffset + chunkLength) >= chunkLength, "integer overflow");
+			g_assertf (chunkOffset >= -chunkLength, "integer overflow");
 			g_assertf (GINT_TO_UINT(chunkOffset + chunkLength) <= capacity, "A chunk in the StringBuilder had a length longer than expected from the offset.");
 			memcpy (str + chunkOffset, MONO_HANDLE_RAW (chunkChars)->vector, chunkLength * sizeof (gunichar2));
 		}


### PR DESCRIPTION
https://github.com/dotnet/runtime/blob/af05ae4672443e875e5b7768cb71bbbfaa351674/src/mono/mono/metadata/marshal.c#L999-L999

fix the issue, the comparison `(chunkOffset + chunkLength) >= chunkLength` should be rewritten to avoid signed integer overflow. This can be achieved by reframing the condition using subtraction instead of addition. Specifically, the condition can be rewritten as `chunkOffset >= -chunkLength`, which avoids the addition operation that could overflow. Alternatively, the code can be modified to use unsigned integers for `chunkOffset` and `chunkLength`, ensuring that overflow results in well-defined wraparound behavior.

The best approach is to rewrite the condition using subtraction, as this avoids changing the signedness of the variables and minimizes the impact on the rest of the code. Additionally, this approach does not require introducing new headers or dependencies.

---

When checking for integer overflow, you may often write tests like `a + b < a`. This works fine if `a` or `b` are unsigned integers, since any overflow in the addition will cause the value to simply "wrap around." However, using signed integers is problematic because signed overflow has undefined behavior according to the C and C++ standards. If the addition overflows and has an undefined result, the comparison will likewise be undefined; it may produce an unintended result, or may be deleted entirely by an optimizing compiler.

#### References
[comp.lang.c FAQ list · Question 3.19 (Preserving rules)](http://c-faq.com/expr/preservingrules.html)
[INT31-C. Ensure that integer conversions do not result in lost or misinterpreted data](https://wiki.sei.cmu.edu/confluence/display/c/INT31-C.+Ensure+that+integer+conversions+do+not+result+in+lost+or+misinterpreted+data)
[Understanding Integer Overflow in C/C++](https://www.cs.utah.edu/~regehr/papers/overflow12.pdf)
