### PR TITLE
Fix broken debugger/debuggee startup handshake protocol on macOS26.

### DIFF
--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -1406,7 +1406,9 @@ static const char* IpcNameFormat = "%s-%d-%llu-%s";
 
 #ifdef ENABLE_RUNTIME_EVENTS_OVER_PIPES
 static const char* RuntimeStartupPipeName = "st";
-static const char* RuntimeContinuePipeName= "co";
+static const char* RuntimeContinuePipeName = "co";
+
+#define PIPE_OPEN_RETRY_DELAY_NS 500000000 // 500 ms
 
 typedef enum
 {
@@ -1433,14 +1435,14 @@ OpenPipe(const char* name, int mode)
     flags |= O_CLOEXEC;
 #endif
 
-    while(fd == -1)
+    while (fd == -1)
     {
         fd = open(name, flags);
         if (fd == -1)
         {
             if (mode == O_WRONLY && errno == ENXIO)
             {
-                PAL_nanosleep(500 * 1000 * 1000);
+                PAL_nanosleep(PIPE_OPEN_RETRY_DELAY_NS);
                 continue;
             }
             else if (errno == EINTR)
@@ -1482,7 +1484,7 @@ ClosePipe(int fd)
 {
     if (fd != -1)
     {
-        while(close(fd) < 0 && errno == EINTR);
+        while (close(fd) < 0 && errno == EINTR);
     }
 }
 

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -1427,13 +1427,57 @@ int
 OpenPipe(const char* name, int mode)
 {
     int fd = -1;
-    int flags = mode;
+    int flags = mode | O_NONBLOCK;
 
 #if defined(FD_CLOEXEC)
     flags |= O_CLOEXEC;
 #endif
 
-    while((fd = open(name, flags)) < 0 && errno == EINTR);
+    while(fd == -1)
+    {
+        if (access(name, F_OK) == -1)
+        {
+            break;
+        }
+
+        fd = open(name, flags);
+        if (fd == -1)
+        {
+            if (mode == O_WRONLY && errno == ENXIO)
+            {
+                PAL_nanosleep(500 * 1000 * 1000);
+                continue;
+            }
+            else if (errno == EINTR)
+            {
+                continue;
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    if (fd != -1)
+    {
+        flags = fcntl(fd, F_GETFL);
+        if (flags != -1)
+        {
+            flags &= ~O_NONBLOCK;
+            if (fcntl(fd, F_SETFL, flags) == -1)
+            {
+                close(fd);
+                fd = -1;
+            }
+        }
+        else
+        {
+            close(fd);
+            fd = -1;
+        }
+    }
+
     return fd;
 }
 

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -1463,38 +1463,36 @@ NotifyRuntimeUsingPipes()
     PAL_GetTransportPipeName(continuePipeName, gPID, applicationGroupId, RuntimeContinuePipeName);
     if (access(continuePipeName, F_OK) == -1)
     {
-        TRACE("access(%s) failed: %d (%s)\n", continuePipeName, errno, strerror(errno));
+        TRACE("NotifyRuntimeUsingPipes: access(%s) failed: %d (%s)\n", continuePipeName, errno, strerror(errno));
         goto exit;
     }
 
     PAL_GetTransportPipeName(startupPipeName, gPID, applicationGroupId, RuntimeStartupPipeName);
     if (access(startupPipeName, F_OK) == -1)
     {
-        TRACE("access(%s) failed: %d (%s)\n", startupPipeName, errno, strerror(errno));
+        TRACE("NotifyRuntimeUsingPipes: access(%s) failed: %d (%s)\n", startupPipeName, errno, strerror(errno));
         goto exit;
     }
 
     result = RuntimeEventsOverPipes_Failed;
 
-    TRACE("opening continue pipe\n");
+    TRACE("NotifyRuntimeUsingPipes: opening continue '%s' startup '%s' pipes\n", continuePipeName, startupPipeName);
 
     continuePipeFd = OpenPipe(continuePipeName, O_RDONLY);
     if (continuePipeFd == -1)
     {
-        TRACE("open(%s) failed: %d (%s)\n", continuePipeName, errno, strerror(errno));
+        TRACE("NotifyRuntimeUsingPipes: open(%s) failed: %d (%s)\n", continuePipeName, errno, strerror(errno));
         goto exit;
     }
-
-    TRACE("opening startup pipe\n");
 
     startupPipeFd = OpenPipe(startupPipeName, O_WRONLY);
     if (startupPipeFd == -1)
     {
-        TRACE("open(%s) failed: %d (%s)\n", startupPipeName, errno, strerror(errno));
+        TRACE("NotifyRuntimeUsingPipes: open(%s) failed: %d (%s)\n", startupPipeName, errno, strerror(errno));
         goto exit;
     }
 
-    TRACE("sending started event\n");
+    TRACE("NotifyRuntimeUsingPipes: sending started event\n");
 
     {
         unsigned char event = (unsigned char)RuntimeEvent_Started;
@@ -1514,12 +1512,12 @@ NotifyRuntimeUsingPipes()
 
         if (offset != bytesToWrite)
         {
-            TRACE("write(%s) failed: %d (%s)\n", startupPipeName, errno, strerror(errno));
+            TRACE("NotifyRuntimeUsingPipes: write(%s) failed: %d (%s)\n", startupPipeName, errno, strerror(errno));
             goto exit;
         }
     }
 
-    TRACE("waiting on continue event\n");
+    TRACE("NotifyRuntimeUsingPipes: waiting on continue event\n");
 
     {
         unsigned char event = (unsigned char)RuntimeEvent_Unknown;
@@ -1540,11 +1538,11 @@ NotifyRuntimeUsingPipes()
 
         if (offset == bytesToRead && event == (unsigned char)RuntimeEvent_Continue)
         {
-            TRACE("received continue event\n");
+            TRACE("NotifyRuntimeUsingPipes: received continue event\n");
         }
         else
         {
-            TRACE("received invalid event\n");
+            TRACE("NotifyRuntimeUsingPipes: received invalid event\n");
             goto exit;
         }
     }
@@ -1590,13 +1588,13 @@ NotifyRuntimeUsingSemaphores()
     CreateSemaphoreName(startupSemName, RuntimeStartupSemaphoreName, unambiguousProcessDescriptor, applicationGroupId);
     CreateSemaphoreName(continueSemName, RuntimeContinueSemaphoreName, unambiguousProcessDescriptor, applicationGroupId);
 
-    TRACE("PAL_NotifyRuntimeStarted opening continue '%s' startup '%s'\n", continueSemName, startupSemName);
+    TRACE("NotifyRuntimeUsingSemaphores: opening continue '%s' startup '%s'\n", continueSemName, startupSemName);
 
     // Open the debugger startup semaphore. If it doesn't exists, then we do nothing and return
     startupSem = sem_open(startupSemName, 0);
     if (startupSem == SEM_FAILED)
     {
-        TRACE("sem_open(%s) failed: %d (%s)\n", startupSemName, errno, strerror(errno));
+        TRACE("NotifyRuntimeUsingSemaphores: sem_open(%s) failed: %d (%s)\n", startupSemName, errno, strerror(errno));
         goto exit;
     }
 
@@ -1619,7 +1617,7 @@ NotifyRuntimeUsingSemaphores()
     {
         if (EINTR == errno)
         {
-            TRACE("sem_wait() failed with EINTR; re-waiting");
+            TRACE("NotifyRuntimeUsingSemaphores: sem_wait() failed with EINTR; re-waiting");
             continue;
         }
         ASSERT("sem_wait(continueSem) failed: errno is %d (%s)\n", errno, strerror(errno));
@@ -1663,13 +1661,13 @@ PAL_NotifyRuntimeStarted()
     switch (result)
     {
     case RuntimeEventsOverPipes_Disabled:
-        // Pipe handshake disabled, try semaphores.
+        TRACE("PAL_NotifyRuntimeStarted: pipe handshake disabled, try semaphores\n");
         return NotifyRuntimeUsingSemaphores();
     case RuntimeEventsOverPipes_Failed:
-        // Pipe handshake failed.
+        TRACE("PAL_NotifyRuntimeStarted: pipe handshake failed\n");
         return FALSE;
     case RuntimeEventsOverPipes_Succeeded:
-        // Pipe handshake succeeded.
+        TRACE("PAL_NotifyRuntimeStarted: pipe handshake succeeded\n");
         return TRUE;
     default:
         // Unexpected result.

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -73,10 +73,6 @@ SET_DEFAULT_DEBUG_CHANNEL(PROCESS); // some headers have code with asserts, so d
 #endif
 #endif
 
-#ifdef HAVE_KQUEUE
-#include <sys/event.h>
-#endif
-
 #ifdef __APPLE__
 #include <pwd.h>
 #include <sys/sysctl.h>
@@ -1427,42 +1423,18 @@ typedef enum
 } PipeHandshakeCommand;
 
 static
-void
-CloseFd(int fd)
-{
-    if (fd != -1)
-    {
-        while(close(fd) < 0 && errno == EINTR);
-    }
-}
-
-static
-ssize_t
-ReadIOFunc(int fd, void *buf, size_t count)
-{
-    return read(fd, buf, count);
-}
-
-static
-ssize_t
-WriteIOFunc(int fd, void *buf, size_t count)
-{
-    return write(fd, buf, count);
-}
-
-static
 int
-OpenNonBlockingPipe(int kq, const char* name, int mode)
+OpenPipe(const char* name, int mode)
 {
     int fd = -1;
     int retries = 0;
-    int flags = mode | O_NONBLOCK;
+    int flags = mode;
 
 #if defined(FD_CLOEXEC)
     flags |= O_CLOEXEC;
 #endif
 
-    while(fd == -1 && retries < 10)
+    while(fd == -1)
     {
         if (access(name, F_OK) == -1)
         {
@@ -1476,7 +1448,6 @@ OpenNonBlockingPipe(int kq, const char* name, int mode)
             if (mode == O_WRONLY && errno == ENXIO)
             {
                 PAL_nanosleep(500 * 1000 * 1000);
-                retries++;
                 continue;
             }
             else if (errno == EINTR)
@@ -1495,228 +1466,19 @@ OpenNonBlockingPipe(int kq, const char* name, int mode)
         TRACE("open failed: errno is %d (%s)\n", errno, strerror(errno));
         return -1;
     }
-
-#if HAVE_KQUEUE && !HAVE_BROKEN_FIFO_KEVENT
-    struct kevent change;
-    EV_SET(&change, fd, (mode & O_ACCMODE) == O_RDONLY ? EVFILT_READ : EVFILT_WRITE, EV_ADD | EV_DISABLE, 0, 0, NULL);
-    if (kevent(kq, &change, 1, NULL, 0, NULL) == -1)
-    {
-        TRACE("kevent failed: errno is %d (%s)\n", errno, strerror(errno));
-        CloseFd(fd);
-        return -1;
-    }
-#endif // HAVE_KQUEUE && !HAVE_BROKEN_FIFO_KEVENT
     
     return fd;
 }
 
-#if HAVE_KQUEUE && !HAVE_BROKEN_FIFO_KEVENT
 static
-int
-DoNonBlockingPipeIO(int kq, int fd, void *buf, size_t count, int timeout, ssize_t (*io_func)(int fd, void *buf, size_t count), short filter)
+void
+ClosePipe(int fd)
 {
-    int result = -1;
-    struct timespec timeout_spec;
-    struct timespec *timeout_ptr = NULL;
-    if (timeout > 0)
+    if (fd != -1)
     {
-        timeout_spec.tv_sec = timeout / 1000;
-        timeout_spec.tv_nsec = (timeout % 1000) * 1000000L;
-        timeout_ptr = &timeout_spec;
+        while(close(fd) < 0 && errno == EINTR);
     }
-
-    struct kevent change;
-    EV_SET(&change, fd, filter, EV_ENABLE, 0, 0, NULL);
-    if (kevent(kq, &change, 1, NULL, 0, NULL) == -1)
-    {
-        return -1;
-    }
-
-    while (1)
-    {    
-        struct kevent event;
-        int nev = kevent(kq, NULL, 0, &event, 1, timeout_ptr);   
-        if (nev == -1 && errno == EINTR)
-        {
-            continue;
-        } 
-        else if (nev == 0)
-        {
-            // Check for timeout or EOF.
-            int n = io_func(fd, buf, count);
-            if (n > 0)
-            {
-                result = n;
-                break;
-            }
-            else if (n == 0)
-            {
-                // EOF - pipe closed
-                result = -2;
-                break;
-            }
-            else if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
-            {
-                // Timeout.
-                result = 0;
-                break;
-            }
-            else
-            {
-                break;
-            }
-        }
-        else if (nev > 0)
-        {
-            if (event.filter == filter && event.ident == fd)
-            {
-                if (event.flags & EV_EOF)
-                {
-                    result = -2;
-                    break;
-                }
-                
-                int n = io_func(fd, buf, count);
-                if (n > 0)
-                {
-                    result = n;
-                    break;
-                }
-                else if (n == 0)
-                {
-                    // EOF - pipe closed
-                    result = -2;
-                    break;
-                }
-                else if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
-                {
-                    continue;
-                }
-                else
-                {
-                    break;
-                }
-            }
-        }
-        else
-        {
-            break;
-        }
-    }
-
-    EV_SET(&change, fd, filter, EV_DISABLE, 0, 0, NULL);
-    kevent(kq, &change, 1, NULL, 0, NULL);
-
-    return result;
 }
-
-static
-int
-ReadNonBlockingPipe(int kq, int fd, void *buf, size_t count, int timeout)
-{
-    return DoNonBlockingPipeIO(kq, fd, buf, count, timeout, ReadIOFunc, EVFILT_READ);
-}
-
-static
-int
-WriteNonBlockingPipe(int kq, int fd, const void *buf, size_t count, int timeout)
-{
-    return DoNonBlockingPipeIO(kq, fd, (void *)buf, count, timeout, WriteIOFunc, EVFILT_WRITE);
-}
-#else
-static
-int
-DoNonBlockingPipeIO(int fd, void *buf, size_t count, int timeout, ssize_t (*io_func)(int fd, void *buf, size_t count), short filter)
-{
-    struct pollfd pfd;
-    pfd.fd = fd;
-    pfd.events = filter;
-
-    while (1)
-    {
-        int poll_ret = poll(&pfd, 1, timeout);
-        if (poll_ret > 0)
-        {
-            if (pfd.revents & filter)
-            {
-                int n = io_func(fd, buf, count);
-                if (n > 0)
-                {
-                    return n;
-                }
-                else if (n == 0)
-                {
-                    // EOF - pipe closed
-                    return -2;
-                }
-                else if (errno == EAGAIN || errno == EWOULDBLOCK)
-                {
-                    continue;
-                }
-                else if (errno == EINTR)
-                {
-                    continue;
-                }
-                else
-                {
-                    return -1;
-                }
-            }
-            else if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))
-            {
-                return -1;
-            }
-        }
-        else if (poll_ret == 0)
-        {
-            // Check for timeout or EOF.
-            int n = io_func(fd, buf, count);
-            if (n > 0)
-            {
-                return n;
-            }
-            else if (n == 0)
-            {
-                // EOF - pipe closed
-                return -2;
-            }
-            else if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
-            {
-                // Timeout.
-                return 0;
-            }
-            else
-            {
-                return -1;
-            }
-        }
-        else if (errno == EINTR)
-        {
-            continue;
-        }
-        else
-        {
-            return -1;
-        }
-    }
-
-    return -1;
-}
-
-static
-int
-ReadNonBlockingPipe(int kq, int fd, void *buf, size_t count, int timeout)
-{
-    return DoNonBlockingPipeIO(fd, buf, count, timeout, ReadIOFunc, POLLIN);
-}
-
-static
-int
-WriteNonBlockingPipe(int kq, int fd, const void *buf, size_t count, int timeout)
-{
-    return DoNonBlockingPipeIO(fd, (void *)buf, count, timeout, WriteIOFunc, POLLOUT);
-}
-#endif // HAVE_KQUEUE && !HAVE_BROKEN_FIFO_KEVENT
 
 static
 PipeHandshakeState
@@ -1725,7 +1487,6 @@ NotifyRuntimeStartedUsingPipes()
     PipeHandshakeState result = PipeHandshakeState_Failed;
     char startupPipeName[MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH];
     char continuePipeName[MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH];
-    int kq = -1;
     int startupPipeFd = -1;
     int continuePipeFd = -1;
     size_t offset = 0;
@@ -1746,23 +1507,14 @@ NotifyRuntimeStartedUsingPipes()
         return PipeHandshakeState_Disabled;
     }
 
-#if HAVE_KQUEUE && !HAVE_BROKEN_FIFO_KEVENT
-    kq = kqueue();
-    if (kq == -1)
-    {
-        TRACE("kqueue() failed: %d (%s)\n", errno, strerror(errno));
-        goto exit;
-    }
-#endif // HAVE_KQUEUE && !HAVE_BROKEN_FIFO_KEVENT
-
-    continuePipeFd = OpenNonBlockingPipe(kq, continuePipeName, O_RDONLY);
+    continuePipeFd = OpenPipe(continuePipeName, O_RDONLY);
     if (continuePipeFd == -1)
     {
         TRACE("open(%s) failed: %d (%s)\n", continuePipeName, errno, strerror(errno));
         goto exit;
     }
 
-    startupPipeFd = OpenNonBlockingPipe(kq, startupPipeName, O_WRONLY);
+    startupPipeFd = OpenPipe(startupPipeName, O_WRONLY);
     if (startupPipeFd == -1)
     {
         TRACE("open(%s) failed: %d (%s)\n", startupPipeName, errno, strerror(errno));
@@ -1778,13 +1530,13 @@ NotifyRuntimeStartedUsingPipes()
 
         do
         {
-            bytesWritten = WriteNonBlockingPipe(kq, startupPipeFd, buffer + offset, bytesToWrite - offset, 1000);
+            bytesWritten = write(startupPipeFd, buffer + offset, bytesToWrite - offset);
             if (bytesWritten > 0)
             {
                 offset += bytesWritten;
             }
         }
-        while (bytesWritten > 0 && offset < bytesToWrite);
+        while ((bytesWritten > 0 && offset < bytesToWrite) || (bytesWritten == -1 && errno == EINTR));
 
         if (offset != bytesToWrite)
         {
@@ -1803,23 +1555,13 @@ NotifyRuntimeStartedUsingPipes()
         offset = 0;
         do
         {
-            bytesRead = ReadNonBlockingPipe(kq, continuePipeFd, buffer + offset, bytesToRead - offset, 1000);
+            bytesRead = read(continuePipeFd, buffer + offset, bytesToRead - offset);
             if (bytesRead > 0)
             {
                 offset += bytesRead;
             }
-            else if (bytesRead == 0)
-            {
-                // Timeout.
-                continue;
-            }
-            else
-            {
-                 // Error or EOF
-                break;
-            }
         }
-        while (offset < bytesToRead);
+        while ((bytesRead > 0 && offset < bytesToRead) || (bytesRead == -1 && errno == EINTR));
 
         if (offset == bytesToRead && command == (unsigned char)PipeHandshakeCommand_Continue)
         {
@@ -1827,7 +1569,7 @@ NotifyRuntimeStartedUsingPipes()
         }
         else
         {
-            TRACE("received invalid command");
+            TRACE("received invalid command\n");
             goto exit;
         }
     }
@@ -1835,19 +1577,15 @@ NotifyRuntimeStartedUsingPipes()
     result = PipeHandshakeState_Suceeded;
 
 exit:
+
     if (startupPipeFd != -1)
     {
-        CloseFd(startupPipeFd);
+        ClosePipe(startupPipeFd);
     }
 
     if (continuePipeFd != -1)
     {
-        CloseFd(continuePipeFd);
-    }
-
-    if (kq != -1)
-    {
-        CloseFd(kq);
+        ClosePipe(continuePipeFd);
     }
 
     return result;


### PR DESCRIPTION
As identified by https://github.com/dotnet/runtime/issues/116545, macOS26 have broken semaphores in case debugger and debuggee have been signed with different team ids, currently only mentioned for iOS/iPadOS, https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes, but testing shows its broken for regular apps as well.

This PR adds support for a different startup handshake protocol for debugger/debuggee using FIFO file (aka named pipes) on Apple platforms due to limitation introduced in macOS26. All other POSIX platforms will continue to use the semaphore based handshake protocol.

The implementation is backward compatible on Apple platforms. First it will check for new FIFO files, if not found, it will fallback to semaphores, making sure old debugger implementation will continue to work as is even if runtime supports new handshake protocol. It will be the debugger that decides what protocol version to use, runtime will continue working with both versions of the protocol. This also makes this PR standalone from the corresponding change in debugger (dbgshim), so debugger should continue to work on Apple platforms (except macOS26) with old dbgshim. 

In order for this change to work E2E, the debugger needs to use a new dbgshim implementing updated startup handshake protocol, https://github.com/dotnet/diagnostics/pull/5530. Until both debugger and debuggee have been update, debug launch on macOS26 won't work.

Names of the two new FIFO files follow the same naming pattern as we have for existing debugger FIFO's, using suffix currently used for the startup and continue semaphores, "st" for startup and "co" for continue, example of full FIFO names:

/var/folders/d0/l_56x0lx6l7bbrv3pfr128xc0000gn/T/clr-debug-pipe-11462-1753451225-st
/var/folders/d0/l_56x0lx6l7bbrv3pfr128xc0000gn/T/clr-debug-pipe-11462-1753451225-co