### PR TITLE
[Android] Fix Android SSL exception propagation in certificate validation

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
@@ -93,7 +93,7 @@ namespace System.Net.Security
                     if (!proxy.ValidationResult.IsValid)
                     {
                         // Throw AuthenticationException if validation failed
-                        proxy.ValidationException = new AuthenticationException(SR.net_ssl_io_cert_custom_validation, null);
+                        proxy.ValidationException = new AuthenticationException(SR.net_ssl_io_cert_custom_validation);
                         return false;
                     }
                     return proxy.ValidationResult.IsValid;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
@@ -89,6 +89,12 @@ namespace System.Net.Security
                 try
                 {
                     proxy.ValidationResult = proxy._sslStream.VerifyRemoteCertificate();
+                    if (!proxy.ValidationResult.IsValid)
+                    {
+                        // Throw AuthenticationException if validation failed
+                        proxy.ValidationException = new AuthenticationException(SR.net_ssl_io_cert_custom_validation, null);
+                        return false;
+                    }
                     return proxy.ValidationResult.IsValid;
                 }
                 catch (Exception exception)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
@@ -94,7 +94,6 @@ namespace System.Net.Security
                     {
                         // Throw AuthenticationException if validation failed
                         proxy.ValidationException = new AuthenticationException(SR.net_ssl_io_cert_custom_validation);
-                        return false;
                     }
                     return proxy.ValidationResult.IsValid;
                 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Android.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Net.Security;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 


### PR DESCRIPTION
## Summary

This fixes Android-specific SSL exception handling to explicitly propagate `AuthenticationException` when certificate validation fails. Additionally, in SSL handshake even when validation exceptions were detected, the SSL handshake continued instead of failing immediately.

## Changes
- Explicitly create and throw AuthenticationException when certificate validation fails
- Ensure SSL handshake is immediately terminated upon validation failure
- Propagate exceptions via SecurityStatusPal to prevent timeouts