### PR TITLE
Implement UnhandledException hook for finalizer scenario in Mono.

### DIFF
--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -278,8 +278,8 @@
 			<method name="GetHashCode" />
 		</type>
 
-		<!-- domain.c: mono_defaults.finalizer_class -->
-		<type fullname="System.FinalizerHelper">
+		<!-- domain.c: mono_defaults.gc_class -->
+		<type fullname="System.GC">
 			<!-- gc.c: mono_gc_run_finalize -->
 			<method name="GuardedFinalize" />
 		</type>

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -276,6 +276,8 @@
 			<!-- class.c: initialize_object_slots -->
 			<method name="Finalize" />
 			<method name="GetHashCode" />
+			<!-- gc.c: mono_gc_run_finalize -->
+			<method name="GuardedFinalize" />
 		</type>
 
 		<!-- appdomain.c (create_domain_objects) domain->out_of_memory_ex -->

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -276,6 +276,10 @@
 			<!-- class.c: initialize_object_slots -->
 			<method name="Finalize" />
 			<method name="GetHashCode" />
+		</type>
+
+		<!-- domain.c: mono_defaults.finalizer_class -->
+		<type fullname="System.FinalizerHelper">
 			<!-- gc.c: mono_gc_run_finalize -->
 			<method name="GuardedFinalize" />
 		</type>

--- a/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
@@ -19,11 +19,11 @@ namespace System
     {
         [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(Finalize))]
         private static extern void CallFinalize(object o);
-        private void GuardedFinalize()
+        private static void GuardedFinalize(object o)
         {
             try
             {
-                CallFinalize(this);
+                CallFinalize(o);
             }
             catch (Exception ex) when (ExceptionHandling.IsHandledByGlobalHandler(ex))
             {

--- a/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 
 namespace System
 {
@@ -13,22 +12,6 @@ namespace System
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         protected extern object MemberwiseClone();
-    }
 
-    internal sealed class FinalizerHelper
-    {
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(Finalize))]
-        private static extern void CallFinalize(object o);
-        private static void GuardedFinalize(object o)
-        {
-            try
-            {
-                CallFinalize(o);
-            }
-            catch (Exception ex) when (ExceptionHandling.IsHandledByGlobalHandler(ex))
-            {
-                // the handler returned "true" means the exception is now "handled" and we should continue.
-            }
-        }
     }
 }

--- a/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 
 namespace System
 {
@@ -13,5 +14,18 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         protected extern object MemberwiseClone();
 
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(Finalize))]
+        private static extern void CallFinalize(object o);
+        private void GuardedFinalize()
+        {
+            try
+            {
+                CallFinalize(this);
+            }
+            catch (Exception ex) when (ExceptionHandling.IsHandledByGlobalHandler(ex))
+            {
+                // the handler returned "true" means the exception is now "handled" and we should continue.
+            }
+        }
     }
 }

--- a/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
@@ -16,7 +16,7 @@ namespace System
 
         [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(Finalize))]
         private static extern void CallFinalize(object o);
