### PR TITLE
Fix few startup path issues with interpreter

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3041,6 +3041,9 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                     m_pLastNewIns->data[2] = lookup.accessType == IAT_PVALUE;
                     if (lookup.accessType == IAT_PPVALUE)
                         NO_WAY("IAT_PPVALUE pinvokes not implemented in interpreter");
+                    bool suppressGCTransition = false;
+                    m_compHnd->getUnmanagedCallConv(callInfo.hMethod, nullptr, &suppressGCTransition);
+                    m_pLastNewIns->data[3] = suppressGCTransition ? 1 : 0;
                 }
             }
             break;

--- a/src/coreclr/interpreter/interpretershared.h
+++ b/src/coreclr/interpreter/interpretershared.h
@@ -35,8 +35,9 @@ struct InterpMethod
     // This stub is used for calling the interpreted method from JITted/AOTed code
     CallStubHeader *pCallStub;
     bool initLocals;
+    bool unmanagedCallersOnly;
 
-    InterpMethod(CORINFO_METHOD_HANDLE methodHnd, int32_t allocaSize, void** pDataItems, bool initLocals)
+    InterpMethod(CORINFO_METHOD_HANDLE methodHnd, int32_t allocaSize, void** pDataItems, bool initLocals, bool unmanagedCallersOnly)
     {
 #if DEBUG
         this->self = this;
@@ -45,6 +46,7 @@ struct InterpMethod
         this->allocaSize = allocaSize;
         this->pDataItems = pDataItems;
         this->initLocals = initLocals;
+        this->unmanagedCallersOnly = unmanagedCallersOnly;
         pCallStub = NULL;
     }
 
@@ -155,6 +157,13 @@ struct InterpGenericLookup
     // here is to allow for the generic dictionary to change in size without requiring any locks.
     uint16_t                sizeOffset;
     uint16_t                offsets[InterpGenericLookup_MaxIndirections];
+};
+
+enum class PInvokeCallFlags : int32_t
+{
+    None = 0,
+    Indirect = 1 << 0, // The call target address is indirect
+    SuppressGCTransition = 1 << 1, // The pinvoke is marked by the SuppressGCTransition attribute
 };
 
 #endif

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -358,7 +358,7 @@ OPDEF(INTOP_LDFLDA, "ldflda", 4, 1, 1, InterpOpInt)
 OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLI, "calli", 5, 1, 2, InterpOpLdPtr)
 OPDEF(INTOP_CALLVIRT, "callvirt", 4, 1, 1, InterpOpMethodHandle)
-OPDEF(INTOP_CALL_PINVOKE, "call.pinvoke", 7, 1, 1, InterpOpMethodHandle) // inlined (no marshaling wrapper) pinvokes only
+OPDEF(INTOP_CALL_PINVOKE, "call.pinvoke", 6, 1, 1, InterpOpMethodHandle) // inlined (no marshaling wrapper) pinvokes only
 OPDEF(INTOP_NEWOBJ, "newobj", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_NEWOBJ_GENERIC, "newobj.generic", 6, 1, 2, InterpOpMethodHandle)
 OPDEF(INTOP_NEWOBJ_VT, "newobj.vt", 5, 1, 1, InterpOpMethodHandle)

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -358,7 +358,7 @@ OPDEF(INTOP_LDFLDA, "ldflda", 4, 1, 1, InterpOpInt)
 OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLI, "calli", 5, 1, 2, InterpOpLdPtr)
 OPDEF(INTOP_CALLVIRT, "callvirt", 4, 1, 1, InterpOpMethodHandle)
-OPDEF(INTOP_CALL_PINVOKE, "call.pinvoke", 6, 1, 1, InterpOpMethodHandle) // inlined (no marshaling wrapper) pinvokes only
+OPDEF(INTOP_CALL_PINVOKE, "call.pinvoke", 7, 1, 1, InterpOpMethodHandle) // inlined (no marshaling wrapper) pinvokes only
 OPDEF(INTOP_NEWOBJ, "newobj", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_NEWOBJ_GENERIC, "newobj.generic", 6, 1, 2, InterpOpMethodHandle)
 OPDEF(INTOP_NEWOBJ_VT, "newobj.vt", 5, 1, 1, InterpOpMethodHandle)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1905,7 +1905,6 @@ CALL_INTERP_METHOD:
                             pInterpreterFrame->SetTopInterpMethodContextFrame(pFrame);
                             GCX_PREEMP();
                             // Attempt to setup the interpreter code for the target method.
