### PR TITLE
Only run host tests for linux-x64 on Azure Linux helix queues

### DIFF
--- a/eng/pipelines/installer/helix-queues-setup.yml
+++ b/eng/pipelines/installer/helix-queues-setup.yml
@@ -42,7 +42,6 @@ jobs:
     # Linux x64
     - ${{ if eq(parameters.platform, 'linux_x64') }}:
       - AzureLinux.3.Amd64.Open
-      - Ubuntu.2204.Amd64.Open
 
     # OSX arm64
     - ${{ if eq(parameters.platform, 'osx_arm64') }}:


### PR DESCRIPTION
We're currently sending tests to both AzureLinux.3.Amd64.Open and Ubuntu.2204.Amd64.Open. Just AzureLinux.3.Amd64.Open should be enough for host tests. I've seen some long wait times and timeouts for host tests sent to Ubuntu.2204.Amd64.Open recently. The libraries tests already run on Ubuntu - they use the live host, so that should have enough basic coverage.

cc @dotnet/appmodel @richlander