-        internal virtual void GuardedFinalize()
+        internal void GuardedFinalize()
         {
             try
             {

--- a/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
@@ -16,7 +16,7 @@ namespace System
 
         [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(Finalize))]
         private static extern void CallFinalize(object o);
-        private void GuardedFinalize()
+        internal virtual void GuardedFinalize()
         {
             try
             {

--- a/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Object.Mono.cs
@@ -13,10 +13,13 @@ namespace System
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         protected extern object MemberwiseClone();
+    }
 
+    internal sealed class FinalizerHelper
+    {
         [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(Finalize))]
         private static extern void CallFinalize(object o);
-        internal void GuardedFinalize()
+        private void GuardedFinalize()
         {
             try
             {

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -857,6 +857,7 @@ mono_generic_param_get_base_type (MonoClass *klass);
 typedef struct {
 	MonoImage *corlib;
 	MonoClass *object_class;
+	MonoClass *finalizer_class;
 	MonoClass *object_class_array; // used via token pasting in mono_array_class_get_cached
 	MonoClass *byte_class;
 	MonoClass *void_class;

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -857,7 +857,6 @@ mono_generic_param_get_base_type (MonoClass *klass);
 typedef struct {
 	MonoImage *corlib;
 	MonoClass *object_class;
-	MonoClass *finalizer_class;
 	MonoClass *object_class_array; // used via token pasting in mono_array_class_get_cached
 	MonoClass *byte_class;
 	MonoClass *void_class;
@@ -890,6 +889,7 @@ typedef struct {
 	MonoClass *threadabortexception_class;
 	MonoClass *thread_class;
 	MonoClass *internal_thread_class;
+	MonoClass *gc_class;
 	MonoClass *autoreleasepool_class;
 	MonoClass *mono_method_message_class;
 	MonoClass *field_info_class;

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -154,9 +154,6 @@ mono_init_internal (const char *root_domain_name)
 	mono_defaults.object_class = mono_class_load_from_name (
                 mono_defaults.corlib, "System", "Object");
 
-	mono_defaults.finalizer_class = mono_class_load_from_name (
-                mono_defaults.corlib, "System", "FinalizerHelper");
-
 	mono_defaults.void_class = mono_class_load_from_name (
                 mono_defaults.corlib, "System", "Void");
 
@@ -240,6 +237,9 @@ mono_init_internal (const char *root_domain_name)
 
 	/* There is only one thread class */
 	mono_defaults.internal_thread_class = mono_defaults.thread_class;
+
+	mono_defaults.gc_class = mono_class_load_from_name (
+                mono_defaults.corlib, "System", "GC");
 
 #if defined(HOST_DARWIN)
 	mono_defaults.autoreleasepool_class = mono_class_try_load_from_name (

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -154,6 +154,9 @@ mono_init_internal (const char *root_domain_name)
 	mono_defaults.object_class = mono_class_load_from_name (
                 mono_defaults.corlib, "System", "Object");
 
+	mono_defaults.finalizer_class = mono_class_load_from_name (
+                mono_defaults.corlib, "System", "FinalizerHelper");
+
 	mono_defaults.void_class = mono_class_load_from_name (
                 mono_defaults.corlib, "System", "Void");
 

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -291,9 +291,10 @@ mono_gc_run_finalize (void *obj, void *data)
 
 #ifndef HOST_WASM
 	if (!finalize_runtime_invoke) {
-		MonoMethod *finalize_method = mono_class_get_method_from_name_checked (mono_defaults.object_class, "Finalize", 0, 0, error);
+		MonoMethod *finalize_method = mono_class_get_method_from_name_checked (mono_defaults.object_class, "GuardedFinalize", 0, 0, error);
+
 		mono_error_assert_ok (error);
-		MonoMethod *invoke = mono_marshal_get_runtime_invoke (finalize_method, TRUE);
+		MonoMethod *invoke = mono_marshal_get_runtime_invoke_full (finalize_method, FALSE, TRUE);
 
 		finalize_runtime_invoke = (RuntimeInvokeFunction)mono_compile_method_checked (invoke, error);
 		mono_error_assert_ok (error); /* expect this not to fail */
@@ -316,7 +317,7 @@ mono_gc_run_finalize (void *obj, void *data)
 	MONO_PROFILER_RAISE (gc_finalizing_object, (o));
 
 #ifdef HOST_WASM
-	MonoMethod* finalizer = mono_class_get_finalizer (o->vtable->klass);
+	MonoMethod* finalizer = mono_class_get_method_from_name_checked (mono_defaults.object_class, "GuardedFinalize", 0, 0, error);
 	if (finalizer) { // null finalizers work fine when using the vcall invoke as Object has an empty one
 		gpointer params [1];
 		params [0] = NULL;

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -279,12 +279,6 @@ mono_gc_run_finalize (void *obj, void *data)
 		return;
 	}
 
-
-	/*
-	 * To avoid the locking plus the other overhead of mono_runtime_invoke_checked (),
-	 * create and precompile a wrapper which calls the finalize method using
-	 * a CALLVIRT.
-	 */
 	if (mono_log_finalizers)
 		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Compiling finalizer.", o_name, o);
 

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -292,7 +292,7 @@ mono_gc_run_finalize (void *obj, void *data)
 		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Compiling finalizer.", o_name, o);
 
 	if (!finalize_method) {
-		finalize_method = mono_class_get_method_from_name_checked (mono_defaults.object_class, "GuardedFinalize", 0, 0, error);
+		finalize_method = mono_class_get_method_from_name_checked (mono_defaults.finalizer_class, "GuardedFinalize", 0, 0, error);
 		mono_error_assert_ok (error);
 	}
 

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -297,14 +297,14 @@ mono_gc_run_finalize (void *obj, void *data)
 	}
 
 #ifndef HOST_WASM
-	if (!finalize_runtime_invoke) {
-		MonoMethod *invoke = mono_marshal_get_runtime_invoke (finalize_method, TRUE);
+	//if (!finalize_runtime_invoke) {
+	//	MonoMethod *invoke = mono_marshal_get_runtime_invoke (finalize_method, TRUE);
 
-		finalize_runtime_invoke = (RuntimeInvokeFunction)mono_compile_method_checked (invoke, error);
-		mono_error_assert_ok (error); /* expect this not to fail */
-	}
+	//	finalize_runtime_invoke = (RuntimeInvokeFunction)mono_compile_method_checked (invoke, error);
+	//	mono_error_assert_ok (error); /* expect this not to fail */
+	//}
 
-	RuntimeInvokeFunction runtime_invoke = finalize_runtime_invoke;
+	//RuntimeInvokeFunction runtime_invoke = finalize_runtime_invoke;
 #endif
 
 	mono_runtime_class_init_full (o->vtable, error);
@@ -325,7 +325,12 @@ mono_gc_run_finalize (void *obj, void *data)
 	params [0] = NULL;
 	mono_runtime_try_invoke (finalize_method, o, params, &exc, error);
 #else
-	runtime_invoke (o, NULL, &exc, NULL);
+	// runtime_invoke (o, NULL, &exc, NULL);
+
+	gpointer params [1];
+	params [0] = NULL;
+	mono_runtime_try_invoke (finalize_method, o, params, &exc, error);
+
 #endif
 
 	MONO_PROFILER_RAISE (gc_finalized_object, (o));

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -298,7 +298,7 @@ mono_gc_run_finalize (void *obj, void *data)
 
 #ifndef HOST_WASM
 	if (!finalize_runtime_invoke) {
-		MonoMethod *invoke = mono_marshal_get_runtime_invoke_full (finalize_method, FALSE, TRUE);
+		MonoMethod *invoke = mono_marshal_get_runtime_invoke (finalize_method, TRUE);
 
 		finalize_runtime_invoke = (RuntimeInvokeFunction)mono_compile_method_checked (invoke, error);
 		mono_error_assert_ok (error); /* expect this not to fail */

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -84,7 +84,7 @@ static MonoInternalThread *gc_thread;
 
 static MonoMethod *finalize_method;
 #ifndef HOST_WASM
-static RuntimeInvokeFunction finalize_runtime_invoke;
+// static RuntimeInvokeFunction finalize_runtime_invoke;
 #endif
 
 /*

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -292,7 +292,7 @@ mono_gc_run_finalize (void *obj, void *data)
 		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Compiling finalizer.", o_name, o);
 
 	if (!finalize_method) {
-		finalize_method = mono_class_get_method_from_name_checked (mono_defaults.finalizer_class, "GuardedFinalize", 0, 0, error);
+		finalize_method = mono_class_get_method_from_name_checked (mono_defaults.finalizer_class, "GuardedFinalize", 1, 0, error);
 		mono_error_assert_ok (error);
 	}
 
@@ -322,14 +322,14 @@ mono_gc_run_finalize (void *obj, void *data)
 
 #ifdef HOST_WASM
 	gpointer params [1];
-	params [0] = NULL;
-	mono_runtime_try_invoke (finalize_method, o, params, &exc, error);
+	params [0] = o;
+	mono_runtime_try_invoke (finalize_method, NULL, params, &exc, error);
 #else
 	// runtime_invoke (o, NULL, &exc, NULL);
 
 	gpointer params [1];
-	params [0] = NULL;
-	mono_runtime_try_invoke (finalize_method, o, params, &exc, error);
+	params [0] = o;
+	mono_runtime_try_invoke (finalize_method, NULL, params, &exc, error);
 
 #endif
 

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4977,7 +4977,7 @@ add_full_aot_wrappers (MonoAotCompile *acfg)
 		add_method (acfg, get_runtime_invoke_sig (csig));
 
 		/* runtime-invoke used by finalizers */
-		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.object_class, "GuardedFinalize", 0, 0), FALSE));
+		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.finalizer_class, "GuardedFinalize", 0, 0), FALSE));
 
 		/* This is used by mono_runtime_capture_context () */
 		method = mono_get_context_capture_method ();

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4977,7 +4977,7 @@ add_full_aot_wrappers (MonoAotCompile *acfg)
 		add_method (acfg, get_runtime_invoke_sig (csig));
 
 		/* runtime-invoke used by finalizers */
-		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.object_class, "GuardedFinalize", 0, 0), FALSE));
+		add_method (acfg, mono_marshal_get_runtime_invoke_full (get_method_nofail (mono_defaults.object_class, "GuardedFinalize", 0, 0), FALSE, TRUE));
 
 		/* This is used by mono_runtime_capture_context () */
 		method = mono_get_context_capture_method ();

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4977,7 +4977,7 @@ add_full_aot_wrappers (MonoAotCompile *acfg)
 		add_method (acfg, get_runtime_invoke_sig (csig));
 
 		/* runtime-invoke used by finalizers */
