### PR TITLE
[System.DirectoryServices] Fixed possible NRE in SAMStoreCtx.cs

### DIFF
--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
@@ -647,7 +647,7 @@ namespace System.DirectoryServices.AccountManagement
                 // The SAMQuerySet will use this to restrict the types of DirectoryEntry objects returned.
                 List<string> schemaTypes = GetSchemaFilter(typeof(GroupPrincipal));
 
-                SecurityIdentifier principalSid = p.Sid;                
+                SecurityIdentifier principalSid = p.Sid;
 
                 if (principalSid == null)
                 {

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
@@ -647,15 +647,16 @@ namespace System.DirectoryServices.AccountManagement
                 // The SAMQuerySet will use this to restrict the types of DirectoryEntry objects returned.
                 List<string> schemaTypes = GetSchemaFilter(typeof(GroupPrincipal));
 
-                SecurityIdentifier principalSid = p.Sid;
-                byte[] SidB = new byte[principalSid.BinaryLength];
-                principalSid.GetBinaryForm(SidB, 0);
+                SecurityIdentifier principalSid = p.Sid;                
 
                 if (principalSid == null)
                 {
                     GlobalDebug.WriteLineIf(GlobalDebug.Warn, "SAMStoreCtx", "GetGroupsMemberOf: bad SID IC");
                     throw new InvalidOperationException(SR.StoreCtxNeedValueSecurityIdentityClaimToQuery);
                 }
+
+                byte[] SidB = new byte[principalSid.BinaryLength];
+                principalSid.GetBinaryForm(SidB, 0);
 
                 // Create the ResultSet that will perform the client-side filtering
                 SAMQuerySet resultSet = new SAMQuerySet(


### PR DESCRIPTION
The principalSid may well have a null value if you create an instance of Principal without initializing _sid in it. The check at 652 confirms this.

Found by Linux Verification Center (linuxtesting.org) with SVACE.