### PR TITLE
JIT: Build community JITs on Windows in superpmi-diffs again

### DIFF
--- a/eng/pipelines/coreclr/superpmi-diffs.yml
+++ b/eng/pipelines/coreclr/superpmi-diffs.yml
@@ -55,8 +55,11 @@ extends:
           platforms:
           - osx_arm64
           - windows_x86
+          # Not needed for subsequent steps, but this ensures we get some build
+          # coverage of community JITs in CI on JIT PRs.
+          - windows_x64
           jobParameters:
-            buildArgs: -s clr.alljits+clr.spmi -c $(_BuildConfig)
+            buildArgs: -s clr.alljitscommunity+clr.spmi -c $(_BuildConfig)
             postBuildSteps:
               # Build CLR assets for x64 as well as the target as we need an x64 mcs
               - template: /eng/pipelines/common/templates/global-build-step.yml

--- a/eng/pipelines/coreclr/templates/jit-replay-pipeline.yml
+++ b/eng/pipelines/coreclr/templates/jit-replay-pipeline.yml
@@ -32,7 +32,7 @@ extends:
           buildConfig: checked
           platforms: ${{ parameters.platforms }}
           jobParameters:
-            buildArgs: -s clr.alljitscommunity+clr.spmi -c $(_BuildConfig)
+            buildArgs: -s clr.alljits+clr.spmi -c $(_BuildConfig)
             postBuildSteps:
               - template: /eng/pipelines/common/upload-artifact-step.yml
                 parameters:

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -69,8 +69,8 @@ bool Compiler::impILConsumesAddr(const BYTE* codeAddr, const BYTE* codeEndp)
 
 void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolvedToken, CorInfoTokenKind kind)
 {
-    pResolvedToken->tokenScope   = info.compScopeHnd;
     pResolvedToken->tokenContext = impTokenLookupContextHandle;
+    pResolvedToken->tokenScope   = info.compScopeHnd;
     pResolvedToken->token        = getU4LittleEndian(addr);
     pResolvedToken->tokenType    = kind;
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -69,8 +69,8 @@ bool Compiler::impILConsumesAddr(const BYTE* codeAddr, const BYTE* codeEndp)
 
 void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolvedToken, CorInfoTokenKind kind)
 {
-    pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->tokenScope   = info.compScopeHnd;
+    pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->token        = getU4LittleEndian(addr);
     pResolvedToken->tokenType    = kind;
 


### PR DESCRIPTION
In #116299 superpmi-diffs was changed to run on macOS arm64. When doing so we lost the build of the community JITs on Windows. This was switched over to build in superpmi-replay, but that pipeline does not run on all JIT PRs.

We have had a couple of build breaks since then (e.g. #118407), so readd the Windows build back to ensure compiler errors do not slip in for the community JITs.