### PR TITLE
Escape dashes in RegexCharClass.DescribeSet

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -2135,6 +2135,7 @@ namespace System.Text.RegularExpressions
                 '\f' => "\\f",
                 '\n' => "\\n",
                 '\\' => "\\\\",
+                '-'  => "\\-",
                 >= ' ' and <= '~' => ch.ToString(),
                 _ => $"\\u{(uint)ch:X4}"
             };

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexCharClassTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexCharClassTests.cs
@@ -28,6 +28,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"[\p{IsGreek}]", @"[\u0370-\u03FF]")]
         [InlineData(@"[\0-ad-\uFFFF]", @"[^bc]")]
         [InlineData(@"[\0-ad-\uFFFF-[a-d]]", @"[\0-ad-\uFFFF-[a-d]]")]
+        [InlineData(@"[- _,|]", @"[ ,\-_|]")]
         public void DescribeSet(string set, string expected)
         {
             RegexNode setNode = RegexParser.Parse($"{set}", RegexOptions.None, CultureInfo.InvariantCulture).Root.Child(0);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/117637.