### PR TITLE
Don't use vfork on android

### DIFF
--- a/src/native/libs/System.Native/pal_process.c
+++ b/src/native/libs/System.Native/pal_process.c
@@ -314,7 +314,11 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     sigfillset(&signal_set);
     pthread_sigmask(SIG_SETMASK, &signal_set, &old_signal_set);
 
-#if HAVE_VFORK && !(defined(__APPLE__)) // We don't trust vfork on OS X right now.
+// vfork on OS X is deprecated
+// On Android, signal handlers between parent and child processes are shared with vfork, so when we reset
+// the signal handlers during child startup, we end up incorrectly clearing also the ones for the parent.
+#if HAVE_VFORK && !defined(__APPLE__) && !defined(TARGET_ANDROID)
+
     // This platform has vfork(). vfork() is either a synonym for fork or provides shared memory
     // semantics. For a one gigabyte process, the expected performance gain of using shared memory
     // vfork() rather than fork() is 99.5% merely due to avoiding page faults as the kernel does not


### PR DESCRIPTION
When we start the child process, we clear all signal handlers. When using vfork, on Android, this operation ends up clearing the signal handlers also for the parent process. Revert to just using fork for simplicity.

vfork usage was added back in https://github.com/dotnet/corefx/pull/33289, seems like there were some potential concerns then.

Legacy Xamarin was using fork.

Fixes https://github.com/dotnet/runtime/issues/97209.

