### PR TITLE
[DAC] Change `EnumMethodInstancesByAddress` behavior

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -4186,6 +4186,11 @@ ClrDataAccess::StartEnumMethodInstancesByAddress(
             goto Exit;
         }
 
+        if (!methodDesc->HasNativeCodeAnyVersion())
+        {
+            goto Exit;
+        }
+
         status = EnumMethodInstances::CdStart(methodDesc, appDomain,
                                               handle);
 
@@ -5990,7 +5995,7 @@ ClrDataAccess::GetMethodVarInfo(MethodDesc* methodDesc,
     BOOL success = DebugInfoManager::GetBoundariesAndVars(
         request,
         DebugInfoStoreNew, NULL, // allocator
-        BoundsType::Instrumented, 
+        BoundsType::Instrumented,
         NULL, NULL,
         &countNativeVarInfo, &nativeVars);
 

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -3798,9 +3798,8 @@ public:
     static HRESULT CdEnd(CLRDATA_ENUM handle);
 
     MethodDesc* m_methodDesc;
-    bool m_appDomainUsed;
     AppDomain* m_appDomain;
-    LoadedMethodDescIterator m_methodIter;
+    bool m_completed;
 };
 
 //----------------------------------------------------------------------------

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -5152,19 +5152,12 @@ EnumMethodDefinitions::CdEnd(CLRDATA_ENUM handle)
 
 EnumMethodInstances::EnumMethodInstances(MethodDesc* methodDesc,
                                          IXCLRDataAppDomain* givenAppDomain)
+    : m_methodDesc(methodDesc),
+      m_appDomain(givenAppDomain ?
+                  ((ClrDataAppDomain*)givenAppDomain)->GetAppDomain() :
+                  AppDomain::GetCurrentDomain()),
+      m_completed(false)
 {
-    m_methodDesc = methodDesc;
-    if (givenAppDomain)
-    {
-        m_appDomain =
-            ((ClrDataAppDomain*)givenAppDomain)->GetAppDomain();
-    }
-    else
-    {
-        m_appDomain = AppDomain::GetCurrentDomain();
-    }
-
-    m_completed = false;
 }
 
 HRESULT


### PR DESCRIPTION
Modifies `EnumMethodInstancesByAddress` to only return a single IXCLRDataMethodInstance representing the instance at the given IP address.

Running diagnostics tests on new behavior