### PR TITLE
Do not look at unboxing bit when looking up constructed generic methods

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericMethodsLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericMethodsLookup.cs
@@ -146,28 +146,53 @@ namespace Internal.Runtime.TypeLoader
                 TypeSystemContext context = _methodToLookup.Context;
 
                 RuntimeTypeHandle parsedDeclaringTypeHandle = externalReferencesLookup.GetRuntimeTypeHandleFromIndex(entryParser.GetUnsigned());
+                TypeDesc parsedDeclaringType = context.ResolveRuntimeTypeHandle(parsedDeclaringTypeHandle);
+                if (_methodToLookup.OwningType != parsedDeclaringType)
+                    return false;
 
                 // Hash table names / sigs are indirected through to the native layout info
                 MethodNameAndSignature nameAndSignature = TypeLoaderEnvironment.GetMethodNameAndSignatureFromToken(moduleHandle, entryParser.GetUnsigned());
+                if (!_methodToLookup.NameAndSignature.Equals(nameAndSignature))
+                    return false;
 
                 RuntimeTypeHandle[] parsedArgsHandles = GetTypeSequence(ref externalReferencesLookup, ref entryParser);
+                if (parsedArgsHandles.Length != _methodToLookup.Instantiation.Length)
+                    return false;
 
-                DefType parsedDeclaringType = context.ResolveRuntimeTypeHandle(parsedDeclaringTypeHandle) as DefType;
-                Instantiation parsedArgs = context.ResolveRuntimeTypeHandles(parsedArgsHandles);
-                InstantiatedMethod parsedGenericMethod = (InstantiatedMethod)context.ResolveGenericMethodInstantiation(false, parsedDeclaringType, nameAndSignature, parsedArgs);
+                for (int i = 0; i < _methodToLookup.Instantiation.Length; i++)
+                {
+                    TypeDesc leftType = context.ResolveRuntimeTypeHandle(parsedArgsHandles[i]);
+                    TypeDesc rightType = _methodToLookup.Instantiation[i];
+                    if (leftType != rightType)
+                        return false;
+                }
 
-                return parsedGenericMethod == _methodToLookup;
+                return true;
             }
 
             internal override bool MatchGenericMethodEntry(GenericMethodEntry entry)
             {
                 TypeSystemContext context = _methodToLookup.Context;
 
-                DefType parsedDeclaringType = context.ResolveRuntimeTypeHandle(entry._declaringTypeHandle) as DefType;
-                Instantiation parsedArgs = context.ResolveRuntimeTypeHandles(entry._genericMethodArgumentHandles);
-                InstantiatedMethod parsedGenericMethod = (InstantiatedMethod)context.ResolveGenericMethodInstantiation(false, parsedDeclaringType, entry._methodNameAndSignature, parsedArgs);
+                TypeDesc parsedDeclaringType = context.ResolveRuntimeTypeHandle(entry._declaringTypeHandle);
+                if (_methodToLookup.OwningType != parsedDeclaringType)
+                    return false;
 
-                return parsedGenericMethod == _methodToLookup;
+                if (!_methodToLookup.NameAndSignature.Equals(entry._methodNameAndSignature))
+                    return false;
+
+                if (entry._genericMethodArgumentHandles.Length != _methodToLookup.Instantiation.Length)
+                    return false;
+
+                for (int i = 0; i < _methodToLookup.Instantiation.Length; i++)
+                {
+                    TypeDesc leftType = context.ResolveRuntimeTypeHandle(entry._genericMethodArgumentHandles[i]);
+                    TypeDesc rightType = _methodToLookup.Instantiation[i];
+                    if (leftType != rightType)
+                        return false;
+                }
+
+                return true;
             }
         }
 

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.main.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.main.cs
@@ -152,6 +152,7 @@ new CoreFXTestLibrary.Internal.TestInfo("B282745.testMDArrayWith3Dimensions", ()
 #if UNIVERSAL_GENERICS
 new CoreFXTestLibrary.Internal.TestInfo("B279085.TestB279085Repro", () => global::B279085.TestB279085Repro(), null),
 #endif
+new CoreFXTestLibrary.Internal.TestInfo("GitHub118072.RunTest", () => global::GitHub118072.RunTest(), null),
 new CoreFXTestLibrary.Internal.TestInfo("GenericVirtualMethods.TestCalls", () => global::GenericVirtualMethods.TestCalls(), null),
 new CoreFXTestLibrary.Internal.TestInfo("GenericVirtualMethods.TestLdFtnToGetStaticMethodOnGenericType", () => global::GenericVirtualMethods.TestLdFtnToGetStaticMethodOnGenericType(), null),
 new CoreFXTestLibrary.Internal.TestInfo("GenericVirtualMethods.TestLdFtnToInstanceGenericMethod", () => global::GenericVirtualMethods.TestLdFtnToInstanceGenericMethod(), null),

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/Github118072.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/Github118072.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using CoreFXTestLibrary;
+
+class GitHub118072
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static MethodInfo GetMI1() => typeof(GitHub118072).GetMethod(nameof(CallMethod1));
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static MethodInfo GetMI2() => typeof(GitHub118072).GetMethod(nameof(CallMethod2));
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static MethodInfo GetMI3() => typeof(GitHub118072).GetMethod(nameof(CallMethod1));
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static MethodInfo GetMI4() => typeof(GitHub118072).GetMethod(nameof(CallMethod2));
+
+    [TestMethod]
+    public static void RunTest()
+    {
+        Type current = typeof(object);
+
+        GetMI1().MakeGenericMethod(typeof(object)).Invoke(null, []);
+        current = FillCache(current);
+        GetMI2().MakeGenericMethod(typeof(object)).Invoke(null, []);
+        current = FillCache(current);
+        GetMI3().MakeGenericMethod(typeof(object)).Invoke(null, []);
+        current = FillCache(current);
+        GetMI4().MakeGenericMethod(typeof(object)).Invoke(null, []);
+
+        static Type FillCache(Type current)
+        {
+            for (int i = 0; i < 400; i++)
+            {
+                Type next = typeof(MyClass<>).MakeGenericType(current);
+                Activator.CreateInstance(next);
+                current = next;
+            }
+
+            return current;
+        }
+    }
+
+    public static string CallMethod1<T>() => default(MyStruct).Method<T>();
+
+    public static string CallMethod2<T>() => default(MyStruct).Method<T>();
+
+    struct MyStruct
+    {
+        public string Method<T>() => typeof(T).Name;
+    }
+
+    class MyClass<T> { }
+}


### PR DESCRIPTION
Fixes #118072.

In the bug we were ending up in a situation where we remember generic dictionary for a `MethodDesc` with `UnboxingStub` bit set to true and then try to look up a generic dictionary for a `MethodDesc` with unboxing stub bit set to false (the false is hardcoded in the code I'm updating).

This is all sorts of wrong. The unboxing MethodDescs in the runtime type system were a mistake. We get by without them in the compiler.

This is really difficult to hit because the runtime type system is mutable (this is yet another mistake) and if we still have a cached version of this mutable type system around, this lookup is not used.

The regression test I added is really annoying and takes like 40 seconds to run in checked builds. I hate it, but this is not hittable in any other way. I'm not sure if this one is 100% reliable at triggering the type system flush either.

Cc @dotnet/ilc-contrib 