### PR TITLE
Avoid redundant GetRVA calls when fetching IL header

### DIFF
--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -3573,13 +3573,13 @@ ClrDataMethodDefinition::GetIlMethod(void)
 {
     if (m_methodDesc)
     {
-        if (!m_methodDesc->HasILHeader())
+        if (m_methodDesc->MayHaveILHeader())
         {
-            return NULL;
+            return m_methodDesc->GetILHeader();
         }
         else
         {
-            return m_methodDesc->GetILHeader();
+            return NULL;
         }
     }
     else

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -7680,10 +7680,11 @@ CEEInfo::getMethodInfo(
     JIT_TO_EE_TRANSITION();
 
     MethodDesc* ftn = GetMethod(ftnHnd);
-    if (ftn->HasILHeader())
+    COR_ILMETHOD* pILHeader;
+    if (ftn->MayHaveILHeader() && (pILHeader = ftn->GetILHeader()) != NULL)
     {
         // Get the IL header and set it.
-        COR_ILMETHOD_DECODER header(ftn->GetILHeader(), ftn->GetMDImport(), NULL);
+        COR_ILMETHOD_DECODER header(pILHeader, ftn->GetMDImport(), NULL);
         getMethodInfoWorker(ftn, &header, methInfo, context);
         result = true;
     }
@@ -7861,9 +7862,10 @@ CorInfoInline CEEInfo::canInline (CORINFO_METHOD_HANDLE hCaller,
 
         if (pRootModule->IsRuntimeWrapExceptions() != pCalleeModule->IsRuntimeWrapExceptions())
         {
-            if (pCallee->HasILHeader())
+            COR_ILMETHOD* pILHeader;
+            if (pCallee->MayHaveILHeader() && (pILHeader = pCallee->GetILHeader()) != NULL)
             {
-                COR_ILMETHOD_DECODER header(pCallee->GetILHeader(), pCallee->GetMDImport(), NULL);
+                COR_ILMETHOD_DECODER header(pILHeader, pCallee->GetMDImport(), NULL);
                 if (header.EHCount() > 0)
                 {
                     result = INLINE_FAIL;
@@ -12771,6 +12773,8 @@ void CEECodeGenInfo::getEHinfo(
     JIT_TO_EE_TRANSITION();
 
     MethodDesc* pMD = GetMethod(ftn);
+
+    COR_ILMETHOD* pILHeader;
     if (IsDynamicMethodHandle(ftn))
     {
         pMD->AsDynamicMethodDesc()->GetResolver()->GetEHInfo(EHnumber, clause);
@@ -12779,9 +12783,9 @@ void CEECodeGenInfo::getEHinfo(
     {
         getEHinfoHelper(ftn, EHnumber, clause, m_ILHeader);
     }
-    else if (pMD->HasILHeader())
+    else if (pMD->MayHaveILHeader() && (pILHeader = pMD->GetILHeader()) != NULL)
     {
-        COR_ILMETHOD_DECODER header(pMD->GetILHeader(), pMD->GetMDImport(), NULL);
+        COR_ILMETHOD_DECODER header(pILHeader, pMD->GetMDImport(), NULL);
         getEHinfoHelper(ftn, EHnumber, clause, &header);
     }
     else if (pMD->IsIL())

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1188,6 +1188,12 @@ COR_ILMETHOD* MethodDesc::GetILHeader()
     }
     CONTRACTL_END
 
+    RVA rva = GetRVA();
+    if (rva == 0)
+    {
+        return NULL;
+    }
+
     Module *pModule = GetModule();
 
     // Always pickup overrides like reflection emit, EnC, etc.
@@ -1195,7 +1201,7 @@ COR_ILMETHOD* MethodDesc::GetILHeader()
 
     if (pIL == (TADDR)NULL)
     {
-        pIL = pModule->GetIL(GetRVA());
+        pIL = pModule->GetIL(rva);
     }
 
 #ifdef _DEBUG_IMPL


### PR DESCRIPTION
Change more places to use MethodDesc::MayHaveILHeader introduced by recent PR