### PR TITLE
Remove redundant write-barriers for stack-allocated arrays

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5114,6 +5114,7 @@ static GCInfo::WriteBarrierForm GetWriteBarrierForm(Compiler* comp, ValueNum vn)
         return GCInfo::WriteBarrierForm::WBF_BarrierUnchecked;
     }
 
+    VNFuncApp funcApp;
     if (vnStore->GetVNFunc(vnStore->VNNormalValue(vn), &funcApp))
     {
         if ((funcApp.m_func == VNF_JitNewLclArr) || (funcApp.m_func == VNF_JitReadyToRunNewLclArr))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5114,8 +5114,14 @@ static GCInfo::WriteBarrierForm GetWriteBarrierForm(Compiler* comp, ValueNum vn)
         return GCInfo::WriteBarrierForm::WBF_BarrierUnchecked;
     }
 
+    if ((type != TYP_I_IMPL) && (type != TYP_BYREF))
+    {
+        return GCInfo::WriteBarrierForm::WBF_BarrierUnknown;
+    }
+
     target_ssize_t offset;
     vnStore->PeelOffsets(&vn, &offset);
+    // Ignore the accumulated offset, it can't convert heap pointer to non-heap or vice versa anyway (it's UB).
 
     VNFuncApp funcApp;
     if (vnStore->GetVNFunc(vnStore->VNNormalValue(vn), &funcApp))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5114,26 +5114,14 @@ static GCInfo::WriteBarrierForm GetWriteBarrierForm(Compiler* comp, ValueNum vn)
         return GCInfo::WriteBarrierForm::WBF_BarrierUnchecked;
     }
 
-    if (type != TYP_BYREF)
-    {
-        VNFuncApp funcApp;
-        if (vnStore->GetVNFunc(vnStore->VNNormalValue(vn), &funcApp))
-        {
-            // Check for known stack allocation functions
-            if ((funcApp.m_func == VNF_JitNewLclArr) || (funcApp.m_func == VNF_JitReadyToRunNewLclArr))
-            {
-                // NOTE: this relies on fgExpandStackArrayAllocations phase to always expand these allocators
-                // TODO: add some debug checks for that.
-                return GCInfo::WriteBarrierForm::WBF_NoBarrier;
-            }
-        }
-
-        return GCInfo::WriteBarrierForm::WBF_BarrierUnknown;
-    }
-
-    VNFuncApp funcApp;
     if (vnStore->GetVNFunc(vnStore->VNNormalValue(vn), &funcApp))
     {
+        if ((funcApp.m_func == VNF_JitNewLclArr) || (funcApp.m_func == VNF_JitReadyToRunNewLclArr))
+        {
+            // NOTE: this relies on fgExpandStackArrayAllocations phase to always expand these allocators
+            // TODO: add some debug checks for that.
+            return GCInfo::WriteBarrierForm::WBF_NoBarrier;
+        }
         if (funcApp.m_func == VNF_PtrToArrElem)
         {
             // Check whether the array is on the heap

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5113,8 +5113,19 @@ static GCInfo::WriteBarrierForm GetWriteBarrierForm(Compiler* comp, ValueNum vn)
     {
         return GCInfo::WriteBarrierForm::WBF_BarrierUnchecked;
     }
+
     if (type != TYP_BYREF)
     {
+        VNFuncApp funcApp;
+        if (vnStore->GetVNFunc(vnStore->VNNormalValue(vn), &funcApp))
+        {
+            // Check for known stack allocation functions
+            if ((funcApp.m_func == VNF_JitNewLclArr) || (funcApp.m_func == VNF_JitReadyToRunNewLclArr))
+            {
+                return GCInfo::WriteBarrierForm::WBF_NoBarrier;
+            }
+        }
+
         return GCInfo::WriteBarrierForm::WBF_BarrierUnknown;
     }
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5122,6 +5122,8 @@ static GCInfo::WriteBarrierForm GetWriteBarrierForm(Compiler* comp, ValueNum vn)
             // Check for known stack allocation functions
             if ((funcApp.m_func == VNF_JitNewLclArr) || (funcApp.m_func == VNF_JitReadyToRunNewLclArr))
             {
+                // NOTE: this relies on fgExpandStackArrayAllocations phase to always expand these allocators
+                // TODO: add some debug checks for that.
                 return GCInfo::WriteBarrierForm::WBF_NoBarrier;
             }
         }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5147,6 +5147,7 @@ static GCInfo::WriteBarrierForm GetWriteBarrierForm(Compiler* comp, ValueNum vn)
                     // Boxed static - always on the heap
                     return GCInfo::WriteBarrierForm::WBF_BarrierUnchecked;
                 }
