### PR TITLE
JIT: Remove side effect detection quirk in loop hoisting

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -3655,21 +3655,12 @@ bool Compiler::optHoistThisLoop(FlowGraphNaturalLoop* loop, LoopHoistContext* ho
     }
 #endif // FEATURE_MASKED_HW_INTRINSICS
 
-    // Find the set of definitely-executed blocks.
+    // Find the set of definitely-executed blocks. These will be given priority for hoisting.
     // Ideally, the definitely-executed blocks are the ones that post-dominate the entry block.
     // Until we have post-dominators, we'll special-case for single-exit blocks.
     //
-    // Todo: it is not clear if this is a correctness requirement or a profitability heuristic.
-    // It seems like the latter. Ideally there are enough safeguards to prevent hoisting exception
-    // or side-effect dependent things. Note that HoistVisitor uses `m_beforeSideEffect` to determine if it's
-    // ok to hoist a side-effect. It allows this only for the first block (the entry block), before any
-    // side-effect has been seen. After the first block, it assumes that there has been a side effect and
-    // no further side-effect can be hoisted. It is true that we don't analyze any program behavior in the
-    // flow graph between the entry block and the subsequent blocks, whether they be the next block dominating
-    // the exit block, or the pre-headers of nested loops.
-    //
-    // We really should consider hoisting from conditionally executed blocks, if they are frequently executed
-    // and it is safe to evaluate the tree early.
+    // TODO: We ought to consider hoisting more aggressively from conditionally executed blocks,
+    // if they are frequently executed and it is safe to evaluate the tree early.
     //
     assert(m_dfsTree != nullptr);
     BitVecTraits traits(m_dfsTree->PostOrderTraits());
@@ -4292,11 +4283,6 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
 
                 m_valueStack.Reset();
             }
-
-            // Only unconditionally executed blocks in the loop are visited (see optHoistThisLoop)
-            // so after we're done visiting the first block we need to assume the worst, that the
-            // blocks that are not visited have side effects.
-            m_beforeSideEffect = false;
         }
 
         fgWalkResult PreOrderVisit(GenTree** use, GenTree* user)
@@ -4475,8 +4461,7 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                     if (!m_beforeSideEffect)
                     {
                         // For now, we give up on an expression that might raise an exception if it is after the
-                        // first possible global side effect (and we assume we're after that if we're not in the first
-                        // block).
+                        // first possible global side effect.
                         // TODO-CQ: this is when we might do loop cloning.
                         //
                         if ((tree->gtFlags & GTF_EXCEPT) != 0)

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4116,12 +4116,12 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
         };
 
         ArrayStack<Value>     m_valueStack;
-        bool                  m_beforeSideEffect;
         FlowGraphNaturalLoop* m_loop;
         LoopHoistContext*     m_hoistContext;
         BasicBlock*           m_currentBlock;
         BitVecTraits*         m_traits;
         BitVec                m_defExec;
+        BitVec                m_sideEffectBlocks;
 
         bool IsNodeHoistable(GenTree* node)
         {
@@ -4251,12 +4251,12 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                      BitVec                defExec)
             : GenTreeVisitor(compiler)
             , m_valueStack(compiler->getAllocator(CMK_LoopHoist))
-            , m_beforeSideEffect(true)
             , m_loop(loop)
             , m_hoistContext(hoistContext)
             , m_currentBlock(nullptr)
             , m_traits(traits)
             , m_defExec(defExec)
+            , m_sideEffectBlocks(BitVecOps::MakeEmpty(traits))
         {
         }
 
@@ -4356,6 +4356,7 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
             bool treeIsInvariant          = true;
             bool treeHasHoistableChildren = false;
             int  childCount;
+            bool beforeSideEffect = !BitVecOps::IsMember(m_traits, m_sideEffectBlocks, m_currentBlock->bbPostorderNum);
 
 #ifdef DEBUG
             const char* failReason = "unknown";