-		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.object_class, "GuardedFinalize", 0, 0), TRUE));
+		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.object_class, "GuardedFinalize", 0, 0), FALSE));
 
 		/* This is used by mono_runtime_capture_context () */
 		method = mono_get_context_capture_method ();

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4977,7 +4977,7 @@ add_full_aot_wrappers (MonoAotCompile *acfg)
 		add_method (acfg, get_runtime_invoke_sig (csig));
 
 		/* runtime-invoke used by finalizers */
-		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.finalizer_class, "GuardedFinalize", 0, 0), FALSE));
+		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.finalizer_class, "GuardedFinalize", 1, 0), FALSE));
 
 		/* This is used by mono_runtime_capture_context () */
 		method = mono_get_context_capture_method ();

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4977,7 +4977,7 @@ add_full_aot_wrappers (MonoAotCompile *acfg)
 		add_method (acfg, get_runtime_invoke_sig (csig));
 
 		/* runtime-invoke used by finalizers */
-		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.object_class, "Finalize", 0, 0), TRUE));
+		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.object_class, "GuardedFinalize", 0, 0), FALSE));
 
 		/* This is used by mono_runtime_capture_context () */
 		method = mono_get_context_capture_method ();

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4977,7 +4977,7 @@ add_full_aot_wrappers (MonoAotCompile *acfg)
 		add_method (acfg, get_runtime_invoke_sig (csig));
 
 		/* runtime-invoke used by finalizers */
