### PR TITLE
Delete ECHash

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1583,8 +1583,7 @@ namespace System.StubHelpers
         internal static partial void ValidateByref(IntPtr byref, IntPtr pMD); // the byref is pinned so we can safely "cast" it to IntPtr
 
         [Intrinsic]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern IntPtr GetStubContext();
+        internal static IntPtr GetStubContext() => throw new UnreachableException(); // Unconditionally expanded intrinsic
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void MulticastDebuggerTraceHelper(object o, int count)
@@ -1596,11 +1595,10 @@ namespace System.StubHelpers
         private static partial void MulticastDebuggerTraceHelperQCall(ObjectHandleOnStack obj, int count);
 
         [Intrinsic]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern IntPtr NextCallReturnAddress();
+        internal static IntPtr NextCallReturnAddress() => throw new UnreachableException(); // Unconditionally expanded intrinsic
 
         [Intrinsic]
-        internal static Continuation? AsyncCallContinuation() => null;
+        internal static Continuation? AsyncCallContinuation() => throw new UnreachableException(); // Unconditionally expanded intrinsic
     }  // class StubHelpers
 
 #if FEATURE_COMINTEROP

--- a/src/coreclr/debug/daccess/reimpl.cpp
+++ b/src/coreclr/debug/daccess/reimpl.cpp
@@ -38,9 +38,9 @@ DacGetThread(ULONG32 osThread)
         UNREACHABLE();
     }
 
-    // Note that if we had access to TLS, we could get this at index gThreadTLSIndex for the specified
-    // thread.  However, this is the only place we might want to use TLS, and it's not performance critical,
-    // so we haven't added TLS support to ICorDebugDataTarget (the legacy ICLRDataTarget interface has it though)
+    // Note that if we had access to TLS, we could get this at TLS for the specified thread.  However, this is
+    // the only place we might want to use TLS, and it's not performance critical, so we haven't added TLS support
+    // to ICorDebugDataTarget (the legacy ICLRDataTarget interface has it though)
 
     // Scan the whole thread store to see if there's a matching thread.
 

--- a/src/coreclr/debug/ee/dactable.cpp
+++ b/src/coreclr/debug/ee/dactable.cpp
@@ -22,12 +22,7 @@
 
 #ifdef DEBUGGING_SUPPORTED
 
-extern PTR_ECHash gFCallMethods[FCALL_HASH_SIZE];
-extern TADDR gLowestFCall;
-extern TADDR gHighestFCall;
 extern PCODE g_FCDynamicallyAssignedImplementations[ECall::NUM_DYNAMICALLY_ASSIGNED_FCALL_IMPLEMENTATIONS];
-extern DWORD gThreadTLSIndex;
-extern DWORD gAppDomainTLSIndex;
 extern "C" void STDCALL ThePreStubPatchLabel(void);
 
 #ifdef FEATURE_COMWRAPPERS

--- a/src/coreclr/inc/daccess.h
+++ b/src/coreclr/inc/daccess.h
@@ -290,9 +290,9 @@
 //
 //     SystemDomain::m_appDomainIndexList;
 //
-//     extern DWORD gThreadTLSIndex;
+//     extern DWORD g_TlsIndex;
 //
-//     DWORD gThreadTLSIndex = TLS_OUT_OF_INDEXES;
+//     DWORD g_TlsIndex = TLS_OUT_OF_INDEXES;
 //
 // Modified Code:
 //
@@ -312,9 +312,9 @@
 //
 //     SVAL_IMPL(ArrayListStatic, SystemDomain, m_appDomainIndexList);
 //
-//     GVAL_DECL(DWORD, gThreadTLSIndex);
+//     GVAL_DECL(DWORD, g_TlsIndex);
 //
-//     GVAL_IMPL_INIT(DWORD, gThreadTLSIndex, TLS_OUT_OF_INDEXES);
+//     GVAL_IMPL_INIT(DWORD, g_TlsIndex, TLS_OUT_OF_INDEXES);
 //
 // When declaring the variable, the first argument declares the
 // variable's type and the second argument declares the variable's

