### PR TITLE
Don't fold CNS_VEC into a broadcast for EQ/NE(AND(X, CnsVec), ZeroVector)

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -9928,7 +9928,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                                 bool isNE = (userId == NI_Vector128_op_Inequality) ||
                                             (userId == NI_Vector256_op_Inequality) ||
                                             (userId == NI_Vector512_op_Inequality);
-                                if ((isEQ != isNE) && (userHw->Op(1)->IsVectorZero() || userHw->Op(2)->IsVectorZero()))
+                                if ((isEQ || isNE) && (userHw->Op(1)->IsVectorZero() || userHw->Op(2)->IsVectorZero()))
                                 {
                                     isEmbeddedBroadcastCompatible = false;
                                 }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -9904,15 +9904,35 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                         // because it will prevent other transforms that will be better for codegen.
 
                         LIR::Use use;
-
-                        if ((oper == GT_XOR) && isEmbeddedBroadcastCompatible && BlockRange().TryGetUse(node, &use) &&
-                            use.User()->OperIsVectorFusedMultiplyOp())
+                        if (isEmbeddedBroadcastCompatible && BlockRange().TryGetUse(node, &use))
                         {
-                            // xor is bitwise and the actual xor node might be a different base type
-                            // from the FMA node, so we check if its negative zero using the FMA base
-                            // type since that's what the end negation would end up using
-                            var_types fmaSimdBaseType     = use.User()->AsHWIntrinsic()->GetSimdBaseType();
-                            isEmbeddedBroadcastCompatible = !containedOperand->IsVectorNegativeZero(fmaSimdBaseType);
+                            if ((oper == GT_XOR) && use.User()->OperIsVectorFusedMultiplyOp())
+                            {
+                                // xor is bitwise and the actual xor node might be a different base type
+                                // from the FMA node, so we check if its negative zero using the FMA base
+                                // type since that's what the end negation would end up using
+                                var_types fmaSimdBaseType = use.User()->AsHWIntrinsic()->GetSimdBaseType();
+                                isEmbeddedBroadcastCompatible =
+                                    !containedOperand->IsVectorNegativeZero(fmaSimdBaseType);
+                            }
+                            else if (((oper == GT_AND) || (oper == GT_AND_NOT)) && use.User()->OperIsHWIntrinsic())
+                            {
+                                // For EQ/NE(AND(X, CnsVec), ZeroVector) we don't need to fold CnsVec into a contained
+                                // broadcast operand - AND will be folded into TestZ anyway.
+                                GenTreeHWIntrinsic* userHw = use.User()->AsHWIntrinsic();
+                                NamedIntrinsic      userId = userHw->GetHWIntrinsicId();
+
+                                bool isEQ = (userId == NI_Vector128_op_Equality) ||
+                                            (userId == NI_Vector256_op_Equality) ||
+                                            (userId == NI_Vector512_op_Equality);
+                                bool isNE = (userId == NI_Vector128_op_Inequality) ||
+                                            (userId == NI_Vector256_op_Inequality) ||
+                                            (userId == NI_Vector512_op_Inequality);
+                                if ((isEQ != isNE) && (userHw->Op(1)->IsVectorZero() || userHw->Op(2)->IsVectorZero()))
+                                {
+                                    isEmbeddedBroadcastCompatible = false;
+                                }
+                            }
                         }
 
                         if (isEmbeddedBroadcastCompatible)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/111824

```cs
bool Test(Vector256<ushort> utf16Vector)
{
    const ushort asciiMask = ushort.MaxValue - 127;
    return (utf16Vector & Vector256.Create(asciiMask)) != Vector256<ushort>.Zero;
}
```
Codegen:
```diff
; Method Program:Test(System.Runtime.Intrinsics.Vector256`1[ushort]):bool:this (FullOpts)
       vmovups  ymm0, ymmword ptr [rdx]
-      vpandd   ymm0, ymm0, dword ptr [reloc @RWD00] {1to8}
-      vptest   ymm0, ymm0
+      vptest   ymm0, ymmword ptr [reloc @RWD00]
       setne    al
       movzx    rax, al
       vzeroupper 
       ret      
-RWD00  	dd	FF80FF80h
+RWD00  	dd	FF80FF80FF80FF80h, FF80FF80FF80FF80h, FF80FF80FF80FF80h, FF80FF80FF80FF80h
-; Total bytes of code: 29
+; Total bytes of code: 23
```