### PR TITLE
Enable lookarounds to influence atomicity

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2326,11 +2326,17 @@ namespace System.Text.RegularExpressions
                         return true;
                 }
 
-                // If this node is a {one/notone/set}loop, see if it overlaps with its successor in the concatenation.
-                // If it doesn't, then we can upgrade it to being a {one/notone/set}loopatomic.
-                // Doing so avoids unnecessary backtracking.
+                // If this node is a loop, see if it overlaps with its successor in the concatenation.
+                // If it doesn't, then we can upgrade it to being atomic to avoid unnecessary backtracking.
                 switch (node.Kind)
                 {
+                    case RegexNodeKind when iterateNullableSubsequent && subsequent.Kind is RegexNodeKind.PositiveLookaround:
+                        if (!CanBeMadeAtomic(node, subsequent.Child(0), iterateNullableSubsequent: false, allowLazy: allowLazy))
+                        {
+                            return false;
+                        }
+                        break;
+
                     case RegexNodeKind.Oneloop:
                     case RegexNodeKind.Onelazy when allowLazy:
                         switch (subsequent.Kind)

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -93,9 +93,55 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"(?:(?!(b)b)\1a)*", "babababa", RegexOptions.None, 0, 8, true, string.Empty);
                 yield return (@"(.*?)a(?!(a+)b\2c)\2(.*)", "baaabaac", RegexOptions.None, 0, 8, false, string.Empty);
                 yield return (@"(?!(abc))+\w\w\w", "abcdef", RegexOptions.None, 0, 6, true, "bcd");
