### PR TITLE
Fix reading Zip64 end of central directory locator

### DIFF
--- a/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/ZipArchiveFuzzer.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/ZipArchiveFuzzer.cs
@@ -15,56 +15,72 @@ internal sealed class ZipArchiveFuzzer : IFuzzer
 
     public void FuzzTarget(ReadOnlySpan<byte> bytes)
     {
-
         if (bytes.IsEmpty)
         {
             return;
         }
 
-        try
-        {
-            using var stream = new MemoryStream(bytes.ToArray());
-
-            Task sync_test = TestArchive(stream, async: false);
-            Task async_test = TestArchive(stream, async: true);
-
-            Task.WaitAll(sync_test, async_test);
-        }
-        catch (Exception) { }
+        TestArchive(CopyToRentedArray(bytes), bytes.Length, async: false).GetAwaiter().GetResult();
+        TestArchive(CopyToRentedArray(bytes), bytes.Length, async: true).GetAwaiter().GetResult();
     }
 
-    private async Task TestArchive(Stream stream, bool async)
+    private byte[] CopyToRentedArray(ReadOnlySpan<byte> bytes)
     {
-        stream.Position = 0;
-
-        ZipArchive archive;
-
-        if (async)
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(bytes.Length);
+        try
         {
-            archive = await ZipArchive.CreateAsync(stream, ZipArchiveMode.Read, leaveOpen: false, entryNameEncoding: null);
+            bytes.CopyTo(buffer);
+            return buffer;
         }
-        else
+        catch
         {
-            archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false, entryNameEncoding: null);
+            ArrayPool<byte>.Shared.Return(buffer);
+            throw;
         }
+    }
 
-        foreach (var entry in archive.Entries)
+    private async Task TestArchive(byte[] buffer, int length, bool async)
+    {
+        try
         {
-            // Access entry properties to simulate usage
-            _ = entry.FullName;
-            _ = entry.Length;
-            _ = entry.Comment;
-            _ = entry.LastWriteTime;
-            _ = entry.Crc32;
-        }
+            using var stream = new MemoryStream(buffer, 0, length);
 
-        if (async)
-        {
-            await archive.DisposeAsync();
+            ZipArchive archive;
+
+            if (async)
+            {
+                archive = await ZipArchive.CreateAsync(stream, ZipArchiveMode.Read, leaveOpen: false, entryNameEncoding: null);
+            }
+            else
+            {
+                archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false, entryNameEncoding: null);
+            }
+
+            foreach (var entry in archive.Entries)
+            {
+                // Access entry properties to simulate usage
+                _ = entry.FullName;
+                _ = entry.Length;
+                _ = entry.Comment;
+                _ = entry.LastWriteTime;
+                _ = entry.Crc32;
+            }
+
+            if (async)
+            {
+                await archive.DisposeAsync();
+            }
+            else
+            {
+                archive.Dispose();
+            }
         }
-        else
+        catch (InvalidDataException)
         {
-            archive.Dispose();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
         }
     }
 }

--- a/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/ZipArchiveFuzzer.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/ZipArchiveFuzzer.cs
@@ -77,6 +77,7 @@ internal sealed class ZipArchiveFuzzer : IFuzzer
         }
         catch (InvalidDataException)
         {
+            // ignore, this exception is expected to be thrown for invalid/corrupted archives.
         }
         finally
         {

--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -293,4 +293,7 @@
   <data name="PlatformNotSupported_Compression" xml:space="preserve">
     <value>System.IO.Compression is not supported on this platform.</value>
   </data>
+  <data name="InvalidOffsetToZip64EOCD" xml:space="preserve">
+    <value>Invalid offset to the Zip64 End of Central Directory record.</value>
+  </data>
 </root>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -653,6 +653,9 @@ namespace System.IO.Compression
 
             long zip64EOCDOffset = (long)locator.OffsetOfZip64EOCD;
 
+            if (zip64EOCDOffset < 0 || zip64EOCDOffset > _archiveStream.Length)
+                throw new InvalidDataException(SR.InvalidOffsetToZip64EOCD);
+
             _archiveStream.Seek(zip64EOCDOffset, SeekOrigin.Begin);
         }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -626,6 +626,7 @@ namespace System.IO.Compression
 
                 // read the EOCD
                 ZipEndOfCentralDirectoryBlock eocd = ZipEndOfCentralDirectoryBlock.ReadBlock(_archiveStream);
