### PR TITLE
fixing a regression in regions related to UOH allocations during BGC

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -428,8 +428,25 @@ size_t gib (size_t num)
 
 #ifdef BACKGROUND_GC
 uint32_t bgc_alloc_spin_count = 140;
-uint32_t bgc_alloc_spin_count_uoh = 16;
 uint32_t bgc_alloc_spin = 2;
+
+// The following 2 ratios dictate how UOH allocations that happen during a BGC should be handled. Because
+// UOH is not collected till the very end of a BGC, by default we don't want to allow UOH to grow too large
+// during a BGC. So if we only increase the size by 10%, we will allow to allocate normally. But if it's
+// too much (ie, > bgc_uoh_inc_ratio_alloc_wait), we will make the allocation wait till the BGC is done.
+//
+// This means threads that allocate heavily on UOH may be paused during a BGC. If you're willing to accept
+// larger UOH sizes in exchange for fewer pauses, you can use the UOHWaitBGCSizeIncPercent config to increase
+// the wait ratio. Likewise, set it to use a smaller ratio if you observe that UOH grows too large during
+// BGCs.
+float bgc_uoh_inc_ratio_alloc_normal = 0.1f;
+// This ratio is 2x for regions because regions could start with a much smaller size since a lot of
+// memory could be in the free pool.
+#ifdef USE_REGIONS
+float bgc_uoh_inc_ratio_alloc_wait = 2.0f;
+#else
+float bgc_uoh_inc_ratio_alloc_wait = 1.0f;
+#endif //USE_REGIONS
 
 inline
 void c_write (uint32_t& place, uint32_t value)
@@ -2720,10 +2737,9 @@ heap_segment* gc_heap::freeable_soh_segment = 0;
 
 size_t      gc_heap::bgc_overflow_count = 0;
 
-size_t      gc_heap::bgc_begin_loh_size = 0;
-size_t      gc_heap::end_loh_size = 0;
-size_t      gc_heap::bgc_begin_poh_size = 0;
-size_t      gc_heap::end_poh_size = 0;
+size_t      gc_heap::bgc_begin_uoh_size[uoh_generation_count] = {};
+size_t      gc_heap::bgc_uoh_current_size[uoh_generation_count] = {};
+size_t      gc_heap::end_uoh_size[uoh_generation_count] = {};
 
 size_t      gc_heap::uoh_a_no_bgc[uoh_generation_count] = {};
 size_t      gc_heap::uoh_a_bgc_marking[uoh_generation_count] = {};
@@ -2732,15 +2748,9 @@ size_t      gc_heap::uoh_a_bgc_planning[uoh_generation_count] = {};
 size_t      gc_heap::bgc_maxgen_end_fl_size = 0;
 #endif //BGC_SERVO_TUNING
 
-size_t      gc_heap::bgc_loh_size_increased = 0;
-
-size_t      gc_heap::bgc_poh_size_increased = 0;
-
 size_t      gc_heap::background_soh_size_end_mark = 0;
 
 size_t      gc_heap::background_soh_alloc_count = 0;
-
-size_t      gc_heap::background_uoh_alloc_count = 0;
 
 uint8_t**   gc_heap::background_mark_stack_tos = 0;
 
@@ -8166,19 +8176,6 @@ bool gc_heap::new_allocation_allowed (int gen_number)
 {
     if (dd_new_allocation (dynamic_data_of (gen_number)) < 0)
     {
-        if (gen_number != 0)
-        {
-            // For UOH we will give it more budget before we try a GC.
-            if (settings.concurrent)
-            {
-                dynamic_data* dd2 = dynamic_data_of (gen_number);
-
-                if (dd_new_allocation (dd2) <= (ptrdiff_t)(-2 * dd_desired_allocation (dd2)))
-                {
-                    return TRUE;
-                }
-            }
-        }
         return FALSE;
     }
 #ifndef MULTIPLE_HEAPS
@@ -14515,6 +14512,26 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
 #endif //WRITE_WATCH
 
 #ifdef BACKGROUND_GC
+#ifdef USE_REGIONS
+    int bgc_uoh_inc_percent_alloc_wait = (int)GCConfig::GetUOHWaitBGCSizeIncPercent();
+    if (bgc_uoh_inc_percent_alloc_wait != -1)
+    {
+        bgc_uoh_inc_ratio_alloc_wait = (float)bgc_uoh_inc_percent_alloc_wait / 100.0f;
+    }
+    else
+    {
+        bgc_uoh_inc_percent_alloc_wait = (int)(bgc_uoh_inc_ratio_alloc_wait * 100.0f);
+    }
+
+    if (bgc_uoh_inc_ratio_alloc_normal > bgc_uoh_inc_ratio_alloc_wait)
+    {
+        bgc_uoh_inc_ratio_alloc_normal = bgc_uoh_inc_ratio_alloc_wait;
+    }
+    GCConfig::SetUOHWaitBGCSizeIncPercent (bgc_uoh_inc_percent_alloc_wait);
+    dprintf (1, ("UOH allocs during BGC are allowed normally when inc ratio is  < %.3f, will wait when > %.3f",
+        bgc_uoh_inc_ratio_alloc_normal, bgc_uoh_inc_ratio_alloc_wait));
+#endif 
+
     // leave the first page to contain only segment info
     // because otherwise we could need to revisit the first page frequently in
     // background GC.
@@ -15584,10 +15601,11 @@ gc_heap::init_gc_heap (int h_number)
     bgc_threads_timeout_cs.Initialize();
     current_bgc_state = bgc_not_in_process;
     background_soh_alloc_count = 0;
-    background_uoh_alloc_count = 0;
     bgc_overflow_count = 0;
-    end_loh_size = dd_min_size (dynamic_data_of (loh_generation));
-    end_poh_size = dd_min_size (dynamic_data_of (poh_generation));
+    for (int i = uoh_start_generation; i < total_generation_count; i++)
+    {
+        end_uoh_size[i - uoh_start_generation] = dd_min_size (dynamic_data_of (i));
+    }
 
     current_sweep_pos = 0;
 #ifdef DOUBLY_LINKED_FL
@@ -18023,6 +18041,7 @@ found_fit:
 #ifdef BACKGROUND_GC
     if (cookie != -1)
     {
+        bgc_record_uoh_end_seg_allocation (gen_number, limit);
         allocated += limit;
         bgc_uoh_alloc_clr (old_alloc, limit, acontext, flags, gen_number, align_const, cookie, TRUE, seg);
     }
@@ -18049,6 +18068,10 @@ found_fit:
             // add space for an AC continuity divider
             limit += Align(min_obj_size, align_const);
         }
+
+#ifdef BACKGROUND_GC
+        bgc_record_uoh_end_seg_allocation (gen_number, limit);
+#endif
 
         allocated += limit;
         adjust_limit_clr (old_alloc, limit, size, acontext, flags, seg, align_const, gen_number);
@@ -18562,60 +18585,6 @@ void gc_heap::bgc_untrack_uoh_alloc()
         dprintf (3, ("h%d: dec lc: %d", heap_number, (int32_t)uoh_alloc_thread_count));
     }
 }
