### PR TITLE
Emit IsAotCompatible attribute metadata

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -25,6 +25,10 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_Parameter1>IsTrimmable</_Parameter1>
       <_Parameter2>True</_Parameter2>
     </AssemblyAttribute>
+    <AssemblyAttribute Condition="'$(IsAotCompatible)' == 'true'" Include="System.Reflection.AssemblyMetadata">
+      <_Parameter1>IsAotCompatible</_Parameter1>
+      <_Parameter2>True</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <!-- We disable features for trimmed apps here so that the feature


### PR DESCRIPTION
This could be used for #117712 and is a useful piece of metadata.

I was going back and forth between placing this here or somewhere in the dotnet/sdk repo but since this is related to the analyzer, it feels okay here too.