### PR TITLE
[browser] Clean up HotReload check

### DIFF
--- a/src/mono/browser/runtime/loader/config.ts
+++ b/src/mono/browser/runtime/loader/config.ts
@@ -216,15 +216,6 @@ export function normalizeConfig () {
         config.environmentVariables!["LANG"] = `${config.applicationCulture}.UTF-8`;
     }
 
-    if (config.debugLevel !== 0 && globalThis.window?.document?.querySelector("script[src*='aspnetcore-browser-refresh']")) {
-        if (!config.environmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"]) {
-            config.environmentVariables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
-        }
-        if (!config.environmentVariables["__ASPNETCORE_BROWSER_TOOLS"]) {
-            config.environmentVariables["__ASPNETCORE_BROWSER_TOOLS"] = "true";
-        }
-    }
-
     runtimeHelpers.diagnosticTracing = loaderHelpers.diagnosticTracing = !!config.diagnosticTracing;
     runtimeHelpers.waitForDebugger = config.waitForDebugger;
 


### PR DESCRIPTION
The check whether the runtime should expect HotReload was move to a HotReload package.
We remove the check from runtime with the removal of built-in Blazor HotReload in https://github.com/dotnet/aspnetcore/pull/62777.

Contributes to https://github.com/dotnet/aspnetcore/issues/61272