### PR TITLE
Use HashSet/SearchValues when known OID list is long

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/CompositeMLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CompositeMLDsa.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Formats.Asn1;
@@ -25,27 +26,35 @@ namespace System.Security.Cryptography
 #pragma warning restore SA1001
 #endif
     {
-        private static readonly string[] s_knownOids =
-        [
-            Oids.MLDsa44WithRSA2048PssPreHashSha256,
-            Oids.MLDsa44WithRSA2048Pkcs15PreHashSha256,
-            Oids.MLDsa44WithEd25519PreHashSha512,
-            Oids.MLDsa44WithECDsaP256PreHashSha256,
-            Oids.MLDsa65WithRSA3072PssPreHashSha512,
-            Oids.MLDsa65WithRSA3072Pkcs15PreHashSha512,
-            Oids.MLDsa65WithRSA4096PssPreHashSha512,
-            Oids.MLDsa65WithRSA4096Pkcs15PreHashSha512,
-            Oids.MLDsa65WithECDsaP256PreHashSha512,
-            Oids.MLDsa65WithECDsaP384PreHashSha512,
-            Oids.MLDsa65WithECDsaBrainpoolP256r1PreHashSha512,
-            Oids.MLDsa65WithEd25519PreHashSha512,
-            Oids.MLDsa87WithECDsaP384PreHashSha512,
-            Oids.MLDsa87WithECDsaBrainpoolP384r1PreHashSha512,
-            Oids.MLDsa87WithEd448PreHashShake256_512,
-            Oids.MLDsa87WithRSA3072PssPreHashSha512,
-            Oids.MLDsa87WithRSA4096PssPreHashSha512,
-            Oids.MLDsa87WithECDsaP521PreHashSha512,
-        ];
+        private static readonly KeyFormatHelper.StringLookup s_knownOids =
+#if NET9_0_OR_GREATER
+            new(SearchValues.Create([
+#else
+            new([
+#endif
+                Oids.MLDsa44WithRSA2048PssPreHashSha256,
+                Oids.MLDsa44WithRSA2048Pkcs15PreHashSha256,
+                Oids.MLDsa44WithEd25519PreHashSha512,
+                Oids.MLDsa44WithECDsaP256PreHashSha256,
+                Oids.MLDsa65WithRSA3072PssPreHashSha512,
+                Oids.MLDsa65WithRSA3072Pkcs15PreHashSha512,
+                Oids.MLDsa65WithRSA4096PssPreHashSha512,
+                Oids.MLDsa65WithRSA4096Pkcs15PreHashSha512,
+                Oids.MLDsa65WithECDsaP256PreHashSha512,
+                Oids.MLDsa65WithECDsaP384PreHashSha512,
+                Oids.MLDsa65WithECDsaBrainpoolP256r1PreHashSha512,
+                Oids.MLDsa65WithEd25519PreHashSha512,
+                Oids.MLDsa87WithECDsaP384PreHashSha512,
+                Oids.MLDsa87WithECDsaBrainpoolP384r1PreHashSha512,
+                Oids.MLDsa87WithEd448PreHashShake256_512,
+                Oids.MLDsa87WithRSA3072PssPreHashSha512,
+                Oids.MLDsa87WithRSA4096PssPreHashSha512,
+                Oids.MLDsa87WithECDsaP521PreHashSha512,
+#if NET9_0_OR_GREATER
+            ], StringComparison.Ordinal));
+#else
+            ]);
+#endif
 
         private const int MaxContextLength = 255;
 

--- a/src/libraries/Common/src/System/Security/Cryptography/DSAKeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAKeyFormatHelper.cs
@@ -10,10 +10,7 @@ namespace System.Security.Cryptography
 {
     internal static class DSAKeyFormatHelper
     {
-        private static readonly string[] s_validOids =
-        {
-            Oids.Dsa,
-        };
+        private static readonly KeyFormatHelper.StringLookupArray s_validOids = new([Oids.Dsa]);
 
         internal static void ReadDsaPrivateKey(
             ReadOnlyMemory<byte> xBytes,

--- a/src/libraries/Common/src/System/Security/Cryptography/EccKeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/EccKeyFormatHelper.cs
@@ -17,10 +17,7 @@ namespace System.Security.Cryptography
         // there's no real point reading anything bigger than this (for now).
         private const int MaxFieldBitSize = 661;
 
-        private static readonly string[] s_validOids =
-        {
-            Oids.EcPublicKey,
-        };
+        private static readonly KeyFormatHelper.StringLookupArray s_validOids = new([Oids.EcPublicKey]);
 
         internal static void ReadSubjectPublicKeyInfo(
             ReadOnlySpan<byte> source,

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography
         internal delegate TRet ReadOnlySpanFunc<TIn, TRet>(ReadOnlySpan<TIn> span);
 
         internal static unsafe void ReadEncryptedPkcs8<TRet>(
-            string[] validOids,
+            IStringLookup validOids,
             ReadOnlySpan<byte> source,
             ReadOnlySpan<char> password,
             KeyReader<TRet> keyReader,
@@ -32,7 +32,7 @@ namespace System.Security.Cryptography
         }
 
         internal static unsafe void ReadEncryptedPkcs8<TRet>(
-            string[] validOids,
+            IStringLookup validOids,
             ReadOnlySpan<byte> source,
             ReadOnlySpan<byte> passwordBytes,
             KeyReader<TRet> keyReader,
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography
         }
 
         private static void ReadEncryptedPkcs8<TRet>(
-            string[] validOids,
+            IStringLookup validOids,
             ReadOnlyMemory<byte> source,
             ReadOnlySpan<char> password,
             KeyReader<TRet> keyReader,
@@ -73,7 +73,7 @@ namespace System.Security.Cryptography
         }
 
         private static void ReadEncryptedPkcs8<TRet>(
-            string[] validOids,
+            IStringLookup validOids,
             ReadOnlyMemory<byte> source,
             ReadOnlySpan<byte> passwordBytes,
             KeyReader<TRet> keyReader,
@@ -91,7 +91,7 @@ namespace System.Security.Cryptography
         }
 
         private static void ReadEncryptedPkcs8<TRet>(
-            string[] validOids,
+            IStringLookup validOids,
             ReadOnlyMemory<byte> source,
             ReadOnlySpan<char> password,
             ReadOnlySpan<byte> passwordBytes,

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -32,12 +32,12 @@ namespace System.Security.Cryptography
 #pragma warning restore SA1001
 #endif
     {
-        private protected static readonly string[] KnownOids =
+        private protected static readonly KeyFormatHelper.StringLookupArray KnownOids = new(
         [
             Oids.MLDsa44,
             Oids.MLDsa65,
             Oids.MLDsa87,
-        ];
+        ]);
 
         private const int MaxContextLength = 255;
 

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography
     [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
     public abstract partial class MLKem : IDisposable
     {
-        private static readonly string[] s_knownOids = [Oids.MlKem512, Oids.MlKem768, Oids.MlKem1024];
+        private static readonly KeyFormatHelper.StringLookupArray s_knownOids = new([Oids.MlKem512, Oids.MlKem768, Oids.MlKem1024]);
 
         private bool _disposed;
 

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAKeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAKeyFormatHelper.cs
@@ -10,10 +10,7 @@ namespace System.Security.Cryptography
 {
     internal static partial class RSAKeyFormatHelper
     {
-        private static readonly string[] s_validOids =
-        {
-            Oids.Rsa,
-        };
+        private static readonly KeyFormatHelper.StringLookupArray s_validOids = new([Oids.Rsa]);
 
         // TODO Currently reading PKCS#1 keys uses BigInteger which is not optimal and uses APIs that are not
         // available downlevel. These methods should eventually be replaced with a more efficient implementation

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
@@ -32,21 +32,29 @@ namespace System.Security.Cryptography
 #pragma warning restore SA1001
 #endif
     {
-        private static readonly string[] s_knownOids =
-        [
-            Oids.SlhDsaSha2_128s,
-            Oids.SlhDsaShake128s,
-            Oids.SlhDsaSha2_128f,
-            Oids.SlhDsaShake128f,
-            Oids.SlhDsaSha2_192s,
-            Oids.SlhDsaShake192s,
-            Oids.SlhDsaSha2_192f,
-            Oids.SlhDsaShake192f,
-            Oids.SlhDsaSha2_256s,
-            Oids.SlhDsaShake256s,
-            Oids.SlhDsaSha2_256f,
-            Oids.SlhDsaShake256f,
-        ];
+        private static readonly KeyFormatHelper.StringLookup s_knownOids =
+#if NET9_0_OR_GREATER
+            new(SearchValues.Create([
+#else
+            new([
+#endif
+                Oids.SlhDsaSha2_128s,
+                Oids.SlhDsaShake128s,
+                Oids.SlhDsaSha2_128f,
+                Oids.SlhDsaShake128f,
+                Oids.SlhDsaSha2_192s,
+                Oids.SlhDsaShake192s,
+                Oids.SlhDsaSha2_192f,
+                Oids.SlhDsaShake192f,
+                Oids.SlhDsaSha2_256s,
+                Oids.SlhDsaShake256s,
+                Oids.SlhDsaSha2_256f,
+                Oids.SlhDsaShake256f,
+#if NET9_0_OR_GREATER
+            ], StringComparison.Ordinal));
+#else
+            ]);
+#endif
 
         private const int MaxContextLength = 255;
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECAlgorithm.cs
@@ -13,11 +13,8 @@ namespace System.Security.Cryptography
     /// </summary>
     public abstract class ECAlgorithm : AsymmetricAlgorithm
     {
-        private static readonly string[] s_validOids =
-        {
-            Oids.EcPublicKey,
-            // ECDH and ECMQV are not valid in this context.
-        };
+        // ECDH and ECMQV are not valid in this context.
+        private static readonly KeyFormatHelper.StringLookupArray s_validOids = new([Oids.EcPublicKey]);
 
         private protected static readonly KeySizes[] s_defaultKeySizes =
         {


### PR DESCRIPTION
When the list of OIDs is long (SLH-DSA and Composite ML-DSA), use a more efficient lookup instead of `Array.IndexOf`.