### PR TITLE
Check source and destination spans overlap in TryNormalize method

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3791,9 +3791,6 @@
   <data name="Argument_OverlapAlignmentMismatch" xml:space="preserve">
     <value>Overlapping spans have mismatching alignment.</value>
   </data>
-  <data name="Argument_OverlapSpansAreNotAllowed" xml:space="preserve">
-    <value>Overlapping source and destination spans are not allowed.</value>
-  </data>
   <data name="Arg_InsufficientNumberOfElements" xml:space="preserve">
     <value>At least {0} element(s) are expected in the parameter "{1}".</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -3790,6 +3790,9 @@
   </data>
   <data name="Argument_OverlapAlignmentMismatch" xml:space="preserve">
     <value>Overlapping spans have mismatching alignment.</value>
+  </data>
+  <data name="Argument_OverlapSpansAreNotAllowed" xml:space="preserve">
+    <value>Overlapping source and destination spans are not allowed.</value>
   </data>
   <data name="Arg_InsufficientNumberOfElements" xml:space="preserve">
     <value>At least {0} element(s) are expected in the parameter "{1}".</value>

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
@@ -44,6 +44,11 @@ namespace System.Globalization
         {
             CheckNormalizationForm(normalizationForm);
 
+            if (source.Overlaps(destination))
+            {
+                throw new ArgumentException(SR.Argument_OverlapSpansAreNotAllowed, nameof(destination));
+            }
+
             // In Invariant mode we assume all characters are normalized because we don't support any linguistic operations on strings.
             // If it's ASCII && one of the 4 main forms, then it's already normalized.
             if (GlobalizationMode.Invariant || Ascii.IsValid(source))

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
@@ -46,7 +46,7 @@ namespace System.Globalization
 
             if (source.Overlaps(destination))
             {
-                throw new ArgumentException(SR.Argument_OverlapSpansAreNotAllowed, nameof(destination));
+                ThrowHelper.ThrowArgumentException(ExceptionResource.InvalidOperation_SpanOverlappedOperation);
             }
 
             // In Invariant mode we assume all characters are normalized because we don't support any linguistic operations on strings.

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
@@ -126,6 +126,11 @@ namespace System.Globalization.Tests
 
             AssertExtensions.Throws<ArgumentException>("strInput", () => "\uD800\uD800".Normalize()); // Invalid surrogate pair
             AssertExtensions.Throws<ArgumentException>("source", () => "\uD800\uD800".AsSpan().TryNormalize(destination, out int charsWritten)); // Invalid surrogate pair
+
+            char[] overlappingDestination = new char[5] { 'a', 'b', 'c', 'd', 'e' };
+            Assert.Throws<ArgumentException>("destination", () => overlappingDestination.AsSpan().TryNormalize(overlappingDestination.AsSpan(), out int charsWritten, NormalizationForm.FormC));
+            Assert.Throws<ArgumentException>("destination", () => overlappingDestination.AsSpan(0, 3).TryNormalize(overlappingDestination.AsSpan(), out int charsWritten, NormalizationForm.FormC));
+            Assert.Throws<ArgumentException>("destination", () => overlappingDestination.AsSpan().TryNormalize(overlappingDestination.AsSpan(4), out int charsWritten, NormalizationForm.FormC));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
@@ -130,7 +130,7 @@ namespace System.Globalization.Tests
             char[] overlappingDestination = new char[5] { 'a', 'b', 'c', 'd', 'e' };
             Assert.Throws<ArgumentException>(() => overlappingDestination.AsSpan().TryNormalize(overlappingDestination.AsSpan(), out int charsWritten, NormalizationForm.FormC));
             Assert.Throws<ArgumentException>(() => overlappingDestination.AsSpan(0, 3).TryNormalize(overlappingDestination.AsSpan(), out int charsWritten, NormalizationForm.FormC));
-            Assert.Throws<ArgumentException>(() => overlappingDestination.AsSpan().TryNormalize(overlappingDestination.AsSpan(4), out int charsWritten, NormalizationForm.FormC));
+            Assert.Throws<ArgumentException>(() => overlappingDestination.AsSpan(4).TryNormalize(overlappingDestination.AsSpan(), out int charsWritten, NormalizationForm.FormC));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
@@ -128,9 +128,9 @@ namespace System.Globalization.Tests
             AssertExtensions.Throws<ArgumentException>("source", () => "\uD800\uD800".AsSpan().TryNormalize(destination, out int charsWritten)); // Invalid surrogate pair
 
             char[] overlappingDestination = new char[5] { 'a', 'b', 'c', 'd', 'e' };
-            Assert.Throws<ArgumentException>("destination", () => overlappingDestination.AsSpan().TryNormalize(overlappingDestination.AsSpan(), out int charsWritten, NormalizationForm.FormC));
-            Assert.Throws<ArgumentException>("destination", () => overlappingDestination.AsSpan(0, 3).TryNormalize(overlappingDestination.AsSpan(), out int charsWritten, NormalizationForm.FormC));
-            Assert.Throws<ArgumentException>("destination", () => overlappingDestination.AsSpan().TryNormalize(overlappingDestination.AsSpan(4), out int charsWritten, NormalizationForm.FormC));
+            Assert.Throws<ArgumentException>(() => overlappingDestination.AsSpan().TryNormalize(overlappingDestination.AsSpan(), out int charsWritten, NormalizationForm.FormC));
+            Assert.Throws<ArgumentException>(() => overlappingDestination.AsSpan(0, 3).TryNormalize(overlappingDestination.AsSpan(), out int charsWritten, NormalizationForm.FormC));
+            Assert.Throws<ArgumentException>(() => overlappingDestination.AsSpan().TryNormalize(overlappingDestination.AsSpan(4), out int charsWritten, NormalizationForm.FormC));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/118017

In .NET we have introduced the extension method https://github.com/dotnet/runtime/blob/1e860a4bd3915f35d51cc079cff212322a6991e7/src/libraries/System.Private.CoreLib/src/System/StringNormalizationExtensions.cs#L80

If the user provides overlapping source and destination spans, it leads to undefined behavior, since we rely on underlying OS components for normalization. The fix is straightforward: disallow overlapping spans and throw an exception. This API is new and hasn’t shipped in any released version yet, so there are no compatibility concerns at this point—we’re addressing it now to prevent future issues.