### PR TITLE
Handle 'lib' variants in ModuleNameVariations to generate DirectPInvokes

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -148,7 +148,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
-      <DirectPInvoke Include="@(NetCoreAppNativeLibrary->'lib%(Identity)')" />
       <NetCoreAppNativeLibrary Include="@(NetCoreAppNativeLibrary->'%(Identity)')">
         <EscapedPath>$(IlcFrameworkNativePath)lib%(Identity).a</EscapedPath>
       </NetCoreAppNativeLibrary>
@@ -180,7 +179,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup Condition="'$(StaticICULinking)' == 'true' and '$(NativeLib)' != 'Static' and '$(InvariantGlobalization)' != 'true'">
       <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Globalization.Native/build/libSystem.Globalization.Native.a" />
-      <DirectPInvoke Include="libSystem.Globalization.Native" />
+      <DirectPInvoke Include="System.Globalization.Native" />
       <StaticICULibs Include="-Wl,-Bstatic" Condition="'$(StaticExecutable)' != 'true'" />
       <StaticICULibs Include="-licuio -licutu -licui18n -licuuc -licudata -lstdc++" />
       <StaticICULibs Include="-Wl,-Bdynamic" Condition="'$(StaticExecutable)' != 'true'" />
@@ -193,7 +192,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup Condition="'$(StaticOpenSslLinking)' == 'true' and '$(NativeLib)' != 'Static'">
       <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Security.Cryptography.Native/build/libSystem.Security.Cryptography.Native.OpenSsl.a" />
-      <DirectPInvoke Include="libSystem.Security.Cryptography.Native.OpenSsl" />
+      <DirectPInvoke Include="System.Security.Cryptography.Native.OpenSsl" />
       <StaticSslLibs Include="-Wl,-Bstatic" Condition="'$(StaticExecutable)' != 'true'" />
       <StaticSslLibs Include="-lssl -lcrypto" />
       <StaticSslLibs Include="-Wl,-Bdynamic" Condition="'$(StaticExecutable)' != 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -148,7 +148,8 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
-      <NetCoreAppNativeLibrary Include="@(NetCoreAppNativeLibrary->'%(Identity)')">
+      <DirectPInvoke Include="@(NetCoreAppNativeLibrary)" />
+      <NetCoreAppNativeLibrary Include="@(NetCoreAppNativeLibrary)">
         <EscapedPath>$(IlcFrameworkNativePath)lib%(Identity).a</EscapedPath>
       </NetCoreAppNativeLibrary>
       <NativeLibrary Include="@(NetCoreAppNativeLibrary->'%(EscapedPath)')" />
@@ -179,7 +180,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup Condition="'$(StaticICULinking)' == 'true' and '$(NativeLib)' != 'Static' and '$(InvariantGlobalization)' != 'true'">
       <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Globalization.Native/build/libSystem.Globalization.Native.a" />
-      <DirectPInvoke Include="System.Globalization.Native" />
+      <DirectPInvoke Include="libSystem.Globalization.Native" />
       <StaticICULibs Include="-Wl,-Bstatic" Condition="'$(StaticExecutable)' != 'true'" />
       <StaticICULibs Include="-licuio -licutu -licui18n -licuuc -licudata -lstdc++" />
       <StaticICULibs Include="-Wl,-Bdynamic" Condition="'$(StaticExecutable)' != 'true'" />
@@ -192,7 +193,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup Condition="'$(StaticOpenSslLinking)' == 'true' and '$(NativeLib)' != 'Static'">
       <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Security.Cryptography.Native/build/libSystem.Security.Cryptography.Native.OpenSsl.a" />
-      <DirectPInvoke Include="System.Security.Cryptography.Native.OpenSsl" />
+      <DirectPInvoke Include="libSystem.Security.Cryptography.Native.OpenSsl" />
       <StaticSslLibs Include="-Wl,-Bstatic" Condition="'$(StaticExecutable)' != 'true'" />
       <StaticSslLibs Include="-lssl -lcrypto" />
       <StaticSslLibs Include="-Wl,-Bdynamic" Condition="'$(StaticExecutable)' != 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -180,7 +180,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup Condition="'$(StaticICULinking)' == 'true' and '$(NativeLib)' != 'Static' and '$(InvariantGlobalization)' != 'true'">
       <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Globalization.Native/build/libSystem.Globalization.Native.a" />
-      <DirectPInvoke Include="libSystem.Globalization.Native" />
+      <DirectPInvoke Include="System.Globalization.Native" />
       <StaticICULibs Include="-Wl,-Bstatic" Condition="'$(StaticExecutable)' != 'true'" />
       <StaticICULibs Include="-licuio -licutu -licui18n -licuuc -licudata -lstdc++" />
       <StaticICULibs Include="-Wl,-Bdynamic" Condition="'$(StaticExecutable)' != 'true'" />
@@ -193,7 +193,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup Condition="'$(StaticOpenSslLinking)' == 'true' and '$(NativeLib)' != 'Static'">
       <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Security.Cryptography.Native/build/libSystem.Security.Cryptography.Native.OpenSsl.a" />
-      <DirectPInvoke Include="libSystem.Security.Cryptography.Native.OpenSsl" />
+      <DirectPInvoke Include="System.Security.Cryptography.Native.OpenSsl" />
       <StaticSslLibs Include="-Wl,-Bstatic" Condition="'$(StaticExecutable)' != 'true'" />
       <StaticSslLibs Include="-lssl -lcrypto" />
       <StaticSslLibs Include="-Wl,-Bdynamic" Condition="'$(StaticExecutable)' != 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -58,7 +58,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
