### PR TITLE
Add condition for 384 bit RSA crypto tests

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -351,7 +351,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(expectedSignature, signature);
         }
 
-        [ConditionalFact(typeof(RSAFactory), nameof(RSAFactory.SupportsSha1Signatures))]
+        [ConditionalFact(typeof(RSAFactory), nameof(RSAFactory.SupportsSha1Signatures_384))]
         public void VerifySignature_SHA1_384()
         {
             byte[] signature =

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -351,7 +351,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(expectedSignature, signature);
         }
 
-        [ConditionalFact(typeof(RSAFactory), nameof(RSAFactory.SupportsSha1Signatures_384))]
+        [ConditionalFact(typeof(RSAFactory), nameof(RSAFactory.Supports384PrivateKey))]
         public void VerifySignature_SHA1_384()
         {
             byte[] signature =

--- a/src/libraries/System.Security.Cryptography/tests/DefaultRSAProvider.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultRSAProvider.cs
@@ -35,6 +35,21 @@ namespace System.Security.Cryptography.Rsa.Tests
                     // For Windows 7 (Microsoft Windows 6.1) and Windows 8 (Microsoft Windows 6.2) this is false for RSACng.
                     _supports384PrivateKey = !RuntimeInformation.OSDescription.Contains("Windows 6.1") &&
                         !RuntimeInformation.OSDescription.Contains("Windows 6.2");
+                    if (_supports384PrivateKey.Value)
+                    {
+                        // Ensure we can make the key
+                        try
+                        {
+                            using (RSA rsa = Create(384))
+                            {
+                                _supports384PrivateKey = rsa.KeySize == 384;
+                            }
+                        }
+                        catch (CryptographicException)
+                        {
+                            _supports384PrivateKey = false;
+                        }
+                    }
                 }
 
                 return _supports384PrivateKey.Value;

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PublicKeyTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PublicKeyTests.cs
@@ -355,7 +355,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal(expectedExponent, originalExponent);
         }
 
-        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsX509Sha1Signatures))]
+        [ConditionalFact(typeof(SignatureSupport), nameof(SignatureSupport.SupportsX509Sha1Signatures_384))]
         public static void TestKey_RSA384_ValidatesSignature()
         {
             byte[] signature =

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/SignatureSupport.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/SignatureSupport.cs
@@ -15,14 +15,19 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         // the logic here will need to get more complicated.
         public static bool SupportsX509Sha1Signatures { get; } = GetSupportsX509Sha1Signatures();
 
+        public static bool SupportsX509Sha1Signatures_384 { get; } = GetSupportsX509Sha1Signatures(384);
 
-        private static bool GetSupportsX509Sha1Signatures()
+
+        private static bool GetSupportsX509Sha1Signatures(int? keysize = null)
         {
             RSA rsa;
 
             try
             {
-                rsa = RSA.Create();
+                if (keysize.HasValue)
+                    rsa = RSA.Create(keysize.Value);
+                else
+                    rsa = RSA.Create();
             }
             catch (PlatformNotSupportedException)
             {


### PR DESCRIPTION
[This test failed](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1111800&view=ms.vss-test-web.build-test-results-tab&runId=30517712&resultId=113411&paneView=debug) in CI running on Android. Key sizes under 512 are not supported on Android, so we should make sure to check the key size is supported before running a test. https://github.com/dotnet/runtime/blob/a483fd3c4cbc6598fab067267332c40206477431/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs#L69-L75