### PR TITLE
[browser] disable UmaReadWriteGenericStringStructArray_ThrowsArgumentException test

### DIFF
--- a/src/libraries/System.Runtime/tests/System.IO.UnmanagedMemoryStream.Tests/Uma.ReadWriteStructArray.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.UnmanagedMemoryStream.Tests/Uma.ReadWriteStructArray.cs
@@ -115,6 +115,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/117166", TestPlatforms.Browser)]
         public static void UmaReadWriteGenericStringStructArray_ThrowsArgumentException()
         {
             const int capacity = 100;


### PR DESCRIPTION
active issue https://github.com/dotnet/runtime/issues/117166

alternatively we could mark `UnmanagedMemoryAccessor.Write<T>` and `UnmanagedMemoryAccessor.Read<T>` with 
`cfg->prefer_instances = TRUE` and see if that helps. 
It should throw `ArgumentException` anyway, so it's not very important scenario.