--- a/src/coreclr/inc/dacvars.h
+++ b/src/coreclr/inc/dacvars.h
@@ -195,10 +195,6 @@ DEFINE_DACVAR(BOOL, Debugger__s_fCanChangeNgenFlags, Debugger::s_fCanChangeNgenF
 DEFINE_DACVAR(PTR_DebuggerPatchTable, DebuggerController__g_patches, DebuggerController::g_patches)
 DEFINE_DACVAR(BOOL, DebuggerController__g_patchTableValid, DebuggerController::g_patchTableValid)
 
-DEFINE_DACVAR(SIZE_T, dac__gLowestFCall, ::gLowestFCall)
-DEFINE_DACVAR(SIZE_T, dac__gHighestFCall, ::gHighestFCall)
-DEFINE_DACVAR(SIZE_T, dac__gFCallMethods, ::gFCallMethods)
-
 DEFINE_DACVAR(PTR_SyncTableEntry, dac__g_pSyncTable, ::g_pSyncTable)
 #ifdef FEATURE_COMINTEROP
 DEFINE_DACVAR(UNKNOWN_POINTER_TYPE, dac__g_pRCWCleanupList, ::g_pRCWCleanupList)

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4609,8 +4609,6 @@ void Module::EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
         }
     }
 
-    ECall::EnumFCallMethods();
-
 #ifdef FEATURE_METADATA_UPDATER
     m_ClassList.EnumMemoryRegions();
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -825,9 +825,6 @@ void EEStartupHelper()
         // Static initialization
         SystemDomain::Attach();
 
-        // Start up the EE initializing all the global variables
-        ECall::Init();
-
         COMDelegate::Init();
 
         ExecutionManager::Init();

