### PR TITLE
Fix printing subset help through msbuild

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -150,7 +150,7 @@ initDistroRid()
 
 showSubsetHelp()
 {
-  "$scriptroot/common/build.sh" "-restore" "-build" "/p:Subset=help" "/clp:nosummary /tl:false"
+  "$scriptroot/common/build.sh" "-restore" "-build" "/p:Subset=help" "/clp:nosummary" "/tl:false"
 }
 
 arguments=()


### PR DESCRIPTION
We need to quote the arguments separately otherwise msbuild just gets a single arg.

Fixes https://github.com/dotnet/runtime/issues/117920