### PR TITLE
[STJ] Optimize  EnumFieldInfo sorting

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -679,7 +679,8 @@ namespace System.Text.Json.Serialization.Converters
             var indices = new (int negativePopCount, int index)[enumFields.Length];
             for (int i = 0; i < enumFields.Length; i++)
             {
-                // we want values with more bits set to come first so negate the pop count
+                // We want values with more bits set to come first so negate the pop count.
+                // Keep the index as a second comparand so that sorting stability is preserved.
                 indices[i] = (-PopCount(enumFields[i].Key), i);
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -676,11 +676,11 @@ namespace System.Text.Json.Serialization.Converters
                 return enumFields;
             }
 
-            var indices = new Tuple<int, int>[enumFields.Length];
+            var indices = new (int negativePopCount, int index)[enumFields.Length];
             for (int i = 0; i < enumFields.Length; i++)
             {
                 // we want values with more bits set to come first so negate the pop count
-                indices[i] = Tuple.Create(-PopCount(enumFields[i].Key), i);
+                indices[i] = (-PopCount(enumFields[i].Key), i);
             }
 
             Array.Sort(indices);
@@ -689,7 +689,7 @@ namespace System.Text.Json.Serialization.Converters
             for (int i = 0; i < indices.Length; i++)
             {
                 // extract the index from the sorted tuple
-                int index = indices[i].Item2;
+                int index = indices[i].index;
                 sortedFields[i] = enumFields[index];
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -676,14 +676,11 @@ namespace System.Text.Json.Serialization.Converters
                 return enumFields;
             }
 
-            var indices = new long[enumFields.Length];
+            var indices = new Tuple<int, int>[enumFields.Length];
             for (int i = 0; i < enumFields.Length; i++)
             {
                 // we want values with more bits set to come first so negate the pop count
-                int popCount = -PopCount(enumFields[i].Key);
-                // pack into a long with the pop count in the high bits and the index in the low bits
-                // this allows us to sort by pop count and then by index in case of ties
-                indices[i] = ((long)popCount << 32) | (uint)i;
+                indices[i] = Tuple.Create(-PopCount(enumFields[i].Key), i);
             }
 
             Array.Sort(indices);
@@ -691,9 +688,8 @@ namespace System.Text.Json.Serialization.Converters
             var sortedFields = new EnumFieldInfo[enumFields.Length];
             for (int i = 0; i < indices.Length; i++)
             {
-                // extract the index from the long, which is the low bits
-                // the high bits are the pop count, which we don't need anymore
-                int index = (int)(uint)indices[i];
+                // extract the index from the sorted tuple
+                int index = indices[i].Item2;
                 sortedFields[i] = enumFields[index];
             }
 


### PR DESCRIPTION
In PR #117730, it now computes the `PopCount` of each `EnumFieldInfo` `.Key` on **every** comparison during the sort. This means we execute the POPCOUNT instruction (or the emulation if NET is not defined)  `2 x O(N log N)`  (average case) to `2 x O(N^2)` (worst case).

We know that the popcount for an long integer can range from 0-64 and the array `index` is an `int`, so we can ~pack them both into a `long`~ place them both in a `Tuple<int, int>` with `Item1` being the negated popcount and then use the `Array.Sort(indices)` to sort them super quick, and then ~extract~ use the original `index` in `Item2`.

The original spec was to sort the "more on bits" elements to the front of the resulting array, with a tie-breaker of the original array-index to ensure this is a stable sort with regard to the input array.

To get the more-on-bits to the front, ~when we pack into the long,~ we _negate_ the popcount, so those with more on-bits will sort **lower** naturally.

Once sorted,  we can just grab the ~low 32 bits~ `Item2` to get the original index value.