### PR TITLE
[RISC-V] Add pseudo instruction `not` and replace `xori` when immediate is -1

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1009,7 +1009,7 @@ void CodeGen::genCodeForIncSaturate(GenTree* tree)
     GetEmitter()->emitIns_R_R_I(INS_addi, attr, targetReg, operandReg, 1);
     // bne targetReg, zero, 2 * 4
     GetEmitter()->emitIns_R_R_I(INS_bne, attr, targetReg, REG_R0, 8);
-    GetEmitter()->emitIns_R_R_I(INS_xori, attr, targetReg, targetReg, -1);
+    GetEmitter()->emitIns_R_R(INS_not, attr, targetReg, targetReg);
 
     genProduceReg(tree);
 }
@@ -1691,7 +1691,7 @@ void CodeGen::genCodeForNegNot(GenTree* tree)
     else if (tree->OperIs(GT_NOT))
     {
         assert(!varTypeIsFloating(targetType));
-        GetEmitter()->emitIns_R_R_I(INS_xori, attr, targetReg, operandReg, -1);
+        GetEmitter()->emitIns_R_R(INS_not, attr, targetReg, operandReg);
     }
 
     genProduceReg(tree);

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -650,7 +650,7 @@ void emitter::emitIns_R_R(
 {
     code_t code = emitInsCode(ins);
 
-    if (INS_mov == ins || INS_sext_w == ins || (INS_clz <= ins && ins <= INS_rev8))
+    if (INS_mov == ins || INS_sext_w == ins || INS_not == ins || (INS_clz <= ins && ins <= INS_rev8))
     {
         assert(isGeneralRegisterOrR0(reg1));
         assert(isGeneralRegisterOrR0(reg2));

--- a/src/coreclr/jit/instrsriscv64.h
+++ b/src/coreclr/jit/instrsriscv64.h
@@ -37,6 +37,7 @@ INST(nop,           "nop",            0,    0x00000013)
 //// R_R
 INST(mov,           "mv",             0,    0x00000013)
 INST(sext_w,        "sext.w",         0,    0x0000001b)
+INST(not,           "not",            0,    0xFFF04013)
 
 ////R_I
 INST(lui,           "lui",            0,    0x00000037)


### PR DESCRIPTION
Add pseudo instruction `not` and replace `xori` when immediate is -1

As this is my first attempt at adding a new instruction, I might have overlooked certain parts (such as parts of the emitter implementation or validation in debug configuration). Any review or suggestion would be greatly appreciated.

@clamp03 @tomeksowi @SkyShield, @namu-lee
part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung