### PR TITLE
JIT: fix retyping of some storeinds during object stack allocation

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -2374,11 +2374,30 @@ void ObjectAllocator::UpdateAncestorTypes(
                 {
                     assert(tree == parent->AsIndir()->Data());
 
-                    // If we are storing to a GC struct field, we may need to retype the store
-                    //
                     if (varTypeIsGC(parent->TypeGet()))
                     {
-                        parent->ChangeType(newType);
+                        // We are storing a non-struct value, possibly to a struct field.
+                        //
+                        // See if we can figure out the field type from the address.
+                        // It might be TYP_BYREF even if the value we are storing is TYP_I_IMPL.
+                        //
+                        StoreInfo* const info       = m_StoreAddressToIndexMap.LookupPointer(parent);
+                        bool             wasRetyped = false;
+
+                        if (info != nullptr)
+                        {
+                            unsigned const addressIndex = info->m_index;
+                            if ((addressIndex != BAD_VAR_NUM) && !DoesIndexPointToStack(addressIndex))
+                            {
+                                parent->ChangeType(TYP_BYREF);
+                                wasRetyped = true;
+                            }
+                        }
+
+                        if (!wasRetyped)
+                        {
+                            parent->ChangeType(newType);
+                        }
                     }
                     else if (retypeFields && parent->OperIs(GT_STORE_BLK))
                     {


### PR DESCRIPTION
This PR fixes an issue that comes up in the LogicArray benchmark where the JIT misses cloning a key loop. In that benchmark there is a struct local `Workspace` that contains an array reference, and the JIT is now able to prove the array does not escape.

In the mainline code the field is retyped to `TYP_BYREF` but the store of the array value is typed as `TYP_I_IMPL`. This mixed typing of this field hinders physical promotion, which in turn induces morph to create a comma-defined temp for the array references, which in turn creates an in-loop assignment that blocks loop cloning.

In general we may sometimes store a non-GC type in a `TYP_BYREF` field of a local struct, if say that field can hold both GC refs and stack allocated object refs, or if (as here) we are in an OSR method where we have to assume that object allocations might come from the Tier0 code.

If so we should still try and consistently type the store as `TYP_BYREF`, so as to not confuse physical promotion. During the escape analysis phase we built up a store map to track how each store is modeled, so we can consult this during retyping to figure out which type to use for the store.

Fixes #114999.