### PR TITLE
Permit `ByRefLike` types with ctor to be activated.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3974,6 +3974,11 @@ namespace System
                 throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, this));
             }
 
+            if (IsByRefLike)
+            {
+                throw new NotSupportedException(SR.NotSupported_ByRefLike);
+            }
+
             // Compat: allocation always takes place outside the try block so that OOMs
             // bubble up to the caller; the ctor invocation is within the try block so
             // that it can be wrapped in TIE if needed.
@@ -4001,6 +4006,11 @@ namespace System
             if (!cache.CtorIsPublic)
             {
                 throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, this));
+            }
+
+            if (IsByRefLike)
+            {
+                throw new NotSupportedException(SR.NotSupported_ByRefLike);
             }
 
             // We reuse ActivatorCache here to ensure that we aren't always creating two entries in the cache.

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -4001,16 +4001,13 @@ namespace System
         [DebuggerHidden]
         internal object? CreateInstanceOfT()
         {
+            Debug.Assert(!IsValueType);
+
             ActivatorCache cache = GetOrCreateCacheEntry<ActivatorCache>();
 
             if (!cache.CtorIsPublic)
             {
                 throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, this));
-            }
-
-            if (IsByRefLike)
-            {
-                throw new NotSupportedException(SR.NotSupported_ByRefLike);
             }
 
             // We reuse ActivatorCache here to ensure that we aren't always creating two entries in the cache.

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -1748,9 +1748,8 @@ extern "C" void QCALLTYPE ReflectionSerialization_GetCreateUninitializedObjectIn
 
     TypeHandle type = pType.AsTypeHandle();
 
-    // Ref structs can't be boxed (allocated as an uninitialized object).
-    bool allowRefLike = false;
-    ValidateTypeAbleToBeInstantiated(type, allowRefLike, true /* fForGetUninitializedInstance */);
+    // ByRefLike types can't be boxed (allocated as an uninitialized object).
+    ValidateTypeAbleToBeInstantiated(type, false /* allowRefLike */, true /* fForGetUninitializedInstance */);
 
     MethodTable* pMT = type.AsMethodTable();
 
