### PR TITLE
Add 'physicalMemoryMode' to SRC.MemoryCache. New mode will follow GC metrics to determine trimming.

### DIFF
--- a/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
+++ b/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
@@ -83,6 +83,7 @@ System.Runtime.Caching.ObjectCache</PackageDescription>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows'">
+    <Compile Include="System\Runtime\Caching\MemoryMonitor.Unix.cs" />
     <Compile Include="System\Runtime\Caching\PhysicalMemoryMonitor.Unix.cs" />
   </ItemGroup>
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/ConfigUtil.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/ConfigUtil.cs
@@ -13,6 +13,7 @@ namespace System.Runtime.Caching.Configuration
     {
         internal const string CacheMemoryLimitMegabytes = "cacheMemoryLimitMegabytes";
         internal const string PhysicalMemoryLimitPercentage = "physicalMemoryLimitPercentage";
+        internal const string PhysicalMemoryBytesAvailable = "physicalMemoryBytesAvailable";
         internal const string PollingInterval = "pollingInterval";
         internal const string UseMemoryCacheManager = "useMemoryCacheManager";
         internal const string ThrowOnDisposed = "throwOnDisposed";
@@ -74,6 +75,26 @@ namespace System.Runtime.Caching.Configuration
             double milliseconds = tValue.TotalMilliseconds;
             int iValue = (milliseconds < (double)int.MaxValue) ? (int)milliseconds : int.MaxValue;
             return iValue;
+        }
+
+        internal static long GetLongValue(NameValueCollection config, string valueName, long defaultValue, long minValueAllowed, long maxValueAllowed)
+        {
+            string sValue = config[valueName];
+
+            if (sValue == null)
+            {
+                return defaultValue;
+            }
+
+            long lValue;
+            if (!long.TryParse(sValue, out lValue)
+                || lValue < minValueAllowed
+                || lValue > maxValueAllowed)
+            {
+                throw new ArgumentException(RH.Format(SR.Argument_out_of_range, valueName, minValueAllowed, maxValueAllowed), nameof(config));
+            }
+
+            return lValue;
         }
 
         internal static bool GetBooleanValue(NameValueCollection config, string valueName, bool defaultValue)

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/ConfigUtil.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/ConfigUtil.cs
@@ -101,34 +101,14 @@ namespace System.Runtime.Caching.Configuration
             return sValue ?? defaultValue;
         }
 
-        internal static void ParsePhysicalMemoryMode(string rawValue, out PhysicalMemoryMode parsedMode, out long? parsedMemoryBytes)
+        internal static PhysicalMemoryMode ParsePhysicalMemoryMode(string rawValue)
         {
-            string[] parts = rawValue.Split(':');
-
-            // Parse the mode part - This part is required
-            if (!Enum.TryParse<PhysicalMemoryMode>(parts[0], true, out PhysicalMemoryMode mode))
+            if (!Enum.TryParse<PhysicalMemoryMode>(rawValue, true, out PhysicalMemoryMode mode))
             {
                 throw new ArgumentException(null, ConfigUtil.PhysicalMemoryMode);
             }
 
-            parsedMode = mode;
-            parsedMemoryBytes = null;
-
-            // Parse the optional memory bytes part
-            if (parts.Length > 1)
-            {
-                if (parts.Length > 2)
-                {
-                    throw new ArgumentException(null, ConfigUtil.PhysicalMemoryMode);
-                }
-
-                if (!long.TryParse(parts[1], out long memoryBytes) || memoryBytes < 0)
-                {
-                    throw new ArgumentException(RH.Format(SR.Argument_out_of_range, ConfigUtil.PhysicalMemoryMode, 0, long.MaxValue));
-                }
-
-                parsedMemoryBytes = memoryBytes;
-            }
+            return mode;
         }
     }
 }

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/ConfigUtil.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/ConfigUtil.cs
@@ -108,9 +108,7 @@ namespace System.Runtime.Caching.Configuration
             // Parse the mode part - This part is required
             if (!Enum.TryParse<PhysicalMemoryMode>(parts[0], true, out PhysicalMemoryMode mode))
             {
-                // Ugly hack until we can add a new localized exception message for this.
-                var msgFormat = new InvalidEnumArgumentException(ConfigUtil.PhysicalMemoryMode, -999, typeof(PhysicalMemoryMode));
-                throw new ArgumentException(msgFormat.Message.Replace("-999", parts[0]));
+                throw new ArgumentException(null, ConfigUtil.PhysicalMemoryMode);
             }
 
             parsedMode = mode;

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheElement.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheElement.cs
@@ -28,6 +28,13 @@ namespace System.Runtime.Caching.Configuration
                 null,
                 new IntegerValidator(0, 100),
                 ConfigurationPropertyOptions.None);
