### PR TITLE
Fix missed places in dataflow analysis that introduce genericness

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
@@ -592,15 +592,20 @@ namespace ILCompiler.Dataflow
                     case ILOpcode.conv_r8:
                     case ILOpcode.ldind_ref:
                     case ILOpcode.ldobj:
-                    case ILOpcode.mkrefany:
                     case ILOpcode.unbox:
                     case ILOpcode.unbox_any:
-                    case ILOpcode.box:
                     case ILOpcode.neg:
                     case ILOpcode.not:
                         PopUnknown(currentStack, 1, methodBody, offset);
                         PushUnknown(currentStack);
                         reader.Skip(opcode);
+                        break;
+
+                    case ILOpcode.box:
+                    case ILOpcode.mkrefany:
+                        HandleTypeTokenAccess(methodBody, offset, (TypeDesc)methodBody.GetObject(reader.ReadILToken()));
+                        PopUnknown(currentStack, 1, methodBody, offset);
+                        PushUnknown(currentStack);
                         break;
 
                     case ILOpcode.isinst:
@@ -622,6 +627,7 @@ namespace ILCompiler.Dataflow
                         {
                             StackSlot count = PopUnknown(currentStack, 1, methodBody, offset);
                             var arrayElement = (TypeDesc)methodBody.GetObject(reader.ReadILToken());
+                            HandleTypeTokenAccess(methodBody, offset, arrayElement);
                             currentStack.Push(new StackSlot(ArrayValue.Create(count.Value, arrayElement)));
                         }
                         break;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -1240,6 +1240,10 @@ namespace ILCompiler
         protected abstract MetadataCategory GetMetadataCategory(TypeDesc type);
         protected abstract MetadataCategory GetMetadataCategory(FieldDesc field);
 
+        public virtual void GetDependenciesDueToAccess(ref DependencyList dependencies, NodeFactory factory, MethodIL methodIL, TypeDesc accessedType)
+        {
+        }
+
         public virtual void GetDependenciesDueToAccess(ref DependencyList dependencies, NodeFactory factory, MethodIL methodIL, MethodDesc calledMethod)
         {
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -773,6 +773,15 @@ namespace ILCompiler
             }
         }
 
+        public override void GetDependenciesDueToAccess(ref DependencyList dependencies, NodeFactory factory, MethodIL methodIL, TypeDesc accessedType)
+        {
+            bool scanReflection = (_generationOptions & UsageBasedMetadataGenerationOptions.ReflectionILScanning) != 0;
+            if (scanReflection && Dataflow.ReflectionMethodBodyScanner.RequiresReflectionMethodBodyScannerForAccess(FlowAnnotations, accessedType))
+            {
+                AddDataflowDependency(ref dependencies, factory, methodIL, "Access to interesting type");
+            }
+        }
+
         public override void GetDependenciesDueToAccess(ref DependencyList dependencies, NodeFactory factory, MethodIL methodIL, MethodDesc calledMethod)
         {
             bool scanReflection = (_generationOptions & UsageBasedMetadataGenerationOptions.ReflectionILScanning) != 0;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -921,6 +921,7 @@ namespace Internal.IL
         {
             _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.TypeHandleToRuntimeType), "mkrefany");
             _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.TypeHandleToRuntimeTypeHandle), "mkrefany");
+            _factory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _factory, _methodIL, (TypeDesc)_canonMethodIL.GetObject(token));
             ImportTypedRefOperationDependencies(token, "mkrefany");
         }
 
@@ -959,6 +960,8 @@ namespace Internal.IL
                         break;
                     }
                 }
+
+                _factory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _factory, _methodIL, (TypeDesc)_canonMethodIL.GetObject(token));
 
                 _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.GetRuntimeTypeHandle), "ldtoken");
                 _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.GetRuntimeType), "ldtoken");
@@ -1190,6 +1193,9 @@ namespace Internal.IL
             if (!type.IsValueType)
                 return;
 
+            TypeDesc typeForAccessCheck = type.IsRuntimeDeterminedSubtype ? type.ConvertToCanonForm(CanonicalFormKind.Specific) : type;
+            _factory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _factory, _methodIL, typeForAccessCheck);
+
             if (type.IsRuntimeDeterminedSubtype)
             {
                 _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.TypeHandle, type), reason);
