### PR TITLE
Refactor handle kinds into a table and mark the static base address cell handle non-null

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -304,6 +304,7 @@ set( JIT_HEADERS
   compilerbitsettraits.hpp
   compmemkind.h
   compphases.h
+  handlekinds.h
   dataflow.h
   debuginfo.h
   decomposelongs.h

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2999,7 +2999,7 @@ public:
 
     GenTree* gtNewJmpTableNode();
 
-    GenTree* gtNewIndOfIconHandleNode(var_types indType, size_t addr, GenTreeFlags iconFlags, bool isInvariant);
+    GenTree* gtNewIndOfIconHandleNode(var_types indType, size_t addr, GenTreeFlags iconFlags);
 
     GenTreeIntCon*   gtNewIconHandleNode(size_t value, GenTreeFlags flags, FieldSeq* fields = nullptr);
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -763,7 +763,7 @@ GenTree* BlockCountInstrumentor::CreateCounterIncrement(Compiler* comp, uint8_t*
 
     // Read Basic-Block count value
     GenTree* valueNode =
-        comp->gtNewIndOfIconHandleNode(countType, reinterpret_cast<size_t>(counterAddr), GTF_ICON_BBC_PTR, false);
+        comp->gtNewIndOfIconHandleNode(countType, reinterpret_cast<size_t>(counterAddr), GTF_ICON_BBC_PTR);
 
     // Increment value by 1
     GenTree* incValueNode = comp->gtNewOperNode(GT_ADD, countType, valueNode, comp->gtNewIconNode(1, countType));

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -322,13 +322,13 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
         {
             // Use a double indirection
             GenTree* addr =
-                gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)pAddrOfCaptureThreadGlobal, GTF_ICON_CONST_PTR, true);
+                gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)pAddrOfCaptureThreadGlobal, GTF_ICON_CONST_PTR);
             value = gtNewIndir(TYP_INT, addr, GTF_IND_NONFAULTING);
         }
         else
         {
             // Use a single indirection
-            value = gtNewIndOfIconHandleNode(TYP_INT, (size_t)addrTrap, GTF_ICON_GLOBAL_PTR, false);
+            value = gtNewIndOfIconHandleNode(TYP_INT, (size_t)addrTrap, GTF_ICON_GLOBAL_PTR);
         }
 
         // NOTE: in c++ an equivalent load is done via LoadWithoutBarrier() to ensure that the

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -336,6 +336,7 @@ struct Statement;
 enum HandleKindFlag
 {
     HKF_INVARIANT = 1, // Points to invariant data.
+    HKF_NONNULL   = 2, // Points to non-null data.
 };
 
 enum class HandleKindIndex : unsigned
@@ -2324,6 +2325,7 @@ public:
 #endif // FEATURE_HW_INTRINSICS
 
     static bool HandleKindDataIsInvariant(GenTreeFlags flags);
