### PR TITLE
Add support for patterns

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -199,21 +199,19 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         public override TValue VisitDynamicIndexerAccess(IDynamicIndexerAccessOperation operation, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
             => ProcessBinderCall(operation, operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Write) ? "SetIndex" : "GetIndex", state);
 
-        private bool IsReferenceToCapturedVariable(ILocalReferenceOperation localReference)
+        private bool IsReferenceToCapturedVariable(ILocalSymbol local)
         {
-            var local = localReference.Local;
-
             if (local.IsConst)
                 return false;
             Debug.Assert(local.ContainingSymbol is IMethodSymbol or IFieldSymbol, // backing field for property initializers
-                $"{local.ContainingSymbol.GetType()}: {localReference.Syntax.GetLocation().GetLineSpan()}");
+                $"{local.ContainingSymbol.GetType()}: {local.Locations[0].GetLineSpan()}");
             return !ReferenceEquals(local.ContainingSymbol, OwningSymbol);
         }
 
         private TValue GetLocal(ILocalReferenceOperation operation, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
         {
             var local = new LocalKey(operation.Local);
-            if (IsReferenceToCapturedVariable(operation))
+            if (IsReferenceToCapturedVariable(operation.Local))
                 InterproceduralState.TrackHoistedLocal(local);
 
             // Get the value from the hoisted locals, if it's tracked there.
@@ -223,10 +221,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             return state.Get(local);
         }
 
-        private void SetLocal(ILocalReferenceOperation operation, TValue value, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state, bool merge = false)
+        private void SetLocal(ILocalSymbol localSymbol, TValue value, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state, bool merge = false)
         {
-            var local = new LocalKey(operation.Local);
-            if (IsReferenceToCapturedVariable(operation))
+            var local = new LocalKey(localSymbol);
+            if (IsReferenceToCapturedVariable(localSymbol))
                 InterproceduralState.TrackHoistedLocal(local);
 
             // Update the value stored in the hoisted locals, if it's tracked there.
@@ -239,7 +237,23 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             state.Set(local, newValue);
         }
 
-        private TValue ProcessSingleTargetAssignment(IOperation targetOperation, IAssignmentOperation operation, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state, bool merge)
+        private TValue ProcessSingleTargetAssignment(
+            IOperation targetOperation,
+            IAssignmentOperation operation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
+            bool merge
+        )
+        {
+            return ProcessSingleTargetAssignment(targetOperation, operation.Value, operation, state, merge);
+        }
+
+        private TValue ProcessSingleTargetAssignment(
+            IOperation targetOperation,
+            IOperation valueOperation,
+            IOperation assignmentOperation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
+            bool merge
+        )
         {
             switch (targetOperation)
             {
@@ -253,8 +267,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                         IParameterReferenceOperation parameterRef => GetParameterTargetValue(parameterRef.Parameter),
                         _ => throw new InvalidOperationException()
                     };
-                    TValue value = Visit(operation.Value, state);
-                    HandleAssignment(value, targetValue, operation, in current.Context);
+                    TValue value = Visit(valueOperation, state);
+                    HandleAssignment(value, targetValue, assignmentOperation, in current.Context);
                     return value;
                 }
 
@@ -266,7 +280,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
                     // https://github.com/dotnet/roslyn/issues/25057
                     TValue instanceValue = Visit(propertyRef.Instance, state);
-                    TValue value = Visit(operation.Value, state);
+                    TValue value = Visit(valueOperation, state);
                     IMethodSymbol? setMethod = propertyRef.Property.GetSetMethod();
 
                     if (setMethod == null ||
@@ -287,7 +301,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
                         var current = state.Current;
                         TValue targetValue = GetBackingFieldTargetValue(propertyRef, in current.Context);
-                        HandleAssignment(value, targetValue, operation, in current.Context);
+                        HandleAssignment(value, targetValue, assignmentOperation, in current.Context);
                         return value;
                     }
 
@@ -297,7 +311,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                         arguments.Add(Visit(val, state));
                     arguments.Add(value);
 
-                    HandleMethodCallHelper(setMethod, instanceValue, arguments.ToImmutableArray(), operation, state);
+                    HandleMethodCallHelper(setMethod, instanceValue, arguments.ToImmutableArray(), assignmentOperation, state);
                     // The return value of a property set expression is the value,
                     // even though a property setter has no return value.
                     return value;
@@ -308,14 +322,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // not a call to an event accessor method. There is no Roslyn API to access the field,
                     // so just visit the instance and the value. https://github.com/dotnet/roslyn/issues/40103
                     Visit(eventRef.Instance, state);
-                    return Visit(operation.Value, state);
+                    return Visit(valueOperation, state);
                 }
                 case IImplicitIndexerReferenceOperation indexerRef:
                 {
                     // An implicit reference to an indexer where the argument is a System.Index
                     TValue instanceValue = Visit(indexerRef.Instance, state);
                     TValue indexArgumentValue = Visit(indexerRef.Argument, state);
-                    TValue value = Visit(operation.Value, state);
+                    TValue value = Visit(valueOperation, state);
 
                     var property = (IPropertySymbol)indexerRef.IndexerSymbol;
 
@@ -331,15 +345,23 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                         break;
                     }
 
