### PR TITLE
fix backcompat issue for standalone GC

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -49779,10 +49779,10 @@ HRESULT GCHeap::Initialize()
 // GC callback functions
 bool GCHeap::IsPromoted(Object* object)
 {
-    return IsPromoted(object, true);
+    return IsPromoted2(object, true);
 }
 
-bool GCHeap::IsPromoted(Object* object, bool bVerifyNextHeader)
+bool GCHeap::IsPromoted2(Object* object, bool bVerifyNextHeader)
 {
     uint8_t* o = (uint8_t*)object;
 

--- a/src/coreclr/gc/gc.h
+++ b/src/coreclr/gc/gc.h
@@ -285,6 +285,9 @@ struct alloc_context : gc_alloc_context
 #endif // FEATURE_SVR_GC
 };
 
+// NOTE!
+// Do not add overloaded methods, always use a different name, different from any methods declared here or
+// on the IGCHeap interface.
 class IGCHeapInternal : public IGCHeap {
 public:
     virtual int GetNumberOfHeaps () PURE_VIRTUAL

--- a/src/coreclr/gc/gc.h
+++ b/src/coreclr/gc/gc.h
@@ -290,6 +290,8 @@ public:
     virtual int GetNumberOfHeaps () PURE_VIRTUAL
     virtual int GetHomeHeapNumber () PURE_VIRTUAL
     virtual size_t GetPromotedBytes(int heap_index) PURE_VIRTUAL
+    // Used by the bridge code.
+    virtual bool IsPromoted2(Object* object, bool bVerifyNextHeader) PURE_VIRTUAL
 
     unsigned GetMaxGeneration()
     {

--- a/src/coreclr/gc/gcbridge.cpp
+++ b/src/coreclr/gc/gcbridge.cpp
@@ -666,7 +666,7 @@ static bool PushObject(Object* obj, void* unused)
     }
 
     // We only care about dead objects
-    if (!data && g_theGCHeap->IsPromoted(obj, false))
+    if (!data && g_theGCHeap->IsPromoted2(obj, false))
     {
 #if DUMP_GRAPH
         printf ("alive\n");

--- a/src/coreclr/gc/gcimpl.h
+++ b/src/coreclr/gc/gcimpl.h
@@ -126,7 +126,7 @@ public:
     // Check if an argument is promoted (ONLY CALL DURING
     // THE PROMOTIONSGRANTED CALLBACK.)
     bool IsPromoted (Object *object);
-    bool IsPromoted (Object *object, bool bVerifyNextHeader);
+    bool IsPromoted2 (Object *object, bool bVerifyNextHeader);
 
     size_t GetPromotedBytes (int heap_index);
 

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -644,6 +644,9 @@ enum class GCConfigurationType
 using ConfigurationValueFunc = void (*)(void* context, void* name, void* publicKey, GCConfigurationType type, int64_t data);
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.
+// NOTE!
+// Only add methods to the end.
+// Do not add overloaded methods. Always use a different name.
 class IGCHeap {
 public:
     /*

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -1065,9 +1065,6 @@ public:
     virtual void DiagWalkHeapWithACHandling(walk_fn fn, void* context, int gen_number, bool walk_large_object_heap_p) PURE_VIRTUAL
 
     virtual void NullBridgeObjectsWeakRefs(size_t length, void* unreachableObjectHandles) PURE_VIRTUAL;
-
-    // Returns whether nor this GC was promoted by the last GC.
-    virtual bool IsPromoted(Object* object, bool bVerifyNextHeader) PURE_VIRTUAL
 };
 
 #ifdef WRITE_BARRIER_CHECK


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/116310 breaks the backward compatibility for the standalone GC - it can no longer work with previous versions of the runtime on both windows and linux. this is easily reproducible by just loading a standalone GC dll built from main with say 8.0 runtime because it will fail as soon as it hits `FinalizeLoad` when coreclr is trying to load the standalone dll.

both msvc and clang put the 2 methods, both named `IsPromoted` next to each other instead of maintaining the order as declared. renaming the new one to `IsPromoted2` worked. but I also just made `IsPromoted2` on `IGCHeapInternal` instead since it's only used by the GC side.