### PR TITLE
Update host to use the optional localPath property when resolving assets

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionCommandResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionCommandResultExtensions.cs
@@ -12,8 +12,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
     public static class DependencyResolutionCommandResultExtensions
     {
         // App asset resolution extensions
-        public const string TRUSTED_PLATFORM_ASSEMBLIES = "TRUSTED_PLATFORM_ASSEMBLIES";
-        public const string NATIVE_DLL_SEARCH_DIRECTORIES = "NATIVE_DLL_SEARCH_DIRECTORIES";
+        private const string TRUSTED_PLATFORM_ASSEMBLIES = nameof(TRUSTED_PLATFORM_ASSEMBLIES);
+        private const string NATIVE_DLL_SEARCH_DIRECTORIES = nameof(NATIVE_DLL_SEARCH_DIRECTORIES);
+        private const string PLATFORM_RESOURCE_ROOTS = nameof(PLATFORM_RESOURCE_ROOTS);
 
         public static AndConstraint<CommandResultAssertions> HaveRuntimePropertyContaining(this CommandResultAssertions assertion, string propertyName, params string[] values)
         {
@@ -65,6 +66,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         public static AndConstraint<CommandResultAssertions> NotHaveResolvedNativeLibraryPath(this CommandResultAssertions assertion, string path, TestApp app = null)
         {
             return assertion.NotHaveRuntimePropertyContaining(NATIVE_DLL_SEARCH_DIRECTORIES, RelativePathsToAbsoluteAppPaths(path, app));
+        }
+
+        public static AndConstraint<CommandResultAssertions> HaveResolvedResourceRootPath(this CommandResultAssertions assertion, string path, TestApp app = null)
+        {
+            return assertion.HaveRuntimePropertyContaining(PLATFORM_RESOURCE_ROOTS, RelativePathsToAbsoluteAppPaths(path, app));
+        }
+
+        public static AndConstraint<CommandResultAssertions> NotHaveResolvedResourceRootPath(this CommandResultAssertions assertion, string path, TestApp app = null)
+        {
+            return assertion.NotHaveRuntimePropertyContaining(PLATFORM_RESOURCE_ROOTS, RelativePathsToAbsoluteAppPaths(path, app));
         }
 
         // Component asset resolution extensions

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/LocalPath.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/LocalPath.cs
@@ -1,0 +1,265 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.Cli.Build;
+using Xunit;
+using static Microsoft.DotNet.CoreSetup.Test.NetCoreAppBuilder;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
+{
+    public class LocalPath : IClassFixture<LocalPath.SharedTestState>
+    {
+        private readonly SharedTestState sharedState;
+
+        public LocalPath(SharedTestState sharedState)
+        {
+            this.sharedState = sharedState;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RuntimeAssemblies_FrameworkDependent(bool useLocalPath) => RuntimeAssemblies(isSelfContained: false, useLocalPath);
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RuntimeAssemblies_SelfContained(bool useLocalPath) => RuntimeAssemblies(isSelfContained: true, useLocalPath);
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NativeLibraries_FrameworkDependent(bool useLocalPath) => NativeLibraries(isSelfContained: false, useLocalPath);
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NativeLibraries_SelfContained(bool useLocalPath) => NativeLibraries(isSelfContained: true, useLocalPath);
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ResourceAssemblies_FrameworkDependent(bool useLocalPath) => ResourceAssemblies(isSelfContained: false, useLocalPath);
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ResourceAssemblies_SelfContained(bool useLocalPath) => ResourceAssemblies(isSelfContained: true, useLocalPath);
+
+        private void RuntimeAssemblies(bool isSelfContained, bool useLocalPath)
+        {
+            RuntimeLibraryType[] libraryTypes = [ RuntimeLibraryType.project, RuntimeLibraryType.package, RuntimeLibraryType.runtimepack ];
+
+            Action<NetCoreAppBuilder> customizer = b =>
+            {
+                foreach (var libraryType in libraryTypes)
+                {
+                    string library = $"Test{libraryType}";
+                    (string path, string localPath) = GetPaths(libraryType, false);
+                    b.WithRuntimeLibrary(libraryType, library, "1.0.0", p => p
+                        .WithAssemblyGroup(null, g => g
+                            .WithAsset(path, useLocalPath ? f => f.WithLocalPath(localPath) : null)));
+
+                    if (!isSelfContained)
+                    {
+                        // Add RID-specific assembly
+                        (string ridPath, string localRidPath) = GetPaths(libraryType, true);
+                        b.WithRuntimeLibrary(libraryType, $"{library}-{TestContext.BuildRID}", "1.0.0", p => p
+                            .WithAssemblyGroup(TestContext.BuildRID, g => g
+                                .WithAsset(ridPath, useLocalPath ? f => f.WithLocalPath(localRidPath) : null)));
+                    }
+                }
+
+                b.WithLocalPathsInDepsJson(useLocalPath);
+            };
+
+            using TestApp app = CreateApp(isSelfContained, customizer);
+            var result = sharedState.DotNetWithNetCoreApp.Exec(app.AppDll)
+                .EnableTracingAndCaptureOutputs()
+                .Execute();
+            result.Should().Pass();
+
+            // Check all library types
+            foreach (var libraryType in libraryTypes)
+            {
+                // Check RID-agnostic assembly
+                (string path, string localPath) = GetPaths(libraryType, false);
+
+                // Without localPath, RID-agnostic non-runtimepack runtime assemblies are assumed to be in <app_directory>
+                string relativePath = useLocalPath
+                    ? localPath
+                    : libraryType == RuntimeLibraryType.runtimepack ? path : Path.GetFileName(path);
+                string expectedPath = Path.Join(app.Location, relativePath);
+                result.Should().HaveResolvedAssembly(expectedPath);
+                if (useLocalPath)
+                {
+                    result.Should().NotHaveResolvedAssembly(Path.Join(app.Location, path));
+                }
+
+                // Check RID-specific assembly
+                if (!isSelfContained)
+                {
+                    (string ridPath, string localRidPath) = GetPaths(libraryType, true);
+                    string expectedRidPath = Path.Join(app.Location, useLocalPath ? localRidPath : ridPath);
+                    result.Should().HaveResolvedAssembly(expectedRidPath);
+                    if (useLocalPath)
+                    {
+                        result.Should().NotHaveResolvedAssembly(Path.Join(app.Location, ridPath));
+                    }
+                }
+            }
+
+            static (string Path, string LocalPath) GetPaths(RuntimeLibraryType libraryType, bool useRid)
+            {
+                string library = $"Test{libraryType}";
+                string path = useRid ? $"lib/{TestContext.BuildRID}/{library}-{TestContext.BuildRID}.dll" : $"lib/{library}.dll";
+                return (path, $"{libraryType}/{path}");
+            }
+        }
+
+        private void NativeLibraries(bool isSelfContained, bool useLocalPath)
+        {
+            NetCoreAppBuilder.RuntimeLibraryType[] libraryTypes = [NetCoreAppBuilder.RuntimeLibraryType.project, NetCoreAppBuilder.RuntimeLibraryType.package, NetCoreAppBuilder.RuntimeLibraryType.runtimepack];
+
+            Action<NetCoreAppBuilder> customizer = b =>
+            {
+                foreach (var libraryType in libraryTypes)
+                {
+                    string library = $"Test{libraryType}";
+                    (string path, string localPath) = GetPaths(libraryType, false);
+                    b.WithRuntimeLibrary(libraryType, library, "1.0.0", p => p
+                        .WithNativeLibraryGroup(null, g => g
+                            .WithAsset($"{path}/{library}.native", useLocalPath ? f => f.WithLocalPath($"{localPath}/{library}.native") : null)));
+
+                    if (!isSelfContained)
+                    {
+                        // Add RID-specific native library
+                        (string ridPath, string localRidPath) = GetPaths(libraryType, true);
+                        b.WithRuntimeLibrary(libraryType, $"{library}-{TestContext.BuildRID}", "1.0.0", p => p
+                            .WithNativeLibraryGroup(TestContext.BuildRID, g => g
+                                .WithAsset($"{ridPath}/{library}-{TestContext.BuildRID}.native", useLocalPath ? f => f.WithLocalPath($"{localRidPath}/{library}-{TestContext.BuildRID}.native") : null)));
+                    }
+                }
+
+                b.WithLocalPathsInDepsJson(useLocalPath);
+            };
+
+            using TestApp app = CreateApp(isSelfContained, customizer);
+            var result = sharedState.DotNetWithNetCoreApp.Exec(app.AppDll)
+                .EnableTracingAndCaptureOutputs()
+                .Execute();
+            result.Should().Pass();
+
+            // Check all library types
+            foreach (NetCoreAppBuilder.RuntimeLibraryType libraryType in libraryTypes)
+            {
+                // Check RID-agnostic native library path
+                (string path, string localPath) = GetPaths(libraryType, false);
+
+                // Without localPath, RID-agnostic non-runtimepack native libraries are assumed to be in <app_directory>
+                string relativePath = useLocalPath
+                    ? localPath
+                    : libraryType == RuntimeLibraryType.runtimepack ? path : string.Empty;
+                string expectedPath = Path.Join(app.Location, relativePath);
+                result.Should().HaveResolvedNativeLibraryPath(expectedPath);
+                if (useLocalPath)
+                {
+                    result.Should().NotHaveResolvedNativeLibraryPath(Path.Join(app.Location, path));
+                }
+
+                // Check RID-specific native library path
+                if (!isSelfContained)
+                {
+                    (string ridPath, string localRidPath) = GetPaths(libraryType, true);
+                    string expectedRidPath = Path.Join(app.Location, useLocalPath ? localRidPath : ridPath);
+                    result.Should().HaveResolvedNativeLibraryPath(expectedRidPath);
+                    if (useLocalPath)
+                    {
+                        result.Should().NotHaveResolvedNativeLibraryPath(Path.Join(app.Location, ridPath));
+                    }
+                }
+            }
+
+            static (string Path, string LocalPath) GetPaths(NetCoreAppBuilder.RuntimeLibraryType libraryType, bool useRid)
+            {
+                string path = useRid ? $"native/{TestContext.BuildRID}" : "native";
+                return (path, $"{libraryType}/{path}");
+            }
+        }
+
+        private void ResourceAssemblies(bool isSelfContained, bool useLocalPath)
+        {
+            NetCoreAppBuilder.RuntimeLibraryType[] libraryTypes = [NetCoreAppBuilder.RuntimeLibraryType.project, NetCoreAppBuilder.RuntimeLibraryType.package, NetCoreAppBuilder.RuntimeLibraryType.runtimepack];
+
+            Action<NetCoreAppBuilder> customizer = b =>
+            {
+                foreach (var libraryType in libraryTypes)
+                {
+                    string library = $"Test{libraryType}";
+                    (string path, string localPath) = GetPaths(libraryType);
+                    b.WithRuntimeLibrary(libraryType, library, "1.0.0", p => p
+                        .WithResourceAssembly($"{path}/fr/{library}.resources.dll", useLocalPath ? f => f.WithLocalPath($"{localPath}/fr/{library}.resources.dll") : null));
+                }
+
+                b.WithLocalPathsInDepsJson(useLocalPath);
+            };
+
+            using TestApp app = CreateApp(isSelfContained, customizer);
+            var result = sharedState.DotNetWithNetCoreApp.Exec(app.AppDll)
+                .EnableTracingAndCaptureOutputs()
+                .Execute();
+            result.Should().Pass();
+
+            // Check all library types
+            foreach (var libraryType in libraryTypes)
+            {
+                (string path, string localPath) = GetPaths(libraryType);
+
+                // Without localPath, non-runtimepack resource assemblies are assumed to be in <app_directory>/<locale>/
+                string relativePath = useLocalPath
+                    ? localPath
+                    : libraryType == RuntimeLibraryType.runtimepack ? path : string.Empty;
+                string expectedPath = Path.Join(app.Location, relativePath);
+                result.Should().HaveResolvedResourceRootPath(expectedPath);
+                if (useLocalPath)
+                {
+                    result.Should().NotHaveResolvedResourceRootPath(Path.Join(app.Location, path));
+                }
+            }
+
+            static (string Path, string LocalPath) GetPaths(NetCoreAppBuilder.RuntimeLibraryType libraryType)
+            {
+                string path = $"resources";
+                return (path, $"{libraryType}/{path}");
+            }
+        }
+
+        private static TestApp CreateApp(bool isSelfContained, Action<NetCoreAppBuilder> customizer)
+        {
+            TestApp app = TestApp.CreateEmpty("App");
+            if (isSelfContained)
+            {
+                app.PopulateSelfContained(TestApp.MockedComponent.CoreClr, customizer);
+            }
+            else
+            {
+                app.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion, customizer);
+            }
+            return app;
+        }
+
+        public class SharedTestState : SharedTestStateBase
+        {
+            public DotNetCli DotNetWithNetCoreApp { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithNetCoreApp = DotNet("WithNetCoreApp")
+                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(TestContext.MicrosoftNETCoreAppVersion)
+                    .Build();
+            }
+        }
+    }
+}

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
@@ -458,7 +458,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                     .WithPackage(AdditionalDependencyName, "2.0.1", p => p.WithAssemblyGroup(null, g => g
                         .WithAsset($"lib/netstandard1.0/{AdditionalDependencyName}.dll", f => f
                             .WithVersion("2.0.0.0", "2.0.1.23344")
-                            .WithFileOnDiskPath($"{AdditionalDependencyName}.dll"))))
+                            .WithLocalPath($"{AdditionalDependencyName}.dll"))))
                     .WithPackage("Libuv", "1.9.1", p => p
                         .WithNativeLibraryGroup("debian-x64", g => g.WithAsset("runtimes/debian-x64/native/libuv.so"))
                         .WithNativeLibraryGroup("fedora-x64", g => g.WithAsset("runtimes/fedora-x64/native/libuv.so"))

--- a/src/installer/tests/HostActivation.Tests/SelfContainedAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/SelfContainedAppLaunch.cs
@@ -3,12 +3,15 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
 using Microsoft.NET.HostModel.AppHost;
 using Xunit;
+using static Microsoft.DotNet.CoreSetup.Test.NetCoreAppBuilder;
+using static Microsoft.NET.HostModel.AppHost.HostWriter;
 
 namespace HostActivation.Tests
 {
@@ -178,6 +181,51 @@ namespace HostActivation.Tests
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
                 .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
+        }
+
+        [Fact]
+        public void CustomRuntimeLocation()
+        {
+            string subdirectory = "runtime-directory";
+            Action<NetCoreAppBuilder> customizer = b =>
+            {
+                // Find the NETCoreApp runtime pack
+                RuntimeLibraryBuilder netCoreApp = b.RuntimeLibraries.First(
+                    r => r.Type == RuntimeLibraryType.runtimepack.ToString() && r.Name == $"runtimepack.{Constants.MicrosoftNETCoreApp}.Runtime.{TestContext.BuildRID}");
+
+                // Update all NETCoreApp asset paths to point to the subdirectory
+                RuntimeAssetGroupBuilder[] groups = [.. netCoreApp.AssemblyGroups, .. netCoreApp.NativeLibraryGroups];
+                foreach (RuntimeAssetGroupBuilder group in groups)
+                {
+                    foreach (RuntimeFileBuilder asset in group.Assets)
+                    {
+                        asset.Path = Path.Join(subdirectory, asset.Path);
+                    }
+                }
+
+                foreach (ResourceAssemblyBuilder resource in netCoreApp.ResourceAssemblies)
+                {
+                    resource.Path = Path.Join(subdirectory, resource.Path);
+                }
+            };
+
+            using TestApp app = TestApp.CreateFromBuiltAssets("HelloWorld");
+            app.PopulateSelfContained(TestApp.MockedComponent.None, customizer);
+            app.CreateAppHost(dotNetRootOptions: new()
+            {
+                Location = DotNetSearchOptions.SearchLocation.AppRelative,
+                AppRelativeDotNet = subdirectory
+            });
+
+            // Apphost should be able to find hostfxr based on the .NET search options
+            // Runtime files should be resolved based on relative path in .deps.json
+            Command.Create(app.AppExe)
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World")
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion)
+                .And.HaveStdErrContaining($"CoreCLR path = '{Path.Join(app.Location, subdirectory, Binaries.CoreClr.FileName)}'");
         }
 
         public class SharedTestState : IDisposable

