### PR TITLE
Update DBG_MAX_EXECUTABLE_ALLOC_SIZE and EXPECTED_CHUNKSIZE

### DIFF
--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -1116,8 +1116,8 @@ protected:
 //     different part of the address space (not on the heap).
 // ------------------------------------------------------------------------ */
 
-constexpr uint64_t DBG_MAX_EXECUTABLE_ALLOC_SIZE=112;
-constexpr uint64_t EXPECTED_CHUNKSIZE=128;
+constexpr uint64_t DBG_MAX_EXECUTABLE_ALLOC_SIZE=120; // sizeof (SharedPatchBypassBuffer)
+constexpr uint64_t EXPECTED_CHUNKSIZE=256; // this must be a power of 2 and can hold 136 bytes - sizeof (char[DBG_MAX_EXECUTABLE_ALLOC_SIZE]) + sizeof (DebuggerHeapExecutableMemoryPage*) + sizeof (uint8_t).
 constexpr uint64_t DEBUGGERHEAP_PAGESIZE=4096;
 constexpr uint64_t CHUNKS_PER_DEBUGGERHEAP=(DEBUGGERHEAP_PAGESIZE / EXPECTED_CHUNKSIZE);
 constexpr uint64_t MAX_CHUNK_MASK=((1ull << CHUNKS_PER_DEBUGGERHEAP) - 1);

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -1117,7 +1117,7 @@ protected:
 // ------------------------------------------------------------------------ */
 
 constexpr uint64_t DBG_MAX_EXECUTABLE_ALLOC_SIZE=120; // sizeof (SharedPatchBypassBuffer)
-constexpr uint64_t EXPECTED_CHUNKSIZE=256; // This must be a power of 2 and is sufficient to hold 136 bytes, which is the sum of sizeof(char[DBG_MAX_EXECUTABLE_ALLOC_SIZE]) + sizeof(DebuggerHeapExecutableMemoryPage*) + sizeof(uint8_t).
+constexpr uint64_t EXPECTED_CHUNKSIZE=256; // This must be a power of 2.  It represents the size of DebuggerHeapExecutableMemoryChunk, can be the sizeof (DataChunk) or sizeof (BookkeepingChunk). Changes to DBG_MAX_EXECUTABLE_ALLOC_SIZE can affect this number.  Currently we require 136 bytes, and so the closest power of 2 is 256.
 constexpr uint64_t DEBUGGERHEAP_PAGESIZE=4096;
 constexpr uint64_t CHUNKS_PER_DEBUGGERHEAP=(DEBUGGERHEAP_PAGESIZE / EXPECTED_CHUNKSIZE);
 constexpr uint64_t MAX_CHUNK_MASK=((1ull << CHUNKS_PER_DEBUGGERHEAP) - 1);

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -1117,7 +1117,7 @@ protected:
 // ------------------------------------------------------------------------ */
 
 constexpr uint64_t DBG_MAX_EXECUTABLE_ALLOC_SIZE=120; // sizeof (SharedPatchBypassBuffer)
-constexpr uint64_t EXPECTED_CHUNKSIZE=256; // this must be a power of 2 and can hold 136 bytes - sizeof (char[DBG_MAX_EXECUTABLE_ALLOC_SIZE]) + sizeof (DebuggerHeapExecutableMemoryPage*) + sizeof (uint8_t).
+constexpr uint64_t EXPECTED_CHUNKSIZE=256; // This must be a power of 2 and is sufficient to hold 136 bytes, which is the sum of sizeof(char[DBG_MAX_EXECUTABLE_ALLOC_SIZE]) + sizeof(DebuggerHeapExecutableMemoryPage*) + sizeof(uint8_t).
 constexpr uint64_t DEBUGGERHEAP_PAGESIZE=4096;
 constexpr uint64_t CHUNKS_PER_DEBUGGERHEAP=(DEBUGGERHEAP_PAGESIZE / EXPECTED_CHUNKSIZE);
 constexpr uint64_t MAX_CHUNK_MASK=((1ull << CHUNKS_PER_DEBUGGERHEAP) - 1);


### PR DESCRIPTION
Recent change to SharedPatchBypassBuffer caused allocation failures in the debugger, leading to linux debugging to fail. This change increases the buffer sizes to allow for the increased size to SharedPatchBypassBuffer