### PR TITLE
Add ETW nostack entries for DebugExceptionProcessing events

### DIFF
--- a/src/coreclr/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/vm/ClrEtwAllMeta.lst
@@ -650,6 +650,8 @@ nomac:CLRStackStress:::CLRStackWalkStress
 #################################
 nostack:DebugIPCEvent:::DebugIPCEventStart
 nostack:DebugIPCEvent:::DebugIPCEventEnd
+nostack:DebugExceptionProcessing:::DebugExceptionProcessingStart
+nostack:DebugExceptionProcessing:::DebugExceptionProcessingEnd
 
 #################################
 # Events from the Mono profiler provider


### PR DESCRIPTION
Fixes #112226.  Similar to #114585, the ETW stackwalk may fail if there is a breakpoint on the stack.