### PR TITLE
Allow MethodDesc::GetILHeader to work correctly under rejit scenarios

### DIFF
--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1189,11 +1189,6 @@ COR_ILMETHOD* MethodDesc::GetILHeader()
     CONTRACTL_END
 
     RVA rva = GetRVA();
-    if (rva == 0)
-    {
-        return NULL;
-    }
-
     Module *pModule = GetModule();
 
     // Always pickup overrides like reflection emit, EnC, etc.
@@ -1201,6 +1196,10 @@ COR_ILMETHOD* MethodDesc::GetILHeader()
 
     if (pIL == (TADDR)NULL)
     {
+        if (rva == 0)
+        {
+            return NULL;
+        }
         pIL = pModule->GetIL(rva);
     }
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1196,12 +1196,7 @@ COR_ILMETHOD* MethodDesc::GetILHeader()
 
     if (pIL == (TADDR)NULL)
     {
-        RVA rva = GetRVA();
-        if (rva == 0)
-        {
-            return NULL;
-        }
-        pIL = pModule->GetIL(rva);
+        pIL = pModule->GetIL(GetRVA());
     }
 
 #ifdef _DEBUG_IMPL

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1188,14 +1188,15 @@ COR_ILMETHOD* MethodDesc::GetILHeader()
     }
     CONTRACTL_END
 
-    RVA rva = GetRVA();
     Module *pModule = GetModule();
 
-    // Always pickup overrides like reflection emit, EnC, etc.
+    // Always pickup overrides like reflection emit, EnC, etc. irrespective of RVA.
+    // Profilers can attach dynamic IL to methods with zero RVA.
     TADDR pIL = pModule->GetDynamicIL(GetMemberDef());
 
     if (pIL == (TADDR)NULL)
     {
+        RVA rva = GetRVA();
         if (rva == 0)
         {
             return NULL;


### PR DESCRIPTION
Internal Visual Studio diagnostic testing caught an issue related to ICorProfiler rejit changing the callsite of a method in a different assembly can result in a BadFormatException.  Regressed by #118318