### PR TITLE
[RyuJit] Ignore missing SPMI data when printing string literals

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8280,6 +8280,8 @@ public:
     const char* eeGetClassAssemblyName(CORINFO_CLASS_HANDLE clsHnd);
 
 #if defined(DEBUG)
+    void eePrintStringLiteral(CORINFO_MODULE_HANDLE module, unsigned token);
+
     unsigned eeTryGetClassSize(CORINFO_CLASS_HANDLE clsHnd);
 #endif
 

--- a/src/coreclr/jit/eeinterface.cpp
+++ b/src/coreclr/jit/eeinterface.cpp
@@ -692,3 +692,35 @@ void Compiler::eePrintObjectDescription(const char* prefix, CORINFO_OBJECT_HANDL
 
     printf("%s '%s'", prefix, str);
 }
+
+#ifdef DEBUG
+//------------------------------------------------------------------------
+// eePrintStringLiteral:
+//   Print a string literal. If missing information (in SPMI),
+//   then print a placeholder string.
+//
+// Arguments:
+//    module - The literal's scope handle
+//    token  - The literal's token
+//
+void Compiler::eePrintStringLiteral(CORINFO_MODULE_HANDLE module, unsigned token)
+{
+    const int MAX_LITERAL_LENGTH      = 256;
+    char16_t  str[MAX_LITERAL_LENGTH] = {};
+    int       length                  = -1;
+    eeRunFunctorWithSPMIErrorTrap([&]() {
+        length = info.compCompHnd->getStringLiteral(module, token, str, MAX_LITERAL_LENGTH);
+    });
+
+    if (length < 0)
+    {
+        printf("<unknown string literal>");
+    }
+    else
+    {
+        char dst[MAX_LITERAL_LENGTH];
+        convertUtf16ToUtf8ForPrinting(str, length, dst, MAX_LITERAL_LENGTH);
+        printf("\"%.50s%s\"", dst, length > 50 ? "..." : "");
+    }
+}
+#endif // DEBUG

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -12279,19 +12279,7 @@ void Compiler::gtDispConst(GenTree* tree)
                 break;
             }
 
-            constexpr int maxLiteralLength      = 256;
-            char16_t      str[maxLiteralLength] = {};
-            int len = info.compCompHnd->getStringLiteral(cnsStr->gtScpHnd, cnsStr->gtSconCPX, str, maxLiteralLength);
-            if (len < 0)
-            {
-                printf("<unknown string literal>");
-            }
-            else
-            {
-                char dst[maxLiteralLength];
-                convertUtf16ToUtf8ForPrinting(str, len, dst, maxLiteralLength);
-                printf("\"%.50s%s\"", dst, len > 50 ? "..." : "");
-            }
+            eePrintStringLiteral(cnsStr->gtScpHnd, cnsStr->gtSconCPX);
         }
         break;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/118217.