### PR TITLE
Expose UTF-8 support from FromHexString, TryToHexString, and TryToHexStringLower on the Convert class

### DIFF
--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -433,12 +433,12 @@ namespace System
 
             if (typeof(TChar) == typeof(byte))
             {
-                fallbackResult = TryDecodeFromUtf8_Scalar(Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(source), destination, out elementsProcessed);
+                fallbackResult = TryDecodeFromUtf8_Scalar(Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(source.Slice((int)offset)), destination.Slice((int)(offset / 2)), out elementsProcessed);
             }
             else
             {
                 Debug.Assert(typeof(TChar) == typeof(char));
-                fallbackResult = TryDecodeFromUtf16_Scalar(Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(source), destination, out elementsProcessed);
+                fallbackResult = TryDecodeFromUtf16_Scalar(Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(source.Slice((int)offset)), destination.Slice((int)(offset / 2)), out elementsProcessed);
             }
 
             elementsProcessed = (int)offset + elementsProcessed;

--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -3,8 +3,9 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Numerics;
+
 #if SYSTEM_PRIVATE_CORELIB
-using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
@@ -98,6 +99,7 @@ namespace System
         internal static (Vector128<byte>, Vector128<byte>) AsciiToHexVector128(Vector128<byte> src, Vector128<byte> hexMap)
         {
             Debug.Assert(Ssse3.IsSupported || AdvSimd.Arm64.IsSupported);
+
             // The algorithm is simple: a single srcVec (contains the whole 16b Guid) is converted
             // into nibbles and then, via hexMap, converted into a HEX representation via
             // Shuffle(nibbles, srcVec). ASCII is then expanded to UTF-16.
@@ -105,18 +107,20 @@ namespace System
             Vector128<byte> lowNibbles = Vector128.UnpackLow(shiftedSrc, src);
             Vector128<byte> highNibbles = Vector128.UnpackHigh(shiftedSrc, src);
 
-            return (Vector128.ShuffleNative(hexMap, lowNibbles & Vector128.Create((byte)0xF)),
-                Vector128.ShuffleNative(hexMap, highNibbles & Vector128.Create((byte)0xF)));
+            return (
+                Vector128.ShuffleNative(hexMap, lowNibbles & Vector128.Create((byte)0xF)),
+                Vector128.ShuffleNative(hexMap, highNibbles & Vector128.Create((byte)0xF))
+            );
         }
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-        private static void EncodeToUtf16_Vector128(ReadOnlySpan<byte> bytes, Span<char> chars, Casing casing)
+        private static void EncodeTo_Vector128<TChar>(ReadOnlySpan<byte> source, Span<TChar> destination, Casing casing)
         {
-            Debug.Assert(bytes.Length >= Vector128<int>.Count);
+            Debug.Assert(source.Length >= (Vector128<TChar>.Count / 2));
 
-            ref byte srcRef = ref MemoryMarshal.GetReference(bytes);
-            ref ushort destRef = ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(chars));
+            ref byte srcRef = ref MemoryMarshal.GetReference(source);
+            ref TChar destRef = ref MemoryMarshal.GetReference(destination);
 
             Vector128<byte> hexMap = casing == Casing.Upper ?
                 Vector128.Create((byte)'0', (byte)'1', (byte)'2', (byte)'3',
@@ -129,25 +133,41 @@ namespace System
                                  (byte)'c', (byte)'d', (byte)'e', (byte)'f');
 
             nuint pos = 0;
-            nuint lengthSubVector128 = (nuint)bytes.Length - (nuint)Vector128<int>.Count;
+            nuint lengthSubVector128 = (nuint)source.Length - (nuint)(Vector128<TChar>.Count / 2);
             do
             {
-                // This implementation processes 4 bytes of input at once, it can be easily modified
+                // This implementation processes 4 or 8 bytes of input at once, it can be easily modified
                 // to support 16 bytes at once, but that didn't demonstrate noticeable wins
                 // for Converter.ToHexString (around 8% faster for large inputs) so
                 // it focuses on small inputs instead.
 
-                uint i32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref srcRef, pos));
-                Vector128<byte> vec = Vector128.CreateScalar(i32).AsByte();
+                Vector128<byte> vec;
+
+                if (typeof(TChar) == typeof(byte))
+                {
+                    vec = Vector128.CreateScalar(Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref srcRef, pos))).AsByte();
+                }
+                else
+                {
+                    Debug.Assert(typeof(TChar) == typeof(ushort));
+                    vec = Vector128.CreateScalar(Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref srcRef, pos))).AsByte();
+                }
 
                 // JIT is expected to eliminate all unused calculations
                 (Vector128<byte> hexLow, _) = AsciiToHexVector128(vec, hexMap);
-                (Vector128<ushort> v0, _) = Vector128.Widen(hexLow);
 
-                v0.StoreUnsafe(ref destRef, pos * 2);
+                if (typeof(TChar) == typeof(byte))
+                {
+                    hexLow.As<byte, TChar>().StoreUnsafe(ref destRef, pos * 2);
+                }
+                else
+                {
+                    Debug.Assert(typeof(TChar) == typeof(ushort));
+                    Vector128.WidenLower(hexLow).As<ushort, TChar>().StoreUnsafe(ref destRef, pos * 2);
+                }
 
-                pos += (nuint)Vector128<int>.Count;
-                if (pos == (nuint)bytes.Length)
+                pos += (nuint)(Vector128<TChar>.Count / 2);
+                if (pos == (nuint)source.Length)
                 {
                     return;
                 }
@@ -162,27 +182,44 @@ namespace System
         }
 #endif
 
