### PR TITLE
Fix ILLink ref assembly build breaks

### DIFF
--- a/src/tools/illink/src/linker/CompatibilitySuppressions.xml
+++ b/src/tools/illink/src/linker/CompatibilitySuppressions.xml
@@ -707,6 +707,10 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Mono.Linker.AnnotationStore.GetEntryPointAssembly</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Mono.Linker.AnnotationStore.GetLinkerAttributes``1(Mono.Cecil.IMemberDefinition)</Target>
   </Suppression>
   <Suppression>
@@ -819,6 +823,10 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Mono.Linker.AnnotationStore.SetEntryPointAssembly(Mono.Cecil.AssemblyDefinition)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Mono.Linker.AnnotationStore.SetMembersPreserve(Mono.Cecil.ExportedType,Mono.Linker.TypePreserveMembers)</Target>
   </Suppression>
   <Suppression>
@@ -868,14 +876,6 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Mono.Linker.AnnotationStore.TryGetPreservedMembers(Mono.Cecil.TypeDefinition,Mono.Linker.TypePreserveMembers@)</Target>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Mono.Linker.AnnotationStore.SetEntryPointAssembly(Mono.Cecil.AssemblyDefinition)</Target>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Mono.Linker.AnnotationStore.GetEntryPointAssembly</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
@@ -1528,6 +1528,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Mono.Linker.Steps.SubStepsDispatcher.Process(Mono.Linker.LinkContext)</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Mono.Linker.LinkContext.get_DisableGeneratedCodeHeuristics</Target>
+    <Left>ref/net10.0/illink.dll</Left>
+    <Right>lib/net10.0/illink.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Mono.Linker.LinkContext.set_DisableGeneratedCodeHeuristics(System.Boolean)</Target>
+    <Left>ref/net10.0/illink.dll</Left>
+    <Right>lib/net10.0/illink.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0008</DiagnosticId>


### PR DESCRIPTION
This is blocking https://github.com/dotnet/dotnet/pull/1546. Looks like this got lost in all the WASM timeout noise in #117624.

We can either suppress or add to ref assembly, but ref assembly only has things ILLink custom steps depend on. So suppression it is.

I just regenerated it with `/p:ApiCompatGenerateSuppressionFile=true` so it shuffled two unrelated lines.

Cc @dotnet/illink