### PR TITLE
JIT: Remove redundant normalizing casts when passing and returning structs

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5315,8 +5315,8 @@ void Lowering::LowerFieldListToFieldListOfRegisters(GenTreeFieldList*   fieldLis
         if ((i == numRegs - 1) && varTypeUsesIntReg(regType))
         {
             GenTree* node = regEntry->GetNode();
-            // If this is a cast cast that affects only bits after the return
-            // size then it can be removed. Those bits are UB in all our ABIs
+            // If this is a cast that affects only bits after the return size
+            // then it can be removed. Those bits are undefined in all our ABIs
             // for structs.
             while (node->OperIs(GT_CAST) && !node->gtOverflow() && varTypeUsesIntReg(node->CastToType()) &&
                    (genTypeSize(regType) <= genTypeSize(node->CastToType())))

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4987,7 +4987,7 @@ void Lowering::LowerRetFieldList(GenTreeOp* ret, GenTreeFieldList* fieldList)
 
     auto getRegInfo = [=, &retDesc](unsigned regIndex) {
         unsigned  offset  = retDesc.GetReturnFieldOffset(regIndex);
-        var_types regType = genActualType(retDesc.GetReturnRegType(regIndex));
+        var_types regType = retDesc.GetReturnRegType(regIndex);
         return LowerFieldListRegisterInfo(offset, regType);
     };
 
@@ -5307,6 +5307,26 @@ void Lowering::LowerFieldListToFieldListOfRegisters(GenTreeFieldList*   fieldLis
             GenTree* bitCast = comp->gtNewBitCastNode(regType, regEntry->GetNode());
             BlockRange().InsertBefore(fieldList, bitCast);
             regEntry->SetNode(bitCast);
+        }
+
+        // If this is the last entry then try to optimize out unnecessary
+        // normalizing casts, similar to how LowerRetSingleRegStructLclVar
+        // avoids inserting them.
+        if ((i == numRegs - 1) && varTypeUsesIntReg(regType))
+        {
+            GenTree* node = regEntry->GetNode();
+            // If this is a cast cast that affects only bits after the return
+            // size then it can be removed. Those bits are UB in all our ABIs
+            // for structs.
+            while (node->OperIs(GT_CAST) && !node->gtOverflow() && varTypeUsesIntReg(node->CastToType()) &&
+                   (genTypeSize(regType) <= genTypeSize(node->CastToType())))
+            {
+                GenTree* op = node->AsCast()->CastOp();
+                regEntry->SetNode(op);
+                op->ClearContained();
+                node->gtBashToNOP();
+                node = op;
+            }
         }
 
         if (fieldListPrev->gtNext != fieldList)


### PR DESCRIPTION
#113178 switched returned promoted structs to always be morphed to `FIELD_LIST` and started handling the introduced `FIELD_LIST` in the backend. However, this change introduced new unnecessary normalization when returning promoted structs that previously would not happen with the old `LowerRetSingleRegStructLclVar` code path.

This change adds an optimization to get rid of the introduced normalization when possible.

Fix #113382

For the benchmark:

| Method     | Toolchain               | Mean     | Error     | StdDev    | Median   | Min      | Max      | Ratio | Allocated | Alloc Ratio |
|----------------- |------------------------ |---------:|----------:|----------:|---------:|---------:|---------:|------:|----------:|------------:|
| WriteHalf | pr      | 3.635 ns | 0.0113 ns | 0.0100 ns | 3.635 ns | 3.616 ns | 3.657 ns |  0.93 |         - |          NA |
| WriteHalf  | main | 3.913 ns | 0.0146 ns | 0.0137 ns | 3.911 ns | 3.885 ns | 3.935 ns |  1.00 |         - |          NA |