### PR TITLE
JIT: Fix RISC-V emitter build

### DIFF
--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -1896,6 +1896,7 @@ unsigned emitter::emitOutputCall(const insGroup* ig, BYTE* dst, instrDesc* id)
     }
 
     assert(dst > origDst);
+    assert((dst - origDst) <= UINT_MAX);
     return (unsigned)(dst - origDst);
 }
 

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -1895,7 +1895,8 @@ unsigned emitter::emitOutputCall(const insGroup* ig, BYTE* dst, instrDesc* id)
         }
     }
 
-    return dst - origDst;
+    assert(dst > origDst);
+    return (unsigned)(dst - origDst);
 }
 
 void emitter::emitJumpDistBind()


### PR DESCRIPTION
SPMI replay runs are red from this ([example](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1114588&view=results)).