### PR TITLE
Fix static virtual methods for delegate creation

### DIFF
--- a/src/coreclr/inc/vptr_list.h
+++ b/src/coreclr/inc/vptr_list.h
@@ -42,6 +42,7 @@ VPTR_CLASS(CallCountingStubManager)
 VPTR_CLASS(PEImageLayout)
 VPTR_CLASS(ConvertedImageLayout)
 VPTR_CLASS(LoadedImageLayout)
+VPTR_CLASS(NativeImageLayout)
 VPTR_CLASS(FlatImageLayout)
 
 #ifdef DEBUGGING_SUPPORTED

--- a/src/coreclr/vm/peimagelayout.h
+++ b/src/coreclr/vm/peimagelayout.h
@@ -145,18 +145,18 @@ public:
 #endif // !DACCESS_COMPILE
 };
 
-#ifndef DACCESS_COMPILE
 // A special layout that is used to load standalone composite r2r files.
 // This layout is not owned by a PEImage and created by simply loading the file
 // at the given path.
 class NativeImageLayout : public PEImageLayout
 {
     VPTR_VTABLE_CLASS(NativeImageLayout, PEImageLayout)
-
-public:
+    
+    public:
+#ifndef DACCESS_COMPILE
     NativeImageLayout(LPCWSTR fullPath);
-};
 #endif
+};
 
 #endif  // PEIMAGELAYOUT_H_
 

--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -953,6 +953,11 @@ MethodDesc *ZapSig::DecodeMethod(ModuleBase *pInfoModule,
             MemberLoader::ThrowMissingMethodException(constrainedType.GetMethodTable(), NULL, NULL, NULL, 0, NULL);
         }
 
+        if (directMethod->IsStatic() && (ppTH != NULL))
+        {
+            *ppTH = directMethod->GetMethodTable();
+        }
+
         // Strip the instantiating stub if the signature did not ask for one
         if (directMethod->IsInstantiatingStub() && !isInstantiatingStub)
         {

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -540,12 +540,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
             <Issue>Not compatible with crossgen2</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTestDefaultImp/**">
-            <Issue>https://github.com/dotnet/runtime/issues/109200</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTest/**">
-            <Issue>https://github.com/dotnet/runtime/issues/109200</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_68278/**">
             <Issue>https://github.com/dotnet/runtime/issues/108255</Issue>
         </ExcludeList>


### PR DESCRIPTION
- Notably for creation of delegates to SVM methods which do not require generic dictionary lookups
- Also a drive by fix of the vtable handling for NativeImageLayout which was causing crashes of the DAC when used in debug builds

Fixes #109200