-        public static void EncodeToUtf16(ReadOnlySpan<byte> bytes, Span<char> chars, Casing casing = Casing.Upper)
+        public static void EncodeToUtf8(ReadOnlySpan<byte> source, Span<byte> utf8Destination, Casing casing = Casing.Upper)
         {
-            Debug.Assert(chars.Length >= bytes.Length * 2);
+            Debug.Assert(utf8Destination.Length >= (source.Length * 2));
 
 #if SYSTEM_PRIVATE_CORELIB
-            if ((AdvSimd.Arm64.IsSupported || Ssse3.IsSupported) && bytes.Length >= 4)
+            if ((AdvSimd.Arm64.IsSupported || Ssse3.IsSupported) && (source.Length >= (Vector128<byte>.Count / 2)))
             {
-                EncodeToUtf16_Vector128(bytes, chars, casing);
+                EncodeTo_Vector128(source, utf8Destination, casing);
                 return;
             }
 #endif
-            for (int pos = 0; pos < bytes.Length; pos++)
+            for (int pos = 0; pos < source.Length; pos++)
             {
-                ToCharsBuffer(bytes[pos], chars, pos * 2, casing);
+                ToBytesBuffer(source[pos], utf8Destination, pos * 2, casing);
+            }
+        }
+
+        public static void EncodeToUtf16(ReadOnlySpan<byte> source, Span<char> destination, Casing casing = Casing.Upper)
+        {
+            Debug.Assert(destination.Length >= (source.Length * 2));
+
+#if SYSTEM_PRIVATE_CORELIB
+            if ((AdvSimd.Arm64.IsSupported || Ssse3.IsSupported) && (source.Length >= (Vector128<ushort>.Count / 2)))
+            {
+                EncodeTo_Vector128(source, Unsafe.BitCast<Span<char>, Span<ushort>>(destination), casing);
+                return;
+            }
+#endif
+            for (int pos = 0; pos < source.Length; pos++)
+            {
+                ToCharsBuffer(source[pos], destination, pos * 2, casing);
             }
         }
 
         public static string ToString(ReadOnlySpan<byte> bytes, Casing casing = Casing.Upper)
         {
 #if NETFRAMEWORK || NETSTANDARD2_0
-            Span<char> result = bytes.Length > 16 ?
+            Span<char> result = (bytes.Length > 16) ?
                 new char[bytes.Length * 2].AsSpan() :
                 stackalloc char[bytes.Length * 2];
 
@@ -241,85 +278,126 @@ namespace System
             return (char)value;
         }
 
-        public static bool TryDecodeFromUtf16(ReadOnlySpan<char> chars, Span<byte> bytes, out int charsProcessed)
+        public static bool TryDecodeFromUtf8(ReadOnlySpan<byte> utf8Source, Span<byte> destination, out int bytesProcessed)
         {
 #if SYSTEM_PRIVATE_CORELIB
             if (BitConverter.IsLittleEndian && (Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) &&
-                chars.Length >= Vector128<ushort>.Count * 2)
+                (utf8Source.Length >= (Vector128<byte>.Count * 2)))
             {
-                return TryDecodeFromUtf16_Vector128(chars, bytes, out charsProcessed);
+                return TryDecodeFrom_Vector128(utf8Source, destination, out bytesProcessed);
             }
 #endif
