### PR TITLE
Report unhandled async exceptions

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -3223,21 +3223,6 @@ BOOL IsExceptionOfType(RuntimeExceptionKind reKind, OBJECTREF *pThrowable)
     return CoreLibBinder::IsException(pThrowableMT, reKind);
 }
 
-BOOL IsAsyncThreadException(OBJECTREF *pThrowable) {
-    STATIC_CONTRACT_NOTHROW;
-    STATIC_CONTRACT_GC_NOTRIGGER;
-    STATIC_CONTRACT_MODE_COOPERATIVE;
-    STATIC_CONTRACT_FORBID_FAULT;
-
-    if (  (GetThreadNULLOk() && GetThread()->IsRudeAbort() && GetThread()->IsRudeAbortInitiated())
-        ||IsExceptionOfType(kThreadAbortException, pThrowable)
-        ||IsExceptionOfType(kThreadInterruptedException, pThrowable)) {
-        return TRUE;
-    } else {
-        return FALSE;
-    }
-}
-
 BOOL IsUncatchable(OBJECTREF *pThrowable)
 {
     CONTRACTL {
@@ -4960,7 +4945,7 @@ DefaultCatchHandler(PEXCEPTION_POINTERS pExceptionPointers,
                     IsOutOfMemory)
                 {
                     // We have to be very careful.  If we walk off the end of the stack, the process will just
-                    // die. e.g. IsAsyncThreadException() and Exception.ToString both consume too much stack -- and can't
+                    // die. e.g. Exception.ToString both consume too much stack -- and can't
                     // be called here.
                     dump = FALSE;
 
@@ -4972,12 +4957,6 @@ DefaultCatchHandler(PEXCEPTION_POINTERS pExceptionPointers,
                     {
                         PrintToStdErrA("Stack overflow.\n");
                     }
-                }
-                else if (IsAsyncThreadException(&throwable))
-                {
-                    // We don't print anything on async exceptions, like ThreadAbort.
-                    dump = FALSE;
-                    INDEBUG(suppressSelectiveBreak=TRUE);
                 }
 
                 // Finally, should we print the message?

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -125,7 +125,6 @@ DWORD ComputeEnclosingHandlerNestingLevel(IJitManager *pIJM, const METHODTOKEN& 
 BOOL IsException(MethodTable *pMT);
 BOOL IsExceptionOfType(RuntimeExceptionKind reKind, OBJECTREF *pThrowable);
 BOOL IsExceptionOfType(RuntimeExceptionKind reKind, Exception *pException);
-BOOL IsAsyncThreadException(OBJECTREF *pThrowable);
 BOOL IsUncatchable(OBJECTREF *pThrowable);
 VOID FixupOnRethrow(Thread *pCurThread, EXCEPTION_POINTERS *pExceptionPointers);
 BOOL UpdateCurrentThrowable(PEXCEPTION_RECORD pExceptionRecord);

--- a/src/tests/baseservices/exceptions/unhandled/unhandled.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandled.cs
@@ -48,10 +48,14 @@ namespace TestUnhandledException
             {
                 throw new Exception("Test");
             }
-            if (args[0] == "mainhardware")
+            else if (args[0] == "mainhardware")
             {
                 string s = null;
                 Console.WriteLine(s.Length); // This will cause a NullReferenceException
+            }
+            else if (args[0] == "mainthreadinterrupted")
+            {
+                throw new ThreadInterruptedException("Test");
             }
             else if (args[0] == "foreign")
             {
@@ -76,6 +80,12 @@ namespace TestUnhandledException
             else if (args[0] == "secondaryunhandled")
             {
                 Thread t = new Thread(() => throw new Exception("Test"));
+                t.Start();
+                t.Join();
+            }
+            else if (args[0] == "secondarythreadinterrupted")
+            {
+                Thread t = new Thread(() => throw new ThreadInterruptedException("Test"));
                 t.Start();
                 t.Join();
             }

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -109,6 +109,13 @@ namespace TestUnhandledExceptionTester
                         throw new Exception("Missing Unhandled exception header");
                     }
                 }
+                if (unhandledType == "mainthreadinterrupted" || unhandledType == "secondarythreadinterrupted")
+                {
+                    if (lines[0] != "Unhandled exception. System.Threading.ThreadInterruptedException: Test")
+                    {
+                        throw new Exception("Missing Unhandled exception header");
+                    }
+                }
                 else if (unhandledType == "foreign")
                 {
                     if (!lines[0].StartsWith("Unhandled exception. System.DllNotFoundException:") &&
@@ -149,8 +156,10 @@ namespace TestUnhandledExceptionTester
         {
             RunExternalProcess("main", "unhandled.dll");
             RunExternalProcess("mainhardware", "unhandled.dll");
+            RunExternalProcess("mainthreadinterrupted", "unhandled.dll");
             RunExternalProcess("secondary", "unhandled.dll");
             RunExternalProcess("secondaryhardware", "unhandled.dll");
+            RunExternalProcess("secondarythreadinterrupted", "unhandled.dll");
             RunExternalProcess("foreign", "unhandled.dll");
             File.Delete(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "dependencytodelete.dll"));
             RunExternalProcess("missingdependency", "unhandledmissingdependency.dll");


### PR DESCRIPTION
Async exceptions like the ThreadInterruptedException are explicitly prevented from logging unhandled exception details to console.

This change removes this special handling and lets them be reported as any other unhandled exception.

Close #107594