### PR TITLE
[EventPipe] Fix user_events metadata label scope

### DIFF
--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -823,6 +823,7 @@ session_tracepoint_write_event (
 
 	uint64_t session_mask = ep_session_get_mask (session);
 	bool should_write_metadata = !ep_event_was_metadata_written (ep_event, session_mask);
+	uint8_t extension_metadata[1 + sizeof(uint32_t)] = {0};
 	if (should_write_metadata) {
 		EventPipeProvider *event_provider = ep_event_get_provider (ep_event);
 		const ep_char16_t *provider_name_utf16 = ep_provider_get_provider_name_utf16 (event_provider);
@@ -831,7 +832,6 @@ session_tracepoint_write_event (
 		uint32_t event_metadata_len = ep_event_get_metadata_len (ep_event);
 		uint32_t complete_metadata_len = provider_name_size_bytes + event_metadata_len;
 
-		uint8_t extension_metadata[1 + sizeof(uint32_t)];
 		extension_metadata[0] = 0x01; // label
 		*(uint32_t*)&extension_metadata[1] = complete_metadata_len;
 		io[io_index].iov_base = extension_metadata;


### PR DESCRIPTION
Alternate internal testing showed that the first 5 bytes of the metadata extension were zeroed out. I missed that the stack allocated variable corresponding to the metadata label + metadata size would be out of scope during the writev, and thus prone to corruption.

The corruption never occurred during my manual testing which read the values from sys/kernel/tracing/trace.