-            return TryDecodeFromUtf16_Scalar(chars, bytes, out charsProcessed);
+            return TryDecodeFromUtf8_Scalar(utf8Source, destination, out bytesProcessed);
+        }
+
+        public static bool TryDecodeFromUtf16(ReadOnlySpan<char> source, Span<byte> destination, out int charsProcessed)
+        {
+#if SYSTEM_PRIVATE_CORELIB
+            if (BitConverter.IsLittleEndian && (Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) &&
+                (source.Length >= (Vector128<ushort>.Count * 2)))
+            {
+                return TryDecodeFrom_Vector128(Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<ushort>>(source), destination, out charsProcessed);
+            }
+#endif
+            return TryDecodeFromUtf16_Scalar(source, destination, out charsProcessed);
         }
 
 #if SYSTEM_PRIVATE_CORELIB
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        public static bool TryDecodeFromUtf16_Vector128(ReadOnlySpan<char> chars, Span<byte> bytes, out int charsProcessed)
+        public static bool TryDecodeFrom_Vector128<TChar>(ReadOnlySpan<TChar> source, Span<byte> destination, out int elementsProcessed)
         {
             Debug.Assert(Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported);
-            Debug.Assert(chars.Length <= bytes.Length * 2);
-            Debug.Assert(chars.Length % 2 == 0);
-            Debug.Assert(chars.Length >= Vector128<ushort>.Count * 2);
+            Debug.Assert(source.Length <= (destination.Length * 2));
+            Debug.Assert((source.Length % 2) == 0);
+            Debug.Assert(source.Length >= (Vector128<TChar>.Count * 2));
 
             nuint offset = 0;
-            nuint lengthSubTwoVector128 = (nuint)chars.Length - ((nuint)Vector128<ushort>.Count * 2);
+            nuint lengthSubTwoVector128 = (nuint)source.Length - ((nuint)Vector128<TChar>.Count * 2);
 
-            ref ushort srcRef = ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(chars));
-            ref byte destRef = ref MemoryMarshal.GetReference(bytes);
+            ref TChar srcRef = ref MemoryMarshal.GetReference(source);
+            ref byte destRef = ref MemoryMarshal.GetReference(destination);
 
             do
             {
                 // The algorithm is UTF8 so we'll be loading two UTF-16 vectors to narrow them into a
                 // single UTF8 ASCII vector - the implementation can be shared with UTF8 paths.
-                Vector128<ushort> vec1 = Vector128.LoadUnsafe(ref srcRef, offset);
-                Vector128<ushort> vec2 = Vector128.LoadUnsafe(ref srcRef, offset + (nuint)Vector128<ushort>.Count);
-                Vector128<byte> vec = Ascii.ExtractAsciiVector(vec1, vec2);
+                Vector128<byte> vec;
+
+                if (typeof(TChar) == typeof(byte))
+                {
+                    vec = Vector128.LoadUnsafe(ref srcRef, offset).AsByte();
+
+                    if (!Utf8Utility.AllBytesInVector128AreAscii(vec))
+                    {
+                        // Input is non-ASCII
+                        break;
+                    }
+                }
+                else
+                {
+                    Debug.Assert(typeof(TChar) == typeof(ushort));
+
+                    Vector128<ushort> vec1 = Vector128.LoadUnsafe(ref srcRef, offset).AsUInt16();
+                    Vector128<ushort> vec2 = Vector128.LoadUnsafe(ref srcRef, offset + (nuint)Vector128<ushort>.Count).AsUInt16();
+
+                    vec = Ascii.ExtractAsciiVector(vec1, vec2);
+
+                    if (!Utf16Utility.AllCharsInVectorAreAscii(vec1 | vec2))
+                    {
+                        // Input is non-ASCII
+                        break;
+                    }
+                }
 
                 // Based on "Algorithm #3" https://github.com/WojciechMula/toys/blob/master/simd-parse-hex/geoff_algorithm.cpp
                 // by Geoff Langdale and Wojciech Mula
                 // Move digits '0'..'9' into range 0xf6..0xff.
-                Vector128<byte> t1 = vec + Vector128.Create((byte)(0xFF - '9'));
+                Vector128<byte> t1 = vec + Vector128.Create<byte>(0xFF - '9');
+
                 // And then correct the range to 0xf0..0xf9.
                 // All other bytes become less than 0xf0.
-                Vector128<byte> t2 = Vector128.SubtractSaturate(t1, Vector128.Create((byte)6));
+                Vector128<byte> t2 = Vector128.SubtractSaturate(t1, Vector128.Create<byte>(6));
+
                 // Convert into uppercase 'a'..'f' => 'A'..'F' and
                 // move hex letter 'A'..'F' into range 0..5.
-                Vector128<byte> t3 = (vec & Vector128.Create((byte)0xDF)) - Vector128.Create((byte)'A');
+                Vector128<byte> t3 = (vec & Vector128.Create<byte>(0xDF)) - Vector128.Create((byte)'A');
+
                 // And correct the range into 10..15.
                 // The non-hex letters bytes become greater than 0x0f.
-                Vector128<byte> t4 = Vector128.AddSaturate(t3, Vector128.Create((byte)10));
+                Vector128<byte> t4 = Vector128.AddSaturate(t3, Vector128.Create<byte>(10));
+
                 // Convert '0'..'9' into nibbles 0..9. Non-digit bytes become
                 // greater than 0x0f. Finally choose the result: either valid nibble (0..9/10..15)
                 // or some byte greater than 0x0f.
-                Vector128<byte> nibbles = Vector128.Min(t2 - Vector128.Create((byte)0xF0), t4);
+                Vector128<byte> nibbles = Vector128.Min(t2 - Vector128.Create<byte>(0xF0), t4);
+
                 // Any high bit is a sign that input is not a valid hex data
-                if (!Utf16Utility.AllCharsInVectorAreAscii(vec1 | vec2) ||
-                    Vector128.AddSaturate(nibbles, Vector128.Create((byte)(127 - 15))).ExtractMostSignificantBits() != 0)
+                if (Vector128.AddSaturate(nibbles, Vector128.Create<byte>(127 - 15)).ExtractMostSignificantBits() != 0)
                 {
-                    // Input is either non-ASCII or invalid hex data
+                    // Input is invalid hex data
                     break;
                 }
+
                 Vector128<byte> output;
                 if (Ssse3.IsSupported)
                 {
-                    output = Ssse3.MultiplyAddAdjacent(nibbles,
-                        Vector128.Create((short)0x0110).AsSByte()).AsByte();
+                    output = Ssse3.MultiplyAddAdjacent(nibbles, Vector128.Create<short>(0x0110).AsSByte()).AsByte();
                 }
                 else if (AdvSimd.Arm64.IsSupported)
                 {
                     // Workaround for missing MultiplyAddAdjacent on ARM
                     Vector128<short> even = AdvSimd.Arm64.TransposeEven(nibbles, Vector128<byte>.Zero).AsInt16();
                     Vector128<short> odd = AdvSimd.Arm64.TransposeOdd(nibbles, Vector128<byte>.Zero).AsInt16();
+
                     even = AdvSimd.ShiftLeftLogical(even, 4).AsInt16();
                     output = AdvSimd.AddSaturate(even, odd).AsByte();
                 }
                 else if (PackedSimd.IsSupported)
                 {
                     Vector128<byte> shiftedNibbles = PackedSimd.ShiftLeft(nibbles, 4);
-                    Vector128<byte> zipped = PackedSimd.BitwiseSelect(nibbles, shiftedNibbles, Vector128.Create((ushort)0xFF00).AsByte());
+                    Vector128<byte> zipped = PackedSimd.BitwiseSelect(nibbles, shiftedNibbles, Vector128.Create<ushort>(0xFF00).AsByte());
                     output = PackedSimd.AddPairwiseWidening(zipped).AsByte();
                 }
                 else
@@ -328,17 +406,20 @@ namespace System
                     ThrowHelper.ThrowUnreachableException();
                     output = default;
                 }
+
                 // Accumulate output in lower INT64 half and take care about endianness
                 output = Vector128.Shuffle(output, Vector128.Create((byte)0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0));
+
                 // Store 8 bytes in dest by given offset
                 Unsafe.WriteUnaligned(ref Unsafe.Add(ref destRef, offset / 2), output.AsUInt64().ToScalar());
 
-                offset += (nuint)Vector128<ushort>.Count * 2;
-                if (offset == (nuint)chars.Length)
+                offset += (nuint)Vector128<byte>.Count;
+                if (offset == (nuint)source.Length)
                 {
-                    charsProcessed = chars.Length;
+                    elementsProcessed = source.Length;
                     return true;
                 }
+
                 // Overlap with the current chunk for trailing elements
                 if (offset > lengthSubTwoVector128)
                 {
@@ -348,37 +429,88 @@ namespace System
             while (true);
 
             // Fall back to the scalar routine in case of invalid input.
-            bool fallbackResult = TryDecodeFromUtf16_Scalar(chars.Slice((int)offset), bytes.Slice((int)(offset / 2)), out int fallbackProcessed);
-            charsProcessed = (int)offset + fallbackProcessed;
+            bool fallbackResult;
+
+            if (typeof(TChar) == typeof(byte))
+            {
+                fallbackResult = TryDecodeFromUtf8_Scalar(Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(source), destination, out elementsProcessed);
+            }
+            else
+            {
+                Debug.Assert(typeof(TChar) == typeof(char));
+                fallbackResult = TryDecodeFromUtf16_Scalar(Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(source), destination, out elementsProcessed);
+            }
+
+            elementsProcessed = (int)offset + elementsProcessed;
             return fallbackResult;
         }
 #endif
 