--- a/src/coreclr/vm/comdependenthandle.cpp
+++ b/src/coreclr/vm/comdependenthandle.cpp
@@ -43,7 +43,6 @@ extern "C" OBJECTHANDLE QCALLTYPE DependentHandle_InternalAllocWithGCTransition(
 FCIMPL1(Object*, DependentHandle::InternalGetTarget, OBJECTHANDLE handle)
 {
     FCALL_CONTRACT;
-    FCUnique(0x54);
 
     _ASSERTE(handle != NULL);
 

--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -96,21 +96,7 @@ void ECall::PopulateManagedStringConstructors()
     INDEBUG(fInitialized = true);
 }
 
-static CrstStatic gFCallLock;
-
 #endif // !DACCESS_COMPILE
-
-// To provide a quick check, this is the lowest and highest
-// addresses of any FCALL starting address
-GVAL_IMPL_INIT(TADDR, gLowestFCall, (TADDR)-1);
-GVAL_IMPL(TADDR, gHighestFCall);
-
-GARY_IMPL(PTR_ECHash, gFCallMethods, FCALL_HASH_SIZE);
-
-inline unsigned FCallHash(PCODE pTarg) {
-    LIMITED_METHOD_DAC_CONTRACT;
-    return pTarg % FCALL_HASH_SIZE;
-}
 
 #ifdef DACCESS_COMPILE
 
@@ -303,7 +289,7 @@ static ECFunc* FindECFuncForMethod(MethodDesc* pMD)
 * Returns 0 if it is an ECALL,
 * Otherwise returns the native entry point (FCALL)
 */
-PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*=NULL*/)
+PCODE ECall::GetFCallImpl(MethodDesc * pMD, bool throwForInvalidFCall)
 {
     CONTRACTL
     {
@@ -322,9 +308,6 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
     //
     if (pMT->IsDelegate())
     {
-        if (pfSharedOrDynamicFCallImpl)
-            *pfSharedOrDynamicFCallImpl = TRUE;
-
         _ASSERTE(pMD->IsCtor());
 
         // We need to set up the ECFunc properly.  We don't want to use the pMD passed in,
@@ -337,9 +320,6 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
     // COM imported classes have special constructors
     if (pMT->IsComObjectType() && pMT != g_pBaseCOMObject)
     {
-        if (pfSharedOrDynamicFCallImpl)
-            *pfSharedOrDynamicFCallImpl = TRUE;
-
         // This has to be tlbimp constructor
         _ASSERTE(pMD->IsCtor());
 
@@ -350,11 +330,19 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
     // This code path is taken when a class marked with ComImport is being created.
     // If we get here and COM interop isn't suppported, throw.
     if (pMT->IsComObjectType())
-        COMPlusThrow(kPlatformNotSupportedException, IDS_EE_ERROR_COM);
+    {
+        if (throwForInvalidFCall)
+            COMPlusThrow(kPlatformNotSupportedException, IDS_EE_ERROR_COM);
+        return (PCODE)NULL;
+    }
 #endif // FEATURE_COMINTEROP
 
     if (!pMD->GetModule()->IsSystem())
-        COMPlusThrow(kSecurityException, BFA_ECALLS_MUST_BE_IN_SYS_MOD);
+    {
+        if (throwForInvalidFCall)
+            COMPlusThrow(kSecurityException, BFA_ECALLS_MUST_BE_IN_SYS_MOD);
+        return (PCODE)NULL;
+    }
 
     ECFunc* ret = FindECFuncForMethod(pMD);
 
@@ -390,72 +378,13 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
     int iDynamicID = ret->DynamicID();
     if (iDynamicID != InvalidDynamicFCallId)
     {
-        if (pfSharedOrDynamicFCallImpl)
-            *pfSharedOrDynamicFCallImpl = TRUE;
-
         pImplementation = g_FCDynamicallyAssignedImplementations[iDynamicID];
         _ASSERTE(pImplementation != (PCODE)NULL);
         return pImplementation;
     }
 
-
-    // Insert the implementation into hash table if it is not there already.
-
-    CrstHolder holder(&gFCallLock);
-
-    MethodDesc * pMDinTable = ECall::MapTargetBackToMethod(pImplementation, &pImplementation);
-
-    if (pMDinTable != NULL)
-    {
-        if (pMDinTable != pMD)
-        {
-            // The fcall entrypoints has to be at unique addresses. If you get failure here, use the following steps
-            // to fix it:
-            // 1. Consider merging the offending fcalls into one fcall. Do they really do different things?
-            // 2. If it does not make sense to merge the offending fcalls into one,
-            // add FCUnique(<a random unique number here>); to one of the offending fcalls.
-
-            _ASSERTE(!"Duplicate pImplementation entries found in reverse fcall table");
-            ThrowHR(E_FAIL);
-        }
-    }
-    else
-    {
-        ECHash * pEntry = (ECHash *)(PVOID)SystemDomain::GetGlobalLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(ECHash)));
-
-        pEntry->m_pImplementation = pImplementation;
-        pEntry->m_pMD = pMD;
-
-        if(gLowestFCall > pImplementation)
-            gLowestFCall = pImplementation;
-        if(gHighestFCall < pImplementation)
-            gHighestFCall = pImplementation;
-
-        // add to hash table
-        ECHash** spot = &gFCallMethods[FCallHash(pImplementation)];
-        for(;;) {
-            if (*spot == 0) {                   // found end of list
-                *spot = pEntry;
-                break;
-            }
-            spot = &(*spot)->m_pNext;
-        }
-    }
-
-    if (pfSharedOrDynamicFCallImpl)
-        *pfSharedOrDynamicFCallImpl = FALSE;
-
     _ASSERTE(pImplementation != (PCODE)NULL);
     return pImplementation;
-}
-
-BOOL ECall::IsSharedFCallImpl(PCODE pImpl)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    PCODE pNativeCode = pImpl;
-
-    return (pNativeCode == GetEEFuncEntryPoint(FCComCtor));
 }
 
 BOOL ECall::CheckUnusedECalls(SetSHash<DWORD>& usedIDs)
@@ -508,179 +437,7 @@ BOOL ECall::CheckUnusedECalls(SetSHash<DWORD>& usedIDs)
 FCIMPL1(VOID, FCComCtor, LPVOID pV)
 {
     FCALL_CONTRACT;
-
-    FCUnique(0x34);
 }
 FCIMPLEND
 
-
-
-/* static */
-void ECall::Init()
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    gFCallLock.Init(CrstFCall);
-}
 #endif // !DACCESS_COMPILE
