### PR TITLE
Remove 2GB allocations from MemoryStream_SeekOverflow_Throws.

### DIFF
--- a/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
@@ -95,16 +95,11 @@ namespace System.IO.Tests
                     (10, 0),
                     (10, 5),
                     (10, 10),
-                    (Array.MaxLength, 0),
-                    (Array.MaxLength, Array.MaxLength)
                 }
             select new object[] {mode, bufferContext.bufferSize, bufferContext.origin};
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [Theory]
         [MemberData(nameof(MemoryStream_PositionOverflow_Throws_MemberData))]
-        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "https://github.com/dotnet/runtime/issues/92467")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/100225", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsX64Process))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/100558", TestPlatforms.Linux)]
         public void MemoryStream_SeekOverflow_Throws(SeekMode mode, int bufferSize, int origin)
         {
             byte[] buffer = new byte[bufferSize];


### PR DESCRIPTION
This test was allocating arrays that were nearly 2GB in size in order to attempt to test an edge case around seek overflowing. These large allocations are very unstable in CI and started failing for Android + CoreCLR.

The test is already disabled for Linux, for iOS, for tvOS, and partially for Windows. Rather than disable it for yet another platform, let's just not test the very large allocation sizes. At this point the test has been disabled on so many platforms for being problematic we aren't getting much value from the large allocations.

Fixes https://github.com/dotnet/runtime/issues/92467
Fixes https://github.com/dotnet/runtime/issues/100225
Fixes https://github.com/dotnet/runtime/issues/100558
Fixes https://github.com/dotnet/runtime/issues/118353