### PR TITLE
Introduce MetadataEEType node halfway between Constructed and Necessary

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DevirtualizationManager.cs
+++ b/src/coreclr/tools/Common/Compiler/DevirtualizationManager.cs
@@ -211,6 +211,12 @@ namespace ILCompiler
         public virtual bool CanReferenceConstructedMethodTable(TypeDesc type) => true;
 
         /// <summary>
+        /// Gets a value indicating whether it might be possible to obtain a metadata type data structure for the given type
+        /// in this compilation (i.e. is it possible to reference a metadata MethodTable symbol for this).
+        /// </summary>
+        public virtual bool CanReferenceMetadataMethodTable(TypeDesc type) => true;
+
+        /// <summary>
         /// Gets a value indicating whether a (potentially canonically-equlivalent) constructed MethodTable could
         /// exist. This is similar to <see cref="CanReferenceConstructedMethodTable"/>, but will return true
         /// for List&lt;__Canon&gt; if a constructed MethodTable for List&lt;object&gt; exists.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -278,6 +278,9 @@ namespace ILCompiler
             if (ConstructedEETypeNode.CreationAllowed(type))
             {
                 if (NodeFactory.DevirtualizationManager.CanReferenceConstructedMethodTable(type.NormalizeInstantiation()))
+                    return ReadyToRunHelperId.TypeHandle;
+
+                if (NodeFactory.DevirtualizationManager.CanReferenceMetadataMethodTable(type.NormalizeInstantiation()))
                     return ReadyToRunHelperId.MetadataTypeHandle;
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -241,6 +241,7 @@ namespace ILCompiler
             {
                 case ReadyToRunHelperId.TypeHandle:
                 case ReadyToRunHelperId.NecessaryTypeHandle:
+                case ReadyToRunHelperId.MetadataTypeHandle:
                 case ReadyToRunHelperId.DefaultConstructor:
                 case ReadyToRunHelperId.TypeHandleForCasting:
                 case ReadyToRunHelperId.ObjectAllocator:
@@ -271,13 +272,14 @@ namespace ILCompiler
             // We need to make a small exception for canonical definitions because of RuntimeAugments.GetCanonType
             Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Any) || type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
 
-            bool canPotentiallyConstruct = ConstructedEETypeNode.CreationAllowed(type)
-                && NodeFactory.DevirtualizationManager.CanReferenceConstructedMethodTable(type.NormalizeInstantiation());
-            if (canPotentiallyConstruct)
-                return ReadyToRunHelperId.TypeHandle;
-
             if (type.IsGenericDefinition && NodeFactory.DevirtualizationManager.IsGenericDefinitionMethodTableReflectionVisible(type))
-                return ReadyToRunHelperId.TypeHandle;
+                return ReadyToRunHelperId.MetadataTypeHandle;
+
+            if (ConstructedEETypeNode.CreationAllowed(type))
+            {
+                if (NodeFactory.DevirtualizationManager.CanReferenceConstructedMethodTable(type.NormalizeInstantiation()))
+                    return ReadyToRunHelperId.MetadataTypeHandle;
+            }
 
             return ReadyToRunHelperId.NecessaryTypeHandle;
         }
