### PR TITLE
[QUIC] Do async validation only from > 2.4, i.e. 2.4.1+

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -62,8 +62,8 @@ internal sealed unsafe partial class MsQuicApi
     internal static string MsQuicLibraryVersion { get; } = "unknown";
     internal static string? NotSupportedReason { get; }
 
-    // workaround for https://github.com/microsoft/msquic/issues/4132
-    internal static bool SupportsAsyncCertValidation => Version >= new Version(2, 4);
+    // Workaround for https://github.com/microsoft/msquic/issues/4132
+    internal static bool SupportsAsyncCertValidation => Version > new Version(2, 4);
 
     internal static bool UsesSChannelBackend { get; }
 


### PR DESCRIPTION
The OSX QUIC timeouts are likely an instance of https://github.com/microsoft/msquic/issues/4132. 

On OSX, We're using MsQuic at this commit: https://github.com/microsoft/msquic/commit/e0385b047d7bd622319e9f6c4c00184a1294eea8 build from main (therefore having version of the next release - 2.4). 
Historically, the above mentioned issue had a fix by that time: https://github.com/microsoft/msquic/pull/4145 
Unfortunately, the were at least 2 follow ups it seems: 
- https://github.com/microsoft/msquic/pull/4169
- https://github.com/microsoft/msquic/pull/4245

Which are not part of the binaries with which we're testing.

TL;DR This should get fixed by new MsQuic, i.e. with [#114912](https://github.com/dotnet/runtime/issues/114912)

This is an alternative which changes the async cert validation condition to `>` in here: https://github.com/dotnet/runtime/blob/02596ba8d937bfbda5d2d7d634d7b3688e28bb69/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs#L66

Note that both Windows and latest Linux MsQuic binaries are 2.4.8 so this shouldn't have any effect on customers.

Fixes #107761
Fixes #105177
Fixes #103482
Fixes #104426