-
-MethodDesc* ECall::MapTargetBackToMethod(PCODE pTarg, PCODE * ppAdjustedEntryPoint /*=NULL*/)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        SUPPORTS_DAC;
-    }
-    CONTRACTL_END;
-
-    // Searching all of the entries is expensive
-    // and we are often called with pTarg == NULL so
-    // check for this value and early exit.
-
-    if (!pTarg)
-        return NULL;
-
-    // Could this possibily be an FCall?
-    if ((pTarg < gLowestFCall) || (pTarg > gHighestFCall))
-        return NULL;
-
-    ECHash * pECHash = gFCallMethods[FCallHash(pTarg)];
-    while (pECHash != NULL)
-    {
-        if (pECHash->m_pImplementation == pTarg)
-        {
-            return pECHash->m_pMD;
-        }
-        pECHash = pECHash->m_pNext;
-    }
-    return NULL;
-}
-
-#ifndef DACCESS_COMPILE
-
-#ifdef _DEBUG
-
-void FCallAssert(void*& cache, void* target)
-{
-    STATIC_CONTRACT_NOTHROW;
-    STATIC_CONTRACT_GC_NOTRIGGER;
-    STATIC_CONTRACT_DEBUG_ONLY;
-
-    if (cache != 0)
-    {
-        return;
-    }
-
-    //
-    // Special case fcalls with 1:N mapping between implementation and methoddesc
-    //
-    if (ECall::IsSharedFCallImpl((PCODE)target))
-    {
-        cache = (void*)1;
-        return;
-    }
-
-    MethodDesc* pMD = ECall::MapTargetBackToMethod((PCODE)target);
-    if (pMD != 0)
-    {
-        return;
-    }
-
-    // Slow but only for debugging.  This is needed because in some places
-    // we call FCALLs directly from EE code.
-
-    unsigned num = c_nECClasses;
-    for (unsigned i=0; i < num; i++)
-    {
-        for (ECFunc* ptr = (ECFunc*)c_rgECClasses[i].m_pECFunc; !ptr->IsEndOfArray(); ptr = ptr->NextInArray())
-        {
-            if (ptr->m_pImplementation  == target)
-            {
-                cache = target;
-                return;
-            }
-        }
-    }
-
-    // Now check the dynamically assigned table too.
-    for (unsigned i=0; i<ECall::NUM_DYNAMICALLY_ASSIGNED_FCALL_IMPLEMENTATIONS; i++)
-    {
-        if (g_FCDynamicallyAssignedImplementations[i] == (PCODE)target)
-        {
-            cache = target;
-            return;
-        }
-    }
-
-    _ASSERTE(!"Could not find FCall implementation in ECall.cpp");
-}
-
-void HCallAssert(void*& cache, void* target)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        DEBUG_ONLY;
-    }
-    CONTRACTL_END;
-
-    if (cache != 0)
-        cache = ECall::MapTargetBackToMethod((PCODE)target);
-    _ASSERTE(cache == 0 || "Use FCIMPL for fcalls");
-}
-
-#endif // _DEBUG
-
-#endif // !DACCESS_COMPILE
-
-#ifdef DACCESS_COMPILE
-
-void ECall::EnumFCallMethods()
-{
-    SUPPORTS_DAC;
-    gLowestFCall.EnumMem();
-    gHighestFCall.EnumMem();
-    gFCallMethods.EnumMem();
-
-    // save all ECFunc for stackwalks.
-    // TODO: we could be smarter and only save buckets referenced during stackwalks. But we
-    // need that entire bucket so that traversals such as MethodDesc* ECall::MapTargetBackToMethod will work.
-    for (UINT i=0;i<FCALL_HASH_SIZE;i++)
-    {
-        ECHash *ecHash = gFCallMethods[i];
-        while (ecHash)
-        {
-            // If we can't read the target memory, stop immediately so we don't work
-            // with broken data.
-            if (!DacEnumMemoryRegion(dac_cast<TADDR>(ecHash), sizeof(ECHash)))
-                break;
-            ecHash = ecHash->m_pNext;
-
-#if defined (_DEBUG)
-            // Test hook: when testing on debug builds, we want an easy way to test that the while
-            // correctly terminates in the face of ridiculous stuff from the target.
-            if (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_DumpGeneration_IntentionallyCorruptDataFromTarget) == 1)
-            {
-                // Force us to struggle on with something bad.
-                if (!ecHash)
-                {
-                    ecHash = (ECHash *)(((unsigned char *)&gFCallMethods[i])+1);
-                }
-            }
-#endif // defined (_DEBUG)
-
-        }
-    }
-}
-
-#endif // DACCESS_COMPILE

--- a/src/coreclr/vm/ecall.h
+++ b/src/coreclr/vm/ecall.h
@@ -15,24 +15,6 @@
 
 class MethodDesc;
 
