### PR TITLE
Fix conditional usage of `OrderedDictionary.TryGetValue`

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonObject.cs
@@ -267,14 +267,14 @@ namespace System.Text.Json.Nodes
             OrderedDictionary<string, JsonNode?> dict = Dictionary;
 
             if (
-#if NET10_0_OR_GREATER
-                !dict.TryAdd(propertyName, value, out int index)
-#else
+#if NET9_0
                 !dict.TryAdd(propertyName, value)
+#else
+                !dict.TryAdd(propertyName, value, out int index)
 #endif
                 )
             {
-#if !NET10_0_OR_GREATER
+#if NET9_0
                 int index = dict.IndexOf(propertyName);
 #endif
                 Debug.Assert(index >= 0);


### PR DESCRIPTION
Enable the use of `OrderedDictionary<TKey, TValue>.TryGetValue(TKey, TValue, Int32)` on .NET Framework and .NET Standard targets, accounting for the build condition defined in:

https://github.com/dotnet/runtime/blob/e1feed82281d371e9a1044cd937b6a213e67f96e/src/libraries/System.Text.Json/src/System.Text.Json.csproj#L368

Although this API is only publicly available starting with .NET 10.0, it is also accessible in .NET 8.0 due to the internal inclusion of the type within `System.Text.Json`.

cc: @PranavSenthilnathan