### PR TITLE
Add searched .NET install locations to error message

### DIFF
--- a/src/native/corehost/apphost/standalone/hostfxr_resolver.cpp
+++ b/src/native/corehost/apphost/standalone/hostfxr_resolver.cpp
@@ -121,6 +121,7 @@ hostfxr_resolver_t::hostfxr_resolver_t(const pal::string_t& app_root)
     else if (!pal::is_path_fully_qualified(m_fxr_path))
     {
         // We should always be loading hostfxr from an absolute path
+        trace::error(_X("Path to %s must be fully qualified: [%s]"), LIBFXR_NAME, m_fxr_path.c_str());
         m_status_code = StatusCode::CoreHostLibMissingFailure;
     }
     else if (pal::load_library(&m_fxr_path, &m_hostfxr_dll))

--- a/src/native/corehost/corehost.cpp
+++ b/src/native/corehost/corehost.cpp
@@ -212,10 +212,7 @@ int exe_start(const int argc, const pal::char_t* argv[])
     // Obtain the entrypoints.
     int rc = fxr.status_code();
     if (rc != StatusCode::Success)
-    {
-        trace::error(_X("Failed to resolve %s [%s]. Error code: 0x%x"), LIBFXR_NAME, fxr.fxr_path().empty() ? _X("not found") : fxr.fxr_path().c_str(), rc);
         return rc;
-    }
 
 #if defined(FEATURE_APPHOST)
     if (bundle_marker_t::is_bundle())

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -360,26 +360,32 @@ pal::string_t get_dotnet_root_env_var_for_arch(pal::architecture arch)
 
 bool get_dotnet_root_from_env(pal::string_t* dotnet_root_env_var_name, pal::string_t* recv)
 {
-    *dotnet_root_env_var_name = get_dotnet_root_env_var_for_arch(get_current_arch());
-    if (get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv))
+    pal::string_t env_var_name = get_dotnet_root_env_var_for_arch(get_current_arch());
+    if (get_file_path_from_env(env_var_name.c_str(), recv))
+    {
+        *dotnet_root_env_var_name = env_var_name;
         return true;
+    }
 
 #if defined(WIN32)
     if (pal::is_running_in_wow64())
     {
-        *dotnet_root_env_var_name = _X("DOTNET_ROOT(x86)");
-        if (get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv))
+        if (get_file_path_from_env(_X("DOTNET_ROOT(x86)"), recv))
+        {
+            *dotnet_root_env_var_name = _X("DOTNET_ROOT(x86)");
             return true;
+        }
     }
 #endif
 
     // If no architecture-specific environment variable was set
     // fallback to the default DOTNET_ROOT.
-    *dotnet_root_env_var_name = DOTNET_ROOT_ENV_VAR;
-    if (get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv))
+    if (get_file_path_from_env(DOTNET_ROOT_ENV_VAR, recv))
+    {
+        *dotnet_root_env_var_name = DOTNET_ROOT_ENV_VAR;
         return true;
+    }
 
-    dotnet_root_env_var_name->clear();
     return false;
 }
 

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -376,7 +376,11 @@ bool get_dotnet_root_from_env(pal::string_t* dotnet_root_env_var_name, pal::stri
     // If no architecture-specific environment variable was set
     // fallback to the default DOTNET_ROOT.
     *dotnet_root_env_var_name = DOTNET_ROOT_ENV_VAR;
-    return get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv);
+    if (get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv))
+        return true;
+
+    dotnet_root_env_var_name->clear();
+    return false;
 }
 
 /**


### PR DESCRIPTION
Include searched locations in error message when host cannot find a .NET install (`hostfxr`)

Example - the 'following locations were searched' section is new:
```
You must install .NET to run this application.

App: /home/elinor/helloworld/bin/Debug/net10.0/helloworld
Architecture: x64
App host version: 10.0.0-dev
.NET location: Not found

The following locations were searched:
  Application directory:
    /home/elinor/helloworld/bin/Debug/net10.0/
  Environment variable:
    DOTNET_ROOT_X64 = <not set>
    DOTNET_ROOT = <not set>
  Registered location:
    /etc/dotnet/install_location_x64 = <not set>
  Default location:
    /usr/share/dotnet

Learn more:
https://aka.ms/dotnet/app-launch-failed

Download the .NET runtime:
https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=x64&rid=linux-x64&os=ubuntu.22.04&apphost_version=10.0.0-dev
```

Resolves https://github.com/dotnet/runtime/issues/116108

cc @dotnet/appmodel @AaronRobinsonMSFT 