### PR TITLE
Fix ML-DSA PKCS8 copying bug

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
@@ -216,7 +216,7 @@ namespace System.Security.Cryptography
                     }
 
                     bytesWritten = pkcs8.Count;
-                    pkcs8.Array.CopyTo(destination);
+                    pkcs8.AsSpan().CopyTo(destination);
                     return true;
                 }
                 finally

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestsBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestsBase.cs
@@ -222,6 +222,12 @@ namespace System.Security.Cryptography.Tests
         [MemberData(nameof(MLDsaTestsData.AllPreHashMLDsaNistTestCases), MemberType = typeof(MLDsaTestsData))]
         public void NistImportPublicKeyVerifyPreHash(MLDsaNistTestCase testCase)
         {
+            if (!HashInfo.KnownHashAlgorithmOids.Contains(testCase.HashAlgOid))
+            {
+                // This test case is not supported by the current platform.
+                return;
+            }
+
             byte[] hash = HashInfo.HashData(testCase.HashAlgOid, testCase.Message);
             using MLDsa mldsa = ImportPublicKey(testCase.Algorithm, testCase.PublicKey);
             Assert.Equal(testCase.ShouldPass, mldsa.VerifyPreHash(hash, testCase.Signature, testCase.HashAlgOid, testCase.Context));
@@ -317,7 +323,7 @@ namespace System.Security.Cryptography.Tests
         public void SignPreHash_ThrowsForUnsupportedAlgorithmCombinations(MLDsaAlgorithm algorithm, HashInfo hashInfo)
         {
             using MLDsa mldsa = GenerateKey(algorithm);
-            byte[] hash = hashInfo.GetHash([1, 2, 3, 4]);
+            byte[] hash = new byte[hashInfo.OutputSize];
 
             CryptographicException ce = Assert.Throws<CryptographicException>(() => mldsa.SignPreHash(hash, hashInfo.Oid));
             Assert.Contains(algorithm.Name, ce.Message);

--- a/src/libraries/Common/tests/System/Security/Cryptography/HashInfo.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/HashInfo.cs
@@ -101,6 +101,8 @@ namespace Test.Cryptography
 #endif
         }
 
+        internal static HashSet<string> KnownHashAlgorithmOids => field ??= AllHashInfos().Select(h => h.Oid).ToHashSet();
+
         private HashInfo(string oid, int outputSize, HashAlgorithmName name)
         {
             Oid = oid;


### PR DESCRIPTION
While I was fixing test failures, this bug was sometimes surfacing as an exception from CopyTo. We were copying the entire `ArraySegment<byte>.Array` when we should be only copying the relevant span.

The rest of the PR changes are the test failures I was fixing, but otherwise unrelated to the above bug. SHAKE and SHA3 are not supported in netfx.