### PR TITLE
log private memory when GCEnd event emitted

### DIFF
--- a/src/coreclr/gc/gcevents.h
+++ b/src/coreclr/gc/gcevents.h
@@ -52,6 +52,7 @@ DYNAMIC_EVENT(CommittedUsage, GCEventLevel_Information, GCEventKeyword_GC, 1)
 DYNAMIC_EVENT(SizeAdaptationTuning, GCEventLevel_Information, GCEventKeyword_GC, 1)
 DYNAMIC_EVENT(SizeAdaptationFullGCTuning, GCEventLevel_Information, GCEventKeyword_GC, 1)
 DYNAMIC_EVENT(SizeAdaptationSample, GCEventLevel_Information, GCEventKeyword_GC, 1)
+DYNAMIC_EVENT(ProcessPrivateMemoryOnGCEnd, GCEventLevel_Information, GCEventKeyword_GC, 1)
 
 #undef KNOWN_EVENT
 #undef DYNAMIC_EVENT


### PR DESCRIPTION
This change enables clr to log private memory via dynamic event each time "GCEnd_v1" is emitted.
<img width="1401" height="322" alt="image" src="https://github.com/user-attachments/assets/6d36075f-69db-435e-9eea-ac4d4abb770f" />

So far, we have tested this feature on following platforms:
- windows11-x64(trace type: gc, cpu, verbose, cpu_managed, threadtime, threadtime_managed, join)
- debian12-x64(trace type: gc-collect, gc-verbose, cpu-sampling)
- OSX15.6-x64(trace type: gc-collect, gc-verbose, cpu-sampling)
- OSX15.6-m1(trace type: gc-collect, gc-verbose, cpu-sampling)