### PR TITLE
Optimize out metadata for `typeof(X).IsValueType` and `.IsEnum`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -970,7 +970,7 @@ namespace Internal.IL
                     {
                         if (reader.HasNext
                             && reader.ReadILOpcode() is ILOpcode.callvirt or ILOpcode.call
-                            && _methodIL.GetObject(reader.ReadILToken()) is MethodDesc{ Name: "get_IsValueType" or "get_IsEnum"})
+                            && _methodIL.GetObject(reader.ReadILToken()) is MethodDesc { Name: "get_IsValueType" or "get_IsEnum"})
                         {
                             helperId = ReadyToRunHelperId.NecessaryTypeHandle;
                         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -970,7 +970,8 @@ namespace Internal.IL
                     {
                         if (reader.HasNext
                             && reader.ReadILOpcode() is ILOpcode.callvirt or ILOpcode.call
-                            && _methodIL.GetObject(reader.ReadILToken()) is MethodDesc { Name: "get_IsValueType" or "get_IsEnum"})
+                            && _methodIL.GetObject(reader.ReadILToken()) is MethodDesc
+                                { Name: "get_IsValueType" or "get_IsEnum" or "get_IsPrimitive" })
                         {
                             helperId = ReadyToRunHelperId.NecessaryTypeHandle;
                         }


### PR DESCRIPTION
We don't need reflection metadata to answer this.

Change salvaged out of #118479, rt-sz will decide if we want it.