+    static bool HandleKindDataIsNotNull(GenTreeFlags flags);
 
     bool IsCall() const
     {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -333,7 +333,17 @@ class GenTreeOperandIterator;
 
 struct Statement;
 
-/*****************************************************************************/
+enum HandleKindFlag
+{
+    HKF_INVARIANT = 1, // Points to invariant data.
+};
+
+enum class HandleKindIndex : unsigned
+{
+#define HANDLE_KIND(name, description, flags) name,
+#include "handlekinds.h"
+    COUNT
+};
 
 // Forward declarations of the subtypes
 #define GTSTRUCT_0(fn, en)                   struct GenTree##fn;
@@ -354,7 +364,7 @@ struct Statement;
 //------------------------------------------------------------------------
 // GenTreeFlags: a bitmask of flags for GenTree stored in gtFlags
 //
-enum GenTreeFlags : unsigned int
+enum GenTreeFlags : unsigned
 {
     GTF_EMPTY         = 0,
 
@@ -507,28 +517,10 @@ enum GenTreeFlags : unsigned int
 
     GTF_ARR_ADDR_NONNULL        = 0x80000000, // GT_ARR_ADDR -- this array's address is not null
 
-    GTF_ICON_HDL_MASK           = 0xFF000000, // Bits used by handle types below
-    GTF_ICON_SCOPE_HDL          = 0x01000000, // GT_CNS_INT -- constant is a scope handle
-    GTF_ICON_CLASS_HDL          = 0x02000000, // GT_CNS_INT -- constant is a class handle
-    GTF_ICON_METHOD_HDL         = 0x03000000, // GT_CNS_INT -- constant is a method handle
-    GTF_ICON_FIELD_HDL          = 0x04000000, // GT_CNS_INT -- constant is a field handle
-    GTF_ICON_STATIC_HDL         = 0x05000000, // GT_CNS_INT -- constant is a handle to static data
-    GTF_ICON_STR_HDL            = 0x06000000, // GT_CNS_INT -- constant is a pinned handle pointing to a string object
-    GTF_ICON_OBJ_HDL            = 0x07000000, // GT_CNS_INT -- constant is an object handle (e.g. frozen string or Type object)
-    GTF_ICON_CONST_PTR          = 0x08000000, // GT_CNS_INT -- constant is a pointer to immutable data, (e.g. IAT_PPVALUE)
-    GTF_ICON_GLOBAL_PTR         = 0x09000000, // GT_CNS_INT -- constant is a pointer to mutable data (e.g. from the VM state)
-    GTF_ICON_VARG_HDL           = 0x0A000000, // GT_CNS_INT -- constant is a var arg cookie handle
-    GTF_ICON_PINVKI_HDL         = 0x0B000000, // GT_CNS_INT -- constant is a pinvoke calli handle
-    GTF_ICON_TOKEN_HDL          = 0x0C000000, // GT_CNS_INT -- constant is a token handle (other than class, method or field)
-    GTF_ICON_TLS_HDL            = 0x0D000000, // GT_CNS_INT -- constant is a TLS ref with offset
-    GTF_ICON_FTN_ADDR           = 0x0E000000, // GT_CNS_INT -- constant is a function address
-    GTF_ICON_CIDMID_HDL         = 0x0F000000, // GT_CNS_INT -- constant is a class ID or a module ID
-    GTF_ICON_BBC_PTR            = 0x10000000, // GT_CNS_INT -- constant is a basic block count pointer
-    GTF_ICON_STATIC_BOX_PTR     = 0x11000000, // GT_CNS_INT -- constant is an address of the box for a STATIC_IN_HEAP field
-    GTF_ICON_FIELD_SEQ          = 0x12000000, // <--------> -- constant is a FieldSeq* (used only as VNHandle)
-    GTF_ICON_STATIC_ADDR_PTR    = 0x13000000, // GT_CNS_INT -- constant is a pointer to a static base address
-    GTF_ICON_SECREL_OFFSET      = 0x14000000, // GT_CNS_INT -- constant is an offset in a certain section.
-    GTF_ICON_TLSGD_OFFSET       = 0x15000000, // GT_CNS_INT -- constant is an argument to tls_get_addr.
+#define HANDLE_KIND_INDEX_SHIFT 24
+    GTF_ICON_HDL_MASK           = (~0u) << HANDLE_KIND_INDEX_SHIFT, // 0xFF000000, bits used by the handle types.
+#define HANDLE_KIND(name, description, flags) name = (static_cast<unsigned>(HandleKindIndex::name) + 1) << HANDLE_KIND_INDEX_SHIFT,
+#include "handlekinds.h"
 
  // GTF_ICON_REUSE_REG_VAL      = 0x00800000  // GT_CNS_INT -- GTF_REUSE_REG_VAL, defined above
     GTF_ICON_SIMD_COUNT         = 0x00200000, // GT_CNS_INT -- constant is Vector<T>.Count
@@ -596,6 +588,14 @@ inline GenTreeFlags& operator ^=(GenTreeFlags& a, GenTreeFlags b)
 // region. In such cases, even stores to locals will have to be restricted.
 #define GTF_GLOBALLY_VISIBLE_SIDE_EFFECTS(flags) \
     (((flags) & (GTF_CALL | GTF_EXCEPT)) || (((flags) & (GTF_ASG | GTF_GLOB_REF)) == (GTF_ASG | GTF_GLOB_REF)))
+
+inline unsigned HandleKindToHandleKindIndex(GenTreeFlags kind)
+{
+    assert((kind & GTF_ICON_HDL_MASK) != 0);
+    unsigned index = (kind >> HANDLE_KIND_INDEX_SHIFT) - 1;
+    assert(index < static_cast<unsigned>(HandleKindIndex::COUNT));
+    return index;
+}
 
 #if defined(DEBUG)
 

--- a/src/coreclr/jit/handlekinds.h
+++ b/src/coreclr/jit/handlekinds.h
@@ -24,7 +24,7 @@ HANDLE_KIND(GTF_ICON_CIDMID_HDL      , "cid/mid"                    , HKF_INVARI
 HANDLE_KIND(GTF_ICON_BBC_PTR         , "bbc"                        , 0)             // basic block count pointer
 HANDLE_KIND(GTF_ICON_STATIC_BOX_PTR  , "static box ptr"             , 0)             // address of the box for a STATIC_IN_HEAP field
 HANDLE_KIND(GTF_ICON_FIELD_SEQ       , "field seq"                  , 0)             // FieldSeq* (used only as VNHandle)
-HANDLE_KIND(GTF_ICON_STATIC_ADDR_PTR , "static base addr cell"      , HKF_INVARIANT) // pointer to a static base address
+HANDLE_KIND(GTF_ICON_STATIC_ADDR_PTR , "static base addr cell"      , HKF_INVARIANT | HKF_NONNULL) // pointer to a static base address
 HANDLE_KIND(GTF_ICON_SECREL_OFFSET   , "relative offset in section" , HKF_INVARIANT) // offset in a certain section.
 HANDLE_KIND(GTF_ICON_TLSGD_OFFSET    , "tls global dynamic offset"  , HKF_INVARIANT) // argument to tls_get_addr.
 

--- a/src/coreclr/jit/handlekinds.h
+++ b/src/coreclr/jit/handlekinds.h
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// clang-format off
+#ifndef HANDLE_KIND
+#error  Define HANDLE_KIND before including this file.
+#endif
+
+HANDLE_KIND(GTF_ICON_SCOPE_HDL       , "scope"                      , HKF_INVARIANT) // scope handle
+HANDLE_KIND(GTF_ICON_CLASS_HDL       , "class"                      , HKF_INVARIANT) // class handle
+HANDLE_KIND(GTF_ICON_METHOD_HDL      , "method"                     , HKF_INVARIANT) // method handle
+HANDLE_KIND(GTF_ICON_FIELD_HDL       , "field"                      , HKF_INVARIANT) // field handle
+HANDLE_KIND(GTF_ICON_STATIC_HDL      , "static"                     , 0)             // handle to static data
+HANDLE_KIND(GTF_ICON_STR_HDL         , "string"                     , HKF_INVARIANT) // pinned handle pointing to a string object
+HANDLE_KIND(GTF_ICON_OBJ_HDL         , "object"                     , 0)             // object handle (e.g. frozen string or Type object)
+HANDLE_KIND(GTF_ICON_CONST_PTR       , "const ptr"                  , HKF_INVARIANT) // pointer to immutable data, (e.g. IAT_PPVALUE)
+HANDLE_KIND(GTF_ICON_GLOBAL_PTR      , "global ptr"                 , 0)             // pointer to mutable data (e.g. from the VM state)
+HANDLE_KIND(GTF_ICON_VARG_HDL        , "vararg"                     , HKF_INVARIANT) // var arg cookie handle
+HANDLE_KIND(GTF_ICON_PINVKI_HDL      , "pinvoke"                    , 0)             // pinvoke calli handle
+HANDLE_KIND(GTF_ICON_TOKEN_HDL       , "token"                      , HKF_INVARIANT) // token handle (other than class, method or field)
+HANDLE_KIND(GTF_ICON_TLS_HDL         , "tls"                        , HKF_INVARIANT) // TLS ref with offset
+HANDLE_KIND(GTF_ICON_FTN_ADDR        , "ftn"                        , 0)             // function address
+HANDLE_KIND(GTF_ICON_CIDMID_HDL      , "cid/mid"                    , HKF_INVARIANT) // class ID or a module ID
+HANDLE_KIND(GTF_ICON_BBC_PTR         , "bbc"                        , 0)             // basic block count pointer
+HANDLE_KIND(GTF_ICON_STATIC_BOX_PTR  , "static box ptr"             , 0)             // address of the box for a STATIC_IN_HEAP field
+HANDLE_KIND(GTF_ICON_FIELD_SEQ       , "field seq"                  , 0)             // FieldSeq* (used only as VNHandle)
+HANDLE_KIND(GTF_ICON_STATIC_ADDR_PTR , "static base addr cell"      , HKF_INVARIANT) // pointer to a static base address
+HANDLE_KIND(GTF_ICON_SECREL_OFFSET   , "relative offset in section" , HKF_INVARIANT) // offset in a certain section.
+HANDLE_KIND(GTF_ICON_TLSGD_OFFSET    , "tls global dynamic offset"  , HKF_INVARIANT) // argument to tls_get_addr.
+
+#undef HANDLE_KIND
+// clang-format on

--- a/src/coreclr/jit/handlekinds.h
+++ b/src/coreclr/jit/handlekinds.h
@@ -11,7 +11,7 @@ HANDLE_KIND(GTF_ICON_CLASS_HDL       , "class"                      , HKF_INVARI
 HANDLE_KIND(GTF_ICON_METHOD_HDL      , "method"                     , HKF_INVARIANT) // method handle
 HANDLE_KIND(GTF_ICON_FIELD_HDL       , "field"                      , HKF_INVARIANT) // field handle
 HANDLE_KIND(GTF_ICON_STATIC_HDL      , "static"                     , 0)             // handle to static data
-HANDLE_KIND(GTF_ICON_STR_HDL         , "string"                     , HKF_INVARIANT) // pinned handle pointing to a string object
+HANDLE_KIND(GTF_ICON_STR_HDL         , "string"                     , HKF_INVARIANT | HKF_NONNULL) // pinned handle pointing to a string object
 HANDLE_KIND(GTF_ICON_OBJ_HDL         , "object"                     , 0)             // object handle (e.g. frozen string or Type object)
 HANDLE_KIND(GTF_ICON_CONST_PTR       , "const ptr"                  , HKF_INVARIANT) // pointer to immutable data, (e.g. IAT_PPVALUE)
 HANDLE_KIND(GTF_ICON_GLOBAL_PTR      , "global ptr"                 , 0)             // pointer to mutable data (e.g. from the VM state)

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -1441,7 +1441,7 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
     {
         assert(isInitOffset == 0);
 
-        isInitedActualValueNode = gtNewIndOfIconHandleNode(TYP_INT, (size_t)flagAddr.addr, GTF_ICON_GLOBAL_PTR, false);
+        isInitedActualValueNode = gtNewIndOfIconHandleNode(TYP_INT, (size_t)flagAddr.addr, GTF_ICON_GLOBAL_PTR);
         isInitedActualValueNode->gtFlags |= GTF_IND_VOLATILE;
         isInitedActualValueNode->SetHasOrderingSideEffect();
 
@@ -1479,8 +1479,7 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
         else
         {
             assert(staticBaseAddr.accessType == IAT_PVALUE);
-            replacementNode =
-                gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)staticBaseAddr.addr, GTF_ICON_GLOBAL_PTR, false);
+            replacementNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)staticBaseAddr.addr, GTF_ICON_GLOBAL_PTR);
         }
     }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4164,7 +4164,7 @@ GenTree* Compiler::impImportStaticFieldAddress(CORINFO_RESOLVED_TOKEN* pResolved
             else
             {
                 assert(pFieldInfo->fieldLookup.accessType == IAT_PVALUE);
-                op1 = gtNewIndOfIconHandleNode(TYP_I_IMPL, fldAddr, GTF_ICON_STATIC_ADDR_PTR, true);
+                op1 = gtNewIndOfIconHandleNode(TYP_I_IMPL, fldAddr, GTF_ICON_STATIC_ADDR_PTR);
             }
             GenTree* offset = gtNewIconNode(pFieldInfo->offset, innerFldSeq);
             isHoistable     = true;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3787,7 +3787,7 @@ GenTree* Compiler::fgMorphExpandInstanceField(GenTree* tree, MorphAddrContext* m
         if (tree->AsFieldAddr()->gtFieldLookup.accessType == IAT_PVALUE)
         {
             offsetNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)tree->AsFieldAddr()->gtFieldLookup.addr,
-                                                  GTF_ICON_CONST_PTR, true);
+                                                  GTF_ICON_CONST_PTR);
 #ifdef DEBUG
             offsetNode->gtGetOp1()->AsIntCon()->gtTargetHandle = (size_t)fieldHandle;
 #endif
