### PR TITLE
Normalize some well-known negated sets

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -51,10 +51,13 @@ namespace System.Text.RegularExpressions
 
         internal const string SpaceClass = "\u0000\u0000\u0001\u0064"; // \s
         internal const string NotSpaceClass = "\u0000\u0000\u0001\uFF9C"; // \S
+        internal const string NegatedSpaceClass = "\u0001\0\u0001d"; // [^\s]
         internal const string WordClass = "\u0000\u0000\u000A\u0000\u0002\u0004\u0005\u0003\u0001\u0006\u0009\u0013\u0000"; // \w
         internal const string NotWordClass = "\u0000\u0000\u000A\u0000\uFFFE\uFFFC\uFFFB\uFFFD\uFFFF\uFFFA\uFFF7\uFFED\u0000"; // \W
+        internal const string NegatedWordClass = "\u0001\0\n\0\u0002\u0004\u0005\u0003\u0001\u0006\t\u0013\0"; // [^\w]
         internal const string DigitClass = "\u0000\u0000\u0001\u0009"; // \d
         internal const string NotDigitClass = "\u0000\u0000\u0001\uFFF7"; // \D
+        internal const string NegatedDigitClass = "\u0001\0\u0001\t"; // [^\d]
         internal const string ControlClass = "\0\0\u0001\u000f"; // \p{Cc}
         internal const string NotControlClass = "\0\0\u0001\ufff1"; // \P{Cc}
         internal const string LetterClass = "\0\0\a\0\u0002\u0004\u0005\u0003\u0001\0"; // \p{L}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -981,6 +981,17 @@ namespace System.Text.RegularExpressions
                 case RegexCharClass.NotSpaceSpaceClass:
                     Str = RegexCharClass.AnyClass;
                     break;
+
+                // Different ways of saying \D, \S, \W
+                case RegexCharClass.NegatedDigitClass: // [^\d]
+                    Str = RegexCharClass.NotDigitClass;
+                    break;
+                case RegexCharClass.NegatedSpaceClass: // [^\s]
+                    Str = RegexCharClass.NotSpaceClass;
+                    break;
+                case RegexCharClass.NegatedWordClass: // [^\w]
+                    Str = RegexCharClass.NotWordClass;
+                    break;
             }
 
             return this;

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
@@ -9,6 +9,12 @@ namespace System.Text.RegularExpressions.Tests
     public class RegexReductionTests
     {
         [Theory]
+        // Well-known sets
+        [InlineData(@"[^\d]", @"\D")]
+        [InlineData(@"[^\w]", @"\W")]
+        [InlineData(@"[^\s]", @"\S")]
+        [InlineData(@"[\s\S]", @"[\d\D]")]
+        [InlineData(@"[\s\S]", @"[\w\W]")]
         // Two greedy one loops
         [InlineData("a*a*", "a*")]
         [InlineData("(a*a*)", "(a*)")]


### PR DESCRIPTION
Some folks end up writing sets like `[^\d]` instead of `\D`, `[^\w]` instead of `\W`, or `[^\s]` instead of `\S`. This defeats some special recognition of the common \D, \W, and \S sets. Normalize them.