### PR TITLE
Skip optimization in getHelperFtn if NativeCodeVersion is null

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10844,7 +10844,9 @@ void CEECodeGenInfo::getHelperFtn(CorInfoHelpFunc    ftnNum,               /* IN
                     activeCodeVersion = manager->GetActiveILCodeVersion(helperMD).GetActiveNativeCodeVersion(helperMD);
                 }
 
-                if (activeCodeVersion.IsFinalTier())
+                // activeCodeVersion may be a null version if the current active ILCodeVersion
+                // does not have an associated NativeCodeVersion
+                if (!activeCodeVersion.IsNull() && activeCodeVersion.IsFinalTier())
                 {
                     finalTierAddr = (LPVOID)activeCodeVersion.GetNativeCode();
                     if (finalTierAddr != NULL)


### PR DESCRIPTION
Closes #112636

ReJIT creates a new `ILCodeVersion` and sets it as active. When we do the lookup to find the active `NativeCodeVersion`, there may not yet be an active `NativeCodeVersion` associated with the new `ILCodeVersion`. Therefor the lookup will return a default initialized object which causes a null dereference and crash.

This optimization was added in https://github.com/dotnet/runtime/pull/90412 which lines up with the issue appearing in .NET9/10.

I verified this fix by modifying the `rejit.cs` coreclr test. The general idea is to trigger a ReJIT on a managed JIT helper then on a method that will call the managed JIT helper. I accomplished this by using the `ThrowIndexOutOfRangeException` helper.

<details>

<summary>Test Modifications</summary>

rejitprofiler.h
```cpp
// Licensed to the .NET Foundation under one or more agreements.
// The .NET Foundation licenses this file to you under the MIT license.

#pragma once

#include "../profiler.h"

#include <unordered_set>
#include <map>
#include <memory>
#include <string>

// TODO: right now this test exercises only one test, it should be generalized in the future.
// It currently hooks JitCompilationFinished looking for a trigger method, after
// the trigger method is seen it calls ReJITWithInliners on Inline.Inlinee and
// verifies that 3 rejits are seen (this is the expected number due to how the code is
// constructed). Then it reverts all three and verifies the reverts go through.
//
// In general it would be better to have a pinvoke in the profiler that can be accessed through
// C#, controlling behavior like the following.
//      ReJitMethod("Inline.exe", "Foo.Bar.Inlinee");
//      Inliner() // assert it has new behavior
//      RevertMethod("Inline.exe", "Foo.Bar.Inlinee");
//      Inliner() // assert it has original behavior

class ReJITProfiler : public Profiler
{
public:
    ReJITProfiler();
    virtual ~ReJITProfiler() = default;

	static GUID GetClsid();
    virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk);
    virtual HRESULT STDMETHODCALLTYPE Shutdown();

    virtual HRESULT STDMETHODCALLTYPE JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock);
    virtual HRESULT STDMETHODCALLTYPE JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock);
    virtual HRESULT STDMETHODCALLTYPE JITInlining(FunctionID callerId, FunctionID calleeId, BOOL* pfShouldInline);
    virtual HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result);

    virtual HRESULT STDMETHODCALLTYPE ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId, BOOL fIsSafeToBlock);
    virtual HRESULT STDMETHODCALLTYPE GetReJITParameters(ModuleID moduleId, mdMethodDef methodId, ICorProfilerFunctionControl* pFunctionControl);
    virtual HRESULT STDMETHODCALLTYPE ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId, HRESULT hrStatus, BOOL fIsSafeToBlock);
    virtual HRESULT STDMETHODCALLTYPE ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId, HRESULT hrStatus);

private:
    void AddInlining(FunctionID inliner, FunctionID inlinee);

    bool FunctionSeen(FunctionID func);

    FunctionID GetFunctionIDFromToken(ModuleID module, mdMethodDef token, bool invalidArgNotFailure);
    mdMethodDef GetMethodDefForFunction(FunctionID functionId);
    ModuleID GetModuleIDForFunction(FunctionID functionId);

    ICorProfilerInfo10 *_profInfo10;
    std::atomic<int> _failures;
    std::atomic<int> _rejits;
    std::atomic<int> _reverts;
    std::map<FunctionID, std::shared_ptr<std::unordered_set<FunctionID>>> _inlinings;
    FunctionID _triggerFuncId;
    FunctionID _targetFuncId;
    ModuleID _targetModuleId;
    mdMethodDef _targetMethodDef;
    
    FunctionID _throwFuncId;
    ModuleID _throwID;
    mdMethodDef _throwMethodDef;

    const String ReJITTriggerMethodName = WCHAR("TriggerReJIT");
    const String RevertTriggerMethodName = WCHAR("TriggerRevert");
    const String TargetMethodName = WCHAR("InlineeTarget");
    const String TargetModuleName = WCHAR("rejit.dll");

    const String TargetMethodName2 = WCHAR("ThrowIndexOutOfRangeException");
    const String TargetModuleName2 = WCHAR("System.Private.CoreLib.dll");
};
```

rejitprofiler.cpp
```cpp
// Licensed to the .NET Foundation under one or more agreements.
// The .NET Foundation licenses this file to you under the MIT license.

#include "rejitprofiler.h"
#include "ilrewriter.h"
#include <iostream>
#include <utility>
#include <vector>
#include <chrono>
#include <thread>

using std::map;
using std::unordered_set;
using std::make_pair;
using std::shared_ptr;
using std::make_shared;
using std::vector;

#ifndef __FUNCTION_NAME__
    #ifdef WIN32   //WINDOWS
        #define __FUNCTION_NAME__   __FUNCTION__
    #else          //*NIX
        #define __FUNCTION_NAME__   __func__
    #endif
#endif

#define _MESSAGE(LVL, MSG) std::wcout << "**" << LVL << "** " << __FUNCTION_NAME__ << " - " << MSG << std::endl;
#define INFO(MSG) _MESSAGE("INFO", MSG)
#define FAIL(MSG) _MESSAGE("FAIL", MSG)

#ifdef __clang__
#pragma clang diagnostic ignored "-Wnull-arithmetic"
#endif // __clang__

ReJITProfiler::ReJITProfiler() : Profiler(),
    _profInfo10(nullptr),
    _failures(0),
    _rejits(0),
    _reverts(0),
    _inlinings(),
    _triggerFuncId(0),
    _targetFuncId(0),
    _targetModuleId(0),
    _targetMethodDef(mdTokenNil)
{

}

GUID ReJITProfiler::GetClsid()
{
    // {66F7A9DF-8858-4A32-9CFF-3AD0787E0186}
    GUID clsid = { 0x66F7A9DF, 0x8858, 0x4A32, {0x9C, 0xFF, 0x3A, 0xD0, 0x78, 0x7E, 0x01, 0x86 } };
    return clsid;
}

HRESULT ReJITProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
{
    HRESULT hr = Profiler::Initialize(pICorProfilerInfoUnk);
    if (FAILED(hr))
    {
        _failures++;
        FAIL(L"Profiler::Initialize failed with hr=" << std::hex << hr);
        return hr;
    }

    hr = pICorProfilerInfoUnk->QueryInterface(IID_ICorProfilerInfo10, (void **)&_profInfo10);
    if (FAILED(hr))
    {
        _failures++;
        FAIL(L"Could not QI for ICorProfilerInfo10");
        return hr;
    }

    INFO(L"Initialize started");

    DWORD eventMaskLow = COR_PRF_ENABLE_REJIT |
                         COR_PRF_MONITOR_JIT_COMPILATION |
                         COR_PRF_MONITOR_CACHE_SEARCHES;
    DWORD eventMaskHigh = 0x0;
    if (FAILED(hr = pCorProfilerInfo->SetEventMask2(eventMaskLow, eventMaskHigh)))
    {
        _failures++;
        FAIL(L"ICorProfilerInfo::SetEventMask2() failed hr=0x" << std::hex << hr);
        return hr;
    }

    return S_OK;
}

HRESULT ReJITProfiler::Shutdown()
{
    Profiler::Shutdown();

    if (_profInfo10 != nullptr)
    {
        _profInfo10->Release();
        _profInfo10 = nullptr;
    }

    int expectedRejitCount = -1;
    auto it = _inlinings.find(_targetFuncId);
    if (it != _inlinings.end())
    {
        // The number of inliners are expected to ReJIT, plus the method itself
        expectedRejitCount = (int)((*it).second->size() + 1);
    }

    INFO(L" rejit count=" << _rejits << L" expected rejit count=" << expectedRejitCount);

    if(_failures == 0 && _rejits == expectedRejitCount)
    {
        printf("PROFILER TEST PASSES\n");
    }
    else
    {
        FAIL(L"Test failed number of failures=" << _failures);
    }
    fflush(stdout);

    return S_OK;
}

HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock)
{
    SHUTDOWNGUARD();

    return S_OK;
}

bool ReJITProfiler::FunctionSeen(FunctionID functionId)
{
    String functionName = GetFunctionIDName(functionId);
    ModuleID moduleId = GetModuleIDForFunction(functionId);
    String moduleName = GetModuleIDName(moduleId);

    // Check for runtime issue #13404, we would return NULL addresses in
    // GetNativeCodeStartAddresses for R2R methods when called from
    // JITCachedFunctionSearchFinished
    ULONG rejitCount;
    HRESULT hr = pCorProfilerInfo->GetReJITIDs(functionId,
                                               0,
                                               &rejitCount,
                                               NULL);
    if (FAILED(hr))
    {
        printf("GetReJITIDs failed with hr=0x%x\n", hr);
        _failures++;
        return S_OK;
    }

    if (rejitCount > 0)
    {
        vector<ReJITID> rejitIds(rejitCount);
        HRESULT hr = pCorProfilerInfo->GetReJITIDs(functionId,
                                                   (ULONG)rejitIds.size(),
                                                   &rejitCount,
                                                   &rejitIds[0]);
        if (FAILED(hr))
        {
            printf("GetReJITIDs failed with hr=0x%x\n", hr);
            _failures++;
            return S_OK;
        }

        for (auto &&id : rejitIds)
        {
            UINT32 countAddresses;
            hr = pCorProfilerInfo->GetNativeCodeStartAddresses(functionId,
                                                               id,
                                                               0,
                                                               &countAddresses,
                                                               NULL);
            if (FAILED(hr))
            {
                printf("GetNativeCodeStartAddresses failed with hr=0x%x\n", hr);
                _failures++;
                continue;
            }
            else if (countAddresses == 0)
            {
                continue;
            }

            vector<UINT_PTR> codeStartAddresses(countAddresses);
            hr = pCorProfilerInfo->GetNativeCodeStartAddresses(functionId,
                                                               id,
                                                               (ULONG)codeStartAddresses.size(),
                                                               &countAddresses,
                                                               &codeStartAddresses[0]);
            if (FAILED(hr))
            {
                printf("GetNativeCodeStartAddresses failed with hr=0x%x\n", hr);
                _failures++;
                continue;
            }

            for (auto &&address : codeStartAddresses)
            {
                if (address == (UINT_PTR)NULL)
                {
                    printf("Found NULL start address from GetNativeCodeStartAddresses.\n");
                    _failures++;
                }
            }
        }
    }

    if (functionName == TargetMethodName2 && EndsWith(moduleName, TargetModuleName2))
    {
        INFO(L"Found function id for target method: " << functionName);
        INFO(L"ModuleName: " << moduleName);
        INFO(L"FunctionID=" << std::hex << functionId); 
        _throwFuncId = functionId;
        _throwID = GetModuleIDForFunction(_throwFuncId);
        _throwMethodDef = GetMethodDefForFunction(_throwFuncId);

        return true;
    }

    if (functionName == TargetMethodName && EndsWith(moduleName, TargetModuleName))
    {
        INFO(L"Found function id for target method: " << functionName);
        INFO(L"ModuleName: " << moduleName); 
        INFO(L"FunctionID=" << std::hex << functionId); 

        _targetFuncId = functionId;
        _targetModuleId = GetModuleIDForFunction(_targetFuncId);
        _targetMethodDef = GetMethodDefForFunction(_targetFuncId);

        return true;
    }
    else if (functionName == ReJITTriggerMethodName && EndsWith(moduleName, TargetModuleName))
    {
        INFO(L"ReJIT Trigger method jitting finished: " << functionName);

        _triggerFuncId = functionId;
        

        INFO(L"Requesting rejit with inliners for method " << GetFunctionIDName(_throwFuncId));
        INFO(L"ModuleID=" << std::hex << _throwID << L" and MethodDef=" << std::hex << _throwMethodDef);
        _profInfo10->RequestReJITWithInliners(COR_PRF_REJIT_BLOCK_INLINING | COR_PRF_REJIT_INLINING_CALLBACKS, 1, &_throwID, &_throwMethodDef);
        
        std::this_thread::sleep_for(std::chrono::milliseconds(1000)); // Wait for the ReJIT to complete

        INFO(L"Requesting rejit with inliners for method " << GetFunctionIDName(_targetFuncId));
        INFO(L"ModuleID=" << std::hex << _targetModuleId << L" and MethodDef=" << std::hex << _targetMethodDef);
        _profInfo10->RequestReJITWithInliners(COR_PRF_REJIT_BLOCK_INLINING | COR_PRF_REJIT_INLINING_CALLBACKS, 1, &_targetModuleId, &_targetMethodDef);
    }
    else if (functionName == RevertTriggerMethodName && EndsWith(moduleName, TargetModuleName))
    {
        INFO(L"Revert trigger method jitting finished: " << functionName);

        INFO(L"Requesting revert for method " << GetFunctionIDName(_targetFuncId));
        INFO(L"ModuleID=" << std::hex << _targetModuleId << L" and MethodDef=" << std::hex << _targetMethodDef);
        _profInfo10->RequestRevert(1, &_targetModuleId, &_targetMethodDef, nullptr);
    }

    return false;
}

HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
{
    SHUTDOWNGUARD();

    FunctionSeen(functionId);
    return S_OK;
}

HRESULT STDMETHODCALLTYPE ReJITProfiler::JITInlining(FunctionID callerId, FunctionID calleeId, BOOL* pfShouldInline)
{
    SHUTDOWNGUARD();

    AddInlining(callerId, calleeId);
    *pfShouldInline = TRUE;

    return S_OK;
}


HRESULT STDMETHODCALLTYPE ReJITProfiler::JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result)
{
    SHUTDOWNGUARD();

    if (result == COR_PRF_CACHED_FUNCTION_FOUND)
    {
        // FunctionSeen will return true if it's a method we're tracking, and false otherwise
        if(!FunctionSeen(functionId))
        {
            return S_OK;
        }

        HRESULT hr;
        // TODO: this only looks in the same module as the function, with version bubbles that may
        // not hold.
        ModuleID modId = GetModuleIDForFunction(functionId);
        mdToken methodDef;
        if (FAILED(hr = pCorProfilerInfo->GetFunctionInfo(functionId, NULL, NULL, &methodDef)))
        {
            printf("Call to GetFunctionInfo failed with hr=0x%x\n", hr);
            return hr;
        }

        COMPtrHolder<ICorProfilerMethodEnum> pEnum = NULL;
        if (FAILED(hr = pCorProfilerInfo->EnumNgenModuleMethodsInliningThisMethod(modId, modId, methodDef, NULL, &pEnum)))
        {
            printf("Call to EnumNgenModuleMethodsInliningThisMethod failed with hr=0x%x\n", hr);
            return hr;
        }

        COR_PRF_METHOD method;
        while (pEnum->Next(1, &method, NULL) == S_OK)
        {
            FunctionID inlinerFuncId = GetFunctionIDFromToken(method.moduleId, method.methodId, true);

            // GetFunctionIDFromToken doesn't handle generics or not yet loaded methods, will return NULL
            if (inlinerFuncId != mdTokenNil)
            {
                AddInlining(inlinerFuncId, functionId);
            }
            else
            {
                String calleeName = GetFunctionIDName(functionId);
                String moduleName = GetModuleIDName(GetModuleIDForFunction(functionId));
                String inlinerModuleId = GetModuleIDName(method.moduleId);
                // INFO(L"Inlining occurred, but name could not be resolved! Inliner=ModuleId=" << inlinerModuleId << L" Token=" << std::hex << method.methodId << L",  Inlinee=" << calleeName << L" Inlinee module name=" << moduleName);
            }
        }
    }

    return S_OK;
}

HRESULT STDMETHODCALLTYPE ReJITProfiler::ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId, BOOL fIsSafeToBlock)
{
    SHUTDOWNGUARD();

    INFO(L"Saw a ReJIT for function " << GetFunctionIDName(functionId));
    _rejits++;
    return S_OK;
}

HRESULT STDMETHODCALLTYPE ReJITProfiler::GetReJITParameters(ModuleID moduleId, mdMethodDef methodId, ICorProfilerFunctionControl* pFunctionControl)
{
    SHUTDOWNGUARD();

    INFO(L"Starting to build IL for method " << GetFunctionIDName(GetFunctionIDFromToken(moduleId, methodId, false)));
    COMPtrHolder<IUnknown> pUnk;
    HRESULT hr = _profInfo10->GetModuleMetaData(moduleId, ofWrite, IID_IMetaDataEmit2, &pUnk);
    if (FAILED(hr))
    {
        _failures++;
        FAIL(L"GetModuleMetaData failed for IID_IMetaDataEmit2 in ModuleID '" << std::hex << moduleId);
        return hr;
    }

    COMPtrHolder<IMetaDataEmit2> pTargetEmit;
    hr = pUnk->QueryInterface(IID_IMetaDataEmit2, (void **)&pTargetEmit);
    if (FAILED(hr))
    {
        _failures++;
        FAIL(L"Unable to QI for IMetaDataEmit2");
        return hr;
    }


    const WCHAR *wszNewUserDefinedString = WCHAR("Hello from profiler rejit!");
    mdString tokmdsUserDefined = mdTokenNil;
    hr = pTargetEmit->DefineUserString(wszNewUserDefinedString,
                                       (ULONG)wcslen(wszNewUserDefinedString),
                                       &tokmdsUserDefined);
    if (FAILED(hr))
    {
        _failures++;
        FAIL(L"DefineUserString failed");
        return S_OK;
    }

    ILRewriter rewriter(pCorProfilerInfo, pFunctionControl, moduleId, methodId);
    hr = rewriter.Import();
    if (FAILED(hr))
    {
        _failures++;
        FAIL(L"IL import failed");
        return hr;
    }

    ILInstr * pInstr = rewriter.GetILList();

    while (true)
    {
        if (pInstr->m_opcode == CEE_LDSTR)
        {
            INFO(L"Replaced function string with new one.");
            pInstr->m_Arg32 = tokmdsUserDefined;
        }

        pInstr = pInstr->m_pNext;
        if (pInstr == nullptr || pInstr == rewriter.GetILList())
        {
            break;
        }
    }

    hr = rewriter.Export();
    if (FAILED(hr))
    {
        _failures++;
        FAIL(L"IL export failed");
        return hr;
    }

    INFO(L"IL build successful for methodDef=" << std::hex << methodId);
    return S_OK;
}

HRESULT STDMETHODCALLTYPE ReJITProfiler::ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId, HRESULT hrStatus, BOOL fIsSafeToBlock)
{
    SHUTDOWNGUARD();

    ULONG rejitIDsCount;
    HRESULT hr = pCorProfilerInfo->GetReJITIDs(functionId, 0, &rejitIDsCount, NULL);
    if (FAILED(hr))
    {
        printf("GetReJITIDs failed with hr=0x%x\n", hr);
        _failures++;
        return hr;
    }

    if (rejitIDsCount == 0)
    {
        printf("GetReJITIDs returned 0 for a method with a known ReJIT.\n");
        _failures++;
        return S_OK;
    }

    return S_OK;
}

HRESULT STDMETHODCALLTYPE ReJITProfiler::ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId, HRESULT hrStatus)
{
    SHUTDOWNGUARD();

    _failures++;

    FAIL(L"ReJIT error reported hr=" << std::hex << hrStatus);

    return S_OK;
}


void ReJITProfiler::AddInlining(FunctionID inliner, FunctionID inlinee)
{
    shared_ptr<unordered_set<FunctionID>> inliners;
    auto result = _inlinings.find(inlinee);
    if (result == _inlinings.end())
    {
        auto p = make_pair(inlinee, make_shared<unordered_set<FunctionID>>());
        inliners = p.second;
        _inlinings.insert(p);
    }
    else
    {
        inliners = (*result).second;
    }

    auto it = inliners->find(inliner);
    if (it == inliners->end())
    {
        inliners->insert(inliner);
    }

    String calleeName = GetFunctionIDName(inlinee);
    String moduleName = GetModuleIDName(GetModuleIDForFunction(inlinee));
    // INFO(L"Inlining occurred! Inliner=" << GetFunctionIDName(inliner) << L" Inlinee=" << calleeName << L" Inlinee module name=" << moduleName);
}

FunctionID ReJITProfiler::GetFunctionIDFromToken(ModuleID module, mdMethodDef token, bool invalidArgNotFailure)
{
    HRESULT hr = S_OK;
    FunctionID functionId;
    hr = pCorProfilerInfo->GetFunctionFromToken(module,
                                                token,
                                                &functionId);

    if (invalidArgNotFailure && hr == E_INVALIDARG)
    {
        printf("Call to GetFunctionFromToken failed with E_INVALIDARG, this may be caused by the method not yet being loaded\n");
        return mdTokenNil;
    }

    if (FAILED(hr))
    {
        printf("Call to GetFunctionFromToken failed with hr=0x%x\n", hr);
        _failures++;
        return mdTokenNil;
    }

    return functionId;
}

mdMethodDef ReJITProfiler::GetMethodDefForFunction(FunctionID functionId)
{
    ClassID classId = 0;
    ModuleID moduleId = 0;
    mdToken token = 0;
    ULONG32 nTypeArgs = 0;
    ClassID typeArgs[SHORT_LENGTH];
    COR_PRF_FRAME_INFO frameInfo = 0;

    HRESULT hr = S_OK;
    hr = pCorProfilerInfo->GetFunctionInfo2(functionId,
                                            frameInfo,
                                            &classId,
                                            &moduleId,
                                            &token,
                                            SHORT_LENGTH,
                                            &nTypeArgs,
                                            typeArgs);
    if (FAILED(hr))
    {
        printf("Call to GetFunctionInfo2 failed with hr=0x%x\n", hr);
        _failures++;
        return mdTokenNil;
    }

    return token;
}

ModuleID ReJITProfiler::GetModuleIDForFunction(FunctionID functionId)
{
    ClassID classId = 0;
    ModuleID moduleId = 0;
    mdToken token = 0;
    ULONG32 nTypeArgs = 0;
    ClassID typeArgs[SHORT_LENGTH];
    COR_PRF_FRAME_INFO frameInfo = 0;

    HRESULT hr = S_OK;
    hr = pCorProfilerInfo->GetFunctionInfo2(functionId,
                                            frameInfo,
                                            &classId,
                                            &moduleId,
                                            &token,
                                            SHORT_LENGTH,
                                            &nTypeArgs,
                                            typeArgs);
    return moduleId;
}
```

rejit.cs
```csharp
// Licensed to the .NET Foundation under one or more agreements.
// The .NET Foundation licenses this file to you under the MIT license.

using System;
using System.Runtime.CompilerServices;

namespace Profiler.Tests
{
    class RejitWithInlining //: ProfilerTest
    {
        static readonly Guid ReJitProfilerGuid = new Guid("66F7A9DF-8858-4A32-9CFF-3AD0787E0186");

        [MethodImplAttribute(MethodImplOptions.NoInlining)]
        private static int MaxInlining(int[] arr)
        {

            // Jit everything normally
            TriggerDirectInlining(arr);
            CallMethodWithoutInlining(arr);
            TriggerInliningChain(arr);

            TriggerReJIT();

            // TriggerInliningChain triggers a ReJIT, now this time we should call
            // in to the ReJITted code
            TriggerDirectInlining(arr);
            CallMethodWithoutInlining(arr);
            TriggerInliningChain(arr);

            TriggerRevert();

            TriggerDirectInlining(arr);
            CallMethodWithoutInlining(arr);
            TriggerInliningChain(arr);

            return 100;
        }

        [MethodImplAttribute(MethodImplOptions.NoInlining)]
        private static void TriggerReJIT()
        {
            Console.WriteLine("ReJIT should be triggered after this method...");
        }

        [MethodImplAttribute(MethodImplOptions.NoInlining)]
        private static void TriggerRevert()
        {
            Console.WriteLine("Revert should be triggered after this method...");
        }

        [MethodImplAttribute(MethodImplOptions.NoInlining)]
        private static void TriggerInliningChain(int[] arr)
        {
            Console.WriteLine("TriggerInlining");
            // Test Inlining through another method
            InlineeChain1(arr);
        }

        [MethodImplAttribute(MethodImplOptions.NoInlining)]
        private static void TriggerDirectInlining(int[] arr)
        {
            Console.WriteLine("TriggerDirectInlining");
            InlineeTarget(arr);
        }

        [MethodImplAttribute(MethodImplOptions.NoInlining)]
        private static void CallMethodWithoutInlining(int[] arr)
        {
            Console.WriteLine("CallMethodWithoutInlining");
            Action callMethod = () => InlineeTarget(arr);
            callMethod();
        }

        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
        private static void InlineeChain1(int[] arr)
        {
            Console.WriteLine("Inline.InlineeChain1");
            InlineeTarget(arr);
        }

        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
        public static void InlineeTarget(int[] arr)
        {
            int b = 0;
            try
            {
                b = 100 / arr[10];
            }
            catch (IndexOutOfRangeException)
            {
                Console.WriteLine("Caught IndexOutOfRangeException as expected.");
                // This is expected, we are trying to access an out of bounds index
            }
            Console.WriteLine($"Inline.InlineeTarget {b}");
        }

        public static int RunTest(string[] args)
        {
            Console.WriteLine("maxinlining");
            return MaxInlining(new int[10]);
        }

        public static int Main(string[] args)
        {
            if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
            {
                return RunTest(args);
            }

            return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
                                          testName: "ReJITWithInlining",
                                          profilerClsid: ReJitProfilerGuid);
        }
    }

    public class SeparateClassNeverLoaded
    {
        [MethodImplAttribute(MethodImplOptions.NoInlining)]
        private static void TriggerInliningChain(int[] arr)
        {
            Console.WriteLine("TriggerInlining");
            // Test Inlining through another method
            InlineeChain1(arr);
        }

        [MethodImplAttribute(MethodImplOptions.NoInlining)]
        private static void TriggerDirectInlining(int[] arr)
        {
            Console.WriteLine("TriggerDirectInlining");
            RejitWithInlining.InlineeTarget(arr);
        }

        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
        private static void InlineeChain1(int[] arr)
        {
            Console.WriteLine("Inline.InlineeChain1");
            RejitWithInlining.InlineeTarget(arr);
        }
    }
}
```

</details>