### PR TITLE
Make IsAlive test reliable and re-enable it for crossgen2

### DIFF
--- a/src/tests/GC/API/WeakReference/IsAlive.cs
+++ b/src/tests/GC/API/WeakReference/IsAlive.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Tests WeakReference.IsAlive : IsAlive=true if GC has not occurred on the object 
+// Tests WeakReference.IsAlive : IsAlive=true if GC has not occurred on the object
 
 
 using System;
@@ -11,35 +11,40 @@ using Xunit;
 
 public class Test_IsAlive {
     public static int[] array;
-    
+    public static WeakReference weak;
+
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void CreateArray() {
         array = new int[50];
+        // HACK: Create the weak reference inside of CreateArray to prevent a dangling 'array' reference
+        //  from surviving inside of TestEntryPoint
+        weak = new WeakReference(array);
     }
-    
+
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void DestroyArray() {
         array = null;
     }
-    
+
     [Fact]
     public static int TestEntryPoint() {
         CreateArray();
 
-        WeakReference weak = new WeakReference(array);
-                
         bool ans1 = weak.IsAlive;
         Console.WriteLine(ans1);
-
-        if(ans1==false) { // GC.Collect() has already occurred..under GCStress
-            Console.WriteLine("Test for WeakReference.IsAlive passed!");
-            return 100;
+        if (ans1 != true)
+        {
+            // This should be impossible; it would indicate that either the array was collected while reachable from
+            //  our static field, or that the WeakReference failed to track the array even though it's still alive.
+            Console.WriteLine("Test for WeakReference.IsAlive failed!");
+            return 2;
         }
 
-        //else, do an expicit collect.
+        // Release our strong reference (via static field) so that the collector will no longer see array as reachable.
         DestroyArray();
+        // Perform a blocking full collection which will hopefully collect the array.
         GC.Collect();
-        
+
         bool ans2 = weak.IsAlive;
         Console.WriteLine(ans2);
 

--- a/src/tests/GC/API/WeakReference/IsAlive.cs
+++ b/src/tests/GC/API/WeakReference/IsAlive.cs
@@ -16,8 +16,8 @@ public class Test_IsAlive {
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void CreateArray() {
         array = new int[50];
-        // HACK: Create the weak reference inside of CreateArray to prevent a dangling 'array' reference
-        //  from surviving inside of TestEntryPoint
+        // Create the weak reference inside of CreateArray to prevent a dangling 'array' reference
+        // from surviving inside of TestEntryPoint.
         weak = new WeakReference(array);
     }
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -576,9 +576,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/Arrays/misc/arrres_il_r/**">
             <Issue>https://github.com/dotnet/runtime/issues/109311</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/API/WeakReference/IsAlive/**">
-            <Issue>https://github.com/dotnet/runtime/issues/109312</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/lifetime/lifetime2/**">
             <Issue>https://github.com/dotnet/runtime/issues/109313</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes issue #109312 

For me the old version of this test fails locally even without R2R involved.