### PR TITLE
Re-enable VarianceSafety tests on crossgen

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -549,9 +549,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/109200</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/NegativeTestCases/VarianceSafety/**">
-            <Issue>https://github.com/dotnet/runtime/issues/109201</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_68278/**">
             <Issue>https://github.com/dotnet/runtime/issues/108255</Issue>
         </ExcludeList>


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/109201 does not reproduce for me locally on Windows, and does not appear to reproduce on CI anymore.