-
-// We need to throttle the UOH allocations during BGC since we can't
-// collect UOH when BGC is in progress (when BGC sweeps UOH allocations on UOH are disallowed)
-// We allow the UOH heap size to double during a BGC. And for every
-// 10% increase we will have the UOH allocating thread sleep for one more
-// ms. So we are already 30% over the original heap size the thread will
-// sleep for 3ms.
-int bgc_allocate_spin(size_t min_gc_size, size_t bgc_begin_size, size_t bgc_size_increased, size_t end_size)
-{
-    if ((bgc_begin_size + bgc_size_increased) < (min_gc_size * 10))
-    {
-        // just do it, no spinning
-        return 0;
-    }
-
-    if ((bgc_begin_size >= (2 * end_size)) || (bgc_size_increased >= bgc_begin_size))
-    {
-        if (bgc_begin_size >= (2 * end_size))
-        {
-            dprintf (3, ("alloc-ed too much before bgc started"));
-        }
-        else
-        {
-            dprintf (3, ("alloc-ed too much after bgc started"));
-        }
-
-        // -1 means wait for bgc
-        return -1;
-    }
-    else
-    {
-        return (int)(((float)bgc_size_increased / (float)bgc_begin_size) * 10);
-    }
-}
-
-int gc_heap::bgc_loh_allocate_spin()
-{
-    size_t min_gc_size = dd_min_size (dynamic_data_of (loh_generation));
-    size_t bgc_begin_size = bgc_begin_loh_size;
-    size_t bgc_size_increased = bgc_loh_size_increased;
-    size_t end_size = end_loh_size;
-
-    return bgc_allocate_spin(min_gc_size, bgc_begin_size, bgc_size_increased, end_size);
-}
-
-int gc_heap::bgc_poh_allocate_spin()
-{
-    size_t min_gc_size = dd_min_size (dynamic_data_of (poh_generation));
-    size_t bgc_begin_size = bgc_begin_poh_size;
-    size_t bgc_size_increased = bgc_poh_size_increased;
-    size_t end_size = end_poh_size;
-
-    return bgc_allocate_spin(min_gc_size, bgc_begin_size, bgc_size_increased, end_size);
-}
 #endif //BACKGROUND_GC
 
 size_t gc_heap::get_uoh_seg_size (size_t size)
@@ -18728,19 +18697,6 @@ BOOL gc_heap::uoh_try_fit (int gen_number,
                                                 acontext, flags, align_const,
                                                 commit_failed_p, oom_r);
 
-#ifdef BACKGROUND_GC
-        if (can_allocate && gc_heap::background_running_p())
-        {
-            if (gen_number == poh_generation)
-            {
-                bgc_poh_size_increased += size;
-            }
-            else
-            {
-                bgc_loh_size_increased += size;
-            }
-        }
-#endif //BACKGROUND_GC
     }
 
     return can_allocate;
@@ -18853,26 +18809,83 @@ bool gc_heap::should_retry_other_heap (int gen_number, size_t size)
 }
 
 #ifdef BACKGROUND_GC
+uoh_allocation_action gc_heap::get_bgc_allocate_action (int gen_number)
+{
+    int uoh_idx = gen_number - uoh_start_generation;
+
+    // We always allocate normally if the total size is small enough.
+    if (bgc_uoh_current_size[uoh_idx] < (dd_min_size (dynamic_data_of (gen_number)) * 10))
+    {
+        return uoh_alloc_normal;
+    }
+
+#ifndef USE_REGIONS
+    // This is legacy behavior for segments - segments' sizes are usually very stable. But for regions we could
+    // have released a bunch of regions into the free pool during the last gen2 GC so checking the last UOH size
+    // doesn't make sense.
+    if (bgc_begin_uoh_size[uoh_idx] >= (2 * end_uoh_size[uoh_idx]))
+    {
+        dprintf (3, ("h%d alloc-ed too much before bgc started, last end %Id, this start %Id, wait",
+            heap_number, end_uoh_size[uoh_idx], bgc_begin_uoh_size[uoh_idx]));
+        return uoh_alloc_wait;
+    }
+#endif //USE_REGIONS
+
+    size_t size_increased = bgc_uoh_current_size[uoh_idx] - bgc_begin_uoh_size[uoh_idx];
+    float size_increased_ratio = (float)size_increased / (float)bgc_begin_uoh_size[uoh_idx];
+
+    if (size_increased_ratio < bgc_uoh_inc_ratio_alloc_normal)
+    {
+        return uoh_alloc_normal;
+    }
+    else if (size_increased_ratio > bgc_uoh_inc_ratio_alloc_wait)
+    {
+        return uoh_alloc_wait;
+    }
+    else
+    {
+        return uoh_alloc_yield;
+    }
+}
+
 void gc_heap::bgc_record_uoh_allocation(int gen_number, size_t size)
 {
     assert((gen_number >= uoh_start_generation) && (gen_number < total_generation_count));
 
+    int uoh_idx = gen_number - uoh_start_generation;
+
     if (gc_heap::background_running_p())
     {
-        background_uoh_alloc_count++;
-
         if (current_c_gc_state == c_gc_state_planning)
         {
-            uoh_a_bgc_planning[gen_number - uoh_start_generation] += size;
+            uoh_a_bgc_planning[uoh_idx] += size;
         }
         else
         {
-            uoh_a_bgc_marking[gen_number - uoh_start_generation] += size;
+            uoh_a_bgc_marking[uoh_idx] += size;
         }
     }
     else
     {
-        uoh_a_no_bgc[gen_number - uoh_start_generation] += size;
+        uoh_a_no_bgc[uoh_idx] += size;
+    }
+}
+
+void gc_heap::bgc_record_uoh_end_seg_allocation (int gen_number, size_t size)
+{
+    if ((gen_number >= uoh_start_generation) && gc_heap::background_running_p())
+    {
+        int uoh_idx = gen_number - uoh_start_generation;
+        bgc_uoh_current_size[uoh_idx] += size;
+
+#ifdef SIMPLE_DPRINTF
+        dynamic_data* dd_uoh = dynamic_data_of (gen_number);
+        size_t gen_size = generation_size (gen_number);
+        dprintf (3, ("h%d g%d size is now %Id (inc-ed %Id), size is %Id (gen size is %Id), budget %.3fmb, new alloc %.3fmb",
+            heap_number, gen_number, bgc_uoh_current_size[uoh_idx],
+            (bgc_uoh_current_size[uoh_idx] - bgc_begin_uoh_size[uoh_idx]), size, gen_size,
+            mb (dd_desired_allocation (dd_uoh)), (dd_new_allocation (dd_uoh) / 1000.0 / 1000.0)));
+#endif //SIMPLE_DPRINTF
     }
 }
 #endif //BACKGROUND_GC
