### PR TITLE
[EventPipe][User_events] Add MetadataID and ProviderName to metadata bytes

### DIFF
--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -765,7 +765,7 @@ session_tracepoint_write_event (
 		return false;
 
 	// Setup iovec array
-	const int max_non_parameter_iov = 8;
+	const int max_non_parameter_iov = 9;
 	const int max_static_io_capacity = 30; // Should account for most events that use EventData structs
 	struct iovec static_io[max_static_io_capacity];
 	struct iovec *io = static_io;
@@ -824,21 +824,33 @@ session_tracepoint_write_event (
 	uint64_t session_mask = ep_session_get_mask (session);
 	bool should_write_metadata = !ep_event_was_metadata_written (ep_event, session_mask);
 	if (should_write_metadata) {
+		EventPipeProvider *event_provider = ep_event_get_provider (ep_event);
+		const ep_char16_t *provider_name_utf16 = ep_provider_get_provider_name_utf16 (event_provider);
+		uint32_t provider_name_len = (uint32_t)ep_rt_utf16_string_len (provider_name_utf16);
+		uint32_t provider_name_size_bytes = (provider_name_len + 1) * sizeof (ep_char16_t);
+		uint32_t event_metadata_len = ep_event_get_metadata_len (ep_event);
+		uint32_t complete_metadata_len = provider_name_size_bytes + event_metadata_len;
+
 		uint8_t extension_metadata[1 + sizeof(uint32_t)];
-		uint32_t metadata_len = ep_event_get_metadata_len (ep_event);
 		extension_metadata[0] = 0x01; // label
-		*(uint32_t*)&extension_metadata[1] = metadata_len;
+		*(uint32_t*)&extension_metadata[1] = complete_metadata_len;
 		io[io_index].iov_base = extension_metadata;
 		io[io_index].iov_len = sizeof(extension_metadata);
 		io_index++;
 		extension_len += sizeof(extension_metadata);
 		io_bytes_to_write += sizeof(extension_metadata);
 
-		io[io_index].iov_base = (void *)ep_event_get_metadata (ep_event);
-		io[io_index].iov_len = metadata_len;
+		io[io_index].iov_base = (void *)provider_name_utf16;
+		io[io_index].iov_len = provider_name_size_bytes;
 		io_index++;
-		extension_len += metadata_len;
-		io_bytes_to_write += metadata_len;
+		extension_len += provider_name_size_bytes;
+		io_bytes_to_write += provider_name_size_bytes;
+
+		io[io_index].iov_base = (void *)ep_event_get_metadata (ep_event);
+		io[io_index].iov_len = event_metadata_len;
+		io_index++;
+		extension_len += event_metadata_len;
+		io_bytes_to_write += event_metadata_len;
 	}
 
 	// Extension Activity IDs


### PR DESCRIPTION
In constructing metadata in https://github.com/dotnet/runtime/pull/115265, it was missed that ProviderName and Metadata ID are prepended to the metadata block instead of being a part of the EventPipeEvent's Metadata. Those two fields assist in correlating Event blocks with Metadata blocks as specified in https://github.com/microsoft/perfview/blob/main/src/TraceEvent/EventPipe/NetTraceFormat_v5.md#metadata-event-encoding.

For User_events EventPipe scenarios, the metadata will be inlined with the event, so there is no need for a MetadataID, and thus we will only prepend the ProviderName to avoid having to encode an unused uint32_t.

### Testing

```
# tracer: nop
#
# entries-in-buffer/entries-written: 34/34   #P:2
#
#                                _-----=> irqs-off/BH-disabled
#                               / _----=> need-resched
#                              | / _---=> hardirq/softirq
#                              || / _--=> preempt-depth
#                              ||| / _-=> migrate-disable
#                              |||| /     delay
#           TASK-PID     CPU#  |||||  TIMESTAMP  FUNCTION
#              | |         |   |||||     |         |
  .NET TP Worker-48238   [001] ..... 16214.532937: mihw: version=(1) event_id=0x50 (80) extension=01,5a,00,00,00,4d,00,69,00,63,00,72,00,6f,00,73,00,6f,00,66,00,74,00,2d,00,57,00,69,00,6e,00,64,00,6f,00,77,00,73,00,2d,00,44,00,6f,00,74,00,4e,00,45,00,54,00,52,00,75,00,6e,00,74,00,69,00,6d,00,65,00,00,00,50,00,00,00,00,00,00,80,00,00,02,00,00,00,01,00,00,00,02,00,00,00,00,00,00,00 payload=53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,45,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,00,00,54,00,68,00,69,00,73,00,20,00,69,00,73,00,20,00,61,00,20,00,74,00,65,00,73,00,74,00,20,00,65,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,20,00,74,00,6f,00,20,00,64,00,65,00,6d,00,6f,00,6e,00,73,00,74,00,72,00,61,00,74,00,65,00,20,00,65,00,72,00,72,00,6f,00,72,00,20,00,68,00,61,00,6e,00,64,00,6c,00,69,00,6e,00,67,00,2e,00,00,00,00,00,00,00,00,00,00,00,00,15,13,80,10,00,00,00
  .NET TP Worker-48146   [000] ..... 16214.834897: mihw: version=(1) event_id=0x50 (80) extension= payload=53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,45,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,00,00,54,00,68,00,69,00,73,00,20,00,69,00,73,00,20,00,61,00,20,00,74,00,65,00,73,00,74,00,20,00,65,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,20,00,74,00,6f,00,20,00,64,00,65,00,6d,00,6f,00,6e,00,73,00,74,00,72,00,61,00,74,00,65,00,20,00,65,00,72,00,72,00,6f,00,72,00,20,00,68,00,61,00,6e,00,64,00,6c,00,69,00,6e,00,67,00,2e,00,00,00,00,00,00,00,00,00,00,00,00,15,13,80,10,00,00,00
  .NET TP Worker-48146   [000] ..... 16215.139393: mihw: version=(1) event_id=0x50 (80) extension= payload=53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,45,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,00,00,54,00,68,00,69,00,73,00,20,00,69,00,73,00,20,00,61,00,20,00,74,00,65,00,73,00,74,00,20,00,65,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,20,00,74,00,6f,00,20,00,64,00,65,00,6d,00,6f,00,6e,00,73,00,74,00,72,00,61,00,74,00,65,00,20,00,65,00,72,00,72,00,6f,00,72,00,20,00,68,00,61,00,6e,00,64,00,6c,00,69,00,6e,00,67,00,2e,00,00,00,00,00,00,00,00,00,00,00,00,15,13,80,10,00,00,00
  .NET TP Worker-48146   [000] ..... 16215.441248: mihw: version=(1) event_id=0x50 (80) extension= payload=53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,45,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,00,00,54,00,68,00,69,00,73,00,20,00,69,00,73,00,20,00,61,00,20,00,74,00,65,00,73,00,74,00,20,00,65,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,20,00,74,00,6f,00,20,00,64,00,65,00,6d,00,6f,00,6e,00,73,00,74,00,72,00,61,00,74,00,65,00,20,00,65,00,72,00,72,00,6f,00,72,00,20,00,68,00,61,00,6e,00,64,00,6c,00,69,00,6e,00,67,00,2e,00,00,00,00,00,00,00,00,00,00,00,00,15,13,80,10,00,00,00
  .NET TP Worker-48238   [000] ..... 16215.743354: mihw: version=(1) event_id=0x50 (80) extension= payload=53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,45,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,00,00,54,00,68,00,69,00,73,00,20,00,69,00,73,00,20,00,61,00,20,00,74,00,65,00,73,00,74,00,20,00,65,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,20,00,74,00,6f,00,20,00,64,00,65,00,6d,00,6f,00,6e,00,73,00,74,00,72,00,61,00,74,00,65,00,20,00,65,00,72,00,72,00,6f,00,72,00,20,00,68,00,61,00,6e,00,64,00,6c,00,69,00,6e,00,67,00,2e,00,00,00,00,00,00,00,00,00,00,00,00,15,13,80,10,00,00,00
  .NET TP Worker-48238   [000] ..... 16216.047708: mihw: version=(1) event_id=0x50 (80) extension= payload=53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,45,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,00,00,54,00,68,00,69,00,73,00,20,00,69,00,73,00,20,00,61,00,20,00,74,00,65,00,73,00,74,00,20,00,65,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,20,00,74,00,6f,00,20,00,64,00,65,00,6d,00,6f,00,6e,00,73,00,74,00,72,00,61,00,74,00,65,00,20,00,65,00,72,00,72,00,6f,00,72,00,20,00,68,00,61,00,6e,00,64,00,6c,00,69,00,6e,00,67,00,2e,00,00,00,00,00,00,00,00,00,00,00,00,15,13,80,10,00,00,00
  .NET TP Worker-48238   [000] ..... 16216.350802: mihw: version=(1) event_id=0x50 (80) extension= payload=53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,45,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,00,00,54,00,68,00,69,00,73,00,20,00,69,00,73,00,20,00,61,00,20,00,74,00,65,00,73,00,74,00,20,00,65,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,20,00,74,00,6f,00,20,00,64,00,65,00,6d,00,6f,00,6e,00,73,00,74,00,72,00,61,00,74,00,65,00,20,00,65,00,72,00,72,00,6f,00,72,00,20,00,68,00,61,00,6e,00,64,00,6c,00,69,00,6e,00,67,00,2e,00,00,00,00,00,00,00,00,00,00,00,00,15,13,80,10,00,00,00
  .NET TP Worker-48146   [001] ..... 16216.652679: mihw: version=(1) event_id=0x50 (80) extension= payload=53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,45,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,00,00,54,00,68,00,69,00,73,00,20,00,69,00,73,00,20,00,61,00,20,00,74,00,65,00,73,00,74,00,20,00,65,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,20,00,74,00,6f,00,20,00,64,00,65,00,6d,00,6f,00,6e,00,73,00,74,00,72,00,61,00,74,00,65,00,20,00,65,00,72,00,72,00,6f,00,72,00,20,00,68,00,61,00,6e,00,64,00,6c,00,69,00,6e,00,67,00,2e,00,00,00,00,00,00,00,00,00,00,00,00,15,13,80,10,00,00,00
  .NET TP Worker-48146   [000] ..... 16216.958208: whim: version=(1) event_id=0x12f (303) extension=01,5a,00,00,00,4d,00,69,00,63,00,72,00,6f,00,73,00,6f,00,66,00,74,00,2d,00,57,00,69,00,6e,00,64,00,6f,00,77,00,73,00,2d,00,44,00,6f,00,74,00,4e,00,45,00,54,00,52,00,75,00,6e,00,74,00,69,00,6d,00,65,00,00,00,2f,01,00,00,00,00,00,00,00,00,00,08,00,00,00,00,00,00,04,00,00,00,00,00,00,00 payload=01,00,00,00,00,00,f8,20,4f,79,ff,7f,00,00,53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,42,00,79,00,74,00,65,00,5b,00,5d,00,00,00,48,00,c0,62,bf,7f,00,00,18,00,10,00,00,00,00,00,d8,ca,00,00,00,00,00,00
  .NET TP Worker-48146   [000] ..... 16216.958341: mihw: version=(1) event_id=0x50 (80) extension= payload=53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,45,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,00,00,54,00,68,00,69,00,73,00,20,00,69,00,73,00,20,00,61,00,20,00,74,00,65,00,73,00,74,00,20,00,65,00,78,00,63,00,65,00,70,00,74,00,69,00,6f,00,6e,00,20,00,74,00,6f,00,20,00,64,00,65,00,6d,00,6f,00,6e,00,73,00,74,00,72,00,61,00,74,00,65,00,20,00,65,00,72,00,72,00,6f,00,72,00,20,00,68,00,61,00,6e,00,64,00,6c,00,69,00,6e,00,67,00,2e,00,00,00,00,00,00,00,00,00,00,00,00,15,13,80,10,00,00,00
  .NET TP Worker-48238   [000] ..... 16217.259988: whim: version=(1) event_id=0x12f (303) extension= payload=01,00,00,00,00,00,f8,20,4f,79,ff,7f,00,00,53,00,79,00,73,00,74,00,65,00,6d,00,2e,00,42,00,79,00,74,00,65,00,5b,00,5d,00,00,00,80,00,d0,62,bf,7f,00,00,18,00,10,00,00,00,00,00,b6,1a,00,00,00,00,00,00
```