### PR TITLE
Update Microsoft.Bcl.Cryptography nuget package text

### DIFF
--- a/src/libraries/Microsoft.Bcl.Cryptography/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/PACKAGE.md
@@ -18,7 +18,7 @@ internal static class Program
     private static void Main()
     {
         byte[] key = LoadKey();
-        SP800108HmacCounterKdf kbkdf = new(key, HashAlgorithmName.SHA256);
+        using SP800108HmacCounterKdf kbkdf = new(key, HashAlgorithmName.SHA256);
         byte[] derivedKey = kbkdf.DeriveKey("label"u8, "context"u8, derivedKeyLengthInBytes: 32);
     }
 }
@@ -29,6 +29,10 @@ internal static class Program
 The main types provided by this library are:
 
 * `System.Security.Cryptography.AesGcm`
+* `System.Security.Cryptography.CompositeMLDsa`
+* `System.Security.Cryptography.MLDsa`
+* `System.Security.Cryptography.MLKem`
+* `System.Security.Cryptography.SlhDsa`
 * `System.Security.Cryptography.SP800108HmacCounterKdf`
 * `System.Security.Cryptography.X509Certificates.X509CertificateLoader`
 


### PR DESCRIPTION
SEO-ify the package text with PQ types and add a `using` so our example shows a good practice.

I don't know if we really need a "how to use" code snippet, so I would be open to removing it entirely. M.B.C has become kind of "Crypto stuff we need down level" and less of anything we are trying to coherently package.