### PR TITLE
Replace nop regex loops with empty

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexFindOptimizationsTests.cs
@@ -43,9 +43,8 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"(?=\b)^abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
         [InlineData(@"(?=\b)(?=^.*$)abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
         [InlineData(@"(?=\b)(?=\B)^abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
-        // The next two could be improved slightly to be LeadingString_LeftToRight.
-        [InlineData(@"(?=^.*def)?abc", 0, (int)FindNextStartingPositionMode.FixedDistanceChar_LeftToRight)] 
-        [InlineData(@"(?=^)?(?=^)abc", 0, (int)FindNextStartingPositionMode.FixedDistanceChar_LeftToRight)]
+        [InlineData(@"(?=^.*def)abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)] 
+        [InlineData(@"(?=^)(?=^)abc", 0, (int)FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning)]
 
         [InlineData(@"^", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Beginning)]
         [InlineData(@"hello^", (int)RegexOptions.RightToLeft, (int)FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Beginning)]

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
@@ -244,6 +244,19 @@ namespace System.Text.RegularExpressions.Tests
         // Large loop patterns
         [InlineData("a*a*a*a*a*a*a*b*b*?a+a*", "a*b*b*?a+")]
         [InlineData("a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "a{0,30}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        // Nop loops
+        [InlineData("(?:)*", "")]
+        [InlineData("a(?=abc)*b", "ab")]
+        [InlineData("a(?<=abc)*b", "ab")]
+        [InlineData("a(?<!abc)*b", "ab")]
+        [InlineData("a$*b", "ab")]
+        [InlineData("a^?b", "ab")]
+        [InlineData(@"a\b*b", "ab")]
+        [InlineData(@"a\B*b", "ab")]
+        [InlineData(@"a\z?b", "ab")]
+        [InlineData(@"a\Z?b", "ab")]
+        [InlineData(@"a\A?b", "ab")]
+        [InlineData(@"a\G?b", "ab")]
         // Group elimination
         [InlineData("(?:(?:(?:(?:(?:(?:a*))))))", "a*")]
         // Nested loops
@@ -532,6 +545,11 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("a*(?(xyz)bcd)", "(?>a*)(?(xyz)bcd)")]
         // Different prefixes on alternation branches
         [InlineData("^abcd|$abce", "^abcd|^abce")]
+        // Zero-width assertions in non-removable loops
+        [InlineData("a(?=abc)+b", "ab")]
+        [InlineData("a(?<=abc)+b", "ab")]
+        [InlineData("a(?<!abc){1,2}b", "ab")]
+        [InlineData("a${3,}b", "ab")]
         public void PatternsReduceDifferently(string actual, string expected)
         {
             // NOTE: RegexNode.ToString is only compiled into debug builds, so DEBUG is currently set on the unit tests project.


### PR DESCRIPTION
When loop bodies end up containing zero-width assertions and the loop has a min bound of 0, the whole loop can be removed, as the zero-width assertion may or may not apply.