### PR TITLE
[RISC-V] Restore temp register in switch table codegen

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2187,6 +2187,8 @@ void CodeGen::genTableBasedSwitch(GenTree* treeNode)
     regNumber idxReg  = treeNode->AsOp()->gtOp1->GetRegNum();
     regNumber baseReg = treeNode->AsOp()->gtOp2->GetRegNum();
 
+    regNumber tmpReg = internalRegisters.GetSingle(treeNode);
+
     // load the ip-relative offset (which is relative to start of fgFirstBB)
     assert(treeNode->gtGetOp2()->TypeIs(TYP_I_IMPL));
     if (compiler->compOpportunisticallyDependsOn(InstructionSet_Zba))
@@ -2198,14 +2200,14 @@ void CodeGen::genTableBasedSwitch(GenTree* treeNode)
     else
     {
         assert(treeNode->gtGetOp1()->TypeIs(TYP_I_IMPL));
-        GetEmitter()->emitIns_R_R_I(INS_slli, EA_8BYTE, idxReg, idxReg, 2);
-        GetEmitter()->emitIns_R_R_R(INS_add, EA_8BYTE, baseReg, baseReg, idxReg);
+        GetEmitter()->emitIns_R_R_I(INS_slli, EA_8BYTE, tmpReg, idxReg, 2);
+        GetEmitter()->emitIns_R_R_R(INS_add, EA_8BYTE, baseReg, baseReg, tmpReg);
     }
     GetEmitter()->emitIns_R_R_I(INS_lw, EA_4BYTE, baseReg, baseReg, 0);
 
     // add it to the absolute address of fgFirstBB
-    GetEmitter()->emitIns_R_L(INS_lea, EA_PTRSIZE, compiler->fgFirstBB, idxReg);
-    GetEmitter()->emitIns_R_R_R(INS_add, EA_PTRSIZE, baseReg, baseReg, idxReg);
+    GetEmitter()->emitIns_R_L(INS_lea, EA_PTRSIZE, compiler->fgFirstBB, tmpReg);
+    GetEmitter()->emitIns_R_R_R(INS_add, EA_PTRSIZE, baseReg, baseReg, tmpReg);
 
     // jr baseReg
     GetEmitter()->emitIns_R_R_I(INS_jalr, emitActualTypeSize(TYP_I_IMPL), REG_R0, baseReg, 0);

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -226,6 +226,7 @@ int LinearScan::BuildNode(GenTree* tree)
             break;
 
         case GT_SWITCH_TABLE:
+            buildInternalIntRegisterDefForNode(tree);
             srcCount = BuildBinaryUses(tree->AsOp());
             assert(dstCount == 0);
             break;


### PR DESCRIPTION
Regression after #117048, using `idxReg` as temp clobbered the value if it was used later

Part of #84834, cc @dotnet/samsung