-                    HandleMethodCallHelper(setMethod, instanceValue, argumentsBuilder.ToImmutableArray(), operation, state);
+                    HandleMethodCallHelper(setMethod, instanceValue, argumentsBuilder.ToImmutableArray(), assignmentOperation, state);
                     return value;
                 }
 
                 // TODO: when setting a property in an attribute, target is an IPropertyReference.
                 case ILocalReferenceOperation localRef:
                 {
-                    TValue value = Visit(operation.Value, state);
-                    SetLocal(localRef, value, state, merge);
+                    TValue value = Visit(valueOperation, state);
+                    SetLocal(localRef.Local, value, state, merge);
+                    return value;
+                }
+                case IDeclarationPatternOperation declPattern:
+                {
+                    if (declPattern.DeclaredSymbol is not { } declaredSymbol)
+                        break;
+                    var value = Visit(valueOperation, state);
+                    SetLocal((ILocalSymbol)declaredSymbol, value, state, merge);
                     return value;
                 }
                 case IArrayElementReferenceOperation arrayElementRef:
@@ -349,22 +371,22 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
                     TValue arrayRef = Visit(arrayElementRef.ArrayReference, state);
                     TValue index = Visit(arrayElementRef.Indices[0], state);
-                    TValue value = Visit(operation.Value, state);
-                    HandleArrayElementWrite(arrayRef, index, value, operation, merge: merge);
+                    TValue value = Visit(valueOperation, state);
+                    HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
                 case IInlineArrayAccessOperation inlineArrayAccess:
                 {
                     TValue arrayRef = Visit(inlineArrayAccess.Instance, state);
                     TValue index = Visit(inlineArrayAccess.Argument, state);
-                    TValue value = Visit(operation.Value, state);
-                    HandleArrayElementWrite(arrayRef, index, value, operation, merge: merge);
+                    TValue value = Visit(valueOperation, state);
+                    HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
                 case IDiscardOperation:
                     // Assignments like "_ = SomeMethod();" don't need dataflow tracking.
                     // Seems like this can't happen with a flow capture operation.
-                    Debug.Assert(operation.Target is not IFlowCaptureReferenceOperation);
+                    Debug.Assert(targetOperation is not IFlowCaptureReferenceOperation);
                     break;
                 case IInstanceReferenceOperation:
                 // Assignment to 'this' is not tracked currently.
@@ -389,12 +411,43 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     UnexpectedOperationHandler.Handle(targetOperation);
                     break;
             }