+        private static readonly ConfigurationProperty s_propPhysicalMemoryBytesAvailable =
+            new ConfigurationProperty("physicalMemoryBytesAvailable",
+                typeof(long),
+                (long)-1,
+                null,
+                new LongValidator(-1, long.MaxValue),
+                ConfigurationPropertyOptions.None);
         private static readonly ConfigurationProperty s_propCacheMemoryLimitMegabytes =
             new ConfigurationProperty("cacheMemoryLimitMegabytes",
                 typeof(int),
@@ -46,6 +53,7 @@ namespace System.Runtime.Caching.Configuration
         {
             s_propName,
             s_propPhysicalMemoryLimitPercentage,
+            s_propPhysicalMemoryBytesAvailable,
             s_propCacheMemoryLimitMegabytes,
             s_propPollingInterval
         };
@@ -93,6 +101,19 @@ namespace System.Runtime.Caching.Configuration
             set
             {
                 base["physicalMemoryLimitPercentage"] = value;
+            }
+        }
+
+        [ConfigurationProperty("physicalMemoryBytesAvailable", DefaultValue = (long)-1)]
+        public long PhysicalMemoryBytesAvailable
+        {
+            get
+            {
+                return (long)base["physicalMemoryBytesAvailable"];
+            }
+            set
+            {
+                base["physicalMemoryBytesAvailable"] = value;
             }
         }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheElement.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheElement.cs
@@ -20,9 +20,9 @@ namespace System.Runtime.Caching.Configuration
         Legacy = 0,
 
         /// <summary>
-        /// Default mode - uses GCMemoryInfo without inducing GC collections.
+        /// Standard mode - uses GCMemoryInfo without inducing GC collections.
         /// </summary>
-        Default = 1,
+        Standard = 1,
 
         /// <summary>
         /// GC thresholds mode - uses GCMemoryInfo.HighMemoryLoadThresholdBytes instead of percentage of total memory.
@@ -134,9 +134,9 @@ namespace System.Runtime.Caching.Configuration
         /// Gets or sets the physical memory monitoring mode.
         /// Valid values:
         /// - "Legacy": Platform-specific memory detection (default)
-        /// - "Default": Use GC.GetGCMemoryInfo().TotalAvailableMemoryBytes without inducing GC
+        /// - "Standard": Use GC.GetGCMemoryInfo().TotalAvailableMemoryBytes without inducing GC
         /// - "GCThresholds": Follow GC's high memory load threshold
-        /// - "Default:1234567890": Use Default mode - specified against a static amount of available RAM (in bytes)
+        /// - "Standard:1234567890": Use Standard mode - specified against a static amount of available RAM (in bytes)
         /// </summary>
         [ConfigurationProperty("physicalMemoryMode", DefaultValue = "Legacy")]
         internal string PhysicalMemoryModeRaw

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheElement.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheElement.cs
@@ -54,7 +54,7 @@ namespace System.Runtime.Caching.Configuration
             new ConfigurationProperty("physicalMemoryMode",
                 typeof(string),
                 "Legacy",
-                null,
+                new GenericEnumConverter(typeof(PhysicalMemoryMode)),
                 null,
                 ConfigurationPropertyOptions.None);
         private static readonly ConfigurationProperty s_propCacheMemoryLimitMegabytes =