@@ -18903,31 +18916,33 @@ allocation_state gc_heap::allocate_uoh (int gen_number,
 
     if (gc_heap::background_running_p())
     {
-        //if ((background_uoh_alloc_count % bgc_alloc_spin_count_uoh) == 0)
+        uoh_allocation_action action = get_bgc_allocate_action (gen_number);
+
+        if (action == uoh_alloc_yield)
         {
-            int spin_for_allocation = (gen_number == loh_generation) ?
-                bgc_loh_allocate_spin() :
-                bgc_poh_allocate_spin();
+            add_saved_spinlock_info (true, me_release, mt_alloc_large, msl_status);
+            leave_spin_lock (&more_space_lock_uoh);
+            bool cooperative_mode = enable_preemptive();
+            GCToOSInterface::YieldThread (0);
+            disable_preemptive (cooperative_mode);
 
-            if (spin_for_allocation > 0)
-            {
-                add_saved_spinlock_info (true, me_release, mt_alloc_large, msl_status);
-                leave_spin_lock (&more_space_lock_uoh);
-                bool cooperative_mode = enable_preemptive();
-                GCToOSInterface::YieldThread (spin_for_allocation);
-                disable_preemptive (cooperative_mode);
+            msl_status = enter_spin_lock_msl (&more_space_lock_uoh);
+            if (msl_status == msl_retry_different_heap) return a_state_retry_allocate;
 
-                msl_status = enter_spin_lock_msl (&more_space_lock_uoh);
-                if (msl_status == msl_retry_different_heap) return a_state_retry_allocate;
+            add_saved_spinlock_info (true, me_acquire, mt_alloc_large, msl_status);
+            dprintf (SPINLOCK_LOG, ("[%d]spin Emsl uoh", heap_number));
+        }
+        else if (action == uoh_alloc_wait)
+        {
+            dynamic_data* dd_uoh = dynamic_data_of (loh_generation);
+            dprintf (3, ("h%d WAIT loh begin %.3fmb, current size recorded is %.3fmb(begin+%.3fmb), budget %.3fmb, new alloc %.3fmb (alloc-ed %.3fmb)",
+                heap_number, mb (bgc_begin_uoh_size[0]), mb (bgc_uoh_current_size[0]),
+                mb (bgc_uoh_current_size[0] - bgc_begin_uoh_size[0]),
+                mb (dd_desired_allocation (dd_uoh)), (dd_new_allocation (dd_uoh) / 1000.0 / 1000.0),
+                mb (dd_desired_allocation (dd_uoh) - dd_new_allocation (dd_uoh))));
 
-                add_saved_spinlock_info (true, me_acquire, mt_alloc_large, msl_status);
-                dprintf (SPINLOCK_LOG, ("[%d]spin Emsl uoh", heap_number));
-            }
-            else if (spin_for_allocation < 0)
-            {
-                msl_status = wait_for_background (awr_uoh_alloc_during_bgc, true);
-                check_msl_status ("uoh a_state_acquire_seg", size);
-            }
+            msl_status = wait_for_background (awr_uoh_alloc_during_bgc, true);
+            check_msl_status ("uoh a_state_acquire_seg", size);
         }
     }
 #endif //BACKGROUND_GC
@@ -38792,7 +38807,6 @@ void gc_heap::background_mark_phase ()
         gen0_must_clear_bricks--;
 
     background_soh_alloc_count = 0;
-    background_uoh_alloc_count = 0;
     bgc_overflow_count = 0;
 
     bpromoted_bytes (heap_number) = 0;
@@ -38824,8 +38838,6 @@ void gc_heap::background_mark_phase ()
     slow  = MAX_PTR;
 #endif //MULTIPLE_HEAPS
 
-    generation*   gen = generation_of (max_generation);
-
     dprintf(3,("BGC: stack marking"));
     sc.concurrent = TRUE;
 
@@ -38836,16 +38848,19 @@ void gc_heap::background_mark_phase ()
     dprintf(3,("BGC: finalization marking"));
     finalize_queue->GcScanRoots(background_promote_callback, heap_number, 0);
 
-    size_t total_soh_size = generation_sizes (generation_of (max_generation));
-    size_t total_loh_size = generation_size (loh_generation);
-    size_t total_poh_size = generation_size (poh_generation);
-    bgc_begin_loh_size = total_loh_size;
-    bgc_begin_poh_size = total_poh_size;
-    bgc_loh_size_increased = 0;
-    bgc_poh_size_increased = 0;
     background_soh_size_end_mark = 0;
 
-    dprintf (GTC_LOG, ("BM: h%d: loh: %zd, soh: %zd, poh: %zd", heap_number, total_loh_size, total_soh_size, total_poh_size));
+    for (int uoh_gen_idx = uoh_start_generation; uoh_gen_idx < total_generation_count; uoh_gen_idx++)
+    {
+        size_t uoh_size = generation_size (uoh_gen_idx);
+        int uoh_idx = uoh_gen_idx - uoh_start_generation;
+        bgc_begin_uoh_size[uoh_idx] = uoh_size;
+        bgc_uoh_current_size[uoh_idx] = uoh_size;
+    }
+
+    dprintf (GTC_LOG, ("BM: h%d: soh: %zd, loh: %zd, poh: %zd",
+        heap_number, generation_sizes (generation_of (max_generation)),
+        bgc_uoh_current_size[loh_generation - uoh_start_generation], bgc_uoh_current_size[poh_generation - uoh_start_generation]));
 
     //concurrent_print_time_delta ("copying stack roots");
     concurrent_print_time_delta ("CS");
@@ -39158,11 +39173,10 @@ void gc_heap::background_mark_phase ()
     //marking
     sc.concurrent = FALSE;
 
-    total_soh_size = generation_sizes (generation_of (max_generation));
-    total_loh_size = generation_size (loh_generation);
-    total_poh_size = generation_size (poh_generation);
-
-    dprintf (GTC_LOG, ("FM: h%d: loh: %zd, soh: %zd, poh: %zd", heap_number, total_loh_size, total_soh_size, total_poh_size));
+    dprintf (GTC_LOG, ("FM: h%d: soh: %zd, loh: %zd, poh: %zd", heap_number,
+        generation_sizes (generation_of (max_generation)),
+        bgc_uoh_current_size[loh_generation - uoh_start_generation],
+        bgc_uoh_current_size[poh_generation - uoh_start_generation]));
 
 #if defined(FEATURE_BASICFREEZE) && !defined(USE_REGIONS)
     if (ro_segments_in_range)
@@ -44886,11 +44900,7 @@ void gc_heap::compute_new_dynamic_data (int gen_number)
             gen_data->free_obj_space_after = generation_free_obj_space (gen);
             gen_data->npinned_surv = out;
 #ifdef BACKGROUND_GC
-            if (i == loh_generation)
-                end_loh_size = total_gen_size;
-
-            if (i == poh_generation)
-                end_poh_size = total_gen_size;
+            end_uoh_size[i - uoh_start_generation] = total_gen_size;
 #endif //BACKGROUND_GC
             dd_promoted_size (dd) = out;
         }