-        private static bool TryDecodeFromUtf16_Scalar(ReadOnlySpan<char> chars, Span<byte> bytes, out int charsProcessed)
+        private static bool TryDecodeFromUtf8_Scalar(ReadOnlySpan<byte> utf8Source, Span<byte> destination, out int bytesProcessed)
         {
-            Debug.Assert(chars.Length % 2 == 0, "Un-even number of characters provided");
-            Debug.Assert(chars.Length / 2 == bytes.Length, "Target buffer not right-sized for provided characters");
+            Debug.Assert((utf8Source.Length % 2) == 0, "Un-even number of characters provided");
+            Debug.Assert((utf8Source.Length / 2) == destination.Length, "Target buffer not right-sized for provided characters");
 
             int i = 0;
             int j = 0;
             int byteLo = 0;
             int byteHi = 0;
-            while (j < bytes.Length)
+
+            while (j < destination.Length)
             {
-                byteLo = FromChar(chars[i + 1]);
-                byteHi = FromChar(chars[i]);
+                byteLo = FromChar(utf8Source[i + 1]);
+                byteHi = FromChar(utf8Source[i]);
 
                 // byteHi hasn't been shifted to the high half yet, so the only way the bitwise or produces this pattern
                 // is if either byteHi or byteLo was not a hex character.
                 if ((byteLo | byteHi) == 0xFF)
+                {
                     break;
+                }
 
-                bytes[j++] = (byte)((byteHi << 4) | byteLo);
+                destination[j++] = (byte)((byteHi << 4) | byteLo);
                 i += 2;
             }
 
             if (byteLo == 0xFF)
+            {
                 i++;
+            }
+
+            bytesProcessed = i;
+            return (byteLo | byteHi) != 0xFF;
+        }
+
+        private static bool TryDecodeFromUtf16_Scalar(ReadOnlySpan<char> source, Span<byte> destination, out int charsProcessed)
+        {
+            Debug.Assert((source.Length % 2) == 0, "Un-even number of characters provided");
+            Debug.Assert((source.Length / 2) == destination.Length, "Target buffer not right-sized for provided characters");
+
+            int i = 0;
+            int j = 0;
+            int byteLo = 0;
+            int byteHi = 0;
+
+            while (j < destination.Length)
+            {
+                byteLo = FromChar(source[i + 1]);
+                byteHi = FromChar(source[i]);
+
+                // byteHi hasn't been shifted to the high half yet, so the only way the bitwise or produces this pattern
+                // is if either byteHi or byteLo was not a hex character.
+                if ((byteLo | byteHi) == 0xFF)
+                {
+                    break;
+                }
+
+                destination[j++] = (byte)((byteHi << 4) | byteLo);
+                i += 2;
+            }
+
+            if (byteLo == 0xFF)
+            {
+                i++;
+            }
 
             charsProcessed = i;
             return (byteLo | byteHi) != 0xFF;
@@ -387,23 +519,27 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int FromChar(int c)
         {
-            return c >= CharToHexLookup.Length ? 0xFF : CharToHexLookup[c];
+            return (c >= CharToHexLookup.Length) ? 0xFF : CharToHexLookup[c];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int FromUpperChar(int c)
         {
-            return c > 71 ? 0xFF : CharToHexLookup[c];
+            return (c > 71) ? 0xFF : CharToHexLookup[c];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int FromLowerChar(int c)
         {
-            if ((uint)(c - '0') <= '9' - '0')
+            if ((uint)(c - '0') <= ('9' - '0'))
+            {
                 return c - '0';
+            }
 
-            if ((uint)(c - 'a') <= 'f' - 'a')
+            if ((uint)(c - 'a') <= ('f' - 'a'))
+            {
                 return c - 'a' + 10;
+            }
 
             return 0xFF;
         }
@@ -442,13 +578,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsHexUpperChar(int c)
         {
-            return (uint)(c - '0') <= 9 || (uint)(c - 'A') <= ('F' - 'A');
+            return ((uint)(c - '0') <= 9) || ((uint)(c - 'A') <= ('F' - 'A'));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsHexLowerChar(int c)
         {
-            return (uint)(c - '0') <= 9 || (uint)(c - 'a') <= ('f' - 'a');
+            return ((uint)(c - '0') <= 9) || ((uint)(c - 'a') <= ('f' - 'a'));
         }
 
         /// <summary>Map from an ASCII char to its hex value, e.g. arr['b'] == 11. 0xFF means it's not a hex digit.</summary>

--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -437,7 +437,7 @@ namespace System
             }
             else
             {
-                Debug.Assert(typeof(TChar) == typeof(char));
+                Debug.Assert(typeof(TChar) == typeof(ushort));
                 fallbackResult = TryDecodeFromUtf16_Scalar(Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(source.Slice((int)offset)), destination.Slice((int)(offset / 2)), out elementsProcessed);
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -2915,9 +2915,7 @@ namespace System
             return (usefulInputLength / 4) * 3 + padding;
         }
 
-        /// <summary>
-        /// Converts the specified string, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer array.
-        /// </summary>
+        /// <summary>Converts the specified string, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer array.</summary>
         /// <param name="s">The string to convert.</param>
         /// <returns>An array of 8-bit unsigned integers that is equivalent to <paramref name="s"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="s"/> is <code>null</code>.</exception>
@@ -2925,17 +2923,14 @@ namespace System
         /// <exception cref="FormatException">The format of <paramref name="s"/> is invalid. <paramref name="s"/> contains a non-hex character.</exception>
         public static byte[] FromHexString(string s)
         {
-            if (s == null)
+            if (s is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             }
-
             return FromHexString(s.AsSpan());
         }
 
-        /// <summary>
-        /// Converts the span, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer array.
-        /// </summary>
+        /// <summary>Converts the span, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer array.</summary>
         /// <param name="chars">The span to convert.</param>
         /// <returns>An array of 8-bit unsigned integers that is equivalent to <paramref name="chars"/>.</returns>
         /// <exception cref="FormatException">The length of <paramref name="chars"/>, is not zero or a multiple of 2.</exception>
@@ -2943,21 +2938,51 @@ namespace System
         public static byte[] FromHexString(ReadOnlySpan<char> chars)
         {
             if (chars.Length == 0)
-                return Array.Empty<byte>();
-            if ((uint)chars.Length % 2 != 0)
-                throw new FormatException(SR.Format_BadHexLength);
+            {
+                return [];
+            }
 
-            byte[] result = GC.AllocateUninitializedArray<byte>(chars.Length >> 1);
+            if (!int.IsEvenInteger(chars.Length))
+            {
+                ThrowHelper.ThrowFormatException_BadHexLength();
+            }
+
+            byte[] result = GC.AllocateUninitializedArray<byte>(chars.Length / 2);
 
             if (!HexConverter.TryDecodeFromUtf16(chars, result, out _))
-                throw new FormatException(SR.Format_BadHexChar);
-
+            {
+                ThrowHelper.ThrowFormatException_BadHexChar();
+            }
             return result;
         }
 
-        /// <summary>
-        /// Converts the string, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer span.
-        /// </summary>
+        /// <summary>Converts the span, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer array.</summary>
+        /// <param name="utf8Source">The UTF-8 span to convert.</param>
+        /// <returns>An array of 8-bit unsigned integers that is equivalent to <paramref name="utf8Source"/>.</returns>
+        /// <exception cref="FormatException">The length of <paramref name="utf8Source"/>, is not zero or a multiple of 2.</exception>
+        /// <exception cref="FormatException">The format of <paramref name="utf8Source"/> is invalid. <paramref name="utf8Source"/> contains a non-hex character.</exception>
+        public static byte[] FromHexString(ReadOnlySpan<byte> utf8Source)
+        {
+            if (utf8Source.Length == 0)
+            {
+                return [];
+            }
+
+            if (!int.IsEvenInteger(utf8Source.Length))
+            {
+                ThrowHelper.ThrowFormatException_BadHexLength();
+            }
+
+            byte[] result = GC.AllocateUninitializedArray<byte>(utf8Source.Length / 2);
+
+            if (!HexConverter.TryDecodeFromUtf8(utf8Source, result, out _))
+            {
+                ThrowHelper.ThrowFormatException_BadHexChar();
+            }
+            return result;
+        }
+
+        /// <summary>Converts the string, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer span.</summary>
         /// <param name="source">The string to convert.</param>
         /// <param name="destination">
         /// The span in which to write the converted 8-bit unsigned integers. When this method returns value different than <see cref="OperationStatus.Done"/>,
@@ -2971,13 +2996,10 @@ namespace System
         public static OperationStatus FromHexString(string source, Span<byte> destination, out int charsConsumed, out int bytesWritten)
         {
             ArgumentNullException.ThrowIfNull(source);
-
             return FromHexString(source.AsSpan(), destination, out charsConsumed, out bytesWritten);
         }
 
-        /// <summary>
-        /// Converts the span of chars, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer span.
-        /// </summary>
+        /// <summary>Converts the span of chars, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer span.</summary>
         /// <param name="source">The span to convert.</param>
         /// <param name="destination">
         /// The span in which to write the converted 8-bit unsigned integers. When this method returns value different than <see cref="OperationStatus.Done"/>,
@@ -2996,7 +3018,7 @@ namespace System
                 charsConsumed = 0;
                 bytesWritten = 0;
 
-                return remainder == 1 ? OperationStatus.NeedMoreData : OperationStatus.Done;
+                return (remainder == 1) ? OperationStatus.NeedMoreData : OperationStatus.Done;
             }
 
             OperationStatus result;
@@ -3033,9 +3055,63 @@ namespace System
             return result;
         }
 
-        /// <summary>
-        /// Converts an array of 8-bit unsigned integers to its equivalent string representation that is encoded with uppercase hex characters.
-        /// </summary>
+        /// <summary>Converts the span of UTF-8 chars, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer span.</summary>
+        /// <param name="utf8Source">The span to convert.</param>
+        /// <param name="destination">
+        /// The span in which to write the converted 8-bit unsigned integers. When this method returns value different than <see cref="OperationStatus.Done"/>,
+        /// either the span remains unmodified or contains an incomplete conversion of <paramref name="utf8Source"/>,
+        /// up to the last valid character.
+        /// </param>
+        /// <param name="bytesWritten">When this method returns, contains the number of bytes that were written to <paramref name="destination"/>.</param>
+        /// <param name="bytesConsumed">When this method returns, contains the number of bytes that were consumed from <paramref name="utf8Source"/>.</param>
+        /// <returns>An <see cref="OperationStatus"/> describing the result of the operation.</returns>
+        public static OperationStatus FromHexString(ReadOnlySpan<byte> utf8Source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+        {
+            (int quotient, int remainder) = Math.DivRem(utf8Source.Length, 2);
+
+            if (quotient == 0)
+            {
+                bytesConsumed = 0;
+                bytesWritten = 0;
+
+                return (remainder == 1) ? OperationStatus.NeedMoreData : OperationStatus.Done;
+            }
+
+            OperationStatus result;
+
+            if (destination.Length < quotient)
+            {
+                utf8Source = utf8Source.Slice(0, destination.Length * 2);
+                quotient = destination.Length;
+                result = OperationStatus.DestinationTooSmall;
+            }
+            else
+            {
+                if (remainder == 1)
+                {
+                    utf8Source = utf8Source.Slice(0, utf8Source.Length - 1);
+                    result = OperationStatus.NeedMoreData;
+                }
+                else
+                {
+                    result = OperationStatus.Done;
+                }
+
+                destination = destination.Slice(0, quotient);
+            }
+
+            if (!HexConverter.TryDecodeFromUtf8(utf8Source, destination, out bytesConsumed))
+            {
+                bytesWritten = bytesConsumed / 2;
+                return OperationStatus.InvalidData;
+            }
+
+            bytesWritten = quotient;
+            bytesConsumed = utf8Source.Length;
+            return result;
+        }
+
+        /// <summary>Converts an array of 8-bit unsigned integers to its equivalent string representation that is encoded with uppercase hex characters.</summary>
         /// <param name="inArray">An array of 8-bit unsigned integers.</param>
         /// <returns>The string representation in hex of the elements in <paramref name="inArray"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="inArray"/> is <code>null</code>.</exception>
@@ -3043,7 +3119,6 @@ namespace System
         public static string ToHexString(byte[] inArray)
         {
             ArgumentNullException.ThrowIfNull(inArray);
-
             return ToHexString(new ReadOnlySpan<byte>(inArray));
         }
 
@@ -3070,24 +3145,22 @@ namespace System
             return ToHexString(new ReadOnlySpan<byte>(inArray, offset, length));
         }
 
-        /// <summary>
-        /// Converts a span of 8-bit unsigned integers to its equivalent string representation that is encoded with uppercase hex characters.
-        /// </summary>
+        /// <summary>Converts a span of 8-bit unsigned integers to its equivalent string representation that is encoded with uppercase hex characters.</summary>
         /// <param name="bytes">A span of 8-bit unsigned integers.</param>
         /// <returns>The string representation in hex of the elements in <paramref name="bytes"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="bytes"/> is too large to be encoded.</exception>
         public static string ToHexString(ReadOnlySpan<byte> bytes)
         {
             if (bytes.Length == 0)
+            {
                 return string.Empty;
+            }
             ArgumentOutOfRangeException.ThrowIfGreaterThan(bytes.Length, int.MaxValue / 2, nameof(bytes));
 
             return HexConverter.ToString(bytes, HexConverter.Casing.Upper);
         }
 
-        /// <summary>
-        /// Converts a span of 8-bit unsigned integers to its equivalent span representation that is encoded with uppercase hex characters.
-        /// </summary>
+        /// <summary>Converts a span of 8-bit unsigned integers to its equivalent span representation that is encoded with uppercase hex characters.</summary>
         /// <param name="source">A span of 8-bit unsigned integers.</param>
         /// <param name="destination">The span representation in hex of the elements in <paramref name="source"/>.</param>
         /// <param name="charsWritten">When this method returns, contains the number of chars that were written in <paramref name="destination"/>.</param>
@@ -3099,7 +3172,7 @@ namespace System
                 charsWritten = 0;
                 return true;
             }
