### PR TITLE
Re-enable tests for Sys.RT.Caching

### DIFF
--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/HostFileChangeMonitorTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/HostFileChangeMonitorTest.cs
@@ -85,7 +85,6 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
-        //[ActiveIssue("https://github.com/dotnet/runtime/issues/34497", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public static void Constructor_MissingFiles_Handler()
         {
             HostFileChangeMonitor monitor;
@@ -133,7 +132,6 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
-        //[ActiveIssue("https://github.com/dotnet/runtime/issues/34497", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void Constructor_Duplicates()
         {
             HostFileChangeMonitor monitor;
@@ -202,7 +200,6 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Fact]
-        //[ActiveIssue("https://github.com/dotnet/runtime/issues/34497", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void UniqueId()
         {
             Tuple<string, string, string, IList<string>> setup = null;
@@ -249,9 +246,8 @@ namespace MonoTests.System.Runtime.Caching
             }
         }
 
+        [OuterLoop]
         [Fact]
-//        [OuterLoop]   // TODO - make this outter loop before merging
-        //[ActiveIssue("https://github.com/dotnet/runtime/issues/34497", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void Reasonable_Delay()
         {
             Tuple<string, string, string, IList<string>> setup = null;

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/HostFileChangeMonitorTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/HostFileChangeMonitorTest.cs
@@ -275,12 +275,12 @@ namespace MonoTests.System.Runtime.Caching
                 // Update the file dependency
                 File.WriteAllText(setup.Item2, "I am the first file. Updated.");
 
-                // Wait for the monitor to detect the change - 100ms should be plenty
-                for (int i = 0; i < 10; i++)
+                // Wait for the monitor to detect the change - 5s should be more than enough
+                for (int i = 0; i < 250; i++)
                 {
                     if (!mc.Contains("key"))
                         break;
-                    Thread.Sleep(10);
+                    Thread.Sleep(20);
                 }
 
                 Assert.Null(mc["key"]);

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -1108,10 +1108,6 @@ namespace MonoTests.System.Runtime.Caching
             Assert.False(onChangedCalled);
         }
 
-        // Due to internal implementation details Trim has very few easily verifiable scenarios
-        // ActiveIssue: https://github.com/dotnet/runtime/issues/36488
-        //[ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))]
-        //https://github.com/dotnet/runtime/pull/36494/files
         [Theory]
         [InlineData("true"), InlineData("false"), InlineData(null)]
         public void Trim(string throwOnDisposed)
@@ -1198,11 +1194,6 @@ namespace MonoTests.System.Runtime.Caching
 
         [OuterLoop] // makes long wait
         [Fact]