@@ -136,50 +136,13 @@ namespace System.Runtime.Caching.Configuration
         /// - "Legacy": Platform-specific memory detection (default)
         /// - "Standard": Use GC.GetGCMemoryInfo().TotalAvailableMemoryBytes without inducing GC
         /// - "GCThresholds": Follow GC's high memory load threshold
-        /// - "Standard:1234567890": Use Standard mode - specified against a static amount of available RAM (in bytes)
         /// </summary>
         [ConfigurationProperty("physicalMemoryMode", DefaultValue = "Legacy")]
-        internal string PhysicalMemoryModeRaw
+        internal PhysicalMemoryMode PhysicalMemoryMode
         {
             get
             {
-                return (string)base["physicalMemoryMode"];
-            }
-        }
-
-        private bool _modeIsParsed;
-        private PhysicalMemoryMode _parsedMode;
-        private long? _parsedMemoryBytes;
-
-        /// <summary>
-        /// Gets the parsed physical memory mode enum value.
-        /// </summary>
-        public PhysicalMemoryMode PhysicalMemoryMode
-        {
-            get
-            {
-                if (!_modeIsParsed)
-                {
-                    ConfigUtil.ParsePhysicalMemoryMode(PhysicalMemoryModeRaw, out _parsedMode, out _parsedMemoryBytes);
-                    _modeIsParsed = true;
-                }
-                return _parsedMode;
-            }
-        }
-
-        /// <summary>
-        /// Gets the parsed memory bytes value if specified in the format "Mode:bytes", otherwise null.
-        /// </summary>
-        public long? PhysicalMemoryBytes
-        {
-            get
-            {
-                if (!_modeIsParsed)
-                {
-                    ConfigUtil.ParsePhysicalMemoryMode(PhysicalMemoryModeRaw, out _parsedMode, out _parsedMemoryBytes);
-                    _modeIsParsed = true;
-                }
-                return _parsedMemoryBytes;
+                return (PhysicalMemoryMode)base["physicalMemoryMode"];
             }
         }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSection.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSection.cs
@@ -13,9 +13,9 @@ namespace System.Runtime.Caching.Configuration
        <system.runtime.caching>
          <memoryCaches>
            <namedCaches>
-             <add name="Default" physicalMemoryPercentage="0" pollingInterval="00:02:00"/>
-             <add name="Foo" physicalMemoryPercentage="0" pollingInterval="00:02:00"/>
-             <add name="Bar" physicalMemoryPercentage="0" pollingInterval="00:02:00"/>
+             <add name="Default" physicalMemoryPercentage="0" physicalMemoryBytesAvailable="0" pollingInterval="00:02:00"/>
+             <add name="Foo" physicalMemoryPercentage="0" physicalMemoryBytesAvailable="0" pollingInterval="00:02:00"/>
+             <add name="Bar" physicalMemoryPercentage="0" physicalMemoryBytesAvailable="0" pollingInterval="00:02:00"/>
            </namedCaches>
          </memoryCaches>
        </system.caching>

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSection.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSection.cs
@@ -13,9 +13,9 @@ namespace System.Runtime.Caching.Configuration
        <system.runtime.caching>
          <memoryCaches>
            <namedCaches>
-             <add name="Default" physicalMemoryPercentage="0" physicalMemoryBytesAvailable="0" pollingInterval="00:02:00"/>
-             <add name="Foo" physicalMemoryPercentage="0" physicalMemoryBytesAvailable="0" pollingInterval="00:02:00"/>
-             <add name="Bar" physicalMemoryPercentage="0" physicalMemoryBytesAvailable="0" pollingInterval="00:02:00"/>
+             <add name="Default" physicalMemoryPercentage="0" physicalMemoryMode="Legacy" pollingInterval="00:02:00"/>
+             <add name="Foo" physicalMemoryPercentage="0" physicalMemoryMode="Default" pollingInterval="00:02:00"/>
+             <add name="Bar" physicalMemoryPercentage="0" physicalMemoryMode="GCThresholds" pollingInterval="00:02:00"/>
            </namedCaches>
          </memoryCaches>
        </system.caching>

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSection.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/MemoryCacheSection.cs
@@ -14,7 +14,7 @@ namespace System.Runtime.Caching.Configuration
          <memoryCaches>
            <namedCaches>
              <add name="Default" physicalMemoryPercentage="0" physicalMemoryMode="Legacy" pollingInterval="00:02:00"/>