-            else if (source.Length > int.MaxValue / 2 || destination.Length < source.Length * 2)
+            else if ((source.Length > (int.MaxValue / 2)) || (destination.Length < (source.Length * 2)))
             {
                 charsWritten = 0;
                 return false;
@@ -3110,9 +3183,30 @@ namespace System
             return true;
         }
 
-        /// <summary>
-        /// Converts an array of 8-bit unsigned integers to its equivalent string representation that is encoded with lowercase hex characters.
-        /// </summary>
+        /// <summary>Converts a span of 8-bit unsigned integers to its equivalent UTF-8 span representation that is encoded with uppercase hex characters.</summary>
+        /// <param name="source">A span of 8-bit unsigned integers.</param>
+        /// <param name="utf8Destination">The UTF-8 span representation in hex of the elements in <paramref name="source"/>.</param>
+        /// <param name="bytesWritten">When this method returns, contains the number of bytes that were written in <paramref name="utf8Destination"/>.</param>
+        /// <returns>true if the conversion was successful; otherwise, false.</returns>
+        public static bool TryToHexString(ReadOnlySpan<byte> source, Span<byte> utf8Destination, out int bytesWritten)
+        {
+            if (source.Length == 0)
+            {
+                bytesWritten = 0;
+                return true;
+            }
+            else if ((source.Length > (int.MaxValue / 2)) || (utf8Destination.Length < (source.Length * 2)))
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            HexConverter.EncodeToUtf8(source, utf8Destination);
+            bytesWritten = source.Length * 2;
+            return true;
+        }
+
+        /// <summary>Converts an array of 8-bit unsigned integers to its equivalent string representation that is encoded with lowercase hex characters.</summary>
         /// <param name="inArray">An array of 8-bit unsigned integers.</param>
         /// <returns>The string representation in hex of the elements in <paramref name="inArray"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="inArray"/> is <code>null</code>.</exception>
