### PR TITLE
Fix documentation for `LoadAndPack*` methods in `TeddyHelper`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
@@ -208,7 +208,7 @@ namespace System.Buffers
         }
 
         /// <summary>
-        /// Read two <see cref="Vector128{ushort}" /> and concatenate their lower bytes together into a single <see cref="Vector128{byte}" />.
+        /// Read two <see cref="Vector128&lt;UInt16&gt;" /> and concatenate their lower bytes together into a single <see cref="Vector128&lt;Byte&gt;" />.
         /// </summary>
         /// <remarks>
         /// On X86, characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.
@@ -238,7 +238,7 @@ namespace System.Buffers
         }
 
         /// <summary>
-        /// Read two <see cref="Vector256{ushort}" /> and concatenate their lower bytes together into a single <see cref="Vector256{byte}" />.
+        /// Read two <see cref="Vector256&lt;UInt16&gt;" /> and concatenate their lower bytes together into a single <see cref="Vector256&lt;Byte&gt;" />.
         /// </summary>
         /// <remarks>
         /// On X86, characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.
@@ -256,7 +256,7 @@ namespace System.Buffers
         }
 
         /// <summary>
-        /// Read two <see cref="Vector512{ushort}" /> and concatenate their lower bytes together into a single <see cref="Vector512{byte}" />.
+        /// Read two <see cref="Vector512&lt;UInt16&gt;" /> and concatenate their lower bytes together into a single <see cref="Vector512&lt;Byte&gt;" />.
         /// </summary>
         /// <remarks>
         /// On X86, characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/TeddyHelper.cs
@@ -207,8 +207,12 @@ namespace System.Buffers
             return (result, match0, match1);
         }
 
-        // Read two Vector512<ushort> and concatenate their lower bytes together into a single Vector512<byte>.
-        // On X86, characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.
+        /// <summary>
+        /// Read two <see cref="Vector128{ushort}" /> and concatenate their lower bytes together into a single <see cref="Vector128{byte}" />.
+        /// </summary>
+        /// <remarks>
+        /// On X86, characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
@@ -233,8 +237,12 @@ namespace System.Buffers
             }
         }
 
-        // Read two Vector512<ushort> and concatenate their lower bytes together into a single Vector512<byte>.
-        // Characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.
+        /// <summary>
+        /// Read two <see cref="Vector256{ushort}" /> and concatenate their lower bytes together into a single <see cref="Vector256{byte}" />.
+        /// </summary>
+        /// <remarks>
+        /// On X86, characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx2))]
         public static Vector256<byte> LoadAndPack32AsciiChars(ref char source)
@@ -247,8 +255,12 @@ namespace System.Buffers
             return PackedSpanHelpers.FixUpPackedVector256Result(packed);
         }
 
-        // Read two Vector512<ushort> and concatenate their lower bytes together into a single Vector512<byte>.
-        // Characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.
+        /// <summary>
+        /// Read two <see cref="Vector512{ushort}" /> and concatenate their lower bytes together into a single <see cref="Vector512{byte}" />.
+        /// </summary>
+        /// <remarks>
+        /// On X86, characters above 32767 are turned into 0, but we account for that by not using Teddy if any of the string values contain a 0.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx512BW))]
         public static Vector512<byte> LoadAndPack64AsciiChars(ref char source)


### PR DESCRIPTION
* Fix mistaken references to `Vector512` (copy-paste error)
* Update to use XML doc comments

cc: @MihaZupan