### PR TITLE
Make dotnet --info print all DOTNET_* environment variables

### DIFF
--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -96,7 +96,7 @@ namespace HostActivation.Tests
                 ("x86", "/x86/dotnet/root"),
                 ("unknown", "/unknown/dotnet/root")
             ];
-            foreach(var envVar in dotnetRootEnvVars)
+            foreach (var envVar in dotnetRootEnvVars)
             {
                 command = command.DotNetRoot(envVar.Path, envVar.Architecture);
             }
@@ -110,9 +110,14 @@ namespace HostActivation.Tests
                 ("DOTNET_SOME_SETTING", "/some/setting"),
                 ("COREHOST_TRACE", "1")
             ];
-            foreach (var envVar in envVars)
+
+            (string Name, string Value)[] differentCaseEnvVars = [
+                ("dotnet_env_var", "dotnet env var value"),
+                ("corehost_env_var", "corehost env var value"),
+            ];
+            foreach ((string name, string value) in envVars.Concat(differentCaseEnvVars))
             {
-                command = command.EnvironmentVariable(envVar.Name, envVar.Value);
+                command = command.EnvironmentVariable(name, value);
             }
 
             var otherEnvVar = "OTHER";
@@ -133,6 +138,19 @@ namespace HostActivation.Tests
             foreach ((string name, string value) in envVars)
             {
                 result.Should().HaveStdOutMatching($@"{name}\s*\[{value}\]");
+            }
+
+            foreach ((string name, string value) in differentCaseEnvVars)
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    // Environment variables are case-insensitive on Windows
+                    result.Should().HaveStdOutMatching($@"{name}\s*\[{value}\]");
+                }
+                else
+                {
+                    result.Should().NotHaveStdOutContaining(name);
+                }
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -104,16 +104,16 @@ namespace HostActivation.Tests
             string dotnetRootNoArch = "/dotnet/root";
             command = command.DotNetRoot(dotnetRootNoArch);
 
-            // Add additional DOTNET_* and COREHOST_* environment variables
+            // Add additional DOTNET_* environment variables
             (string Name, string Value)[] envVars = [
                 ("DOTNET_ROLL_FORWARD", "Major"),
                 ("DOTNET_SOME_SETTING", "/some/setting"),
-                ("COREHOST_TRACE", "1")
+                ("DOTNET_HOST_TRACE", "1")
             ];
 
             (string Name, string Value)[] differentCaseEnvVars = [
                 ("dotnet_env_var", "dotnet env var value"),
-                ("corehost_env_var", "corehost env var value"),
+                ("dOtNeT_setting", "doOtNeT setting value"),
             ];
             foreach ((string name, string value) in envVars.Concat(differentCaseEnvVars))
             {

--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -120,7 +120,7 @@ namespace HostActivation.Tests
                 command = command.EnvironmentVariable(name, value);
             }
 
-            var otherEnvVar = "OTHER";
+            string otherEnvVar = "OTHER";
             command = command.EnvironmentVariable(otherEnvVar, "value");
 
             var result = command.Execute();
@@ -152,6 +152,20 @@ namespace HostActivation.Tests
                     result.Should().NotHaveStdOutContaining(name);
                 }
             }
+        }
+
+        [Fact]
+        public void Info_ListEnvironment_LegacyPrefixDetection()
+        {
+            string comPlusEnvVar = "COMPlus_ReadyToRun";
+            TestContext.BuiltDotNet.Exec("--info")
+                .EnvironmentVariable(comPlusEnvVar, "0")
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Environment variables:")
+                .And.NotHaveStdOutContaining(comPlusEnvVar)
+                .And.HaveStdOutContaining("Detected COMPlus_* environment variable(s). Consider transitioning to DOTNET_* equivalent.");
         }
 
         [Fact]

--- a/src/installer/tests/HostActivation.Tests/InstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/InstallLocation.cs
@@ -122,42 +122,6 @@ namespace HostActivation.Tests
         }
 
         [Fact]