@@ -3120,7 +3214,6 @@ namespace System
         public static string ToHexStringLower(byte[] inArray)
         {
             ArgumentNullException.ThrowIfNull(inArray);
-
             return ToHexStringLower(new ReadOnlySpan<byte>(inArray));
         }
 
@@ -3147,24 +3240,22 @@ namespace System
             return ToHexStringLower(new ReadOnlySpan<byte>(inArray, offset, length));
         }
 
-        /// <summary>
-        /// Converts a span of 8-bit unsigned integers to its equivalent string representation that is encoded with lowercase hex characters.
-        /// </summary>
+        /// <summary>Converts a span of 8-bit unsigned integers to its equivalent string representation that is encoded with lowercase hex characters.</summary>
         /// <param name="bytes">A span of 8-bit unsigned integers.</param>
         /// <returns>The string representation in hex of the elements in <paramref name="bytes"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="bytes"/> is too large to be encoded.</exception>
         public static string ToHexStringLower(ReadOnlySpan<byte> bytes)
         {
             if (bytes.Length == 0)
+            {
                 return string.Empty;
+            }
             ArgumentOutOfRangeException.ThrowIfGreaterThan(bytes.Length, int.MaxValue / 2, nameof(bytes));
 
             return HexConverter.ToString(bytes, HexConverter.Casing.Lower);
         }
 
-        /// <summary>
-        /// Converts a span of 8-bit unsigned integers to its equivalent span representation that is encoded with lowercase hex characters.
-        /// </summary>
+        /// <summary>Converts a span of 8-bit unsigned integers to its equivalent span representation that is encoded with lowercase hex characters.</summary>
         /// <param name="source">A span of 8-bit unsigned integers.</param>
         /// <param name="destination">The span representation in hex of the elements in <paramref name="source"/>.</param>
         /// <param name="charsWritten">When this method returns, contains the number of chars that were written in <paramref name="destination"/>.</param>
@@ -3176,7 +3267,7 @@ namespace System
                 charsWritten = 0;
                 return true;
             }
-            else if (source.Length > int.MaxValue / 2 || destination.Length < source.Length * 2)
+            else if ((source.Length > (int.MaxValue / 2)) || (destination.Length < (source.Length * 2)))
             {
                 charsWritten = 0;
                 return false;
@@ -3186,5 +3277,28 @@ namespace System
             charsWritten = source.Length * 2;
             return true;
         }
