### PR TITLE
Start using parameter defined for ToString

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
@@ -55,7 +55,7 @@ namespace System.Runtime.Serialization
             }
             catch (ArgumentException exception)
             {
-                throw XmlExceptionHelper.CreateConversionException(value.ToString(CultureInfo.InvariantCulture), "DateTimeOffset", exception);
+                throw XmlExceptionHelper.CreateConversionException(value.ToString(null), "DateTimeOffset", exception);
             }
         }
 
@@ -64,11 +64,9 @@ namespace System.Runtime.Serialization
             return new DateTimeOffsetAdapter(value.UtcDateTime, (short)value.Offset.TotalMinutes);
         }
 
-#pragma warning disable IDE0060 // https://github.com/dotnet/runtime/issues/76012
-        public string ToString(IFormatProvider provider)
+        public string ToString(IFormatProvider? provider)
         {
-            return "DateTime: " + UtcDateTime + ", Offset: " + OffsetMinutes;
+            return "DateTime: " + UtcDateTime.ToString(provider) + ", Offset: " + OffsetMinutes;
         }
-#pragma warning restore IDE0060
     }
 }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
@@ -55,18 +55,14 @@ namespace System.Runtime.Serialization
             }
             catch (ArgumentException exception)
             {
-                throw XmlExceptionHelper.CreateConversionException(value.ToString(null), "DateTimeOffset", exception);
+                var formattedValue = "DateTime: " + value.UtcDateTime + ", Offset: " + value.OffsetMinutes;
+                throw XmlExceptionHelper.CreateConversionException(formattedValue, "DateTimeOffset", exception);
             }
         }
 
         public static DateTimeOffsetAdapter GetDateTimeOffsetAdapter(DateTimeOffset value)
         {
             return new DateTimeOffsetAdapter(value.UtcDateTime, (short)value.Offset.TotalMinutes);
-        }
-
-        public string ToString(IFormatProvider? provider)
-        {
-            return "DateTime: " + UtcDateTime.ToString(provider) + ", Offset: " + OffsetMinutes;
         }
     }
 }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DateTimeOffsetAdapter.cs
@@ -55,7 +55,7 @@ namespace System.Runtime.Serialization
             }
             catch (ArgumentException exception)
             {
-                var formattedValue = "DateTime: " + value.UtcDateTime + ", Offset: " + value.OffsetMinutes;
+                string formattedValue = "DateTime: " + value.UtcDateTime + ", Offset: " + value.OffsetMinutes;
                 throw XmlExceptionHelper.CreateConversionException(formattedValue, "DateTimeOffset", exception);
             }
         }


### PR DESCRIPTION
Historically, this adapter struct took an `IFormatProvider` agrument for it's `ToString()` method... and never used it. This makes the compiler unhappy now. So to keep the API (partly for binary compat, and partly to not bump heads with Object.ToString()), lets start using the format provider as one might expect. And then pass a null value in the one place that we call this ToString overload so the existing behavior is maintained.

Fixes #76012