### PR TITLE
Don't do an invalid mask conversion optimization for conditional select nodes

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -28462,22 +28462,6 @@ bool GenTree::OperIsConvertVectorToMask() const
 }
 
 //------------------------------------------------------------------------
-// OperIsVectorConditionalSelect: Is this a vector ConditionalSelect hwintrinsic
-//
-// Return Value:
-//    true if the node is a vector ConditionalSelect hwintrinsic
-//    otherwise; false
-//
-bool GenTree::OperIsVectorConditionalSelect() const
-{
-    if (OperIsHWIntrinsic())
-    {
-        return AsHWIntrinsic()->OperIsVectorConditionalSelect();
-    }
-    return false;
-}
-
-//------------------------------------------------------------------------
 // OperIsVectorFusedMultiplyOp: Is this a vector FusedMultiplyOp hwintrinsic
 //
 // Return Value:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1715,7 +1715,6 @@ public:
     bool OperIsHWIntrinsic(NamedIntrinsic intrinsicId) const;
     bool OperIsConvertMaskToVector() const;
     bool OperIsConvertVectorToMask() const;
-    bool OperIsVectorConditionalSelect() const;
     bool OperIsVectorFusedMultiplyOp() const;
 
     // This is here for cleaner GT_LONG #ifdefs.
@@ -6574,34 +6573,6 @@ struct GenTreeHWIntrinsic : public GenTreeJitIntrinsic
 #else
         return false;
 #endif
-    }
-
-    bool OperIsVectorConditionalSelect() const
-    {
-        switch (GetHWIntrinsicId())
-        {
-#if defined(TARGET_XARCH)
-            case NI_Vector128_ConditionalSelect:
-            case NI_Vector256_ConditionalSelect:
-            case NI_Vector512_ConditionalSelect:
-            {
-                return true;
-            }
-#endif // TARGET_XARCH
-
-#if defined(TARGET_ARM64)
-            case NI_AdvSimd_BitwiseSelect:
-            case NI_Sve_ConditionalSelect:
-            {
-                return true;
-            }
-#endif // TARGET_ARM64
-
-            default:
-            {
-                return false;
-            }
-        }
     }
 
     bool OperIsVectorFusedMultiplyOp() const

--- a/src/tests/JIT/Regression/JitBlue/Runtime_118143/Runtime_118143.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_118143/Runtime_118143.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Text;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Xunit;
+
+public class Runtime_118143
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        for (int i = 0; i < 300; i++)
+        {
+            RunBase64Test();
+            Thread.Sleep(1);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RunBase64Test()
+    {
+        byte[] input = new byte[64];
+        byte[] output = new byte[Base64.GetMaxEncodedToUtf8Length(input.Length)];
+        byte[] expected = Convert.FromHexString(
+            "5957466859574668595746685957466859574668595746685957466859574668595746685957466859574668" +
+            "5957466859574668595746685957466859574668595746685957466859574668595746685957466859513D3D");
+        input.AsSpan().Fill((byte)'a');
+        Base64.EncodeToUtf8(input, output, out _, out _);
+        if (!output.SequenceEqual(expected))
+            throw new InvalidOperationException("Invalid Base64 output");
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_118143/Runtime_118143.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_118143/Runtime_118143.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <!-- The issue reproduces only with tiered compilation and PGO enabled -->
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This resolves #118143 

This was exposed in, but not actually introduced by, #116983. The actual bug was introduced a bit over 10 months ago (still unique to .NET 10), as part of enabling the `mask conversion` optimization pass for xarch.

The general issue was that the transform was introducing invalid IR as it was creating a `ConditionalSelect(mask, simd, simd)` node when in actuality IR requires this to be: `ConditionalSelect(simd, simd, simd)`. Cases like `Sve.ConditionalSelect(mask, simd, simd)` and `BlendVariableMask(simd, simd, mask)` do exist. But they will already be in the right shape as the mask operand will either directly be taking a mask (no conversion necessary) or they  will have something like `CvtSimdToMask(simd)` for that argument position (which is handled by a different logical path in the mask conversion optimization phase).

The side effect of this invalid IR is that we would end up with an incorrect mask, which was logically being treated as `zero` when it should have been treated as a bitwise operation instead. This resulted in one path being dropped as dead code and us always returning `op2` of `ConditionalSelect(mask, op1, op2)`.

The intent of the handling was rather to look for cases that were logically `ConditionalSelect(MaskToSimd(mask), simd, simd)` and say "this could instead be `BlendVariableMask(simd, simd, mask)`, but that is a bit more involved and is largely irrelevant with #116983 as we're preferring importing things to be handled as masks natively where possible already, which would allow the normal `CvtSimdToMask(lcl)` and `CvtMaskToSimd(lcl)` handling to kick-in.