-		add_method (acfg, mono_marshal_get_runtime_invoke_full (get_method_nofail (mono_defaults.object_class, "GuardedFinalize", 0, 0), FALSE, TRUE));
+		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.object_class, "GuardedFinalize", 0, 0), TRUE));
 
 		/* This is used by mono_runtime_capture_context () */
 		method = mono_get_context_capture_method ();

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4977,7 +4977,7 @@ add_full_aot_wrappers (MonoAotCompile *acfg)
 		add_method (acfg, get_runtime_invoke_sig (csig));
 
 		/* runtime-invoke used by finalizers */
-		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.finalizer_class, "GuardedFinalize", 1, 0), FALSE));
+		add_method (acfg, get_runtime_invoke (acfg, get_method_nofail (mono_defaults.gc_class, "GuardedFinalize", 1, 0), FALSE));
 
 		/* This is used by mono_runtime_capture_context () */
 		method = mono_get_context_capture_method ();

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -5363,8 +5363,8 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			continue;
 		}
-		if (strcmp (method->name, "Finalize") == 0) {
-			invoke = mono_marshal_get_runtime_invoke (method, FALSE);
+		if (strcmp (method->name, "GuardedFinalize") == 0) {
+			invoke = mono_marshal_get_runtime_invoke_full (method, FALSE, TRUE);
 			mono_compile_method_checked (invoke, error);
 			mono_error_assert_ok (error);
 		}

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -5363,10 +5363,12 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			continue;
 		}
-		if (strcmp (method->name, "GuardedFinalize") == 0) {
-			invoke = mono_marshal_get_runtime_invoke_full (method, FALSE, TRUE);
-			mono_compile_method_checked (invoke, error);
-			mono_error_assert_ok (error);
+		if (mono_is_corlib_image (image)) {
+			if (strcmp (method->name, "GuardedFinalize") == 0) {
+				invoke = mono_marshal_get_runtime_invoke_full (method, FALSE, TRUE);
+				mono_compile_method_checked (invoke, error);
+				mono_error_assert_ok (error);
+			}
 		}
 	}
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -5363,12 +5363,10 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			continue;
 		}
-		if (mono_is_corlib_image (image)) {
-			if (strcmp (method->name, "GuardedFinalize") == 0) {
-				invoke = mono_marshal_get_runtime_invoke_full (method, FALSE, TRUE);
-				mono_compile_method_checked (invoke, error);
-				mono_error_assert_ok (error);
-			}
+		if (strcmp (method->name, "GuardedFinalize") == 0) {
+			invoke = mono_marshal_get_runtime_invoke (method, FALSE);
+			mono_compile_method_checked (invoke, error);
+			mono_error_assert_ok (error);
 		}
 	}
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1732,8 +1732,11 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/Structs/MemsetMemcpyNullref/*">
             <Issue>https://github.com/dotnet/runtime/issues/98628</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/UnhandledExceptionHandler/HandlerThrows/*">
+            <Issue>https://github.com/dotnet/runtime/issues/47624</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/UnhandledExceptionHandler/NoEffectInMainThread/*">
-          <Issue>Test issue. The test relies on overriding the process return code.</Issue>
+            <Issue>Test issue. The test relies on overriding the process return code.</Issue>
         </ExcludeList>
     </ItemGroup>
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1732,8 +1732,8 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/Structs/MemsetMemcpyNullref/*">
             <Issue>https://github.com/dotnet/runtime/issues/98628</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/UnhandledExceptionHandler/**">
-          <Issue>NYI on Mono</Issue>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/UnhandledExceptionHandler/NoEffectInMainThread/*">
+          <Issue>Test issue. The test relies on overriding the process return code.</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
A follow-up for https://github.com/dotnet/runtime/pull/109806

Most of the implementation is in the shared corelib code and works for Mono, but finalization scenario needs special handling as that part is not shared.