### PR TITLE
Fix thread abort issue with funceval

### DIFF
--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2303,11 +2303,7 @@ void Thread::HandleThreadAbort ()
             exceptObj = CLRException::GetThrowableFromException(&eeExcept);
         }
 
-#ifdef FEATURE_EH_FUNCLETS
-        DispatchManagedException(exceptObj);
-#else // FEATURE_EH_FUNCLETS
         RaiseTheExceptionInternalOnly(exceptObj, FALSE);
-#endif // FEATURE_EH_FUNCLETS
     }
 
     ::SetLastError(lastError);


### PR DESCRIPTION
There is a problem with thread abort in funceval in case there is no managed frame on the stack between the abortion point and the `FuncEvalFrame`. That can happen e.g. when invoking a static method via funceval for a type with static constructor that was not invoked yet and takes a long time to complete.

The problem is caused by the fact that when EH is called to propagate the `ThreadAbortException`, it starts at the first managed frame and so it skips the try/catch in the funceval native code.

This change fixes it by using `RaiseTheExceptionInternalOnly` to raise the `ThreadAbortException` in the `Thread::HandleThreadAbort`. The `Thread::HandleThreadAbort` is always called by native code that has a native catch or (on Windows) ends up calling the `ProcessCLRException`.

I have originally made the change to call the `DispatchManagedException` from the `Thread::HandleThreadAbort`, but this issue shows it is problematic.

I have verified that the repro provided by @eterekhin in the issue report no longer causes the process to crash with failfast, but reports the funceval as timed out as expected.

Close #118015