### PR TITLE
Conditionally set SYSTEM PATH in host install

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -12,7 +12,11 @@
     <!-- Contributes to DependencyKey which ensures stable provider key - do not change -->
     <WixDependencyKeyName>Dotnet_CLI_SharedHost</WixDependencyKeyName>
     <OutputFilesCandleVariable>HostSrc</OutputFilesCandleVariable>
-    <MajorUpgradeSchedule>afterInstallExecute</MajorUpgradeSchedule>
+
+    <!-- Scheduling RemoveExistingProducts after InstallInitialize will remove the previous install first
+         before installing the new version. This allows compositional changes in major upgrades
+         and supports rollback, provided it is not turned off using machine policies (DisableRollback is not set to 1). -->
+    <MajorUpgradeSchedule>afterInstallInitialize</MajorUpgradeSchedule>
     <VersionInstallerName>false</VersionInstallerName>
     <UseBrandingNameInLinuxPackageDescription>true</UseBrandingNameInLinuxPackageDescription>
     <MacOSComponentNamePackType>sharedhost</MacOSComponentNamePackType>
@@ -26,7 +30,7 @@
   <ItemGroup>
     <WixSrcFile Include="host.wxs" />
     <WixExtraComponentGroupRefId Include="InstallSharedHostandDetectionKeys" />
-    <CandleVariables Include="ExtraPropertyRefIds" Value="ProductCPU;RTM_ProductVersion" />
+    <CandleVariables Include="ExtraPropertyRefIds" Value="ProductCPU;RTM_ProductVersion;DISABLE_SETTING_HOST_PATH" />
     <!-- Enables stable provider key - do not change -->
     <CandleVariables Include="DependencyKey" Value="$(WixDependencyKeyName)_$(MajorVersion).$(MinorVersion)_$(TargetArchitecture)" />
   </ItemGroup>

--- a/src/installer/pkg/sfx/installers/host.wxs
+++ b/src/installer/pkg/sfx/installers/host.wxs
@@ -38,12 +38,12 @@
         </RegistryKey>
       </Component>
 
-      <Component Id="cmdPath" Directory="DOTNETHOME" Guid="*">
+      <Component Id="cmpPath" Directory="DOTNETHOME" Guid="*">
         <?if $(var.Platform)~=x64 ?>
-        <!-- For x64 installer, only add to PATH when actually on native architecture -->
+        <!-- For x64 installer, only add the sharedhost key when actually on native architecture. -->
         <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
         <?elseif $(var.Platform)~=x86 ?>
-        <!-- For x86 installer, only add to PATH when not on 64-bit platform -->
+        <!-- For x86 installer, only add the key when not on 64-bit platform. -->
         <Condition>NOT VersionNT64</Condition>
         <?endif?>
 
@@ -51,7 +51,6 @@
         <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedhost">
           <RegistryValue KeyPath="yes" Action="write" Name="Path" Type="string" Value="[DOTNETHOME]"/>
         </RegistryKey>
-        <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]" Part="last" Action="set" System="yes" />
       </Component>
 
       <Component Id="cmpLicenseFiles" Directory="DOTNETHOME" Guid="{A61CBE5B-1282-4F29-90AD-63597AA2372E}">
@@ -63,6 +62,7 @@
         </File>
       </Component>
 
+      <ComponentRef Id="cmpSetPath" />
     </ComponentGroup>
 
     <Property Id="ProductCPU" Value="$(var.Platform)" />
@@ -75,6 +75,31 @@
     <?if $(var.Platform)~=x64 ?>
     <CustomActionRef Id="Set_PROGRAMFILES_DOTNET_NON_NATIVE_ARCHITECTURE" />
     <?endif?>
