### PR TITLE
[NRBF] Allow the users to decode System.Nullable<UserStruct>

### DIFF
--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/MemberTypeInfo.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/MemberTypeInfo.cs
@@ -91,8 +91,10 @@ internal readonly struct MemberTypeInfo
         const AllowedRecordTypes SystemClass = Classes | AllowedRecordTypes.SystemClassWithMembersAndTypes
             // All primitive types can be stored by using one of the interfaces they implement.
             // Example: `new IEnumerable[1] { "hello" }` or `new IComparable[1] { int.MaxValue }`.
-            | AllowedRecordTypes.BinaryObjectString | AllowedRecordTypes.MemberPrimitiveTyped;
-        const AllowedRecordTypes NonSystemClass = Classes |  AllowedRecordTypes.ClassWithMembersAndTypes;
+            | AllowedRecordTypes.BinaryObjectString | AllowedRecordTypes.MemberPrimitiveTyped
+            // System.Nullable<UserStruct> is a special case of SystemClassWithMembersAndTypes
+            | AllowedRecordTypes.ClassWithMembersAndTypes;
+        const AllowedRecordTypes NonSystemClass = Classes | AllowedRecordTypes.ClassWithMembersAndTypes;
 
         return binaryType switch
         {

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/MemberTypeInfo.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/MemberTypeInfo.cs
@@ -91,9 +91,7 @@ internal readonly struct MemberTypeInfo
         const AllowedRecordTypes SystemClass = Classes | AllowedRecordTypes.SystemClassWithMembersAndTypes
             // All primitive types can be stored by using one of the interfaces they implement.
             // Example: `new IEnumerable[1] { "hello" }` or `new IComparable[1] { int.MaxValue }`.
-            | AllowedRecordTypes.BinaryObjectString | AllowedRecordTypes.MemberPrimitiveTyped
-            // System.Nullable<UserStruct> is a special case of SystemClassWithMembersAndTypes
-            | AllowedRecordTypes.ClassWithMembersAndTypes;
+            | AllowedRecordTypes.BinaryObjectString | AllowedRecordTypes.MemberPrimitiveTyped;
         const AllowedRecordTypes NonSystemClass = Classes | AllowedRecordTypes.ClassWithMembersAndTypes;
 
         return binaryType switch
@@ -104,10 +102,29 @@ internal readonly struct MemberTypeInfo
             BinaryType.StringArray => (StringArray, default),
             BinaryType.PrimitiveArray => (PrimitiveArray, default),
             BinaryType.Class => (NonSystemClass, default),
+            BinaryType.SystemClass when IsNullableUserTypeRepresentedAsSystemType((TypeName)additionalInfo!) => (SystemClass | AllowedRecordTypes.ClassWithMembersAndTypes, default),
             BinaryType.SystemClass => (SystemClass, default),
             BinaryType.ObjectArray => (ObjectArray, default),
             _ => throw new InvalidOperationException()
         };
+
+        static bool IsNullableUserTypeRepresentedAsSystemType(TypeName typeName)
+        {
+            if (!typeName.IsConstructedGenericType || typeName.Name != typeof(Nullable<>).Name)
+            {
+                return false;
+            }
+
+            var genericArgs = typeName.GetGenericArguments();
+            if (genericArgs.Length != 1)
+            {
+                return false;
+            }
+
+            // If the generic argument is not from CoreLib, then it is a user type.
+            var assemblyName = genericArgs[0].AssemblyName;
+            return assemblyName is not null && !assemblyName.FullName.Equals(TypeNameHelpers.CoreLibAssemblyName.FullName, StringComparison.Ordinal);
+        }
     }
 
     internal TypeName GetArrayTypeName(ArrayInfo arrayInfo)

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/Utils/TypeNameHelpers.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/Utils/TypeNameHelpers.cs
@@ -21,6 +21,9 @@ internal static class TypeNameHelpers
     private static readonly TypeName?[] s_primitiveSZArrayTypeNames = new TypeName?[(int)UIntPtrPrimitiveType + 1];
     private static AssemblyNameInfo? s_coreLibAssemblyName;
 
