### PR TITLE
Standardize netfx test helper for pem encoding

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/ByteUtils.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/ByteUtils.cs
@@ -109,8 +109,22 @@ namespace Test.Cryptography
 #if NET
             return PemEncoding.WriteString(label, data);
 #else
-            return
-                $"-----BEGIN {label}-----\n{Convert.ToBase64String(data, Base64FormattingOptions.InsertLineBreaks)}\n-----END {label}-----";
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("-----BEGIN "); sb.Append(label); sb.Append("-----\n");
+
+            string base64 = Convert.ToBase64String(data);
+
+            for (int i = 0; i < base64.Length; i += 64)
+            {
+                int len = Math.Min(64, base64.Length - i);
+                sb.Append(base64, i, len);
+                sb.Append('\n');
+            }
+
+            sb.Append("-----END "); sb.Append(label); sb.Append("-----");
+
+            return sb.ToString();
 #endif
         }
     }

--- a/src/libraries/Common/tests/System/Security/Cryptography/ByteUtils.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/ByteUtils.cs
@@ -111,7 +111,9 @@ namespace Test.Cryptography
 #else
             StringBuilder sb = new StringBuilder();
 
-            sb.Append("-----BEGIN "); sb.Append(label); sb.Append("-----\n");
+            sb.Append("-----BEGIN ");
+            sb.Append(label);
+            sb.Append("-----\n");
 
             string base64 = Convert.ToBase64String(data);
 
@@ -122,7 +124,9 @@ namespace Test.Cryptography
                 sb.Append('\n');
             }
 
-            sb.Append("-----END "); sb.Append(label); sb.Append("-----");
+            sb.Append("-----END ");
+            sb.Append(label);
+            sb.Append("-----");
 
             return sb.ToString();
 #endif


### PR DESCRIPTION
(Note: This change only affects PQC tests on netfx in the Windows 11 Canary Channel, so it's not related to pem other failures.)

The NetFx fallback uses `Convert.ToBase64String` which inserts line breaks (`\r\n`) every 76 characters. RFC 1421 says that each line must contain exactly 64 characters:

>   To represent the encapsulated text of a PEM message, the encoding
   function's output is delimited into text lines (using local
   conventions), with each line except the last containing exactly 64
   printable characters and the final line containing 64 or fewer
   printable characters.

This PR standardizes the polyfill to use 64 characters and '\n' as the new line character. This fixes some ML-DSA tests that started failing with #118088.