### PR TITLE
Print specific error when framework in runtimeconfig.json is missing a version

### DIFF
--- a/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.Extensions.DependencyModel;
@@ -325,12 +326,50 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             }
 
             command.EnableTracingAndCaptureOutputs()
-                .MultilevelLookup(false)
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining($"The library '{Binaries.HostPolicy.FileName}' required to execute the application was not found")
                 .And.HaveStdErrContaining("Failed to run as a self-contained app")
                 .And.HaveStdErrContaining($"'{app.RuntimeConfigJson}' did not specify a framework");
+        }
+
+        [Fact]
+        public void MissingFrameworkName()
+        {
+            TestApp app = sharedTestState.MockApp.Copy();
+
+            // Create a runtimeconfig.json with a framework that has no name property
+            var framework = new RuntimeConfig.Framework(null, TestContext.MicrosoftNETCoreAppVersion);
+            new RuntimeConfig(app.RuntimeConfigJson)
+                .WithFramework(framework)
+                .Save();
+
+            Command.Create(app.AppExe)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdErrContaining($"No framework name specified: {framework.ToJson().ToJsonString(new JsonSerializerOptions { WriteIndented = false })}")
+                .And.HaveStdErrContaining($"Invalid runtimeconfig.json [{app.RuntimeConfigJson}]");
+        }
+
+        [Fact]
+        public void MissingFrameworkVersion()
+        {
+            TestApp app = sharedTestState.MockApp.Copy();
+
+            // Create a runtimeconfig.json with a framework that has no version property
+            new RuntimeConfig(app.RuntimeConfigJson)
+                .WithFramework(Constants.MicrosoftNETCoreApp, null)
+                .Save();
+
+            Command.Create(app.AppExe)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdErrContaining($"Framework '{Constants.MicrosoftNETCoreApp}' is missing a version")
+                .And.HaveStdErrContaining($"Invalid runtimeconfig.json [{app.RuntimeConfigJson}]");
         }
 
         [Theory]

