### PR TITLE
JIT: Fix check for cast type for cast on top of address

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1241,10 +1241,12 @@ public:
                 break;
 
             case GT_CAST:
+            {
                 assert(TopValue(1).Node() == node);
                 assert(TopValue(0).Node() == node->AsCast()->CastOp());
 
-                if (!node->TypeIs(TYP_I_IMPL, TYP_BYREF) || node->gtOverflow() || !TopValue(0).IsAddress() ||
+                bool isPtrCast = (node->CastToType() == TYP_I_IMPL) || (node->CastToType() == TYP_BYREF);
+                if (!isPtrCast || node->gtOverflow() || !TopValue(0).IsAddress() ||
                     !TopValue(1).AddOffset(TopValue(0), 0))
                 {
                     EscapeValue(TopValue(0), node);
@@ -1252,7 +1254,7 @@ public:
 
                 PopValue();
                 break;
-
+            }
             case GT_CALL:
                 while (TopValue(0).Node() != node)
                 {

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1245,7 +1245,8 @@ public:
                 assert(TopValue(1).Node() == node);
                 assert(TopValue(0).Node() == node->AsCast()->CastOp());
 
-                bool isPtrCast = (node->CastToType() == TYP_I_IMPL) || (node->CastToType() == TYP_BYREF);
+                var_types castToType = node->CastToType();
+                bool isPtrCast = (castToType == TYP_I_IMPL) || (castToType == TYP_U_IMPL) || (castToType == TYP_BYREF);
                 if (!isPtrCast || node->gtOverflow() || !TopValue(0).IsAddress() ||
                     !TopValue(1).AddOffset(TopValue(0), 0))
                 {


### PR DESCRIPTION
The failing test in #118006 casts addresses of locals to small types, and this check was not checking the right type to filter out those casts.

Fix #118006