@@ -1923,9 +1922,8 @@ extern "C" void QCALLTYPE ReflectionInvocation_GetBoxInfo(
 
     TypeHandle type = pType.AsTypeHandle();
 
-    // Ref structs can't be boxed.
-    bool allowRefLike = false;
-    ValidateTypeAbleToBeInstantiated(type, allowRefLike, true /* fForGetUninitializedInstance */);
+    // ByRefLike types can't be boxed.
+    ValidateTypeAbleToBeInstantiated(type, false /* allowRefLike */, true /* fForGetUninitializedInstance */);
 
     MethodTable* pMT = type.AsMethodTable();
 

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -1475,11 +1475,13 @@ extern "C" void QCALLTYPE ReflectionInvocation_GetGuid(MethodTable* pMT, GUID* r
  * doesn't guarantee that a ctor will succeed, only that the VM is able
  * to support an instance of this type on the heap.
  * ==========
+ * The 'allowByRefLike' parameter controls whether the type should be validated as not ByRefLike.
  * The 'fForGetUninitializedInstance' parameter controls the type of
  * exception that is thrown if a check fails.
  */
-void RuntimeTypeHandle::ValidateTypeAbleToBeInstantiated(
+static void ValidateTypeAbleToBeInstantiated(
     TypeHandle typeHandle,
+    bool allowByRefLike,
     bool fGetUninitializedObject)
 {
     STANDARD_VM_CONTRACT;
@@ -1535,14 +1537,14 @@ void RuntimeTypeHandle::ValidateTypeAbleToBeInstantiated(
     }
 
     // Don't allow ref structs
-    if (pMT->IsByRefLike())
+    if (!allowByRefLike && pMT->IsByRefLike())
     {
         COMPlusThrow(kNotSupportedException, W("NotSupported_ByRefLike"));
     }
 }
 
 /*
- * Given a RuntimeType, queries info on how to instantiate the object.
+ * Given a RuntimeType, queries info on how to instantiate the type.
  * pRuntimeType - [required] the RuntimeType object
  * ppfnAllocator - [required, null-init] fnptr to the allocator
  *                 mgd sig: void* -> object
@@ -1593,7 +1595,7 @@ extern "C" void QCALLTYPE RuntimeTypeHandle_GetActivationInfo(
         typeHandle = ((REFLECTCLASSBASEREF)pRuntimeType.Get())->GetType();
     }
 
-    RuntimeTypeHandle::ValidateTypeAbleToBeInstantiated(typeHandle, false /* fGetUninitializedObject */);
+    ValidateTypeAbleToBeInstantiated(typeHandle, true /* allowByRefLike */, false /* fGetUninitializedObject */);
 
     MethodTable* pMT = typeHandle.AsMethodTable();
     _ASSERTE(pMT != NULL);
@@ -1746,7 +1748,9 @@ extern "C" void QCALLTYPE ReflectionSerialization_GetCreateUninitializedObjectIn
 
     TypeHandle type = pType.AsTypeHandle();
 
-    RuntimeTypeHandle::ValidateTypeAbleToBeInstantiated(type, true /* fForGetUninitializedInstance */);
+    // Ref structs can't be boxed (allocated as an uninitialized object).
+    bool allowRefLike = false;
+    ValidateTypeAbleToBeInstantiated(type, allowRefLike, true /* fForGetUninitializedInstance */);
 
     MethodTable* pMT = type.AsMethodTable();
 
@@ -1919,7 +1923,9 @@ extern "C" void QCALLTYPE ReflectionInvocation_GetBoxInfo(
 
     TypeHandle type = pType.AsTypeHandle();
 
-    RuntimeTypeHandle::ValidateTypeAbleToBeInstantiated(type, true /* fForGetUninitializedInstance */);
+    // Ref structs can't be boxed.
+    bool allowRefLike = false;
+    ValidateTypeAbleToBeInstantiated(type, allowRefLike, true /* fForGetUninitializedInstance */);
 
     MethodTable* pMT = type.AsMethodTable();
 

--- a/src/coreclr/vm/runtimehandles.h
+++ b/src/coreclr/vm/runtimehandles.h
@@ -130,10 +130,6 @@ public:
 
     static FCDECL1(MethodDesc *, GetFirstIntroducedMethod, ReflectClassBaseObject* pType);
     static FCDECL1(void, GetNextIntroducedMethod, MethodDesc **ppMethod);
-
-    // Helper methods not called by managed code
-
-    static void ValidateTypeAbleToBeInstantiated(TypeHandle typeHandle, bool fGetUninitializedObject);
 };
 
 extern "C" void QCALLTYPE RuntimeTypeHandle_GetRuntimeTypeFromHandleSlow(void* typeHandleRaw, QCall::ObjectHandleOnStack result);

--- a/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
@@ -145,7 +145,7 @@ namespace System
 
                 // Casting the above object to T is technically invalid because
                 // T can be ByRefLike (that is, ref struct). Roslyn blocks the
-                // cast this in function with a "CS0030: Cannot convert type 'object' to 'T'",
+                // cast in this function with a "CS0030: Cannot convert type 'object' to 'T'",
                 // which is correct. However, since we are doing the IsValueType
                 // check above, we know this code path will only be taken with
                 // reference types and therefore the below Unsafe.As<> is safe.

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ActivatorTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ActivatorTests.cs
@@ -343,6 +343,8 @@ namespace System.Tests
         [InlineData(typeof(RuntimeArgumentHandle))]
         [InlineData(typeof(Span<int>))]
         [InlineData(typeof(ReadOnlySpan<string>))]
+        [InlineData(typeof(RSNoCtor))]
+        [InlineData(typeof(RSCtor))]
         public void CreateInstance_BoxedByRefType_ThrowsNotSupportedException(Type type)
         {
             Assert.Throws<NotSupportedException>(() => Activator.CreateInstance(type));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ActivatorTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ActivatorTests.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.InteropServices;
 using System.Runtime.Remoting;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
@@ -92,6 +93,28 @@ namespace System.Tests
 
             TypeWithPrivateDefaultConstructor c2 = (TypeWithPrivateDefaultConstructor)Activator.CreateInstance(typeof(TypeWithPrivateDefaultConstructor), nonPublic: true);
             Assert.Equal(-1, c2.Property);
+        }
+
+        // Add attribute to avoid unused field warning
+        [StructLayout(LayoutKind.Sequential)]
+        ref struct RSNoCtor
+        {
+            public int Value;
+        }
+
+        ref struct RSCtor
+        {
+            public int Value;
+            public RSCtor() => Value = 10;
+        }
+
+        [Fact]
+        public void CreateInstance_ByRefTypeAsGenericParameter_Success()
+        {
+            Assert.Equal(0, Activator.CreateInstance<Span<int>>().Length);
+            Assert.Equal(0, Activator.CreateInstance<ReadOnlySpan<string>>().Length);
+            Assert.Equal(0, Activator.CreateInstance<RSNoCtor>().Value);
+            Assert.Equal(10, Activator.CreateInstance<RSCtor>().Value);
         }
 
         [Fact]
@@ -318,15 +341,11 @@ namespace System.Tests
         [Theory]
         [InlineData(typeof(TypedReference))]
         [InlineData(typeof(RuntimeArgumentHandle))]
+        [InlineData(typeof(Span<int>))]
+        [InlineData(typeof(ReadOnlySpan<string>))]
         public void CreateInstance_BoxedByRefType_ThrowsNotSupportedException(Type type)
         {
             Assert.Throws<NotSupportedException>(() => Activator.CreateInstance(type));
-        }
-
-        [Fact]
-        public void CreateInstance_Span_ThrowsNotSupportedException()
-        {
-            CreateInstance_BoxedByRefType_ThrowsNotSupportedException(typeof(Span<int>));
         }
 
         [Fact]


### PR DESCRIPTION
This was an oversight from #102636.
Added tests.

Fixes #117838 