@@ -1217,6 +1223,7 @@ namespace Internal.IL
         private void ImportNewArray(int token)
         {
             var elementType = (TypeDesc)_methodIL.GetObject(token);
+            _factory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _factory, _methodIL, (TypeDesc)_canonMethodIL.GetObject(token));
             if (elementType.IsRuntimeDeterminedSubtype)
             {
                 _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.TypeHandle, elementType.MakeArrayType()), "newarr");

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -868,6 +868,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         [ExpectedWarning("IL2091", "IRequireParameterlessCtor", Tool.Trimmer, "")]
+        [ExpectedWarning("IL2091", "IRequireParameterlessCtor", Tool.Trimmer, "")]
         static void TestValueTypeBox<T>()
         {
             if (default(RequiresParameterlessCtor<T>) is IRequireParameterlessCtor<T> i)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -881,6 +881,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         }
 
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         static void TestInArray<T>()
         {
             var arr = new RequiresParameterlessCtor<T>[1];

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -875,6 +875,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         }
 
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         static void TestMkrefAny<T>()
         {
             RequiresParameterlessCtor<T> val = default;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -49,6 +49,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             TestNoWarningsInRUCMethod<TestType>();
             TestNoWarningsInRUCType<TestType, TestType>();
             TestGenericParameterFlowsToNestedType.Test();
+
+            TestInstanceMethodOnValueType<object>();
+            TestValueTypeBox<object>();
+            TestMkrefAny<object>();
+            TestInArray<object>();
         }
 
         static void TestSingleGenericParameterOnType()
@@ -850,6 +855,49 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             rucType.InstanceMethodRequiresPublicMethods<T>();
             rucType.VirtualMethod();
             rucType.VirtualMethodRequiresPublicMethods<T>();
+        }
+
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        static void TestInstanceMethodOnValueType<T>()
+        {
+            default(RequiresParameterlessCtor<T>).Do();
+        }
+
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        static void TestValueTypeBox<T>()
+        {
+            if (default(RequiresParameterlessCtor<T>) is IRequireParameterlessCtor<T> i)
+            {
+                i.Do();
+            }
+        }
+
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        static void TestMkrefAny<T>()
+        {
+            RequiresParameterlessCtor<T> val = default;
+            TypedReference tr = __makeref(val);
+            // This is a potential box operation, e.g. TypedReference.ToObject(tr);
+        }
+
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        static void TestInArray<T>()
+        {
+            var arr = new RequiresParameterlessCtor<T>[1];
+            // This is a potential box operation, e.g. arr.GetValue(0)
+        }
+
+        interface IRequireParameterlessCtor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>
+        {
+            T Do();
+        }
+
+        struct RequiresParameterlessCtor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : IRequireParameterlessCtor<T>
+        {
+            public T Do()
+            {
+                return Activator.CreateInstance<T>();
+            }
         }
 
         class TestGenericParameterFlowsToNestedType

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -876,6 +876,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         static void TestMkrefAny<T>()
         {
             RequiresParameterlessCtor<T> val = default;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -867,6 +867,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
+        [ExpectedWarning("IL2091", "IRequireParameterlessCtor", Tool.Trimmer, "")]
         static void TestValueTypeBox<T>()
         {
             if (default(RequiresParameterlessCtor<T>) is IRequireParameterlessCtor<T> i)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -867,6 +867,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         [ExpectedWarning("IL2091", "IRequireParameterlessCtor", Tool.Trimmer, "")]
         [ExpectedWarning("IL2091", "IRequireParameterlessCtor", Tool.Trimmer, "")]
         static void TestValueTypeBox<T>()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -858,6 +858,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         }
 
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         static void TestInstanceMethodOnValueType<T>()
         {
             default(RequiresParameterlessCtor<T>).Do();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -859,6 +859,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         static void TestInstanceMethodOnValueType<T>()
         {
             default(RequiresParameterlessCtor<T>).Do();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -866,6 +866,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         }
 
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         static void TestValueTypeBox<T>()
         {
             if (default(RequiresParameterlessCtor<T>) is IRequireParameterlessCtor<T> i)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -857,7 +857,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             rucType.VirtualMethodRequiresPublicMethods<T>();
         }
 
-        [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer | Tool.NativeAot, "")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         static void TestInstanceMethodOnValueType<T>()
@@ -865,7 +865,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             default(RequiresParameterlessCtor<T>).Do();
         }
 
-        [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer | Tool.NativeAot, "")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         [ExpectedWarning("IL2091", "IRequireParameterlessCtor", Tool.Trimmer, "")]
@@ -878,7 +878,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
         }
 
-        [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer | Tool.NativeAot, "")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         static void TestMkrefAny<T>()
@@ -888,7 +888,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             // This is a potential box operation, e.g. TypedReference.ToObject(tr);
         }
 
-        [ExpectedWarning("IL2091", "RequiresParameterlessCtor")]
+        [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer | Tool.NativeAot, "")]
         [ExpectedWarning("IL2091", "RequiresParameterlessCtor", Tool.Trimmer, "")]
         static void TestInArray<T>()
         {


### PR DESCRIPTION
Resolves #117998.

Fixes the cases in the bug and adds a couple more obscure corner cases.

Cc @dotnet/ilc-contrib 