### PR TITLE
JIT: Fix unique successors in `BBswtDesc` in async

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -2305,8 +2305,8 @@ void AsyncTransformation::CreateResumptionSwitch()
             }
         }
 
-        BBswtDesc* const swtDesc =
-            new (m_comp, CMK_BasicBlock) BBswtDesc(cases, (unsigned)numCases, succs, numUniqueSuccs, true);
+        BBswtDesc* const swtDesc = new (m_comp, CMK_BasicBlock)
+            BBswtDesc(succs, numUniqueSuccs, cases, (unsigned)numCases, /* hasDefault */ true);
         switchBB->SetSwitch(swtDesc);
     }
 


### PR DESCRIPTION
Cases and successors were swapped in #117423.