-            return Visit(operation.Value, state);
+            return Visit(valueOperation, state);
         }
 
         public override TValue VisitSimpleAssignment(ISimpleAssignmentOperation operation, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
         {
             return ProcessAssignment(operation, state);
+        }
+
+        public override TValue VisitIsPattern(IIsPatternOperation operation, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            if (operation.Pattern is IDeclarationPatternOperation declarationPattern)
+            {
+                // A declaration pattern is like an assignment to a local
+                return ProcessSingleTargetAssignment(
+                    declarationPattern,
+                    operation.Value,
+                    operation,
+                    state,
+                    merge: false
+                );
+            }
+            return base.VisitIsPattern(operation, state);
+        }
+
+        public override TValue VisitPropertySubpattern(IPropertySubpatternOperation propPattern, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            if (propPattern.Pattern is IDeclarationPatternOperation declPattern)
+            {
+                return ProcessSingleTargetAssignment(
+                    declPattern,
+                    propPattern.Member,
+                    propPattern.Pattern,
+                    state,
+                    merge: false
+                );
+            }
+            return base.VisitPropertySubpattern(propPattern, state);
         }
 
         public override TValue VisitCompoundAssignment(ICompoundAssignmentOperation operation, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
@@ -45,12 +45,6 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         // are tracked as part of the dictionary of values, keyed by LocalKey.
         public DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>> CapturedReferences;
 
-        public LocalState(TValue defaultValue)
-            : this(new DefaultValueDictionary<LocalKey, TValue>(defaultValue),
-                new DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>>(default(ValueSet<CapturedReferenceValue>)))
-        {
-        }
-
         public LocalState(DefaultValueDictionary<LocalKey, TValue> dictionary, DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>> capturedReferences)
         {
             Dictionary = dictionary;

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -294,7 +294,6 @@ namespace ILLink.RoslynAnalyzer.Tests
             return RunTest(nameof(LocalDataFlow));
         }
 
-
         [Fact]
         public Task ExceptionalDataFlow()
         {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/BaseInAssemblyAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/BaseInAssemblyAttribute.cs
@@ -10,6 +10,6 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
         /// This property can override that by setting only the platforms
         /// which are expected to preserve the desired behavior.
         /// </summary>
-        public Tool Tool { get; set; } = Tool.TrimmerAnalyzerAndNativeAot;
+        public Tool Tool { get; set; } = Tool.All;
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/IgnoreTestCaseAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/IgnoreTestCaseAttribute.cs
@@ -14,6 +14,6 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
             ArgumentNullException.ThrowIfNull(reason);
         }
 
-        public Tool IgnoredBy { get; set; } = Tool.TrimmerAnalyzerAndNativeAot;
+        public Tool IgnoredBy { get; set; } = Tool.All;
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAttribute.cs
@@ -13,6 +13,6 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
         /// This property can override that by setting only the platforms
         /// which are expected to keep the target.
         /// </summary>
-        public Tool By { get; set; } = Tool.TrimmerAnalyzerAndNativeAot;
+        public Tool By { get; set; } = Tool.All;
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogContainsAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogContainsAttribute.cs
@@ -21,6 +21,6 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
         /// Property used by the result checkers of trimmer and analyzers to determine whether
         /// the tool should have produced the specified warning on the annotated member.
         /// </summary>
-        public Tool ProducedBy { get; set; } = Tool.TrimmerAnalyzerAndNativeAot;
+        public Tool ProducedBy { get; set; } = Tool.All;
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogDoesNotContainAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/LogDoesNotContainAttribute.cs
@@ -21,6 +21,6 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
         /// Property used by the result checkers of trimmer and analyzers to determine whether
         /// the tool should have produced the specified warning on the annotated member.
         /// </summary>
-        public Tool ProducedBy { get; set; } = Tool.TrimmerAnalyzerAndNativeAot;
+        public Tool ProducedBy { get; set; } = Tool.All;
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/SkipKeptItemsValidationAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/SkipKeptItemsValidationAttribute.cs
@@ -10,6 +10,6 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
     {
         public SkipKeptItemsValidationAttribute() { }
 
-        public Tool By { get; set; } = Tool.TrimmerAnalyzerAndNativeAot;
+        public Tool By { get; set; } = Tool.All;
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/Tool.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/Tool.cs
@@ -17,6 +17,6 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
         Trimmer = 1,
         Analyzer = 2,
         NativeAot = 4,
-        TrimmerAnalyzerAndNativeAot = Trimmer | Analyzer | NativeAot
+        All = Trimmer | Analyzer | NativeAot
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
@@ -592,7 +592,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             // ILLink only incidentally matches the analyzer behavior here.
-            [UnexpectedWarning("IL2062", nameof(DataFlowTypeExtensions.RequiresAll), Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/linker/issues/2737")]
+            [UnexpectedWarning("IL2062", nameof(DataFlowTypeExtensions.RequiresAll), Tool.All, "https://github.com/dotnet/linker/issues/2737")]
             [ExpectedWarning("IL2072", nameof(GetUnknownType), nameof(DataFlowTypeExtensions.RequiresAll), Tool.None, "https://github.com/dotnet/linker/issues/2737")]
             [ExpectedWarning("IL2072", nameof(GetTypeWithPublicConstructors), nameof(DataFlowTypeExtensions.RequiresAll), Tool.None, "https://github.com/dotnet/linker/issues/2737")]
             static void TestNullCoalescingAssignmentToEmptyComplex()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
@@ -59,7 +59,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
         // The type.GetMethods call generates a warning because we're not able to correctly track the value of the "this".
         // (there's a ldind.ref insruction here which we currently don't handle and the "this" becomes unknown)
-        [UnexpectedWarning("IL2065", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/linker/issues/2158")]
+        [UnexpectedWarning("IL2065", Tool.All, "https://github.com/dotnet/linker/issues/2158")]
         static void TestAssignStaticToAnnotatedRefParameter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] ref Type type)
         {
             type = typeof(TestTypeWithRequires);
@@ -72,7 +72,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
         // The type.GetMethods call generates a warning because we're not able to correctly track the value of the "this".
         // (there's a ldind.ref insruction here which we currently don't handle and the "this" becomes unknown)
-        [UnexpectedWarning("IL2065", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/linker/issues/2158")]
+        [UnexpectedWarning("IL2065", Tool.All, "https://github.com/dotnet/linker/issues/2158")]
         static void TestAssignParameterToAnnotatedRefParameter(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] ref Type type,
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type typeWithFields)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/NullableAnnotations.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/NullableAnnotations.cs
@@ -110,7 +110,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
             static Type FieldWithMethods;
             [Kept]
-            [UnexpectedWarning("IL2080", nameof(UnannotatedField), Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/93800")]
+            [UnexpectedWarning("IL2080", nameof(UnannotatedField), Tool.All, "https://github.com/dotnet/runtime/issues/93800")]
             static void Field()
             {
                 typeof(Nullable<>).MakeGenericType(UnannotatedField).GetMethods();
@@ -118,7 +118,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             [Kept]
-            [UnexpectedWarning("IL2090", nameof(unannotated), Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/93800")]
+            [UnexpectedWarning("IL2090", nameof(unannotated), Tool.All, "https://github.com/dotnet/runtime/issues/93800")]
             static void Parameter(
                 Type unannotated,
                 [KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
@@ -140,7 +140,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             [Kept]
-            [UnexpectedWarning("IL2075", nameof(GetUnannotated), Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/93800")]
+            [UnexpectedWarning("IL2075", nameof(GetUnannotated), Tool.All, "https://github.com/dotnet/runtime/issues/93800")]
             static void ReturnValue()
             {
                 typeof(Nullable<>).MakeGenericType(GetUnannotated()).GetMethods();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -1530,7 +1530,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
             }
 
             [Kept]
-            [UnexpectedWarning("IL2072", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/93720")]
+            [UnexpectedWarning("IL2072", Tool.All, "https://github.com/dotnet/runtime/issues/93720")]
             static void TestIsInstOf(object o)
             {
                 if (o is Target t)
@@ -1540,7 +1540,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
             }
 
             [Kept]
-            [ExpectedWarning("IL2072", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/93720")]
+            [ExpectedWarning("IL2072", Tool.All, "https://github.com/dotnet/runtime/issues/93720")]
             static void TestIsInstOfMismatch(object o)
             {
                 if (o is Target t)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -897,8 +897,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
             [ExpectedWarning("IL3050", nameof(WithRequires), "InstanceEvent.add", Tool.NativeAot, "")]
             [ExpectedWarning("IL2026", nameof(WithRequires), "InstanceEvent.remove")]
             [ExpectedWarning("IL3050", nameof(WithRequires), "InstanceEvent.remove", Tool.NativeAot, "")]
-            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.add", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/102525")]
-            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.remove", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/102525")]
+            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.add", Tool.All, "https://github.com/dotnet/runtime/issues/102525")]
+            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.remove", Tool.All, "https://github.com/dotnet/runtime/issues/102525")]
             [UnexpectedWarning("IL3050", nameof(WithRequires), "StaticEvent.add", Tool.NativeAot, "https://github.com/dotnet/runtime/issues/102525")]
             [UnexpectedWarning("IL3050", nameof(WithRequires), "StaticEvent.remove", Tool.NativeAot, "https://github.com/dotnet/runtime/issues/102525")]
             [ExpectedWarning("IL2026", nameof(DerivedRequires), "DerivedStaticEvent.add")]
@@ -942,8 +942,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
             [ExpectedWarning("IL3050", nameof(WithRequires), "InstanceEvent.add", Tool.NativeAot, "")]
             [ExpectedWarning("IL2026", nameof(WithRequires), "InstanceEvent.remove")]
             [ExpectedWarning("IL3050", nameof(WithRequires), "InstanceEvent.remove", Tool.NativeAot, "")]
-            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.add", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/102525")]
-            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.remove", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/102525")]
+            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.add", Tool.All, "https://github.com/dotnet/runtime/issues/102525")]
+            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.remove", Tool.All, "https://github.com/dotnet/runtime/issues/102525")]
             [UnexpectedWarning("IL3050", nameof(WithRequires), "StaticEvent.add", Tool.NativeAot, "https://github.com/dotnet/runtime/issues/102525")]
             [UnexpectedWarning("IL3050", nameof(WithRequires), "StaticEvent.remove", Tool.NativeAot, "https://github.com/dotnet/runtime/issues/102525")]
             [ExpectedWarning("IL2026", nameof(DerivedRequires), "DerivedStaticEvent.add")]
@@ -983,8 +983,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
             [ExpectedWarning("IL3050", nameof(WithRequires), "InstanceEvent.add", Tool.NativeAot, "")]
             [ExpectedWarning("IL2026", nameof(WithRequires), "InstanceEvent.remove")]
             [ExpectedWarning("IL3050", nameof(WithRequires), "InstanceEvent.remove", Tool.NativeAot, "")]
-            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.add", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/102525")]
-            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.remove", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/102525")]
+            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.add", Tool.All, "https://github.com/dotnet/runtime/issues/102525")]
+            [UnexpectedWarning("IL2026", nameof(WithRequires), "StaticEvent.remove", Tool.All, "https://github.com/dotnet/runtime/issues/102525")]
             [UnexpectedWarning("IL3050", nameof(WithRequires), "StaticEvent.add", Tool.NativeAot, "https://github.com/dotnet/runtime/issues/102525")]
             [UnexpectedWarning("IL3050", nameof(WithRequires), "StaticEvent.remove", Tool.NativeAot, "https://github.com/dotnet/runtime/issues/102525")]
             [ExpectedWarning("IL2026", nameof(DerivedRequires), "DerivedStaticEvent.add")]
@@ -1359,14 +1359,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
             }
 
             // This warning should ideally be suppressed by the RUC on the type:
-            [UnexpectedWarning("IL2091", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/108523")]
+            [UnexpectedWarning("IL2091", Tool.All, "https://github.com/dotnet/runtime/issues/108523")]
             [RequiresUnreferencedCode("--GenericClassWithWarningWithRequires--")]
             public class GenericClassWithWarningWithRequires<U> : RequiresAll<U>
             {
             }
 
             // This warning should ideally be suppressed by the RUC on the type:
-            [UnexpectedWarning("IL2091", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/108523")]
+            [UnexpectedWarning("IL2091", Tool.All, "https://github.com/dotnet/runtime/issues/108523")]
             [RequiresUnreferencedCode("--ClassWithWarningWithRequires--")]
             public class ClassWithWarningWithRequires : RequiresAll<T>
             {
@@ -1382,13 +1382,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
                 }
             }
 
-            [UnexpectedWarning("IL2026", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/108507")]
+            [UnexpectedWarning("IL2026", Tool.All, "https://github.com/dotnet/runtime/issues/108507")]
             [RequiresUnreferencedCode("--ClassWithWarningOnGenericArgumentConstructorWithRequires--")]
             class ClassWithWarningOnGenericArgumentConstructorWithRequires : RequiresNew<ClassWithRequires>
             {
             }
 
-            [UnexpectedWarning("IL2091", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/runtime/issues/108523")]
+            [UnexpectedWarning("IL2091", Tool.All, "https://github.com/dotnet/runtime/issues/108523")]
             [RequiresUnreferencedCode("--GenericAnnotatedWithWarningWithRequires--")]
             public class GenericAnnotatedWithWarningWithRequires<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TFields> : RequiresAll<TFields>
             {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/CompilerGeneratedCodeSubstitutions.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/CompilerGeneratedCodeSubstitutions.cs
@@ -180,7 +180,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
             }
 
             [ExpectedWarning("IL2026", "--UsedMethod--", CompilerGeneratedCode = true)]
-            [UnexpectedWarning("IL2026", "--RemovedMethod--", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/linker/issues/3087", CompilerGeneratedCode = true)]
+            [UnexpectedWarning("IL2026", "--RemovedMethod--", Tool.All, "https://github.com/dotnet/linker/issues/3087", CompilerGeneratedCode = true)]
             static IEnumerable<int> TestBranchWithYieldBefore()
             {
                 if (AlwaysFalse)
@@ -224,7 +224,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
             }
 
             [ExpectedWarning("IL2026", "--UsedMethod--", CompilerGeneratedCode = true)]
-            [UnexpectedWarning("IL2026", "--RemovedMethod--", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/linker/issues/3087", CompilerGeneratedCode = true)]
+            [UnexpectedWarning("IL2026", "--RemovedMethod--", Tool.All, "https://github.com/dotnet/linker/issues/3087", CompilerGeneratedCode = true)]
             static async Task TestBranchWithNormalCallAfterWAwait()
             {
                 if (AlwaysFalse)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -589,7 +589,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
             }
 
             // The suppression on the lambda is ignored
-            [UnexpectedWarning("IL2026", Tool.TrimmerAnalyzerAndNativeAot, "https://github.com/dotnet/roslyn/issues/59746 https://github.com/dotnet/roslyn/issues/82956", CompilerGeneratedCode = true)]
+            [UnexpectedWarning("IL2026", Tool.All, "https://github.com/dotnet/roslyn/issues/59746 https://github.com/dotnet/roslyn/issues/82956", CompilerGeneratedCode = true)]
             [UnexpectedWarning("IL2121", Tool.Trimmer, "https://github.com/dotnet/runtime/issues/82956", CompilerGeneratedCode = true)]
             static void TestLocalFunctionInLambda()
             {


### PR DESCRIPTION
This adds local and property pattern support, but may not cover all possible ways a pattern can introduce a local variable.

Fixes https://github.com/dotnet/runtime/issues/113922