### PR TITLE
[HTTP] WinHTTP fix exception

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -2216,14 +2216,13 @@ namespace System.Net.Http.Functional.Tests
                     // WinHTTP validates the input before opening connection whereas SocketsHttpHandler opens connection first and validates only when writing to the wire.
                     acceptConnection.SetResult(!IsWinHttpHandler);
                     var ex = await Assert.ThrowsAnyAsync<Exception>(() => client.SendAsync(request));
+                    var hrex = Assert.IsType<HttpRequestException>(ex);
                     if (IsWinHttpHandler)
                     {
-                        var fex = Assert.IsType<FormatException>(ex);
-                        Assert.Contains("Latin-1", fex.Message);
+                        Assert.Contains("Error 87", hrex.InnerException.Message);
                     }
                     else
                     {
-                        var hrex = Assert.IsType<HttpRequestException>(ex);
                         var message = UseVersion == HttpVersion30 ? hrex.InnerException.Message : hrex.Message;
                         Assert.Contains("ASCII", message);
                     }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -135,7 +135,4 @@
   <data name="net_http_unsupported_version" xml:space="preserve">
     <value>Request version value must be one of 1.0, 1.1, 2.0, or 3.0.</value>
   </data>
-  <data name="net_http_invalid_header_value" xml:space="preserve">
-    <value>Request headers must be valid Latin-1 characters.</value>
-  </data>
 </root>

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
@@ -80,15 +80,7 @@ namespace System.Net.Http
                     (uint)cookieHeader.Length,
                     Interop.WinHttp.WINHTTP_ADDREQ_FLAG_ADD))
                 {
-                    int lastError = Marshal.GetLastWin32Error();
-                    if (lastError == Interop.WinHttp.ERROR_INVALID_PARAMETER)
-                    {
-                        throw new FormatException(SR.net_http_invalid_header_value);
-                    }
-                    else
-                    {
-                        throw WinHttpException.CreateExceptionUsingError(lastError, nameof(Interop.WinHttp.WinHttpAddRequestHeaders));
-                    }
+                    throw WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpAddRequestHeaders));
                 }
             }
         }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -769,15 +769,7 @@ namespace System.Net.Http
                 (uint)requestHeadersBuffer.Length,
                 Interop.WinHttp.WINHTTP_ADDREQ_FLAG_ADD))
             {
-                int lastError = Marshal.GetLastWin32Error();
-                if (lastError == Interop.WinHttp.ERROR_INVALID_PARAMETER)
-                {
-                    throw new FormatException(SR.net_http_invalid_header_value);
-                }
-                else
-                {
-                    throw WinHttpException.CreateExceptionUsingError(lastError, nameof(Interop.WinHttp.WinHttpAddRequestHeaders));
-                }
+                throw WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpAddRequestHeaders));
             }
         }
 


### PR DESCRIPTION
As noted in the issue, the special-cased error code is used more widely than just for invalid Latin-1. So I'm removing the special casing and leaving the plain `WinHttpException` there.

Fixes #117391