### PR TITLE
[browser] Remove placeholder for docs link from warning

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -226,7 +226,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Workaround for https://github.com/dotnet/sdk/issues/12114-->
       <PublishDir Condition="'$(AppendRuntimeIdentifierToOutputPath)' != 'true' AND '$(PublishDir)' == '$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\'">$(OutputPath)$(PublishDirName)\</PublishDir>
     </PropertyGroup>
-    <Warning Text="Custom Blazor cache has been removed and setting 'BlazorCacheBootResources' has no effect. Follow a migration path at TODO: PLACEHOLDER FOR LINK" Condition="'$(_BlazorCacheBootResources)' != 'false' and '$(_TargetingNET100OrLater)' == 'true'" />
+    <Warning Text="Custom Blazor cache has been removed and setting 'BlazorCacheBootResources' has no effect." Condition="'$(_BlazorCacheBootResources)' != 'false' and '$(_TargetingNET100OrLater)' == 'true'" />
   </Target>
 
   <Target Name="ResolveWasmOutputs" DependsOnTargets="_ResolveWasmOutputs" />


### PR DESCRIPTION
Remove placeholder for link to custom cache removal. Other APIs don't have such link either. The change is documented in release notes. I don't expect it to be a big impact, as most apps didn't set the value (to opt-out) and those that did, they'll just remove the property with opt-out