### PR TITLE
Avoid extra boundary checks when preceeded/succeeded char set is known

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -302,42 +302,105 @@ namespace System.Text.RegularExpressions.Generator
                 "Regex.InfiniteMatchTimeout" :
                 $"TimeSpan.FromMilliseconds({matchTimeout.ToString(CultureInfo.InvariantCulture)})";
 
-        /// <summary>Adds the IsWordChar helper to the required helpers collection.</summary>
-        private static void AddIsWordCharHelper(Dictionary<string, string[]> requiredHelpers)
+        private const string IsBoundary = nameof(IsBoundary);
+        private const string IsECMABoundary = nameof(IsECMABoundary);
+        private const string IsWordChar = nameof(IsWordChar);
+        private const string IsBoundaryWordChar = nameof(IsBoundaryWordChar);
+        private const string IsPostWordCharBoundary = nameof(IsPostWordCharBoundary);
+        private const string IsPreWordCharBoundary = nameof(IsPreWordCharBoundary);
+        private const string IsECMABoundaryWordChar = nameof(IsECMABoundaryWordChar);
+        private const string WordCategoriesMask = nameof(WordCategoriesMask);
+        private const string WordCharBitmap = nameof(WordCharBitmap);
+
+        private static void AddWordCharHelpersSupport(Dictionary<string, string[]> requiredHelpers)
         {
-            const string IsWordChar = nameof(IsWordChar);
-            if (!requiredHelpers.ContainsKey(IsWordChar))
+            const string WordCharHelpersSupport = nameof(WordCharHelpersSupport);
+            if (!requiredHelpers.ContainsKey(WordCharHelpersSupport))
             {
-                requiredHelpers.Add(IsWordChar,
+                requiredHelpers.Add(WordCharHelpersSupport,
                 [
-                    "/// <summary>Determines whether the character is part of the [\\w] set.</summary>",
-                    "[MethodImpl(MethodImplOptions.AggressiveInlining)]",
-                    "internal static bool IsWordChar(char ch)",
-                    "{",
-                    "    // Mask of Unicode categories that combine to form [\\w]",
-                    "    const int WordCategoriesMask =",
-                    "        1 << (int)UnicodeCategory.UppercaseLetter |",
-                    "        1 << (int)UnicodeCategory.LowercaseLetter |",
-                    "        1 << (int)UnicodeCategory.TitlecaseLetter |",
-                    "        1 << (int)UnicodeCategory.ModifierLetter |",
-                    "        1 << (int)UnicodeCategory.OtherLetter |",
-                    "        1 << (int)UnicodeCategory.NonSpacingMark |",
-                    "        1 << (int)UnicodeCategory.DecimalDigitNumber |",
-                    "        1 << (int)UnicodeCategory.ConnectorPunctuation;",
+                    "/// <summary>Provides a mask of Unicode categories that combine to form [\\w].</summary>",
+                    $"private const int {WordCategoriesMask} =",
+                    "    1 << (int)UnicodeCategory.UppercaseLetter |",
+                    "    1 << (int)UnicodeCategory.LowercaseLetter |",
+                    "    1 << (int)UnicodeCategory.TitlecaseLetter |",
+                    "    1 << (int)UnicodeCategory.ModifierLetter |",
+                    "    1 << (int)UnicodeCategory.OtherLetter |",
+                    "    1 << (int)UnicodeCategory.NonSpacingMark |",
+                    "    1 << (int)UnicodeCategory.DecimalDigitNumber |",
+                    "    1 << (int)UnicodeCategory.ConnectorPunctuation;",
                     "",
-                    "    // Bitmap for whether each character 0 through 127 is in [\\w]",
-                    "    ReadOnlySpan<byte> ascii = new byte[]",
+                    "/// <summary>Gets a bitmap for whether each character 0 through 127 is in [\\w]</summary>",
+                    $"private static ReadOnlySpan<byte> {WordCharBitmap} => new byte[]",
                     "    {",
                     "        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x03,",
                     "        0xFE, 0xFF, 0xFF, 0x87, 0xFE, 0xFF, 0xFF, 0x07",
                     "    };",
                     "",
-                    "    // If the char is ASCII, look it up in the bitmap. Otherwise, query its Unicode category.",
-                    "    int chDiv8 = ch >> 3;",
-                    "    return (uint)chDiv8 < (uint)ascii.Length ?",
-                    "        (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :",
-                    "        (WordCategoriesMask & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;",
-                    "}",
+                ]);
+            }
+        }
+
+        /// <summary>Adds the IsWordChar helper to the required helpers collection.</summary>
+        private static void AddIsWordCharHelper(Dictionary<string, string[]> requiredHelpers)
+        {
+            if (!requiredHelpers.ContainsKey(IsWordChar))
+            {
+                requiredHelpers.Add(IsWordChar,
+                [
+                    $"/// <summary>Determines whether the character is part of the [\\w] set.</summary>",
+                    $"[MethodImpl(MethodImplOptions.AggressiveInlining)]",
+                    $"internal static bool {IsWordChar}(char ch)",
+                    $"{{",
+                    $"    // If the char is ASCII, look it up in the bitmap. Otherwise, query its Unicode category.",
+                    $"    ReadOnlySpan<byte> ascii = {WordCharBitmap};",
+                    $"    int chDiv8 = ch >> 3;",
+                    $"    return (uint)chDiv8 < (uint)ascii.Length ?",
+                    $"        (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :",
+                    $"        ({WordCategoriesMask} & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;",
+                    $"}}",
+                ]);
+
+                AddWordCharHelpersSupport(requiredHelpers);
+            }
+        }
+
+        /// <summary>Adds the IsBoundary helper to the required helpers collection.</summary>
+        private static void AddIsBoundaryWordCharHelper(Dictionary<string, string[]> requiredHelpers)
+        {
+            if (!requiredHelpers.ContainsKey(IsBoundaryWordChar))
+            {
+                requiredHelpers.Add(IsBoundaryWordChar,
+                [
+                    $"/// <summary>Determines whether the specified index is a boundary word character.</summary>",
+                    $"/// <remarks>This is the same as \\w plus U+200C ZERO WIDTH NON-JOINER and U+200D ZERO WIDTH JOINER.</remarks>",
+                    $"[MethodImpl(MethodImplOptions.AggressiveInlining)]",
+                    $"internal static bool {IsBoundaryWordChar}(char ch)",
+                    $"{{",
+                    $"    ReadOnlySpan<byte> ascii = {WordCharBitmap};",
+                    $"    int chDiv8 = ch >> 3;",
+                    $"    return (uint)chDiv8 < (uint)ascii.Length ?",
+                    $"        (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :",
+                    $"        (({WordCategoriesMask} & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0) || (ch is '\u200C' or '\u200D');",
+                    $"}}",
+                ]);
+
+                AddWordCharHelpersSupport(requiredHelpers);
+            }
+        }
+
+        /// <summary>Adds the IsECMABoundary helper to the required helpers collection.</summary>
+        private static void AddIsECMABoundaryWordCharHelper(Dictionary<string, string[]> requiredHelpers)
+        {
+            if (!requiredHelpers.ContainsKey(IsECMABoundaryWordChar))
+            {
+                requiredHelpers.Add(IsECMABoundaryWordChar,
+                [
+                    $"/// <summary>Determines whether the specified index is a boundary (ECMAScript) word character.</summary>",
+                    $"[MethodImpl(MethodImplOptions.AggressiveInlining)]",
+                    $"internal static bool {IsECMABoundaryWordChar}(char ch) =>",
+                    $"    char.IsAsciiLetterOrDigit(ch) ||",
+                    $"    ch is '_' or '\\u0130'; // latin capital letter I with dot above",
                 ]);
             }
         }
@@ -345,7 +408,6 @@ namespace System.Text.RegularExpressions.Generator
         /// <summary>Adds the IsBoundary helper to the required helpers collection.</summary>
         private static void AddIsBoundaryHelper(Dictionary<string, string[]> requiredHelpers, bool checkOverflow)
         {
-            const string IsBoundary = nameof(IsBoundary);
             if (!requiredHelpers.ContainsKey(IsBoundary))
             {
                 string uncheckedKeyword = checkOverflow ? "unchecked" : "";
@@ -353,24 +415,62 @@ namespace System.Text.RegularExpressions.Generator
                 [
                     $"/// <summary>Determines whether the specified index is a boundary.</summary>",
                     $"[MethodImpl(MethodImplOptions.AggressiveInlining)]",
-                    $"internal static bool IsBoundary(ReadOnlySpan<char> inputSpan, int index)",
+                    $"internal static bool {IsBoundary}(ReadOnlySpan<char> inputSpan, int index)",
                     $"{{",
                     $"    int indexMinus1 = index - 1;",
-                    $"    return {uncheckedKeyword}((uint)indexMinus1 < (uint)inputSpan.Length && IsBoundaryWordChar(inputSpan[indexMinus1])) !=",
-                    $"           {uncheckedKeyword}((uint)index < (uint)inputSpan.Length && IsBoundaryWordChar(inputSpan[index]));",
-                    $"",
-                    $"    static bool IsBoundaryWordChar(char ch) => IsWordChar(ch) || (ch == '\\u200C' | ch == '\\u200D');",
+                    $"    return {uncheckedKeyword}((uint)indexMinus1 < (uint)inputSpan.Length && {IsBoundaryWordChar}(inputSpan[indexMinus1])) !=",
+                    $"           {uncheckedKeyword}((uint)index < (uint)inputSpan.Length && {IsBoundaryWordChar}(inputSpan[index]));",
                     $"}}",
                 ]);
 
-                AddIsWordCharHelper(requiredHelpers);
+                AddIsBoundaryWordCharHelper(requiredHelpers);
+            }
+        }
+
+        /// <summary>Adds the IsPreWordCharBoundary helper to the required helpers collection.</summary>
+        private static void AddIsPreWordCharBoundaryHelper(Dictionary<string, string[]> requiredHelpers, bool checkOverflow)
+        {
+            if (!requiredHelpers.ContainsKey(IsPreWordCharBoundary))
+            {
+                string uncheckedKeyword = checkOverflow ? "unchecked" : "";
+                requiredHelpers.Add(IsPreWordCharBoundary,
+                [
+                    $"/// <summary>Determines whether the specified index is a boundary.</summary>",
+                    $"/// <remarks>This variant is only employed when the subsequent character will separately be validated as a word character.</remarks>",
+                    $"[MethodImpl(MethodImplOptions.AggressiveInlining)]",
+                    $"internal static bool {IsPreWordCharBoundary}(ReadOnlySpan<char> inputSpan, int index)",
+                    $"{{",
+                    $"    int indexMinus1 = index - 1;",
+                    $"    return {uncheckedKeyword}((uint)indexMinus1 >= (uint)inputSpan.Length || !{IsBoundaryWordChar}(inputSpan[indexMinus1]));",
+                    $"}}",
+                ]);
+
+                AddIsBoundaryWordCharHelper(requiredHelpers);
+            }
+        }
+
+        /// <summary>Adds the IsPostWordCharBoundary helper to the required helpers collection.</summary>
+        private static void AddIsPostWordCharBoundaryHelper(Dictionary<string, string[]> requiredHelpers, bool checkOverflow)
+        {
+            if (!requiredHelpers.ContainsKey(IsPostWordCharBoundary))
+            {
+                string uncheckedKeyword = checkOverflow ? "unchecked" : "";
+                requiredHelpers.Add(IsPostWordCharBoundary,
+                [
+                    $"/// <summary>Determines whether the specified index is a boundary.</summary>",
+                    $"/// <remarks>This variant is only employed when the previous character has already been validated as a word character.</remarks>",
+                    $"[MethodImpl(MethodImplOptions.AggressiveInlining)]",
+                    $"internal static bool {IsPostWordCharBoundary}(ReadOnlySpan<char> inputSpan, int index) =>",
+                    $"    {uncheckedKeyword}((uint)index >= (uint)inputSpan.Length || !{IsBoundaryWordChar}(inputSpan[index]));",
+                ]);
+
+                AddIsBoundaryWordCharHelper(requiredHelpers);
             }
         }
 
         /// <summary>Adds the IsECMABoundary helper to the required helpers collection.</summary>
         private static void AddIsECMABoundaryHelper(Dictionary<string, string[]> requiredHelpers, bool checkOverflow)
         {
-            const string IsECMABoundary = nameof(IsECMABoundary);
             if (!requiredHelpers.ContainsKey(IsECMABoundary))
             {
                 string uncheckedKeyword = checkOverflow ? "unchecked" : "";
@@ -378,18 +478,15 @@ namespace System.Text.RegularExpressions.Generator
                 [
                     $"/// <summary>Determines whether the specified index is a boundary (ECMAScript).</summary>",
                     $"[MethodImpl(MethodImplOptions.AggressiveInlining)]",
-                    $"internal static bool IsECMABoundary(ReadOnlySpan<char> inputSpan, int index)",
+                    $"internal static bool {IsECMABoundary}(ReadOnlySpan<char> inputSpan, int index)",
                     $"{{",
                     $"    int indexMinus1 = index - 1;",
-                    $"    return {uncheckedKeyword}((uint)indexMinus1 < (uint)inputSpan.Length && IsECMAWordChar(inputSpan[indexMinus1])) !=",
-                    $"           {uncheckedKeyword}((uint)index < (uint)inputSpan.Length && IsECMAWordChar(inputSpan[index]));",
-                    $"",
-                    $"    static bool IsECMAWordChar(char ch) =>",
-                    $"        char.IsAsciiLetterOrDigit(ch) ||",
-                    $"        ch == '_' ||",
-                    $"        ch == '\\u0130'; // latin capital letter I with dot above",
+                    $"    return {uncheckedKeyword}((uint)indexMinus1 < (uint)inputSpan.Length && {IsECMABoundaryWordChar}(inputSpan[indexMinus1])) !=",
+                    $"           {uncheckedKeyword}((uint)index < (uint)inputSpan.Length && {IsECMABoundaryWordChar}(inputSpan[index]));",
                     $"}}",
                 ]);
+
+                AddIsECMABoundaryWordCharHelper(requiredHelpers);
             }
         }
 
