### PR TITLE
JIT: allow inliner to use up more of the lva "budget"

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1100,7 +1100,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result, 
     }
 #endif // defined(DEBUG)
 
-    if (lvaCount >= MAX_LV_NUM_COUNT_FOR_INLINING)
+    if (lvaHaveManyLocals(0.9f))
     {
         // For now, attributing this to call site, though it's really
         // more of a budget issue (lvaCount currently includes all


### PR DESCRIPTION
We currently stop inlining once we hit a fixed limit of 512 local vars (specified via `MAX_LV_NUM_COUNT_FOR_INLINING`). We hit this limit now more often because of increased inliner aggressiveness, and at any rate it should be some fraction of `JitMaxLocalsToTrack` instead of a fixed value.

When the inliner hits this limit it often leaves quite valuable inlines on the table.

Revise this so the inliner is allowed to consume 90% of the max locals during inlining (50% would be a no-diff change).

This fixes some regressions reported in #114996 which were then made worse by #116054.