--- a/src/installer/tests/TestUtils/DotNetBuilder.cs
+++ b/src/installer/tests/TestUtils/DotNetBuilder.cs
@@ -140,13 +140,13 @@ namespace Microsoft.DotNet.CoreSetup.Test
                         // ./shared/Microsoft.NETCore.App/<version>/coreclr.dll - this is a mock, will not actually run CoreClr
                         .WithAsset((new NetCoreAppBuilder.RuntimeFileBuilder($"runtimes/{currentRid}/native/{Binaries.CoreClr.FileName}"))
                             .CopyFromFile(Binaries.CoreClr.MockPath)
-                            .WithFileOnDiskPath(Binaries.CoreClr.FileName))))
+                            .WithLocalPath(Binaries.CoreClr.FileName))))
                 .WithPackage($"runtime.{currentRid}.Microsoft.NETCore.DotNetHostPolicy", version, p => p
                     .WithNativeLibraryGroup(null, g => g
                         // ./shared/Microsoft.NETCore.App/<version>/hostpolicy.dll - this is the real component and will load CoreClr library
                         .WithAsset((new NetCoreAppBuilder.RuntimeFileBuilder($"runtimes/{currentRid}/native/{Binaries.HostPolicy.FileName}"))
                             .CopyFromFile(Binaries.HostPolicy.FilePath)
-                            .WithFileOnDiskPath(Binaries.HostPolicy.FileName))))
+                            .WithLocalPath(Binaries.HostPolicy.FileName))))
                 .WithCustomizer(customizer)
                 .Build(new TestApp(netCoreAppPath, "Microsoft.NETCore.App"));
 

