### PR TITLE
Revert "Show specific error message for `dotnet <app_path>` where app_path is a non-dll/exe file that exists"

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
+++ b/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
@@ -69,41 +69,6 @@ namespace HostActivation.Tests
         }
 
         [Fact]
-        public void File_ExistsNoDirectorySeparator_RoutesToSDK()
-        {
-            // Create a file named "build" in the current directory to simulate a file that happens to match the name of a command
-            string buildFile = Path.Combine(sharedTestState.BaseDirectory.Location, "build");
-            File.WriteAllText(buildFile, string.Empty);
-
-            // Test that "dotnet build" still routes to SDK, not to the file
-            TestContext.BuiltDotNet.Exec("build")
-                .WorkingDirectory(sharedTestState.BaseDirectory.Location)
-                .EnableTracingAndCaptureOutputs()
-                .Execute()
-                .Should().Fail()
-                .And.HaveStdErrContaining("The command could not be loaded, possibly because:") // This is a generic error for when we can't tell what exactly the user intended to do
-                .And.HaveStdErrContaining("Resolving SDKs");
-        }
-
-        [Fact]
-        public void RelativePathToNonManagedFile_ShowsSpecificError()
-        {
-            // Test relative path with directory separator
-            Directory.CreateDirectory(Path.Combine(sharedTestState.BaseDirectory.Location, "subdir"));
-            string testFile = Path.Combine(sharedTestState.BaseDirectory.Location, "subdir", "test.json");
-            File.WriteAllText(testFile, "{}");
-
-            string relativePath = Path.GetRelativePath(sharedTestState.BaseDirectory.Location, testFile);
-            TestContext.BuiltDotNet.Exec(relativePath)
-                .WorkingDirectory(sharedTestState.BaseDirectory.Location)
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute()
-                .Should().Fail()
-                .And.HaveStdErrContaining($"The application '{relativePath}' is not a managed .dll.");
-        }
-
-        [Fact]
         public void InvalidFileOrCommand_NoSDK_ListsPossibleIssues()
         {
             string fileName = "NonExistent";

--- a/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute()
                 .Should().Fail()
-                .And.HaveStdErrContaining($"The application '{appOtherExt}' is not a managed .dll.");
+                .And.HaveStdErrContaining($"The application '{appOtherExt}' does not exist or is not a managed .dll or .exe");
         }
 
         [Fact]

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -164,17 +164,6 @@ namespace
                 trace::verbose(_X("Application '%s' is not a managed executable."), app_candidate.c_str());
                 if (!exec_mode)
                 {
-                    // Check if this is a non-managed file with directory separator that exists
-                    // This should show a specific error instead of routing to CLI
-                    bool has_dir_separator = app_candidate.find(DIR_SEPARATOR) != pal::string_t::npos;
-                    if (has_dir_separator)
-                    {
-                        if (pal::file_exists(app_candidate))
-                        {
-                            trace::error(_X("The application '%s' is not a managed .dll."), app_candidate.c_str());
-                            return StatusCode::InvalidArgFailure;
-                        }
-                    }
                     // Route to CLI.
                     return StatusCode::AppArgNotRunnable;
                 }


### PR DESCRIPTION
Reverts dotnet/runtime#116940

See https://github.com/dotnet/runtime/pull/116940#discussion_r2223018858