### PR TITLE
JIT: Do not mark small types RegOptional as part of GT_LONG contained by HWIntrinsic

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -9781,14 +9781,16 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
 
                             for (GenTree* longOp : op1->Operands())
                             {
-                                if (!varTypeIsSmall(longOp) && IsContainableMemoryOp(longOp) &&
-                                    IsSafeToContainMem(node, longOp))
+                                if (!varTypeIsSmall(longOp))
                                 {
-                                    MakeSrcContained(node, longOp);
-                                }
-                                else if (IsSafeToMarkRegOptional(node, longOp))
-                                {
-                                    MakeSrcRegOptional(node, longOp);
+                                    if (IsContainableMemoryOp(longOp) && IsSafeToContainMem(node, longOp))
+                                    {
+                                        MakeSrcContained(node, longOp);
+                                    }
+                                    else if (IsSafeToMarkRegOptional(node, longOp))
+                                    {
+                                        MakeSrcRegOptional(node, longOp);
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
Fixes #118466

I was unable to get the repro from #118466 to fail when converted to an Xunit test, but this fixes the assert (and codegen) seen in the standalone repro.

Before (when bypassing the assert):
```asm
IN0015: 00004E xor      edx, edx
IN0016: 000050 vmovd    xmm0, dword ptr [V00 ebp-0x08]
IN0017: 000055 vpinsrd  xmm0, xmm0, edx, 1
IN0018: 00005B vpbroadcastq xmm0, xmm0
```

After:
```asm
IN0015: 00004E movzx    edx, byte  ptr [V00 ebp-0x08]
IN0016: 000052 xor      ecx, ecx
IN0017: 000054 vmovd    xmm0, edx
IN0018: 000058 vpinsrd  xmm0, xmm0, ecx, 1
IN0019: 00005E vpbroadcastq xmm0, xmm0
```