--- a/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
+++ b/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
@@ -44,7 +44,7 @@ namespace
                 // Extract the version information that occurs after '/'
                 pal::string_t version = lib_name.substr(utils::strlen(prefix));
                 trace::verbose(_X("Resolved version %s from dependency manifest file [%s]"), version.c_str(), deps_json.c_str());
-                break;
+                return version;
             }
         }
 

--- a/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
+++ b/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
@@ -27,11 +27,10 @@ namespace
     {
         trace::verbose(_X("--- Resolving %s version from deps json [%s]"), LIBHOSTPOLICY_NAME, deps_json.c_str());
 
-        pal::string_t retval;
         json_parser_t json;
         if (!json.parse_file(deps_json))
         {
-            return retval;
+            return {};
         }
 
         // Look up the root package instead of the "runtime" package because we can't do a full rid resolution.
@@ -43,13 +42,13 @@ namespace
             if (utils::starts_with(lib_name, prefix, false))
             {
                 // Extract the version information that occurs after '/'
-                retval = lib_name.substr(utils::strlen(prefix));
+                pal::string_t version = lib_name.substr(utils::strlen(prefix));
+                trace::verbose(_X("Resolved version %s from dependency manifest file [%s]"), version.c_str(), deps_json.c_str());
                 break;
             }
         }
 
