### PR TITLE
[clr-interp] Handle some forms of unboxing stub

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1973,7 +1973,7 @@ CALL_INTERP_METHOD:
                             pInterpreterFrame->SetTopInterpMethodContextFrame(pFrame);
                             GCX_PREEMP();
                             // Attempt to setup the interpreter code for the target method.
-                            if (targetMethod->IsIL() || targetMethod->IsNoMetadata())
+                            if ((targetMethod->IsIL() || targetMethod->IsNoMetadata()) && !targetMethod->IsUnboxingStub())
                             {
                                 targetMethod->PrepareInitialCode(CallerGCMode::Coop);
                             }


### PR DESCRIPTION
When encountering an UnboxingStub to execute, invoke it as a compiled method instead of as a interpreted one

This is probably not the long term fix here, as it won't work for WASM scenarios, but it should be good enough for now as we bring up the interpreter on non WASM workloads