@@ -307,6 +309,8 @@ namespace ILCompiler
             {
                 case ReadyToRunHelperId.TypeHandle:
                     return NodeFactory.ConstructedTypeSymbol((TypeDesc)targetOfLookup);
+                case ReadyToRunHelperId.MetadataTypeHandle:
+                    return NodeFactory.MetadataTypeSymbol((TypeDesc)targetOfLookup);
                 case ReadyToRunHelperId.NecessaryTypeHandle:
                     return NecessaryTypeSymbolIfPossible((TypeDesc)targetOfLookup);
                 case ReadyToRunHelperId.TypeHandleForCasting:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -82,7 +82,7 @@ namespace ILCompiler.DependencyAnalysis
         protected override FrozenRuntimeTypeNode GetFrozenRuntimeTypeNode(NodeFactory factory)
         {
             Debug.Assert(!_type.IsCanonicalSubtype(CanonicalFormKind.Any));
-            return factory.SerializedConstructedRuntimeTypeObject(_type);
+            return factory.SerializedMetadataRuntimeTypeObject(_type);
         }
 
         protected override ISymbolNode GetNonNullableValueTypeArrayElementTypeNode(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -33,9 +33,6 @@ namespace ILCompiler.DependencyAnalysis
             // relocs to nodes we emit.
             dependencyList.Add(factory.MetadataTypeSymbol(_type), "MetadataType for constructed type");
 
-            if (_type is MetadataType mdType)
-                ModuleUseBasedDependencyAlgorithm.AddDependenciesDueToModuleUse(ref dependencyList, factory, mdType.Module);
-
             DefType closestDefType = _type.GetClosestDefType();
 
             if (_type.IsArray)
@@ -65,9 +62,6 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                // Ask the metadata manager if we have any dependencies due to the presence of the EEType.
-                factory.MetadataManager.GetDependenciesDueToEETypePresence(ref dependencyList, factory, _type);
-
                 factory.InteropStubManager.AddInterestingInteropConstructedTypeDependencies(ref dependencyList, factory, _type);
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -22,14 +22,16 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override bool EmitVirtualSlots => true;
 
+        protected override bool IsReflectionVisible => true;
+
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             DependencyList dependencyList = base.ComputeNonRelocationBasedDependencies(factory);
 
-            // Ensure that we track the necessary type symbol if we are working with a constructed type symbol.
+            // Ensure that we track the metadata type symbol if we are working with a constructed type symbol.
             // The emitter will ensure we don't emit both, but this allows us assert that we only generate
             // relocs to nodes we emit.
-            dependencyList.Add(factory.NecessaryTypeSymbol(_type), "NecessaryType for constructed type");
+            dependencyList.Add(factory.MetadataTypeSymbol(_type), "MetadataType for constructed type");
 
             if (_type is MetadataType mdType)
                 ModuleUseBasedDependencyAlgorithm.AddDependenciesDueToModuleUse(ref dependencyList, factory, mdType.Module);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -212,13 +212,23 @@ namespace ILCompiler.DependencyAnalysis
         {
             slot = Array.IndexOf(_layout, entry);
 
-            // If we're looking for a necessary type handle and it doesn't exist, check for a constructed type handle.
-            if (slot < 0 && entry is NecessaryTypeHandleGenericLookupResult necessaryLookup)
+
+            // If we're looking for a low type handle load level and it doesn't exist, check for a higher load level.
+            var necessaryLookup = entry as NecessaryTypeHandleGenericLookupResult;
+            var metadataLookup = entry as MetadataTypeHandleGenericLookupResult;
+            if (slot < 0
+                && (necessaryLookup != null || metadataLookup != null))
             {
                 for (int i = 0; i < _layout.Length; i++)
                 {
-                    if (_layout[i] is TypeHandleGenericLookupResult other
-                        && other.Type == necessaryLookup.Type)
+                    if (_layout[i] is TypeHandleGenericLookupResult thOther
+                        && (thOther.Type == necessaryLookup?.Type || thOther.Type == metadataLookup?.Type))
+                    {
+                        slot = i;
+                        return true;
+                    }
+                    if (_layout[i] is MetadataTypeHandleGenericLookupResult mdOther
+                        && mdOther.Type == necessaryLookup?.Type)
                     {
                         slot = i;
                         return true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1136,7 +1136,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (!_type.IsTypeDefinition)
                 {
-                    IEETypeNode typeDefNode = factory.MaximallyConstructableType(_type) == this ?
+                    IEETypeNode typeDefNode = IsReflectionVisible ?
                         factory.MetadataTypeSymbol(_type.GetTypeDefinition()) : factory.NecessaryTypeSymbol(_type.GetTypeDefinition());
                     if (factory.Target.SupportsRelativePointers)
                         objData.EmitReloc(typeDefNode, RelocType.IMAGE_REL_BASED_RELPTR32);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -323,7 +323,7 @@ namespace ILCompiler.DependencyAnalysis
 
             if (IsReflectionVisible)
             {
-                factory.MetadataManager.GetConditionalDependenciesDueToEETypePresence(ref result, factory, _type);
+                factory.MetadataManager.GetConditionalDependenciesDueToEETypePresence(ref result, factory, _type, allocated: EmitVirtualSlots);
 
                 if (!_type.IsCanonicalSubtype(CanonicalFormKind.Any))
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -200,11 +200,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {
-            // If there is a constructed version of this node in the graph, emit that instead
-            if (ConstructedEETypeNode.CreationAllowed(_type))
-                return factory.ConstructedTypeSymbol(_type).Marked;
-
-            return false;
+            return factory.MetadataTypeSymbol(_type).Marked;
         }
 
         public virtual ISymbolNode NodeForLinkage(NodeFactory factory)
@@ -225,6 +221,8 @@ namespace ILCompiler.DependencyAnalysis
         public int MinimumObjectSize => EETypeBuilderHelpers.GetMinimumObjectSize(_type.Context);
 
         protected virtual bool EmitVirtualSlots => false;
+
+        protected virtual bool IsReflectionVisible => false;
 
         public override bool InterestingForDynamicDependencyAnalysis
             => (_virtualMethodAnalysisFlags & VirtualMethodAnalysisFlags.InterestingForDynamicDependencies) != 0;
@@ -283,6 +281,9 @@ namespace ILCompiler.DependencyAnalysis
                 if (_type.RuntimeInterfaces.Length > 0)
                     return true;
 
+                if (IsReflectionVisible && _hasConditionalDependenciesFromMetadataManager)
+                    return true;
+
                 if (!EmitVirtualSlots)
                     return false;
 
@@ -312,13 +313,30 @@ namespace ILCompiler.DependencyAnalysis
                     currentType = currentType.BaseType;
                 }
 
-                return _hasConditionalDependenciesFromMetadataManager;
+                return false;
             }
         }
 
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
             List<CombinedDependencyListEntry> result = new List<CombinedDependencyListEntry>();
+
+            if (IsReflectionVisible)
+            {
+                factory.MetadataManager.GetConditionalDependenciesDueToEETypePresence(ref result, factory, _type);
+
+                if (!_type.IsCanonicalSubtype(CanonicalFormKind.Any))
+                {
+                    foreach (DefType iface in _type.RuntimeInterfaces)
+                    {
+                        var ifaceDefinition = (DefType)iface.GetTypeDefinition();
+                        result.Add(new CombinedDependencyListEntry(
+                            GetInterfaceTypeNode(factory, iface),
+                            factory.InterfaceUse(ifaceDefinition),
+                            "Interface definition was visible"));
+                    }
+                }
+            }
 
             IEETypeNode maximallyConstructableType = factory.MaximallyConstructableType(_type);
 
@@ -341,18 +359,6 @@ namespace ILCompiler.DependencyAnalysis
                     factory.GenericStaticBaseInfo((MetadataType)_type),
                     factory.NativeLayout.TemplateTypeLayout(canonOwningType),
                     "Information about static bases for type with template"));
-            }
-
-            if (!_type.IsCanonicalSubtype(CanonicalFormKind.Any))
-            {
-                foreach (DefType iface in _type.RuntimeInterfaces)
-                {
-                    var ifaceDefinition = (DefType)iface.GetTypeDefinition();
-                    result.Add(new CombinedDependencyListEntry(
-                        GetInterfaceTypeNode(factory, iface),
-                        factory.InterfaceUse(ifaceDefinition),
-                        "Interface definition was visible"));
-                }
             }
 
             if (!EmitVirtualSlots)
@@ -554,8 +560,6 @@ namespace ILCompiler.DependencyAnalysis
                     }
                 }
             }
-
-            factory.MetadataManager.GetConditionalDependenciesDueToEETypePresence(ref result, factory, _type);
 
             return result;
         }
