### PR TITLE
Use minipal_hires_ticks() as random seed

### DIFF
--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -38,7 +38,7 @@ static Thread* g_RuntimeInitializingThread;
 
 ee_alloc_context::PerThreadRandom::PerThreadRandom()
 {
-    minipal_xoshiro128pp_init(&random_state, (uint32_t)minipal_lowres_ticks());
+    minipal_xoshiro128pp_init(&random_state, (uint32_t)minipal_hires_ticks());
 }
 
 thread_local ee_alloc_context::PerThreadRandom ee_alloc_context::t_random = PerThreadRandom();


### PR DESCRIPTION
minipal_hires_ticks is much more likely to guarantee that different threads end up with different seeds