### PR TITLE
[EventPipe] Optimize ThreadSessionState Management and Cleanup

### DIFF
--- a/src/native/containers/dn-umap-t.h
+++ b/src/native/containers/dn-umap-t.h
@@ -56,6 +56,7 @@ dn_umap_ ## key_type_name ## _ ## value_type_name ## _find (dn_umap_t *map, key_
 }
 
 DN_UMAP_IT_KEY_T (ptr, void *)
+DN_UMAP_IT_KEY_T (threadid, ep_rt_thread_id_t)
 
 DN_UMAP_IT_VALUE_T (bool, bool)
 DN_UMAP_IT_VALUE_T (int8_t, int8_t)
@@ -73,5 +74,6 @@ DN_UMAP_T (ptr, void *, uint16, uint16_t)
 DN_UMAP_T (ptr, void *, int32, int32_t)
 DN_UMAP_T (ptr, void *, uint32, uint32_t)
 DN_UMAP_T (uint32, uint32_t, ptr, void *)
+DN_UMAP_T (threadid, ep_rt_thread_id_t, uint32, uint32_t)
 
 #endif /* __DN_UMAP_T_H__ */

--- a/src/native/eventpipe/ep-block.c
+++ b/src/native/eventpipe/ep-block.c
@@ -906,10 +906,10 @@ ep_sequence_point_block_init (
 	const uint32_t thread_count = dn_umap_size (map);
 	ep_write_buffer_uint32_t (&sequence_point_block->block.write_pointer, thread_count);
 
-	DN_UMAP_FOREACH_BEGIN (const EventPipeThreadSessionState *, key, uint32_t, sequence_number, map) {
+	DN_UMAP_FOREACH_BEGIN (ep_rt_thread_id_t, key, uint32_t, sequence_number, map) {
 		ep_write_buffer_uint64_t (
 			&sequence_point_block->block.write_pointer,
-			ep_thread_get_os_thread_id (ep_thread_session_state_get_thread (key)));
+			ep_rt_thread_id_t_to_uint64_t (key));
 
 		ep_write_buffer_uint32_t (
 			&sequence_point_block->block.write_pointer,

--- a/src/native/eventpipe/ep-buffer-manager.h
+++ b/src/native/eventpipe/ep-buffer-manager.h
@@ -31,9 +31,6 @@ struct _EventPipeBufferList_Internal {
 	EventPipeBuffer *tail_buffer;
 	// The number of buffers in the list.
 	uint32_t buffer_count;
-	// The sequence number of the last event that was read, only
-	// updated/read by the reader thread.
-	uint32_t last_read_sequence_number;
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_BUFFER_MANAGER_GETTER_SETTER)
@@ -113,6 +110,9 @@ struct _EventPipeBufferManager_Internal {
 	EventPipeEventInstance *current_event;
 	EventPipeBuffer *current_buffer;
 	EventPipeBufferList *current_buffer_list;
+	// The thread session state grabbed from the thread_session_state_list containing the current event
+	// that is being processed by the reader thread.
+	EventPipeThreadSessionState *current_thread_session_state;
 	// The total allocation size of buffers under management.
 	volatile size_t size_of_all_buffers;
 	// The maximum allowable size of buffers under management.

--- a/src/native/eventpipe/ep-buffer-manager.h
+++ b/src/native/eventpipe/ep-buffer-manager.h
@@ -243,5 +243,10 @@ bool
 ep_buffer_manager_ensure_consistency (EventPipeBufferManager *buffer_manager);
 #endif
 
+void
+ep_buffer_manager_remove_thread_if_buffer_list_empty (
+	EventPipeBufferManager *buffer_manager,
+	EventPipeThreadSessionState *thread_session_state);
+
 #endif /* ENABLE_PERFTRACING */
 #endif /* __EVENTPIPE_BUFFERMANAGER_H__ */

--- a/src/native/eventpipe/ep-event-instance.c
+++ b/src/native/eventpipe/ep-event-instance.c
@@ -229,13 +229,6 @@ sequence_point_fini (EventPipeSequencePoint *sequence_point)
 {
 	EP_ASSERT (sequence_point != NULL);
 
-	// Each entry in the map owns a ref-count on the corresponding thread
-	if (dn_umap_size (sequence_point->thread_sequence_numbers) != 0) {
-		DN_UMAP_FOREACH_KEY_BEGIN (EventPipeThreadSessionState *, key, sequence_point->thread_sequence_numbers) {
-			ep_thread_release (ep_thread_session_state_get_thread (key));
-		} DN_UMAP_FOREACH_END;
-	}
-
 	dn_umap_free (sequence_point->thread_sequence_numbers);
 }
 

--- a/src/native/eventpipe/ep-thread.c
+++ b/src/native/eventpipe/ep-thread.c
@@ -343,7 +343,6 @@ ep_thread_session_state_alloc (
 
 	instance->session = session;
 	instance->sequence_number = 1;
-	instance->last_read_sequence_number = 0;
 
 #ifdef EP_CHECKED_BUILD
 	instance->buffer_manager = buffer_manager;

--- a/src/native/eventpipe/ep-thread.c
+++ b/src/native/eventpipe/ep-thread.c
@@ -34,7 +34,7 @@ ep_thread_alloc (void)
 	ep_rt_spin_lock_alloc (&instance->rt_lock);
 	ep_raise_error_if_nok (ep_rt_spin_lock_is_valid (&instance->rt_lock));
 
-	instance->os_thread_id = ep_rt_thread_id_t_to_uint64_t (ep_rt_current_thread_get_id ());
+	instance->os_thread_id = ep_rt_current_thread_get_id ();
 	memset (instance->session_state, 0, sizeof (instance->session_state));
 
 	instance->writing_event_in_progress = UINT32_MAX;

--- a/src/native/eventpipe/ep-thread.c
+++ b/src/native/eventpipe/ep-thread.c
@@ -343,6 +343,7 @@ ep_thread_session_state_alloc (
 
 	instance->session = session;
 	instance->sequence_number = 1;
+	instance->last_read_sequence_number = 0;
 
 #ifdef EP_CHECKED_BUILD
 	instance->buffer_manager = buffer_manager;

--- a/src/native/eventpipe/ep-thread.h
+++ b/src/native/eventpipe/ep-thread.h
@@ -36,7 +36,7 @@ struct _EventPipeThread_Internal {
 	ep_rt_spin_lock_handle_t rt_lock;
 	// This is initialized when the Thread object is first constructed and remains
 	// immutable afterwards.
-	uint64_t os_thread_id;
+	ep_rt_thread_id_t os_thread_id;
 	// The EventPipeThreadHolder maintains one count while the thread is alive
 	// and each session's EventPipeBufferList maintains one count while it
 	// exists.
@@ -73,7 +73,7 @@ ep_thread_get_activity_id_cref (ep_rt_thread_activity_id_handle_t activity_id_ha
 EP_DEFINE_GETTER(EventPipeThread *, thread, EventPipeSession *, rundown_session);
 EP_DEFINE_SETTER(EventPipeThread *, thread, EventPipeSession *, rundown_session);
 EP_DEFINE_GETTER_REF(EventPipeThread *, thread, ep_rt_spin_lock_handle_t *, rt_lock);
-EP_DEFINE_GETTER(EventPipeThread *, thread, uint64_t, os_thread_id);
+EP_DEFINE_GETTER(EventPipeThread *, thread, ep_rt_thread_id_t, os_thread_id);
 EP_DEFINE_GETTER_REF(EventPipeThread *, thread, int32_t *, ref_count);
 EP_DEFINE_GETTER_REF(EventPipeThread *, thread, volatile uint32_t *, unregistered);
 

--- a/src/native/eventpipe/ep-thread.h
+++ b/src/native/eventpipe/ep-thread.h
@@ -267,10 +267,8 @@ struct _EventPipeThreadSessionState_Internal {
 	// the buffer allocation logic is estimating how many
 	// buffers a given thread has used (see: ep_thread_session_state_get_buffer_count_estimate and its uses).
 	EventPipeBufferList *buffer_list;
-#ifdef EP_CHECKED_BUILD
 	// protected by the buffer manager lock.
 	EventPipeBufferManager *buffer_manager;
-#endif
 	// The number of events that were attempted to be written by this
 	// thread. Each event was either successfully recorded in a buffer
 	// or it was dropped.
@@ -301,6 +299,7 @@ struct _EventPipeThreadSessionState {
 
 EP_DEFINE_GETTER_REF(EventPipeThreadSessionState *, thread_session_state, EventPipeThreadHolder *, thread_holder)
 EP_DEFINE_GETTER(EventPipeThreadSessionState *, thread_session_state, EventPipeSession *, session)
+EP_DEFINE_GETTER(EventPipeThreadSessionState *, thread_session_state, EventPipeBufferManager *, buffer_manager)
 
 EventPipeThreadSessionState *
 ep_thread_session_state_alloc (

--- a/src/native/eventpipe/ep-thread.h
+++ b/src/native/eventpipe/ep-thread.h
@@ -267,6 +267,9 @@ struct _EventPipeThreadSessionState_Internal {
 	// the buffer allocation logic is estimating how many
 	// buffers a given thread has used (see: ep_thread_session_state_get_buffer_count_estimate and its uses).
 	EventPipeBufferList *buffer_list;
+	// The sequence number of the last event that was read, only
+	// updated/read by the reader thread.
+	uint32_t last_read_sequence_number;
 #ifdef EP_CHECKED_BUILD
 	// protected by the buffer manager lock.
 	EventPipeBufferManager *buffer_manager;
@@ -301,6 +304,8 @@ struct _EventPipeThreadSessionState {
 
 EP_DEFINE_GETTER_REF(EventPipeThreadSessionState *, thread_session_state, EventPipeThreadHolder *, thread_holder)
 EP_DEFINE_GETTER(EventPipeThreadSessionState *, thread_session_state, EventPipeSession *, session)
+EP_DEFINE_GETTER(EventPipeThreadSessionState *, thread_session_state, uint32_t, last_read_sequence_number);
+EP_DEFINE_SETTER(EventPipeThreadSessionState *, thread_session_state, uint32_t, last_read_sequence_number);
 
 EventPipeThreadSessionState *
 ep_thread_session_state_alloc (

--- a/src/native/eventpipe/ep-thread.h
+++ b/src/native/eventpipe/ep-thread.h
@@ -267,9 +267,6 @@ struct _EventPipeThreadSessionState_Internal {
 	// the buffer allocation logic is estimating how many
 	// buffers a given thread has used (see: ep_thread_session_state_get_buffer_count_estimate and its uses).
 	EventPipeBufferList *buffer_list;
-	// The sequence number of the last event that was read, only
-	// updated/read by the reader thread.
-	uint32_t last_read_sequence_number;
 #ifdef EP_CHECKED_BUILD
 	// protected by the buffer manager lock.
 	EventPipeBufferManager *buffer_manager;
@@ -304,8 +301,6 @@ struct _EventPipeThreadSessionState {
 
 EP_DEFINE_GETTER_REF(EventPipeThreadSessionState *, thread_session_state, EventPipeThreadHolder *, thread_holder)
 EP_DEFINE_GETTER(EventPipeThreadSessionState *, thread_session_state, EventPipeSession *, session)
-EP_DEFINE_GETTER(EventPipeThreadSessionState *, thread_session_state, uint32_t, last_read_sequence_number);
-EP_DEFINE_SETTER(EventPipeThreadSessionState *, thread_session_state, uint32_t, last_read_sequence_number);
 
 EventPipeThreadSessionState *
 ep_thread_session_state_alloc (


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/111368

This PR implements a comprehensive cleanup and optimization of EventPipe's ThreadSessionState management to address performance issues in scenarios with many short-lived threads.

### Background
Throughout an EventPipe Session's lifetime, threads that write events induce allocations of `EventPipeThread`, `EventPipeThreadSessionState`, `EventPipeBufferList`, `EventPipeBuffer`, and `EventPipeSequencePoint` objects. Many of these objects were held throughout the entire session lifetime instead of just their scope of utility, leading to:

- Performance degradation due to bloated thread_session_state_list containing exhausted instances
- Memory inefficiency from retaining objects for threads that have exited
- Suboptimal event discovery as the buffer manager holds instances whose buffers are exhausted and will never receive new events

This PR does the following:

1. **ThreadSessionState Cleanup**: Added cleanup measures to remove ThreadSessionState instances whose buffer_list is empty and the corresponding thread has been unregistered, indicating the thread has exited and will not write new events.
2. **Sequence Point Map Optimization**: Moved sequence point map updates to occur in tandem with event processing rather than relying on the potentially trimmed thread_session_state_list. The update now happens after processing all available events from a thread.
3. **Direct Thread ID Storage**: Simplified sequence point handling by directly storing native thread IDs in the sequence point map instead of dynamically retrieving them through EventPipeThreadSessionState, eliminating associated ref counting complexity.

4. **Buffer Manager State Tracking**: Enhanced the buffer manager to track the current ThreadSessionState being processed, enabling proper cleanup while maintaining the ability to re-add instances that receive new events.
5. **Code Quality Improvements**: Updated loops to use foreach macros, consolidated sequence point logic, and improved code organization.

### Testing

Running the repro provided in the original issue, 
#### Before
```
Q:\source\mdh1418\TestApp> corerun .\bin\Debug\net10.0\win-x64\publish\TestApp.dll 10000 10000
Press any key to start spawning threads and throwing exceptions
Enabling CLR EventPipe

Throwing and catching 1000 exceptions (warm up JIT)

Throwing and catching 10000 exceptions
RSS: 79.5MiB, user CPU: 96.9%
40000 EventPipe events received, 10000 exceptions thrown

Spawning 10000 short-lived threads
RSS: 118.7MiB, user CPU: 195.8%
32485 EventPipe events received, 10000 exceptions thrown

Throwing and catching 10000 exceptions
RSS: 126.5MiB, user CPU: 199.7%
7128 EventPipe events received, 10000 exceptions thrown

Reconfiguring EventPipe with identical settings

Throwing and catching 10000 exceptions
RSS: 116.0MiB, user CPU: 104.1%
40014 EventPipe events received, 10000 exceptions thrown
```

#### After
```
Q:\source\mdh1418\TestApp> corerun .\bin\Debug\net10.0\win-x64\publish\TestApp.dll 10000 10000
Press any key to start spawning threads and throwing exceptions
Enabling CLR EventPipe

Throwing and catching 1000 exceptions (warm up JIT)

Throwing and catching 10000 exceptions
RSS: 79.3MiB, user CPU: 97.1%
40000 EventPipe events received, 10000 exceptions thrown

Spawning 10000 short-lived threads
RSS: 117.1MiB, user CPU: 121.9%
40000 EventPipe events received, 10000 exceptions thrown

Throwing and catching 10000 exceptions
RSS: 118.2MiB, user CPU: 103.6%
40000 EventPipe events received, 10000 exceptions thrown

Reconfiguring EventPipe with identical settings

Throwing and catching 10000 exceptions
RSS: 116.9MiB, user CPU: 104.7%
40000 EventPipe events received, 10000 exceptions thrown
```