### PR TITLE
Improve SearchValues<string> Teddy throughput on Arm64

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
@@ -211,7 +211,7 @@ namespace System.Buffers
         // On X86, characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
-        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static Vector128<byte> LoadAndPack16AsciiChars(ref char source)
         {
             Vector128<ushort> source0 = Vector128.LoadUnsafe(ref source);
@@ -221,9 +221,9 @@ namespace System.Buffers
             {
                 return Sse2.PackUnsignedSaturate(source0.AsInt16(), source1.AsInt16());
             }
-            else if (AdvSimd.IsSupported)
+            else if (AdvSimd.Arm64.IsSupported)
             {
-                return AdvSimd.ExtractNarrowingSaturateUpper(AdvSimd.ExtractNarrowingSaturateLower(source0), source1);
+                return AdvSimd.Arm64.UnzipEven(source0.AsByte(), source1.AsByte());
             }
             else
             {


### PR DESCRIPTION
`ExtractNarrowingSaturate` and `UnzipEven` are very similar in this case, but `UnzipEven` is a bit cheaper (better searching throughput).

`UnzipEven` may lead to more false positive matches of the anchor characters (some non-ASCII chars will look like matching ASCII ones), but we'll rule those out in the verification step if we happen to hit that on all 3 chars. Since we're only using the Teddy aproach if all anchor chars are ASCII, this seems like a good tradeoff.

From Cobalt 100
| Method          | Toolchain               | Mean     | Error    | Ratio |
|---------------- |------------------------ |---------:|---------:|------:|
| SV_Throughput   | Main | 24.03 μs | 0.005 μs |  1.00 |
| SV_Throughput   | PR   | 20.98 μs | 0.002 μs |  0.87 |
|                 |                         |          |          |       |
| SV_ThroughputIC | Main | 26.05 μs | 0.003 μs |  1.00 |
| SV_ThroughputIC | PR   | 23.54 μs | 0.014 μs |  0.90 |

```c#
public class SearchValuesStringTests_Teddy
{
    private static readonly SearchValues<string> s_values = SearchValues.Create(["Sherlock", "Holmes"], StringComparison.Ordinal);
    private static readonly SearchValues<string> s_valuesIC = SearchValues.Create(["Sherlock", "Holmes"], StringComparison.OrdinalIgnoreCase);
    private static readonly string s_text_noMatches = new('a', 100_000);

    [Benchmark] public bool SV_Throughput() => s_text_noMatches.AsSpan().ContainsAny(s_values);
    [Benchmark] public bool SV_ThroughputIC() => s_text_noMatches.AsSpan().ContainsAny(s_valuesIC);
}
```