-// CoreCLR defines fewer FCalls so make the hashtable even smaller.
-#define FCALL_HASH_SIZE 127
-
-typedef DPTR(struct ECHash) PTR_ECHash;
-
-struct ECHash
-{
-    PTR_ECHash          m_pNext;
-    PCODE               m_pImplementation;
-    PTR_MethodDesc      m_pMD;               // for reverse mapping
-};
-
-#ifdef DACCESS_COMPILE
-GVAL_DECL(TADDR, gLowestFCall);
-GVAL_DECL(TADDR, gHighestFCall);
-GARY_DECL(PTR_ECHash, gFCallMethods, FCALL_HASH_SIZE);
-#endif
-
 enum {
     FCFuncFlag_EndOfArray   = 0x01,
     FCFuncFlag_HasSignature = 0x02,
@@ -74,30 +56,14 @@ struct ECClass
 class ECall
 {
     public:
-        //---------------------------------------------------------
-        // One-time init
-        //---------------------------------------------------------
-        static void Init();
-
-        static PCODE GetFCallImpl(MethodDesc* pMD, BOOL * pfSharedOrDynamicFCallImpl = NULL);
-        static MethodDesc* MapTargetBackToMethod(PCODE pTarg, PCODE * ppAdjustedEntryPoint = NULL);
+        static PCODE GetFCallImpl(MethodDesc* pMD, bool throwForInvalidFCall = true);
         static DWORD GetIDForMethod(MethodDesc *pMD);
-
-        // Some fcalls (delegate ctors and tlbimpl ctors) shared one implementation.
-        // We should never patch vtable for these since they have 1:N mapping between
-        // MethodDesc and the actual implementation
-        static BOOL IsSharedFCallImpl(PCODE pImpl);
 
         static BOOL CheckUnusedECalls(SetSHash<DWORD>& usedIDs);
 
         static void DynamicallyAssignFCallImpl(PCODE impl, DWORD index);
 
         static void PopulateManagedStringConstructors();
-
-#ifdef DACCESS_COMPILE
-        // Enumerates all gFCallMethods for minidumps.
-        static void EnumFCallMethods();
-#endif // DACCESS_COMPILE
 
 #define _DYNAMICALLY_ASSIGNED_FCALLS_BASE() \
     DYNAMICALLY_ASSIGNED_FCALL_IMPL(FastAllocateString,                RhpNewVariableSizeObject) \

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -356,8 +356,6 @@ FCFuncStart(gStubHelperFuncs)
 #endif // FEATURE_COMINTEROP
     FCFuncElement("CalcVaListSize", StubHelpers::CalcVaListSize)
     FCFuncElement("LogPinnedArgument", StubHelpers::LogPinnedArgument)
-    FCFuncElement("GetStubContext", StubHelpers::GetStubContext)
-    FCFuncElement("NextCallReturnAddress", StubHelpers::NextCallReturnAddress)
 FCFuncEnd()
 
 FCFuncStart(gGCHandleFuncs)

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9133,7 +9133,17 @@ void CEEInfo::getFunctionEntryPoint(CORINFO_METHOD_HANDLE  ftnHnd,
     // Resolve methodImpl.
     ftn = ftn->GetMethodTable()->MapMethodDeclToMethodImpl(ftn);
 
-    if (!ftn->IsFCall() && ftn->IsVersionableWithPrecode() && (ftn->GetPrecodeType() == PRECODE_FIXUP) && !ftn->IsPointingToStableNativeCode())
+    if (ftn->IsFCall())
+    {
+        // FCalls can be called directly
+        ret = (void*)ECall::GetFCallImpl(ftn, false /* throwForInvalidFCall */);
+        if (ret == NULL)
+        {
+            ret = ((FixupPrecode*)ftn->GetOrCreatePrecode())->GetTargetSlot();
+            accessType = IAT_PVALUE;
+        }
+    }
+    else if (ftn->IsVersionableWithPrecode() && (ftn->GetPrecodeType() == PRECODE_FIXUP) && !ftn->IsPointingToStableNativeCode())
     {
         ret = ((FixupPrecode*)ftn->GetOrCreatePrecode())->GetTargetSlot();
         accessType = IAT_PVALUE;

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -6213,27 +6213,8 @@ MethodDesc* MethodTable::GetMethodDescForSlotAddress(PCODE addr, BOOL fSpeculati
     }
     CONTRACT_END;
 
-    // If we see shared fcall implementation as an argument to this
-    // function, it means that a vtable slot for the shared fcall
-    // got backpatched when it shouldn't have.  The reason we can't
-    // backpatch this method is that it is an FCall that has many
-    // MethodDescs for one implementation.  If we backpatch delegate
-    // constructors, this function will not be able to recover the
-    // MethodDesc for the method.
-    //
-    _ASSERTE_IMPL(!ECall::IsSharedFCallImpl(addr) &&
-                  "someone backpatched shared fcall implementation -- "
-                  "see comment in code");
-
     MethodDesc* pMethodDesc = ExecutionManager::GetCodeMethodDesc(addr);
     if (NULL != pMethodDesc)
-    {
-        goto lExit;
-    }
-
-    // Is it an FCALL?
-    pMethodDesc = ECall::MapTargetBackToMethod(addr);
-    if (pMethodDesc != 0)
     {
         goto lExit;
     }

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -212,17 +212,6 @@ BOOL Precode::IsPointingToPrestub(PCODE target)
     return FALSE;
 }
 
-// If addr is patched fixup precode, returns address that it points to. Otherwise returns NULL.
-PCODE Precode::TryToSkipFixupPrecode(PCODE addr)
-{
-    CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-    } CONTRACTL_END;
-
-    return 0;
-}
-
 #ifndef DACCESS_COMPILE
 
 void FlushCacheForDynamicMappedStub(void* code, SIZE_T size)

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -774,9 +774,6 @@ public:
         return pPrecode;
     }
 
-    // If addr is patched fixup precode, returns address that it points to. Otherwise returns NULL.
-    static PCODE TryToSkipFixupPrecode(PCODE addr);
-
     //
     // Precode as temporary entrypoint
     //

--- a/src/coreclr/vm/stubhelpers.cpp
+++ b/src/coreclr/vm/stubhelpers.cpp
@@ -724,15 +724,6 @@ extern "C" void QCALLTYPE StubHelpers_ValidateByref(void *pByref, MethodDesc *pM
     END_QCALL;
 }
 
-FCIMPL0(void*, StubHelpers::GetStubContext)
-{
-    FCALL_CONTRACT;
-
-    FCUnique(0xa0);
-    UNREACHABLE_MSG_RET("This is a JIT intrinsic!");
-}
-FCIMPLEND
-
 FCIMPL2(void, StubHelpers::LogPinnedArgument, MethodDesc *target, Object *pinnedArg)
 {
     FCALL_CONTRACT;
@@ -776,10 +767,3 @@ extern "C" void QCALLTYPE StubHelpers_MulticastDebuggerTraceHelper(QCall::Object
 
     END_QCALL;
 }
-
-FCIMPL0(void*, StubHelpers::NextCallReturnAddress)
-{
-    FCALL_CONTRACT;
-    UNREACHABLE_MSG("This is a JIT intrinsic!");
-}
-FCIMPLEND

--- a/src/coreclr/vm/stubhelpers.h
+++ b/src/coreclr/vm/stubhelpers.h
@@ -35,11 +35,8 @@ public:
 
     static FCDECL2(FC_BOOL_RET,     TryGetStringTrailByte,  StringObject* thisRefUNSAFE, UINT8 *pbData);
 
-    static FCDECL0(void*,           GetStubContext);
     static FCDECL2(void,            LogPinnedArgument, MethodDesc *localDesc, Object *nativeArg);
     static FCDECL1(DWORD,           CalcVaListSize, VARARGS *varargs);
-
-    static FCDECL0(void*,           NextCallReturnAddress);
 };
 
 extern "C" void QCALLTYPE StubHelpers_CreateCustomMarshaler(MethodDesc* pMD, mdToken paramToken, TypeHandle hndManagedType, QCall::ObjectHandleOnStack retObject);

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -2322,11 +2322,6 @@ VirtualCallStubManager::Resolver(
         BOOL fSlotCallsPrestub = DoesSlotCallPrestub(implSlot.GetTarget());
         if (!fSlotCallsPrestub)
         {
-            // Skip fixup precode jump for better perf
-            PCODE pDirectTarget = Precode::TryToSkipFixupPrecode(implSlot.GetTarget());
-            if (pDirectTarget != (PCODE)NULL)
-                implSlot = DispatchSlot(pDirectTarget);
-
             // Only patch to a target if it's not going to call the prestub.
             fShouldPatch = TRUE;
         }


### PR DESCRIPTION
We do not need FCall entrypoint to MethodDesc reverse mappinng now that there are no FCall with HelperMethodFrames