-      <DirectPInvoke Include="@(NetCoreAppNativeLibrary->'%(Identity)')" />
       <NetCoreAppNativeLibrary Include="@(NetCoreAppNativeLibrary->'%(Identity)')">
         <EscapedPath>$(IlcSdkPath)%(Identity).Aot$(LibrarySuffix)</EscapedPath>
       </NetCoreAppNativeLibrary>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -58,6 +58,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
+      <DirectPInvoke Include="@(NetCoreAppNativeLibrary)" />
       <NetCoreAppNativeLibrary Include="@(NetCoreAppNativeLibrary->'%(Identity)')">
         <EscapedPath>$(IlcSdkPath)%(Identity).Aot$(LibrarySuffix)</EscapedPath>
       </NetCoreAppNativeLibrary>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -337,7 +337,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Unix.targets" Condition="'$(_targetOS)' != 'win'" />
 
   <ItemGroup>
-    <DirectPInvoke Include="@(NetCoreAppNativeLibrary->'%(Identity)')" />
+    <DirectPInvoke Include="@(NetCoreAppNativeLibrary)" />
   </ItemGroup>
 
   <Target Name="MultiFileCopyNative"

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -336,10 +336,6 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Windows.targets" Condition="'$(_targetOS)' == 'win'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Unix.targets" Condition="'$(_targetOS)' != 'win'" />
 
-  <ItemGroup>
-    <DirectPInvoke Include="@(NetCoreAppNativeLibrary)" />
-  </ItemGroup>
-
   <Target Name="MultiFileCopyNative"
       Inputs="@(NativeObjects)"
       Outputs="$(NativeOutputPath)"

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -336,6 +336,10 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Windows.targets" Condition="'$(_targetOS)' == 'win'" />
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Unix.targets" Condition="'$(_targetOS)' != 'win'" />
 
+  <ItemGroup>
+    <DirectPInvoke Include="@(NetCoreAppNativeLibrary->'%(Identity)')" />
+  </ItemGroup>
+
   <Target Name="MultiFileCopyNative"
       Inputs="@(NativeObjects)"
       Outputs="$(NativeOutputPath)"

--- a/src/coreclr/tools/aot/ILCompiler/ConfigurablePInvokePolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ConfigurablePInvokePolicy.cs
@@ -93,14 +93,15 @@ namespace ILCompiler
             {
                 string suffix = _target.IsApplePlatform ? ".dylib" : ".so";
                 bool hasSharedLibraryExtension = name.EndsWith(suffix, StringComparison.Ordinal);
-                bool hasLibPrefix = name.StartsWith("lib", StringComparison.Ordinal);
+                const string LibPrefix = "lib";
+                bool hasLibPrefix = name.StartsWith(LibPrefix, StringComparison.Ordinal);
 
                 if (hasSharedLibraryExtension)
                     yield return name.Substring(0, name.Length - suffix.Length);
                 if (hasLibPrefix)
-                    yield return name.Substring(3);
+                    yield return name.Substring(LibPrefix.Length);
                 if (hasLibPrefix && hasSharedLibraryExtension)
-                    yield return name.Substring(3, name.Length - suffix.Length - 3);
+                    yield return name.Substring(LibPrefix.Length, name.Length - suffix.Length - LibPrefix.Length);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler/ConfigurablePInvokePolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ConfigurablePInvokePolicy.cs
@@ -92,9 +92,15 @@ namespace ILCompiler
             else
             {
                 string suffix = _target.IsApplePlatform ? ".dylib" : ".so";
+                bool hasSharedLibraryExtension = name.EndsWith(suffix, StringComparison.Ordinal);
+                bool hasLibPrefix = name.StartsWith("lib");
 
-                if (name.EndsWith(suffix, StringComparison.Ordinal))
+                if (hasSharedLibraryExtension)
                     yield return name.Substring(0, name.Length - suffix.Length);
+                if (hasLibPrefix)
+                    yield return name.Substring(3);
+                if (hasLibPrefix && hasSharedLibraryExtension)
+                    yield return name.Substring(3, name.Length - suffix.Length - 3);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler/ConfigurablePInvokePolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ConfigurablePInvokePolicy.cs
@@ -93,7 +93,7 @@ namespace ILCompiler
             {
                 string suffix = _target.IsApplePlatform ? ".dylib" : ".so";
                 bool hasSharedLibraryExtension = name.EndsWith(suffix, StringComparison.Ordinal);
-                bool hasLibPrefix = name.StartsWith("lib");
+                bool hasLibPrefix = name.StartsWith("lib", StringComparison.Ordinal);
 
                 if (hasSharedLibraryExtension)
                     yield return name.Substring(0, name.Length - suffix.Length);


### PR DESCRIPTION
In ILC, when a DirectPInvokes item was prefixed with 'lib', it wouldn't recognize the library and wouldn't generate a direct pinvoke. There are a lot of places within the repo (and I assume other codebases) that use the 'lib' prefix in DirectPInvokes, so it seems to make more sense to handle that case rather than remove the prefix from all usages.

fixes https://github.com/dotnet/runtime/issues/118284