### PR TITLE
Fix issues with rejit profiler test

### DIFF
--- a/src/coreclr/vm/rejit.cpp
+++ b/src/coreclr/vm/rejit.cpp
@@ -750,7 +750,7 @@ HRESULT ReJitManager::UpdateNativeInlinerActiveILVersions(
                     CodeVersionManager *pCodeVersionManager = pModule->GetCodeVersionManager();
                     CodeVersionManager::LockHolder codeVersioningLockHolder;
                     ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(inliner.m_module, inliner.m_methodDef);
-                    if (!ilVersion.HasDefaultIL())
+                    if (!ilVersion.HasDefaultIL() && !fIsRevert)
                     {
                         // This method has already been ReJITted, no need to request another ReJIT at this point.
                         // The ReJITted method will be in the JIT inliner check below.

--- a/src/coreclr/vm/rejit.cpp
+++ b/src/coreclr/vm/rejit.cpp
@@ -548,7 +548,9 @@ HRESULT ReJitManager::UpdateActiveILVersions(
 
         if ((flags & COR_PRF_REJIT_BLOCK_INLINING) == COR_PRF_REJIT_BLOCK_INLINING)
         {
-            hr = UpdateNativeInlinerActiveILVersions(&mgrToCodeActivationBatch, pModule, rgMethodDefs[i], fIsRevert, flags);
+            _ASSERTE(!fIsRevert);
+
+            hr = UpdateNativeInlinerActiveILVersions(&mgrToCodeActivationBatch, pModule, rgMethodDefs[i], flags);
             if (FAILED(hr))
             {
                 return hr;
@@ -711,7 +713,6 @@ HRESULT ReJitManager::UpdateNativeInlinerActiveILVersions(
     SHash<CodeActivationBatchTraits>   *pMgrToCodeActivationBatch,
     Module                             *pInlineeModule,
     mdMethodDef                         inlineeMethodDef,
-    BOOL                                fIsRevert,
     COR_PRF_REJIT_FLAGS                 flags)
 {
     CONTRACTL
@@ -750,7 +751,7 @@ HRESULT ReJitManager::UpdateNativeInlinerActiveILVersions(
                     CodeVersionManager *pCodeVersionManager = pModule->GetCodeVersionManager();
                     CodeVersionManager::LockHolder codeVersioningLockHolder;
                     ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(inliner.m_module, inliner.m_methodDef);
-                    if (!ilVersion.HasDefaultIL() && !fIsRevert)
+                    if (!ilVersion.HasDefaultIL())
                     {
                         // This method has already been ReJITted, no need to request another ReJIT at this point.
                         // The ReJITted method will be in the JIT inliner check below.
@@ -758,7 +759,7 @@ HRESULT ReJitManager::UpdateNativeInlinerActiveILVersions(
                     }
                 }
 
-                hr = UpdateActiveILVersion(pMgrToCodeActivationBatch, inliner.m_module, inliner.m_methodDef, fIsRevert, flags);
+                hr = UpdateActiveILVersion(pMgrToCodeActivationBatch, inliner.m_module, inliner.m_methodDef, FALSE /* fIsRevert */, flags);
                 if (FAILED(hr))
                 {
                     ReportReJITError(inliner.m_module, inliner.m_methodDef, NULL, hr);

--- a/src/coreclr/vm/rejit.h
+++ b/src/coreclr/vm/rejit.h
@@ -166,7 +166,6 @@ private:
         SHash<CodeActivationBatchTraits> *pMgrToCodeActivationBatch,
         Module             *pInlineeModule,
         mdMethodDef         inlineeMethodDef,
-        BOOL                fIsRevert,
         COR_PRF_REJIT_FLAGS flags);
 
     static HRESULT UpdateJitInlinerActiveILVersions(

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -570,11 +570,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/multidimmarray/rank1array/**">
             <Issue>https://github.com/dotnet/runtime/issues/108255</Issue>
         </ExcludeList>
-        <!-- testing
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/rejit/rejit/**">
-            <Issue>https://github.com/dotnet/runtime/issues/109310</Issue>
-        </ExcludeList>
-        -->
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/Arrays/misc/arrres_il_r/**">
             <Issue>https://github.com/dotnet/runtime/issues/109311</Issue>
         </ExcludeList>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -570,9 +570,11 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/multidimmarray/rank1array/**">
             <Issue>https://github.com/dotnet/runtime/issues/108255</Issue>
         </ExcludeList>
+        <!-- testing
         <ExcludeList Include="$(XunitTestBinBase)/profiler/rejit/rejit/**">
             <Issue>https://github.com/dotnet/runtime/issues/109310</Issue>
         </ExcludeList>
+        -->
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/Arrays/misc/arrres_il_r/**">
             <Issue>https://github.com/dotnet/runtime/issues/109311</Issue>
         </ExcludeList>

--- a/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
+++ b/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
@@ -95,12 +95,18 @@ HRESULT ReJITProfiler::Shutdown()
         _profInfo10 = nullptr;
     }
 
-    int expectedRejitCount = -1;
+    int expectedRejitCount;
     auto it = _inlinings.find(_targetFuncId);
     if (it != _inlinings.end())
     {
         // The number of inliners are expected to ReJIT, plus the method itself
         expectedRejitCount = (int)((*it).second->size() + 1);
+    }
+    else
+    {
+        // No inlinings happened, which can occur in composite R2R mode on some targets.
+        // This is fine as long as we rejitted the target method itself.
+        expectedRejitCount = 1;
     }
 
     INFO(L" rejit count=" << _rejits << L" expected rejit count=" << expectedRejitCount);

--- a/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
+++ b/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
@@ -341,11 +341,12 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::GetReJITParameters(ModuleID moduleId, m
     }
 
 
-    WCHAR wszNewUserDefinedString[4096] = { 0 };
-    swprintf_s(wszNewUserDefinedString, L"Hello from profiler rejit method '%lS'!", functionName.ToWString().c_str());
+    String newUserDefinedString = String(L"Hello from profiler rejit method '");
+    newUserDefinedString += functionName;
+    newUserDefinedString += L"'!";
     mdString tokmdsUserDefined = mdTokenNil;
-    hr = pTargetEmit->DefineUserString(wszNewUserDefinedString,
-                                       (ULONG)wcslen(wszNewUserDefinedString),
+    hr = pTargetEmit->DefineUserString(newUserDefinedString.ToCStr(),
+                                       (ULONG)newUserDefinedString.Length(),
                                        &tokmdsUserDefined);
     if (FAILED(hr))
     {

--- a/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
+++ b/src/tests/profiler/native/rejitprofiler/rejitprofiler.cpp
@@ -320,7 +320,8 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::GetReJITParameters(ModuleID moduleId, m
 {
     SHUTDOWNGUARD();
 
-    INFO(L"Starting to build IL for method " << GetFunctionIDName(GetFunctionIDFromToken(moduleId, methodId, false)));
+    String functionName = GetFunctionIDName(GetFunctionIDFromToken(moduleId, methodId, false));
+    INFO(L"Starting to build IL for method " << functionName);
     COMPtrHolder<IUnknown> pUnk;
     HRESULT hr = _profInfo10->GetModuleMetaData(moduleId, ofWrite, IID_IMetaDataEmit2, &pUnk);
     if (FAILED(hr))
@@ -340,7 +341,8 @@ HRESULT STDMETHODCALLTYPE ReJITProfiler::GetReJITParameters(ModuleID moduleId, m
     }
 
 
-    const WCHAR *wszNewUserDefinedString = WCHAR("Hello from profiler rejit!");
+    WCHAR wszNewUserDefinedString[4096] = { 0 };
+    swprintf_s(wszNewUserDefinedString, L"Hello from profiler rejit method '%lS'!", functionName.ToWString().c_str());
     mdString tokmdsUserDefined = mdTokenNil;
     hr = pTargetEmit->DefineUserString(wszNewUserDefinedString,
                                        (ULONG)wcslen(wszNewUserDefinedString),

--- a/src/tests/profiler/rejit/rejit.cs
+++ b/src/tests/profiler/rejit/rejit.cs
@@ -49,7 +49,7 @@ namespace Profiler.Tests
             TriggerInliningChain();
 
             if (OutputBuilder.ToString().Contains("Hello from profiler rejit method"))
-                return 1235;
+                Console.WriteLine("WARNING: ReJIT revert was not complete!");
 
             return 100;
         }

--- a/src/tests/profiler/rejit/rejit.cs
+++ b/src/tests/profiler/rejit/rejit.cs
@@ -69,7 +69,7 @@ namespace Profiler.Tests
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private static void TriggerInliningChain()
         {
-            TestWriteLine("TriggerInlining");
+            TestWriteLine("TriggerInliningChain");
             // Test Inlining through another method
             InlineeChain1();
         }
@@ -85,21 +85,27 @@ namespace Profiler.Tests
         private static void CallMethodWithoutInlining()
         {
             TestWriteLine("CallMethodWithoutInlining");
-            Action callMethod = InlineeTarget;
-            callMethod();
+            Action<string> callMethod = InlineeTarget;
+            callMethod("CallMethodWithoutInlining");
         }
 
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static void InlineeChain1()
         {
-            TestWriteLine("Inline.InlineeChain1");
+            TestWriteLine(" Inline.InlineeChain1");
             InlineeTarget();
         }
 
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
-        public static void InlineeTarget()
+        public static void InlineeTarget([CallerMemberName] string callerMemberName = null)
         {
-            TestWriteLine("Inline.InlineeTarget");
+            var sb = new System.Text.StringBuilder();
+            sb.Append("  Inline.InlineeTarget");
+            sb.Append(' ');
+            sb.Append('(');
+            sb.Append(callerMemberName);
+            sb.Append(')');
+            TestWriteLine(sb.ToString());
         }
 
         public static int RunTest(string[] args)

--- a/src/tests/profiler/rejit/rejit.cs
+++ b/src/tests/profiler/rejit/rejit.cs
@@ -37,8 +37,13 @@ namespace Profiler.Tests
             CallMethodWithoutInlining();
             TriggerInliningChain();
 
-            if (!OutputBuilder.ToString().Contains("Hello from profiler rejit method"))
+            string matchString = "Hello from profiler rejit method 'InlineeTarget'!";
+            int numRejittedTargets = OutputBuilder.ToString().Split(matchString).Length;
+            if (numRejittedTargets != 4)
+            {
+                Console.WriteLine("ReJIT did not update all instances of InlineeTarget!");
                 return 1234;
+            }
 
             TriggerRevert();
 
@@ -48,8 +53,16 @@ namespace Profiler.Tests
             CallMethodWithoutInlining();
             TriggerInliningChain();
 
-            if (OutputBuilder.ToString().Contains("Hello from profiler rejit method"))
-                Console.WriteLine("WARNING: ReJIT revert was not complete!");
+            if (OutputBuilder.ToString().Contains(matchString))
+            {
+                Console.WriteLine("ReJIT revert of InlineeTarget was not complete!");
+                return 1235;
+            }
+
+            // FIXME: Currently there will still be some 'Hello from profiler rejit method' messages left
+            //  in the output in certain configurations. This is because the profiler does not revert all
+            //  the methods that it modified - reverts are not symmetric with rejits.
+            // See https://github.com/dotnet/runtime/issues/117823
 
             return 100;
         }

--- a/src/tests/profiler/rejit/rejit.cs
+++ b/src/tests/profiler/rejit/rejit.cs
@@ -59,8 +59,8 @@ namespace Profiler.Tests
                 return 1235;
             }
 
-            // FIXME: Currently there will still be some 'Hello from profiler rejit method' messages left
-            //  in the output in certain configurations. This is because the profiler does not revert all
+            // Currently there will still be some 'Hello from profiler rejit method' messages left
+            //  in the output in certain configurations. This is because the test profiler does not revert all
             //  the methods that it modified - reverts are not symmetric with rejits.
             // See https://github.com/dotnet/runtime/issues/117823
 

--- a/src/tests/profiler/rejit/rejit.cs
+++ b/src/tests/profiler/rejit/rejit.cs
@@ -10,6 +10,15 @@ namespace Profiler.Tests
     {
         static readonly Guid ReJitProfilerGuid = new Guid("66F7A9DF-8858-4A32-9CFF-3AD0787E0186");
 
+        static System.Text.StringBuilder OutputBuilder = new ();
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static void TestWriteLine(string s)
+        {
+            OutputBuilder.AppendLine(s);
+            Console.WriteLine(s);
+        }
+
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private static int MaxInlining()
         {
@@ -20,17 +29,27 @@ namespace Profiler.Tests
 
             TriggerReJIT();
 
+            OutputBuilder.Clear();
+
             // TriggerInliningChain triggers a ReJIT, now this time we should call
             // in to the ReJITted code
             TriggerDirectInlining();
             CallMethodWithoutInlining();
             TriggerInliningChain();
 
+            if (!OutputBuilder.ToString().Contains("Hello from profiler rejit method"))
+                return 1234;
+
             TriggerRevert();
+
+            OutputBuilder.Clear();
 
             TriggerDirectInlining();
             CallMethodWithoutInlining();
             TriggerInliningChain();
+
+            if (OutputBuilder.ToString().Contains("Hello from profiler rejit method"))
+                return 1235;
 
             return 100;
         }
@@ -50,7 +69,7 @@ namespace Profiler.Tests
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private static void TriggerInliningChain()
         {
-            Console.WriteLine("TriggerInlining");
+            TestWriteLine("TriggerInlining");
             // Test Inlining through another method
             InlineeChain1();
         }
@@ -58,14 +77,14 @@ namespace Profiler.Tests
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private static void TriggerDirectInlining()
         {
-            Console.WriteLine("TriggerDirectInlining");
+            TestWriteLine("TriggerDirectInlining");
             InlineeTarget();
         }
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private static void CallMethodWithoutInlining()
         {
-            Console.WriteLine("CallMethodWithoutInlining");
+            TestWriteLine("CallMethodWithoutInlining");
             Action callMethod = InlineeTarget;
             callMethod();
         }
@@ -73,19 +92,19 @@ namespace Profiler.Tests
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static void InlineeChain1()
         {
-            Console.WriteLine("Inline.InlineeChain1");
+            TestWriteLine("Inline.InlineeChain1");
             InlineeTarget();
         }
 
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         public static void InlineeTarget()
         {
-            Console.WriteLine("Inline.InlineeTarget");
+            TestWriteLine("Inline.InlineeTarget");
         }
 
         public static int RunTest(string[] args)
         {
-            Console.WriteLine("maxinlining");
+            TestWriteLine("maxinlining");
             return MaxInlining();
         }
 
@@ -108,7 +127,7 @@ namespace Profiler.Tests
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private static void TriggerInliningChain()
         {
-            Console.WriteLine("TriggerInlining");
+            RejitWithInlining.TestWriteLine("TriggerInlining");
             // Test Inlining through another method
             InlineeChain1();
         }
@@ -116,14 +135,14 @@ namespace Profiler.Tests
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private static void TriggerDirectInlining()
         {
-            Console.WriteLine("TriggerDirectInlining");
+            RejitWithInlining.TestWriteLine("TriggerDirectInlining");
             RejitWithInlining.InlineeTarget();
         }
 
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
         private static void InlineeChain1()
         {
-            Console.WriteLine("Inline.InlineeChain1");
+            RejitWithInlining.TestWriteLine("Inline.InlineeChain1");
             RejitWithInlining.InlineeTarget();
         }
     }


### PR DESCRIPTION
* Include the name of the current method in the replacement strings inserted by the custom profiler
* Capture and validate the stdout messages in the test so we can check whether the rejit revert actually worked
* Fix failure when running r2r composite version of test on some configurations (it expected inlining to happen, but there's no guarantee it will)
* Fix a small oversight in rejit.cpp