-    }  // class Convert
-}  // namespace
+
+        /// <summary>Converts a span of 8-bit unsigned integers to its equivalent UTF-8 span representation that is encoded with lowercase hex characters.</summary>
+        /// <param name="source">A span of 8-bit unsigned integers.</param>
+        /// <param name="utf8Destination">The UTF-8 span representation in hex of the elements in <paramref name="source"/>.</param>
+        /// <param name="bytesWritten">When this method returns, contains the number of bytes that were written in <paramref name="utf8Destination"/>.</param>
+        /// <returns>true if the conversion was successful; otherwise, false.</returns>
+        public static bool TryToHexStringLower(ReadOnlySpan<byte> source, Span<byte> utf8Destination, out int bytesWritten)
+        {
+            if (source.Length == 0)
+            {
+                bytesWritten = 0;
+                return true;
+            }
+            else if ((source.Length > (int.MaxValue / 2)) || (utf8Destination.Length < (source.Length * 2)))
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            HexConverter.EncodeToUtf8(source, utf8Destination, HexConverter.Casing.Lower);
+            bytesWritten = source.Length * 2;
+            return true;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
@@ -287,7 +287,7 @@ namespace System.Text.Unicode
         internal static bool AllCharsInVectorAreAscii<TVector>(TVector vec)
             where TVector : struct, ISimdVector<TVector, ushort>
         {
-            return (vec & TVector.Create(unchecked((ushort)~0x007F))).Equals(TVector.Zero);
+            return (vec & TVector.Create(unchecked((ushort)~0x007F))) == TVector.Zero;
         }
 #endif
     }

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -609,6 +609,18 @@ namespace System
         }
 
         [DoesNotReturn]
+        internal static void ThrowFormatException_BadHexChar()
+        {
+            throw new FormatException(SR.Format_BadHexChar);
+        }
+
+        [DoesNotReturn]
+        internal static void ThrowFormatException_BadHexLength()
+        {
+            throw new FormatException(SR.Format_BadHexLength);
+        }
+
+        [DoesNotReturn]
         internal static void ThrowFormatException_NeedSingleChar()
         {
             throw new FormatException(SR.Format_NeedSingleChar);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -1294,7 +1294,9 @@ namespace System
         public static object? ChangeType(object? value, System.TypeCode typeCode, System.IFormatProvider? provider) { throw null; }
         public static byte[] FromBase64CharArray(char[] inArray, int offset, int length) { throw null; }
         public static byte[] FromBase64String(string s) { throw null; }
+        public static byte[] FromHexString(System.ReadOnlySpan<byte> utf8Source) { throw null; }
         public static byte[] FromHexString(System.ReadOnlySpan<char> chars) { throw null; }
+        public static System.Buffers.OperationStatus FromHexString(System.ReadOnlySpan<byte> utf8Source, System.Span<byte> destination, out int bytesConsumed, out int bytesWritten) { throw null; }
         public static System.Buffers.OperationStatus FromHexString(System.ReadOnlySpan<char> source, System.Span<byte> destination, out int charsConsumed, out int bytesWritten) { throw null; }
         public static byte[] FromHexString(string s) { throw null; }
         public static System.Buffers.OperationStatus FromHexString(string source, System.Span<byte> destination, out int charsConsumed, out int bytesWritten) { throw null; }
@@ -1738,7 +1740,9 @@ namespace System
         public static bool TryFromBase64Chars(System.ReadOnlySpan<char> chars, System.Span<byte> bytes, out int bytesWritten) { throw null; }
         public static bool TryFromBase64String(string s, System.Span<byte> bytes, out int bytesWritten) { throw null; }
         public static bool TryToBase64Chars(System.ReadOnlySpan<byte> bytes, System.Span<char> chars, out int charsWritten, System.Base64FormattingOptions options = System.Base64FormattingOptions.None) { throw null; }
+        public static bool TryToHexString(System.ReadOnlySpan<byte> source, System.Span<byte> utf8Destination, out int bytesWritten) { throw null; }
         public static bool TryToHexString(System.ReadOnlySpan<byte> source, System.Span<char> destination, out int charsWritten) { throw null; }
+        public static bool TryToHexStringLower(System.ReadOnlySpan<byte> source, System.Span<byte> utf8Destination, out int bytesWritten) { throw null; }
         public static bool TryToHexStringLower(System.ReadOnlySpan<byte> source, System.Span<char> destination, out int charsWritten) { throw null; }
     }
     public delegate TOutput Converter<in TInput, out TOutput>(TInput input) where TInput : allows ref struct where TOutput : allows ref struct;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToHexString.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToHexString.cs
@@ -19,6 +19,11 @@ namespace System.Tests
             Assert.True(Convert.TryToHexString(inputBytes, output, out int charsWritten));
             Assert.Equal(12, charsWritten);
             Assert.Equal("000102FDFEFF", output.ToString());
+
+            Span<byte> outputUtf8 = stackalloc byte[12];
+            Assert.True(Convert.TryToHexString(inputBytes, outputUtf8, out int bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal("000102FDFEFF", Encoding.UTF8.GetString(outputUtf8));
         }
 
         [Fact]
@@ -31,6 +36,11 @@ namespace System.Tests
             Assert.True(Convert.TryToHexStringLower(inputBytes, output, out int charsWritten));
             Assert.Equal(12, charsWritten);
             Assert.Equal("000102fdfeff", output.ToString());
+
+            Span<byte> outputUtf8 = stackalloc byte[12];
+            Assert.True(Convert.TryToHexStringLower(inputBytes, outputUtf8, out int bytesWritten));
+            Assert.Equal(12, bytesWritten);
+            Assert.Equal("000102fdfeff", Encoding.UTF8.GetString(outputUtf8));
         }
 
         [Fact]
@@ -51,6 +61,11 @@ namespace System.Tests
             Assert.True(Convert.TryToHexString(values, output, out int charsWritten));
             Assert.Equal(512, charsWritten);
             Assert.Equal(excepted, output.ToString());
+
+            Span<byte> outputUtf8 = stackalloc byte[512];
+            Assert.True(Convert.TryToHexString(values, outputUtf8, out int bytesWritten));
+            Assert.Equal(512, bytesWritten);
+            Assert.Equal(excepted, Encoding.UTF8.GetString(outputUtf8));
         }
 
         [Fact]
@@ -71,6 +86,11 @@ namespace System.Tests
             Assert.True(Convert.TryToHexStringLower(values, output, out int charsWritten));
             Assert.Equal(512, charsWritten);
             Assert.Equal(excepted, output.ToString());
+
+            Span<byte> outputUtf8 = stackalloc byte[512];
+            Assert.True(Convert.TryToHexStringLower(values, outputUtf8, out int bytesWritten));
+            Assert.Equal(512, bytesWritten);
+            Assert.Equal(excepted, Encoding.UTF8.GetString(outputUtf8));
         }
 
         [Fact]
