### PR TITLE
Revert "[release/9.0-staging] Update dependencies from dotnet/sdk"

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,8 +14,8 @@
     <add key="darc-pub-dotnet-emsdk-0bcc3e6-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-0bcc3e67-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-sdk -->
-    <add key="darc-pub-dotnet-sdk-eb8e854" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-sdk-eb8e8545/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-sdk -->
+    <add key="darc-pub-dotnet-sdk-81289841" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-sdk-81289841/nuget/v3/index.json" />    
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!--
       'src/test/PrepareTestAssets/PrepareTestAssets.proj' generates a NuGet.config file using this

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -388,12 +388,12 @@
     </Dependency>
     <Dependency Name="Microsoft.DotNet.ApiCompat.Task" Version="9.0.109">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>eb8e854575399c14203dada1d2a6d5883fe23a4a</Sha>
+      <Sha>8128984181a05a7dc0de748ad3371e0a7f153f35</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.sdk" Version="9.0.109-servicing.25365.26">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.sdk" Version="9.0.109-servicing.25360.24">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>eb8e854575399c14203dada1d2a6d5883fe23a4a</Sha>
+      <Sha>8128984181a05a7dc0de748ad3371e0a7f153f35</Sha>
       <SourceBuild RepoName="sdk" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="optimization.windows_nt-arm64.MIBC.Runtime" Version="1.0.0-prerelease.24462.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -263,7 +263,7 @@
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- sdk version, for testing workloads -->
     <!-- <SdkVersionForWorkloadTesting>$(MicrosoftDotNetApiCompatTaskVersion)</SdkVersionForWorkloadTesting> -->
-    <SdkVersionForWorkloadTesting>9.0.109</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>9.0.107</SdkVersionForWorkloadTesting>
     <runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>9.0.0-alpha.1.24175.1</runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
     <EmsdkPackageVersion>$(MicrosoftNETRuntimeEmscriptenVersion)</EmsdkPackageVersion>
     <NodePackageVersion>$(runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion)</NodePackageVersion>


### PR DESCRIPTION
Reverts dotnet/runtime#117873  Don't update to an unreleased version of the sdk