### PR TITLE
Remove workaround in tests for clearing EnableUnsafeBinaryFormatterSerialization

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/Disabled/System.Runtime.Serialization.Formatters.Disabled.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/Disabled/System.Runtime.Serialization.Formatters.Disabled.Tests.csproj
@@ -4,20 +4,19 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-freebsd;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-solaris;$(NetCoreAppCurrent)-haiku;$(NetCoreAppCurrent)-linux;$(NetCoreAppCurrent)-osx;$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup>
+    <!--
+      We're testing the BinaryFormatter enablement / disablement switch, so we need to suppress any inherited behavior.
+      The specific combination below accomplishes this. Normal apps should *NOT* set this combination of switches and
+      should instead set the switches documented at:
+      https://learn.microsoft.com/dotnet/core/compatibility/core-libraries/7.0/binaryformatter-apis-produce-errors#recommended-action
+    -->
+    <_ProjectTypeRequiresBinaryFormatter>true</_ProjectTypeRequiresBinaryFormatter>
+    <EnableUnsafeBinaryFormatterSerialization><!-- intentionally left blank --></EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="DisableBitTests.cs" />
     <Compile Include="..\TestConfiguration.cs" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj" />
   </ItemGroup>
-  <!--
-      We're testing the BinaryFormatter enablement / disablement switch, so we need to suppress any inherited behavior.
-      See https://github.com/dotnet/runtime/issues/87811 for more details.
-      This is a temporary solution and should be reverted back to the original once the necessary changes are made in
-      shared frameworks and SDK.
-    -->
-  <Target Name="RemoveSerializationRuntimeOption" BeforeTargets="GenerateBuildRuntimeConfigurationFiles">
-    <ItemGroup>
-      <RuntimeHostConfigurationOption Remove="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
This is effectively a revert of https://github.com/dotnet/runtime/commit/b63f588212e4497e8e22bf1a555f17bfba9c04b8

Fixes https://github.com/dotnet/runtime/issues/87811
