### PR TITLE
Report invalid global.json state in `dotnet --info` and `hostfxr_resolve_sdk2`

### DIFF
--- a/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostFXR.cs
+++ b/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostFXR.cs
@@ -23,6 +23,7 @@ namespace HostApiInvokerApp
                 resolved_sdk_dir = 0,
                 global_json_path = 1,
                 requested_version = 2,
+                global_json_state = 3,
             }
 
             [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
@@ -159,7 +160,7 @@ namespace HostApiInvokerApp
             var data = new List<(hostfxr.hostfxr_resolve_sdk2_result_key_t, string)>();
             int rc = hostfxr.hostfxr_resolve_sdk2(
                 exe_dir: args[0],
-                working_dir: args[1],
+                working_dir: args[1] == "<none>" ? string.Empty : args[1], // Empty string disables global.json look-up
                 flags: Enum.Parse<hostfxr.hostfxr_resolve_sdk2_flags_t>(args[2]),
                 result: (key, value) => data.Add((key, value)));
 

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/ResolveComponentDependencies.cs
@@ -365,7 +365,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 .Should().Fail()
                 .And.HaveStdOutContaining($"corehost_resolve_component_dependencies:Fail[0x{Constants.ErrorCode.ResolverInitFailure.ToString("x")}]")
                 .And.HaveStdOutContaining("corehost reported errors:")
-                .And.HaveStdOutContaining($"A JSON parsing exception occurred in [{component.DepsJson}], offset 0 (line 1, column 1): Invalid value.")
+                .And.HaveStdOutContaining($"Failed to parse file [{component.DepsJson}]. JSON parsing exception: Invalid value. [offset 0: line 1, column 1]")
                 .And.HaveStdOutContaining($"Error initializing the dependency resolver: An error occurred while parsing: {component.DepsJson}");
         }
 
@@ -426,7 +426,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 .Should().Fail()
                 .And.HaveStdOutContaining($"ComponentA: corehost_resolve_component_dependencies:Fail[0x{Constants.ErrorCode.ResolverInitFailure.ToString("x")}]")
                 .And.HaveStdOutContaining($"ComponentA: corehost reported errors:")
-                .And.HaveStdOutContaining($"ComponentA: A JSON parsing exception occurred in [{componentWithNoDependencies.DepsJson}], offset 0 (line 1, column 1): Invalid value.")
+                .And.HaveStdOutContaining($"ComponentA: Failed to parse file [{componentWithNoDependencies.DepsJson}]. JSON parsing exception: Invalid value. [offset 0: line 1, column 1]")
                 .And.HaveStdOutContaining($"ComponentA: Error initializing the dependency resolver: An error occurred while parsing: {componentWithNoDependencies.DepsJson}")
                 .And.HaveStdOutContaining($"ComponentB: corehost_resolve_component_dependencies:Fail[0x{Constants.ErrorCode.LibHostInvalidArgs.ToString("x")}]")
                 .And.HaveStdOutContaining($"ComponentB: corehost reported errors:")

--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -187,7 +187,9 @@ namespace HostActivation.Tests
         }
 
         [Theory]
+        [InlineData("9")]
         [InlineData("9.0")]
+        [InlineData("9.0.x")]
         [InlineData("invalid")]
         public void Info_GlobalJson_InvalidData(string version)
         {

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -310,6 +310,34 @@ namespace HostActivation.Tests
         }
 
         [Fact]
+        public void Hostfxr_resolve_sdk2_GlobalJson_InvalidDataNoFallback()
+        {
+            // With global.json with invalid version value - feature band < 1
+            // No match, report invalid data for global.json
+
+            var f = sharedTestState.SdkAndFrameworkFixture;
+            using (TestArtifact workingDir = TestArtifact.Create(nameof(Hostfxr_resolve_sdk2_GlobalJson_InvalidData)))
+            {
+                string invalidVersion = "1.2.0";
+                string globalJson = GlobalJson.CreateWithVersion(workingDir.Location, invalidVersion);
+                string expectedData = string.Join(';', new[]
+                {
+                    ("global_json_path", globalJson),
+                    ("requested_version", invalidVersion),
+                    ("global_json_state", "__invalid_data_no_fallback"),
+                });
+
+                string api = ApiNames.hostfxr_resolve_sdk2;
+                TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "0")
+                    .EnableTracingAndCaptureOutputs()
+                    .Execute()
+                    .Should().Pass()
+                    .And.ReturnStatusCode(api, Constants.ErrorCode.SdkResolveFailure)
+                    .And.HaveStdOutContaining($"{api} data:[{expectedData}]");
+            }
+        }
+
+        [Fact]
         public void Hostfxr_corehost_set_error_writer_test()
         {
             TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, "Test_hostfxr_set_error_writer")

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -4,12 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.DotNet.CoreSetup.Test.HostActivation;
 using Microsoft.DotNet.TestUtils;
 using Xunit;
 
-namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
+namespace HostActivation.Tests
 {
     internal class ApiNames
     {
@@ -33,11 +36,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             private readonly TestArtifact _artifact;
 
-
+            // Versions are assumed to be in ascending order. We use these properties to check against the
+            // expected values passed to hostfxr API callbacks in the expected order.
             public string ExeDir => Path.Combine(_artifact.Location, "ed");
             public string LocalSdkDir => Path.Combine(ExeDir, "sdk");
             public string LocalFrameworksDir => Path.Combine(ExeDir, "shared");
-            public string[] LocalSdks = new[] { "0.1.2", "5.6.7-preview", "1.2.3" };
+            public string[] LocalSdks = new[] { "0.1.200", "1.2.300", "5.6.701-preview" };
+            public IEnumerable<string> LocalSdkPaths => LocalSdks.Select(sdk => Path.Combine(LocalSdkDir, sdk));
             public List<(string fwName, string[] fwVersions)> LocalFrameworks =
                 new List<(string fwName, string[] fwVersions)>()
                 {
@@ -48,7 +53,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             public string ProgramFiles => Path.Combine(_artifact.Location, "pf");
             public string ProgramFilesGlobalSdkDir => Path.Combine(ProgramFiles, "dotnet", "sdk");
             public string ProgramFilesGlobalFrameworksDir => Path.Combine(ProgramFiles, "dotnet", "shared");
-            public string[] ProgramFilesGlobalSdks = new[] { "4.5.6", "1.2.3", "2.3.4-preview" };
+            public string[] ProgramFilesGlobalSdks = new[] { "1.2.300", "2.3.400-preview", "4.5.600" };
             public List<(string fwName, string[] fwVersions)> ProgramFilesGlobalFrameworks =
                 new List<(string fwName, string[] fwVersions)>()
                 {
@@ -58,7 +63,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             public string SelfRegistered => Path.Combine(_artifact.Location, "sr");
             public string SelfRegisteredGlobalSdkDir => Path.Combine(SelfRegistered, "sdk");
-            public string[] SelfRegisteredGlobalSdks = new[] { "3.0.0", "15.1.4-preview", "5.6.7" };
+            public string[] SelfRegisteredGlobalSdks = new[] { "3.0.100", "5.6.700", "15.1.400-preview" };
 
             public SdkAndFrameworkFixture()
             {
@@ -122,12 +127,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Starting with .NET 7, multi-level lookup is completely disabled for hostfxr API calls.
             // This test is still valuable to validate that it is in fact disabled
             var f = sharedTestState.SdkAndFrameworkFixture;
-            string expectedList = string.Join(';', new[]
-            {
-                Path.Combine(f.LocalSdkDir, "0.1.2"),
-                Path.Combine(f.LocalSdkDir, "1.2.3"),
-                Path.Combine(f.LocalSdkDir, "5.6.7-preview"),
-            });
+            string expectedList = string.Join(';', f.LocalSdkPaths);
 
             string api = ApiNames.hostfxr_get_available_sdks;
             sharedTestState.TestBehaviorEnabledDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
@@ -146,12 +146,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Get SDKs sorted by ascending version
 
             var f = sharedTestState.SdkAndFrameworkFixture;
-            string expectedList = string.Join(';', new[]
-            {
-                 Path.Combine(f.LocalSdkDir, "0.1.2"),
-                 Path.Combine(f.LocalSdkDir, "1.2.3"),
-                 Path.Combine(f.LocalSdkDir, "5.6.7-preview"),
-            });
+            string expectedList = string.Join(';', f.LocalSdkPaths);
 
             string api = ApiNames.hostfxr_get_available_sdks;
             TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
@@ -170,7 +165,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var f = sharedTestState.SdkAndFrameworkFixture;
             string expectedData = string.Join(';', new[]
             {
-                ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "5.6.7-preview")),
+                ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "5.6.701-preview")),
                 ("global_json_state", "not_found"),
             });
 
@@ -191,7 +186,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var f = sharedTestState.SdkAndFrameworkFixture;
             string expectedData = string.Join(';', new[]
             {
-                ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "1.2.3")),
+                ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "1.2.300")),
                 ("global_json_state", "not_found"),
             });
 
@@ -214,11 +209,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var f = sharedTestState.SdkAndFrameworkFixture;
             using (TestArtifact workingDir = TestArtifact.Create(nameof(workingDir)))
             {
-                string requestedVersion = "5.6.6-preview";
+                string requestedVersion = "5.6.700-preview";
                 string globalJson = GlobalJson.CreateWithVersion(workingDir.Location, requestedVersion);
                 string expectedData = string.Join(';', new[]
                 {
-                    ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "5.6.7-preview")),
+                    ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "5.6.701-preview")),
                     ("global_json_path", globalJson),
                     ("requested_version", requestedVersion),
                     ("global_json_state", "valid"),
@@ -246,7 +241,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 string globalJson = GlobalJson.Write(workingDir.Location, new GlobalJson.Sdk() { Paths = [ f.SelfRegistered, f.LocalSdkDir ] });
                 string expectedData = string.Join(';', new[]
                 {
-                    ("resolved_sdk_dir", Path.Combine(f.SelfRegisteredGlobalSdkDir, "15.1.4-preview")),
+                    ("resolved_sdk_dir", Path.Combine(f.SelfRegisteredGlobalSdkDir, "15.1.400-preview")),
                     ("global_json_path", globalJson),
                     ("global_json_state", "valid"),
                 });
@@ -273,7 +268,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 GlobalJson.Write(workingDir.Location, "{ \"sdk\": { }");
                 string expectedData = string.Join(';', new[]
                 {
-                    ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "5.6.7-preview")),
+                    ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "5.6.701-preview")),
                     ("global_json_state", "invalid_json"),
                 });
 
@@ -300,7 +295,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 GlobalJson.CreateWithVersion(workingDir.Location, invalidVersion);
                 string expectedData = string.Join(';', new[]
                 {
-                    ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "5.6.7-preview")),
+                    ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "5.6.701-preview")),
                     ("global_json_state", "invalid_data"),
                 });
 