-        public void EnvironmentVariable_DotNetInfo_ListEnvironment()
-        {
-            var command = TestContext.BuiltDotNet.Exec("--info")
-                .CaptureStdOut();
-
-            var envVars = new (string Architecture, string Path)[] {
-                ("arm64", "/arm64/dotnet/root"),
-                ("x64", "/x64/dotnet/root"),
-                ("x86", "/x86/dotnet/root")
-            };
-            foreach(var envVar in envVars)
-            {
-                command = command.DotNetRoot(envVar.Path, envVar.Architecture);
-            }
-
-            string dotnetRootNoArch = "/dotnet/root";
-            command = command.DotNetRoot(dotnetRootNoArch);
-
-            (string Architecture, string Path) unknownEnvVar = ("unknown", "/unknown/dotnet/root");
-            command = command.DotNetRoot(unknownEnvVar.Path, unknownEnvVar.Architecture);
-
-            var result = command.Execute();
-            result.Should().Pass()
-                .And.HaveStdOutContaining("Environment variables:")
-                .And.HaveStdOutMatching($@"{Constants.DotnetRoot.EnvironmentVariable}\s*\[{dotnetRootNoArch}\]")
-                .And.NotHaveStdOutContaining($"{Constants.DotnetRoot.ArchitectureEnvironmentVariablePrefix}{unknownEnvVar.Architecture.ToUpper()}")
-                .And.NotHaveStdOutContaining($"[{unknownEnvVar.Path}]");
-
-            foreach ((string architecture, string path) in envVars)
-            {
-                result.Should()
-                    .HaveStdOutMatching($@"{Constants.DotnetRoot.ArchitectureEnvironmentVariablePrefix}{architecture.ToUpper()}\s*\[{path}\]");
-            }
-        }
-
-        [Fact]
         public void DefaultInstallLocation()
         {
             TestApp app = sharedTestState.TestBehaviourEnabledApp;

--- a/src/native/corehost/fxr/install_info.cpp
+++ b/src/native/corehost/fxr/install_info.cpp
@@ -13,6 +13,7 @@ bool install_info::print_environment(const pal::char_t* leading_whitespace)
 {
     // Enumerate environment variables and filter for DOTNET_
     std::vector<std::pair<pal::string_t, pal::string_t>> env_vars;
+    bool found_complus_var = false;
     pal::enumerate_environment_variables([&](const pal::char_t* name, const pal::char_t* value)
     {
         // Check if the environment variable starts with DOTNET_
@@ -26,6 +27,10 @@ bool install_info::print_environment(const pal::char_t* leading_whitespace)
         {
             env_vars.push_back(std::make_pair(name, value));
         }
+        else if (!found_complus_var && comp_func(name, _X("COMPlus_"), STRING_LENGTH("COMPlus_")) == 0)
+        {
+            found_complus_var = true;
+        }
     });
 
     // Sort for consistent output
@@ -38,7 +43,10 @@ bool install_info::print_environment(const pal::char_t* leading_whitespace)
         trace::println(fmt, leading_whitespace, env_var.first.c_str(), env_var.second.c_str());
     }
 
-    return env_vars.size() > 0;
+    if (found_complus_var)
+        trace::println(_X("%sDetected COMPlus_* environment variable(s). Consider transitioning to DOTNET_* equivalent."), leading_whitespace);
+
+    return env_vars.size() > 0 || found_complus_var;
 }
 
 bool install_info::try_get_install_location(pal::architecture arch, pal::string_t& out_install_location, bool* out_is_registered)

