### PR TITLE
Disable Test_wait_interrupted_user_apc on NAOT due to no support for alertable waits.

### DIFF
--- a/src/tests/baseservices/threading/regressions/115178/115178.cs
+++ b/src/tests/baseservices/threading/regressions/115178/115178.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 public class Test_wait_interrupted_user_apc
 {
-    public static bool Run115178Test => TestLibrary.Utilities.IsWindows;
+    public static bool Run115178Test => TestLibrary.Utilities.IsWindows && !TestLibrary.Utilities.IsNativeAot;
 
     [DllImport("kernel32.dll")]
     private static extern IntPtr GetCurrentProcess();

--- a/src/tests/baseservices/threading/regressions/115178/115178.cs
+++ b/src/tests/baseservices/threading/regressions/115178/115178.cs
@@ -16,8 +16,6 @@ using Xunit;
 
 public class Test_wait_interrupted_user_apc
 {
-    public static bool Run115178Test => TestLibrary.Utilities.IsWindows && !TestLibrary.Utilities.IsNativeAot;
-
     [DllImport("kernel32.dll")]
     private static extern IntPtr GetCurrentProcess();
 
@@ -285,7 +283,8 @@ public class Test_wait_interrupted_user_apc
         GC.KeepAlive(callback);
     }
 
-    [ConditionalFact(nameof(Run115178Test))]
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsWindows))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/118233", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static int TestEntryPoint()
     {
         RunTestUsingInfiniteWait();


### PR DESCRIPTION
This test tests that our wait functions won't break in case when user APC are queued. That requires wait to be alertable, but in NAOT case, waits are not, meaning that APC won't run and test won't work. Since the whole point of the test is to make sure waits are not broken due to user APC, this test is not applicable on NAOT, therefore it needs to be disabled.