### PR TITLE
JIT: constrain max IL size for OSR inlining

### DIFF
--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -1377,15 +1377,21 @@ void ExtendedDefaultPolicy::NoteInt(InlineObservation obs, int value)
             }
             else if (m_RootCompiler->fgHaveSufficientProfileWeights())
             {
-                // For now we want to inline somewhat less aggressively in Tier1+Instr. We can reconsider
+                // For now we want to inline somewhat less aggressively in Tier1+Instr and OSR. We can reconsider
                 // when we have inlinee instrumentation. Otherwise we may lose profile data for key inlinees.
                 //
                 const bool isTier1Instr = m_RootCompiler->opts.IsInstrumentedAndOptimized();
-                JITDUMP("Root has sufficient profile%s\n",
-                        isTier1Instr ? "; but we are not boosting max IL size for Tier1+Instr" : "");
-                if (!isTier1Instr)
+                const bool isOSR        = m_RootCompiler->opts.IsOSR();
+
+                if (isTier1Instr || isOSR)
+                {
+                    JITDUMP("Root has sufficient profile. Leaving max IL size at %u for Tier1+Instr or OSR\n",
+                            maxCodeSize);
+                }
+                else
                 {
                     maxCodeSize = static_cast<unsigned>(JitConfig.JitExtDefaultPolicyMaxILRoot());
+                    JITDUMP("Root has sufficient profile. Boosting max IL size to %u\n", maxCodeSize);
                 }
             }
             else


### PR DESCRIPTION
If we inline too aggressively at intermediate tiers, we can lose profile data that would be beneficial at the final tier.

Extend the recent fixes made for limiting max IL size at Tier1+Instr to include OSR as well. This one is a arguably bit more delicate as OSR may well be the final tier, but there is no way to know that.

We are just returning to the .NET 9 behavior here.

Fixes #117717. May also fix some of the other regressions that have not yet been analyzed in depth.