--- a/src/native/corehost/fxr/install_info.cpp
+++ b/src/native/corehost/fxr/install_info.cpp
@@ -16,8 +16,14 @@ bool install_info::print_environment(const pal::char_t* leading_whitespace)
     pal::enumerate_environment_variables([&](const pal::char_t* name, const pal::char_t* value)
     {
         // Check if the environment variable starts with DOTNET_ or COREHOST_
-        if (pal::strncmp(name, _X("DOTNET_"), STRING_LENGTH("DOTNET_")) == 0
-            || pal::strncmp(name, _X("COREHOST_"), STRING_LENGTH("COREHOST_")) == 0)
+#if defined(TARGET_WINDOWS)
+        // Environment variables are case-insensitive on Windows
+        auto comp_func = pal::strncasecmp;
+#else
+        auto comp_func = pal::strncmp;
+#endif
+        if (comp_func(name, _X("DOTNET_"), STRING_LENGTH("DOTNET_")) == 0
+            || comp_func(name, _X("COREHOST_"), STRING_LENGTH("COREHOST_")) == 0)
         {
             env_vars.push_back(std::make_pair(name, value));
         }

--- a/src/native/corehost/fxr/install_info.cpp
+++ b/src/native/corehost/fxr/install_info.cpp
@@ -11,19 +11,18 @@
 
 bool install_info::print_environment(const pal::char_t* leading_whitespace)
 {
-    // Enumerate environment variables and filter for DOTNET_ and COREHOST_
+    // Enumerate environment variables and filter for DOTNET_
     std::vector<std::pair<pal::string_t, pal::string_t>> env_vars;
     pal::enumerate_environment_variables([&](const pal::char_t* name, const pal::char_t* value)
     {
-        // Check if the environment variable starts with DOTNET_ or COREHOST_
+        // Check if the environment variable starts with DOTNET_
 #if defined(TARGET_WINDOWS)
         // Environment variables are case-insensitive on Windows
         auto comp_func = pal::strncasecmp;
 #else
         auto comp_func = pal::strncmp;
 #endif
-        if (comp_func(name, _X("DOTNET_"), STRING_LENGTH("DOTNET_")) == 0
-            || comp_func(name, _X("COREHOST_"), STRING_LENGTH("COREHOST_")) == 0)
+        if (comp_func(name, _X("DOTNET_"), STRING_LENGTH("DOTNET_")) == 0)
         {
             env_vars.push_back(std::make_pair(name, value));
         }

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <algorithm>
 #include <cassert>
+#include <functional>
 
 #if defined(_WIN32)
 
@@ -305,6 +306,7 @@ namespace pal
     bool get_module_path(dll_t mod, string_t* recv);
     bool get_current_module(dll_t* mod);
     bool getenv(const char_t* name, string_t* recv);
+    void enumerate_environment_variables(const std::function<void(const char_t*, const char_t*)> callback);
     bool get_default_servicing_directory(string_t* recv);
 
     enum class architecture

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -965,10 +965,11 @@ void pal::enumerate_environment_variables(const std::function<void(const pal::ch
 
     for (char **env = environ; *env != nullptr; ++env)
     {
-        const char* separator = ::strchr(*env, '=');
-        if (separator != nullptr && separator != *env)
+        const char* current = *env;
+        const char* separator = ::strchr(current, '=');
+        if (separator != nullptr && separator != current)
         {
-            pal::string_t name(*env, separator - *env);
+            pal::string_t name(current, separator - current);
             callback(name.c_str(), separator + 1);
         }
     }

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -957,6 +957,23 @@ bool pal::getenv(const pal::char_t* name, pal::string_t* recv)
     return (recv->length() > 0);
 }
 
+extern char **environ;
+void pal::enumerate_environment_variables(const std::function<void(const pal::char_t*, const pal::char_t*)> callback)
+{
+    if (environ == nullptr)
+        return;
+
+    for (char **env = environ; *env != nullptr; ++env)
+    {
+        const char* separator = ::strchr(*env, '=');
+        if (separator != nullptr && separator != *env)
+        {
+            pal::string_t name(*env, separator - *env);
+            callback(name.c_str(), separator + 1);
+        }
+    }
+}
+
 bool pal::fullpath(pal::string_t* path, bool skip_error_logging)
 {
     return realpath(path, skip_error_logging);

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -714,6 +714,28 @@ bool pal::getenv(const char_t* name, string_t* recv)
     return true;
 }
 
+void pal::enumerate_environment_variables(const std::function<void(const pal::char_t*, const pal::char_t*)> callback)
+{
+    LPWCH env_strings = ::GetEnvironmentStringsW();
+    if (env_strings == nullptr)
+        return;
+
+    LPWCH current = env_strings;
+    while (*current != L'\0')
+    {
+        LPWCH eq_ptr = ::wcschr(current, L'=');
+        if (eq_ptr != nullptr && eq_ptr != current)
+        {
+            pal::string_t name(current, eq_ptr - current);
+            callback(name.c_str(), eq_ptr + 1);
+        }
+
+        current += pal::strlen(current) + 1; // Move to next string
+    }
+
+    ::FreeEnvironmentStringsW(env_strings);
+}
+
 int pal::xtoi(const char_t* input)
 {
     return ::_wtoi(input);


### PR DESCRIPTION
`dotnet --info` currently only prints `DOTNET_ROOT` / `DOTNET_ROOT_<ARCH>` if they are set. Expand it to all environment variables with a `DOTNET_` prefix. Also add a line about detecting COMPlus_* variables.

Example:
```
Environment variables:
  DOTNET_ROLL_FORWARD                      [Major]
  DOTNET_ROOT                              [C:\repos\runtime\.dotnet]
  DOTNET_SKIP_FIRST_TIME_EXPERIENCE        [1]
  Detected COMPlus_* environment variable(s). Consider transitioning to DOTNET_* equivalent.
```

Resolves https://github.com/dotnet/runtime/issues/117732

cc @dotnet/appmodel @AaronRobinsonMSFT @richlander 