### PR TITLE
Rename SecretKey to PrivateKey for SLH-DSA

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
@@ -616,8 +616,8 @@ namespace System.Security.Cryptography
                 3 + // Version Integer
                 2 + // AlgorithmIdentifier Sequence
                 3 + // AlgorithmIdentifier OID value, undervalued to be safe
-                2 + // Secret key Octet String prefix, undervalued to be safe
-                Algorithm.SecretKeySizeInBytes;
+                2 + // Private key Octet String prefix, undervalued to be safe
+                Algorithm.PrivateKeySizeInBytes;
 
             if (destination.Length < MinimumPossiblePkcs8SlhDsaKey)
             {
@@ -650,19 +650,19 @@ namespace System.Security.Cryptography
         /// </exception>
         protected virtual bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
         {
-            // Secret key size for SLH-DSA is at most 128 bytes so we can stack allocate it.
-            int secretKeySizeInBytes = Algorithm.SecretKeySizeInBytes;
-            Debug.Assert(secretKeySizeInBytes is <= 128);
-            Span<byte> secretKey = (stackalloc byte[128])[..secretKeySizeInBytes];
+            // Private key size for SLH-DSA is at most 128 bytes so we can stack allocate it.
+            int privateKeySizeInBytes = Algorithm.PrivateKeySizeInBytes;
+            Debug.Assert(privateKeySizeInBytes is <= 128);
+            Span<byte> privateKey = (stackalloc byte[128])[..privateKeySizeInBytes];
 
             try
             {
-                ExportSlhDsaSecretKey(secretKey);
+                ExportSlhDsaPrivateKey(privateKey);
 
                 // The ASN.1 overhead of a PrivateKeyInfo encoding a private key is 22 bytes.
                 // Round it off to 32. This checked operation should never throw because the inputs are not
                 // user provided.
-                int capacity = checked(32 + secretKeySizeInBytes);
+                int capacity = checked(32 + privateKeySizeInBytes);
                 AsnWriter writer = new AsnWriter(AsnEncodingRules.DER, capacity);
 
                 using (writer.PushSequence())
@@ -674,7 +674,7 @@ namespace System.Security.Cryptography
                         writer.WriteObjectIdentifier(Algorithm.Oid);
                     }
 
-                    writer.WriteOctetString(secretKey);
+                    writer.WriteOctetString(privateKey);
                 }
 
                 Debug.Assert(writer.GetEncodedLength() <= capacity);
@@ -682,7 +682,7 @@ namespace System.Security.Cryptography
             }
             finally
             {
-                CryptographicOperations.ZeroMemory(secretKey);
+                CryptographicOperations.ZeroMemory(privateKey);
             }
         }
 
@@ -1108,55 +1108,55 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Exports the current key in the FIPS 205 secret key format.
+        ///   Exports the current key in the FIPS 205 private key format.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the secret key. Its length must be exactly
-        ///   <see cref="SlhDsaAlgorithm.SecretKeySizeInBytes"/>.
+        ///   The buffer to receive the private key. Its length must be exactly
+        ///   <see cref="SlhDsaAlgorithm.PrivateKeySizeInBytes"/>.
         /// </param>
         /// <exception cref="ArgumentException">
-        ///   <paramref name="destination"/> is the incorrect length to receive the secret key.
+        ///   <paramref name="destination"/> is the incorrect length to receive the private key.
         /// </exception>
         /// <exception cref="CryptographicException">
-        ///   <para>The current instance cannot export a secret key.</para>
+        ///   <para>The current instance cannot export a private key.</para>
         ///   <para>-or-</para>
         ///   <para>An error occurred while exporting the key.</para>
         /// </exception>
         /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
-        public void ExportSlhDsaSecretKey(Span<byte> destination)
+        public void ExportSlhDsaPrivateKey(Span<byte> destination)
         {
-            int secretKeySizeInBytes = Algorithm.SecretKeySizeInBytes;
+            int privateKeySizeInBytes = Algorithm.PrivateKeySizeInBytes;
 
-            if (destination.Length != secretKeySizeInBytes)
+            if (destination.Length != privateKeySizeInBytes)
             {
                 throw new ArgumentException(
-                    SR.Format(SR.Argument_DestinationImprecise, secretKeySizeInBytes),
+                    SR.Format(SR.Argument_DestinationImprecise, privateKeySizeInBytes),
                     nameof(destination));
             }
 
             ThrowIfDisposed();
 
-            ExportSlhDsaSecretKeyCore(destination);
+            ExportSlhDsaPrivateKeyCore(destination);
         }
 
         /// <summary>
-        ///   Exports the current key in the FIPS 205 secret key format.
+        ///   Exports the current key in the FIPS 205 private key format.
         /// </summary>
         /// <returns>
-        ///   The FIPS 205 secret key.
+        ///   The FIPS 205 private key.
         /// </returns>
         /// <exception cref="CryptographicException">
-        ///   <para>The current instance cannot export a secret key.</para>
+        ///   <para>The current instance cannot export a private key.</para>
         ///   <para>-or-</para>
         ///   <para>An error occurred while exporting the key.</para>
         /// </exception>
         /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
-        public byte[] ExportSlhDsaSecretKey()
+        public byte[] ExportSlhDsaPrivateKey()
         {
             ThrowIfDisposed();
 
-            byte[] destination = new byte[Algorithm.SecretKeySizeInBytes];
-            ExportSlhDsaSecretKeyCore(destination);
+            byte[] destination = new byte[Algorithm.PrivateKeySizeInBytes];
+            ExportSlhDsaPrivateKeyCore(destination);
             return destination;
         }
 
@@ -1293,12 +1293,12 @@ namespace System.Security.Cryptography
                     SlhDsaAlgorithm info = GetAlgorithmIdentifier(in algId);
                     ReadOnlySpan<byte> privateKey = key.Span;
 
-                    if (privateKey.Length != info.SecretKeySizeInBytes)
+                    if (privateKey.Length != info.PrivateKeySizeInBytes)
                     {
                         throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
                     }
 
-                    ret = ImportSlhDsaSecretKey(info, key.Span);
+                    ret = ImportSlhDsaPrivateKey(info, key.Span);
                 },
                 out int read,
                 out SlhDsa slhDsa);
@@ -1704,13 +1704,13 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Imports an SLH-DSA private key in the FIPS 205 secret key format.
+        ///   Imports an SLH-DSA private key in the FIPS 205 private key format.
         /// </summary>
         /// <param name="algorithm">
         ///   The specific SLH-DSA algorithm for this key.
         /// </param>
         /// <param name="source">
-        ///   The bytes of a FIPS 205 secret key.
+        ///   The bytes of a FIPS 205 private key.
         /// </param>
         /// <returns>
         ///   The imported key.
@@ -1728,29 +1728,29 @@ namespace System.Security.Cryptography
         ///   The platform does not support SLH-DSA. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports SLH-DSA.
         /// </exception>
-        public static SlhDsa ImportSlhDsaSecretKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             ArgumentNullException.ThrowIfNull(algorithm);
 
-            if (source.Length != algorithm.SecretKeySizeInBytes)
+            if (source.Length != algorithm.PrivateKeySizeInBytes)
             {
-                throw new ArgumentException(SR.Argument_SecretKeyWrongSizeForAlgorithm, nameof(source));
+                throw new ArgumentException(SR.Argument_PrivateKeyWrongSizeForAlgorithm, nameof(source));
             }
 
             ThrowIfNotSupported();
 
-            return SlhDsaImplementation.ImportSecretKey(algorithm, source);
+            return SlhDsaImplementation.ImportPrivateKey(algorithm, source);
         }
 
-        /// <inheritdoc cref="ImportSlhDsaSecretKey(SlhDsaAlgorithm, ReadOnlySpan{byte})" />
+        /// <inheritdoc cref="ImportSlhDsaPrivateKey(SlhDsaAlgorithm, ReadOnlySpan{byte})" />
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="algorithm"/> or <paramref name="source" /> is <see langword="null" />.
         /// </exception>
-        public static SlhDsa ImportSlhDsaSecretKey(SlhDsaAlgorithm algorithm, byte[] source)
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, byte[] source)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return ImportSlhDsaSecretKey(algorithm, new ReadOnlySpan<byte>(source));
+            return ImportSlhDsaPrivateKey(algorithm, new ReadOnlySpan<byte>(source));
         }
 
         /// <summary>
@@ -1856,12 +1856,12 @@ namespace System.Security.Cryptography
         protected abstract void ExportSlhDsaPublicKeyCore(Span<byte> destination);
 
         /// <summary>
-        ///   When overridden in a derived class, exports the FIPS 205 secret key to the specified buffer.
+        ///   When overridden in a derived class, exports the FIPS 205 private key to the specified buffer.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the secret key.
+        ///   The buffer to receive the private key.
         /// </param>
