### PR TITLE
[Json] Avoid ReadOnlySequence with Stream deserializing

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IReadBufferState.cs
@@ -22,5 +22,7 @@ namespace System.Text.Json.Serialization
         public abstract void Read(TStream utf8Json);
 
         public abstract void Advance(long bytesConsumed);
+
+        public abstract Utf8JsonReader GetReader(JsonReaderState jsonReaderState);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IReadBufferState.cs
@@ -12,7 +12,10 @@ namespace System.Text.Json.Serialization
     {
         public abstract bool IsFinalBlock { get; }
 
+#if DEBUG
+        // Used for Debug.Assert's
         public abstract ReadOnlySequence<byte> Bytes { get; }
+#endif
 
         public abstract ValueTask<TReadBufferState> ReadAsync(
             TStream utf8Json,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
@@ -136,21 +136,7 @@ namespace System.Text.Json.Serialization.Metadata
             out T? value)
             where TReadBufferState : struct, IReadBufferState<TReadBufferState, TStream>
         {
-            Utf8JsonReader reader;
-            if (bufferState.Bytes.IsSingleSegment)
-            {
-                reader = new Utf8JsonReader(
-#if NET
-                    bufferState.Bytes.FirstSpan,
-#else
-                    bufferState.Bytes.First.Span,
-#endif
-                    bufferState.IsFinalBlock, jsonReaderState);
-            }
-            else
-            {
-                reader = new Utf8JsonReader(bufferState.Bytes, bufferState.IsFinalBlock, jsonReaderState);
-            }
+            Utf8JsonReader reader = bufferState.GetReader(jsonReaderState);
 
             try
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
@@ -142,9 +142,11 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 bool success = EffectiveConverter.ReadCore(ref reader, out value, Options, ref readStack);
 
+#if DEBUG
                 Debug.Assert(reader.BytesConsumed <= bufferState.Bytes.Length);
                 Debug.Assert(!bufferState.IsFinalBlock || reader.AllowMultipleValues || reader.BytesConsumed == bufferState.Bytes.Length,
                     "The reader should have thrown if we have remaining bytes.");
+#endif
 
                 jsonReaderState = reader.CurrentState;
                 return success;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PipeReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PipeReadBufferState.cs
@@ -27,7 +27,9 @@ namespace System.Text.Json.Serialization
 
         public readonly bool IsFinalBlock => _isFinalBlock;
 
+#if DEBUG
         public readonly ReadOnlySequence<byte> Bytes => _sequence;
+#endif
 
         public void Advance(long bytesConsumed)
         {
@@ -75,19 +77,19 @@ namespace System.Text.Json.Serialization
 
         public Utf8JsonReader GetReader(JsonReaderState jsonReaderState)
         {
-            if (Bytes.IsSingleSegment)
+            if (_sequence.IsSingleSegment)
             {
                 return new Utf8JsonReader(
 #if NET
-                    Bytes.FirstSpan,
+                    _sequence.FirstSpan,
 #else
-                    Bytes.First.Span,
+                    _sequence.First.Span,
 #endif
                     IsFinalBlock, jsonReaderState);
             }
             else
             {
-                return new Utf8JsonReader(Bytes, IsFinalBlock, jsonReaderState);
+                return new Utf8JsonReader(_sequence, IsFinalBlock, jsonReaderState);
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PipeReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PipeReadBufferState.cs
@@ -73,6 +73,24 @@ namespace System.Text.Json.Serialization
 
         public void Read(PipeReader utf8Json) => throw new NotImplementedException();
 
+        public Utf8JsonReader GetReader(JsonReaderState jsonReaderState)
+        {
+            if (Bytes.IsSingleSegment)
+            {
+                return new Utf8JsonReader(
+#if NET
+                    Bytes.FirstSpan,
+#else
+                    Bytes.First.Span,
+#endif
+                    IsFinalBlock, jsonReaderState);
+            }
+            else
+            {
+                return new Utf8JsonReader(Bytes, IsFinalBlock, jsonReaderState);
+            }
+        }
+
         private void ProcessReadBytes()
         {
             if (_isFirstBlock)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/StreamReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/StreamReadBufferState.cs
@@ -51,7 +51,9 @@ namespace System.Text.Json.Serialization
 
         public readonly bool IsFinalBlock => _isFinalBlock;
 
+#if DEBUG
         public readonly ReadOnlySequence<byte> Bytes => new(_buffer.AsMemory(_offset, _count));
+#endif
 
         /// <summary>
         /// Read from the stream until either our buffer is filled or we hit EOF.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/StreamReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/StreamReadBufferState.cs
@@ -155,6 +155,14 @@ namespace System.Text.Json.Serialization
             _offset = 0;
         }
 
+        public Utf8JsonReader GetReader(JsonReaderState jsonReaderState)
+        {
+            return new Utf8JsonReader(
+                _buffer.AsSpan(_offset, _count),
+                IsFinalBlock,
+                jsonReaderState);
+        }
+
         private void ProcessReadBytes()
         {
             if (_count > _maxCount)


### PR DESCRIPTION
Removes the construction of a `ReadOnlySequence` and `if` checks for creating a `Utf8JsonReader` in the `Stream` case. Might fix the regressions shown in https://github.com/dotnet/runtime/issues/118173#event-18963963675.

I say might because locally running the microbenchmarks didn't give the most consistent results, but over a bunch of runs the general trend was that this change improved things.