@@ -80,12 +100,17 @@ namespace System.Tests
             Assert.Same(string.Empty, Convert.ToHexString(inputBytes, 0, 0));
             Assert.Same(string.Empty, Convert.ToHexStringLower(inputBytes, 0, 0));
 
-            int charsWritten;
             Span<char> output = stackalloc char[12];
-            Assert.True(Convert.TryToHexString(default, output, out charsWritten));
+            Assert.True(Convert.TryToHexString(default, output, out int charsWritten));
             Assert.Equal(0, charsWritten);
             Assert.True(Convert.TryToHexStringLower(default, output, out charsWritten));
             Assert.Equal(0, charsWritten);
+
+            Span<byte> outputUtf8 = stackalloc byte[12];
+            Assert.True(Convert.TryToHexString(default, outputUtf8, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.True(Convert.TryToHexStringLower(default, outputUtf8, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
         }
 
         [Fact]
@@ -101,16 +126,26 @@ namespace System.Tests
         public static void InvalidOutputBuffer()
         {
             byte[] inputBytes = new byte[] { 0x00, 0x01, 0x02, 0xFD, 0xFE, 0xFF };
-            int charsWritten;
+
             Span<char> output = stackalloc char[11];
-            Assert.False(Convert.TryToHexString(inputBytes, default, out charsWritten));
+            Assert.False(Convert.TryToHexString(inputBytes, Span<char>.Empty, out int charsWritten));
             Assert.Equal(0, charsWritten);
             Assert.False(Convert.TryToHexString(inputBytes, output, out charsWritten));
             Assert.Equal(0, charsWritten);
-            Assert.False(Convert.TryToHexStringLower(inputBytes, default, out charsWritten));
+            Assert.False(Convert.TryToHexStringLower(inputBytes, Span<char>.Empty, out charsWritten));
             Assert.Equal(0, charsWritten);
             Assert.False(Convert.TryToHexStringLower(inputBytes, output, out charsWritten));
             Assert.Equal(0, charsWritten);
+
+            Span<byte> outputUtf8 = stackalloc byte[11];
+            Assert.False(Convert.TryToHexString(inputBytes, Span<byte>.Empty, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.False(Convert.TryToHexString(inputBytes, outputUtf8, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.False(Convert.TryToHexStringLower(inputBytes, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.False(Convert.TryToHexStringLower(inputBytes, outputUtf8, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
         }
 
         [Fact]
@@ -138,15 +173,20 @@ namespace System.Tests
         [Fact]
         public static unsafe void InputTooLarge()
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => Convert.ToHexString(new ReadOnlySpan<byte>((void*)0, Int32.MaxValue)));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => Convert.ToHexStringLower(new ReadOnlySpan<byte>((void*)0, Int32.MaxValue)));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => Convert.ToHexString(new ReadOnlySpan<byte>((void*)0, int.MaxValue)));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => Convert.ToHexStringLower(new ReadOnlySpan<byte>((void*)0, int.MaxValue)));
 
-            int charsWritten;
-            Span<char> output = new Span<char>((void*)0, Int32.MaxValue);
-            Assert.False(Convert.TryToHexString(new ReadOnlySpan<byte>((void*)0, Int32.MaxValue), output, out charsWritten));
+            Span<char> output = new Span<char>((void*)0, int.MaxValue);
+            Assert.False(Convert.TryToHexString(new ReadOnlySpan<byte>((void*)0, int.MaxValue), output, out int charsWritten));
             Assert.Equal(0, charsWritten);
-            Assert.False(Convert.TryToHexStringLower(new ReadOnlySpan<byte>((void*)0, Int32.MaxValue), output, out charsWritten));
+            Assert.False(Convert.TryToHexStringLower(new ReadOnlySpan<byte>((void*)0, int.MaxValue), output, out charsWritten));
             Assert.Equal(0, charsWritten);
+
+            Span<byte> outputUtf8 = new Span<byte>((void*)0, int.MaxValue);
+            Assert.False(Convert.TryToHexString(new ReadOnlySpan<byte>((void*)0, int.MaxValue), outputUtf8, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.False(Convert.TryToHexStringLower(new ReadOnlySpan<byte>((void*)0, int.MaxValue), outputUtf8, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
         }
 
         public static IEnumerable<object[]> ToHexStringTestData()
@@ -197,6 +237,11 @@ namespace System.Tests
             Assert.True(Convert.TryToHexString(input, output, out int charsWritten));
             Assert.Equal(expected.Length, charsWritten);
             Assert.Equal(expected, output.ToString());
+
+            Span<byte> outputUtf8 = new byte[expected.Length];
+            Assert.True(Convert.TryToHexString(input, outputUtf8, out int bytesWritten));
+            Assert.Equal(expected.Length, bytesWritten);
+            Assert.Equal(expected, Encoding.UTF8.GetString(outputUtf8));
         }
 
 
@@ -216,6 +261,11 @@ namespace System.Tests
             Assert.True(Convert.TryToHexStringLower(input, output, out int charsWritten));
             Assert.Equal(expected.Length, charsWritten);
             Assert.Equal(expected.ToLower(), output.ToString());
+
+            Span<byte> outputUtf8 = new byte[expected.Length];
+            Assert.True(Convert.TryToHexStringLower(input, outputUtf8, out int bytesWritten));
+            Assert.Equal(expected.Length, bytesWritten);
+            Assert.Equal(expected.ToLower(), Encoding.UTF8.GetString(outputUtf8));
         }
     }
 }


### PR DESCRIPTION
This resolves #114079 

## Customer Impact

We exposed the `FromHexString`, `ToHexString`, and related APIs back in .NET 5 (2020) and have been getting requests to add UTF-8 support essentially as long. However, we didn't really make a more targeted effort to add native UTF-8 support until .NET 8 when we introduced `IUtf8SpanParsable`, `IUtf8SpanFormattable`, and ensured the core primitive numeric types all implemented these interfaces.

Exposing these as part of .NET 10 will unblock customers that have been waiting for this functionality and will give them the higher performance and quality they rely on from built-in APIs.

## Testing

All the existing UTF-16 tests were updated to also test the UTF-8 paths.

## Risk

Low. This is using the existing UTF-16 algorithms and simply updating them to work for `byte`. In most cases this is 1-to-1, in a couple places it uses the internal `where TChar : IUtfChar<TChar>` we use for other shared UTF-8/16 code paths.