### PR TITLE
Clear contained flag from AND->NOT transformation

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4308,6 +4308,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
             // Transform EQ|NE(AND(x, y), y) into EQ|NE(AND(NOT(x), y), 0) when y is a constant.
             //
 
+            andOp1->ClearContained();
             GenTree* notNode               = comp->gtNewOperNode(GT_NOT, andOp1->TypeGet(), andOp1);
             cmp->gtGetOp1()->AsOp()->gtOp1 = notNode;
             BlockRange().InsertAfter(andOp1, notNode);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116657/Runtime_116657.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116657/Runtime_116657.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_116657
+{
+    public static void TestEntryPoint()
+    {
+        ulong x = 0x7ffc000000000000;
+        double result = Problem(ref x);
+        Assert.Equal(0, result);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe double Problem(ref ulong x)
+    {
+        if ((x & 0x7ffc000000000000) != 0x7ffc000000000000)
+        {
+            fixed (void* p = &x)
+                return *(double*)p;
+        }
+        return 0;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116657/Runtime_116657.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116657/Runtime_116657.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 public class Runtime_116657
 {
+    [Fact]
     public static void TestEntryPoint()
     {
         ulong x = 0x7ffc000000000000;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116657/Runtime_116657.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116657/Runtime_116657.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/117795
Fixes https://github.com/dotnet/runtime/issues/117783
Fixes https://github.com/dotnet/runtime/issues/116657
Fixes https://github.com/dotnet/runtime/issues/116674

Introduced in https://github.com/dotnet/runtime/pull/111933


We had `AND(X, CNS)` where we marked X as contained. Then this transformation converted `AND(X, CNS)` into `NOT(X)` while `X` is still marked as contained when the emitter doesn't support containment for this node.