@@ -4458,7 +4459,7 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
 
                 if (treeIsHoistable)
                 {
-                    if (!m_beforeSideEffect)
+                    if (beforeSideEffect)
                     {
                         // For now, we give up on an expression that might raise an exception if it is after the
                         // first possible global side effect.
@@ -4484,11 +4485,11 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                 }
             }
 
-            // Next check if we need to set 'm_beforeSideEffect' to false.
+            // Next check if we need to set 'beforeSideEffect' to false.
             //
             // If we have already set it to false then we can skip these checks
             //
-            if (m_beforeSideEffect)
+            if (beforeSideEffect)
             {
                 // Is the value of the whole tree loop invariant?
                 if (!treeIsInvariant)
@@ -4496,12 +4497,11 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                     // We have a tree that is not loop invariant and we thus cannot hoist
                     assert(treeIsHoistable == false);
 
-                    // Check if we should clear m_beforeSideEffect.
-                    // If 'tree' can throw an exception then we need to set m_beforeSideEffect to false.
+                    // Check if we should mark this block as having side effects.
                     // Note that calls are handled below
                     if (tree->OperMayThrow(m_compiler) && !tree->IsCall())
                     {
-                        m_beforeSideEffect = false;
+                        beforeSideEffect = false;
                     }
                 }
 
@@ -4517,19 +4517,19 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                     GenTreeCall* call = tree->AsCall();
                     if (!call->IsHelperCall())
                     {
-                        m_beforeSideEffect = false;
+                        beforeSideEffect = false;
                     }
                     else
                     {
                         CorInfoHelpFunc helpFunc = eeGetHelperNum(call->gtCallMethHnd);
                         if (s_helperCallProperties.MutatesHeap(helpFunc))
                         {
-                            m_beforeSideEffect = false;
+                            beforeSideEffect = false;
                         }
                         else if (s_helperCallProperties.MayRunCctor(helpFunc) &&
                                  (call->gtFlags & GTF_CALL_HOISTABLE) == 0)
                         {
-                            m_beforeSideEffect = false;
+                            beforeSideEffect = false;
                         }
 
                         // Additional check for helper calls that throw exceptions
@@ -4541,7 +4541,7 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                             // Does this helper call throw?
                             if (!s_helperCallProperties.NoThrow(helpFunc))
                             {
-                                m_beforeSideEffect = false;
+                                beforeSideEffect = false;
                             }
                         }
                     }
@@ -4562,9 +4562,20 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                     if (isGloballyVisibleStore)
                     {
                         INDEBUG(failReason = "store to globally visible memory");
-                        treeIsHoistable    = false;
-                        m_beforeSideEffect = false;
+                        treeIsHoistable  = false;
+                        beforeSideEffect = false;
                     }
+                }
+            }
+
+            // If this block does not execute before the first side effect in the loop,
+            // mark it and its successors.
+            if (!beforeSideEffect)
+            {
+                BitVecOps::AddElemD(m_traits, m_sideEffectBlocks, m_currentBlock->bbPostorderNum);
+                for (BasicBlock* const succ : m_currentBlock->Succs())
+                {
+                    BitVecOps::AddElemD(m_traits, m_sideEffectBlocks, succ->bbPostorderNum);
                 }
             }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4116,12 +4116,12 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
         };
 
         ArrayStack<Value>     m_valueStack;
+        bool                  m_beforeSideEffect;
         FlowGraphNaturalLoop* m_loop;
         LoopHoistContext*     m_hoistContext;
         BasicBlock*           m_currentBlock;
         BitVecTraits*         m_traits;
         BitVec                m_defExec;
-        BitVec                m_sideEffectBlocks;
 
         bool IsNodeHoistable(GenTree* node)
         {
@@ -4251,12 +4251,12 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                      BitVec                defExec)
             : GenTreeVisitor(compiler)
             , m_valueStack(compiler->getAllocator(CMK_LoopHoist))
+            , m_beforeSideEffect(true)
             , m_loop(loop)
             , m_hoistContext(hoistContext)
             , m_currentBlock(nullptr)
             , m_traits(traits)
             , m_defExec(defExec)