@@ -3909,7 +3909,7 @@ GenTree* Compiler::fgMorphExpandTlsFieldAddr(GenTree* tree)
     }
     else
     {
-        dllRef = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)pIdAddr, GTF_ICON_CONST_PTR, true);
+        dllRef = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)pIdAddr, GTF_ICON_CONST_PTR);
 
         // Next we multiply by 4
         dllRef = gtNewOperNode(GT_MUL, TYP_I_IMPL, dllRef, gtNewIconNode(4, TYP_I_IMPL));
@@ -6804,14 +6804,14 @@ GenTree* Compiler::fgMorphLeaf(GenTree* tree)
         switch (addrInfo.accessType)
         {
             case IAT_PPVALUE:
-                indNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)addrInfo.handle, GTF_ICON_CONST_PTR, true);
+                indNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)addrInfo.handle, GTF_ICON_CONST_PTR);
 
                 // Add the second indirection
                 indNode = gtNewIndir(TYP_I_IMPL, indNode, GTF_IND_NONFAULTING | GTF_IND_INVARIANT);
                 break;
 
             case IAT_PVALUE:
-                indNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)addrInfo.handle, GTF_ICON_FTN_ADDR, true);
+                indNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)addrInfo.handle, GTF_ICON_FTN_ADDR);
                 INDEBUG(indNode->gtGetOp1()->AsIntCon()->gtTargetHandle = reinterpret_cast<size_t>(funcHandle));
                 break;
 


### PR DESCRIPTION
There are two parts to this change:
1) Centralizing knowledge about handles into a table (like with e. g. intrinsics). This is no-diff.
2) Marking `GTF_ICON_STATIC_ADDR_PTR` as producing non-null values. This handle type is used for NAOT GC static bases which are initialized at startup. This part has some minor positive diffs on NAOT.