### PR TITLE
Add `DOTNET_HOST_PATH` property when initializing for framework-dependent apps

### DIFF
--- a/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
@@ -24,13 +24,21 @@ namespace AppHost.Bundle.Tests
 
         private void RunTheApp(string path, bool selfContained)
         {
-            Command.Create(path)
-                .CaptureStdErr()
-                .CaptureStdOut()
+            var result = Command.Create(path)
+                .EnableTracingAndCaptureOutputs()
                 .DotNetRoot(selfContained ? null : TestContext.BuiltDotNet.BinPath)
-                .Execute()
-                .Should().Pass()
+                .Execute();
+            result.Should().Pass()
                 .And.HaveStdOutContaining("Hello World!");
+
+            if (selfContained)
+            {
+                result.Should().NotHaveProperty(Constants.RuntimeProperty.DotnetHostPath);
+            }
+            else
+            {
+                result.Should().HaveProperty(Constants.RuntimeProperty.DotnetHostPath, TestContext.BuiltDotNet.BinPath);
+            }
         }
 
         private string MakeUniversalBinary(string path, Architecture architecture)

--- a/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
@@ -37,7 +37,7 @@ namespace AppHost.Bundle.Tests
             }
             else
             {
-                result.Should().HaveProperty(Constants.RuntimeProperty.DotnetHostPath, TestContext.BuiltDotNet.BinPath);
+                result.Should().HaveProperty(Constants.RuntimeProperty.DotnetHostPath, TestContext.BuiltDotNet.DotnetExecutablePath);
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
+using HostActivation.Tests;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {
@@ -37,6 +38,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .Execute()
                 .Should().Pass()
                 .And.InitializeContextForApp(app.AppDll)
+                .And.HaveProperty(Constants.RuntimeProperty.DotnetHostPath, TestContext.BuiltDotNet.DotnetExecutablePath)
                 .And.ExecuteApplication(sharedState.NativeHostPath, app.AppDll);
         }
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             result.Should()
                 .InitializeContextForConfig(component.RuntimeConfigJson)
-                .And.HaveProperty(Constants.RuntimeProperty.DotnetHostPath, TestContext.BuiltDotNet.DotnetExecutablePath); ;
+                .And.HaveProperty(Constants.RuntimeProperty.DotnetHostPath, TestContext.BuiltDotNet.DotnetExecutablePath);
 
             // This should fail even with the valid type and valid method,
             // because the type is not resolvable from the default AssemblyLoadContext.

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using HostActivation.Tests;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Xunit;
 
@@ -40,7 +41,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .Execute();
 
             result.Should()
-                .InitializeContextForApp(app.AppDll);
+                .InitializeContextForApp(app.AppDll)
+                .And.HaveProperty(Constants.RuntimeProperty.DotnetHostPath, TestContext.BuiltDotNet.DotnetExecutablePath);
 
             if (validType && validMethod)
             {
@@ -73,7 +75,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .Execute();
 
             result.Should()
-                .InitializeContextForConfig(component.RuntimeConfigJson);
+                .InitializeContextForConfig(component.RuntimeConfigJson)
+                .And.HaveProperty(Constants.RuntimeProperty.DotnetHostPath, TestContext.BuiltDotNet.DotnetExecutablePath); ;
 
             // This should fail even with the valid type and valid method,
             // because the type is not resolvable from the default AssemblyLoadContext.
@@ -96,6 +99,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .Execute();
 
             result.Should().Pass()
+                .And.NotHaveProperty(Constants.RuntimeProperty.DotnetHostPath)
                 .And.InitializeContextForApp(app.AppDll)
                 .And.ExecuteFunctionPointer(sharedState.FunctionPointerEntryPoint1, 1, 1)
                 .And.ExecuteInDefaultContext(app.AssemblyName);

--- a/src/installer/tests/HostActivation.Tests/SelfContainedAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/SelfContainedAppLaunch.cs
@@ -34,7 +34,8 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion)
+                .And.NotHaveProperty(Constants.RuntimeProperty.DotnetHostPath);
 
             if (OperatingSystem.IsWindows())
             {

--- a/src/installer/tests/TestUtils/Assertions/CommandResultExtensions.RuntimeProperty.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultExtensions.RuntimeProperty.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+
+namespace Microsoft.DotNet.CoreSetup.Test
+{
+    public static partial class CommandResultExtensions
+    {
+        public static AndConstraint<CommandResultAssertions> HaveProperty(this CommandResultAssertions assertion, string name, string value)
+        {
+            // Expected trace message from hostpolicy
+            return assertion.HaveStdErrContaining($"Property {name} = {value}");
+        }
+
+        public static AndConstraint<CommandResultAssertions> NotHaveProperty(this CommandResultAssertions assertion, string name)
+        {
+            return assertion.NotHaveStdErrContaining($"Property {name} =");
+        }
+    }
+}

--- a/src/installer/tests/TestUtils/Assertions/CommandResultExtensions.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultExtensions.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
-    public static class CommandResultExtensions
+    public static partial class CommandResultExtensions
     {
         public static CommandResultAssertions Should(this CommandResult commandResult)
         {

--- a/src/installer/tests/TestUtils/Constants.cs
+++ b/src/installer/tests/TestUtils/Constants.cs
@@ -134,5 +134,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
             public const int COMPlusException = unchecked((int)0xe0434352);
             public const int SIGABRT = 134;
         }
+
+        public static class RuntimeProperty
+        {
+            public const string DotnetHostPath = "DOTNET_HOST_PATH";
+        }
     }
 }

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -71,12 +71,15 @@
 #if defined(TARGET_WINDOWS)
 #define LIB_PREFIX ""
 #define LIB_FILE_EXT ".dll"
+#define EXE_FILE_EXT ".exe"
 #elif defined(TARGET_OSX)
 #define LIB_PREFIX "lib"
 #define LIB_FILE_EXT ".dylib"
+#define EXE_FILE_EXT ""
 #else
 #define LIB_PREFIX "lib"
 #define LIB_FILE_EXT ".so"
+#define EXE_FILE_EXT ""
 #endif
 
 #define _STRINGIFY(s) _X(s)
@@ -138,8 +141,6 @@ namespace pal
     private:
         CRITICAL_SECTION _impl;
     };
