### PR TITLE
[clr-interp] Implement missing support for startup path

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/String.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/String.CoreCLR.cs
@@ -25,10 +25,10 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern unsafe string FastAllocateString(MethodTable *pMT, int length);
+        internal static extern unsafe string FastAllocateString(MethodTable *pMT, nint length);
 
         [DebuggerHidden]
-        internal static unsafe string FastAllocateString(int length)
+        internal static unsafe string FastAllocateString(nint length)
         {
             return FastAllocateString(TypeHandle.TypeHandleOf<string>().AsMethodTable(), length);
         }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -4,7 +4,6 @@
 
 #include "interpreter.h"
 #include "stackmap.h"
-#include "../vm/classnames.h"
 
 #include <inttypes.h>
 
@@ -2835,7 +2834,6 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
     if (newObjThisArgLocation != INT_MAX)
     {
         ctorType = GetInterpType(m_compHnd->asCorInfoType(resolvedCallToken.hClass));
-
         if (ctorType != InterpTypeO)
         {
             vtsize = m_compHnd->getClassSize(resolvedCallToken.hClass);

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2834,11 +2834,14 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
 
     if (newObjThisArgLocation != INT_MAX)
     {
-        const char* className = m_compHnd->getClassNameFromMetadata(resolvedCallToken.hClass, NULL);
+        const char* namespaceName = nullptr;
+        const char* className = m_compHnd->getClassNameFromMetadata(resolvedCallToken.hClass, &namespaceName);
         CorInfoType corInfoType;
-        if (!strcmp(className, g_RuntimeMethodHandleInternalName) ||
-            !strcmp(className, g_RuntimeFieldHandleInternalName) ||
-            !strcmp(className, g_RuntimeArgumentHandleName))
+        if (namespaceName != NULL && className != NULL &&
+            !strcmp(namespaceName, "System") &&
+            (!strcmp(className, g_RuntimeMethodHandleInternalName) ||
+             !strcmp(className, g_RuntimeFieldHandleInternalName) ||
+             !strcmp(className, g_RuntimeArgumentHandleName)))
         {
             corInfoType = CORINFO_TYPE_VALUECLASS;
         }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2834,25 +2834,9 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
 
     if (newObjThisArgLocation != INT_MAX)
     {
-        const char* namespaceName = nullptr;
-        const char* className = m_compHnd->getClassNameFromMetadata(resolvedCallToken.hClass, &namespaceName);
-        CorInfoType corInfoType;
-        if (namespaceName != NULL && className != NULL &&
-            !strcmp(namespaceName, "System") &&
-            (!strcmp(className, g_RuntimeMethodHandleInternalName) ||
-             !strcmp(className, g_RuntimeFieldHandleInternalName) ||
-             !strcmp(className, g_RuntimeArgumentHandleName)))
-        {
-            corInfoType = CORINFO_TYPE_VALUECLASS;
-        }
-        else
-        {
-            corInfoType = m_compHnd->asCorInfoType(resolvedCallToken.hClass);
-        }
+        ctorType = GetInterpType(m_compHnd->asCorInfoType(resolvedCallToken.hClass));
 
-        ctorType = GetInterpType(corInfoType);
-
-        if (ctorType == InterpTypeVT)
+        if (ctorType != InterpTypeO)
         {
             vtsize = m_compHnd->getClassSize(resolvedCallToken.hClass);
             PushTypeVT(resolvedCallToken.hClass, vtsize);
@@ -2984,7 +2968,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
         case CORINFO_CALL:
             if (newObj && !doCallInsteadOfNew)
             {
-                if (ctorType == InterpTypeVT)
+                if (ctorType != InterpTypeO)
                 {
                     // If this is a newobj for a value type, we need to call the constructor
                     // and then copy the value type to the stack.

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -390,6 +390,7 @@ OPDEF(INTOP_GENERICLOOKUP, "generic", 4, 1, 1, InterpOpGenericLookup)
 OPDEF(INTOP_CALL_FINALLY, "call.finally", 2, 0, 0, InterpOpBranch)
 
 OPDEF(INTOP_ZEROBLK_IMM, "zeroblk.imm", 3, 0, 1, InterpOpInt)
+OPDEF(INTOP_CPBLK, "cpblk", 4, 0, 3, InterpOpNoArgs)
 OPDEF(INTOP_LOCALLOC, "localloc", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_BREAKPOINT, "breakpoint", 1, 0, 0, InterpOpNoArgs)
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2020,7 +2020,7 @@ CALL_INTERP_METHOD:
                     if (size && (!dst || !src))
                         COMPlusThrow(kNullReferenceException);
                     else
-                        memcpy(dst, src, size);
+                        memcpyNoGCRefs(dst, src, size);
                     ip += 4;
                     break;
                 }

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2012,6 +2012,15 @@ CALL_INTERP_METHOD:
                     memset(LOCAL_VAR(ip[1], void*), 0, ip[2]);
                     ip += 3;
                     break;
+                case INTOP_CPBLK:
+                {
+                    void* dst = LOCAL_VAR(ip[1], void*);
+                    void* src = LOCAL_VAR(ip[2], void*);
+                    size_t size = LOCAL_VAR(ip[3], size_t);
+                    memcpy(dst, src, size);
+                    ip += 4;
+                    break;
+                }
                 case INTOP_LOCALLOC:
                 {
                     size_t len = LOCAL_VAR(ip[2], size_t);

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2017,7 +2017,10 @@ CALL_INTERP_METHOD:
                     void* dst = LOCAL_VAR(ip[1], void*);
                     void* src = LOCAL_VAR(ip[2], void*);
                     size_t size = LOCAL_VAR(ip[3], size_t);
-                    memcpy(dst, src, size);
+                    if (size && (!dst || !src))
+                        COMPlusThrow(kNullReferenceException);
+                    else
+                        memcpy(dst, src, size);
                     ip += 4;
                     break;
                 }


### PR DESCRIPTION
## Description

This PR includes several improvements to support interpreting methods on startup path:
 - Refactor string allocation to use a native-sized integer instead of a fixed-size integer type
 - Add support for CPBLK operation in the interpreter
 - Special-case constructors for RuntimeMethodHandle, RuntimeFieldHandle, and similar types to support value-type semantics

Contributes to https://github.com/dotnet/runtime/issues/117556