### PR TITLE
Removes IEquatable constraint from ThrowIfEqual/NotEqual

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/ArgumentOutOfRangeException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ArgumentOutOfRangeException.cs
@@ -157,7 +157,7 @@ namespace System
         /// <param name="value">The argument to validate as not equal to <paramref name="other"/>.</param>
         /// <param name="other">The value to compare with <paramref name="value"/>.</param>
         /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
-        public static void ThrowIfEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null) where T : IEquatable<T>?
+        public static void ThrowIfEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
             if (EqualityComparer<T>.Default.Equals(value, other))
                 ThrowEqual(value, other, paramName);
@@ -167,7 +167,7 @@ namespace System
         /// <param name="value">The argument to validate as equal to <paramref name="other"/>.</param>
         /// <param name="other">The value to compare with <paramref name="value"/>.</param>
         /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
-        public static void ThrowIfNotEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null) where T : IEquatable<T>?
+        public static void ThrowIfNotEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
             if (!EqualityComparer<T>.Default.Equals(value, other))
                 ThrowNotEqual(value, other, paramName);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -474,14 +474,14 @@ namespace System
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public static void ThrowIfEqual<T>(T value, T other, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) where T : System.IEquatable<T>? { }
+        public static void ThrowIfEqual<T>(T value, T other, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) { }
         public static void ThrowIfGreaterThanOrEqual<T>(T value, T other, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) where T : System.IComparable<T> { }
         public static void ThrowIfGreaterThan<T>(T value, T other, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) where T : System.IComparable<T> { }
         public static void ThrowIfLessThanOrEqual<T>(T value, T other, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) where T : System.IComparable<T> { }
         public static void ThrowIfLessThan<T>(T value, T other, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) where T : System.IComparable<T> { }
         public static void ThrowIfNegativeOrZero<T>(T value, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) where T : System.Numerics.INumberBase<T> { }
         public static void ThrowIfNegative<T>(T value, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) where T : System.Numerics.INumberBase<T> { }
-        public static void ThrowIfNotEqual<T>(T value, T other, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) where T : System.IEquatable<T>? { }
+        public static void ThrowIfNotEqual<T>(T value, T other, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) { }
         public static void ThrowIfZero<T>(T value, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("value")] string? paramName = null) where T : System.Numerics.INumberBase<T> { }
     }
     public partial class ArithmeticException : System.SystemException

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArgumentOutOfRangeExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArgumentOutOfRangeExceptionTests.cs
@@ -74,8 +74,8 @@ namespace System.Tests
         private static Action GreaterThanOrEqualHelper<T>(T value, T other) where T : IComparable<T> => () => ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(value, other);
         private static Action LessThanHelper<T>(T value, T other) where T : IComparable<T> => () => ArgumentOutOfRangeException.ThrowIfLessThan(value, other);
         private static Action LessThanOrEqualHelper<T>(T value, T other) where T : IComparable<T> => () => ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, other);
-        private static Action EqualHelper<T>(T value, T other) where T : IEquatable<T> => () => ArgumentOutOfRangeException.ThrowIfEqual(value, other);
-        private static Action NotEqualHelper<T>(T value, T other) where T : IEquatable<T> => () => ArgumentOutOfRangeException.ThrowIfNotEqual(value, other);
+        private static Action EqualHelper<T>(T value, T other) => () => ArgumentOutOfRangeException.ThrowIfEqual(value, other);
+        private static Action NotEqualHelper<T>(T value, T other) => () => ArgumentOutOfRangeException.ThrowIfNotEqual(value, other);
 
         [Fact]
         public static void GenericHelpers_ThrowIfZero_Throws()


### PR DESCRIPTION
Removes the `IEquatable` constraint from the `ThrowIfEqual` and `ThrowIfNotEqual` methods in `ArgumentOutOfRangeException`.

- Allows these methods to be used with types that don't implement `IEquatable`, relying on `EqualityComparer.Default.Equals` for equality comparisons.
- This broadens the applicability of these methods without sacrificing functionality.

Resolves #118053