### PR TITLE
Remove List<T>.Enumerator.MoveNextRare

### DIFF
--- a/src/libraries/Common/tests/System/Collections/IEnumerableTest.cs
+++ b/src/libraries/Common/tests/System/Collections/IEnumerableTest.cs
@@ -20,6 +20,7 @@ namespace Tests.Collections
         protected T DefaultValue => default(T);
 
         protected bool MoveNextAtEndThrowsOnModifiedCollection => true;
+        protected virtual bool CurrentAfterFullEnumerationThrows => true;
 
         protected virtual CollectionOrder CollectionOrder => CollectionOrder.Sequential;
 
@@ -352,7 +353,7 @@ namespace Tests.Collections
             VerifyModifiedEnumerator(
                 enumerator,
                 DefaultValue,
-                false,
+                CurrentAfterFullEnumerationThrows,
                 true);
         }
 

--- a/src/libraries/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
+++ b/src/libraries/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
@@ -391,6 +391,7 @@ namespace System.Collections.ObjectModel.Tests
         protected override bool IsGenericCompatibility { get { return false; } }
         protected override bool ItemsMustBeUnique { get { return true; } }
         protected override bool ItemsMustBeNonNull { get { return true; } }
+        protected override bool CurrentAfterFullEnumerationThrows { get { return false; } }
         protected override object GenerateItem()
         {
             return new KeyValuePair<string, int>(m_next_item.ToString(), m_next_item++);
@@ -429,6 +430,7 @@ namespace System.Collections.ObjectModel.Tests
         protected override bool IsGenericCompatibility { get { return false; } }
         protected override bool ItemsMustBeUnique { get { return true; } }
         protected override bool ItemsMustBeNonNull { get { return true; } }
+        protected override bool CurrentAfterFullEnumerationThrows { get { return false; } }
         protected override object GenerateItem()
         {
             return new KeyValuePair<string, int>(m_next_item.ToString(), m_next_item++);

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -1185,16 +1185,15 @@ namespace System.Collections.Generic
         public struct Enumerator : IEnumerator<T>, IEnumerator
         {
             private readonly List<T> _list;
-            private int _index;
             private readonly int _version;
+
+            private int _index;
             private T? _current;
 
             internal Enumerator(List<T> list)
             {
                 _list = list;
-                _index = 0;
                 _version = list._version;
-                _current = default;
             }
 
             public void Dispose()
@@ -1205,24 +1204,20 @@ namespace System.Collections.Generic
             {
                 List<T> localList = _list;
 
-                if (_version == localList._version && ((uint)_index < (uint)localList._size))
-                {
-                    _current = localList._items[_index];
-                    _index++;
-                    return true;
-                }
-                return MoveNextRare();
-            }
-
-            private bool MoveNextRare()
-            {
                 if (_version != _list._version)
                 {
                     ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                 }
 
-                _index = _list._size + 1;
+                if ((uint)_index < (uint)localList._size)
+                {
+                    _current = localList._items[_index];
+                    _index++;
+                    return true;
+                }
+
                 _current = default;
+                _index = -1;
                 return false;
             }
 
@@ -1232,11 +1227,12 @@ namespace System.Collections.Generic
             {
                 get
                 {
-                    if (_index == 0 || _index == _list._size + 1)
+                    if (_index <= 0)
                     {
                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
                     }
-                    return Current;
+
+                    return _current;
                 }
             }
 


### PR DESCRIPTION
Take 2 on https://github.com/dotnet/runtime/pull/116150

The JIT work to stack allocate enumerators stops working with `List<T>` when `List<T>` gets sufficiently long, e.g. around 1000 elements. At that point, profiling sees the MoveNextRare method used for the last MoveNext as being cold and doesn't inline it. With it not inlined, the boxed enumerator escapes, and the enumerator is then not stack allocated.

(This change only moves the boundary significantly, from ~1000 elements to ~10000 elements. At ~10000, it starts hitting a new limit, due to OSR.)