-             <add name="Foo" physicalMemoryPercentage="0" physicalMemoryMode="Default" pollingInterval="00:02:00"/>
+             <add name="Foo" physicalMemoryPercentage="0" physicalMemoryMode="Standard" pollingInterval="00:02:00"/>
              <add name="Bar" physicalMemoryPercentage="0" physicalMemoryMode="GCThresholds" pollingInterval="00:02:00"/>
            </namedCaches>
          </memoryCaches>

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.Unix.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.Unix.cs
@@ -25,7 +25,8 @@ namespace System.Runtime.Caching
             s_totalPhysical = memInfo.TotalAvailableMemoryBytes;
 
             // s_totalVirtual/TotalVirtual on the other hand is only used to decide if an x86 Windows machine is running in /3GB mode or not...
-            //  ... so it can appropriately set the "Auto" memory limit of the cache size - which again, is never enforced in .Net Core.
+            //  ... but only so it can appropriately set the "Auto" memory limit of the cache size - which again, is never enforced in .Net Core.
+            //  So we don't need to worry about it here.
             //s_totalVirtual = default(long);
         }
 #pragma warning restore CA1810

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.Unix.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.Unix.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Specialized;
+using System.Security;
+using System.Runtime.InteropServices;
+
+
+namespace System.Runtime.Caching
+{
+    internal abstract partial class MemoryMonitor
+    {
+#if NETCOREAPP
+#pragma warning disable CA1810 // explicit static cctor
+        static MemoryMonitor()
+        {
+            // Get stats from GC.
+            GCMemoryInfo memInfo = GC.GetGCMemoryInfo();
+
+            // s_totalPhysical/TotalPhysical are used in two places:
+            //   1. PhysicalMemoryMonitor - to determine the high pressure level. We really just need to know if we have more memory than a 2005-era x86 machine.
+            //   2. CacheMemoryMonitor - for setting the "Auto" memory limit of the cache size - which is never enforced anyway because we don't have SRef's in .NET Core.
+            // Which is to say, it's OK if 'TotalAvailableMemoryBytes' is not an exact representation of the physical memory on the machine, as long as it is in the ballpark of magnitude.
+            s_totalPhysical = memInfo.TotalAvailableMemoryBytes;
+
+            // s_totalVirtual/TotalVirtual on the other hand is only used to decide if an x86 Windows machine is running in /3GB mode or not...
+            //  ... so it can appropriately set the "Auto" memory limit of the cache size - which again, is never enforced in .Net Core.
+            //s_totalVirtual = default(long);
+        }
+#pragma warning restore CA1810
+#endif
+    }
+}

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Unix.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Unix.cs
@@ -25,7 +25,7 @@ namespace System.Runtime.Caching
 #if NETCOREAPP
         private int lastGCCount;
 
-        protected override int GetCurrentPressure()
+        private int LegacyGetCurrentPressure()
         {
             // Try to refresh GC stats if they haven't been updated since our last check.
             int ccount = GC.CollectionCount(0);
@@ -50,7 +50,7 @@ namespace System.Runtime.Caching
             return (memInfo.MemoryLoadBytes > 0) ? 100 : 0;
         }
 #else
-        protected override int GetCurrentPressure() => 0;
+        private static int LegacyGetCurrentPressure() => 0;
 #endif
     }
 }

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Unix.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Unix.cs
@@ -39,9 +39,10 @@ namespace System.Runtime.Caching
             // Get stats from GC.
             GCMemoryInfo memInfo = GC.GetGCMemoryInfo();
 