+
                 ReadEndOfCentralDirectoryInnerWork(eocd);
 
                 TryReadZip64EndOfCentralDirectory(eocd, eocdStart);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -587,10 +587,8 @@ namespace System.IO.Compression
             }
         }
 
-        private void ReadEndOfCentralDirectoryInnerWork(ZipEndOfCentralDirectoryBlock eocd, out long eocdStart)
+        private void ReadEndOfCentralDirectoryInnerWork(ZipEndOfCentralDirectoryBlock eocd)
         {
-            eocdStart = _archiveStream.Position;
-
             if (eocd.NumberOfThisDisk != eocd.NumberOfTheDiskWithTheStartOfTheCentralDirectory)
                 throw new InvalidDataException(SR.SplitSpanned);
 
@@ -624,10 +622,11 @@ namespace System.IO.Compression
                         ZipEndOfCentralDirectoryBlock.ZipFileCommentMaxLength + ZipEndOfCentralDirectoryBlock.FieldLengths.Signature))
                     throw new InvalidDataException(SR.EOCDNotFound);
 
+                long eocdStart = _archiveStream.Position;
+
                 // read the EOCD
                 ZipEndOfCentralDirectoryBlock eocd = ZipEndOfCentralDirectoryBlock.ReadBlock(_archiveStream);
-
-                ReadEndOfCentralDirectoryInnerWork(eocd, out long eocdStart);
+                ReadEndOfCentralDirectoryInnerWork(eocd);
 
                 TryReadZip64EndOfCentralDirectory(eocd, eocdStart);
 
@@ -686,6 +685,12 @@ namespace System.IO.Compression
             {
                 // Read Zip64 End of Central Directory Locator
 
+                // Check if there's enough space before the EOCD to look for the Zip64 EOCDL
+                if (eocdStart < Zip64EndOfCentralDirectoryLocator.TotalSize)
+                {
+                    throw new InvalidDataException(SR.Zip64EOCDNotWhereExpected);
+                }
+
                 // This seeks forwards almost to the beginning of the Zip64-EOCDL, one byte after where the signature would be located
                 _archiveStream.Seek(eocdStart - Zip64EndOfCentralDirectoryLocator.SizeOfBlockWithoutSignature, SeekOrigin.Begin);
 
@@ -701,7 +706,6 @@ namespace System.IO.Compression
 
                     // Read Zip64 End of Central Directory Record
                     Zip64EndOfCentralDirectoryRecord record = Zip64EndOfCentralDirectoryRecord.TryReadBlock(_archiveStream);
-
                     TryReadZip64EndOfCentralDirectoryInnerFinalWork(record);
                 }
             }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.Async.cs
@@ -54,7 +54,7 @@ internal static partial class ZipHelper
 
             int totalBytesRead = 0;
 
