### PR TITLE
Fix rebuilding mono aot cross compiler when building locally

### DIFF
--- a/src/mono/mono/offsets/offsets-tool.py
+++ b/src/mono/mono/offsets/offsets-tool.py
@@ -373,11 +373,7 @@ class OffsetsTool:
 		outfile = self.args.outfile
 		validate_outfile = self.args.validate_outfile
 		target = self.target
-
-		if validate_outfile:
-			f = ComparableFile ()
-		else:
-			f = open (outfile, 'w')
+		f = ComparableFile ()
 
 		f.write ("#ifndef USED_CROSS_COMPILER_OFFSETS\n")
 		if target.arch_define:
@@ -435,9 +431,18 @@ class OffsetsTool:
 		f.write ("#endif //USED_CROSS_COMPILER_OFFSETS check\n")
 		f.close ()
 
-		if validate_outfile and f.compare (outfile):
-			print ("Offsets file has changed.", file=sys.stderr)
-			f.dump (outfile + ".new")
+		if os.path.isfile (outfile):
+			if f.compare (outfile):
+				if validate_outfile:
+					print ("Offsets file has changed, writing new offsets to " + outfile + ".new", file=sys.stderr)
+					f.dump (outfile + ".new")
+				else:
+					print ("Offsets file has changed, updating " + outfile)
+					f.dump (outfile)
+			else:
+					print ("Offsets file is up to date, no changes to " + outfile)
+		else:
+			f.dump (outfile)
 
 tool = OffsetsTool ()
 tool.parse_args ()

--- a/src/mono/mono/offsets/offsets-tool.py
+++ b/src/mono/mono/offsets/offsets-tool.py
@@ -440,7 +440,7 @@ class OffsetsTool:
 					print ("Offsets file has changed, updating " + outfile)
 					f.dump (outfile)
 			else:
-					print ("Offsets file is up to date, no changes to " + outfile)
+				print ("Offsets file is up to date, no changes to " + outfile)
 		else:
 			f.dump (outfile)
 


### PR DESCRIPTION
This is a side-effect of the changes made in https://github.com/dotnet/runtime/pull/109612. When we do rerun the offsets generation script locally it causes the file to be touched even if it's identical, which in turn causes the whole aot cross compiler binary to be rebuilt.

To fix this only write to the output offsets file when it actually changed.