@@ -3177,20 +3274,33 @@ namespace System.Text.RegularExpressions.Generator
             {
                 Debug.Assert(node.Kind is RegexNodeKind.Boundary or RegexNodeKind.NonBoundary or RegexNodeKind.ECMABoundary or RegexNodeKind.NonECMABoundary, $"Unexpected kind: {node.Kind}");
 
+                string negation = node.Kind is RegexNodeKind.Boundary or RegexNodeKind.ECMABoundary ? "!" : "";
+
                 string call;
-                if (node.Kind is RegexNodeKind.Boundary or RegexNodeKind.NonBoundary)
+                switch (node.Kind)
                 {
-                    call = node.Kind is RegexNodeKind.Boundary ?
-                        $"!{HelpersTypeName}.IsBoundary" :
-                        $"{HelpersTypeName}.IsBoundary";
-                    AddIsBoundaryHelper(requiredHelpers, checkOverflow);
-                }
-                else
-                {
-                    call = node.Kind is RegexNodeKind.ECMABoundary ?
-                        $"!{HelpersTypeName}.IsECMABoundary" :
-                        $"{HelpersTypeName}.IsECMABoundary";
-                    AddIsECMABoundaryHelper(requiredHelpers, checkOverflow);
+                    case RegexNodeKind.Boundary or RegexNodeKind.NonBoundary:
+                        if (node.IsKnownPrecededByWordChar())
+                        {
+                            call = $"{negation}{HelpersTypeName}.{IsPostWordCharBoundary}";
+                            AddIsPostWordCharBoundaryHelper(requiredHelpers, checkOverflow);
+                        }
+                        else if (node.IsKnownSuccededByWordChar())
+                        {
+                            call = $"{negation}{HelpersTypeName}.{IsPreWordCharBoundary}";
+                            AddIsPreWordCharBoundaryHelper(requiredHelpers, checkOverflow);
+                        }
+                        else
+                        {
+                            call = $"{negation}{HelpersTypeName}.{IsBoundary}";
+                            AddIsBoundaryHelper(requiredHelpers, checkOverflow);
+                        }
+                        break;
+
+                    default:
+                        call = $"{negation}{HelpersTypeName}.{IsECMABoundary}";
+                        AddIsECMABoundaryHelper(requiredHelpers, checkOverflow);
+                        break;
                 }
 
                 using (EmitBlock(writer, $"if ({call}(inputSpan, pos{(sliceStaticPos > 0 ? $" + {sliceStaticPos}" : "")}))"))

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -332,11 +332,10 @@ namespace System.Text.RegularExpressions.Generator
                     "",
                     "/// <summary>Gets a bitmap for whether each character 0 through 127 is in [\\w]</summary>",
                     $"private static ReadOnlySpan<byte> {WordCharBitmap} => new byte[]",
-                    "    {",
-                    "        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x03,",
-                    "        0xFE, 0xFF, 0xFF, 0x87, 0xFE, 0xFF, 0xFF, 0x07",
-                    "    };",
-                    "",
+                    "{",
+                    "    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x03,",
+                    "    0xFE, 0xFF, 0xFF, 0x87, 0xFE, 0xFF, 0xFF, 0x07",
+                    "};",
                 ]);
             }
         }
