### PR TITLE
Mark the vectorized CRC update methods noinline

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.Vectorized.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.Vectorized.cs
@@ -29,6 +29,10 @@ namespace System.IO.Hashing
         // Computation for Generic Polynomials Using PCLMULQDQ Instruction" in December, 2009.
         // https://github.com/intel/isa-l/blob/33a2d9484595c2d6516c920ce39a694c144ddf69/crc/crc32_ieee_by4.asm
         // https://github.com/SixLabors/ImageSharp/blob/f4f689ce67ecbcc35cebddba5aacb603e6d1068a/src/ImageSharp/Formats/Png/Zlib/Crc32.cs#L80
+        //
+        // Marking this as noinline so the JIT doesn't try and inline this and end up not inlining some of the calls it makes.
+        //
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static uint UpdateVectorized(uint crc, ReadOnlySpan<byte> source)
         {
             Debug.Assert(CanBeVectorized(source), "source cannot be vectorized.");

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Vectorized.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Vectorized.cs
@@ -43,6 +43,10 @@ namespace System.IO.Hashing
         // "Fast CRC Computation for Generic Polynomials Using PCLMULQDQ Instruction" in December, 2009 and the
         // Intel reference implementation.
         // https://github.com/intel/isa-l/blob/33a2d9484595c2d6516c920ce39a694c144ddf69/crc/crc64_ecma_norm_by8.asm
+        //
+        // Marking this as noinline so the JIT doesn't try and inline this and end up not inlining some of the calls it makes.
+        //
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static ulong UpdateVectorized(ulong crc, ReadOnlySpan<byte> source)
         {
             Debug.Assert(CanBeVectorized(source), "source cannot be vectorized.");


### PR DESCRIPTION
This works around a deficiency in the jit inliner. When it tries to inline a large method with many important callees into a small method, it runs out of budget trying to inline the callees.

The budget is set based on the size of the root method, so the vectorized update methods have enough budget to inline their callees.

Fixes #114383.