-        protected abstract void ExportSlhDsaSecretKeyCore(Span<byte> destination);
+        protected abstract void ExportSlhDsaPrivateKeyCore(Span<byte> destination);
 
         private AsnWriter ExportSubjectPublicKeyInfoCore()
         {
@@ -1952,7 +1952,7 @@ namespace System.Security.Cryptography
         {
             // A PKCS#8 SLH-DSA-SHA2-256s private key has an ASN.1 overhead of 22 bytes, assuming no attributes.
             // Make it an even 32 and that should give a good starting point for a buffer size.
-            int size = Algorithm.SecretKeySizeInBytes + 32;
+            int size = Algorithm.PrivateKeySizeInBytes + 32;
             // The buffer is only being passed out as a span, so the derived type can't meaningfully
             // hold on to it without being malicious.
             byte[] buffer = CryptoPool.Rent(size);

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsaAlgorithm.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsaAlgorithm.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography
         /// <value>
         ///  The size of the secret key in bytes for this algorithm.
         /// </value>
-        public int SecretKeySizeInBytes { get; }
+        public int PrivateKeySizeInBytes { get; }
 
         /// <summary>
         ///  Gets the size of the public key in bytes for this algorithm.
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography
 
             // The secret key and public key sizes are shown to be 4n and 2n respectively in
             // section 9.1 "Key Generation", particularly figure 15 and 16.
-            SecretKeySizeInBytes = 4 * n;
+            PrivateKeySizeInBytes = 4 * n;
             PublicKeySizeInBytes = 2 * n;
             SignatureSizeInBytes = signatureSizeInBytes;
             Oid = oid;

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsaAlgorithm.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsaAlgorithm.cs
@@ -22,10 +22,10 @@ namespace System.Security.Cryptography
         public string Name { get; }
 
         /// <summary>
-        ///  Gets the size of the secret key in bytes for this algorithm.
+        ///  Gets the size of the private key in bytes for this algorithm.
         /// </summary>
         /// <value>
-        ///  The size of the secret key in bytes for this algorithm.
+        ///  The size of the private key in bytes for this algorithm.
         /// </value>
         public int PrivateKeySizeInBytes { get; }
 
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography
         {
             Name = name;
 
-            // The secret key and public key sizes are shown to be 4n and 2n respectively in
+            // The private key and public key sizes are shown to be 4n and 2n respectively in
             // section 9.1 "Key Generation", particularly figure 15 and 16.
             PrivateKeySizeInBytes = 4 * n;
             PublicKeySizeInBytes = 2 * n;

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsaCng.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsaCng.cs
@@ -82,7 +82,7 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException();
 
         /// <inheritdoc />
-        protected override void ExportSlhDsaSecretKeyCore(Span<byte> destination) =>
+        protected override void ExportSlhDsaPrivateKeyCore(Span<byte> destination) =>
             throw new PlatformNotSupportedException();
 
         /// <inheritdoc />

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsaImplementation.NotSupported.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsaImplementation.NotSupported.cs
@@ -32,7 +32,7 @@ namespace System.Security.Cryptography
         protected override void ExportSlhDsaPublicKeyCore(Span<byte> destination) =>
             throw new PlatformNotSupportedException();
 
-        protected override void ExportSlhDsaSecretKeyCore(Span<byte> destination) =>
+        protected override void ExportSlhDsaPrivateKeyCore(Span<byte> destination) =>
             throw new PlatformNotSupportedException();
 
         protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) =>
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography
         internal static partial SlhDsaImplementation ImportPkcs8PrivateKeyValue(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial SlhDsaImplementation ImportSecretKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial SlhDsaImplementation ImportPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsaImplementation.Windows.cs
@@ -32,7 +32,7 @@ namespace System.Security.Cryptography
         protected override void ExportSlhDsaPublicKeyCore(Span<byte> destination) =>
             throw new PlatformNotSupportedException();
 
-        protected override void ExportSlhDsaSecretKeyCore(Span<byte> destination) =>
+        protected override void ExportSlhDsaPrivateKeyCore(Span<byte> destination) =>
             throw new PlatformNotSupportedException();
 
         protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) =>
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography
         internal static partial SlhDsaImplementation ImportPkcs8PrivateKeyValue(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial SlhDsaImplementation ImportSecretKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+        internal static partial SlhDsaImplementation ImportPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsaImplementation.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsaImplementation.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography
         internal static partial SlhDsaImplementation GenerateKeyCore(SlhDsaAlgorithm algorithm);
         internal static partial SlhDsaImplementation ImportPublicKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
         internal static partial SlhDsaImplementation ImportPkcs8PrivateKeyValue(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
-        internal static partial SlhDsaImplementation ImportSecretKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
+        internal static partial SlhDsaImplementation ImportPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
 
         /// <summary>
         ///   Duplicates an SLH-DSA private key by export/import.
@@ -23,14 +23,14 @@ namespace System.Security.Cryptography
         internal static SlhDsaImplementation DuplicatePrivateKey(SlhDsa key)
         {
             Debug.Assert(key is not SlhDsaImplementation);
-            Debug.Assert(key.Algorithm.SecretKeySizeInBytes <= 128);
+            Debug.Assert(key.Algorithm.PrivateKeySizeInBytes <= 128);
 
-            Span<byte> secretKey = (stackalloc byte[128])[..key.Algorithm.SecretKeySizeInBytes];
-            key.ExportSlhDsaSecretKey(secretKey);
+            Span<byte> secretKey = (stackalloc byte[128])[..key.Algorithm.PrivateKeySizeInBytes];
+            key.ExportSlhDsaPrivateKey(secretKey);
 
             try
             {
-                return ImportSecretKey(key.Algorithm, secretKey);
+                return ImportPrivateKey(key.Algorithm, secretKey);
             }
             finally
             {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaAlgorithmTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaAlgorithmTests.cs
@@ -16,73 +16,73 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             algorithm = SlhDsaAlgorithm.SlhDsaSha2_128s;
             Assert.Equal("SLH-DSA-SHA2-128s", algorithm.Name);
             Assert.Equal(32, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(64, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(64, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(7856, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaShake128s;
             Assert.Equal("SLH-DSA-SHAKE-128s", algorithm.Name);
             Assert.Equal(32, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(64, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(64, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(7856, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaSha2_128f;
             Assert.Equal("SLH-DSA-SHA2-128f", algorithm.Name);
             Assert.Equal(32, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(64, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(64, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(17088, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaShake128f;
             Assert.Equal("SLH-DSA-SHAKE-128f", algorithm.Name);
             Assert.Equal(32, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(64, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(64, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(17088, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaSha2_192s;
             Assert.Equal("SLH-DSA-SHA2-192s", algorithm.Name);
             Assert.Equal(48, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(96, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(96, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(16224, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaShake192s;
             Assert.Equal("SLH-DSA-SHAKE-192s", algorithm.Name);
             Assert.Equal(48, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(96, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(96, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(16224, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaSha2_192f;
             Assert.Equal("SLH-DSA-SHA2-192f", algorithm.Name);
             Assert.Equal(48, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(96, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(96, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(35664, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaShake192f;
             Assert.Equal("SLH-DSA-SHAKE-192f", algorithm.Name);
             Assert.Equal(48, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(96, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(96, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(35664, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaSha2_256s;
             Assert.Equal("SLH-DSA-SHA2-256s", algorithm.Name);
             Assert.Equal(64, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(128, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(128, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(29792, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaShake256s;
             Assert.Equal("SLH-DSA-SHAKE-256s", algorithm.Name);
             Assert.Equal(64, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(128, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(128, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(29792, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaSha2_256f;
             Assert.Equal("SLH-DSA-SHA2-256f", algorithm.Name);
             Assert.Equal(64, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(128, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(128, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(49856, algorithm.SignatureSizeInBytes);
 
             algorithm = SlhDsaAlgorithm.SlhDsaShake256f;
             Assert.Equal("SLH-DSA-SHAKE-256f", algorithm.Name);
             Assert.Equal(64, algorithm.PublicKeySizeInBytes);
-            Assert.Equal(128, algorithm.SecretKeySizeInBytes);
+            Assert.Equal(128, algorithm.PrivateKeySizeInBytes);
             Assert.Equal(49856, algorithm.SignatureSizeInBytes);
         }
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaFactoryTests.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => SlhDsa.GenerateKey(null));
             AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => SlhDsa.ImportSlhDsaPublicKey(null, []));
-            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => SlhDsa.ImportSlhDsaSecretKey(null, []));
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => SlhDsa.ImportSlhDsaPrivateKey(null, []));
 
             AssertExtensions.Throws<ArgumentNullException>("source", static () => SlhDsa.ImportEncryptedPkcs8PrivateKey(string.Empty, (byte[])null));
             AssertExtensions.Throws<ArgumentNullException>("source", static () => SlhDsa.ImportFromEncryptedPem((string)null, string.Empty));
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             AssertExtensions.Throws<ArgumentNullException>("source", static () => SlhDsa.ImportFromPem(null));
             AssertExtensions.Throws<ArgumentNullException>("source", static () => SlhDsa.ImportPkcs8PrivateKey(null));
             AssertExtensions.Throws<ArgumentNullException>("source", static () => SlhDsa.ImportSlhDsaPublicKey(SlhDsaAlgorithm.SlhDsaSha2_128f, null));
-            AssertExtensions.Throws<ArgumentNullException>("source", static () => SlhDsa.ImportSlhDsaSecretKey(SlhDsaAlgorithm.SlhDsaSha2_128f, null));
+            AssertExtensions.Throws<ArgumentNullException>("source", static () => SlhDsa.ImportSlhDsaPrivateKey(SlhDsaAlgorithm.SlhDsaSha2_128f, null));
             AssertExtensions.Throws<ArgumentNullException>("source", static () => SlhDsa.ImportSubjectPublicKeyInfo(null));
 
             AssertExtensions.Throws<ArgumentNullException>("password", static () => SlhDsa.ImportEncryptedPkcs8PrivateKey((string)null, Array.Empty<byte>()));
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         public static void ArgumentValidation_WrongKeySizeForAlgorithm(SlhDsaAlgorithm algorithm)
         {
             int publicKeySize = algorithm.PublicKeySizeInBytes;
-            int secretKeySize = algorithm.SecretKeySizeInBytes;
+            int privateKeySize = algorithm.PrivateKeySizeInBytes;
 
             // SLH-DSA key size is wrong when importing algorithm key. Throw an argument exception.
             Action<Func<SlhDsa>> assertDirectImport = import => AssertExtensions.Throws<ArgumentException>("source", import);
@@ -51,9 +51,9 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             SlhDsaTestHelpers.AssertImportPublicKey(assertDirectImport, assertEmbeddedImport, algorithm, new byte[publicKeySize - 1]);
             SlhDsaTestHelpers.AssertImportPublicKey(assertDirectImport, assertEmbeddedImport, algorithm, new byte[0]);
 
-            SlhDsaTestHelpers.AssertImportSecretKey(assertDirectImport, assertEmbeddedImport, algorithm, new byte[secretKeySize + 1]);
-            SlhDsaTestHelpers.AssertImportSecretKey(assertDirectImport, assertEmbeddedImport, algorithm, new byte[secretKeySize - 1]);
-            SlhDsaTestHelpers.AssertImportSecretKey(assertDirectImport, assertEmbeddedImport, algorithm, new byte[0]);
+            SlhDsaTestHelpers.AssertImportPrivateKey(assertDirectImport, assertEmbeddedImport, algorithm, new byte[privateKeySize + 1]);
+            SlhDsaTestHelpers.AssertImportPrivateKey(assertDirectImport, assertEmbeddedImport, algorithm, new byte[privateKeySize - 1]);
+            SlhDsaTestHelpers.AssertImportPrivateKey(assertDirectImport, assertEmbeddedImport, algorithm, new byte[0]);
         }
 
         [Fact]
@@ -179,7 +179,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                     Algorithm = SlhDsaTestHelpers.AlgorithmToOid(SlhDsaAlgorithm.SlhDsaSha2_128s),
                     Parameters = SlhDsaTestHelpers.s_derBitStringFoo, // <-- Invalid
                 },
-                PrivateKey = new byte[SlhDsaAlgorithm.SlhDsaSha2_128s.SecretKeySizeInBytes]
+                PrivateKey = new byte[SlhDsaAlgorithm.SlhDsaSha2_128s.PrivateKeySizeInBytes]
             };
 
             SlhDsaTestHelpers.AssertImportPkcs8PrivateKey(
@@ -253,9 +253,9 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 AssertThrowIfNotSupported(() =>
                     Assert.Equal(algorithm, import().Algorithm)), algorithm, new byte[algorithm.PublicKeySizeInBytes]);
 
-            SlhDsaTestHelpers.AssertImportSecretKey(import =>
+            SlhDsaTestHelpers.AssertImportPrivateKey(import =>
                 AssertThrowIfNotSupported(() =>
-                    Assert.Equal(algorithm, import().Algorithm)), algorithm, new byte[algorithm.SecretKeySizeInBytes]);
+                    Assert.Equal(algorithm, import().Algorithm)), algorithm, new byte[algorithm.PrivateKeySizeInBytes]);
         }
 
         /// <summary>

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaImplementationTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaImplementationTests.cs
@@ -28,9 +28,9 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             SlhDsaTestHelpers.AssertImportPublicKey(
                 AssertSlhDsaIsOnlyPublicAncestor, info.Algorithm, info.PublicKey);
 
-            // Tests ImportSecretKey, ImportPKCS8PrivateKey, ImportPem (with PRIVATE KEY)
-            SlhDsaTestHelpers.AssertImportSecretKey(
-                AssertSlhDsaIsOnlyPublicAncestor, info.Algorithm, info.SecretKey);
+            // Tests ImportPrivateKey, ImportPKCS8PrivateKey, ImportPem (with PRIVATE KEY)
+            SlhDsaTestHelpers.AssertImportPrivateKey(
+                AssertSlhDsaIsOnlyPublicAncestor, info.Algorithm, info.PrivateKey);
 
             // Tests ImportEncryptedPKCS8PrivateKey, ImportEncryptedPem (with ENCRYPTED PRIVATE KEY)
             SlhDsaTestHelpers.AssertImportEncryptedPkcs8PrivateKey(import =>
@@ -71,32 +71,32 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                     // Verify the roundtripped object has the same key
                     Assert.Equal(algorithm, roundTrippedSlhDsa.Algorithm);
                     AssertExtensions.SequenceEqual(slhDsa.ExportSlhDsaPublicKey(), roundTrippedSlhDsa.ExportSlhDsaPublicKey());
-                    Assert.Throws<CryptographicException>(() => roundTrippedSlhDsa.ExportSlhDsaSecretKey());
+                    Assert.Throws<CryptographicException>(() => roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
                 }, algorithm, exportedPublicKey);
             });
         }
 
         [Theory]
         [MemberData(nameof(SlhDsaTestData.AlgorithmsData), MemberType = typeof(SlhDsaTestData))]
-        public void RoundTrip_Export_Import_SecretKey(SlhDsaAlgorithm algorithm)
+        public void RoundTrip_Export_Import_PrivateKey(SlhDsaAlgorithm algorithm)
         {
             // Generate new key
             using SlhDsa slhDsa = GenerateKey(algorithm);
 
-            SlhDsaTestHelpers.AssertExportSlhDsaSecretKey(export =>
+            SlhDsaTestHelpers.AssertExportSlhDsaPrivateKey(export =>
             {
-                // Roundtrip using secret key. First export it.
-                byte[] exportedSecretKey = export(slhDsa);
-                SlhDsaTestHelpers.AssertImportSecretKey(import =>
+                // Roundtrip using private key. First export it.
+                byte[] exportedPrivateKey = export(slhDsa);
+                SlhDsaTestHelpers.AssertImportPrivateKey(import =>
                 {
                     // Then import it.
                     using SlhDsa roundTrippedSlhDsa = import();
 
                     // Verify the roundtripped object has the same key
                     Assert.Equal(algorithm, roundTrippedSlhDsa.Algorithm);
-                    AssertExtensions.SequenceEqual(slhDsa.ExportSlhDsaSecretKey(), roundTrippedSlhDsa.ExportSlhDsaSecretKey());
+                    AssertExtensions.SequenceEqual(slhDsa.ExportSlhDsaPrivateKey(), roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
                     AssertExtensions.SequenceEqual(slhDsa.ExportSlhDsaPublicKey(), roundTrippedSlhDsa.ExportSlhDsaPublicKey());
-                }, algorithm, exportedSecretKey);
+                }, algorithm, exportedPrivateKey);
             });
         }
 
@@ -106,7 +106,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         {
             // Generate new key
             using SlhDsa slhDsa = GenerateKey(algorithm);
-            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
+            byte[] privateKey = slhDsa.ExportSlhDsaPrivateKey();
             byte[] publicKey = slhDsa.ExportSlhDsaPublicKey();
 
             SlhDsaTestHelpers.AssertExportPkcs8PrivateKey(export =>
@@ -118,7 +118,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                     // The keys should be the same
                     Assert.Equal(algorithm, roundTrippedSlhDsa.Algorithm);
                     AssertExtensions.SequenceEqual(publicKey, roundTrippedSlhDsa.ExportSlhDsaPublicKey());
-                    AssertExtensions.SequenceEqual(secretKey, roundTrippedSlhDsa.ExportSlhDsaSecretKey());
+                    AssertExtensions.SequenceEqual(privateKey, roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
                 }));
         }
 
@@ -129,7 +129,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             // Generate new key
             using SlhDsa slhDsa = GenerateKey(algorithm);
             byte[] publicKey = slhDsa.ExportSlhDsaPublicKey();
-            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
+            byte[] privateKey = slhDsa.ExportSlhDsaPrivateKey();
 
             SlhDsaTestHelpers.AssertExportPkcs8PrivateKey(export =>
                 SlhDsaTestHelpers.AssertImportPkcs8PrivateKey(import =>
@@ -140,7 +140,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                     // The keys should be the same
                     Assert.Equal(algorithm, roundTrippedSlhDsa.Algorithm);
                     AssertExtensions.SequenceEqual(publicKey, roundTrippedSlhDsa.ExportSlhDsaPublicKey());
-                    AssertExtensions.SequenceEqual(secretKey, roundTrippedSlhDsa.ExportSlhDsaSecretKey());
+                    AssertExtensions.SequenceEqual(privateKey, roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
                 }));
         }
 
@@ -150,7 +150,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         {
             // Generate new key
             using SlhDsa slhDsa = GenerateKey(algorithm);
-            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
+            byte[] privateKey = slhDsa.ExportSlhDsaPrivateKey();
             byte[] publicKey = slhDsa.ExportSlhDsaPublicKey();
 
             PbeParameters pbeParameters = new PbeParameters(PbeEncryptionAlgorithm.Aes128Cbc, HashAlgorithmName.SHA1, 1);
@@ -163,7 +163,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
                     // The keys should be the same
                     Assert.Equal(algorithm, roundTrippedSlhDsa.Algorithm);
-                    AssertExtensions.SequenceEqual(secretKey, roundTrippedSlhDsa.ExportSlhDsaSecretKey());
+                    AssertExtensions.SequenceEqual(privateKey, roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
                     AssertExtensions.SequenceEqual(publicKey, roundTrippedSlhDsa.ExportSlhDsaPublicKey());
                 }));
         }
@@ -174,7 +174,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         {
             // Generate new key
             using SlhDsa slhDsa = GenerateKey(algorithm);
-            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
+            byte[] privateKey = slhDsa.ExportSlhDsaPrivateKey();
             byte[] publicKey = slhDsa.ExportSlhDsaPublicKey();
 
             SlhDsaTestHelpers.AssertExportToPrivateKeyPem(export =>
@@ -185,7 +185,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
                     // The keys should be the same
                     Assert.Equal(algorithm, roundTrippedSlhDsa.Algorithm);
-                    AssertExtensions.SequenceEqual(secretKey, roundTrippedSlhDsa.ExportSlhDsaSecretKey());
+                    AssertExtensions.SequenceEqual(privateKey, roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
                     AssertExtensions.SequenceEqual(publicKey, roundTrippedSlhDsa.ExportSlhDsaPublicKey());
                 }));
         }
@@ -196,7 +196,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         {
             // Generate new key
             using SlhDsa slhDsa = GenerateKey(algorithm);
-            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
+            byte[] privateKey = slhDsa.ExportSlhDsaPrivateKey();
             byte[] publicKey = slhDsa.ExportSlhDsaPublicKey();
 
             SlhDsaTestHelpers.AssertExportToPublicKeyPem(export =>
@@ -208,7 +208,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                     // The keys should be the same
                     Assert.Equal(algorithm, roundTrippedSlhDsa.Algorithm);
                     AssertExtensions.SequenceEqual(publicKey, roundTrippedSlhDsa.ExportSlhDsaPublicKey());
-                    Assert.Throws<CryptographicException>(() => roundTrippedSlhDsa.ExportSlhDsaSecretKey());
+                    Assert.Throws<CryptographicException>(() => roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
                 }));
         }
 
@@ -218,7 +218,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         {
             // Generate new key
             using SlhDsa slhDsa = GenerateKey(algorithm);
-            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
+            byte[] privateKey = slhDsa.ExportSlhDsaPrivateKey();
             byte[] publicKey = slhDsa.ExportSlhDsaPublicKey();
 
             PbeParameters pbeParameters = new PbeParameters(PbeEncryptionAlgorithm.Aes128Cbc, HashAlgorithmName.SHA1, 1);
@@ -231,7 +231,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
                     // The keys should be the same
                     Assert.Equal(algorithm, roundTrippedSlhDsa.Algorithm);
-                    AssertExtensions.SequenceEqual(secretKey, roundTrippedSlhDsa.ExportSlhDsaSecretKey());
+                    AssertExtensions.SequenceEqual(privateKey, roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
                     AssertExtensions.SequenceEqual(publicKey, roundTrippedSlhDsa.ExportSlhDsaPublicKey());
                 }));
         }
@@ -256,12 +256,12 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         [MemberData(nameof(SlhDsaTestData.GeneratedKeyInfosData), MemberType = typeof(SlhDsaTestData))]
         public void RoundTrip_Import_Export_PrivateKey(SlhDsaTestData.SlhDsaGeneratedKeyInfo info)
         {
-            SlhDsaTestHelpers.AssertImportSecretKey(import =>
-                SlhDsaTestHelpers.AssertExportSlhDsaSecretKey(export =>
+            SlhDsaTestHelpers.AssertImportPrivateKey(import =>
+                SlhDsaTestHelpers.AssertExportSlhDsaPrivateKey(export =>
                     SlhDsaTestHelpers.WithDispose(import(), slhDsa =>
-                        AssertExtensions.SequenceEqual(info.SecretKey, export(slhDsa)))),
+                        AssertExtensions.SequenceEqual(info.PrivateKey, export(slhDsa)))),
                 info.Algorithm,
-                info.SecretKey);
+                info.PrivateKey);
         }
 
         [Theory]
@@ -314,8 +314,8 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using SlhDsa slhDsa = SlhDsa.ImportPkcs8PrivateKey(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyPkcs8);
             Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s, slhDsa.Algorithm);
 
-            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
-            AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, secretKey);
+            byte[] privateKey = slhDsa.ExportSlhDsaPrivateKey();
+            AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, privateKey);
         }
 
         [Fact]
@@ -335,8 +335,8 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using SlhDsa slhDsa = SlhDsa.ImportFromPem(pem);
             Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s, slhDsa.Algorithm);
 
-            byte[] secretKey = slhDsa.ExportSlhDsaSecretKey();
-            AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, secretKey);
+            byte[] privateKey = slhDsa.ExportSlhDsaPrivateKey();
+            AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, privateKey);
         }
 
         [Fact]
@@ -365,7 +365,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             byte[] skPrf = vector.SecretKeyPrf;
             byte[] pkSeed = vector.PublicKeySeed;
 
-            byte[] sk = vector.SecretKey;
+            byte[] sk = vector.PrivateKey;
             byte[] pk = vector.PublicKey;
 
             // Sanity test for input vectors: SLH-DSA keys are composed of skSeed, skPrf and pkSeed
@@ -374,14 +374,14 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             AssertExtensions.SequenceEqual(pkSeed.AsSpan(), sk.AsSpan(skSeed.Length + skPrf.Length, pkSeed.Length));
             AssertExtensions.SequenceEqual(pkSeed.AsSpan(), pk.AsSpan(0, pkSeed.Length));
 
-            // Import secret key and verify exports
-            using (SlhDsa secretSlhDsa = ImportSlhDsaSecretKey(vector.Algorithm, sk))
+            // Import private key and verify exports
+            using (SlhDsa privateSlhDsa = ImportSlhDsaPrivateKey(vector.Algorithm, sk))
             {
-                byte[] pubKey = secretSlhDsa.ExportSlhDsaPublicKey();
+                byte[] pubKey = privateSlhDsa.ExportSlhDsaPublicKey();
                 AssertExtensions.SequenceEqual(pk, pubKey);
 
-                byte[] secretKey = secretSlhDsa.ExportSlhDsaSecretKey();
-                AssertExtensions.SequenceEqual(sk, secretKey);
+                byte[] privateKey = privateSlhDsa.ExportSlhDsaPrivateKey();
+                AssertExtensions.SequenceEqual(sk, privateKey);
             }
 
             // Import public key and verify exports
@@ -390,8 +390,8 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 byte[] pubKey = publicSlhDsa.ExportSlhDsaPublicKey();
                 AssertExtensions.SequenceEqual(pk, pubKey);
 
-                byte[] secretKey = new byte[vector.Algorithm.SecretKeySizeInBytes];
-                Assert.Throws<CryptographicException>(() => publicSlhDsa.ExportSlhDsaSecretKey(secretKey));
+                byte[] privateKey = new byte[vector.Algorithm.PrivateKeySizeInBytes];
+                Assert.Throws<CryptographicException>(() => publicSlhDsa.ExportSlhDsaPrivateKey(privateKey));
             }
         }
 
@@ -400,16 +400,16 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         [Fact]
         public static void ImportPkcs8_BerEncoding()
         {
-            // Secret key is DER encoded, so create a BER encoding from it by making it use indefinite length encoding.
-            byte[] secretKeyPkcs8 = SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyPkcs8;
+            // Private key is DER encoded, so create a BER encoding from it by making it use indefinite length encoding.
+            byte[] privateKeyPkcs8 = SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyPkcs8;
 
             // Two 0x00 bytes at the end signal the end of the indefinite length encoding
-            byte[] indefiniteLengthOctet = new byte[secretKeyPkcs8.Length + 2];
-            secretKeyPkcs8.CopyTo(indefiniteLengthOctet);
+            byte[] indefiniteLengthOctet = new byte[privateKeyPkcs8.Length + 2];
+            privateKeyPkcs8.CopyTo(indefiniteLengthOctet);
             indefiniteLengthOctet[1] = 0b1000_0000; // change length to indefinite
 
             SlhDsaTestHelpers.AssertImportPkcs8PrivateKey(import =>
-                SlhDsaTestHelpers.AssertExportSlhDsaSecretKey(export =>
+                SlhDsaTestHelpers.AssertExportSlhDsaPrivateKey(export =>
                     SlhDsaTestHelpers.WithDispose(import(indefiniteLengthOctet), slhDsa =>
                         AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, export(slhDsa)))));
         }
@@ -442,7 +442,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         [MemberData(nameof(SlhDsaTestData.GeneratedKeyInfosData), MemberType = typeof(SlhDsaTestData))]
         public void ExportEncryptedPkcs8PrivateKey_PbeParameters(SlhDsaTestData.SlhDsaGeneratedKeyInfo info)
         {
-            using SlhDsa slhDsa = ImportSlhDsaSecretKey(info.Algorithm, info.SecretKey);
+            using SlhDsa slhDsa = ImportSlhDsaPrivateKey(info.Algorithm, info.PrivateKey);
             SlhDsaTestHelpers.EncryptionPasswordType passwordTypeToTest =
                 SlhDsaTestHelpers.GetValidPasswordTypes(info.EncryptionParameters);
 
@@ -460,7 +460,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         [MemberData(nameof(SlhDsaTestData.GeneratedKeyInfosData), MemberType = typeof(SlhDsaTestData))]
         public void ExportKey_DestinationTooSmall(SlhDsaTestData.SlhDsaGeneratedKeyInfo info)
         {
-            using SlhDsa slhDsa = ImportSlhDsaSecretKey(info.Algorithm, info.SecretKey);
+            using SlhDsa slhDsa = ImportSlhDsaPrivateKey(info.Algorithm, info.PrivateKey);
             byte[] pkcs8PrivateKey = slhDsa.ExportPkcs8PrivateKey();
             byte[] spki = slhDsa.ExportSubjectPublicKeyInfo();
             byte[] encryptedPkcs8 = slhDsa.ExportEncryptedPkcs8PrivateKey(info.EncryptionPassword, info.EncryptionParameters);
@@ -518,6 +518,6 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
         protected override SlhDsa GenerateKey(SlhDsaAlgorithm algorithm) => SlhDsa.GenerateKey(algorithm);
         protected override SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) => SlhDsa.ImportSlhDsaPublicKey(algorithm, source);
-        protected override SlhDsa ImportSlhDsaSecretKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) => SlhDsa.ImportSlhDsaSecretKey(algorithm, source);
+        protected override SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) => SlhDsa.ImportSlhDsaPrivateKey(algorithm, source);
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaMockImplementation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaMockImplementation.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         }
 
         public delegate void ExportSlhDsaPublicKeyCoreAction(Span<byte> s);
-        public delegate void ExportSlhDsaSecretKeyCoreAction(Span<byte> s);
+        public delegate void ExportSlhDsaPrivateKeyCoreAction(Span<byte> s);
         public delegate bool TryExportPkcs8PrivateKeyCoreFunc(Span<byte> destination, out int bytesWritten);
         public delegate void SignDataCoreAction(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> s);
         public delegate bool VerifyDataCoreFunc(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
@@ -41,12 +41,12 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         public int VerifyPreHashCoreCallCount = 0;
         public int SignPreHashCoreCallCount = 0;
         public int ExportSlhDsaPublicKeyCoreCallCount = 0;
-        public int ExportSlhDsaSecretKeyCoreCallCount = 0;
+        public int ExportSlhDsaPrivateKeyCoreCallCount = 0;
         public int TryExportPkcs8PrivateKeyCoreCallCount = 0;
         public int DisposeCallCount = 0;
 
         public ExportSlhDsaPublicKeyCoreAction ExportSlhDsaPublicKeyCoreHook { get; set; } = _ => Assert.Fail();
-        public ExportSlhDsaSecretKeyCoreAction ExportSlhDsaSecretKeyCoreHook { get; set; } = _ => Assert.Fail();
+        public ExportSlhDsaPrivateKeyCoreAction ExportSlhDsaPrivateKeyCoreHook { get; set; } = _ => Assert.Fail();
         public TryExportPkcs8PrivateKeyCoreFunc TryExportPkcs8PrivateKeyCoreHook { get; set; } =
             (_, out bytesWritten) => { Assert.Fail(); bytesWritten = 0; return false; };
         public SignDataCoreAction SignDataCoreHook { get; set; } = (_, _, _) => Assert.Fail();
@@ -61,10 +61,10 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             ExportSlhDsaPublicKeyCoreHook(destination);
         }
 
-        protected override void ExportSlhDsaSecretKeyCore(Span<byte> destination)
+        protected override void ExportSlhDsaPrivateKeyCore(Span<byte> destination)
         {
-            ExportSlhDsaSecretKeyCoreCallCount++;
-            ExportSlhDsaSecretKeyCoreHook(destination);
+            ExportSlhDsaPrivateKeyCoreCallCount++;
+            ExportSlhDsaPrivateKeyCoreHook(destination);
         }
 
         protected override void Dispose(bool disposing)
@@ -112,11 +112,11 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 Assert.Equal(Algorithm.PublicKeySizeInBytes, destination.Length);
             };
 
-            ExportSlhDsaSecretKeyCoreAction oldExportSlhDsaSecretKeyCoreHook = ExportSlhDsaSecretKeyCoreHook;
-            ExportSlhDsaSecretKeyCoreHook = (Span<byte> destination) =>
+            ExportSlhDsaPrivateKeyCoreAction oldExportSlhDsaPrivateKeyCoreHook = ExportSlhDsaPrivateKeyCoreHook;
+            ExportSlhDsaPrivateKeyCoreHook = (Span<byte> destination) =>
             {
-                oldExportSlhDsaSecretKeyCoreHook(destination);
-                Assert.Equal(Algorithm.SecretKeySizeInBytes, destination.Length);
+                oldExportSlhDsaPrivateKeyCoreHook(destination);
+                Assert.Equal(Algorithm.PrivateKeySizeInBytes, destination.Length);
             };
 
             SignDataCoreAction oldSignDataCoreHook = SignDataCoreHook;
@@ -159,10 +159,10 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 AssertExtensions.Same(buffer.Span, destination);
             };
 
-            ExportSlhDsaSecretKeyCoreAction oldExportSlhDsaSecretKeyCoreHook = ExportSlhDsaSecretKeyCoreHook;
-            ExportSlhDsaSecretKeyCoreHook = (Span<byte> destination) =>
+            ExportSlhDsaPrivateKeyCoreAction oldExportSlhDsaPrivateKeyCoreHook = ExportSlhDsaPrivateKeyCoreHook;
+            ExportSlhDsaPrivateKeyCoreHook = (Span<byte> destination) =>
             {
-                oldExportSlhDsaSecretKeyCoreHook(destination);
+                oldExportSlhDsaPrivateKeyCoreHook(destination);
                 AssertExtensions.Same(buffer.Span, destination);
             };
 
@@ -301,10 +301,10 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 destination.Fill(b);
             };
 
-            ExportSlhDsaSecretKeyCoreAction oldExportSlhDsaSecretKeyCoreHook = ExportSlhDsaSecretKeyCoreHook;
-            ExportSlhDsaSecretKeyCoreHook = (Span<byte> destination) =>
+            ExportSlhDsaPrivateKeyCoreAction oldExportSlhDsaPrivateKeyCoreHook = ExportSlhDsaPrivateKeyCoreHook;
+            ExportSlhDsaPrivateKeyCoreHook = (Span<byte> destination) =>
             {
-                oldExportSlhDsaSecretKeyCoreHook(destination);
+                oldExportSlhDsaPrivateKeyCoreHook(destination);
                 destination.Fill(b);
             };
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTestData.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTestData.cs
@@ -542,7 +542,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         // Generate private key pem:
         // > openssl genpkey -algorithm "SLH-DSA-SHA2-128f" > private.pem
         //
-        // Get secret key:
+        // Get private key:
         // > openssl asn1parse -in private.pem | tail -1 | cut -d':' -f4
         //
         // Get base64 private key info:
@@ -558,7 +558,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             public SlhDsaGeneratedKeyInfo(
                 int Id,
                 SlhDsaAlgorithm Algorithm,
-                string SecretKeyHex,
+                string PrivateKeyHex,
                 string Pkcs8PrivateKeyBase64,
                 string Pkcs8PublicKeyBase64,
                 string Pkcs8EncryptedPrivateKeyBase64,
@@ -570,7 +570,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             {
                 this.Id = Id;
                 this.Algorithm = Algorithm;
-                this.SecretKeyHex = SecretKeyHex;
+                this.PrivateKeyHex = PrivateKeyHex;
                 this.Pkcs8PrivateKeyBase64 = Pkcs8PrivateKeyBase64;
                 this.Pkcs8PublicKeyBase64 = Pkcs8PublicKeyBase64;
                 this.Pkcs8EncryptedPrivateKeyBase64 = Pkcs8EncryptedPrivateKeyBase64;
@@ -583,7 +583,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
             public int Id { get; }
             public SlhDsaAlgorithm Algorithm { get; }
-            public string SecretKeyHex { get; }
+            public string PrivateKeyHex { get; }
             public string Pkcs8PrivateKeyBase64 { get; }
             public string Pkcs8PublicKeyBase64 { get; }
             public string Pkcs8EncryptedPrivateKeyBase64 { get; }
@@ -593,8 +593,8 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             public string EncryptionPassword { get; }
             public PbeParameters EncryptionParameters { get; }
 
-            public byte[] SecretKey => SecretKeyHex.HexToByteArray();
-            public byte[] PublicKey => SecretKey.AsSpan(Algorithm.SecretKeySizeInBytes/2).ToArray();
+            public byte[] PrivateKey => PrivateKeyHex.HexToByteArray();
+            public byte[] PublicKey => PrivateKey.AsSpan(Algorithm.PrivateKeySizeInBytes/2).ToArray();
             public byte[] Pkcs8PrivateKey => Convert.FromBase64String(Pkcs8PrivateKeyBase64);
             public byte[] Pkcs8PublicKey => Convert.FromBase64String(Pkcs8PublicKeyBase64);
             public byte[] Pkcs8EncryptedPrivateKey => Convert.FromBase64String(Pkcs8EncryptedPrivateKeyBase64);
@@ -624,7 +624,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 string SecretKeySeedHex,
                 string SecretKeyPrfHex,
                 string PublicKeySeedHex,
-                string SecretKeyHex,
+                string PrivateKeyHex,
                 string PublicKeyHex)
             {
                 this.TestCaseId = TestCaseId;
@@ -632,7 +632,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 this.SecretKeySeedHex = SecretKeySeedHex;
                 this.SecretKeyPrfHex = SecretKeyPrfHex;
                 this.PublicKeySeedHex = PublicKeySeedHex;
-                this.SecretKeyHex = SecretKeyHex;
+                this.PrivateKeyHex = PrivateKeyHex;
                 this.PublicKeyHex = PublicKeyHex;
             }
 
@@ -641,14 +641,14 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             public string SecretKeySeedHex { get; }
             public string SecretKeyPrfHex { get; }
             public string PublicKeySeedHex { get; }
-            public string SecretKeyHex { get; }
+            public string PrivateKeyHex { get; }
             public string PublicKeyHex { get; }
 
             public byte[] SecretKeySeed => SecretKeySeedHex.HexToByteArray();
             public byte[] SecretKeyPrf => SecretKeyPrfHex.HexToByteArray();
             public byte[] PublicKeySeed => PublicKeySeedHex.HexToByteArray();
 
-            public byte[] SecretKey => SecretKeyHex.HexToByteArray();
+            public byte[] PrivateKey => PrivateKeyHex.HexToByteArray();
             public byte[] PublicKey => PublicKeyHex.HexToByteArray();
 
             public override string ToString() => $"{nameof(SlhDsaKeyGenTestVector)} {{ {nameof(TestCaseId)} = {TestCaseId}, {nameof(Algorithm)} = \"{Algorithm.Name}\" }}";
@@ -774,7 +774,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 int TestCaseId,
                 bool TestPassed,
                 SlhDsaAlgorithm Algorithm,
-                string SecretKeyHex,
+                string PrivateKeyHex,
                 string PublicKeyHex,
                 string MessageHex,
                 string ContextHex,
@@ -784,7 +784,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 this.TestCaseId = TestCaseId;
                 this.TestPassed = TestPassed;
                 this.Algorithm = Algorithm;
-                this.SecretKeyHex = SecretKeyHex;
+                this.PrivateKeyHex = PrivateKeyHex;
                 this.PublicKeyHex = PublicKeyHex;
                 this.MessageHex = MessageHex;
                 this.ContextHex = ContextHex;
@@ -795,14 +795,14 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             public int TestCaseId { get; }
             public bool TestPassed { get; }
             public SlhDsaAlgorithm Algorithm { get; }
-            public string SecretKeyHex { get; }
+            public string PrivateKeyHex { get; }
             public string PublicKeyHex { get; }
             public string MessageHex { get; }
             public string ContextHex { get; }
             public string SignatureHex { get; }
 			public string HashAlgorithm { get; }
 
-            public byte[] SecretKey => SecretKeyHex.HexToByteArray();
+            public byte[] PrivateKey => PrivateKeyHex.HexToByteArray();
             public byte[] PublicKey => PublicKeyHex.HexToByteArray();
             public byte[] Message => MessageHex.HexToByteArray();
             public byte[] Context => ContextHex.HexToByteArray();

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTestHelpers.cs
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             Assert.Throws<ObjectDisposedException>(() => slhDsa.ExportPkcs8PrivateKey());
             Assert.Throws<ObjectDisposedException>(() => slhDsa.ExportPkcs8PrivateKeyPem());
             Assert.Throws<ObjectDisposedException>(() => slhDsa.ExportSlhDsaPublicKey(tempBuffer.AsSpan(0, slhDsa.Algorithm.PublicKeySizeInBytes)));
-            Assert.Throws<ObjectDisposedException>(() => slhDsa.ExportSlhDsaSecretKey(tempBuffer.AsSpan(0, slhDsa.Algorithm.SecretKeySizeInBytes)));
+            Assert.Throws<ObjectDisposedException>(() => slhDsa.ExportSlhDsaPrivateKey(tempBuffer.AsSpan(0, slhDsa.Algorithm.PrivateKeySizeInBytes)));
             Assert.Throws<ObjectDisposedException>(() => slhDsa.ExportSubjectPublicKeyInfo());
             Assert.Throws<ObjectDisposedException>(() => slhDsa.ExportSubjectPublicKeyInfoPem());
             Assert.Throws<ObjectDisposedException>(() => slhDsa.TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte>.Empty, pbeParameters, [], out _));
@@ -94,21 +94,21 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             testEmbeddedCall(spki => SlhDsa.ImportFromPem(PemEncoding.WriteString("PUBLIC KEY", spki).AsSpan()));
         }
 
-        internal static void AssertImportSecretKey(Action<Func<SlhDsa>> test, SlhDsaAlgorithm algorithm, byte[] secretKey) =>
-            AssertImportSecretKey(test, test, algorithm, secretKey);
+        internal static void AssertImportPrivateKey(Action<Func<SlhDsa>> test, SlhDsaAlgorithm algorithm, byte[] PrivateKey) =>
+            AssertImportPrivateKey(test, test, algorithm, PrivateKey);
 
-        internal static void AssertImportSecretKey(Action<Func<SlhDsa>> testDirectCall, Action<Func<SlhDsa>> testEmbeddedCall, SlhDsaAlgorithm algorithm, byte[] secretKey)
+        internal static void AssertImportPrivateKey(Action<Func<SlhDsa>> testDirectCall, Action<Func<SlhDsa>> testEmbeddedCall, SlhDsaAlgorithm algorithm, byte[] PrivateKey)
         {
-            testDirectCall(() => SlhDsa.ImportSlhDsaSecretKey(algorithm, secretKey));
+            testDirectCall(() => SlhDsa.ImportSlhDsaPrivateKey(algorithm, PrivateKey));
 
-            if (secretKey?.Length == 0)
+            if (PrivateKey?.Length == 0)
             {
-                testDirectCall(() => SlhDsa.ImportSlhDsaSecretKey(algorithm, Array.Empty<byte>().AsSpan()));
-                testDirectCall(() => SlhDsa.ImportSlhDsaSecretKey(algorithm, ReadOnlySpan<byte>.Empty));
+                testDirectCall(() => SlhDsa.ImportSlhDsaPrivateKey(algorithm, Array.Empty<byte>().AsSpan()));
+                testDirectCall(() => SlhDsa.ImportSlhDsaPrivateKey(algorithm, ReadOnlySpan<byte>.Empty));
             }
             else
             {
-                testDirectCall(() => SlhDsa.ImportSlhDsaSecretKey(algorithm, secretKey.AsSpan()));
+                testDirectCall(() => SlhDsa.ImportSlhDsaPrivateKey(algorithm, PrivateKey.AsSpan()));
             }
 
             PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
@@ -118,7 +118,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                     Algorithm = AlgorithmToOid(algorithm),
                     Parameters = default(ReadOnlyMemory<byte>?),
                 },
-                PrivateKey = secretKey,
+                PrivateKey = PrivateKey,
             };
 
             AssertImportPkcs8PrivateKey(import =>
@@ -220,14 +220,14 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                     SubjectPublicKeyInfoAsn.Decode(exportSpki(slhDsa), AsnEncodingRules.DER).SubjectPublicKey.Span.ToArray()));
         }
 
-        internal static void AssertExportSlhDsaSecretKey(Action<Func<SlhDsa, byte[]>> callback)
+        internal static void AssertExportSlhDsaPrivateKey(Action<Func<SlhDsa, byte[]>> callback)
         {
-            callback(slhDsa => slhDsa.ExportSlhDsaSecretKey());
+            callback(slhDsa => slhDsa.ExportSlhDsaPrivateKey());
             callback(
                 slhDsa =>
                 {
-                    byte[] buffer = new byte[slhDsa.Algorithm.SecretKeySizeInBytes];
-                    slhDsa.ExportSlhDsaSecretKey(buffer.AsSpan());
+                    byte[] buffer = new byte[slhDsa.Algorithm.PrivateKeySizeInBytes];
+                    slhDsa.ExportSlhDsaPrivateKey(buffer.AsSpan());
                     return buffer;
                 });
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTests.cs
@@ -13,7 +13,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
     {
         protected abstract SlhDsa GenerateKey(SlhDsaAlgorithm algorithm);
         protected abstract SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
-        protected abstract SlhDsa ImportSlhDsaSecretKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
+        protected abstract SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source);
 
         public static IEnumerable<object[]> NistPureSigVerTestVectorsData =>
             from vector in SlhDsaTestData.NistSigVerTestVectors
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             Assert.Equal(vector.TestPassed, publicSlhDsa.VerifyData(msg, sig, ctx));
 
             // Test signature verification with secret key
-            using SlhDsa secretSlhDsa = ImportSlhDsaSecretKey(vector.Algorithm, vector.SecretKey);
+            using SlhDsa secretSlhDsa = ImportSlhDsaPrivateKey(vector.Algorithm, vector.PrivateKey);
             Assert.Equal(vector.TestPassed, secretSlhDsa.VerifyData(msg, sig, ctx));
         }
 
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             Assert.Equal(vector.TestPassed, publicSlhDsa.VerifyPreHash(hash, sig, vector.HashAlgorithm, ctx));
 
             // Test signature verification with secret key
-            using SlhDsa secretSlhDsa = ImportSlhDsaSecretKey(vector.Algorithm, vector.SecretKey);
+            using SlhDsa secretSlhDsa = ImportSlhDsaPrivateKey(vector.Algorithm, vector.PrivateKey);
             Assert.Equal(vector.TestPassed, secretSlhDsa.VerifyPreHash(hash, sig, vector.HashAlgorithm, ctx));
         }
 
@@ -156,19 +156,19 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
         [Theory]
         [MemberData(nameof(AlgorithmsData_Small))]
-        public void GenerateExportSecretKeySignAndVerify(SlhDsaAlgorithm algorithm)
+        public void GenerateExportPrivateKeySignAndVerify(SlhDsaAlgorithm algorithm)
         {
-            byte[] secretKey;
+            byte[] privateKey;
             byte[] data = [1, 2, 3, 4, 5];
             byte[] signature;
 
             using (SlhDsa slhDsa = GenerateKey(algorithm))
             {
                 signature = slhDsa.SignData(data);
-                secretKey = slhDsa.ExportSlhDsaSecretKey();
+                privateKey = slhDsa.ExportSlhDsaPrivateKey();
             }
 
-            using (SlhDsa slhDsa = ImportSlhDsaSecretKey(algorithm, secretKey))
+            using (SlhDsa slhDsa = ImportSlhDsaPrivateKey(algorithm, privateKey))
             {
                 ExerciseSuccessfulVerify(slhDsa, data, signature, []);
 
@@ -204,9 +204,9 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
         [Theory]
         [MemberData(nameof(AlgorithmsData_Small))]
-        public void GenerateExportSecretKeySignPreHashAndVerify(SlhDsaAlgorithm algorithm)
+        public void GenerateExportPrivateKeySignPreHashAndVerify(SlhDsaAlgorithm algorithm)
         {
-            byte[] secretKey;
+            byte[] privateKey;
             string shake256Oid = HashInfo.Shake256.Oid;
             byte[] data = new byte[HashInfo.Shake256.OutputSize];
             byte[] signature;
@@ -214,10 +214,10 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using (SlhDsa slhDsa = GenerateKey(algorithm))
             {
                 signature = slhDsa.SignPreHash(data, shake256Oid);
-                secretKey = slhDsa.ExportSlhDsaSecretKey();
+                privateKey = slhDsa.ExportSlhDsaPrivateKey();
             }
 
-            using (SlhDsa slhDsa = ImportSlhDsaSecretKey(algorithm, secretKey))
+            using (SlhDsa slhDsa = ImportSlhDsaPrivateKey(algorithm, privateKey))
             {
                 ExerciseSuccessfulVerifyPreHash(slhDsa, data, signature, shake256Oid, []);
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTests.cs
@@ -32,7 +32,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using SlhDsa publicSlhDsa = ImportSlhDsaPublicKey(vector.Algorithm, vector.PublicKey);
             Assert.Equal(vector.TestPassed, publicSlhDsa.VerifyData(msg, sig, ctx));
 
-            // Test signature verification with secret key
+            // Test signature verification with private key
             using SlhDsa secretSlhDsa = ImportSlhDsaPrivateKey(vector.Algorithm, vector.PrivateKey);
             Assert.Equal(vector.TestPassed, secretSlhDsa.VerifyData(msg, sig, ctx));
         }
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             using SlhDsa publicSlhDsa = ImportSlhDsaPublicKey(vector.Algorithm, vector.PublicKey);
             Assert.Equal(vector.TestPassed, publicSlhDsa.VerifyPreHash(hash, sig, vector.HashAlgorithm, ctx));
 
-            // Test signature verification with secret key
+            // Test signature verification with private key
             using SlhDsa secretSlhDsa = ImportSlhDsaPrivateKey(vector.Algorithm, vector.PrivateKey);
             Assert.Equal(vector.TestPassed, secretSlhDsa.VerifyPreHash(hash, sig, vector.HashAlgorithm, ctx));
         }

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.Shared.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.Shared.cs
@@ -113,7 +113,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
             {
                 using (SlhDsaMockImplementation publicSlhDsa = SlhDsaMockImplementation.Create(SlhDsaAlgorithm.SlhDsaSha2_128s))
                 {
-                    Exception e = new Exception("no secret key");
+                    Exception e = new Exception("no private key");
                     publicSlhDsa.ExportSlhDsaPrivateKeyCoreHook = _ => throw e;
                     publicSlhDsa.ExportSlhDsaPublicKeyCoreHook = (Span<byte> destination) =>
                         SlhDsaTestData.IetfSlhDsaSha2_128sPublicKeyValue.CopyTo(destination);

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.Shared.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateCreation/PrivateKeyAssociationTests.Shared.cs
@@ -69,7 +69,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     // Verify the key is actually private
                     AssertExtensions.SequenceEqual(
                         SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue,
-                        certKey.ExportSlhDsaSecretKey());
+                        certKey.ExportSlhDsaPrivateKey());
                 }
             }
         }
@@ -114,7 +114,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 using (SlhDsaMockImplementation publicSlhDsa = SlhDsaMockImplementation.Create(SlhDsaAlgorithm.SlhDsaSha2_128s))
                 {
                     Exception e = new Exception("no secret key");
-                    publicSlhDsa.ExportSlhDsaSecretKeyCoreHook = _ => throw e;
+                    publicSlhDsa.ExportSlhDsaPrivateKeyCoreHook = _ => throw e;
                     publicSlhDsa.ExportSlhDsaPublicKeyCoreHook = (Span<byte> destination) =>
                         SlhDsaTestData.IetfSlhDsaSha2_128sPublicKeyValue.CopyTo(destination);
 
@@ -124,7 +124,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 SlhDsaMockImplementation privateSlhDsa = SlhDsaMockImplementation.Create(SlhDsaAlgorithm.SlhDsaSha2_128s);
                 privateSlhDsa.ExportSlhDsaPublicKeyCoreHook = (Span<byte> destination) =>
                     SlhDsaTestData.IetfSlhDsaSha2_128sPublicKeyValue.CopyTo(destination);
-                privateSlhDsa.ExportSlhDsaSecretKeyCoreHook = (Span<byte> destination) =>
+                privateSlhDsa.ExportSlhDsaPrivateKeyCoreHook = (Span<byte> destination) =>
                     SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue.CopyTo(destination);
 
                 using (X509Certificate2 privCert = CopyWithPrivateKey_SlhDsa(pubOnly, privateSlhDsa))
@@ -135,16 +135,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     {
                         AssertExtensions.SequenceEqual(
                             SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue,
-                            certPrivateSlhDsa.ExportSlhDsaSecretKey());
+                            certPrivateSlhDsa.ExportSlhDsaPrivateKey());
 
                         privateSlhDsa.Dispose();
                         privateSlhDsa.ExportSlhDsaPublicKeyCoreHook = _ => Assert.Fail();
-                        privateSlhDsa.ExportSlhDsaSecretKeyCoreHook = _ => Assert.Fail();
+                        privateSlhDsa.ExportSlhDsaPrivateKeyCoreHook = _ => Assert.Fail();
 
                         // Ensure the key is actual a clone
                         AssertExtensions.SequenceEqual(
                             SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue,
-                            certPrivateSlhDsa.ExportSlhDsaSecretKey());
+                            certPrivateSlhDsa.ExportSlhDsaPrivateKey());
                     }
                 }
             }
@@ -784,7 +784,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         private static X509Certificate2 LoadShlDsaIetfCertificateWithPrivateKey()
         {
             using (X509Certificate2 cert = X509CertificateLoader.LoadCertificate(SlhDsaTestData.IetfSlhDsaSha2_128sCertificate))
-            using (SlhDsa? privateKey = SlhDsa.ImportSlhDsaSecretKey(SlhDsaAlgorithm.SlhDsaSha2_128s, SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue))
+            using (SlhDsa? privateKey = SlhDsa.ImportSlhDsaPrivateKey(SlhDsaAlgorithm.SlhDsaSha2_128s, SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue))
                 return cert.CopyWithPrivateKey(privateKey);
         }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.netcoreapp.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.netcoreapp.cs
@@ -559,7 +559,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [ConditionalFact(typeof(SlhDsa), nameof(SlhDsa.IsSupported))]
         public static void AddSigner_SlhDsa_EphemeralKey()
         {
-            using (SlhDsa slhDsa = SlhDsa.ImportSlhDsaSecretKey(SlhDsaAlgorithm.SlhDsaSha2_128s, SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue))
+            using (SlhDsa slhDsa = SlhDsa.ImportSlhDsaPrivateKey(SlhDsaAlgorithm.SlhDsaSha2_128s, SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue))
             using (X509Certificate2 publicCertificate = Certificates.SlhDsaSha2_128s_Ietf.GetCertificate())
             using (X509Certificate2 certificateWithKey = Certificates.SlhDsaSha2_128s_Ietf.TryGetCertificateWithPrivateKey(exportable: true))
             {
@@ -738,7 +738,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             SignedCms cms = new SignedCms(content);
 
             SlhDsa slhDsa =
-                SlhDsa.ImportSlhDsaSecretKey(
+                SlhDsa.ImportSlhDsaPrivateKey(
                     SlhDsaAlgorithm.SlhDsaSha2_128s,
                     SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue);
 

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -3061,12 +3061,12 @@ namespace System.Security.Cryptography
         public string ExportEncryptedPkcs8PrivateKeyPem(string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
         public byte[] ExportPkcs8PrivateKey() { throw null; }
         public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSlhDsaPrivateKey() { throw null; }
+        public void ExportSlhDsaPrivateKey(System.Span<byte> destination) { }
+        protected abstract void ExportSlhDsaPrivateKeyCore(System.Span<byte> destination);
         public byte[] ExportSlhDsaPublicKey() { throw null; }
         public void ExportSlhDsaPublicKey(System.Span<byte> destination) { }
         protected abstract void ExportSlhDsaPublicKeyCore(System.Span<byte> destination);
-        public byte[] ExportSlhDsaSecretKey() { throw null; }
-        public void ExportSlhDsaSecretKey(System.Span<byte> destination) { }
-        protected abstract void ExportSlhDsaSecretKeyCore(System.Span<byte> destination);
         public byte[] ExportSubjectPublicKeyInfo() { throw null; }
         public string ExportSubjectPublicKeyInfoPem() { throw null; }
         public static System.Security.Cryptography.SlhDsa GenerateKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm) { throw null; }
@@ -3081,10 +3081,10 @@ namespace System.Security.Cryptography
         public static System.Security.Cryptography.SlhDsa ImportFromPem(string source) { throw null; }
         public static System.Security.Cryptography.SlhDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
         public static System.Security.Cryptography.SlhDsa ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.SlhDsa ImportSlhDsaPrivateKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static System.Security.Cryptography.SlhDsa ImportSlhDsaPrivateKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.SlhDsa ImportSlhDsaPublicKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
         public static System.Security.Cryptography.SlhDsa ImportSlhDsaPublicKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
-        public static System.Security.Cryptography.SlhDsa ImportSlhDsaSecretKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
-        public static System.Security.Cryptography.SlhDsa ImportSlhDsaSecretKey(System.Security.Cryptography.SlhDsaAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
         public static System.Security.Cryptography.SlhDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
         public static System.Security.Cryptography.SlhDsa ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source) { throw null; }
         public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
@@ -3111,8 +3111,8 @@ namespace System.Security.Cryptography
     {
         internal SlhDsaAlgorithm() { }
         public string Name { get { throw null; } }
+        public int PrivateKeySizeInBytes { get { throw null; } }
         public int PublicKeySizeInBytes { get { throw null; } }
-        public int SecretKeySizeInBytes { get { throw null; } }
         public int SignatureSizeInBytes { get { throw null; } }
         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaSha2_128f { get { throw null; } }
         public static System.Security.Cryptography.SlhDsaAlgorithm SlhDsaSha2_128s { get { throw null; } }
@@ -3138,8 +3138,8 @@ namespace System.Security.Cryptography
     {
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public SlhDsaCng(System.Security.Cryptography.CngKey key) : base (default(System.Security.Cryptography.SlhDsaAlgorithm)) { }
+        protected override void ExportSlhDsaPrivateKeyCore(System.Span<byte> destination) { }
         protected override void ExportSlhDsaPublicKeyCore(System.Span<byte> destination) { }
-        protected override void ExportSlhDsaSecretKeyCore(System.Span<byte> destination) { }
         public System.Security.Cryptography.CngKey GetKey() { throw null; }
         protected override void SignDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.Span<byte> destination) { }
         protected override void SignPreHashCore(System.ReadOnlySpan<byte> hash, System.ReadOnlySpan<byte> context, string hashAlgorithmOid, System.Span<byte> destination) { }
@@ -3159,8 +3159,8 @@ namespace System.Security.Cryptography
         public SlhDsaOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) : base (default(System.Security.Cryptography.SlhDsaAlgorithm)) { }
         protected override void Dispose(bool disposing) { }
         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle() { throw null; }
+        protected override void ExportSlhDsaPrivateKeyCore(System.Span<byte> destination) { }
         protected override void ExportSlhDsaPublicKeyCore(System.Span<byte> destination) { }
-        protected override void ExportSlhDsaSecretKeyCore(System.Span<byte> destination) { }
         protected override void SignDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.Span<byte> destination) { }
         protected override void SignPreHashCore(System.ReadOnlySpan<byte> hash, System.ReadOnlySpan<byte> context, string hashAlgorithmOid, System.Span<byte> destination) { }
         protected override bool VerifyDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.ReadOnlySpan<byte> signature) { throw null; }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaImplementation.OpenSsl.cs
@@ -91,7 +91,7 @@ namespace System.Security.Cryptography
         protected override void ExportSlhDsaPublicKeyCore(Span<byte> destination) =>
             Interop.Crypto.SlhDsaExportPublicKey(_key, destination);
 
-        protected override void ExportSlhDsaSecretKeyCore(Span<byte> destination) =>
+        protected override void ExportSlhDsaPrivateKeyCore(Span<byte> destination) =>
             Interop.Crypto.SlhDsaExportSecretKey(_key, destination);
 
         internal static partial SlhDsaImplementation ImportPublicKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
@@ -104,9 +104,9 @@ namespace System.Security.Cryptography
         internal static partial SlhDsaImplementation ImportPkcs8PrivateKeyValue(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) =>
             throw new PlatformNotSupportedException();
 
-        internal static partial SlhDsaImplementation ImportSecretKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
+        internal static partial SlhDsaImplementation ImportPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            Debug.Assert(source.Length == algorithm.SecretKeySizeInBytes, $"Secret key was expected to be {algorithm.SecretKeySizeInBytes} bytes, but was {source.Length} bytes.");
+            Debug.Assert(source.Length == algorithm.PrivateKeySizeInBytes, $"Secret key was expected to be {algorithm.PrivateKeySizeInBytes} bytes, but was {source.Length} bytes.");
             SafeEvpPKeyHandle key = Interop.Crypto.EvpPKeyFromData(algorithm.Name, source, privateKey: true);
             return new SlhDsaImplementation(algorithm, key);
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaImplementation.OpenSsl.cs
@@ -106,7 +106,7 @@ namespace System.Security.Cryptography
 
         internal static partial SlhDsaImplementation ImportPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
-            Debug.Assert(source.Length == algorithm.PrivateKeySizeInBytes, $"Secret key was expected to be {algorithm.PrivateKeySizeInBytes} bytes, but was {source.Length} bytes.");
+            Debug.Assert(source.Length == algorithm.PrivateKeySizeInBytes, $"Private key was expected to be {algorithm.PrivateKeySizeInBytes} bytes, but was {source.Length} bytes.");
             SafeEvpPKeyHandle key = Interop.Crypto.EvpPKeyFromData(algorithm.Name, source, privateKey: true);
             return new SlhDsaImplementation(algorithm, key);
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaOpenSsl.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaOpenSsl.NotSupported.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException();
         }
 
-        protected override void ExportSlhDsaSecretKeyCore(Span<byte> destination)
+        protected override void ExportSlhDsaPrivateKeyCore(Span<byte> destination)
         {
             Debug.Fail("Caller should have checked platform availability.");
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SlhDsaOpenSsl.OpenSsl.cs
@@ -111,7 +111,7 @@ namespace System.Security.Cryptography
         protected override void ExportSlhDsaPublicKeyCore(Span<byte> destination) =>
             Interop.Crypto.SlhDsaExportPublicKey(_key, destination);
 
-        protected override void ExportSlhDsaSecretKeyCore(Span<byte> destination) =>
+        protected override void ExportSlhDsaPrivateKeyCore(Span<byte> destination) =>
             Interop.Crypto.SlhDsaExportSecretKey(_key, destination);
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/SlhDsaOpenSslTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/SlhDsaOpenSslTests.cs
@@ -75,7 +75,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
         private static void VerifyInstanceIsUsable(SlhDsaOpenSsl slhDsa)
         {
-            _ = slhDsa.ExportSlhDsaSecretKey(); // does not throw
+            _ = slhDsa.ExportSlhDsaPrivateKey(); // does not throw
 
             // usable
             byte[] data = [1, 2, 3];
@@ -97,7 +97,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             return new SlhDsaOpenSsl(key);
         }
 
-        protected override SlhDsa ImportSlhDsaSecretKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
+        protected override SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source)
         {
             using SafeEvpPKeyHandle key = Interop.Crypto.EvpPKeyFromData(algorithm.Name, source, privateKey: true);
             return new SlhDsaOpenSsl(key);

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -169,7 +169,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 Assert.NotNull(certKey);
                 byte[] expectedKey = SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue;
-                AssertExtensions.SequenceEqual(expectedKey, certKey.ExportSlhDsaSecretKey());
+                AssertExtensions.SequenceEqual(expectedKey, certKey.ExportSlhDsaPrivateKey());
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -450,7 +450,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 {
                     Assert.NotNull(slhDsa);
                     Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s, slhDsa.Algorithm);
-                    AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, slhDsa.ExportSlhDsaSecretKey());
+                    AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, slhDsa.ExportSlhDsaPrivateKey());
                 }
             }
         }
@@ -479,7 +479,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 {
                     Assert.NotNull(slhDsa);
                     Assert.Equal(info.Algorithm, slhDsa.Algorithm);
-                    AssertExtensions.SequenceEqual(info.SecretKey, slhDsa.ExportSlhDsaSecretKey());
+                    AssertExtensions.SequenceEqual(info.PrivateKey, slhDsa.ExportSlhDsaPrivateKey());
                     AssertExtensions.SequenceEqual(info.Certificate, reLoaded.RawData);
                 }
             }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
@@ -782,7 +782,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(SlhDsaAlgorithm.SlhDsaSha2_128s, slhDsa.Algorithm);
                 // Note this display string is reversed from the one in the IETF example but equivalent.
                 Assert.Equal("O=Bogus SLH-DSA-SHA2-128s CA, L=Paris, C=FR", cert.Subject);
-                AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, slhDsa.ExportSlhDsaSecretKey());
+                AssertExtensions.SequenceEqual(SlhDsaTestData.IetfSlhDsaSha2_128sPrivateKeyValue, slhDsa.ExportSlhDsaPrivateKey());
             }
         }
 


### PR DESCRIPTION
* Adjusted all public API on SlhDsa and SlhDsaAlgorithm to change `...SecretKey...` to `...PrivateKey...`
* Adjusted API docs, code comments, and locals to reflect the rename
* Adjusted test names, helpers, locals, etc. to align with the rename
  * Except for SecretKeySeed and SecretKeyPrf for the key generation tests
* Did not get overzealous and do it for ML-DSA (that's a separate change)
* Did not apply renames to any Interop types or the crypto shim

Fixes #117958