-            if (memInfo.TotalAvailableMemoryBytes >= memInfo.MemoryLoadBytes)
+            var limit = _followGCThresholds ? memInfo.HighMemoryLoadThresholdBytes : memInfo.TotalAvailableMemoryBytes;
+            if (limit > memInfo.MemoryLoadBytes)
             {
-                int memoryLoad = (int)((float)memInfo.MemoryLoadBytes * 100.0 / (float)memInfo.TotalAvailableMemoryBytes);
+                int memoryLoad = (int)((float)memInfo.MemoryLoadBytes * 100.0 / (float)limit);
                 return Math.Max(1, memoryLoad);
             }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Unix.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Unix.cs
@@ -39,10 +39,9 @@ namespace System.Runtime.Caching
             // Get stats from GC.
             GCMemoryInfo memInfo = GC.GetGCMemoryInfo();
 
-            var limit = _followGCThresholds ? memInfo.HighMemoryLoadThresholdBytes : memInfo.TotalAvailableMemoryBytes;
-            if (limit > memInfo.MemoryLoadBytes)
+            if (memInfo.TotalAvailableMemoryBytes > memInfo.MemoryLoadBytes)
             {
-                int memoryLoad = (int)((float)memInfo.MemoryLoadBytes * 100.0 / (float)limit);
+                int memoryLoad = (int)((float)memInfo.MemoryLoadBytes * 100.0 / (float)memInfo.TotalAvailableMemoryBytes);
                 return Math.Max(1, memoryLoad);
             }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Windows.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.Windows.cs
