### PR TITLE
[clr-interp] Enable SIMD feature for callstubgenerator.cpp on supported architectures

### DIFF
--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1839,7 +1839,6 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIterator *pArg
                                     break;
                             }
                                 break;
-#ifdef FEATURE_SIMD
                             case CORINFO_HFA_ELEM_VECTOR64:
                                 switch (thReturnValueType.GetSize())
                                 {
@@ -1860,7 +1859,6 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIterator *pArg
                                         break;
                                 }
                                 break;
-#endif
                         default:
                             _ASSERTE(!"HFA type is not supported");
                             break;

--- a/src/coreclr/vm/wks/CMakeLists.txt
+++ b/src/coreclr/vm/wks/CMakeLists.txt
@@ -11,12 +11,6 @@ add_library_clr(cee_wks_core OBJECT ${VM_SOURCES_WKS} ${VM_SOURCES_WKS_ARCH_ASM}
 add_library_clr(cee_wks OBJECT ${VM_SOURCES_WKS_SPECIAL})
 add_library_clr(cee_wks_mergeable OBJECT ${VM_SOURCES_WKS_SPECIAL})
 
-if(CLR_CMAKE_TARGET_ARCH_AMD64 OR CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_I386)
-  target_compile_definitions(cee_wks_core PRIVATE FEATURE_SIMD)
-  target_compile_definitions(cee_wks PRIVATE FEATURE_SIMD)
-  target_compile_definitions(cee_wks_mergeable PRIVATE FEATURE_SIMD)
-endif()
-
 target_precompile_headers(cee_wks_core PRIVATE [["common.h"]])
 target_precompile_headers(cee_wks PRIVATE [["common.h"]])
 target_precompile_headers(cee_wks_mergeable PRIVATE [["common.h"]])

--- a/src/coreclr/vm/wks/CMakeLists.txt
+++ b/src/coreclr/vm/wks/CMakeLists.txt
@@ -11,6 +11,12 @@ add_library_clr(cee_wks_core OBJECT ${VM_SOURCES_WKS} ${VM_SOURCES_WKS_ARCH_ASM}
 add_library_clr(cee_wks OBJECT ${VM_SOURCES_WKS_SPECIAL})
 add_library_clr(cee_wks_mergeable OBJECT ${VM_SOURCES_WKS_SPECIAL})
 
+if(CLR_CMAKE_TARGET_ARCH_AMD64 OR CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_I386)
+  target_compile_definitions(cee_wks_core PRIVATE FEATURE_SIMD)
+  target_compile_definitions(cee_wks PRIVATE FEATURE_SIMD)
+  target_compile_definitions(cee_wks_mergeable PRIVATE FEATURE_SIMD)
+endif()
+
 target_precompile_headers(cee_wks_core PRIVATE [["common.h"]])
 target_precompile_headers(cee_wks PRIVATE [["common.h"]])
 target_precompile_headers(cee_wks_mergeable PRIVATE [["common.h"]])


### PR DESCRIPTION
## Description

This PR removes `FEATURE_SIMD` condition used in `callstubgenerator.cpp` for `CORINFO_HFA_ELEM_VECTOR64` and `CORINFO_HFA_ELEM_VECTOR128` return types.

This change should enable 11 methods on the startup path.