### PR TITLE
Partially revert "Combine cast => negate => compare on ARM64 #112944"

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -384,7 +384,7 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
     if (childNode->OperIs(GT_NEG))
     {
         // If we have a contained LSH, RSH or RSZ, we can still contain NEG if the parent is a EQ or NE.
-        if (childNode->gtGetOp1()->isContained() && !childNode->gtGetOp1()->OperIs(GT_LSH, GT_RSH, GT_RSZ, GT_CAST))
+        if (childNode->gtGetOp1()->isContained() && !childNode->gtGetOp1()->OperIs(GT_LSH, GT_RSH, GT_RSZ))
         {
             // Cannot contain if the childs op1 is already contained
             return false;
@@ -403,31 +403,6 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
             {
                 return false;
             }
-
-            if (childNode->gtGetOp1()->OperIs(GT_CAST))
-            {
-                // Grab the cast as well, we can contain this with cmn (extended-register).
-                GenTreeCast* cast   = childNode->gtGetOp1()->AsCast();
-                GenTree*     castOp = cast->CastOp();
-
-                // Cannot contain the cast from floating point.
-                if (!varTypeIsIntegral(castOp))
-                {
-                    return false;
-                }
-
-                // Cannot contain the cast if it already contains it's CastOp.
-                if (castOp->isContained())
-                {
-                    return false;
-                }
-
-                assert(!cast->gtOverflow());
-                assert(varTypeIsIntegral(cast) && varTypeIsIntegral(cast->CastToType()));
-
-                MakeSrcContained(childNode, cast);
-            }
-
             return true;
         }
 

--- a/src/tests/JIT/opt/InstructionCombining/Cmn.cs
+++ b/src/tests/JIT/opt/InstructionCombining/Cmn.cs
@@ -50,31 +50,6 @@ namespace TestCompareNegative
                 fail = true;
             }
 
-            if (!CmnExtendedB(1, 0xff))
-            {
-                fail = true;
-            }
-            if (!CmnExtendedH(1, 0xffff))
-            {
-                fail = true;
-            }
-            if (!CmnExtendedS(1, 0xffffffff))
-            {
-                fail = true;
-            }
-            if (!CmnExtendedUB(-1, 0x101))
-            {
-                fail = true;
-            }
-            if (!CmnExtendedUH(-1, 0x10001))
-            {
-                fail = true;
-            }
-            if (!CmnExtendedUS(-1, 0x100000001))
-            {
-                fail = true;
-            }
-
             if (fail)
             {
                 return 101;

--- a/src/tests/JIT/opt/InstructionCombining/Cmn.cs
+++ b/src/tests/JIT/opt/InstructionCombining/Cmn.cs
@@ -159,47 +159,5 @@ namespace TestCompareNegative
             }
             return false;
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static bool CmnExtendedB(int a, int b)
-        {
-            //ARM64-FULL-LINE: cmn {{w[0-9]+}}, {{w[0-9]+}}, SXTB
-            return (a == -(sbyte)b);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static bool CmnExtendedH(int a, int b)
-        {
-            //ARM64-FULL-LINE: cmn {{w[0-9]+}}, {{w[0-9]+}}, SXTH
-            return (a == -(short)b);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static bool CmnExtendedS(long a, long b)
-        {
-            //ARM64-FULL-LINE: cmn {{x[0-9]+}}, {{w[0-9]+}}, SXTW
-            return (a == -(long)(int)b);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static bool CmnExtendedUB(int a, int b)
-        {
-            //ARM64-FULL-LINE: cmn {{w[0-9]+}}, {{w[0-9]+}}, UXTB
-            return (a == -(byte)b);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static bool CmnExtendedUH(int a, int b)
-        {
-            //ARM64-FULL-LINE: cmn {{w[0-9]+}}, {{w[0-9]+}}, UXTH
-            return (a == -(ushort)b);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static bool CmnExtendedUS(long a, long b)
-        {
-            //ARM64-FULL-LINE: cmn {{x[0-9]+}}, {{w[0-9]+}}, UXTW
-            return (a == -(uint)b);
-        }
     }
 }


### PR DESCRIPTION
Partially revert #112944 to fix https://github.com/dotnet/runtime/issues/118117 bug.

That PR recognizes `EQ(NEG(CAST(...)))` tree and marks the `CAST` as contained in lower. So now the change expects that nobody will touch this tree and if someone changes EQ to e.g. CCMP - the emitter fails due to CAST being marked as contained. I think it's quite fragile to rely nobody will change the IR like this. Since the PR generated only [a few diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1109533&view=ms.vss-build-web.run-extensions-tab), and we're late in the cycle, I've reverted it.

