### PR TITLE
Fix the issue of Mono.AotCross build errors

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -558,7 +558,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+mono.aotcross+'))">
-    <ProjectToBuild Include="$(MonoProjectRoot)monoaotcross.proj" Category="mono" AdditionalProperties="%(AdditionalProperties);DotNetBuildMonoCrossAOT=true" />
+    <ProjectToBuild Include="$(MonoProjectRoot)monoaotcross.proj" Category="mono" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+mono.corelib+'))">

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -153,7 +153,7 @@
     <BootstrapSubsets Condition="'$(UseNativeAotForComponents)' == 'true'">$(BootstrapSubsets)+clr.nativeaotlibs+clr.nativeaotruntime+libs.native</BootstrapSubsets>
 
     <SwapNativeForIL Condition="$(_subset.Contains('+bootstrap+')) and '$(RuntimeFlavor)' == 'CoreCLR'">true</SwapNativeForIL>
-    
+
     <!-- Define AllSubsets to include all available subsets including OnDemand ones -->
     <AllSubsetsExpansion>clr.nativeprereqs+clr.iltools+clr.runtime+clr.native+clr.aot+clr.nativeaotlibs+clr.nativeaotruntime+clr.crossarchtools</AllSubsetsExpansion>
     <AllSubsetsExpansion>$(AllSubsetsExpansion)+clr.paltests+clr.paltestlist+clr.hosts+clr.jit+clr.alljits+clr.alljitscommunity+clr.spmi+clr.corelib+clr.nativecorelib+clr.tools+clr.toolstests+clr.packages</AllSubsetsExpansion>
@@ -558,7 +558,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+mono.aotcross+'))">
-    <ProjectToBuild Include="$(MonoProjectRoot)monoaotcross.proj" Category="mono" />
+    <ProjectToBuild Include="$(MonoProjectRoot)monoaotcross.proj" Category="mono" AdditionalProperties="%(AdditionalProperties);DotNetBuildMonoCrossAOT=true" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+mono.corelib+'))">

--- a/src/mono/monoaotcross.proj
+++ b/src/mono/monoaotcross.proj
@@ -22,6 +22,15 @@
     <MonoAotTargetRids Include="$(MonoAotTargets.Split(';'))" />
   </ItemGroup>
 
+  <Target Name="CheckMonoAotTargets" BeforeTargets="BuildMonoCrossAllTargets">
+    <PropertyGroup>
+      <_SupportOS>android, browser, wasi</_SupportOS>
+      <_SupportOS Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(_SupportOS), tvos, ios, maccatalyst</_SupportOS>
+    </PropertyGroup>
+
+    <Error Condition="'@(MonoAotTargetRids->Count())' == '0'" Text="MonoAotTargets is empty. Please configure MonoCrossAOTTargetOS with supported values: $(_SupportOS). Multiple values should be separated with '+' (e.g., /p:MonoCrossAOTTargetOS=android+browser)." />
+  </Target>
+
   <Target Name="BuildMonoCrossAllTargets" AfterTargets="Build">
     <MSBuild Targets="Restore"
              Projects="$(MSBuildThisFileDirectory)mono.proj"


### PR DESCRIPTION
Configure the DotNetBuildMonoCrossAOT property when building Mono.AotCross

Fixes dotnet#117970