+                yield return (@"a+(?!c)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"a+(?!c)", "aaac", RegexOptions.None, 0, 4, true, "aa");
+                yield return (@"a*(?!c)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"a{2,5}(?!c)", "aaaaac", RegexOptions.None, 0, 6, true, "aaaa");
+                yield return (@"a+?(?!c)", "aaab", RegexOptions.None, 0, 4, true, "a");
+                yield return (@"a*?(?!c)", "aaab", RegexOptions.None, 0, 4, true, "");
+                yield return (@"a{2,5}?(?!c)", "aaaaab", RegexOptions.None, 0, 6, true, "aa");
+                yield return (@"[ab]*(?!x)", "ababc", RegexOptions.None, 0, 5, true, "abab");
+                yield return (@"a+(?=b)(?!c)", "aabx", RegexOptions.None, 0, 4, true, "aa");
+                yield return (@"a+?(?=b)(?!c)", "aabx", RegexOptions.None, 0, 4, true, "aa");
+
+                // Zero-width positive lookahead assertion
                 yield return (@"(?=(abc))?\1", "abc", RegexOptions.None, 0, 3, true, "abc");
                 yield return (@"(?=(abc))+\1", "abc", RegexOptions.None, 0, 3, true, "abc");
                 yield return (@"(?=(abc))*\1", "abc", RegexOptions.None, 0, 3, true, "abc");
+                yield return (@"^.*?(?=.)b", "ab", RegexOptions.None, 0, 2, true, "ab");
+                yield return (@".*?(?=.)b", "ab", RegexOptions.None, 0, 2, true, "ab");
+                yield return (@"^(?>.*?)(?=.)b", "ab", RegexOptions.None, 0, 2, false, "");
+                yield return (@"(?>.*?)(?=.)b", "ab", RegexOptions.None, 0, 2, true, "b");
+                yield return (@"a+(?=b)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"a+(?=b)", "aaabc", RegexOptions.None, 0, 5, true, "aaa");
+                yield return (@"a*(?=b)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"a{2,5}(?=b)", "aaaaab", RegexOptions.None, 0, 6, true, "aaaaa");
+                yield return (@"a+?(?=b)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"a*?(?=b)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"a{2,5}?(?=b)", "aaaaab", RegexOptions.None, 0, 6, true, "aaaaa");
+                yield return (@"a+b+(?=c)", "aabbbc", RegexOptions.None, 0, 6, true, "aabbb");
+                yield return (@"a+?b+(?=c)", "aabbbc", RegexOptions.None, 0, 6, true, "aabbb");
+                yield return (@"a+b+?(?=c)", "aabbbc", RegexOptions.None, 0, 6, true, "aabbb");
+                yield return (@"[ab]+(?=c)", "ababc", RegexOptions.None, 0, 5, true, "abab");
+                yield return (@"[ab]+?(?=c)", "ababc", RegexOptions.None, 0, 5, true, "abab");
+                yield return (@"\w+(?=\b)", "hello world", RegexOptions.None, 0, 11, true, "hello");
+                yield return (@"\w+?(?=\b)", "hello world", RegexOptions.None, 0, 11, true, "hello");
+                yield return (@"(?>a+)(?=b)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"(?>a*)(?=b)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"(?>a{2,5})(?=b)", "aaaaab", RegexOptions.None, 0, 6, true, "aaaaa");
+                yield return (@"a*(?=a)", "aaa", RegexOptions.None, 0, 3, true, "aa");
+                yield return (@"a*?(?=a)", "aaa", RegexOptions.None, 0, 3, true, "");
+                yield return (@"a+(?=a*b)ab", "aaaab", RegexOptions.None, 0, 5, true, "aaaab");
+                yield return (@"a+?(?=a*b)ab", "aaaab", RegexOptions.None, 0, 5, true, "aaaab");
+                yield return (@"(a+)+(?=b)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"(a+?)+(?=b)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"(a+)+?(?=b)", "aaab", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"(a+|b+)(?=c)", "aaac", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"(a+?|b+?)(?=c)", "aaac", RegexOptions.None, 0, 4, true, "aaa");
+                yield return (@"(a+)(?=\1b)", "aaaaaab", RegexOptions.None, 0, 7, true, "aaa");
+                yield return (@"(a+?)(?=\1b)", "aaaaaab", RegexOptions.None, 0, 7, true, "aaa");
+                yield return (@"[A-Z]+(?=b)", "AAAb", RegexOptions.IgnoreCase, 0, 4, true, "AAA");
+                yield return (@"[A-Z]+?(?=b)", "AAAb", RegexOptions.IgnoreCase, 0, 4, true, "AAA");
 
                 // Zero-width positive lookbehind assertion
                 yield return (@"(\w){6}(?<=XXX)def", "abcXXXdef", RegexOptions.None, 0, 9, true, "abcXXXdef");
@@ -136,6 +182,9 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"(?<=(abc)+?)", "123abc", RegexOptions.None, 0, 6, true, "");
                 yield return (@"(?<=(abc)+?)", "123ab", RegexOptions.None, 0, 5, false, "");
                 yield return (@"(?<=(abc)+?123)", "abcabc123", RegexOptions.None, 0, 9, true, "");
+                yield return (@"a+(?!c)(?<=y)", "yaab", RegexOptions.None, 0, 4, false, "");
+                yield return (@"(?<=a{2,4})b+", "aaabbb", RegexOptions.None, 0, 6, true, "bbb");
+                yield return (@"(?<=a+)b+?", "aaabbb", RegexOptions.None, 0, 6, true, "b");
 
                 // Zero-width negative lookbehind assertion: Actual - "(\\w){6}(?<!XXX)def"
                 yield return (@"(\w){6}(?<!XXX)def", "XXXabcdef", RegexOptions.None, 0, 9, true, "XXXabcdef");
@@ -143,6 +192,11 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"(abc)\w(?<!(?(1)e|d))", "abcdabc", RegexOptions.None, 0, 7, true, "abcd");
                 yield return (@"(abc)\w(?<!(?(cd)e|d))", "abcdabc", RegexOptions.None, 0, 7, true, "abcd");
                 yield return (@"(?<!(b)a)\1", "bb", RegexOptions.None, 0, 2, false, string.Empty); // negative assertion should not capture
+                yield return (@"(?<=a)b+c", "abbbbc", RegexOptions.None, 0, 6, true, "bbbbc");
+                yield return (@"(?<=a+)bc", "aaabc", RegexOptions.None, 0, 5, true, "bc");
+                yield return (@"(?<!x)a+b", "yaab", RegexOptions.None, 0, 4, true, "aab");
+                yield return (@"(?<!x)a+b", "xaab", RegexOptions.None, 0, 4, true, "ab");
+                yield return (@"a+(?=b)(?<!x)", "yaab", RegexOptions.None, 0, 4, true, "aa");
 
                 // Nonbacktracking subexpression: Actual - "[^0-9]+(?>[0-9]+)3"
                 // The last 3 causes the match to fail, since the non backtracking subexpression does not give up the last digit it matched

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
@@ -576,7 +576,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("(?=a(b*)c)", "(?=ab*c)")]
         [InlineData("(?=a((((b))))c)", "(?=abc)")]
         [InlineData(@"a*(?=a)", @"(?>a*)(?=a)")]
-        [InlineData(@"a*(?!b)b", @"(?>a*)(?!a)b")]
+        [InlineData(@"a*(?!b)b", @"(?>a*)(?!b)b")]
         [InlineData(@"a*(?<!b)cde", @"(?>a*)(?<!b)cde")]
         [InlineData(@"a*(?<=b)cde", @"(?>a*)(?<=b)cde")]
         // Loops inside alternation constructs

--- a/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/UnitTests/RegexReductionTests.cs
@@ -288,6 +288,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"abc(?=\Z)", @"abc\Z")]
         [InlineData(@"abc(?=\A)", @"abc\A")]
         [InlineData(@"abc(?=$)", @"abc$")]
+        [InlineData(@"a*(?=b)bcd", @"(?>a*)(?=b)bcd")]
         // Alternation reduction
         [InlineData("a|b", "[ab]")]
         [InlineData("a|b|c|d|e|g|h|z", "[a-eghz]")]
@@ -574,6 +575,10 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("(?=(abc))", "(?=abc)")]
         [InlineData("(?=a(b*)c)", "(?=ab*c)")]
         [InlineData("(?=a((((b))))c)", "(?=abc)")]
+        [InlineData(@"a*(?=a)", @"(?>a*)(?=a)")]
+        [InlineData(@"a*(?!b)b", @"(?>a*)(?!a)b")]
+        [InlineData(@"a*(?<!b)cde", @"(?>a*)(?<!b)cde")]
+        [InlineData(@"a*(?<=b)cde", @"(?>a*)(?<=b)cde")]
         // Loops inside alternation constructs
         [InlineData("(abc*|def)chi", "(ab(?>c*)|def)chi")]
         [InlineData("(abc|def*)fhi", "(abc|de(?>f*))fhi")]


### PR DESCRIPTION
As part of our auto-atomicity handling, today we give up when the subsequent node is a lookaround. This improves it to support the case when the subsequent node is a positive lookahead.