### PR TITLE
Platform dependency doc changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-/src/libraries/Common/src/Interop/                                  @dotnet/platform-deps-team
 /src/libraries/Common/src/System/Net/Http/aspnetcore/               @dotnet/http
 /src/libraries/Common/tests/Tests/System/Net/aspnetcore/            @dotnet/http
 

--- a/docs/coding-guidelines/interop-guidelines.md
+++ b/docs/coding-guidelines/interop-guidelines.md
@@ -15,10 +15,6 @@ We have the following goals related to interop code being used in dotnet/runtime
 - Ensure maximal managed code reuse across different OS flavors which have  the same API but not the same ABI.
    - This is the case for UNIX and addressing it is a work-in-progress (see issue #2137 and section on "shims" below.)
 
-## Submitting Changes
-
-Interop code implicitly defines the native platform dependencies that .NET has. These dependencies are tracked and modeled according to the [`os-packages.json` file](https://github.com/dotnet/core/tree/main/release-notes/schemas#os-packages----os-packagesjson) for each version. Whenever a PR is submitted that changes interop code, it needs to be reviewed to determine whether a change to the `os-packages.json` file is required.
-
 ## Approach
 
 ### Interop type

--- a/docs/coding-guidelines/interop-guidelines.md
+++ b/docs/coding-guidelines/interop-guidelines.md
@@ -17,9 +17,7 @@ We have the following goals related to interop code being used in dotnet/runtime
 
 ## Submitting Changes
 
-Interop code implicitly defines the native platform dependencies that .NET has. These dependencies are tracked and modeled according to the [Tracking Platform Dependencies design](https://github.com/dotnet/designs/blob/main/accepted/2021/platform-dependencies/platform-dependencies.md). Whenever a PR is submitted that changes interop code, it needs to be reviewed to determine whether a change to the platform dependencies model is required.
-
-By default, any change to `src/libraries/Common/src/Interop` folder will add @dotnet/platform-deps-team as a reviewer. If necessary, update the corresponding `https://github.com/dotnet/core/blob/main/release-notes/<product-version>/runtime-deps.json` file to reflect the dependency change. The scope of dependencies is at the file/package level, not individual functions, so interop changes rarely require an update to the model.
+Interop code implicitly defines the native platform dependencies that .NET has. These dependencies are tracked and modeled according to the [`os-packages.json` file](https://github.com/dotnet/core/tree/main/release-notes/schemas#os-packages----os-packagesjson) for each version. Whenever a PR is submitted that changes interop code, it needs to be reviewed to determine whether a change to the `os-packages.json` file is required.
 
 ## Approach
 


### PR DESCRIPTION
* Removed references to the now defunct [platform dependencies design](https://github.com/dotnet/designs/blob/main/accepted/2021/platform-dependencies/platform-dependencies.md).
* Replaced with references to the [OS packages design](https://github.com/dotnet/core/tree/main/release-notes/schemas#os-packages----os-packagesjson).
* Removed references to the `dotnet/platform-deps-team` of which only I am a member. I'm deleting that team.