### PR TITLE
Fix Regex source generator multithreading issue

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -403,13 +403,15 @@ namespace System.Text.RegularExpressions.Generator
             // - There are only 4 or 5 characters in the needle and they're all ASCII.
 
             return chars.Length > 5 || RegexCharClass.IsAscii(chars)
-                ? EmitSearchValues(chars.ToArray(), requiredHelpers)
+                ? EmitSearchValues(chars, requiredHelpers)
                 : Literal(chars.ToString());
         }
 
         /// <summary>Adds a SearchValues instance declaration to the required helpers collection.</summary>
-        private static string EmitSearchValues(char[] chars, Dictionary<string, string[]> requiredHelpers, string? fieldName = null)
+        private static string EmitSearchValues(ReadOnlySpan<char> charsSpan, Dictionary<string, string[]> requiredHelpers, string? fieldName = null)
         {
+            char[] chars = charsSpan.ToArray();
+
             Array.Sort(chars);
 
             if (fieldName is null)


### PR DESCRIPTION
Fixes the issue discussed in https://github.com/dotnet/runtime/pull/118083#issuecomment-3122479571

Alternatively we could make copies only in `IsUnicodeCategoryOfSmallCharCount`, but this seemed more likely to prevent us from introducing the same issue from a different caller elsewhere.