### PR TITLE
JIT: postorder local assertion prop for fieldwise block op indirs

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1164,6 +1164,32 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
         addrSpillStore->SetMorphed(m_comp);
     }
 
+    auto postOrderAssertionProp = [=](GenTree* tree) {
+        if (m_comp->fgGlobalMorph && m_comp->optLocalAssertionProp && (m_comp->optAssertionCount > 0))
+        {
+            GenTree* optimizedTree = tree;
+            bool     again         = JitConfig.JitEnablePostorderLocalAssertionProp() > 0;
+            bool     didOptimize   = false;
+
+            while (again)
+            {
+                tree          = optimizedTree;
+                optimizedTree = m_comp->optAssertionProp(m_comp->apLocalPostorder, tree, nullptr, nullptr);
+                again         = (optimizedTree != nullptr);
+                didOptimize |= again;
+            }
+
+            assert(tree != nullptr);
+
+            if (didOptimize)
+            {
+                m_comp->gtUpdateNodeSideEffects(tree);
+            }
+        }
+
+        return tree;
+    };
+
     auto grabAddr = [=, &result](unsigned offs) {
         GenTree* addrClone = nullptr;
         // Need address of the source.
@@ -1316,6 +1342,8 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
             }
         }
         assert(srcFld != nullptr);
+
+        srcFld = postOrderAssertionProp(srcFld);
         srcFld->SetMorphed(m_comp);
 
         GenTree* dstFldStore;
@@ -1372,7 +1400,16 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                 }
             }
         }
-        noway_assert(dstFldStore->TypeGet() == srcFld->TypeGet());
+
+        // Allow mismatched types only when srcFld is an integer constant
+        //
+        if (dstFldStore->TypeGet() != srcFld->TypeGet())
+        {
+            noway_assert(genActualType(dstFldStore->TypeGet()) == genActualType(srcFld->TypeGet()));
+            assert(srcFld->IsIntegralConst());
+        }
+
+        dstFldStore = postOrderAssertionProp(dstFldStore);
         dstFldStore->SetMorphed(m_comp);
 
         if (m_comp->optLocalAssertionProp)


### PR DESCRIPTION
After we form the block op field indirs, run postorder local assertion prop on them, so that they see the same amount of assertion prop as other indirs.

Fixes (parts of) #115789.