### PR TITLE
Disable AdvSimd_ro test on native AOT

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd/AdvSimd_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd/AdvSimd_r.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- https://github.com/dotnet/runtime/issues/118234 -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd/AdvSimd_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd/AdvSimd_ro.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- https://github.com/dotnet/runtime/issues/118234 -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>


### PR DESCRIPTION
Native AOT outerloops are broken, we need outerloops green.

Cc @dotnet/ilc-contrib @dotnet/jit-contrib 