+  </Fragment>
+
+  <Fragment>
+    <Property Id="DISABLE_SETTING_HOST_PATH" Secure="yes">
+      <RegistrySearch Id="DisableSettingHostPathSearch" Root="HKLM" Key="SOFTWARE\Microsoft\.NET" Type="raw" Name="DisableSettingHostPath"/>
+    </Property>
+
+    <Component Id="cmpSetPath" Guid="{0B910ED8-0877-473D-8658-647382324433}" Directory="DOTNETHOME">
+      <!-- Always set the SYSTEM PATH, unless DisableSettingHostPath is 1. -->
+      <?if $(var.Platform)~=x64 ?>
+      <!-- For x64 installer, only add to PATH when actually on native architecture. -->
+      <Condition><![CDATA[DISABLE_SETTING_HOST_PATH <> "#1" AND NOT NON_NATIVE_ARCHITECTURE]]></Condition>
+      <?elseif $(var.Platform)~=x86 ?>
+      <!-- For x86 installer, only add to PATH when not on 64-bit platform. -->
+      <Condition><![CDATA[DISABLE_SETTING_HOST_PATH <> "#1" AND NOT VersionNT64]]></Condition>
+      <?endif?>
+      <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]" Part="last" Action="set" System="yes" />
+    </Component>
+
+    <InstallExecuteSequence>
+      <!-- Only broadcast the change if the component is enabled. -->
+      <Custom Action="WixBroadcastEnvironmentChange" After="InstallFinalize">
+        <![CDATA[DISABLE_SETTING_HOST_PATH <> "#1"]]>
+      </Custom>
+    </InstallExecuteSequence>
   </Fragment>
   
   <Fragment>

--- a/src/installer/pkg/sfx/installers/host.wxs
+++ b/src/installer/pkg/sfx/installers/host.wxs
@@ -83,6 +83,7 @@
     </Property>
 
     <Component Id="cmpSetPath" Guid="{0B910ED8-0877-473D-8658-647382324433}" Directory="DOTNETHOME">
+      <CreateFolder />
       <!-- Always set the SYSTEM PATH, unless DisableSettingHostPath is 1. -->
       <?if $(var.Platform)~=x64 ?>
       <!-- For x64 installer, only add to PATH when actually on native architecture. -->


### PR DESCRIPTION
## Description

Conditionally turn off setting the SYSTEM PATH from the host installer. .NET supports a number of [machine keys](https://learn.microsoft.com/en-us/dotnet/core/install/windows) and values that determine how installers behave on Windows. This PR adds a new value under `HKLM\SOFTWARE\Microsoft\.NET` named `DisableSettingHostPath` (type `REG_DWORD`). When set to 1, the host installer will skip setting the SYSTEM PATH.

The change is needed to support new scenarios in the SDK to manage user installs.

## Changes

### Current Implementation

The host MSI performs major upgrades by installing the new product first (RemoveExistingProducts executes after InstallExecute). The component writing the `DOTNETHOME` to the `sharedhost` registry key also modifies the SYSTEM PATH. 

### New Implementation

The PATH variable will be set by separate component. Since the previous upgrade model does not support compositional changes, RemoveExistingProducts now runs after InstallInitialize. This ensures that the old product is removed before the new version is installed. It also supports rollback if a failure occurs (provided that rollbacks have not been turned off). While less efficient, the host MSI only contains a single file so there's no incurred overhead.

* Minor fix in the component ID for writing the registry key to make it consistent with current authoring.
* Registry search added to retrieve the new machine key. The property must be public
* Environment entry is moved to a separate component. The component uses the same conditional logic for native vs. non-native platforms while also checking the property based on the machine key. The component has an explicit GUID because it contains neither a file nor a registry key and therefore WiX cannot generate a stable GUID.
* `WixBroadcastEnvironmentChange` custom action is conditioned and set to execute after InstallFinalize.

## Testing

Manually tested some scenarios using the bundles.

* Tested clean install+uninstall with/without the registry key on sandbox. Below excerpt is from a log showing the property is set during AppSearch, the component action is set to `Null` (it won't be installed) and `WixBroadcastEnvironmentChange` custom action is skipped.

```
Action start 12:44:58: AppSearch.
MSI (s) (24:28) [12:44:58:287]: PROPERTY CHANGE: Adding DISABLE_SETTING_HOST_PATH property. Its value is '#1'.
...
MSI (s) (24:28) [12:44:58:437]: Component: cmpSetPath; Installed: Absent;   Request: Local;   Action: Null
...
MSI (s) (24:28) [12:44:58:924]: Skipping action: WixBroadcastEnvironmentChange (condition is false)
```

* Tested upgrade from 9.0.

Verified that the existing component IDs did not change

8.0.117:

<img width="681" height="149" alt="image" src="https://github.com/user-attachments/assets/3c547ce4-bb65-4f02-92cd-c0bd581531fd" />

10 dev build:

<img width="702" height="185" alt="image" src="https://github.com/user-attachments/assets/a49e1666-67b7-40e9-8b5e-e5cba3bd67e3" />