--- a/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public AndConstraint<CommandResultAssertions> HaveStdOutContaining(string pattern)
         {
-            CurrentAssertionChain.ForCondition(Result.StdOut.Contains(pattern))
+            CurrentAssertionChain.ForCondition(!string.IsNullOrEmpty(Result.StdOut) && Result.StdOut.Contains(pattern))
                 .FailWith($"The command output did not contain expected result: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public AndConstraint<CommandResultAssertions> HaveStdErrContaining(string pattern)
         {
-            CurrentAssertionChain.ForCondition(Result.StdErr.Contains(pattern))
+            CurrentAssertionChain.ForCondition(!string.IsNullOrEmpty(Result.StdErr) && Result.StdErr.Contains(pattern))
                 .FailWith($"The command error output did not contain expected result: '{pattern}'{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }

--- a/src/installer/tests/TestUtils/RuntimeConfig.cs
+++ b/src/installer/tests/TestUtils/RuntimeConfig.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 return this;
             }
 
-            internal JsonObject ToJson()
+            public JsonObject ToJson()
             {
                 JsonObject frameworkReference = new();
 

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -623,7 +623,12 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_frameworks_for_runtime_confi
     const runtime_config_t::settings_t override_settings;
     app->parse_runtime_config(runtime_config, _X(""), override_settings);
 
-    const runtime_config_t app_config = app->get_runtime_config();
+    const runtime_config_t& app_config = app->get_runtime_config();
+    if (!app_config.is_valid())
+    {
+        trace::error(_X("Invalid runtimeconfig.json [%s]"), app_config.get_path().c_str());
+        return StatusCode::InvalidConfigFile;
+    }
 
     // Resolve frameworks for framework-dependent apps.
     // Self-contained apps assume the framework is next to the app, so we just treat it as success.

--- a/src/native/corehost/runtime_config.cpp
+++ b/src/native/corehost/runtime_config.cpp
@@ -249,22 +249,34 @@ bool runtime_config_t::parse_framework(const json_parser_t::value_t& fx_obj, fx_
     }
 
     const auto& fx_name = fx_obj.FindMember(_X("name"));
-    if (fx_name != fx_obj.MemberEnd())
+    if (fx_name == fx_obj.MemberEnd())
     {
-        fx_out.set_fx_name(fx_name->value.GetString());
+        using string_buffer_t = rapidjson::GenericStringBuffer<json_parser_t::internal_encoding_type_t>;
+        string_buffer_t sb;
+        rapidjson::Writer<string_buffer_t, json_parser_t::internal_encoding_type_t,
+            json_parser_t::internal_encoding_type_t> writer{sb};
+        fx_obj.Accept(writer);
+
+        trace::error(_X("No framework name specified: %s"), sb.GetString());
+        return false;
     }
 
-    const auto& fx_ver = fx_obj.FindMember(_X("version"));
-    if (fx_ver != fx_obj.MemberEnd())
-    {
-        fx_out.set_fx_version(fx_ver->value.GetString());
+    fx_out.set_fx_name(fx_name->value.GetString());
 
-        // Release version should prefer release versions, unless the rollForwardToPrerelease is set
-        // in which case no preference should be applied.
-        if (!name_and_version_only && !fx_out.get_fx_version_number().is_prerelease() && !m_roll_forward_to_prerelease)
-        {
-            fx_out.set_prefer_release(true);
-        }
+    const auto& fx_ver = fx_obj.FindMember(_X("version"));
+    if (fx_ver == fx_obj.MemberEnd())
+    {
+        trace::error(_X("Framework '%s' is missing a version."), fx_out.get_fx_name().c_str());
+        return false;
+    }
+
+    fx_out.set_fx_version(fx_ver->value.GetString());
+
+    // Release version should prefer release versions, unless the rollForwardToPrerelease is set
+    // in which case no preference should be applied.
+    if (!name_and_version_only && !fx_out.get_fx_version_number().is_prerelease() && !m_roll_forward_to_prerelease)
+    {
+        fx_out.set_prefer_release(true);
     }
 
     if (name_and_version_only)
@@ -359,23 +371,11 @@ bool runtime_config_t::ensure_dev_config_parsed()
 
 bool runtime_config_t::read_framework_array(const json_parser_t::value_t& frameworks_json, fx_reference_vector_t& frameworks_out, bool name_and_version_only)
 {
-    bool rc = true;
-
     for (const auto& fx_json : frameworks_json.GetArray())
     {
         fx_reference_t fx_out;
-        rc = parse_framework(fx_json, fx_out, name_and_version_only);
-        if (!rc)
-        {
-            break;
-        }
-
-        if (fx_out.get_fx_name().length() == 0)
-        {
-            trace::verbose(_X("No framework name specified."));
-            rc = false;
-            break;
-        }
+        if (!parse_framework(fx_json, fx_out, name_and_version_only))
+            return false;
 
         if (std::find_if(
                 frameworks_out.begin(),
@@ -384,14 +384,13 @@ bool runtime_config_t::read_framework_array(const json_parser_t::value_t& framew
             != frameworks_out.end())
         {
             trace::verbose(_X("Framework %s already specified."), fx_out.get_fx_name().c_str());
-            rc = false;
-            break;
+            return false;
         }
 
         frameworks_out.push_back(fx_out);
     }
 
-    return rc;
+    return true;
 }
 
 bool runtime_config_t::ensure_parsed()

--- a/src/native/corehost/runtime_config.h
+++ b/src/native/corehost/runtime_config.h
@@ -79,8 +79,8 @@ private:
     // If set to true, all versions (including pre-release) are considered even if starting from a release framework reference.
     bool m_roll_forward_to_prerelease;
 
-    bool parse_framework(const json_parser_t::value_t& fx_obj, fx_reference_t& fx_out, bool name_and_version_only = false);
-    bool read_framework_array(const json_parser_t::value_t& frameworks, fx_reference_vector_t& frameworks_out, bool name_and_version_only = false);
+    bool parse_framework(const json_parser_t::value_t& fx_obj, bool name_and_version_only, fx_reference_t& fx_out);
+    bool read_framework_array(const json_parser_t::value_t& frameworks, bool name_and_version_only, fx_reference_vector_t& frameworks_out);
 
     bool mark_specified_setting(specified_setting setting);
 };


### PR DESCRIPTION
Error should now call out the invalid runtimeconfig.json (rather than just failing to find a matching version later):
```
Framework '<name>' is missing a version.
Invalid runtimeconfig.json [<path>]
```

Resolves #3743

cc @dotnet/appmodel @AaronRobinsonMSFT 