@@ -10,7 +10,7 @@ namespace System.Runtime.Caching
 {
     internal sealed partial class PhysicalMemoryMonitor : MemoryMonitor
     {
-        protected override unsafe int GetCurrentPressure()
+        private static unsafe int LegacyGetCurrentPressure()
         {
             Interop.Kernel32.MEMORYSTATUSEX memoryStatus = default;
             memoryStatus.dwLength = (uint)sizeof(Interop.Kernel32.MEMORYSTATUSEX);

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
@@ -64,9 +64,21 @@ namespace System.Runtime.Caching
             }
             else
             {
-                // Legacy and Standard modes: Use specified percentage with appropriate monitoring
-                _pressureHigh = Math.Max(3, physicalMemoryLimitPercentage);
-                _pressureLow = Math.Max(1, _pressureHigh - 9);
+#if NETCOREAPP
+                // The GC.GetGCMemoryInfo API is available only in .NET Core
+                if (_physicalMemoryMode == PhysicalMemoryMode.GCThresholds)
+                {
+                    // GCThresholds mode always targets HighMemoryLoadThresholdBytes, but we can still adjust the low threshold.
+                    _pressureHigh = 100;
+                    _pressureLow = Math.Max(3, physicalMemoryLimitPercentage);
+                }
+                else
+#endif
+                {
+                    // Legacy and Standard modes: Use specified percentage with appropriate monitoring
+                    _pressureHigh = Math.Max(3, physicalMemoryLimitPercentage);
+                    _pressureLow = Math.Max(1, _pressureHigh - 9);
+                }
             }
 
             Dbg.Trace("MemoryCacheStats", $"PhysicalMemoryMonitor.SetLimit: _pressureHigh={_pressureHigh}, _pressureLow={_pressureLow}, mode={_physicalMemoryMode}");

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/PhysicalMemoryMonitor.cs
@@ -53,7 +53,7 @@ namespace System.Runtime.Caching
 #if NETCOREAPP
             _physicalMemoryMode = physicalMemoryMode;
 #if SRC_ALLOW_CUSTOM_PHYSICAL_BYTES
-            _physicalMemoryBytes = (physicalMemoryMode == PhysicalMemoryMode.Default) ? physicalMemoryBytes : null;
+            _physicalMemoryBytes = (physicalMemoryMode == PhysicalMemoryMode.Standard) ? physicalMemoryBytes : null;
 #else
             _physicalMemoryBytes = null;
 #endif // SRC_ALLOW_CUSTOM_PHYSICAL_BYTES
@@ -73,7 +73,7 @@ namespace System.Runtime.Caching
             }
             else
             {
-                // Legacy and Default modes: Use specified percentage with appropriate monitoring
+                // Legacy and Standard modes: Use specified percentage with appropriate monitoring
                 _pressureHigh = Math.Max(3, physicalMemoryLimitPercentage);
                 _pressureLow = Math.Max(1, _pressureHigh - 9);
             }
@@ -151,7 +151,7 @@ namespace System.Runtime.Caching
             int currentPressure = CalculateCurrentPressure();
 
 #if NETCOREAPP
-            if (currentPressure < PressureHigh) // Reset in any mode. No ill effects in Legacy/Default modes.
+            if (currentPressure < PressureHigh) // Reset in any mode. No ill effects in Legacy/Standard modes.
             {
                 // Not above high pressure - reset tracking
                 _initialMemInfo = null;
@@ -166,7 +166,7 @@ namespace System.Runtime.Caching
         private int CalculateCurrentPressure()
         {
 #if NETCOREAPP
-            // Modern GC-based monitoring for Default and GCThresholds modes
+            // Modern GC-based monitoring for Standard and GCThresholds modes
             if (_physicalMemoryMode != PhysicalMemoryMode.Legacy)
             {
                 // Get stats from GC without inducing collection

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -288,11 +288,11 @@ namespace MonoTests.System.Runtime.Caching
             config.Add("PhysicalMemoryMode", "Standard");
             mc = new MemoryCache("MyCache", config);
             // Full .Net Framework uses the in-box SRC. So none of this 'PhysicalMemoryMode' setting matters. Just make sure it doesn't get in the way.
-            Assert.Equal(IsFullFramework ? autoCalculatedPhysicalMemoryLimit : autoCalculatedPhysicalMemoryLimit, mc.PhysicalMemoryLimit);
+            Assert.Equal(autoCalculatedPhysicalMemoryLimit, mc.PhysicalMemoryLimit);
 
             config.Set("PhysicalMemoryMode", "Legacy");
             mc = new MemoryCache("MyCache", config);
-            Assert.Equal(IsFullFramework ? autoCalculatedPhysicalMemoryLimit : autoCalculatedPhysicalMemoryLimit, mc.PhysicalMemoryLimit);
+            Assert.Equal(autoCalculatedPhysicalMemoryLimit, mc.PhysicalMemoryLimit);
 
             config.Set("PhysicalMemoryMode", "GCThresholds");
             mc = new MemoryCache("MyCache", config);

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -347,7 +347,11 @@ namespace MonoTests.System.Runtime.Caching
 
             config.Set("PhysicalMemoryMode", "Default:" + ((long)0x50000000).ToString()); // A value known to result in 97% physical memory limit
             mc = new MemoryCache("MyCache", config);
+#if SRC_ALLOW_CUSTOM_PHYSICAL_BYTES
             Assert.Equal(IsFullFramework ? autoCalculatedPhysicalMemoryLimit : 97, mc.PhysicalMemoryLimit);
+#else
+            Assert.Equal(autoCalculatedPhysicalMemoryLimit, mc.PhysicalMemoryLimit);    // PhysicalMemoryBytes within PhysicalMemoryMode is ignored
+#endif
 
             // This sneaky way of setting physical memory available is only supported in 'Default' mode.
             config.Set("PhysicalMemoryMode", "Legacy:" + ((long)0x50000000).ToString());

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -179,7 +179,7 @@ namespace MonoTests.System.Runtime.Caching
             });
 
             config.Clear();
-            config.Add("PhysicalMemoryMode", "Default");
+            config.Add("PhysicalMemoryMode", "Standard");
             // Just make sure it doesn't throw any exception
             mc = new MemoryCache("MyCache", config);
 
@@ -194,54 +194,7 @@ namespace MonoTests.System.Runtime.Caching
             mc = new MemoryCache("MyCache", config);
 
             config.Clear();
-            config.Add("PhysicalMemoryMode", "Default:12345");
-            // Just make sure it doesn't throw any exception
-            mc = new MemoryCache("MyCache", config);
-
-            config.Clear();
-            config.Add("PhysicalMemoryMode", "Legacy:12345");   // The added bytes have no effect, but that's not enforced by config validation.
-            // Just make sure it doesn't throw any exception
-            mc = new MemoryCache("MyCache", config);
-
-            config.Clear();
-            config.Add("PhysicalMemoryMode", "GCThresholds:12345");   // The added bytes have no effect, but that's not enforced by config validation.
-            // Just make sure it doesn't throw any exception
-            mc = new MemoryCache("MyCache", config);
-
-            config.Clear();
-            config.Add("PhysicalMemoryMode", "NotDefault");
-            if (IsFullFramework)
-            {
-                // On .NET Framework, this does not throw, because the Framework version of SRC gets loaded,
-                // and it cares nothing for this setting.
-                mc = new MemoryCache("MyCache", config);
-            }
-            else
-            {
-                Assert.Throws<ArgumentException>(() =>
-                {
-                    mc = new MemoryCache("MyCache", config);
-                });
-            }
-
-            config.Clear();
-            config.Add("PhysicalMemoryMode", "Default:-1");
-            if (IsFullFramework)
-            {
-                // On .NET Framework, this does not throw, because the Framework version of SRC gets loaded,
-                // and it cares nothing for this setting.
-                mc = new MemoryCache("MyCache", config);
-            }
-            else
-            {
-                Assert.Throws<ArgumentException>(() =>
-                {
-                    mc = new MemoryCache("MyCache", config);
-                });
-            }
-
-            config.Clear();
-            config.Add("PhysicalMemoryMode", "Default:NotANum");
+            config.Add("PhysicalMemoryMode", "NotValidMode");
             if (IsFullFramework)
             {
                 // On .NET Framework, this does not throw, because the Framework version of SRC gets loaded,
@@ -332,7 +285,7 @@ namespace MonoTests.System.Runtime.Caching
             // for our test environment later
             var autoCalculatedPhysicalMemoryLimit = mc.PhysicalMemoryLimit;
 
-            config.Add("PhysicalMemoryMode", "Default");
+            config.Add("PhysicalMemoryMode", "Standard");
             mc = new MemoryCache("MyCache", config);
             // Full .Net Framework uses the in-box SRC. So none of this 'PhysicalMemoryMode' setting matters. Just make sure it doesn't get in the way.
             Assert.Equal(IsFullFramework ? autoCalculatedPhysicalMemoryLimit : autoCalculatedPhysicalMemoryLimit, mc.PhysicalMemoryLimit);
@@ -342,22 +295,6 @@ namespace MonoTests.System.Runtime.Caching
             Assert.Equal(IsFullFramework ? autoCalculatedPhysicalMemoryLimit : autoCalculatedPhysicalMemoryLimit, mc.PhysicalMemoryLimit);
 
             config.Set("PhysicalMemoryMode", "GCThresholds");
-            mc = new MemoryCache("MyCache", config);
-            Assert.Equal(IsFullFramework ? autoCalculatedPhysicalMemoryLimit : 100, mc.PhysicalMemoryLimit);
-
-            config.Set("PhysicalMemoryMode", "Default:" + ((long)0x50000000).ToString()); // A value known to result in 97% physical memory limit
-            mc = new MemoryCache("MyCache", config);
-#if SRC_ALLOW_CUSTOM_PHYSICAL_BYTES
-            Assert.Equal(IsFullFramework ? autoCalculatedPhysicalMemoryLimit : 97, mc.PhysicalMemoryLimit);
-#else
-            Assert.Equal(autoCalculatedPhysicalMemoryLimit, mc.PhysicalMemoryLimit);    // PhysicalMemoryBytes within PhysicalMemoryMode is ignored
-#endif
-
-            // This sneaky way of setting physical memory available is only supported in 'Default' mode.
-            config.Set("PhysicalMemoryMode", "Legacy:" + ((long)0x50000000).ToString());
-            mc = new MemoryCache("MyCache", config);
-            Assert.Equal(autoCalculatedPhysicalMemoryLimit, mc.PhysicalMemoryLimit);
-            config.Set("PhysicalMemoryMode", "GCThresholds:" + ((long)0x50000000).ToString());
             mc = new MemoryCache("MyCache", config);
             Assert.Equal(IsFullFramework ? autoCalculatedPhysicalMemoryLimit : 100, mc.PhysicalMemoryLimit);
 
@@ -371,7 +308,7 @@ namespace MonoTests.System.Runtime.Caching
             Assert.Equal(5242880, mc.CacheMemoryLimit);
             Assert.Equal(TimeSpan.FromMinutes(70), mc.PollingInterval);
 
-            config.Add("PhysicalMemoryMode", "Default");
+            config.Add("PhysicalMemoryMode", "Standard");
             mc = new MemoryCache("MyCache", config);
             Assert.Equal(10, mc.PhysicalMemoryLimit);
 
@@ -380,10 +317,6 @@ namespace MonoTests.System.Runtime.Caching
             Assert.Equal(10, mc.PhysicalMemoryLimit);
 
             config.Set("PhysicalMemoryMode", "GCThresholds");
-            mc = new MemoryCache("MyCache", config);
-            Assert.Equal(10, mc.PhysicalMemoryLimit);
-
-            config.Set("PhysicalMemoryMode", "Default:" + ((long)0x50000000).ToString()); // A value known to result in 97% physical memory limit
             mc = new MemoryCache("MyCache", config);
             Assert.Equal(10, mc.PhysicalMemoryLimit);
         }


### PR DESCRIPTION
This pull request introduces a new configuration option to the .NET `System.Runtime.Caching` library, allowing users to control how physical memory usage is monitored and managed by the cache. The main enhancement is the addition of a `physicalMemoryMode` setting, which supports multiple monitoring strategies for different platforms and scenarios. The changes include updates to configuration files, new enum definitions, logic to parse and apply the new setting, and supporting code for Unix and Windows implementations.

Key changes:

**Configuration Enhancements:**
* Added a new `physicalMemoryMode` configuration property to `MemoryCacheElement`, allowing users to select between "Legacy", "Standard", and "GCThresholds" modes for physical memory monitoring. This property is now parsed and stored in cache configuration.
* Updated sample configuration XML to demonstrate usage of the new `physicalMemoryMode` option for different named caches.

**Code Infrastructure and Parsing:**
* Introduced the `PhysicalMemoryMode` enum and integrated it into configuration parsing and validation logic. Added utility methods for parsing and handling the new enum value from configuration.
* Extended the `ConfigUtil` class with methods for retrieving string values and parsing the `PhysicalMemoryMode` enum from configuration.

**Platform-Specific Monitoring Logic:**
* Added a new file, `MemoryMonitor.Unix.cs`,which corrects our previously incorrect initializing of total physical memory information for Unix platforms using `GC.GetGCMemoryInfo()`.
* Refactored Unix and Windows implementations of `PhysicalMemoryMonitor` to support the new memory monitoring modes, including splitting out legacy pressure calculation methods. Essentially, bringing the windows implementation in line with the new platform-agnostic way our non-windows code was working. (This is the new `Standard` mode that no longer relies on Windows-specific API's - and it also removes an unnecessary/ephemeral call to GC Collect.)

These changes provide more flexibility and control over how the caching system responds to memory pressure, improving adaptability for different environments and workloads.

The **big** difference is the introduction of the `GCThresholds` mode. `GCThresholds` mode uses the garbage collector's own high memory load threshold (`GCMemoryInfo.HighMemoryLoadThresholdBytes`) as the upper limit for cache memory pressure calculations, rather than a percentage of total available physical memory like Legacy and Standard modes. While Legacy and Standard modes are nearly identical in concept—both monitor memory load as a percentage of total available physical memory (with Legacy using platform-specific detection on older frameworks and Standard using `GC.GetGCMemoryInfo()` without inducing collections)—`GCThresholds` fundamentally changes the reference point by aligning the cache's memory pressure monitoring with the GC's internal threshold for high memory conditions. This means the cache will trim entries based on when the GC itself considers memory to be critically high (typically around 90% of available memory), making the cache behavior more responsive to actual GC pressure rather than an arbitrary percentage of physical RAM, and ensuring the cache doesn't hold onto entries when the GC is already struggling with memory.