### PR TITLE
Disable IL offset mapping validation

### DIFF
--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -1314,7 +1314,6 @@ size_t WalkILOffsetsCallback(ICorDebugInfo::OffsetMapping *pOffsetMapping, void 
             }
             pWalkData->dwCurrentNativeOffset = pOffsetMapping->nativeOffset;
             pWalkData->prevILOffsetFound = pWalkData->dwILOffsetFound;
-            pWalkData->dwCurrentNativeOffset = pOffsetMapping->nativeOffset;
             pWalkData->dwILOffsetFound = pOffsetMapping->ilOffset;
         }
         else if (((int32_t)pOffsetMapping->ilOffset < (int32_t)pWalkData->dwILOffsetFound) && (pOffsetMapping->ilOffset != (DWORD)ICorDebugInfo::NO_MAPPING))

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -13103,9 +13103,12 @@ static TADDR UnsafeJitFunctionWorker(
         if (g_pDebugInterface)
         {
             g_pDebugInterface->JITComplete(nativeCodeVersion, (TADDR)nativeEntry);
-#ifdef DEBUG
-            ValidateILOffsets(ftn, NULL, 0, (uint8_t*)nativeEntry, sizeOfCode);
-#endif // DEBUG
+
+            // Validation currently disabled, see https://github.com/dotnet/runtime/issues/117561
+            //
+//#ifdef DEBUG
+//            ValidateILOffsets(ftn, NULL, 0, (uint8_t*)nativeEntry, sizeOfCode);
+//#endif // DEBUG
         }
 #endif // DEBUGGING_SUPPORTED
     }


### PR DESCRIPTION
@davidwrighton suggested just disabling this in https://github.com/dotnet/runtime/issues/117561#issuecomment-3071167431.

Makes #117561 non blocking.

Some additional context from the case in https://github.com/dotnet/runtime/issues/117561#issuecomment-3089203646:
> I looked briefly and it looks like the old logic considers the last range of the IL mappings to be [184, 220) while the new logic considers the last range to be [184,261). Hence the old logic finds no mapping while the new logic does.
> 
> It's quite convoluted, but I get the impression that the intention of the old code is to ignore the CALL_INSTRUCTION mapping completely and that the new code is actually implementing the intention of the old code more properly.
> 
> I will do what @davidwrighton suggested and disable the validation for now since this is failing all our jitstress runs.