### PR TITLE
Disable LargeUriAndHeaders_Works test on browser

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -2345,12 +2345,11 @@ namespace System.Net.Http.Functional.Tests
             Cookie
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
         public async Task LargeUriAndHeaders_Works()
         {
             int length =
                 IsWinHttpHandler ? 65_000 :
-                PlatformDetection.IsBrowser ? 4_000 :
                 10_000_000;
 
             string longPath = "/" + new string('X', length);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -2348,9 +2348,7 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
         public async Task LargeUriAndHeaders_Works()
         {
-            int length =
-                IsWinHttpHandler ? 65_000 :
-                10_000_000;
+            int length = IsWinHttpHandler ? 65_000 : 10_000_000;
 
             string longPath = "/" + new string('X', length);
             string longHeaderName = new string('Y', length);


### PR DESCRIPTION
Closes #117942

I added the test just to see if large Uris flow through the SocketsHttpHandler stack E2E, not that interesting for browser.