+                break;
 
             default:
                 break;


### PR DESCRIPTION
Just a small CQ issue I noticed while was checking codegen in https://github.com/dotnet/runtime/pull/118288

```cs
object A;
object B;
object C;
object D;

[MethodImpl(MethodImplOptions.NoInlining)]
private void Test()
{
    object[] roots = new object[] {
        A,B,C,D
    };

    foreach (object key in roots)
        Console.WriteLine(key);
}
```
Was:
```asm
; Method Program:Test():this (FullOpts)
       push     rsi
       push     rbx
       sub      rsp, 88
       xor      eax, eax
       mov      qword ptr [rsp+0x28], rax
       vxorps   xmm4, xmm4, xmm4
       vmovdqu  ymmword ptr [rsp+0x30], ymm4
       mov      qword ptr [rsp+0x50], rax
       mov      rbx, rcx
       mov      rcx, 0x7FFA4D76E6F8      ; System.Object[]
       mov      qword ptr [rsp+0x28], rcx
       lea      rcx, [rsp+0x28]
       mov      dword ptr [rcx+0x08], 4
       lea      rsi, [rsp+0x28]
       mov      rdx, gword ptr [rbx+0x08]
       lea      rcx, [rsi+0x10]
       call     CORINFO_HELP_CHECKED_ASSIGN_REF
       mov      rdx, gword ptr [rbx+0x10]
       lea      rcx, [rsi+0x18]
       call     CORINFO_HELP_CHECKED_ASSIGN_REF
       mov      rdx, gword ptr [rbx+0x18]
       lea      rcx, [rsi+0x20]
       call     CORINFO_HELP_CHECKED_ASSIGN_REF
       mov      rdx, gword ptr [rbx+0x20]
       lea      rcx, [rsi+0x28]
       call     CORINFO_HELP_CHECKED_ASSIGN_REF
       add      rsi, 16
       mov      ebx, 4
G_M36831_IG03:
       mov      rcx, gword ptr [rsi]
       call     [System.Console:WriteLine(System.Object)]
       add      rsi, 8
       dec      ebx
       jne      SHORT G_M36831_IG03
       add      rsp, 88
       pop      rbx
       pop      rsi
       ret      
; Total bytes of code: 148
```
Now:
```asm
; Method Program:Test():this (FullOpts)
       push     rsi
       push     rbx
       sub      rsp, 88
       xor      eax, eax
       mov      qword ptr [rsp+0x28], rax
       vxorps   xmm4, xmm4, xmm4
       vmovdqu  ymmword ptr [rsp+0x30], ymm4
       mov      qword ptr [rsp+0x50], rax
       mov      rax, 0x7FFA4B2CE6F8      ; System.Object[]
       mov      qword ptr [rsp+0x28], rax
       lea      rax, [rsp+0x28]
       mov      dword ptr [rax+0x08], 4
       lea      rbx, [rsp+0x28]
       mov      rax, gword ptr [rcx+0x08]
       mov      gword ptr [rbx+0x10], rax
       mov      rax, gword ptr [rcx+0x10]
       mov      gword ptr [rbx+0x18], rax
       mov      rax, gword ptr [rcx+0x18]
       mov      gword ptr [rbx+0x20], rax
       mov      rcx, gword ptr [rcx+0x20]
       mov      gword ptr [rbx+0x28], rcx
       add      rbx, 16
       mov      esi, 4
G_M36831_IG03:  ;; offset=0x0065
       mov      rcx, gword ptr [rbx]
       call     [System.Console:WriteLine(System.Object)]
       add      rbx, 8
       dec      esi
       jne      SHORT G_M36831_IG03
       add      rsp, 88
       pop      rbx
       pop      rsi
       ret      
; Total bytes of code: 125
```