-        // This little dance is needed to prevent this test from running against the OS-specific
-        // runtime binary on the wrong OS. Without it, this test will run for each 'TargetFramework'
-        // in the test csproj, and the non-windows framework will run against the non-windows library
-        // because 'netstandard' is still valid for windows execution.
-        //[PlatformSpecific(TestPlatforms.Windows)]
         public void TestCacheSliding()
         {
             var config = new NameValueCollection();
@@ -1511,7 +1502,6 @@ namespace MonoTests.System.Runtime.Caching
         public static bool SupportsPhysicalMemoryMonitor => MemoryCacheTest.SupportsPhysicalMemoryMonitor;
 
         [ConditionalFact(nameof(SupportsPhysicalMemoryMonitor))]
-        //[SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93106")]
         public async Task TestCacheShrink()
         {
             const int HEAP_RESIZE_THRESHOLD = 8192 + 2;
@@ -1571,7 +1561,6 @@ namespace MonoTests.System.Runtime.Caching
         public static bool SupportsPhysicalMemoryMonitor => MemoryCacheTest.SupportsPhysicalMemoryMonitor;
 
         [ConditionalFact(nameof(SupportsPhysicalMemoryMonitor))]
-        //[SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93106")]
         public async Task TestCacheExpiryOrdering()
         {
             var config = new NameValueCollection();

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -304,7 +304,6 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         [Theory, InlineData("true"), InlineData("false"), InlineData(null)]
-        //[ActiveIssue("https://github.com/dotnet/runtime/issues/1429")]
         public void Contains(string throwOnDisposed)
         {
             var mc = CreatePokerMemoryCache("MyCache", throwOnDisposed);
@@ -1111,7 +1110,9 @@ namespace MonoTests.System.Runtime.Caching
 
         // Due to internal implementation details Trim has very few easily verifiable scenarios
         // ActiveIssue: https://github.com/dotnet/runtime/issues/36488
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))]
+        //[ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))]
+        //https://github.com/dotnet/runtime/pull/36494/files
+        [Theory]
         [InlineData("true"), InlineData("false"), InlineData(null)]
         public void Trim(string throwOnDisposed)
         {
@@ -1201,7 +1202,7 @@ namespace MonoTests.System.Runtime.Caching
         // runtime binary on the wrong OS. Without it, this test will run for each 'TargetFramework'
         // in the test csproj, and the non-windows framework will run against the non-windows library
         // because 'netstandard' is still valid for windows execution.
-        [PlatformSpecific(TestPlatforms.Windows)]
+        //[PlatformSpecific(TestPlatforms.Windows)]
         public void TestCacheSliding()
         {
             var config = new NameValueCollection();
@@ -1510,7 +1511,7 @@ namespace MonoTests.System.Runtime.Caching
         public static bool SupportsPhysicalMemoryMonitor => MemoryCacheTest.SupportsPhysicalMemoryMonitor;
 
         [ConditionalFact(nameof(SupportsPhysicalMemoryMonitor))]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93106")]
+        //[SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93106")]
         public async Task TestCacheShrink()
         {
             const int HEAP_RESIZE_THRESHOLD = 8192 + 2;
@@ -1570,7 +1571,7 @@ namespace MonoTests.System.Runtime.Caching
         public static bool SupportsPhysicalMemoryMonitor => MemoryCacheTest.SupportsPhysicalMemoryMonitor;
 
         [ConditionalFact(nameof(SupportsPhysicalMemoryMonitor))]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93106")]
+        //[SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93106")]
         public async Task TestCacheExpiryOrdering()
         {
             var config = new NameValueCollection();


### PR DESCRIPTION
This pull request updates the `System.Runtime.Caching` test suite to improve coverage and maintainability. The main changes include removing obsolete or restrictive test annotations, refactoring test helpers for better isolation, and adding a new test to verify cache item expiration behavior when file dependencies change.

**Test coverage and reliability improvements:**

* Added a new `[OuterLoop]` test `Reasonable_Delay` in `HostFileChangeMonitorTest.cs` to verify that cache items expire promptly when a monitored file changes.
* Refactored the `SetupMonitoring` helper to accept a unique ID, ensuring test file isolation and reducing interference between tests. [[1]](diffhunk://#diff-e3b0f135ce65d2a29cf66a4a98add35658336ba5893bd6a73753f59a8fa6c38bL151-R152) [[2]](diffhunk://#diff-e3b0f135ce65d2a29cf66a4a98add35658336ba5893bd6a73753f59a8fa6c38bL204-R208)

**Test annotation and platform restriction cleanup:**

* Removed `[ActiveIssue]`, `[PlatformSpecific]`, and `[SkipOnPlatform]` annotations from several tests in both `HostFileChangeMonitorTest.cs` and `MemoryCacheTest.cs`, enabling broader test execution across platforms and configurations. [[1]](diffhunk://#diff-e3b0f135ce65d2a29cf66a4a98add35658336ba5893bd6a73753f59a8fa6c38bL87) [[2]](diffhunk://#diff-e3b0f135ce65d2a29cf66a4a98add35658336ba5893bd6a73753f59a8fa6c38bL135) [[3]](diffhunk://#diff-23a9a8ef4fa301d7bb4b398dc310c710a4a24ea7f621b3c8a5bf51c3095893eeL307) [[4]](diffhunk://#diff-23a9a8ef4fa301d7bb4b398dc310c710a4a24ea7f621b3c8a5bf51c3095893eeL1112-R1111) [[5]](diffhunk://#diff-23a9a8ef4fa301d7bb4b398dc310c710a4a24ea7f621b3c8a5bf51c3095893eeL1200-L1204) [[6]](diffhunk://#diff-23a9a8ef4fa301d7bb4b398dc310c710a4a24ea7f621b3c8a5bf51c3095893eeL1513) [[7]](diffhunk://#diff-23a9a8ef4fa301d7bb4b398dc310c710a4a24ea7f621b3c8a5bf51c3095893eeL1573)

**General code and import maintenance:**

* Cleaned up using directives in `HostFileChangeMonitorTest.cs` to remove unnecessary imports and improve code clarity.