-            while (!signatureFound && !outOfBytes && totalBytesRead <= maxBytesToRead)
+            while (!signatureFound && !outOfBytes && totalBytesRead < maxBytesToRead)
             {
                 int overlap = totalBytesRead == 0 ? 0 : signatureToFind.Length;
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.Async.cs
@@ -58,10 +58,10 @@ internal static partial class ZipHelper
             {
                 int overlap = totalBytesRead == 0 ? 0 : signatureToFind.Length;
 
-                if (maxBytesToRead - totalBytesRead + overlap < bufferSpan.Length)
+                if (maxBytesToRead - totalBytesRead + overlap < bufferMemory.Length)
                 {
                     // If we have less than a full buffer left to read, we adjust the buffer size.
-                    bufferSpan = bufferSpan.Slice(0, maxBytesToRead - totalBytesRead + overlap);
+                    bufferMemory = bufferMemory.Slice(0, maxBytesToRead - totalBytesRead + overlap);
                 }
 
                 int bytesRead = await SeekBackwardsAndReadAsync(stream, bufferMemory, overlap, cancellationToken).ConfigureAwait(false);

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -1659,6 +1659,18 @@ namespace System.IO.Compression.Tests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task ReadArchive_FrontTruncatedFile_Throws(bool async)
+        {
+            for (int i = 1; i < s_slightlyIncorrectZip64.Length - 1; i++)
+            {
+                await Assert.ThrowsAsync<InvalidDataException>(
+                    // The archive is truncated, so it should throw an exception
+                    () => CreateZipArchive(async, new MemoryStream(s_slightlyIncorrectZip64, i, s_slightlyIncorrectZip64.Length - i), ZipArchiveMode.Read));
+            }
+        }
+
         // Generates a copy of s_invalidExtraFieldData with a variable number of bytes as extra field data.
         private static byte[] GenerateInvalidExtraFieldData(byte modifiedVersionToExtract, ushort extraFieldDataLength,
             out int lhVersionToExtractOffset,

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -195,7 +195,7 @@ namespace System.IO.Compression.Tests
             Stream source = await OpenEntryStream(async, e);
             byte[] buffer = new byte[s_bufferSize];
             int read = await source.ReadAsync(buffer, 0, buffer.Length);   // We don't want to inflate this large archive entirely
-                                                                // just making sure it read successfully
+                                                                           // just making sure it read successfully
             Assert.Equal(s_bufferSize, read);
             foreach (byte b in buffer)
             {
@@ -564,7 +564,7 @@ namespace System.IO.Compression.Tests
             byte[] buffer2 = new byte[1024];
             file.Seek(0, SeekOrigin.Begin);
 
-            while (await s.ReadAsync(buffer1, 0, buffer1.Length) != 0 )
+            while (await s.ReadAsync(buffer1, 0, buffer1.Length) != 0)
             {
                 await file.ReadAsync(buffer2, 0, buffer2.Length);
                 Assert.Equal(buffer1, buffer2);
@@ -1418,7 +1418,7 @@ namespace System.IO.Compression.Tests
             // for first.bin would normally be skipped (because it hasn't changed) but it needs to be rewritten
             // because the central directory headers will be rewritten with a valid value and the local file header
             // needs to match.
-            await using (ZipArchive updatedArchive = await ZipArchive.CreateAsync(updatedStream, ZipArchiveMode.Update, leaveOpen: true, entryNameEncoding:  null))
+            await using (ZipArchive updatedArchive = await ZipArchive.CreateAsync(updatedStream, ZipArchiveMode.Update, leaveOpen: true, entryNameEncoding: null))
             {
                 ZipArchiveEntry newEntry = updatedArchive.CreateEntry("second.bin", CompressionLevel.NoCompression);
 
@@ -1668,6 +1668,27 @@ namespace System.IO.Compression.Tests
                 await Assert.ThrowsAsync<InvalidDataException>(
                     // The archive is truncated, so it should throw an exception
                     () => CreateZipArchive(async, new MemoryStream(s_slightlyIncorrectZip64, i, s_slightlyIncorrectZip64.Length - i), ZipArchiveMode.Read));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task ReadArchive_Zip64EocdLocatorInvalidOffset_Throws(bool async)
+        {
+            byte[] data = s_slightlyIncorrectZip64.ToArray();
+
+            foreach (long offset in new[] { -1, int.MaxValue - 1 })
+            {
+                // Find Zip64 EOCD locator record
+                int eocdlOffset = data.AsSpan().LastIndexOf(new byte[] { 0x50, 0x4b, 0x06, 0x07 });
+                Assert.True(eocdlOffset >= 0, "Zip64 EOCD locator not found in test data");
+
+                // skip 4B signature and 4B index of disk, then overwrite the 8B offset to start of central directory
+                BinaryPrimitives.WriteInt64LittleEndian(data.AsSpan(eocdlOffset + 8, 8), offset);
+
+                await Assert.ThrowsAsync<InvalidDataException>(
+                    // The archive is truncated, so it should throw an exception
+                    () => CreateZipArchive(async, new MemoryStream(data), ZipArchiveMode.Read));
             }
         }
 


### PR DESCRIPTION
Fixes #117147.
Replaces https://github.com/dotnet/runtime/pull/118230.

The structure of Zip64 ZIP file is as follows:
- local file header
- ....
- central directory
- ZIP64 end of central directory record
- ZIP64 end of central directory locator
- End of central directory record

The applications reading the ZIP archive are expected to parse it from the end, where presence of ZIP64 fields is indicated by special values in the eocd record.

the problematic input is too short to contain eocd locator, which triggers the assert, this PR adds a stream length check for that.

This PR also fixes some internal methods (SeekBackwardsToSignature(Async)) to now behave as expected. Previous implementation always read at least 4kb even if maxBytesToRead was less. This in turn uncovered a different bug where expected offset of eocd locator was not calculated correctly.

Review of the fuzzing code (ZipArchiveFuzzer) revealed some issues (like disposing the stream between runs and ignoring all exceptions), so this PR fixes improves the fuzzer az well.