@@ -1133,7 +1137,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (!_type.IsTypeDefinition)
                 {
                     IEETypeNode typeDefNode = factory.MaximallyConstructableType(_type) == this ?
-                        factory.ConstructedTypeSymbol(_type.GetTypeDefinition()) : factory.NecessaryTypeSymbol(_type.GetTypeDefinition());
+                        factory.MetadataTypeSymbol(_type.GetTypeDefinition()) : factory.NecessaryTypeSymbol(_type.GetTypeDefinition());
                     if (factory.Target.SupportsRelativePointers)
                         objData.EmitReloc(typeDefNode, RelocType.IMAGE_REL_BASED_RELPTR32);
                     else
@@ -1141,7 +1145,7 @@ namespace ILCompiler.DependencyAnalysis
 
                     ISymbolNode compositionNode;
 
-                    if (this == factory.MaximallyConstructableType(_type)
+                    if (IsReflectionVisible //this == factory.MaximallyConstructableType(_type)
                         && factory.MetadataManager.IsTypeInstantiationReflectionVisible(_type))
                     {
                         compositionNode = _type.Instantiation.Length > 1

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1145,7 +1145,7 @@ namespace ILCompiler.DependencyAnalysis
 
                     ISymbolNode compositionNode;
 
-                    if (IsReflectionVisible //this == factory.MaximallyConstructableType(_type)
+                    if (IsReflectionVisible
                         && factory.MetadataManager.IsTypeInstantiationReflectionVisible(_type))
                     {
                         compositionNode = _type.Instantiation.Length > 1

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenRuntimeTypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenRuntimeTypeNode.cs
@@ -12,13 +12,13 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class FrozenRuntimeTypeNode : FrozenObjectNode
     {
         private readonly TypeDesc _type;
-        private readonly bool _constructed;
+        private readonly bool _withMetadata;
 
-        public FrozenRuntimeTypeNode(TypeDesc type, bool constructed)
+        public FrozenRuntimeTypeNode(TypeDesc type, bool withMetadata)
         {
             Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Any));
             _type = type;
-            _constructed = constructed;
+            _withMetadata = withMetadata;
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -30,8 +30,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void EncodeContents(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {
-            IEETypeNode typeSymbol = _constructed
-                ? factory.MaximallyConstructableType(_type)
+            IEETypeNode typeSymbol = _withMetadata
+                ? factory.MetadataTypeSymbol(_type)
                 : factory.NecessaryTypeSymbol(_type);
 
             dataBuilder.EmitPointerReloc(factory.ConstructedTypeSymbol(ObjectType));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenRuntimeTypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenRuntimeTypeNode.cs
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysis
         public override void EncodeContents(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {
             IEETypeNode typeSymbol = _constructed
-                ? factory.ConstructedTypeSymbol(_type)
+                ? factory.MaximallyConstructableType(_type)
                 : factory.NecessaryTypeSymbol(_type);
 
             dataBuilder.EmitPointerReloc(factory.ConstructedTypeSymbol(ObjectType));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -69,7 +69,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
         {
-            return factory.ConstructedTypeSymbol(_type).Marked;
+            return factory.MetadataTypeSymbol(_type).Marked;
         }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -93,7 +93,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override FrozenRuntimeTypeNode GetFrozenRuntimeTypeNode(NodeFactory factory)
         {
-            return factory.SerializedConstructedRuntimeTypeObject(_type);
+            return factory.SerializedMetadataRuntimeTypeObject(_type);
         }
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler) + " reflection visible";

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
@@ -54,7 +54,9 @@ namespace ILCompiler.DependencyAnalysis
             MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();
 
             factory.MetadataManager.GetNativeLayoutMetadataDependencies(ref dependencies, factory, openCallingMethod);
+            dependencies.Add(factory.NecessaryTypeSymbol(openCallingMethod.OwningType), "Owning type of GVM declaration");
             factory.MetadataManager.GetNativeLayoutMetadataDependencies(ref dependencies, factory, openImplementationMethod);
+            dependencies.Add(factory.NecessaryTypeSymbol(openImplementationMethod.OwningType), "Owning type of GVM implementation");
         }
 
         private void AddGenericVirtualMethodImplementation(MethodDesc callingMethod, MethodDesc implementationMethod)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MetadataEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MetadataEETypeNode.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+using Internal.Runtime;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public sealed class MetadataEETypeNode : EETypeNode
+    {
+        public MetadataEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
+        {
+            Debug.Assert(!type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
+        }
+
+        protected override bool IsReflectionVisible => true;
+
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler) + " with metadata";
+
+        public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
+        {
+            // If there is a constructed version of this node in the graph, emit that instead
+            if (ConstructedEETypeNode.CreationAllowed(_type))
+                return factory.ConstructedTypeSymbol(_type).Marked;
+
+            return false;
+        }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            DependencyList dependencyList = base.ComputeNonRelocationBasedDependencies(factory);
+
+            // Ensure that we track the necessary type symbol if we are working with a metadata type symbol.
+            // The emitter will ensure we don't emit both, but this allows us assert that we only generate
+            // relocs to nodes we emit.
+            dependencyList.Add(factory.NecessaryTypeSymbol(_type), "NecessaryType for metadata type");
+
+            if (_type is MetadataType mdType)
+                ModuleUseBasedDependencyAlgorithm.AddDependenciesDueToModuleUse(ref dependencyList, factory, mdType.Module);
+
+            // Ask the metadata manager if we have any dependencies due to the presence of the EEType.
+            factory.MetadataManager.GetDependenciesDueToEETypePresence(ref dependencyList, factory, _type);
+
+            // Reflection-visible valuetypes are considered constructed due to APIs like RuntimeHelpers.Box,
+            // or Enum.ToObject.
+            if (_type.IsValueType)
+                dependencyList.Add(factory.MaximallyConstructableType(_type), "Reflection visible valuetype");
+
+            // Delegates can be constructed through runtime magic APIs so consider constructed.
+            if (_type.IsDelegate)
+                dependencyList.Add(factory.MaximallyConstructableType(_type), "Reflection visible delegate");
+
+            // Arrays can be constructed through Array.CreateInstanceFromArrayType so consider constructed.
+            if (_type.IsArray)
+                dependencyList.Add(factory.MaximallyConstructableType(_type), "Reflection visible array");
+
+            // TODO-SIZE: We need to separate tracking the use of static and instance virtual methods
+            // Unconstructed MethodTables only need to track the static virtuals.
+            // For now, conservatively upgrade to constructed types when static virtuals are present
+            bool hasStaticVirtuals = false;
+            foreach (MetadataType intface in _type.RuntimeInterfaces)
+            {
+                foreach (MethodDesc intfaceMethod in intface.GetAllVirtualMethods())
+                {
+                    if (intfaceMethod.Signature.IsStatic)
+                    {
+                        hasStaticVirtuals = true;
+                        break;
+                    }
+                }
+            }
+            if (hasStaticVirtuals)
+                dependencyList.Add(factory.MaximallyConstructableType(_type), "Has static virtual methods");
+
+            return dependencyList;
+        }
+
+        protected override ISymbolNode GetBaseTypeNode(NodeFactory factory)
+        {
+            return _type.BaseType != null ? factory.MetadataTypeSymbol(_type.BaseType.NormalizeInstantiation()) : null;
+        }
+
+        protected override FrozenRuntimeTypeNode GetFrozenRuntimeTypeNode(NodeFactory factory)
+        {
+            // TODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODO
+            // Do we need a new node for this?
+            // TODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODO
+            return factory.SerializedNecessaryRuntimeTypeObject(_type);
+        }
+
+        protected override ISymbolNode GetNonNullableValueTypeArrayElementTypeNode(NodeFactory factory)
+        {
+            return factory.MetadataTypeSymbol(((ArrayType)_type).ElementType);
+        }
+
+        protected override IEETypeNode GetInterfaceTypeNode(NodeFactory factory, TypeDesc interfaceType)
+        {
+            return factory.MetadataTypeSymbol(interfaceType);
+        }
+
+        public override int ClassCode => 99298112;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MetadataEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MetadataEETypeNode.cs
@@ -84,10 +84,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override FrozenRuntimeTypeNode GetFrozenRuntimeTypeNode(NodeFactory factory)
         {
-            // TODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODO
-            // Do we need a new node for this?
-            // TODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODOTODO
-            return factory.SerializedNecessaryRuntimeTypeObject(_type);
+            return factory.SerializedMetadataRuntimeTypeObject(_type);
         }
 
         protected override ISymbolNode GetNonNullableValueTypeArrayElementTypeNode(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.GenericLookups.cs
@@ -32,6 +32,11 @@ namespace ILCompiler.DependencyAnalysis
                     return new NecessaryTypeHandleGenericLookupResult(type);
                 });
 
+                _metadataTypeSymbols = new NodeCache<TypeDesc, GenericLookupResult>(type =>
+                {
+                    return new MetadataTypeHandleGenericLookupResult(type);
+                });
+
                 _unwrapNullableSymbols = new NodeCache<TypeDesc, GenericLookupResult>(type =>
                 {
                     return new UnwrapNullableTypeHandleGenericLookupResult(type);
@@ -105,6 +110,13 @@ namespace ILCompiler.DependencyAnalysis
             public GenericLookupResult NecessaryType(TypeDesc type)
             {
                 return _necessaryTypeSymbols.GetOrAdd(type);
+            }
+
+            private NodeCache<TypeDesc, GenericLookupResult> _metadataTypeSymbols;
+
+            public GenericLookupResult MetadataType(TypeDesc type)
+            {
+                return _metadataTypeSymbols.GetOrAdd(type);
             }
 
             private NodeCache<TypeDesc, GenericLookupResult> _unwrapNullableSymbols;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -439,14 +439,14 @@ namespace ILCompiler.DependencyAnalysis
                 return new SerializedFrozenObjectNode(key.OwnerType, key.AllocationSiteId, key.SerializableObject);
             });
 
-            _frozenConstructedRuntimeTypeNodes = new NodeCache<TypeDesc, FrozenRuntimeTypeNode>(key =>
+            _frozenMetadataRuntimeTypeNodes = new NodeCache<TypeDesc, FrozenRuntimeTypeNode>(key =>
             {
-                return new FrozenRuntimeTypeNode(key, constructed: true);
+                return new FrozenRuntimeTypeNode(key, withMetadata: true);
             });
 
             _frozenNecessaryRuntimeTypeNodes = new NodeCache<TypeDesc, FrozenRuntimeTypeNode>(key =>
             {
-                return new FrozenRuntimeTypeNode(key, constructed: false);
+                return new FrozenRuntimeTypeNode(key, withMetadata: false);
             });
 
             _interfaceDispatchCells = new NodeCache<DispatchCellKey, InterfaceDispatchCellNode>(callSiteCell =>
@@ -1466,18 +1466,11 @@ namespace ILCompiler.DependencyAnalysis
             return _frozenObjectNodes.GetOrAdd(new SerializedFrozenObjectKey(owningType, allocationSiteId, data));
         }
 
-        public FrozenRuntimeTypeNode SerializedMaximallyConstructableRuntimeTypeObject(TypeDesc type)
-        {
-            if (ConstructedEETypeNode.CreationAllowed(type) || type.IsGenericDefinition)
-                return SerializedConstructedRuntimeTypeObject(type);
-            return SerializedNecessaryRuntimeTypeObject(type);
-        }
+        private NodeCache<TypeDesc, FrozenRuntimeTypeNode> _frozenMetadataRuntimeTypeNodes;
 
-        private NodeCache<TypeDesc, FrozenRuntimeTypeNode> _frozenConstructedRuntimeTypeNodes;
-
-        public FrozenRuntimeTypeNode SerializedConstructedRuntimeTypeObject(TypeDesc type)
+        public FrozenRuntimeTypeNode SerializedMetadataRuntimeTypeObject(TypeDesc type)
         {
-            return _frozenConstructedRuntimeTypeNodes.GetOrAdd(type);
+            return _frozenMetadataRuntimeTypeNodes.GetOrAdd(type);
         }
 
         private NodeCache<TypeDesc, FrozenRuntimeTypeNode> _frozenNecessaryRuntimeTypeNodes;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -57,6 +57,8 @@ namespace ILCompiler.DependencyAnalysis
                     return factory.GenericLookup.Type((TypeDesc)target);
                 case ReadyToRunHelperId.NecessaryTypeHandle:
                     return factory.GenericLookup.NecessaryType((TypeDesc)target);
+                case ReadyToRunHelperId.MetadataTypeHandle:
+                    return factory.GenericLookup.MetadataType((TypeDesc)target);
                 case ReadyToRunHelperId.TypeHandleForCasting:
                     // Check that we unwrapped the cases that could be unwrapped to prevent duplicate entries
                     Debug.Assert(factory.GenericLookup.Type((TypeDesc)target) != factory.GenericLookup.UnwrapNullableType((TypeDesc)target));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -30,6 +30,7 @@ namespace ILCompiler.DependencyAnalysis
         // The following helpers are used for generic lookups only
         TypeHandle,
         NecessaryTypeHandle,
+        MetadataTypeHandle,
         DeclaringTypeHandle,
         MethodHandle,
         FieldHandle,

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
@@ -189,6 +189,7 @@ namespace ILCompiler.DependencyAnalysis
                 // These are all simple: just get the thing from the dictionary and we're done
                 case ReadyToRunHelperId.TypeHandle:
                 case ReadyToRunHelperId.NecessaryTypeHandle:
+                case ReadyToRunHelperId.MetadataTypeHandle:
                 case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.FieldHandle:
                 case ReadyToRunHelperId.MethodDictionary:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
@@ -187,6 +187,7 @@ namespace ILCompiler.DependencyAnalysis
                 // These are all simple: just get the thing from the dictionary and we're done
                 case ReadyToRunHelperId.TypeHandle:
                 case ReadyToRunHelperId.NecessaryTypeHandle:
+                case ReadyToRunHelperId.MetadataTypeHandle:
                 case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.FieldHandle:
                 case ReadyToRunHelperId.MethodDictionary:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunGenericHelperNode.cs
@@ -189,6 +189,7 @@ namespace ILCompiler.DependencyAnalysis
                 // These are all simple: just get the thing from the dictionary and we're done
                 case ReadyToRunHelperId.TypeHandle:
                 case ReadyToRunHelperId.NecessaryTypeHandle:
+                case ReadyToRunHelperId.MetadataTypeHandle:
                 case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.FieldHandle:
                 case ReadyToRunHelperId.MethodDictionary:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_RiscV64/RiscV64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_RiscV64/RiscV64ReadyToRunGenericHelperNode.cs
@@ -186,6 +186,7 @@ namespace ILCompiler.DependencyAnalysis
                 // These are all simple: just get the thing from the dictionary and we're done
                 case ReadyToRunHelperId.TypeHandle:
                 case ReadyToRunHelperId.NecessaryTypeHandle:
+                case ReadyToRunHelperId.MetadataTypeHandle:
                 case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.FieldHandle:
                 case ReadyToRunHelperId.MethodDictionary:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -197,6 +197,7 @@ namespace ILCompiler.DependencyAnalysis
                 // These are all simple: just get the thing from the dictionary and we're done
                 case ReadyToRunHelperId.TypeHandle:
                 case ReadyToRunHelperId.NecessaryTypeHandle:
+                case ReadyToRunHelperId.MetadataTypeHandle:
                 case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.FieldHandle:
                 case ReadyToRunHelperId.MethodDictionary:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunGenericHelperNode.cs
@@ -191,6 +191,7 @@ namespace ILCompiler.DependencyAnalysis
                 // These are all simple: just get the thing from the dictionary and we're done
                 case ReadyToRunHelperId.TypeHandle:
                 case ReadyToRunHelperId.NecessaryTypeHandle:
+                case ReadyToRunHelperId.MetadataTypeHandle:
                 case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.FieldHandle:
                 case ReadyToRunHelperId.MethodDictionary:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -493,6 +493,7 @@ namespace ILCompiler
         {
             private CompilerTypeSystemContext _context;
             private HashSet<TypeDesc> _constructedMethodTables = new HashSet<TypeDesc>();
+            private HashSet<TypeDesc> _metadataMethodTables = new HashSet<TypeDesc>();
             private HashSet<TypeDesc> _reflectionVisibleGenericDefinitionMethodTables = new HashSet<TypeDesc>();
             private HashSet<TypeDesc> _canonConstructedMethodTables = new HashSet<TypeDesc>();
             private HashSet<TypeDesc> _canonConstructedTypes = new HashSet<TypeDesc>();
@@ -521,6 +522,11 @@ namespace ILCompiler
                     if (node is ReflectionVisibleGenericDefinitionEETypeNode reflectionVisibleMT)
                     {
                         _reflectionVisibleGenericDefinitionMethodTables.Add(reflectionVisibleMT.Type);
+                    }
+
+                    if (node is MetadataEETypeNode metadataMT)
+                    {
+                        _metadataMethodTables.Add(metadataMT.Type);
                     }
 
                     TypeDesc type = (node as ConstructedEETypeNode)?.Type;
@@ -778,6 +784,13 @@ namespace ILCompiler
                 Debug.Assert(type.NormalizeInstantiation() == type);
                 Debug.Assert(ConstructedEETypeNode.CreationAllowed(type));
                 return _constructedMethodTables.Contains(type);
+            }
+
+            public override bool CanReferenceMetadataMethodTable(TypeDesc type)
+            {
+                Debug.Assert(type.NormalizeInstantiation() == type);
+                Debug.Assert(ConstructedEETypeNode.CreationAllowed(type));
+                return _metadataMethodTables.Contains(type);
             }
 
             public override bool CanReferenceConstructedTypeOrCanonicalFormOfType(TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -565,7 +565,7 @@ namespace ILCompiler
             // and property setters)
         }
 
-        public virtual void GetConditionalDependenciesDueToEETypePresence(ref CombinedDependencyList dependencies, NodeFactory factory, TypeDesc type)
+        public virtual void GetConditionalDependenciesDueToEETypePresence(ref CombinedDependencyList dependencies, NodeFactory factory, TypeDesc type, bool allocated)
         {
             // MetadataManagers can override this to provide additional dependencies caused by the presence of
             // an MethodTable.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MultiFileCompilationModuleGroup.cs
@@ -97,7 +97,7 @@ namespace ILCompiler
 
         public override bool ShouldPromoteToFullType(TypeDesc type)
         {
-            return ShouldProduceFullVTable(type) || type.IsGenericDefinition;
+            return ShouldProduceFullVTable(type);
         }
 
         public override bool PresenceOfEETypeImpliesAllMethodsOnType(TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -2868,7 +2868,7 @@ namespace ILCompiler
 
             public override bool GetRawData(NodeFactory factory, out object data)
             {
-                data = factory.SerializedMaximallyConstructableRuntimeTypeObject(TypeRepresented);
+                data = factory.SerializedMetadataRuntimeTypeObject(TypeRepresented);
                 return true;
             }
 
@@ -2882,7 +2882,7 @@ namespace ILCompiler
             }
             public override void WriteFieldData(ref ObjectDataBuilder builder, NodeFactory factory)
             {
-                builder.EmitPointerReloc(factory.SerializedMaximallyConstructableRuntimeTypeObject(TypeRepresented));
+                builder.EmitPointerReloc(factory.SerializedMetadataRuntimeTypeObject(TypeRepresented));
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -405,13 +405,13 @@ namespace ILCompiler
             return false;
         }
 
-        public override void GetConditionalDependenciesDueToEETypePresence(ref CombinedDependencyList dependencies, NodeFactory factory, TypeDesc type)
+        public override void GetConditionalDependenciesDueToEETypePresence(ref CombinedDependencyList dependencies, NodeFactory factory, TypeDesc type, bool allocated)
         {
             // Check to see if we have any dataflow annotations on the type.
             // The check below also covers flow annotations inherited through base classes and implemented interfaces.
-            bool hasFlowAnnotations = type.IsDefType && FlowAnnotations.GetTypeAnnotation(type) != default;
+            bool allocatedWithFlowAnnotations = allocated && type.IsDefType && FlowAnnotations.GetTypeAnnotation(type) != default;
 
-            if (hasFlowAnnotations)
+            if (allocatedWithFlowAnnotations)
             {
                 dependencies ??= new CombinedDependencyList();
                 dependencies.Add(new DependencyNodeCore<NodeFactory>.CombinedDependencyListEntry(
@@ -420,7 +420,7 @@ namespace ILCompiler
                     "Type exists and GetType called on it"));
             }
 
-            if (hasFlowAnnotations
+            if (allocatedWithFlowAnnotations
                 && !type.IsInterface /* "IFoo x; x.GetType();" -> this doesn't actually return an interface type */)
             {
                 // We have some flow annotations on this type.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -840,6 +840,9 @@ namespace ILCompiler
 
             foreach (var constructedType in GetTypesWithEETypes())
             {
+                if (IsReflectionBlocked(constructedType))
+                    continue;
+
                 reflectableTypes[constructedType] |= MetadataCategory.RuntimeMapping;
 
                 // Also set the description bit if the definition is getting metadata.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -718,25 +718,6 @@ namespace ILCompiler
             return _modulesWithMetadata;
         }
 
-        private IEnumerable<TypeDesc> GetTypesWithRuntimeMapping()
-        {
-            // All constructed types that are not blocked get runtime mapping
-            foreach (var constructedType in GetTypesWithConstructedEETypes())
-            {
-                if (!IsReflectionBlocked(constructedType))
-                    yield return constructedType;
-            }
-
-            // All necessary types for which this is the highest load level that are not blocked
-            // get runtime mapping.
-            foreach (var necessaryType in GetTypesWithEETypes())
-            {
-                if (!ConstructedEETypeNode.CreationAllowed(necessaryType) &&
-                    !IsReflectionBlocked(necessaryType))
-                    yield return necessaryType;
-            }
-        }
-
         public override void GetDependenciesDueToAccess(ref DependencyList dependencies, NodeFactory factory, MethodIL methodIL, FieldDesc writtenField)
         {
             bool scanReflection = (_generationOptions & UsageBasedMetadataGenerationOptions.ReflectionILScanning) != 0;
@@ -857,7 +838,7 @@ namespace ILCompiler
                 reflectableTypes[typeWithMetadata] = MetadataCategory.Description;
             }
 
-            foreach (var constructedType in GetTypesWithRuntimeMapping())
+            foreach (var constructedType in GetTypesWithEETypes())
             {
                 reflectableTypes[constructedType] |= MetadataCategory.RuntimeMapping;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -548,6 +548,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ISpecialUnboxThunkNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchCellNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MetadataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\MetadataEETypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MethodAssociatedDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedPointersNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunHeaderNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -78,16 +78,23 @@ namespace ILCompiler
             // information proving that it isn't, give RyuJIT the constructed symbol even
             // though we just need the unconstructed one.
             // https://github.com/dotnet/runtimelab/issues/1128
-            return GetLdTokenHelperForType(type) == ReadyToRunHelperId.MetadataTypeHandle
-                ? _nodeFactory.MaximallyConstructableType(type)
-                : _nodeFactory.NecessaryTypeSymbol(type);
+            return GetLdTokenHelperForType(type) switch
+            {
+                ReadyToRunHelperId.MetadataTypeHandle => _nodeFactory.MetadataTypeSymbol(type),
+                ReadyToRunHelperId.TypeHandle => _nodeFactory.MaximallyConstructableType(type),
+                ReadyToRunHelperId.NecessaryTypeHandle => _nodeFactory.NecessaryTypeSymbol(type),
+                _ => throw new UnreachableException()
+            };
         }
 
         public FrozenRuntimeTypeNode NecessaryRuntimeTypeIfPossible(TypeDesc type)
         {
-            return GetLdTokenHelperForType(type) == ReadyToRunHelperId.MetadataTypeHandle
-                ? _nodeFactory.SerializedMaximallyConstructableRuntimeTypeObject(type)
-                : _nodeFactory.SerializedNecessaryRuntimeTypeObject(type);
+            return GetLdTokenHelperForType(type) switch
+            {
+                ReadyToRunHelperId.TypeHandle or ReadyToRunHelperId.MetadataTypeHandle => _nodeFactory.SerializedMetadataRuntimeTypeObject(type),
+                ReadyToRunHelperId.NecessaryTypeHandle => _nodeFactory.SerializedNecessaryRuntimeTypeObject(type),
+                _ => throw new UnreachableException()
+            };
         }
 
         protected override void CompileInternal(string outputFile, ObjectDumper dumper)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -78,15 +78,15 @@ namespace ILCompiler
             // information proving that it isn't, give RyuJIT the constructed symbol even
             // though we just need the unconstructed one.
             // https://github.com/dotnet/runtimelab/issues/1128
-            return GetLdTokenHelperForType(type) == ReadyToRunHelperId.TypeHandle
-                ? _nodeFactory.ConstructedTypeSymbol(type)
+            return GetLdTokenHelperForType(type) == ReadyToRunHelperId.MetadataTypeHandle
+                ? _nodeFactory.MaximallyConstructableType(type)
                 : _nodeFactory.NecessaryTypeSymbol(type);
         }
 
         public FrozenRuntimeTypeNode NecessaryRuntimeTypeIfPossible(TypeDesc type)
         {
-            return GetLdTokenHelperForType(type) == ReadyToRunHelperId.TypeHandle
-                ? _nodeFactory.SerializedConstructedRuntimeTypeObject(type)
+            return GetLdTokenHelperForType(type) == ReadyToRunHelperId.MetadataTypeHandle
+                ? _nodeFactory.SerializedMaximallyConstructableRuntimeTypeObject(type)
                 : _nodeFactory.SerializedNecessaryRuntimeTypeObject(type);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -75,8 +75,11 @@ namespace Internal.JitInterface
                 // https://github.com/dotnet/runtimelab/issues/1128
                 for (int i = 0; i < _codeRelocs.Count; i++)
                 {
-                    Debug.Assert(_codeRelocs[i].Target.GetType() != typeof(EETypeNode)
-                        || _compilation.NecessaryTypeSymbolIfPossible(((EETypeNode)_codeRelocs[i].Target).Type) == _codeRelocs[i].Target);
+                    if (_codeRelocs[i].Target is EETypeNode eetype)
+                    {
+                        IEETypeNode expectedeetype = _compilation.NecessaryTypeSymbolIfPossible(eetype.Type);
+                        Debug.Assert(expectedeetype == eetype);
+                    }
                 }
 #endif
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.NotSupported.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemCngTests.NotSupported.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.Tests
     [PlatformSpecific(~TestPlatforms.Windows)]
     public sealed class MLKemCngNotSupportedTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public static void MLKemCng_NotSupportedOnNonWindowsPlatforms()
         {
             // We cannot actually construct a CngKey on non-Windows platforms, so this cheats by just instantiating

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
@@ -41,7 +41,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             RequirePublicMethods(typeof(ImplementationClass));
             RequirePublicMethods(typeof(IBaseImplementedInterface));
             RequirePublicMethods(typeof(BaseImplementsInterfaceViaDerived));
-            RequirePublicMethods(typeof(DerivedWithInterfaceImplementedByBase));
+            RequirePublicMethodsAndConstructor(typeof(DerivedWithInterfaceImplementedByBase));
             RequirePublicMethods(typeof(VirtualMethodHierarchyDataflowAnnotationValidationTypeTestBase));
             RequirePublicMethods(typeof(VirtualMethodHierarchyDataflowAnnotationValidationTypeTestDerived));
             RequirePublicMethods(typeof(ITwoInterfacesImplementedByOneMethod_One));
@@ -56,6 +56,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         }
 
         static void RequirePublicMethods([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+        {
+        }
+
+        static void RequirePublicMethodsAndConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
         }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -1374,11 +1374,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
             static AnnotatedBase GetInstance() => new Derived();
 
             [Kept]
+            static AnnotatedBase GetDerivedWithInterfaceInstance() => new DerivedWithInterface();
+
+            [Kept]
             public static void Test()
             {
                 Type t = GetInstance().GetType();
                 t.RequiresAll();
-                var t2 = typeof(DerivedWithInterface);
+                var t2 = GetDerivedWithInterfaceInstance().GetType();
             }
         }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -18,17 +18,19 @@ namespace Mono.Linker.Tests.Cases.Reflection
     public class TypeHierarchyReflectionWarnings
     {
         [ExpectedWarning("IL2026", "--AnnotatedRUCPublicMethods--")]
+        [ExpectedWarning("IL2026", "DerivedFromAnnotatedPublicParameterlessConstructor()")]
+        [ExpectedWarning("IL2026", "AnnotatedPublicParameterlessConstructor()")]
         public static void Main()
         {
             annotatedBase.GetType().RequiresPublicMethods();
             var baseType = annotatedBaseSharedByNestedTypes.GetType();
             baseType.RequiresPublicNestedTypes();
             baseType.RequiresPublicMethods();
-            var derivedType = typeof(DerivedWithNestedTypes);
+            var derivedType = new DerivedWithNestedTypes();
             // Reference to the derived type should apply base annotations
-            var t1 = typeof(DerivedFromAnnotatedBase);
-            var t2 = typeof(AnnotatedDerivedFromAnnotatedBase);
-            var t3 = typeof(AnnotatedAllDerivedFromAnnotatedBase);
+            var t1 = new DerivedFromAnnotatedBase();
+            var t2 = new AnnotatedDerivedFromAnnotatedBase();
+            var t3 = new AnnotatedAllDerivedFromAnnotatedBase();
             annotatedDerivedFromBase.GetType().RequiresPublicMethods();
             annotatedPublicNestedTypes.GetType().RequiresPublicNestedTypes();
             derivedFromAnnotatedDerivedFromBase.GetType().RequiresPublicFields();
@@ -42,8 +44,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
             annotatedAll.GetType().RequiresAll();
             var t4 = typeof(DerivedFromAnnotatedAll1);
             var t5 = typeof(DerivedFromAnnotatedAll2);
-            var t6 = typeof(DerivedFromAnnotatedAllWithInterface);
-            var t7 = typeof(DerivedFromAnnotatedPublicParameterlessConstructor);
+            var t6 = new DerivedFromAnnotatedAllWithInterface();
+            var t7 = new DerivedFromAnnotatedPublicParameterlessConstructor();
             annotatedRUCPublicMethods.GetType().RequiresPublicMethods();
 
             // Instantiate these types just so things are considered reachable
@@ -55,6 +57,10 @@ namespace Mono.Linker.Tests.Cases.Reflection
             _ = new AnnotatedInterfaces();
             _ = new AnnotatedPublicNestedTypes();
             _ = new AnnotatedRUCPublicMethods();
+            _ = new AnnotatedAll();
+            _ = new AnnotatedPublicParameterlessConstructor();
+            _ = new AnnotatedBase();
+            _ = new AnnotatedBaseSharedByNestedTypes();
 
             // Check that this field doesn't produce a warning even if it is kept
             // for some non-reflection access.
@@ -358,6 +364,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
         }
 
         [KeptBaseType(typeof(AnnotatedBase))]
+        [KeptMember(".ctor()")]
         class DerivedFromAnnotatedBase : AnnotatedBase
         {
             [Kept]
@@ -369,6 +376,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
         [KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
         [KeptBaseType(typeof(AnnotatedBase))]
+        [KeptMember(".ctor()")]
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicFields)]
         // No warning for public methods on base type because that annotation is already
         // inherited from the base type.
@@ -595,6 +603,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
         }
 
         [KeptBaseType(typeof(AnnotatedBaseSharedByNestedTypes))]
+        [KeptMember(".ctor()")]
         // Nested types that share the outer class base type can produce warnings about base methods of the annotated type.
         [ExpectedWarning("IL2113", "--RUC on AnnotatedBaseSharedByNestedTypes.RUCMethod--")]
         class DerivedWithNestedTypes : AnnotatedBaseSharedByNestedTypes

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchySuppressions.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchySuppressions.cs
@@ -27,15 +27,21 @@ namespace Mono.Linker.Tests.Cases.Reflection
             // derived types to access annotated methods without any warnings:
             derivedFromSuppressed.GetType().GetMethod("RUCDerivedMethod");
 
+            _ = new Unsuppressed();
+            _ = new Suppressed();
             _ = new AnnotatedAllSuppressed();
+            _ = new DerivedFromUnsuppressed1();
+            _ = new DerivedFromSuppressed1();
+            _ = new SuppressedOnDerived1();
+            _ = new SuppressedBaseWarningsOnDerived();
         }
 
         [Kept]
         static void UseDerivedTypes()
         {
-            var t = typeof(DerivedFromUnsuppressed2);
-            var t2 = typeof(DerivedFromSuppressed2);
-            var t3 = typeof(SuppressedOnDerived2);
+            _ = new DerivedFromUnsuppressed2();
+            _ = new DerivedFromSuppressed2();
+            _ = new SuppressedOnDerived2();
         }
 
         [Kept]
@@ -63,6 +69,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
         [Kept]
         [KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+        [KeptMember(".ctor()")]
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
         class Unsuppressed
         {
@@ -74,6 +81,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
         }
 
         [Kept]
+        [KeptMember(".ctor()")]
         [KeptBaseType(typeof(Unsuppressed))]
         class DerivedFromUnsuppressed1 : Unsuppressed
         {
@@ -85,6 +93,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
         }
 
         [Kept]
+        [KeptMember(".ctor()")]
         [KeptBaseType(typeof(Unsuppressed))]
         class DerivedFromUnsuppressed2 : Unsuppressed
         {
@@ -98,6 +107,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
         [Kept]
         [KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
         [KeptAttributeAttribute(typeof(UnconditionalSuppressMessageAttribute))]
+        [KeptMember(".ctor()")]
         [UnconditionalSuppressMessage("TrimAnalysis", "IL2112")]
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
         class Suppressed
@@ -110,6 +120,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
         [Kept]
         [KeptBaseType(typeof(Suppressed))]
+        [KeptMember(".ctor()")]
         class DerivedFromSuppressed1 : Suppressed
         {
             [Kept]
@@ -121,6 +132,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
         [Kept]
         [KeptBaseType(typeof(Suppressed))]
+        [KeptMember(".ctor()")]
         class DerivedFromSuppressed2 : Suppressed
         {
             [Kept]
@@ -132,6 +144,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
         [Kept]
         [KeptBaseType(typeof(Unsuppressed))]
+        [KeptMember(".ctor()")]
         class SuppressedOnDerived1 : Unsuppressed
         {
             [Kept]
@@ -144,6 +157,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
         [Kept]
         [KeptBaseType(typeof(Unsuppressed))]
+        [KeptMember(".ctor()")]
         class SuppressedOnDerived2 : Unsuppressed
         {
             [Kept]
@@ -156,6 +170,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
         [Kept]
         [KeptBaseType(typeof(Unsuppressed))]
+        [KeptMember(".ctor()")]
         class SuppressedBaseWarningsOnDerived : Unsuppressed
         {
             [Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -571,7 +571,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
             [KeptInterface(typeof(ITest))]
             class BaseType : ITest
             {
-                [Kept]
+                [Kept(By = Tool.Trimmer)]
                 public void Method() { }
             }
 
@@ -580,7 +580,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
             [KeptInterface(typeof(ITest))]
             class DerivedType : BaseType, ITest
             {
-                [Kept]
+                [Kept(By = Tool.Trimmer)]
                 public void Method() { }
             }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAttributeMismatch.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAttributeMismatch.cs
@@ -119,7 +119,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
             typeof(IBaseWithoutRequires).RequiresPublicMethods();
             typeof(ImplementationClassWithRequires).RequiresPublicMethods();
             typeof(ImplementationClassWithoutRequires).RequiresPublicMethods();
+            new ExplicitImplementationClassWithRequires(); // we need to see this one as constructed too
             typeof(ExplicitImplementationClassWithRequires).RequiresPublicMethods();
+            new ExplicitImplementationClassWithoutRequires(); // we need to see this one as constructed too
             typeof(ExplicitImplementationClassWithoutRequires).RequiresPublicMethods();
             typeof(ImplementationClassWithoutRequiresInSource).RequiresPublicMethods();
             typeof(ImplementationClassWithRequiresInSource).RequiresPublicMethods();


### PR DESCRIPTION
Fixes #116032
Contributes to #116301

This adds a third way of referring to `MethodTable` objects within the compiler:

|                     | Unconstructed ("necessary") | Metadata (🆕) | Constructed |
|---------------------|-----------------------------|-------------|-------------|
| Base type           |              ✔              |      ✔      |      ✔      |
| Interfaces          |              ✔              |      ✔      |      ✔      |
| GCDesc              |                             |             |      ✔      |
| VTable              |                             |             |      ✔      |
| Reflection metadata |                             |      ✔      |      ✔      |

With this just having a `typeof` of something within the compiler no longer materializes the vtable of the thing. This aligns us with how ILLinker thinks of `typeof`.

The size improvements are not too exciting:

| Project | Size before | Size after | Difference |
|---------|-------------|------------|------------|
| TodosApi-linux | [ 24253880 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657415833) | [ 24188168 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657416694) | -65712 |
| TodosApi-windows | [ 25534976 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657411728) | [ 25496064 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657425762) | -38912 |
| avalonia.app-linux | [ 19464848 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657408012) | [ 18803504 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657405895) | -661344 |
| avalonia.app-windows | [ 20068864 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657416082) | [ 19328000 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657414253) | -740864 |
| hello-linux | [ 1364944 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657396672) | [ 1364944 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657404106) | 0 |
| hello-minimal-linux | [ 1086264 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657397399) | [ 1086264 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657402460) | 0 |
| hello-minimal-windows | [ 839168 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657415274) | [ 839168 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657407607) | 0 |
| hello-windows | [ 1136640 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657403498) | [ 1136640 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657405926) | 0 |
| kestrel-minimal-linux | [ 5205720 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657411124) | [ 5197464 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657410945) | -8256 |
| kestrel-minimal-windows | [ 4748800 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657416763) | [ 4743168 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657408168) | -5632 |
| reflection-linux | [ 1964096 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657396329) | [ 1964096 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657405692) | 0 |
| reflection-windows | [ 1820672 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657414113) | [ 1820672 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657412814) | 0 |
| webapiaot-linux | [ 9694992 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657400322) | [ 9678448 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657400370) | -16544 |
| webapiaot-windows | [ 10263552 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657417865) | [ 10246144 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657407672) | -17408 |
| winrt-component-full-windows | [ 6695936 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657408631) | [ 6674432 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657406168) | -21504 |
| winrt-component-minimal-windows | [ 1705472 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657403324) | [ 1704960 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/16647052387/artifacts/3657405552) | -512 |

However, it kicks in pretty well for Avalonia because of one type with a big closure that is now unused.

I don't look at this as a size improvement PR, but a warning reduction PR since #116032 hit this when ILC was generating trim warnings that ILLink does not.

Cc @dotnet/ilc-contrib 