--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -128,6 +128,7 @@ public:
     INT_CONFIG   (BGCFLEnableTBH,            "BGCFLEnableTBH",            NULL,                                0,                  "Enables TBH")                                                                            \
     INT_CONFIG   (BGCFLEnableFF,             "BGCFLEnableFF",             NULL,                                0,                  "Enables FF")                                                                             \
     INT_CONFIG   (BGCG2RatioStep,            "BGCG2RatioStep",            NULL,                                5,                  "Ratio correction factor for ML loop")                                                    \
+    INT_CONFIG   (UOHWaitBGCSizeIncPercent,  "UOHWaitBGCSizeIncPercent",  "System.GC.UOHWaitBGCSizeIncPercent",-1,                 "UOH allocation during a BGC waits till end of BGC after UOH increases by this percent")  \
     INT_CONFIG   (GCHeapHardLimitSOH,        "GCHeapHardLimitSOH",        "System.GC.HeapHardLimitSOH",        0,                  "Specifies a hard limit for the GC heap SOH")                                             \
     INT_CONFIG   (GCHeapHardLimitLOH,        "GCHeapHardLimitLOH",        "System.GC.HeapHardLimitLOH",        0,                  "Specifies a hard limit for the GC heap LOH")                                             \
     INT_CONFIG   (GCHeapHardLimitPOH,        "GCHeapHardLimitPOH",        "System.GC.HeapHardLimitPOH",        0,                  "Specifies a hard limit for the GC heap POH")                                             \