-        trace::verbose(_X("Resolved version %s from dependency manifest file [%s]"), retval.c_str(), deps_json.c_str());
-        return retval;
+        return {};
     }
 
     /**

--- a/src/native/corehost/hostpolicy/deps_entry.cpp
+++ b/src/native/corehost/hostpolicy/deps_entry.cpp
@@ -29,7 +29,7 @@ static pal::string_t normalize_dir_separator(const pal::string_t& path)
 //
 // Parameters:
 //    base - The base directory to look for the relative path of this entry
-//    ietf_dir - If this is a resource asset, the IETF intermediate directory
+//    relative_path - Relative path of to look for this entry
 //    str  - (out parameter) If the method returns true, contains the file path for this deps entry
 //    search_options - Flags to instruct where to look for this deps entry
 //    found_in_bundle - (out parameter) True if the candidate is located within the single-file bundle.
@@ -38,7 +38,7 @@ static pal::string_t normalize_dir_separator(const pal::string_t& path)
 //    If the file exists in the path relative to the "base" directory within the
 //    single-file or on disk.
 
-bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_dir, pal::string_t* str, uint32_t search_options, bool &found_in_bundle) const
+bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& relative_path, pal::string_t* str, uint32_t search_options, bool &found_in_bundle) const
 {
     pal::string_t& candidate = *str;
 
@@ -51,17 +51,11 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
         return false;
     }
 
-    pal::string_t normalized_path = normalize_dir_separator(asset.relative_path);
-
     // Reserve space for the path below
-    candidate.reserve(base.length() + ietf_dir.length() + normalized_path.length() + 3);
+    candidate.reserve(base.length() + relative_path.length() + 2);
 
-    bool look_in_base = search_options & deps_entry_t::search_options::look_in_base;
     bool look_in_bundle = search_options & deps_entry_t::search_options::look_in_bundle;
     bool is_servicing = search_options & deps_entry_t::search_options::is_servicing;
-    pal::string_t file_path = look_in_base ? get_filename(normalized_path) : normalized_path;
-    pal::string_t sub_path = ietf_dir;
-    append_path(&sub_path, file_path.c_str());
 
     assert(!is_servicing || !look_in_bundle);
 
@@ -71,45 +65,44 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
 
         if (app->has_base(base))
         {
-            // If sub_path is found in the single-file bundle,
+            // If relative_path is found in the single-file bundle,
             // app::locate() will set candidate to the full-path to the assembly extracted out to disk.
             bool extracted_to_disk = false;
-            if (app->locate(sub_path, candidate, extracted_to_disk))
+            if (app->locate(relative_path, candidate, extracted_to_disk))
             {
                 found_in_bundle = !extracted_to_disk;
-                trace::verbose(_X("    %s found in bundle [%s] %s"), sub_path.c_str(), candidate.c_str(), extracted_to_disk ? _X("(extracted)") : _X(""));
+                trace::verbose(_X("    %s found in bundle [%s] %s"), relative_path.c_str(), candidate.c_str(), extracted_to_disk ? _X("(extracted)") : _X(""));
                 return true;
             }
             else
             {
-                trace::verbose(_X("    %s not found in bundle"), sub_path.c_str());
+                trace::verbose(_X("    %s not found in bundle"), relative_path.c_str());
             }
         }
         else
         {
             trace::verbose(_X("    %s not searched in bundle base path %s doesn't match bundle base %s."),
-                             sub_path.c_str(), base.c_str(), app->base_path().c_str());
+                             relative_path.c_str(), base.c_str(), app->base_path().c_str());
         }
     }
 
     candidate.assign(base);
-    append_path(&candidate, sub_path.c_str());
+    append_path(&candidate, relative_path.c_str());
 
-    const pal::char_t* query_type = look_in_base ? _X("Local") : _X("Relative");
     if (search_options & deps_entry_t::search_options::file_existence)
     {
         if (!pal::file_exists(candidate))
         {
-            trace::verbose(_X("    %s path query did not exist %s"), query_type, candidate.c_str());
+            trace::verbose(_X("    Does not exist: %s"), candidate.c_str());
             candidate.clear();
             return false;
         }
 
-        trace::verbose(_X("    %s path query exists %s"), query_type, candidate.c_str());
+        trace::verbose(_X("    Exists: %s"), candidate.c_str());
     }
     else
     {
-        trace::verbose(_X("    %s path query %s (skipped file existence check)"), query_type, candidate.c_str());
+        trace::verbose(_X("    Skipped file existence check: %s"), candidate.c_str());
     }
 
     // If a file is resolved to the servicing directory, mark it as disabled in the bundle.
@@ -123,9 +116,9 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
         assert(!app->has_base(base));
         assert(!found_in_bundle);
 
-        if (app->disable(sub_path))
+        if (app->disable(relative_path))
         {
-            trace::verbose(_X("    %s disabled in bundle because of servicing override %s"), sub_path.c_str(), candidate.c_str());
+            trace::verbose(_X("    %s disabled in bundle because of servicing override %s"), relative_path.c_str(), candidate.c_str());
         }
     }
 
@@ -139,37 +132,50 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& ietf_
 //    base - The base directory to look for the relative path of this entry
 //    str  - If the method returns true, contains the file path for this deps entry
 //    search_options - Flags to instruct where to look for this deps entry
-//    look_in_bundle - Whether to look within the single-file bundle
+//    found_in_bundle - Whether the asset was found in the single-file bundle
 //
 // Returns:
 //    If the file exists in the path relative to the "base" directory.
 //
 bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options, bool& found_in_bundle) const
 {
-    pal::string_t ietf_dir;
-
-    if (asset_type == asset_types::resources)
+    pal::string_t relative_path = normalize_dir_separator(asset.local_path);
+    if (relative_path.empty())
     {
-        pal::string_t pal_relative_path = normalize_dir_separator(asset.relative_path);
+        relative_path = normalize_dir_separator(asset.relative_path);
+        pal::string_t file_name = get_filename(relative_path);
 
-        // Resources are represented as "lib/<netstandrd_ver>/<ietf-code>/<ResourceAssemblyName.dll>" in the deps.json.
-        // The <ietf-code> is the "directory" in the pal_relative_path below, so extract it.
-        ietf_dir = get_directory(pal_relative_path);
+        // Compute the expected relative path for this asset.
+        //   resource: <ietf-code>/<asset_file_name>
+        //   runtime/native: <asset_file_name>
+        if (asset_type == asset_types::resources)
+        {
+            // Resources are represented as "lib/<netstandrd_ver>/<ietf-code>/<ResourceAssemblyName.dll>" in the deps.json.
+            // The <ietf-code> is the "directory" in the relative_path below, so extract it.
+            pal::string_t ietf_dir = get_directory(relative_path);
 
-        // get_directory returns with DIR_SEPARATOR appended that we need to remove.
-        remove_trailing_dir_separator(&ietf_dir);
+            // get_directory returns with DIR_SEPARATOR appended that we need to remove.
+            remove_trailing_dir_separator(&ietf_dir);
 
-        // Extract IETF code from "lib/<netstandrd_ver>/<ietf-code>"
-        ietf_dir = get_filename(ietf_dir);
+            // Extract IETF code from "lib/<netstandrd_ver>/<ietf-code>"
+            ietf_dir = get_filename(ietf_dir);
 
-        trace::verbose(_X("Detected a resource asset, will query dir/ietf-tag/resource base: %s ietf: %s asset: %s"),
-                        base.c_str(), ietf_dir.c_str(), asset.name.c_str());
+            trace::verbose(_X("  Detected a resource asset, will query <base>/<ietf>/<file_name> base: %s ietf: %s asset: %s"),
+                base.c_str(), ietf_dir.c_str(), asset.name.c_str());
+
+            relative_path = ietf_dir;
+            append_path(&relative_path, file_name.c_str());
+        }
+        else
+        {
+            relative_path = file_name;
+        }
+
+        trace::verbose(_X("  Computed relative path: %s"), relative_path.c_str());
     }
 
-
-    search_options |= deps_entry_t::search_options::look_in_base;
     search_options &= ~deps_entry_t::search_options::is_servicing;
-    return to_path(base, ietf_dir, str, search_options, found_in_bundle);
+    return to_path(base, relative_path, str, search_options, found_in_bundle);
 }
 
 // -----------------------------------------------------------------------------
@@ -184,11 +190,10 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, ui
 // Returns:
 //    If the file exists in the path relative to the "base" directory.
 //
-bool deps_entry_t::to_rel_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const
+bool deps_entry_t::to_package_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const
 {
     bool found_in_bundle;
-    search_options &= ~deps_entry_t::search_options::look_in_base;
-    bool result = to_path(base, _X(""), str, search_options, found_in_bundle);
+    bool result = to_path(base, normalize_dir_separator(asset.relative_path), str, search_options, found_in_bundle);
     assert(!found_in_bundle);
     return result;
 }
@@ -205,7 +210,7 @@ bool deps_entry_t::to_rel_path(const pal::string_t& base, pal::string_t* str, ui
 // Returns:
 //    If the file exists in the path relative to the "base" directory.
 //
-bool deps_entry_t::to_full_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const
+bool deps_entry_t::to_library_package_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const
 {
     str->clear();
 
@@ -228,5 +233,5 @@ bool deps_entry_t::to_full_path(const pal::string_t& base, pal::string_t* str, u
     }
 
     search_options &= ~deps_entry_t::search_options::look_in_bundle;
-    return to_rel_path(new_base, str, search_options);
+    return to_package_path(new_base, str, search_options);
 }

--- a/src/native/corehost/hostpolicy/deps_entry.cpp
+++ b/src/native/corehost/hostpolicy/deps_entry.cpp
@@ -52,7 +52,7 @@ bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& relat
     }
 
     // Reserve space for the path below
-    candidate.reserve(base.length() + relative_path.length() + 2);
+    candidate.reserve(base.length() + relative_path.length() + 2); // +2 for directory separator and null terminator
 
     bool look_in_bundle = search_options & deps_entry_t::search_options::look_in_bundle;
     bool is_servicing = search_options & deps_entry_t::search_options::is_servicing;
@@ -157,6 +157,7 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, ui
                 pal::string_t ietf_dir = get_directory(relative_path);
 
                 // get_directory returns with DIR_SEPARATOR appended that we need to remove.
+                assert(ietf_dir.back() == DIR_SEPARATOR);
                 remove_trailing_dir_separator(&ietf_dir);
 
                 // Extract IETF code from "lib/<netstandrd_ver>/<ietf-code>"
@@ -170,7 +171,7 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, ui
             }
             else
             {
-                relative_path = file_name;
+                relative_path = std::move(file_name);
             }
         }
 

--- a/src/native/corehost/hostpolicy/deps_entry.cpp
+++ b/src/native/corehost/hostpolicy/deps_entry.cpp
@@ -143,32 +143,35 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, ui
     if (relative_path.empty())
     {
         relative_path = normalize_dir_separator(asset.relative_path);
-        pal::string_t file_name = get_filename(relative_path);
-
-        // Compute the expected relative path for this asset.
-        //   resource: <ietf-code>/<asset_file_name>
-        //   runtime/native: <asset_file_name>
-        if (asset_type == asset_types::resources)
+        if (library_type != _X("runtimepack")) // runtimepack assets set the path to the local path
         {
-            // Resources are represented as "lib/<netstandrd_ver>/<ietf-code>/<ResourceAssemblyName.dll>" in the deps.json.
-            // The <ietf-code> is the "directory" in the relative_path below, so extract it.
-            pal::string_t ietf_dir = get_directory(relative_path);
+            pal::string_t file_name = get_filename(relative_path);
 
-            // get_directory returns with DIR_SEPARATOR appended that we need to remove.
-            remove_trailing_dir_separator(&ietf_dir);
+            // Compute the expected relative path for this asset.
+            //   resource: <ietf-code>/<asset_file_name>
+            //   runtime/native: <asset_file_name>
+            if (asset_type == asset_types::resources)
+            {
+                // Resources are represented as "lib/<netstandrd_ver>/<ietf-code>/<ResourceAssemblyName.dll>" in the deps.json.
+                // The <ietf-code> is the "directory" in the relative_path below, so extract it.
+                pal::string_t ietf_dir = get_directory(relative_path);
 
-            // Extract IETF code from "lib/<netstandrd_ver>/<ietf-code>"
-            ietf_dir = get_filename(ietf_dir);
+                // get_directory returns with DIR_SEPARATOR appended that we need to remove.
+                remove_trailing_dir_separator(&ietf_dir);
 
-            trace::verbose(_X("  Detected a resource asset, will query <base>/<ietf>/<file_name> base: %s ietf: %s asset: %s"),
-                base.c_str(), ietf_dir.c_str(), asset.name.c_str());
+                // Extract IETF code from "lib/<netstandrd_ver>/<ietf-code>"
+                ietf_dir = get_filename(ietf_dir);
 
-            relative_path = ietf_dir;
-            append_path(&relative_path, file_name.c_str());
-        }
-        else
-        {
-            relative_path = file_name;
+                trace::verbose(_X("  Detected a resource asset, will query <base>/<ietf>/<file_name> base: %s ietf: %s asset: %s"),
+                    base.c_str(), ietf_dir.c_str(), asset.name.c_str());
+
+                relative_path = ietf_dir;
+                append_path(&relative_path, file_name.c_str());
+            }
+            else
+            {
+                relative_path = file_name;
+            }
         }
 
         trace::verbose(_X("  Computed relative path: %s"), relative_path.c_str());

--- a/src/native/corehost/hostpolicy/deps_entry.cpp
+++ b/src/native/corehost/hostpolicy/deps_entry.cpp
@@ -23,22 +23,23 @@ static pal::string_t normalize_dir_separator(const pal::string_t& path)
 // -----------------------------------------------------------------------------
 // Given a "base" directory, determine the resolved path for this file.
 //
-// * If this file exists within the single-file bundle candidate is
-//   the full-path to the extracted file.
+// * If this file exists within the single-file bundle:
+//     - if extracted, candidate is the full-path to the extracted file.
+//     - if not extracted, candidate is empty.
 // * Otherwise, candidate is the full local path of the file.
 //
 // Parameters:
 //    base - The base directory to look for the relative path of this entry
 //    relative_path - Relative path of to look for this entry
-//    str  - (out parameter) If the method returns true, contains the file path for this deps entry
+//    str  - (out) If the method returns true, contains the file path for this deps entry
 //    search_options - Flags to instruct where to look for this deps entry
-//    found_in_bundle - (out parameter) True if the candidate is located within the single-file bundle.
+//    found_in_bundle - (out) True if the candidate is located within the single-file bundle and not extracted.
 //
 // Returns:
 //    If the file exists in the path relative to the "base" directory within the
 //    single-file or on disk.
 
-bool deps_entry_t::to_path(const pal::string_t& base, const pal::string_t& relative_path, pal::string_t* str, uint32_t search_options, bool &found_in_bundle) const
+static bool to_path(const pal::string_t& base, const pal::string_t& relative_path, pal::string_t* str, uint32_t search_options, bool &found_in_bundle)
 {
     pal::string_t& candidate = *str;
 

--- a/src/native/corehost/hostpolicy/deps_entry.h
+++ b/src/native/corehost/hostpolicy/deps_entry.h
@@ -12,18 +12,23 @@
 
 struct deps_asset_t
 {
-    deps_asset_t() : deps_asset_t(_X(""), _X(""), version_t(), version_t()) { }
+    deps_asset_t() : deps_asset_t(_X(""), _X(""), version_t(), version_t(), _X("")) { }
 
     deps_asset_t(const pal::string_t& name, const pal::string_t& relative_path, const version_t& assembly_version, const version_t& file_version)
+        : deps_asset_t(name, relative_path, assembly_version, file_version, _X("")) { }
+
+    deps_asset_t(const pal::string_t& name, const pal::string_t& relative_path, const version_t& assembly_version, const version_t& file_version, const pal::string_t& local_path)
         : name(name)
         , relative_path(get_replaced_char(relative_path, _X('\\'), _X('/'))) // Deps file does not follow spec. It uses '\\', should use '/'
         , assembly_version(assembly_version)
-        , file_version(file_version) { }
+        , file_version(file_version)
+        , local_path(local_path.empty() ? pal::string_t() : get_replaced_char(local_path, _X('\\'), _X('/'))) { }
 
     pal::string_t name;
     pal::string_t relative_path;
     version_t assembly_version;
     version_t file_version;
+    pal::string_t local_path;
 };
 
 struct deps_entry_t

--- a/src/native/corehost/hostpolicy/deps_entry.h
+++ b/src/native/corehost/hostpolicy/deps_entry.h
@@ -44,7 +44,7 @@ struct deps_entry_t
     enum search_options : uint32_t
     {
         none = 0x0,
-        look_in_base = 0x1,     // Search entry as a relative path
+        // unused = 0x1,
         look_in_bundle = 0x2,   // Look for entry within the single-file bundle
         is_servicing = 0x4,     // Whether the base directory is the core-servicing directory
         file_existence = 0x8,   // Check for entry file existence
@@ -69,16 +69,16 @@ struct deps_entry_t
     bool to_dir_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options, bool& found_in_bundle) const;
 
     // Given a "base" dir, yield the relative path in the package layout or servicing directory.
-    bool to_rel_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const;
+    bool to_package_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const;
 
     // Given a "base" dir, yield the relative path with package name/version in the package layout or servicing location.
-    bool to_full_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const;
+    bool to_library_package_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const;
 
 private:
     // Given a "base" dir, yield the filepath within this directory or relative to this directory based on "look_in_base"
     // flag in "search_options".
     // Returns a path within the single-file bundle, or a file on disk,
-    bool to_path(const pal::string_t& base, const pal::string_t& ietf_code, pal::string_t* str, uint32_t search_options, bool & found_in_bundle) const;
+    bool to_path(const pal::string_t& base, const pal::string_t& relative_path, pal::string_t* str, uint32_t search_options, bool & found_in_bundle) const;
 
 };
 

--- a/src/native/corehost/hostpolicy/deps_entry.h
+++ b/src/native/corehost/hostpolicy/deps_entry.h
@@ -73,13 +73,6 @@ struct deps_entry_t
 
     // Given a "base" dir, yield the relative path with package name/version in the package layout or servicing location.
     bool to_library_package_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const;
-
-private:
-    // Given a "base" dir, yield the filepath within this directory or relative to this directory based on "look_in_base"
-    // flag in "search_options".
-    // Returns a path within the single-file bundle, or a file on disk,
-    bool to_path(const pal::string_t& base, const pal::string_t& relative_path, pal::string_t* str, uint32_t search_options, bool & found_in_bundle) const;
-
 };
 
 #endif // __DEPS_ENTRY_H_

--- a/src/native/corehost/hostpolicy/deps_format.cpp
+++ b/src/native/corehost/hostpolicy/deps_format.cpp
@@ -406,19 +406,19 @@ void deps_json_t::process_runtime_targets(const json_parser_t::value_t& json, co
 
                 version_t assembly_version, file_version;
 
-                const pal::string_t& assembly_version_str = get_optional_property(file.value, _X("assemblyVersion"));
+                pal::string_t assembly_version_str = get_optional_property(file.value, _X("assemblyVersion"));
                 if (!assembly_version_str.empty())
                 {
                     version_t::parse(assembly_version_str, &assembly_version);
                 }
 
-                const pal::string_t& file_version_str = get_optional_property(file.value, _X("fileVersion"));
+                pal::string_t file_version_str = get_optional_property(file.value, _X("fileVersion"));
                 if (!file_version_str.empty())
                 {
                     version_t::parse(file_version_str, &file_version);
                 }
 
-                const pal::string_t& local_path = get_optional_path(file.value, _X("localPath"));
+                pal::string_t local_path = get_optional_path(file.value, _X("localPath"));
 
                 pal::string_t file_name{file.name.GetString()};
                 deps_asset_t asset(get_filename_without_ext(file_name), file_name, assembly_version, file_version, local_path);
@@ -468,19 +468,19 @@ void deps_json_t::process_targets(const json_parser_t::value_t& json, const pal:
             {
                 version_t assembly_version, file_version;
 
-                const pal::string_t& assembly_version_str = get_optional_property(file.value, _X("assemblyVersion"));
+                pal::string_t assembly_version_str = get_optional_property(file.value, _X("assemblyVersion"));
                 if (assembly_version_str.length() > 0)
                 {
                     version_t::parse(assembly_version_str, &assembly_version);
                 }
 
-                const pal::string_t& file_version_str = get_optional_property(file.value, _X("fileVersion"));
+                pal::string_t file_version_str = get_optional_property(file.value, _X("fileVersion"));
                 if (file_version_str.length() > 0)
                 {
                     version_t::parse(file_version_str, &file_version);
                 }
 
-                const pal::string_t& local_path = get_optional_path(file.value, _X("localPath"));
+                pal::string_t local_path = get_optional_path(file.value, _X("localPath"));
 
                 pal::string_t file_name{file.name.GetString()};
                 deps_asset_t asset(get_filename_without_ext(file_name), file_name, assembly_version, file_version, local_path);

--- a/src/native/corehost/hostpolicy/deps_format.cpp
+++ b/src/native/corehost/hostpolicy/deps_format.cpp
@@ -166,12 +166,13 @@ void deps_json_t::reconcile_libraries_with_targets(
 
                 if (trace::is_enabled())
                 {
-                    trace::info(_X("    Entry %zu for asset name: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
+                    trace::info(_X("    Entry %zu for asset name: %s, relpath: %s, assemblyVersion %s, fileVersion %s, localPath %s"),
                         m_deps_entries[i].size(),
                         entry.asset.name.c_str(),
                         entry.asset.relative_path.c_str(),
                         entry.asset.assembly_version.as_str().c_str(),
-                        entry.asset.file_version.as_str().c_str());
+                        entry.asset.file_version.as_str().c_str(),
+                        entry.asset.local_path.empty() ? _X("(not set)") : entry.asset.local_path.c_str());
                 }
 
                 m_deps_entries[i].push_back(std::move(entry));
@@ -417,19 +418,22 @@ void deps_json_t::process_runtime_targets(const json_parser_t::value_t& json, co
                     version_t::parse(file_version_str, &file_version);
                 }
 
+                const pal::string_t& local_path = get_optional_path(file.value, _X("localPath"));
+
                 pal::string_t file_name{file.name.GetString()};
-                deps_asset_t asset(get_filename_without_ext(file_name), file_name, assembly_version, file_version);
+                deps_asset_t asset(get_filename_without_ext(file_name), file_name, assembly_version, file_version, local_path);
 
                 const auto& rid = file.value[_X("rid")].GetString();
 
                 if (trace::is_enabled())
                 {
-                    trace::info(_X("  %s asset: %s rid=%s assemblyVersion=%s fileVersion=%s"),
+                    trace::info(_X("  %s asset: %s rid=%s assemblyVersion=%s fileVersion=%s localPath=%s"),
                         deps_entry_t::s_known_asset_types[asset_type_index],
                         asset.relative_path.c_str(),
                         rid,
                         asset.assembly_version.as_str().c_str(),
-                        asset.file_version.as_str().c_str());
+                        asset.file_version.as_str().c_str(),
+                        asset.local_path.empty() ? _X("(not set)") : asset.local_path.c_str());
                 }
 
                 assets.libs[package.name.GetString()][asset_type_index].rid_assets[rid].push_back(asset);
@@ -476,15 +480,18 @@ void deps_json_t::process_targets(const json_parser_t::value_t& json, const pal:
                     version_t::parse(file_version_str, &file_version);
                 }
 
+                const pal::string_t& local_path = get_optional_path(file.value, _X("localPath"));
+
                 pal::string_t file_name{file.name.GetString()};
-                deps_asset_t asset(get_filename_without_ext(file_name), file_name, assembly_version, file_version);
+                deps_asset_t asset(get_filename_without_ext(file_name), file_name, assembly_version, file_version, local_path);
 
                 if (trace::is_enabled())
                 {
-                    trace::info(_X("    %s assemblyVersion=%s fileVersion=%s"),
+                    trace::info(_X("    %s assemblyVersion=%s fileVersion=%s localPath=%s"),
                         asset.relative_path.c_str(),
                         asset.assembly_version.as_str().c_str(),
-                        asset.file_version.as_str().c_str());
+                        asset.file_version.as_str().c_str(),
+                        asset.local_path.empty() ? _X("(not set)") : asset.local_path.c_str());
                 }
 
                 asset_files.push_back(std::move(asset));

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -332,15 +332,18 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
             if (entry.is_rid_specific)
             {
                 // Look up rid specific assets in the rid folders.
-                if (entry.to_rel_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle))
+                // if (entry.to_package_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle))
+                if (entry.to_dir_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle, found_in_bundle))
                 {
+                    // Bundles are expected to be RID-specific themselves, so RID-specific assets are not expected to be found in the bundle.
+                    assert(!entry.is_rid_specific || !found_in_bundle);
                     trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                     return true;
                 }
             }
             else
             {
-                // Non-rid assets, lookup in the published dir.
+                // Look up assets relative to the deps directory
                 if (entry.to_dir_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle, found_in_bundle))
                 {
                     trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
@@ -352,7 +355,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
         }
         else
         {
-            if (entry.to_full_path(config.probe_dir, candidate, search_options | (config.is_servicing() ? deps_entry_t::search_options::is_servicing : 0)))
+            if (entry.to_library_package_path(config.probe_dir, candidate, search_options | (config.is_servicing() ? deps_entry_t::search_options::is_servicing : 0)))
             {
                 trace::verbose(_X("    Probed package dir and matched '%s'"), candidate->c_str());
                 return true;
@@ -431,8 +434,8 @@ bool deps_resolver_t::resolve_tpa_list(
             return true;
         }
 
-        trace::info(_X("Processing TPA for deps entry [%s, %s, %s] with fx level: %d"),
-            entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str(), fx_level);
+        trace::info(_X("Processing TPA for deps entry [%s, %s, %s, local_path: %s] with fx level: %d"),
+            entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str(), entry.asset.local_path.empty() ? _X("<not_set>") : entry.asset.local_path.c_str(), fx_level);
 
         pal::string_t resolved_path;
 
@@ -779,8 +782,8 @@ bool deps_resolver_t::resolve_probe_dirs(
             return true;
         }
 
-        trace::verbose(_X("Processing native/culture for deps entry [%s, %s, %s]"),
-            entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str());
+        trace::verbose(_X("Processing native/culture for deps entry [%s, %s, %s, local_path: %s]"),
+            entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str(), entry.asset.local_path.empty() ? _X("<not_set>") : entry.asset.local_path.c_str());
 
         bool found_in_bundle = false;
         if (probe_deps_entry(entry, deps_dir, fx_level, &candidate, found_in_bundle))

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -329,14 +329,11 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
         else if (config.is_app())
         {
             assert(fx_level == AppFxLevel);
-            if (entry.is_rid_specific)
+            if (entry.is_rid_specific && entry.asset.local_path.empty())
             {
-                // Look up rid specific assets in the rid folders.
-                // if (entry.to_package_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle))
-                if (entry.to_dir_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle, found_in_bundle))
+                // Look up rid specific assets without a local path specified in the rid folders.
+                if (entry.to_package_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle))
                 {
-                    // Bundles are expected to be RID-specific themselves, so RID-specific assets are not expected to be found in the bundle.
-                    assert(!entry.is_rid_specific || !found_in_bundle);
                     trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                     return true;
                 }
@@ -346,6 +343,8 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 // Look up assets relative to the deps directory
                 if (entry.to_dir_path(deps_dir, candidate, search_options | deps_entry_t::search_options::look_in_bundle, found_in_bundle))
                 {
+                    // Bundles are expected to be RID-specific themselves, so RID-specific assets are not expected to be found in the bundle.
+                    assert(!entry.is_rid_specific || !found_in_bundle);
                     trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                     return true;
                 }


### PR DESCRIPTION
Currently, when resolving RID-agnostic assets from an application itself (that is, those in the app's .deps.json), any subdirectory specified in the file path is ignored. We just take the file name and expect it to be next to the .deps.json.

https://github.com/dotnet/runtime/issues/117682 added an optional `localPath` property for assets. If set, this represents the path on disk relative to the .deps.json. This change updates the host to consume that property. When resolving assets from an application itself:
1. `localPath` property is set: use `<deps_dir>/<localPath>`
2. asset is from a runtimepack: use `<deps_dir>/<file_path>`
    - runtimepack assets are always generated with the actual destination path in the file path
3. otherwise (this is the existing behaviour):
    - RID-specific assets: use `<deps_dir>/<file_path>`
    - RID-agnostic assets:
      - runtime: take only the file name, use `<deps_dir>/<file_name>`
      - resources: take parent directory name of the file path, use `<deps_dir>/<dir_name>/<file_name>`

<details><summary>Example .deps.json resolution</summary>

With the following package in a .deps.json:
```jsonc
"MyPackage/1.0.0": {
  "runtime": {
    // resolves to <deps_dir>/pkg/lib.dll
    "lib/net10.0/lib.dll": {
      "localPath": "pkg/lib.dll"
    },
    // resolves to <deps_dir>/lib2.dll
    "lib/net10.0/lib2.dll": { },
    "resources": {
      // resolves to <deps_dir>/pkg/fr/lib.resources.dll
      "lib/net10.0/fr/lib.resources.dll": {
        "localPath": "pkg/fr/lib.resources.dll"
      },
      // resolves to <deps_dir>/de/lib.resources.dll
      "lib/net10.0/de/lib.resources.dll": { },
    }
  },
 "runtimeTargets": {
    // resolves to <deps_dir>/pkg/runtimes/win-x64/native/libnative.dll
    "runtimes/win-x64/native/libnative.dll": {
      "localPath": "pkg/runtimes/win-x64/native/libnative.dll"
    },
    // resolves to <deps_dir>/runtimes/win-x64/native/libnative2.dll
    "runtimes/win-x64/native/libnative2.dll": { }
  }
}
```

The paths would be:
- TPA: `<deps_dir>/pkg/lib.dll`, `<deps_dir>/lib2.dll`
- Resource roots: `<deps_dir>/pkg`
- Native search directories: `<deps_dir>/pkg/runtimes/win-x64/native`

</details>

With this change, usage of app-relative .NET search, and some msbuild hackery, it is possible to publish a self-contained application and stick the runtimepack in a subdirectory:
```xml
<PropertyGroup>
  <AppHostRelativeDotNet>runtimepack</AppHostRelativeDotNet>
</PropertyGroup>
<Target Name="UpdateRuntimePackAssets" AfterTargets="ResolveRuntimePackAssets">
  <ItemGroup>
    <RuntimePackAsset Update="@(RuntimePackAsset)->WithMetadataValue('CopyLocal', 'true')"
      DestinationSubPath="$(AppHostRelativeDotNet)\%(FileName)%(Extension)"
      DestinationSubDirectory="$(AppHostRelativeDotNet)\" />
    <ReferenceCopyLocalPaths Remove="@(RuntimePackAsset)" />
    <ReferenceCopyLocalPaths Include="@(RuntimePackAsset)" />
  </ItemGroup>
</Target>
```

Resolves https://github.com/dotnet/runtime/issues/3525
cc @dotnet/appmodel @AaronRobinsonMSFT 