-
-    inline const pal::char_t* exe_suffix() { return _X(".exe"); }
 
     inline int cstrcasecmp(const char* str1, const char* str2) { return ::_stricmp(str1, str2); }
     inline int strcmp(const char_t* str1, const char_t* str2) { return ::wcscmp(str1, str2); }
@@ -212,8 +213,6 @@ namespace pal
     typedef void* dll_t;
     typedef void* proc_t;
     typedef std::mutex mutex_t;
-
-    inline const pal::char_t* exe_suffix() { return nullptr; }
 
     inline int cstrcasecmp(const char* str1, const char* str2) { return ::strcasecmp(str1, str2); }
     inline int strcmp(const char_t* str1, const char_t* str2) { return ::strcmp(str1, str2); }

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -71,15 +71,11 @@ void append_path(pal::string_t* path1, const pal::char_t* path2)
 
 pal::string_t strip_executable_ext(const pal::string_t& filename)
 {
-    const pal::char_t* exe_suffix = pal::exe_suffix();
-    if (exe_suffix == nullptr)
-        return filename;
-
-    size_t suffix_len = pal::strlen(exe_suffix);
+    size_t suffix_len = STRING_LENGTH(EXE_FILE_EXT);
     if (suffix_len == 0)
         return filename;
 
-    if (utils::ends_with(filename, exe_suffix, suffix_len, false))
+    if (utils::ends_with(filename, _STRINGIFY(EXE_FILE_EXT), false))
     {
         // We need to strip off the old extension
         pal::string_t result(filename);

--- a/src/native/corehost/hostpolicy/coreclr.cpp
+++ b/src/native/corehost/hostpolicy/coreclr.cpp
@@ -165,6 +165,7 @@ namespace
         _X("STARTUP_HOOKS"),
         _X("APP_PATHS"),
         _X("RUNTIME_IDENTIFIER"),
+        _X("DOTNET_HOST_PATH"),
     };
 
     static_assert((sizeof(PropertyNameMapping) / sizeof(*PropertyNameMapping)) == static_cast<size_t>(common_property::Last), "Invalid property count");

--- a/src/native/corehost/hostpolicy/coreclr.h
+++ b/src/native/corehost/hostpolicy/coreclr.h
@@ -64,6 +64,7 @@ enum class common_property
     StartUpHooks,
     AppPaths,
     RuntimeIdentifier,
+    DotNetHostPath,
     // Sentinel value - new values should be defined above
     Last
 };

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -351,13 +351,10 @@ int hostpolicy_context_t::initialize(const hostpolicy_init_t &hostpolicy_init, c
         pal::string_t dotnet_host_path = hostpolicy_init.host_info.dotnet_root;
         append_path(&dotnet_host_path, _X("dotnet"));
         dotnet_host_path.append(_STRINGIFY(EXE_FILE_EXT));
-        if (pal::file_exists(dotnet_host_path))
+        if (!coreclr_properties.add(common_property::DotNetHostPath, dotnet_host_path.c_str()))
         {
-            if (!coreclr_properties.add(common_property::DotNetHostPath, dotnet_host_path.c_str()))
-            {
-                log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::DotNetHostPath));
-                return StatusCode::LibHostDuplicateProperty;
-            }
+            log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::DotNetHostPath));
+            return StatusCode::LibHostDuplicateProperty;
         }
     }
 #endif


### PR DESCRIPTION
Add `DOTNET_HOST_PATH` runtime property to represent the path to the `dotnet` executable corresponding to the runtime being used to run the application. Applications will be able to retrieve this value with `AppContext.GetData("DOTNET_HOST_PATH")`.

This goes through the properties passed directly at initialization, instead of just the callback on the host-runtime contract. Currently, `AppContext` is populated with the runtime properties from initialization and does not flow through to calling the host-runtime callback. Long-term, I think it should, but that is a much more impactful change.

cc @dotnet/appmodel @AaronRobinsonMSFT @baronfel @jaredpar @richlander 

See https://github.com/dotnet/runtime/issues/88754#issuecomment-3137043791