### PR DESCRIPTION
customer reported much longer/frequent waits on threads allocating UOH objects during a BGC with regions than with segments. this can be observed in the "LOH allocation pause (due to background GC) > 200 msec Events" table in the GCStats view in perfview. this is because we have a policy that says "if the begin UOH size is 2x the last gen2's UOH end size, always wait". for segments this makes sense because segments UOH size is fairly stable. but with regions it's more likely for the end size to be much smaller because regions released a bunch of free regions back to the region free pool.

+ don't apply this particular policy for regions as it doesn't make sense.
+ this kind of perf fixes can always regress someone. Due to the very different perf characteristics of regions wrt this, it's not practical to keep the original behavior for everyone during to the very different perf characteristics between the 2 implementations. So I'm adding a config for scenarios that allocate heavily on UOH therefore can be paused during a BGC. If you're willing to accept larger UOH sizes in exchange for fewer pauses, you can use the UOHWaitBGCSizeIncPercent config to increase the wait ratio. Likewise, set it to use a smaller ratio if you observe that UOH grows too large during BGCs. I will be submitting a doc PR for this.
+ refactored various things kept separately for LOH and POH into UOH generations. I had a much more complicated fix before and having to update both generations was tedious so I took the opportunity to refactor. I didn't go with that fix (because it regressed edge cases too much and there wasn't a good way to make it work without way riskier changes. But I kept the refactoring changes as it just makes the code cleaner.
+ fixed how the current UOH size is computed so it's updated correctly (it had a racing condition as `bgc_uoh_alloc_clr` and `adjust_limit_clr` would release the msl).
+ got rid of the unproductive code in `new_allocation_allowed` and `allocate_uoh`.
+ misc - fixed an error in a comment related to how free regions are aged.

note that it's better to add additional diagnostics info (in a separate PR), to indicate how much the UOH size had changed since the start of that BGC and how much UOH allocation was made during the BGC. Right now the `size_before` we set for UOH is larger than it actually is.