### PR TITLE
[Android][CoreCLR] Use relative path instead of just the filename when probing for assembly

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -229,7 +229,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <!-- https://github.com/dotnet/runtime/issues/114951 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Resources.ResourceManager.Tests\System.Resources.ResourceManager.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests\InvariantTimezone\System.Runtime.InvariantTimezone.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Text.Encoding.Tests\System.Text.Encoding.Tests.csproj" />
     <!-- https://github.com/dotnet/runtime/issues/62547 -->

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
@@ -106,11 +106,6 @@ external_assembly_probe(const char* name, void** data, int64_t* size)
         return false;
     }
 
-    // Get just the file name
-    const char* pos = strrchr(name, '/');
-    if (pos != NULL)
-        name = pos + 1;
-
     // Look in the bundle path where the files were extracted
     char full_path[1024];
     size_t path_len = strlen(g_bundle_path) + strlen(name) + 1; // +1 for '/'

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid-coreclr.c
@@ -98,18 +98,18 @@ bundle_executable_path (const char* executable, const char* bundle_path, const c
 }
 
 static bool
-external_assembly_probe(const char* name, void** data, int64_t* size)
+external_assembly_probe(const char* relative_assembly_path, void** data, int64_t* size)
 {
     if (g_mapped_files_count >= MAX_MAPPED_COUNT)
     {
-        LOG_ERROR("Too many mapped files, cannot map %s", name);
+        LOG_ERROR("Too many mapped files, cannot map %s", relative_assembly_path);
         return false;
     }
 
     // Look in the bundle path where the files were extracted
     char full_path[1024];
-    size_t path_len = strlen(g_bundle_path) + strlen(name) + 1; // +1 for '/'
-    size_t res = snprintf(full_path, path_len + 1, "%s/%s", g_bundle_path, name);
+    size_t path_len = strlen(g_bundle_path) + strlen(relative_assembly_path) + 1; // +1 for '/'
+    size_t res = snprintf(full_path, path_len + 1, "%s/%s", g_bundle_path, relative_assembly_path);
     if (res < 0 || res != path_len)
         return false;
 
@@ -132,7 +132,7 @@ external_assembly_probe(const char* name, void** data, int64_t* size)
         return false;
     }
 
-    LOG_INFO("Mapped %s -> %s", name, full_path);
+    LOG_INFO("Mapped %s -> %s", relative_assembly_path, full_path);
     g_mapped_files[g_mapped_files_count] = mapped;
     g_mapped_file_sizes[g_mapped_files_count] = size_local;
     g_mapped_files_count++;


### PR DESCRIPTION
## Description

In this PR, we improve our CoreCLR Android test host by using the whole relative path to an assembly when probing for it, instead of just using the assembly name to search in the app root. Furthermore, newly fixed tests were enabled.

### Why it works

- The `external_assembly_probe` function in `monodroid-coreclr.c` is used for loading assemblies on the android test host.
- This function receives the path to assembly relative to the app root.
- Originally, it stripped the relative path and extracted only the name of the assembly
- Finally, it tried looking for the assembly at `app_root/assembly_name`, which wasn't always successful
- We fix this by looking for the assembly at `app_root/relative_assembly_path`
- This issue primarily affected satellite assemblies (localization resources) which are stored in culture-specific subdirectories like `fr/`, `es/`, etc.
- E.g. the assembly is located at `app_root/fr/App.resources.dll`, but the function would incorrectly look for `app_root/App.resources.dll`

## Related issues

- Fixes #118012
- Contributes to #114951