@@ -3285,7 +3284,7 @@ namespace System.Text.RegularExpressions.Generator
                             call = $"{negation}{HelpersTypeName}.{IsPostWordCharBoundary}";
                             AddIsPostWordCharBoundaryHelper(requiredHelpers, checkOverflow);
                         }
-                        else if (node.IsKnownSuccededByWordChar())
+                        else if (node.IsKnownSucceededByWordChar())
                         {
                             call = $"{negation}{HelpersTypeName}.{IsPreWordCharBoundary}";
                             AddIsPreWordCharBoundaryHelper(requiredHelpers, checkOverflow);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -3057,7 +3057,7 @@ namespace System.Text.RegularExpressions
                         {
                             Call(IsPostWordCharBoundaryMethod);
                         }
-                        else if (node.IsKnownSuccededByWordChar())
+                        else if (node.IsKnownSucceededByWordChar())
                         {
                             Call(IsPreWordCharBoundaryMethod);
                         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -35,6 +35,8 @@ namespace System.Text.RegularExpressions
         private static MethodInfo MatchLengthMethod => field ??= RegexRunnerMethod("MatchLength");
         private static MethodInfo MatchIndexMethod => field ??= RegexRunnerMethod("MatchIndex");
         private static MethodInfo IsBoundaryMethod => field ??= typeof(RegexRunner).GetMethod("IsBoundary", BindingFlags.NonPublic | BindingFlags.Static, [typeof(ReadOnlySpan<char>), typeof(int)])!;
+        private static MethodInfo IsPreWordCharBoundaryMethod => field ??= typeof(RegexRunner).GetMethod("IsPreWordCharBoundary", BindingFlags.NonPublic | BindingFlags.Static, [typeof(ReadOnlySpan<char>), typeof(int)])!;
+        private static MethodInfo IsPostWordCharBoundaryMethod => field ??= typeof(RegexRunner).GetMethod("IsPostWordCharBoundary", BindingFlags.NonPublic | BindingFlags.Static, [typeof(ReadOnlySpan<char>), typeof(int)])!;
         private static MethodInfo IsWordCharMethod => field ??= RegexRunnerMethod("IsWordChar");
         private static MethodInfo IsECMABoundaryMethod => field ??= typeof(RegexRunner).GetMethod("IsECMABoundary", BindingFlags.NonPublic | BindingFlags.Static, [typeof(ReadOnlySpan<char>), typeof(int)])!;
         private static MethodInfo CrawlposMethod => field ??= RegexRunnerMethod("Crawlpos");
@@ -3050,25 +3052,41 @@ namespace System.Text.RegularExpressions
                 }
                 switch (node.Kind)
                 {
-                    case RegexNodeKind.Boundary:
-                        Call(IsBoundaryMethod);
-                        BrfalseFar(doneLabel);
-                        break;
+                    case RegexNodeKind.Boundary or RegexNodeKind.NonBoundary:
+                        if (node.IsKnownPrecededByWordChar())
+                        {
+                            Call(IsPostWordCharBoundaryMethod);
+                        }
+                        else if (node.IsKnownSuccededByWordChar())
+                        {
+                            Call(IsPreWordCharBoundaryMethod);
+                        }
+                        else
+                        {
+                            Call(IsBoundaryMethod);
+                        }
 
-                    case RegexNodeKind.NonBoundary:
-                        Call(IsBoundaryMethod);
-                        BrtrueFar(doneLabel);
-                        break;
-
-                    case RegexNodeKind.ECMABoundary:
-                        Call(IsECMABoundaryMethod);
-                        BrfalseFar(doneLabel);
+                        if (node.Kind is RegexNodeKind.Boundary)
+                        {
+                            BrfalseFar(doneLabel);
+                        }
+                        else
+                        {
+                            BrtrueFar(doneLabel);
+                        }
                         break;
 
                     default:
-                        Debug.Assert(node.Kind == RegexNodeKind.NonECMABoundary);
                         Call(IsECMABoundaryMethod);
-                        BrtrueFar(doneLabel);
+
+                        if (node.Kind is RegexNodeKind.ECMABoundary)
+                        {
+                            BrfalseFar(doneLabel);
+                        }
+                        else
+                        {
+                            BrtrueFar(doneLabel);
+                        }
                         break;
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2452,20 +2452,16 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /// <summary>Gets whether this node is known to be immediately preceeded by a word character.</summary>
-        public bool IsKnownPrecededByWordChar() =>  IsKnownPrecededOrSuccededByWordChar(false);
+        /// <summary>Gets whether this node is known to be immediately preceded by a word character.</summary>
+        public bool IsKnownPrecededByWordChar() =>  IsKnownPrecededOrSucceededByWordChar(false);
 
         /// <summary>Gets whether this node is known to be immediately succeeded by a word character.</summary>
-        public bool IsKnownSuccededByWordChar() =>  IsKnownPrecededOrSuccededByWordChar(true);
+        public bool IsKnownSucceededByWordChar() =>  IsKnownPrecededOrSucceededByWordChar(true);
 
-        private bool IsKnownPrecededOrSuccededByWordChar(bool succeeded)
+        private bool IsKnownPrecededOrSucceededByWordChar(bool succeeded)
         {
             RegexNode node = this;
-
-            if (node.Kind is RegexNodeKind.Concatenate)
-            {
-                return false;
-            }
+            Debug.Assert(node.Kind is not RegexNodeKind.Concatenate, "The existing logic assumes that the node itself isn't a concatenation.");
 
             // As in CanBeMadeAtomic, conservatively walk up through a limited set of constructs to the next concatenation.
             while (true)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2433,6 +2433,59 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Gets whether this node is known to be immediately preceeded by a word character.</summary>
+        public bool IsKnownPrecededByWordChar() =>  IsKnownPrecededOrSuccededByWordChar(false);
+
+        /// <summary>Gets whether this node is known to be immediately succeeded by a word character.</summary>
+        public bool IsKnownSuccededByWordChar() =>  IsKnownPrecededOrSuccededByWordChar(true);
+
+        private bool IsKnownPrecededOrSuccededByWordChar(bool succeeded)
+        {
+            RegexNode node = this;
+
+            if (node.Kind is RegexNodeKind.Concatenate)
+            {
+                return false;
+            }
+
+            // As in CanBeMadeAtomic, conservatively walk up through a limited set of constructs to the next concatenation.
+            while (true)
+            {
+                if ((node.Options & RegexOptions.RightToLeft) != 0 ||
+                    node.Parent is not RegexNode parent)
+                {
+                    return false;
+                }
+
+                switch (parent.Kind)
+                {
+                    case RegexNodeKind.Atomic:
+                    case RegexNodeKind.Alternate:
+                    case RegexNodeKind.Capture:
+                        node = parent;
+                        continue;
+
+                    case RegexNodeKind.Concatenate:
+                        var peers = (List<RegexNode>)parent.Children!;
+                        int index = peers.IndexOf(node) + (succeeded ? 1 : -1);
+                        if ((uint)index < (uint)peers.Count)
+                        {
+                            // Now that we've found the concatenation, build a set that represents the characters that could come
+                            // before or after this node, depending on whether we're looking for a preceding or succeeding word character.
+                            return
+                                RegexPrefixAnalyzer.FindFirstOrLastCharClass(peers[index], findFirst: succeeded) is string set &&
+                                RegexCharClass.IsKnownWordClassSubset(set);
+                        }
+
+                        node = parent;
+                        continue;
+
+                    default:
+                        return false;
+                }
+            }
+        }
+
         /// <summary>Computes a min bound on the required length of any string that could possibly match.</summary>
         /// <returns>The min computed length.  If the result is 0, there is no minimum we can enforce.</returns>
         /// <remarks>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -910,7 +910,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public static string? FindLastCharClass(RegexNode root) => FindFirstOrLastCharClass(root, findFirst: false);
 
-        private static string? FindFirstOrLastCharClass(RegexNode root, bool findFirst)
+        public static string? FindFirstOrLastCharClass(RegexNode root, bool findFirst)
         {
             // Explore the graph, adding found chars into a result set, which is lazily initialized so that
             // we can initialize it to a parsed set if we discover one first (this is helpful not just for allocation

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -418,6 +418,21 @@ namespace System.Text.RegularExpressions
                    ((uint)index < (uint)inputSpan.Length && RegexCharClass.IsBoundaryWordChar(inputSpan[index]));
         }
 
+        /// <summary>Determines whether the specified index is a boundary.</summary>",
+        /// <remarks>This variant is only employed when the subsequent character will separately be validated as a word character.</remarks>",
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsPreWordCharBoundary(ReadOnlySpan<char> inputSpan, int index)
+        {
+            int indexMinus1 = index - 1;
+            return (uint)indexMinus1 >= (uint)inputSpan.Length || !RegexCharClass.IsBoundaryWordChar(inputSpan[indexMinus1]);
+        }
+
+        /// <summary>Determines whether the specified index is a boundary.</summary>
+        /// <remarks>This variant is only employed when the previous character has already been validated as a word character.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsPostWordCharBoundary(ReadOnlySpan<char> inputSpan, int index) =>
+            (uint)index >= (uint)inputSpan.Length || !RegexCharClass.IsBoundaryWordChar(inputSpan[index]);
+
         /// <summary>Called to determine a char's inclusion in the \w set.</summary>
         internal static bool IsWordChar(char ch) => RegexCharClass.IsWordChar(ch);
 

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
@@ -367,25 +367,8 @@ namespace System.Text.RegularExpressions.Tests
                         [MethodImpl(MethodImplOptions.AggressiveInlining)]
                         internal static bool IsWordChar(char ch)
                         {
-                            // Mask of Unicode categories that combine to form [\w]
-                            const int WordCategoriesMask =
-                                1 << (int)UnicodeCategory.UppercaseLetter |
-                                1 << (int)UnicodeCategory.LowercaseLetter |
-                                1 << (int)UnicodeCategory.TitlecaseLetter |
-                                1 << (int)UnicodeCategory.ModifierLetter |
-                                1 << (int)UnicodeCategory.OtherLetter |
-                                1 << (int)UnicodeCategory.NonSpacingMark |
-                                1 << (int)UnicodeCategory.DecimalDigitNumber |
-                                1 << (int)UnicodeCategory.ConnectorPunctuation;
-
-                            // Bitmap for whether each character 0 through 127 is in [\w]
-                            ReadOnlySpan<byte> ascii = new byte[]
-                            {
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x03,
-                                0xFE, 0xFF, 0xFF, 0x87, 0xFE, 0xFF, 0xFF, 0x07
-                            };
-
                             // If the char is ASCII, look it up in the bitmap. Otherwise, query its Unicode category.
+                            ReadOnlySpan<byte> ascii = WordCharBitmap;
                             int chDiv8 = ch >> 3;
                             return (uint)chDiv8 < (uint)ascii.Length ?
                                 (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :
@@ -454,6 +437,24 @@ namespace System.Text.RegularExpressions.Tests
                             }
                             return actual;
                         }
+
+                        /// <summary>Provides a mask of Unicode categories that combine to form [\w].</summary>
+                        private const int WordCategoriesMask =
+                            1 << (int)UnicodeCategory.UppercaseLetter |
+                            1 << (int)UnicodeCategory.LowercaseLetter |
+                            1 << (int)UnicodeCategory.TitlecaseLetter |
+                            1 << (int)UnicodeCategory.ModifierLetter |
+                            1 << (int)UnicodeCategory.OtherLetter |
+                            1 << (int)UnicodeCategory.NonSpacingMark |
+                            1 << (int)UnicodeCategory.DecimalDigitNumber |
+                            1 << (int)UnicodeCategory.ConnectorPunctuation;
+
+                        /// <summary>Gets a bitmap for whether each character 0 through 127 is in [\w]</summary>
+                        private static ReadOnlySpan<byte> WordCharBitmap => new byte[]
+                        {
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x03,
+                            0xFE, 0xFF, 0xFF, 0x87, 0xFE, 0xFF, 0xFF, 0x07
+                        };
                     }
                 }
                 """


### PR DESCRIPTION
If we statically know by construction that what comes before or after a \b is guaranteed to be a word char, then we can avoid half the run-time checks.

This also tweaks the source-generated implementation of IsBoundaryWordChar in order to avoid an extra branch on every check. It's currently delegating to IsWordChar and then if that returns false, checking whether it's one of the other two joiner characters that are considered as part of the boundary set. Instead, this duplicates the IsWordChar implementation (which is just a couple of lines once the helpers are separated out into their own members), such that for ASCII, the additional check isn't necessary. The implementation used by the interpreter and RegexCompiler already do this.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

public partial class Tests
{
    private static readonly string s_text = new HttpClient().GetStringAsync(@"https://www.gutenberg.org/cache/epub/42671/pg42671.txt").Result;

    [Benchmark]
    public int CountWords() => StandaloneA.Count(s_text);

    [GeneratedRegex(@"\ba\b", RegexOptions.IgnoreCase)]
    private static partial Regex StandaloneA { get; }
}
```

Before:
| Method     | Mean     |
|----------- |---------:|
| CountWords | 908.9 us |

After:
| Method     | Mean     |
|----------- |---------:|
| CountWords | 780.8 us | 3.78 us |