-
                             if (targetMethod->IsIL() || targetMethod->IsNoMetadata())
                             {
                                 targetMethod->PrepareInitialCode(CallerGCMode::Coop);

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1857,7 +1857,7 @@ MAIN_LOOP:
                     int32_t targetAddrSlot = ip[4];
                     int32_t flags = ip[5];
 
-                    ip += 7;
+                    ip += 6;
                     targetMethod = (MethodDesc*)pMethod->pDataItems[methodSlot];
                     PCODE callTarget = (flags & (int32_t)PInvokeCallFlags::Indirect)
                         ? *(PCODE *)pMethod->pDataItems[targetAddrSlot]

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1873,7 +1873,11 @@ MAIN_LOOP:
 
                     {
                         GCX_PREEMP();
-                        InvokeCompiledMethod(targetMethod, stack + callArgsOffset, stack + returnOffset, callTarget);
+                        bool shouldSuppressGCTransition = targetMethod->ShouldSuppressGCTransition();
+                        {
+                            GCX_MAYBE_COOP(shouldSuppressGCTransition);
+                            InvokeCompiledMethod(targetMethod, stack + callArgsOffset, stack + returnOffset, callTarget);
+                        }
                     }
 
                     inlinedCallFrame.Pop();

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2010,6 +2010,17 @@ extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBl
 
     InterpByteCodeStart* pInterpreterCode = dac_cast<PTR_InterpByteCodeStart>(byteCodeAddr);
 
+    if (pInterpreterCode->Method->unmanagedCallersOnly)
+    {
+        Thread* thread = GetThreadNULLOk();
+        if (thread == NULL)
+            CREATETHREAD_IF_NULL_FAILFAST(thread, W("Failed to setup new thread during reverse P/Invoke"));
+
+        // Verify the current thread isn't in COOP mode.
+        if (thread->PreemptiveGCDisabled())
+            ReversePInvokeBadTransition();
+    }
+
     GCX_MAYBE_COOP(pInterpreterCode->Method->unmanagedCallersOnly);
 
     // This construct ensures that the InterpreterFrame is always stored at a higher address than the

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2001,6 +2001,8 @@ static InterpThreadContext* GetInterpThreadContext()
     return threadContext;
 }
 
+EXTERN_C void STDCALL ReversePInvokeBadTransition();
+
 extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBlock, TADDR byteCodeAddr, void* retBuff)
 {
     // Argument registers are in the TransitionBlock

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1004,9 +1004,6 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, COR_ILMETHOD_
         InterpreterPrecode* pPrecode = InterpreterPrecode::FromEntryPoint(pCode);
         InterpByteCodeStart* interpreterCode = dac_cast<InterpByteCodeStart*>(pPrecode->GetData()->ByteCodeAddr);
         pConfig->GetMethodDesc()->SetInterpreterCode(interpreterCode);
-        // The current MethodDesc is different from the pConfig->GetMethodDesc() in case of a call that goes through
-        // an IL stub. Make sure we set the same interpreter code on both.
-        SetInterpreterCode(interpreterCode);
     }
 #endif // FEATURE_INTERPRETER
 
@@ -2013,7 +2010,7 @@ extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBl
 
     InterpByteCodeStart* pInterpreterCode = dac_cast<PTR_InterpByteCodeStart>(byteCodeAddr);
 
-    GCX_MAYBE_COOP(((MethodDesc*)pInterpreterCode->Method->methodHnd)->HasUnmanagedCallersOnlyAttribute());
+    GCX_MAYBE_COOP(pInterpreterCode->Method->unmanagedCallersOnly);
 
     // This construct ensures that the InterpreterFrame is always stored at a higher address than the
     // InterpMethodContextFrame. This is important for the stack walking code.


### PR DESCRIPTION
This change fixes the following issues:
* Reverse pinvoke to method marked by UnmanagedCallersOnly attribute. The InterpExecMethod is entered in GC preemptive mode in that case, but it is expected to run in GC cooperative mode.
* Pinvoke to method marked by SuppressGCTransition attribute . The pinvoke is entered in GC preemtive mode, but it needs to be called in GC cooperative mode.
* Calling a delegate or a similar case when IL stub is used. The interpreter code is set only on the IL stub MethodDesc, but it needs to be set on both the IL stub and the original MethodDesc.