-            , m_sideEffectBlocks(BitVecOps::MakeEmpty(traits))
         {
         }
 
@@ -4356,7 +4356,6 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
             bool treeIsInvariant          = true;
             bool treeHasHoistableChildren = false;
             int  childCount;
-            bool beforeSideEffect = !BitVecOps::IsMember(m_traits, m_sideEffectBlocks, m_currentBlock->bbPostorderNum);
 
 #ifdef DEBUG
             const char* failReason = "unknown";
@@ -4459,7 +4458,7 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
 
                 if (treeIsHoistable)
                 {
-                    if (beforeSideEffect)
+                    if (!m_beforeSideEffect)
                     {
                         // For now, we give up on an expression that might raise an exception if it is after the
                         // first possible global side effect.
@@ -4485,11 +4484,11 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                 }
             }
 
-            // Next check if we need to set 'beforeSideEffect' to false.
+            // Next check if we need to set 'm_beforeSideEffect' to false.
             //
             // If we have already set it to false then we can skip these checks
             //
-            if (beforeSideEffect)
+            if (m_beforeSideEffect)
             {
                 // Is the value of the whole tree loop invariant?
                 if (!treeIsInvariant)
@@ -4497,11 +4496,12 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                     // We have a tree that is not loop invariant and we thus cannot hoist
                     assert(treeIsHoistable == false);
 
-                    // Check if we should mark this block as having side effects.
+                    // Check if we should clear m_beforeSideEffect.
+                    // If 'tree' can throw an exception then we need to set m_beforeSideEffect to false.
                     // Note that calls are handled below
                     if (tree->OperMayThrow(m_compiler) && !tree->IsCall())
                     {
-                        beforeSideEffect = false;
+                        m_beforeSideEffect = false;
                     }
                 }
 
@@ -4517,19 +4517,19 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                     GenTreeCall* call = tree->AsCall();
                     if (!call->IsHelperCall())
                     {
-                        beforeSideEffect = false;
+                        m_beforeSideEffect = false;
                     }
                     else
                     {
                         CorInfoHelpFunc helpFunc = eeGetHelperNum(call->gtCallMethHnd);
                         if (s_helperCallProperties.MutatesHeap(helpFunc))
                         {
-                            beforeSideEffect = false;
+                            m_beforeSideEffect = false;
                         }
                         else if (s_helperCallProperties.MayRunCctor(helpFunc) &&
                                  (call->gtFlags & GTF_CALL_HOISTABLE) == 0)
                         {
-                            beforeSideEffect = false;
+                            m_beforeSideEffect = false;
                         }
 
                         // Additional check for helper calls that throw exceptions
@@ -4541,7 +4541,7 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                             // Does this helper call throw?
                             if (!s_helperCallProperties.NoThrow(helpFunc))
                             {
-                                beforeSideEffect = false;
+                                m_beforeSideEffect = false;
                             }
                         }
                     }
@@ -4562,20 +4562,9 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                     if (isGloballyVisibleStore)
                     {
                         INDEBUG(failReason = "store to globally visible memory");
-                        treeIsHoistable  = false;
-                        beforeSideEffect = false;
+                        treeIsHoistable    = false;
+                        m_beforeSideEffect = false;
                     }
-                }
-            }
-
-            // If this block does not execute before the first side effect in the loop,
-            // mark it and its successors.
-            if (!beforeSideEffect)
-            {
-                BitVecOps::AddElemD(m_traits, m_sideEffectBlocks, m_currentBlock->bbPostorderNum);
-                for (BasicBlock* const succ : m_currentBlock->Succs())
-                {
-                    BitVecOps::AddElemD(m_traits, m_sideEffectBlocks, succ->bbPostorderNum);
                 }
             }
 


### PR DESCRIPTION
Addresses some of the regressions in #116486 and #116754. Hoisting's traversal of the loop body was previously not sensitive to execution flow, so it was overly conservative in its side effect detection, operating under the assumption that every block after the loop header could execute after the first global side effect. Now that hoisting visits every loop block in RPO, we can remove this assumption.