### PR TITLE
Make the HardwareIntrinsic tests rebuild when templates are updated

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/Arm/Directory.Build.targets
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Directory.Build.targets
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <Target Name="ExecuteGenerateTestsScript"
-          Inputs="$(MSBuildAllProjects);$(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_Arm.cs"
+          Inputs="$(MSBuildAllProjects);$(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_Arm.cs;$(MSBuildThisFileDirectory)/Shared/*.template"
           Outputs="$(GeneratedHWIntrinsicTestListFile)"
           Condition="'$(Language)' == 'C#'">
     <Exec Command="$(DotNetCli) build $(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_Arm.csproj -c $(Configuration) --no-restore /p:IntermediateOutputPath=$(IntermediateOutputPath)/GenerateHWIntrinsicTests/ /p:OutputPath=$(OutputPath)/GenerateHWIntrinsicTests/" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Directory.Build.targets
+++ b/src/tests/JIT/HardwareIntrinsics/General/Directory.Build.targets
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <Target Name="ExecuteGenerateTestsScript"
-          Inputs="$(MSBuildAllProjects);$(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_General.cs"
+          Inputs="$(MSBuildAllProjects);$(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_General.cs;$(MSBuildThisFileDirectory)/Shared/*.template"
           Outputs="$(GeneratedHWIntrinsicTestListFile)"
           Condition="'$(Language)' == 'C#'">
     <Exec Command="$(DotNetCli) build $(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_General.csproj -c $(Configuration) --no-restore /p:IntermediateOutputPath=$(IntermediateOutputPath)/GenerateHWIntrinsicTests/ /p:OutputPath=$(OutputPath)/GenerateHWIntrinsicTests/" />


### PR DESCRIPTION
Adds the template files to the build dependencies of the `GenerateHWIntrinsicTests` script for ARM64.