+    internal static AssemblyNameInfo CoreLibAssemblyName
+        => s_coreLibAssemblyName ??= AssemblyNameInfo.Parse("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089".AsSpan());
+
     internal static TypeName GetPrimitiveTypeName(PrimitiveType primitiveType)
     {
         TypeName? typeName = s_primitiveTypeNames[(int)primitiveType];
@@ -155,7 +158,7 @@ internal static class TypeNameHelpers
                 .WithCoreLibAssemblyName(); // We know it's a System Record, so we set the LibraryName to CoreLib
 
     internal static TypeName WithCoreLibAssemblyName(this TypeName systemType)
-        => systemType.With(s_coreLibAssemblyName ??= AssemblyNameInfo.Parse("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089".AsSpan()));
+        => systemType.With(CoreLibAssemblyName);
 
     private static TypeName With(this TypeName typeName, AssemblyNameInfo assemblyName)
     {

--- a/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/Utils/TypeNameHelpers.cs
+++ b/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/Utils/TypeNameHelpers.cs
@@ -21,9 +21,6 @@ internal static class TypeNameHelpers
     private static readonly TypeName?[] s_primitiveSZArrayTypeNames = new TypeName?[(int)UIntPtrPrimitiveType + 1];
     private static AssemblyNameInfo? s_coreLibAssemblyName;
 
-    internal static AssemblyNameInfo CoreLibAssemblyName
-        => s_coreLibAssemblyName ??= AssemblyNameInfo.Parse("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089".AsSpan());
-
     internal static TypeName GetPrimitiveTypeName(PrimitiveType primitiveType)
     {
         TypeName? typeName = s_primitiveTypeNames[(int)primitiveType];
@@ -158,7 +155,7 @@ internal static class TypeNameHelpers
                 .WithCoreLibAssemblyName(); // We know it's a System Record, so we set the LibraryName to CoreLib
 
     internal static TypeName WithCoreLibAssemblyName(this TypeName systemType)
-        => systemType.With(CoreLibAssemblyName);
+        => systemType.With(s_coreLibAssemblyName ??= AssemblyNameInfo.Parse("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089".AsSpan()));
 
     private static TypeName With(this TypeName typeName, AssemblyNameInfo assemblyName)
     {


### PR DESCRIPTION
When `BinaryFormatter` serializes a type different than primitive type or array, it serializes some information about ever member (field). To be exact is serializes on byte that specifies the kind and additional information for specific kind (for example, a string thar represents the type name).

This information is decoded [here](https://github.com/dotnet/runtime/blob/41c675e5adf23ce7bdf5ac18a3ab3f90042e3787/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/MemberTypeInfo.cs#L26-L65).

In this particular edge case, where the payload contains `System.Nullable<$UserStruct>` and it's null at least once, BF emits an information that it's a `BinaryType.SystemClass`. When there are no nulls, it emits `BinaryType.Class`. In both cases, the actual record is persisted as `ClassWithMembersAndTypesRecord`, not `**System**ClassWithMembersAndTypesRecord`. And so far `NrbfDecoder` was rejecting such inputs, as they are simply invalid from the specification point of view (the record could be `ClassWithMembersAndTypesRecord`, `ClassWithIdRecord` or `NullRecord`). 

Since we can't update `BinaryFormatter` (it's no longer supported) and such payloads could be persisted somewhere, I believe that we should relax the `NrbfDecoder` check.

I have [tried](https://github.com/dotnet/runtime/pull/118276/commits/3636ebe09b0d72df99bb8fea9196a80538852f4d) to make this check more restrictive (allow only for `System.Nullable<$UserType>` to be handled like this), but I can't guarantee that there is no other similar edge case. So the proposed fix is to always allow `BinaryType.SystemClass` to be represented as non-system class record in the payload.

This fix is going to unblock an important first party customer, so please keep in mind that I am going to try to backport it to 9.0.