@@ -327,19 +322,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void Hostfxr_get_dotnet_environment_info_dotnet_root_only()
         {
             var f = sharedTestState.SdkAndFrameworkFixture;
-            string expectedSdkVersions = string.Join(";", new[]
-            {
-                "0.1.2",
-                "1.2.3",
-                "5.6.7-preview"
-            });
-
-            string expectedSdkPaths = string.Join(';', new[]
-            {
-                 Path.Combine(f.LocalSdkDir, "0.1.2"),
-                 Path.Combine(f.LocalSdkDir, "1.2.3"),
-                 Path.Combine(f.LocalSdkDir, "5.6.7-preview"),
-            });
+            string expectedSdkVersions = string.Join(";", f.LocalSdks);
+            string expectedSdkPaths = string.Join(';', f.LocalSdkPaths);
 
             string expectedFrameworkNames = string.Join(';', new[]
             {
@@ -380,19 +364,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void Hostfxr_get_dotnet_environment_info_with_multilevel_lookup_with_dotnet_root()
         {
             var f = sharedTestState.SdkAndFrameworkFixture;
-            string expectedSdkVersions = string.Join(';', new[]
-            {
-                "0.1.2",
-                "1.2.3",
-                "5.6.7-preview",
-            });
-
-            string expectedSdkPaths = string.Join(';', new[]
-            {
-                Path.Combine(f.LocalSdkDir, "0.1.2"),
-                Path.Combine(f.LocalSdkDir, "1.2.3"),
-                Path.Combine(f.LocalSdkDir, "5.6.7-preview"),
-            });
+            string expectedSdkVersions = string.Join(';', f.LocalSdks);
+            string expectedSdkPaths = string.Join(';', f.LocalSdkPaths);
 
             string expectedFrameworkNames = string.Join(';', new[]
             {

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetNativeSearchDirectories.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetNativeSearchDirectories.cs
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .And.HaveStdOutContaining($"get_native_search_directories (null,0) returned unexpected error code 0x{Constants.ErrorCode.ResolverInitFailure:x} expected HostApiBufferTooSmall (0x80008098).")
                 .And.HaveStdOutContaining("buffer_size: 0")
                 .And.HaveStdOutContaining("hostfxr reported errors:")
-                .And.HaveStdOutContaining($"A JSON parsing exception occurred in [{depsJsonFile}], offset 1 (line 1, column 2): Missing a name for object member.")
+                .And.HaveStdOutContaining($"Failed to parse file [{depsJsonFile}]. JSON parsing exception: Missing a name for object member. [offset 1: line 1, column 2]")
                 .And.HaveStdOutContaining($"Error initializing the dependency resolver: An error occurred while parsing: {depsJsonFile}");
         }
 

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -632,7 +632,7 @@ namespace HostActivation.Tests
                 yield return new object[] {
                     "{ sdk: { \"version\": \"9999.0.100\" } }",
                     new[] {
-                        "A JSON parsing exception occurred",
+                        "JSON parsing exception:",
                         IgnoringSDKSettings
                     }
                 };

--- a/src/installer/tests/TestUtils/Constants.cs
+++ b/src/installer/tests/TestUtils/Constants.cs
@@ -128,6 +128,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             public const int AppArgNotRunnable = unchecked((int)0x80008094);
             public const int AppHostExeNotBoundFailure = unchecked((int)0x80008095);
             public const int FrameworkMissingFailure = unchecked((int)0x80008096);
+            public const int SdkResolveFailure = unchecked((int)0x8000809b);
             public const int FrameworkCompatFailure = unchecked((int)0x8000809c);
             public const int BundleExtractionFailure = unchecked((int)0x8000809f);
 

--- a/src/native/corehost/comhost/clsidmap.cpp
+++ b/src/native/corehost/comhost/clsidmap.cpp
@@ -102,7 +102,7 @@ namespace
         json_parser_t json;
         if (!json.parse_raw_data(reinterpret_cast<char*>(data), size, _X("<embedded .clsidmap>")))
         {
-            trace::error(_X("Embedded .clsidmap format is invalid"));
+            trace::error(_X("Embedded .clsidmap is invalid.\n  %s"), json.get_error_message().c_str());
             throw HResultException{ StatusCode::InvalidConfigFile };
         }
 
@@ -180,7 +180,7 @@ namespace
         json_parser_t json;
         if (!json.parse_file(map_file_name))
         {
-            trace::error(_X("File .clsidmap format is invalid"));
+            trace::error(_X("File .clsidmap [%s] is invalid.\n  %s"), map_file_name.c_str(), json.get_error_message().c_str());
             throw HResultException{ StatusCode::InvalidConfigFile };
         }
 

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -280,7 +280,7 @@ int command_line::parse_args_for_sdk_command(
     return parse_args(host_info, 1, argc, argv, false, host_mode_t::muxer, new_argoff, app_candidate, opts);
 }
 
-void command_line::print_muxer_info(const pal::string_t &dotnet_root, const pal::string_t &global_json_path, bool skip_sdk_info_output)
+void command_line::print_muxer_info(const pal::string_t &dotnet_root, const sdk_resolver::global_file_info &global_json, bool skip_sdk_info_output)
 {
     pal::string_t commit = _STRINGIFY(REPO_COMMIT_HASH);
     trace::println(_X("\n")
@@ -322,9 +322,25 @@ void command_line::print_muxer_info(const pal::string_t &dotnet_root, const pal:
     }
 
     trace::println(_X("\n")
-        _X("global.json file:\n")
-        _X("  %s"),
-        global_json_path.empty() ? _X("Not found") : global_json_path.c_str());
+        _X("global.json file:"));
+    switch (global_json.state)
+    {
+        case sdk_resolver::global_file_info::state::not_found:
+            trace::println(_X("  Not found"));
+            break;
+        case sdk_resolver::global_file_info::state::valid:
+            trace::println(_X("  %s"), global_json.path.c_str());
+            break;
+        case sdk_resolver::global_file_info::state::invalid_json:
+        case sdk_resolver::global_file_info::state::invalid_data:
+            trace::println(_X("  Invalid [%s]"), global_json.path.c_str());
+            if (!global_json.error_message.empty())
+            {
+                trace::println(_X("    %s"), global_json.error_message.c_str());
+            }
+            trace::println(_X("    Invalid global.json is ignored for SDK resolution."));
+            break;
+    }
 
     trace::println(_X("\n")
         _X("Learn more:\n")

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -340,6 +340,9 @@ void command_line::print_muxer_info(const pal::string_t &dotnet_root, const sdk_
             }
             trace::println(_X("    Invalid global.json is ignored for SDK resolution."));
             break;
+        case sdk_resolver::global_file_info::state::__last:
+            assert(false && "Unexpected __last state");
+            break;
     }
 
     trace::println(_X("\n")

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -333,12 +333,16 @@ void command_line::print_muxer_info(const pal::string_t &dotnet_root, const sdk_
             break;
         case sdk_resolver::global_file_info::state::invalid_json:
         case sdk_resolver::global_file_info::state::invalid_data:
+        case sdk_resolver::global_file_info::state::__invalid_data_no_fallback:
             trace::println(_X("  Invalid [%s]"), global_json.path.c_str());
             if (!global_json.error_message.empty())
             {
                 trace::println(_X("    %s"), global_json.error_message.c_str());
             }
-            trace::println(_X("    Invalid global.json is ignored for SDK resolution."));
+            if (global_json.state != sdk_resolver::global_file_info::state::__invalid_data_no_fallback)
+            {
+                trace::println(_X("    Invalid global.json is ignored for SDK resolution."));
+            }
             break;
         case sdk_resolver::global_file_info::state::__last:
             assert(false && "Unexpected __last state");

--- a/src/native/corehost/fxr/command_line.h
+++ b/src/native/corehost/fxr/command_line.h
@@ -8,6 +8,8 @@
 #include <host_startup_info.h>
 #include <pal.h>
 
+#include "sdk_resolver.h"
+
 enum class known_options
 {
     additional_probing_path,
@@ -59,7 +61,7 @@ namespace command_line
 
     // skip_sdk_info_output indicates whether or not to skip any information that the SDK would have
     // already printed. Related: https://github.com/dotnet/sdk/issues/33697
-    void print_muxer_info(const pal::string_t &dotnet_root, const pal::string_t &global_json_path, bool skip_sdk_info_output);
+    void print_muxer_info(const pal::string_t &dotnet_root, const sdk_resolver::global_file_info& global_json, bool skip_sdk_info_output);
     void print_muxer_usage(bool is_sdk_present);
 };
 

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -1103,7 +1103,7 @@ int fx_muxer_t::handle_cli(
         }
         else if (pal::strcasecmp(_X("--info"), argv[1]) == 0)
         {
-            command_line::print_muxer_info(host_info.dotnet_root, resolver.global_file_path(), false /*skip_sdk_info_output*/);
+            command_line::print_muxer_info(host_info.dotnet_root, resolver.global_file(), false /*skip_sdk_info_output*/);
             return StatusCode::Success;
         }
 
@@ -1160,7 +1160,7 @@ int fx_muxer_t::handle_cli(
 
     if (pal::strcasecmp(_X("--info"), argv[1]) == 0)
     {
-        command_line::print_muxer_info(host_info.dotnet_root, resolver.global_file_path(), result == 0 /*skip_sdk_info_output*/);
+        command_line::print_muxer_info(host_info.dotnet_root, resolver.global_file(), result == 0 /*skip_sdk_info_output*/);
     }
 
     return result;

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -273,11 +273,12 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk2(
             resolved_sdk_dir.c_str());
     }
 
-    if (!resolver.global_file_path().empty())
+    if (resolver.global_file().state == sdk_resolver::global_file_info::state::valid
+        && !resolver.global_file().path.empty())
     {
         result(
             hostfxr_resolve_sdk2_result_key_t::global_json_path,
-            resolver.global_file_path().c_str());
+            resolver.global_file().path.c_str());
     }
 
     if (!resolver.get_requested_version().is_empty())

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -188,6 +188,7 @@ namespace
         _X("valid"),
         _X("invalid_json"),
         _X("invalid_data"),
+        _X("__invalid_data_no_fallback"),
     };
     static_assert((sizeof(GlobalJsonStates) / sizeof(*GlobalJsonStates)) == static_cast<size_t>(sdk_resolver::global_file_info::state::__last), "Invalid state count");
 }

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -290,8 +290,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk2(
             resolved_sdk_dir.c_str());
     }
 
-    if (resolver.global_file().state == sdk_resolver::global_file_info::state::valid
-        && !resolver.global_file().path.empty())
+    if (resolver.global_file().is_data_used() && !resolver.global_file().path.empty())
     {
         result(
             hostfxr_resolve_sdk2_result_key_t::global_json_path,

--- a/src/native/corehost/fxr/sdk_resolver.cpp
+++ b/src/native/corehost/fxr/sdk_resolver.cpp
@@ -29,22 +29,10 @@ namespace
 }
 
 sdk_resolver::sdk_resolver(bool allow_prerelease)
-    : sdk_resolver({}, sdk_roll_forward_policy::latest_major, allow_prerelease)
-{
-}
-
-sdk_resolver::sdk_resolver(fx_ver_t version, sdk_roll_forward_policy roll_forward, bool allow_prerelease)
-    : requested_version(std::move(version))
-    , roll_forward(roll_forward)
-    , allow_prerelease(allow_prerelease)
-    , has_custom_paths(false)
-{
-}
-
-const pal::string_t& sdk_resolver::global_file_path() const
-{
-    return global_file;
-}
+    : roll_forward{sdk_roll_forward_policy::latest_major}
+    , allow_prerelease{allow_prerelease}
+    , has_custom_paths{false}
+{ }
 
 const fx_ver_t& sdk_resolver::get_requested_version() const
 {
@@ -121,7 +109,7 @@ std::vector<pal::string_t> sdk_resolver::get_search_paths(const pal::string_t& d
     else
     {
         // Use custom paths specified in the global.json
-        pal::string_t json_dir = get_directory(global_file);
+        pal::string_t json_dir = get_directory(global_json.path);
         for (const pal::string_t& path : paths)
         {
             if (path == _X("$host$"))
@@ -166,10 +154,10 @@ void sdk_resolver::print_resolution_error(const pal::string_t& dotnet_root, cons
             main_error_prefix,
             requested.c_str());
 
-        bool has_global_file = !global_file.empty();
+        bool has_global_file = global_json.state == global_file_info::state::valid;
         if (has_global_file)
         {
-            trace::error(_X("global.json file: %s"), global_file.c_str());
+            trace::error(_X("global.json file: %s"), global_json.path.c_str());
             if (has_custom_paths)
             {
                 trace::error(_X("  Search paths:"));
@@ -188,7 +176,7 @@ void sdk_resolver::print_resolution_error(const pal::string_t& dotnet_root, cons
         trace::error(_X(""));
         if (has_global_file)
         {
-            trace::error(_X("Install the [%s] .NET SDK or update [%s] to match an installed SDK."), requested.c_str(), global_file.c_str());
+            trace::error(_X("Install the [%s] .NET SDK or update [%s] to match an installed SDK."), requested.c_str(), global_json.path.c_str());
         }
         else
         {
@@ -200,7 +188,7 @@ void sdk_resolver::print_resolution_error(const pal::string_t& dotnet_root, cons
         trace::error(_X("%s%s"), main_error_prefix, no_sdk_message);
         if (has_custom_paths && paths.empty())
         {
-            trace::error(_X("%sEmpty search paths specified in global.json file: %s"), main_error_prefix, global_file.c_str());
+            trace::error(_X("%sEmpty search paths specified in global.json file: %s"), main_error_prefix, global_json.path.c_str());
         }
     }
 
@@ -237,14 +225,27 @@ sdk_resolver sdk_resolver::from_nearest_global_file(const pal::string_t& cwd, bo
 {
     sdk_resolver resolver{ allow_prerelease };
 
-    if (!resolver.parse_global_file(find_nearest_global_file(cwd)))
-    {
-        // Fall back to a default SDK resolver
-        resolver = sdk_resolver{ allow_prerelease };
+    pal::string_t global_file_path = find_nearest_global_file(cwd);
 
-        trace::warning(
-            _X("Ignoring SDK settings in global.json: the latest installed .NET SDK (%s prereleases) will be used"),
-            resolver.allow_prerelease ? _X("including") : _X("excluding"));
+    if (global_file_path.empty())
+    {
+        resolver.global_json.state = global_file_info::state::not_found;
+    }
+    else
+    {
+        global_file_info global_file = resolver.parse_global_file(global_file_path);
+        if (global_file.state != global_file_info::state::valid)
+        {
+            // Fall back to a default SDK resolver
+            resolver = sdk_resolver{ allow_prerelease };
+
+            trace::verbose(_X("Invalid global.json [%s]:\n  %s"), global_file.path.c_str(), global_file.error_message.c_str());
+            trace::warning(
+                _X("Ignoring SDK settings in global.json: the latest installed .NET SDK (%s prereleases) will be used"),
+                resolver.allow_prerelease ? _X("including") : _X("excluding"));
+        }
+
+        resolver.global_json = std::move(global_file);
     }
 
     // If the requested version is a prerelease, always allow prerelease versions
@@ -312,22 +313,27 @@ pal::string_t sdk_resolver::find_nearest_global_file(const pal::string_t& cwd)
     return {};
 }
 
-bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
+sdk_resolver::global_file_info sdk_resolver::parse_global_file(const pal::string_t& global_file_path)
 {
+    global_file_info ret;
     if (global_file_path.empty())
     {
         // Missing global.json is treated as success (use default resolver)
-        return true;
+        ret.state = global_file_info::state::not_found;
+        return ret;
     }
 
     trace::verbose(_X("--- Resolving SDK information from global.json [%s]"), global_file_path.c_str());
+    ret.path = global_file_path;
 
     // After we're done parsing `global_file_path`, none of its contents will be referenced
     // from the data private to json_parser_t; it's safe to declare it on the stack.
     json_parser_t json;
     if (!json.parse_file(global_file_path))
     {
-        return false;
+        ret.error_message = json.get_error_message();
+        ret.state = global_file_info::state::invalid_json;
+        return ret;
     }
 
     const auto& sdk = json.document().FindMember(_X("sdk"));
@@ -335,13 +341,16 @@ bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
     {
         // Missing SDK is treated as success (use default resolver)
         trace::verbose(_X("Value 'sdk' is missing or null in [%s]"), global_file_path.c_str());
-        return true;
+        ret.state = global_file_info::state::valid;
+        return ret;
     }
+
+    ret.state = global_file_info::state::invalid_data;
 
     if (!sdk->value.IsObject())
     {
-        trace::warning(_X("Expected a JSON object for the 'sdk' value in [%s]"), global_file_path.c_str());
-        return false;
+        ret.error_message = _X("Expected a JSON object for the 'sdk' value");
+        return ret;
     }
 
     const auto& version_value = sdk->value.FindMember(_X("version"));
@@ -353,18 +362,14 @@ bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
     {
         if (!version_value->value.IsString())
         {
-            trace::warning(_X("Expected a string for the 'sdk/version' value in [%s]"), global_file_path.c_str());
-            return false;
+            ret.error_message = _X("Expected a string for the 'sdk/version' value");
+            return ret;
         }
 
         if (!fx_ver_t::parse(version_value->value.GetString(), &requested_version, false))
         {
-            trace::warning(
-                _X("Version '%s' is not valid for the 'sdk/version' value in [%s]"),
-                version_value->value.GetString(),
-                global_file_path.c_str()
-            );
-            return false;
+            ret.error_message = utils::format_string(_X("Version '%s' is not valid for the 'sdk/version' value"), version_value->value.GetString());
+            return ret;
         }
 
         // The default policy when a version is specified is 'patch'
@@ -380,30 +385,22 @@ bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
     {
         if (!roll_forward_value->value.IsString())
         {
-            trace::warning(_X("Expected a string for the 'sdk/rollForward' value in [%s]"), global_file_path.c_str());
-            return false;
+            ret.error_message = _X("Expected a string for the 'sdk/rollForward' value");
+            return ret;
         }
 
         roll_forward = to_policy(roll_forward_value->value.GetString());
         if (roll_forward == sdk_roll_forward_policy::unsupported)
         {
-            trace::warning(
-                _X("The roll-forward policy '%s' is not supported for the 'sdk/rollForward' value in [%s]"),
-                roll_forward_value->value.GetString(),
-                global_file_path.c_str()
-            );
-            return false;
+            ret.error_message = utils::format_string(_X("The roll-forward policy '%s' is not supported for the 'sdk/rollForward' value"), roll_forward_value->value.GetString());
+            return ret;
         }
 
         // All policies other than 'latestMajor' require a version to operate
         if (roll_forward != sdk_roll_forward_policy::latest_major && requested_version.is_empty())
         {
-            trace::warning(
-                _X("The roll-forward policy '%s' requires a 'sdk/version' value in [%s]"),
-                roll_forward_value->value.GetString(),
-                global_file_path.c_str()
-            );
-            return false;
+            ret.error_message = utils::format_string(_X("The roll-forward policy '%s' requires a 'sdk/version' value"), roll_forward_value->value.GetString());
+            return ret;
         }
     }
 
@@ -416,8 +413,8 @@ bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
     {
         if (!allow_prerelease_value->value.IsBool())
         {
-            trace::warning(_X("Expected a boolean for the 'sdk/allowPrerelease' value in [%s]"), global_file_path.c_str());
-            return false;
+            ret.error_message = _X("Expected a boolean for the 'sdk/allowPrerelease' value");
+            return ret;
         }
 
         allow_prerelease = allow_prerelease_value->value.GetBool();
@@ -434,8 +431,8 @@ bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
     {
         if (!paths_value->value.IsArray())
         {
-            trace::warning(_X("Expected an array for 'sdk/paths' value in [%s]"), global_file_path.c_str());
-            return false;
+            ret.error_message = _X("Expected an array for 'sdk/paths' value");
+            return ret;
         }
 
         has_custom_paths = true;
@@ -459,15 +456,15 @@ bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
     {
         if (!error_message_value->value.IsString())
         {
-            trace::warning(_X("Expected a string for the 'sdk/errorMessage' value in [%s]"), global_file_path.c_str());
-            return false;
+            ret.error_message = _X("Expected a string for the 'sdk/errorMessage' value");
+            return ret;
         }
 
         error_message = error_message_value->value.GetString();
     }
 
-    global_file = std::move(global_file_path);
-    return true;
+    ret.state = global_file_info::state::valid;
+    return ret;
 }
 
 bool sdk_resolver::matches_policy(const fx_ver_t& current) const

--- a/src/native/corehost/fxr/sdk_resolver.cpp
+++ b/src/native/corehost/fxr/sdk_resolver.cpp
@@ -154,7 +154,7 @@ void sdk_resolver::print_resolution_error(const pal::string_t& dotnet_root, cons
             main_error_prefix,
             requested.c_str());
 
-        bool has_global_file = global_json.state == global_file_info::state::valid;
+        bool has_global_file = global_json.is_data_used();
         if (has_global_file)
         {
             trace::error(_X("global.json file: %s"), global_json.path.c_str());
@@ -234,7 +234,7 @@ sdk_resolver sdk_resolver::from_nearest_global_file(const pal::string_t& cwd, bo
     else
     {
         global_file_info global_file = resolver.parse_global_file(global_file_path);
-        if (global_file.state != global_file_info::state::valid && global_file.state != global_file_info::state::__invalid_data_no_fallback)
+        if (!global_file.is_data_used())
         {
             // Fall back to a default SDK resolver
             resolver = sdk_resolver{ allow_prerelease };

--- a/src/native/corehost/fxr/sdk_resolver.cpp
+++ b/src/native/corehost/fxr/sdk_resolver.cpp
@@ -471,14 +471,12 @@ sdk_resolver::global_file_info sdk_resolver::parse_global_file(const pal::string
         error_message = error_message_value->value.GetString();
     }
 
-    // SDK feature bands start at 1, so setting version with a feature band < 1 and not rolling forward on feature band will always
-    // fail when trying to resolve the SDK. We want to provide an error message, but we should not fall back to the default resolver.
-    if (!requested_version.is_empty() && get_feature_band(requested_version) < 1
-        && (roll_forward == sdk_roll_forward_policy::disable
-            || roll_forward == sdk_roll_forward_policy::patch
-            || roll_forward == sdk_roll_forward_policy::latest_patch))
+    // SDK feature bands start at 1, so a version with a feature band < 1 is not a valid version.
+    // We want to provide an error message, but we should still use the settings in the global.json
+    // and not fall back to the default resolver.
+    if (!requested_version.is_empty() && get_feature_band(requested_version) < 1)
     {
-        ret.error_message = utils::format_string(_X("Version '%s' feature band does not exist and roll-forward policy '%s' does not roll forward on feature band"), requested_version.as_str().c_str(), to_policy_name(roll_forward));
+        ret.error_message = utils::format_string(_X("Version '%s' is not valid for the 'sdk/version' value. SDK feature bands start at 1 - for example, %d.%d.100"), requested_version.as_str().c_str(), requested_version.get_major(), requested_version.get_minor());
         ret.state = global_file_info::state::__invalid_data_no_fallback;
         return ret;
     }

--- a/src/native/corehost/fxr/sdk_resolver.h
+++ b/src/native/corehost/fxr/sdk_resolver.h
@@ -34,10 +34,22 @@ enum class sdk_roll_forward_policy
 class sdk_resolver
 {
 public:
-    explicit sdk_resolver(bool allow_prerelease = true);
-    sdk_resolver(fx_ver_t version, sdk_roll_forward_policy roll_forward, bool allow_prerelease);
+    struct global_file_info
+    {
+        enum class state
+        {
+            not_found,
+            valid,
+            invalid_json,
+            invalid_data
+        };
 
-    const pal::string_t& global_file_path() const;
+        state state;
+        pal::string_t path;
+        pal::string_t error_message;
+    };
+
+    const global_file_info& global_file() const { return global_json; }
 
     const fx_ver_t& get_requested_version() const;
 
@@ -54,10 +66,11 @@ public:
         bool allow_prerelease = true);
 
 private:
+    explicit sdk_resolver(bool allow_prerelease = true);
     static sdk_roll_forward_policy to_policy(const pal::string_t& name);
     static const pal::char_t* to_policy_name(sdk_roll_forward_policy policy);
     static pal::string_t find_nearest_global_file(const pal::string_t& cwd);
-    bool parse_global_file(pal::string_t global_file_path);
+    global_file_info parse_global_file(const pal::string_t& global_file_path);
     bool matches_policy(const fx_ver_t& current) const;
     bool is_better_match(const fx_ver_t& current, const fx_ver_t& previous) const;
     bool exact_match_preferred() const;
@@ -66,7 +79,7 @@ private:
     // Returns true and sets sdk_path/resolved_version if a matching SDK was found
     bool resolve_sdk_path_and_version(const pal::string_t& dir, pal::string_t& sdk_path, fx_ver_t& resolved_version) const;
 
-    pal::string_t global_file;
+    global_file_info global_json;
     fx_ver_t requested_version;
     sdk_roll_forward_policy roll_forward;
     bool allow_prerelease;

--- a/src/native/corehost/fxr/sdk_resolver.h
+++ b/src/native/corehost/fxr/sdk_resolver.h
@@ -41,7 +41,8 @@ public:
             not_found,
             valid,
             invalid_json,
-            invalid_data
+            invalid_data,
+            __last
         };
 
         state state;

--- a/src/native/corehost/fxr/sdk_resolver.h
+++ b/src/native/corehost/fxr/sdk_resolver.h
@@ -51,6 +51,9 @@ public:
         state state;
         pal::string_t path;
         pal::string_t error_message;
+
+        // Whether or not the global.json is actually used for resolution.
+        bool is_data_used() const { return state == state::valid || state == state::__invalid_data_no_fallback; }
     };
 
     const global_file_info& global_file() const { return global_json; }

--- a/src/native/corehost/fxr/sdk_resolver.h
+++ b/src/native/corehost/fxr/sdk_resolver.h
@@ -42,6 +42,9 @@ public:
             valid,
             invalid_json,
             invalid_data,
+            // Invalid data that doesn't fall back to default resolution. If we are able to remove the fallback
+            // and just fail on invalid data, this should be removed and invalid_data used instead.
+            __invalid_data_no_fallback,
             __last
         };
 

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -160,6 +160,12 @@ namespace pal
     inline int str_vprintf(char_t* buffer, size_t count, const char_t* format, va_list vl) { return ::_vsnwprintf_s(buffer, count, _TRUNCATE, format, vl); }
     inline int strlen_vprintf(const char_t* format, va_list vl) { return ::_vscwprintf(format, vl); }
 
+    template <typename... Args>
+    int str_printf(char_t* buffer, size_t count, const char_t* format, Args&&... args) { return ::_snwprintf_s(buffer, count, _TRUNCATE, format, std::forward<Args>(args)...); }
+
+    template <typename... Args>
+    inline int strlen_printf(const char_t* format, Args&&... args) { return ::_scwprintf(format, std::forward<Args>(args)...); }
+
     inline const string_t strerror(int errnum)
     {
         // Windows does not provide strerrorlen to get the actual error length.
@@ -230,6 +236,12 @@ namespace pal
     inline void out_vprint_line(const char_t* format, va_list vl) { ::vfprintf(stdout, format, vl); ::fputc('\n', stdout); }
     inline int str_vprintf(char_t* str, size_t size, const char_t* format, va_list vl) { return ::vsnprintf(str, size, format, vl); }
     inline int strlen_vprintf(const char_t* format, va_list vl) { return ::vsnprintf(nullptr, 0, format, vl); }
+
+    template <typename... Args>
+    int str_printf(char_t* buffer, size_t size, const char_t* format, Args&&... args) { return ::snprintf(buffer, size, format, std::forward<Args>(args)...); }
+
+    template <typename... Args>
+    inline int strlen_printf(const char_t* format, Args&&... args) { return ::snprintf(nullptr, 0, format, std::forward<Args>(args)...); }
 
     inline const string_t strerror(int errnum) { return ::strerror(errnum); }
 

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -76,7 +76,7 @@ namespace utils
         int len = pal::strlen_printf(format, std::forward<Args>(args)...) + 1;
         std::vector<pal::char_t> buffer(len);
         pal::str_printf(&buffer[0], len, format, std::forward<Args>(args)...);
-        return pal::string_t{buffer.data()};
+        return pal::string_t(buffer.data(), len - 1);
     }
 }
 

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -76,7 +76,7 @@ namespace utils
         int len = pal::strlen_printf(format, std::forward<Args>(args)...) + 1;
         std::vector<pal::char_t> buffer(len);
         pal::str_printf(&buffer[0], len, format, std::forward<Args>(args)...);
-        return pal::string_t(buffer.data(), len - 1);
+        return pal::string_t(buffer.data(), buffer.size() - 1);
     }
 }
 

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -69,6 +69,15 @@ namespace utils
     {
         return starts_with(value, prefix, L - 1, match_case);
     }
+
+    template <typename... Args>
+    pal::string_t format_string(const pal::char_t* format, Args&&... args)
+    {
+        int len = pal::strlen_printf(format, std::forward<Args>(args)...) + 1;
+        std::vector<pal::char_t> buffer(len);
+        pal::str_printf(&buffer[0], len, format, std::forward<Args>(args)...);
+        return pal::string_t{buffer.data()};
+    }
 }
 
 pal::string_t strip_executable_ext(const pal::string_t& filename);

--- a/src/native/corehost/hostpolicy/deps_format.cpp
+++ b/src/native/corehost/hostpolicy/deps_format.cpp
@@ -587,7 +587,10 @@ void deps_json_t::load(bool is_framework_dependent, std::function<void(const jso
 
     json_parser_t json;
     if (!json.parse_file(m_deps_file))
+    {
+        trace::error(_X("Failed to parse deps file [%s]. %s"), m_deps_file.c_str(), json.get_error_message().c_str());
         return;
+    }
 
     m_valid = true;
     const auto& runtime_target = json.document()[_X("runtimeTarget")];

--- a/src/native/corehost/hostpolicy/deps_format.cpp
+++ b/src/native/corehost/hostpolicy/deps_format.cpp
@@ -588,7 +588,7 @@ void deps_json_t::load(bool is_framework_dependent, std::function<void(const jso
     json_parser_t json;
     if (!json.parse_file(m_deps_file))
     {
-        trace::error(_X("Failed to parse deps file [%s]. %s"), m_deps_file.c_str(), json.get_error_message().c_str());
+        trace::error(_X("Failed to parse file [%s]. %s"), m_deps_file.c_str(), json.get_error_message().c_str());
         return;
     }
 

--- a/src/native/corehost/json_parser.cpp
+++ b/src/native/corehost/json_parser.cpp
@@ -66,15 +66,16 @@ bool json_parser_t::parse_raw_data(char* data, int64_t size, const pal::string_t
 
         get_line_column_from_offset(data, size, offset, &line, &column);
 
-        trace::error(_X("A JSON parsing exception occurred in [%s], offset %zu (line %d, column %d): %s"),
-            context.c_str(), offset, line, column,
-            rapidjson::GetParseError_En(m_document.GetParseError()));
+        m_parse_error = utils::format_string(_X("JSON parsing exception: %s [offset %zu: line %d, column %d]"),
+            rapidjson::GetParseError_En(m_document.GetParseError()),
+            offset, line, column
+        );
         return false;
     }
 
     if (!m_document.IsObject())
     {
-        trace::error(_X("Expected a JSON object in [%s]"), context.c_str());
+        m_parse_error = _X("Expected a JSON object");
         return false;
     }
 

--- a/src/native/corehost/json_parser.h
+++ b/src/native/corehost/json_parser.h
@@ -9,7 +9,7 @@
 #define RAPIDJSON_48BITPOINTER_OPTIMIZATION 0
 
 // see https://github.com/Tencent/rapidjson/issues/1448
-// including windows.h on purpose to provoke a compile time problem as GetObject is a 
+// including windows.h on purpose to provoke a compile time problem as GetObject is a
 // macro that gets defined when windows.h is included
 #ifdef _WIN32
 #define NOMINMAX
@@ -35,6 +35,7 @@ class json_parser_t {
         using document_t = rapidjson::GenericDocument<internal_encoding_type_t>;
 
         const document_t& document() const { return m_document; }
+        const pal::string_t& get_error_message() const { return m_parse_error; }
 
         bool parse_raw_data(char* data, int64_t size, const pal::string_t& context);
         bool parse_file(const pal::string_t& path);
@@ -56,6 +57,9 @@ class json_parser_t {
         // If a json file is parsed from a single-file bundle, the following fields represents
         // the location of this json file within the bundle.
         const bundle::location_t* m_bundle_location;
+
+        // Error message from parsing
+        pal::string_t m_parse_error;
 };
 
 #endif // __JSON_PARSER_H__

--- a/src/native/corehost/runtime_config.cpp
+++ b/src/native/corehost/runtime_config.cpp
@@ -409,6 +409,7 @@ bool runtime_config_t::ensure_parsed()
     json_parser_t json;
     if (!json.parse_file(m_path))
     {
+        trace::error(_X("Failed to parse runtime config [%s]. %s"), m_path.c_str(), json.get_error_message().c_str());
         return false;
     }
 

--- a/src/native/corehost/runtime_config.cpp
+++ b/src/native/corehost/runtime_config.cpp
@@ -409,7 +409,7 @@ bool runtime_config_t::ensure_parsed()
     json_parser_t json;
     if (!json.parse_file(m_path))
     {
-        trace::error(_X("Failed to parse runtime config [%s]. %s"), m_path.c_str(), json.get_error_message().c_str());
+        trace::error(_X("Failed to parse file [%s]. %s"), m_path.c_str(), json.get_error_message().c_str());
         return false;
     }
 


### PR DESCRIPTION
We currently ignore invalid global.json, which can lead to unexpected/undesired behaviour. While we're not going to change that behaviour right now, this change adds some indication about this situation in `dotnet --info` and updates a `hostfxr` API to indicate if an invalid global.json was found.

- Make `sdk_resolver` track/store information about global.json even when it is deemed invalid
- Update `dotnet --info` to list invalid global.json file path and error message
- Add `hostfxr_resolve_sdk2_result_key_t::global_json_state` for `hostfxr_resolve_sdk2` API
  - string values of: `not_found`, `valid`, `invalid_json`, `invalid_data`
  - This can be used in the SDK to add telemetry for when we have invalid global.json

Example part of `dotnet --info`:
```
global.json file:
  Invalid [C:\repos\helloworld\global.json]
    Version '9.0' is not valid for the 'sdk/version' value
    Invalid global.json is ignored for SDK resolution.
```
Before:
```
global.json file:
  Not found
```

cc @dotnet/appmodel @AaronRobinsonMSFT @richlander 

Resolves https://github.com/dotnet/runtime/issues/94496

Related:
- https://github.com/dotnet/sdk/issues/50058
- https://github.com/dotnet/runtime/issues/96299
- https://github.com/dotnet/sdk/issues/49816