### PR TITLE
Make DeflateStream write out headers and footers on empty streams.

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -29,7 +29,7 @@ namespace System.IO.Compression
         // always wrote zero output for zero input and upstack code (e.g. ZipArchiveEntry)
         // took dependencies on it. Thus, if we are opened from ZipArchiveEntry, we make
         // sure to only "flush" when we actually had some input.
-        private bool _noFlushOnEmpty;
+        private bool _writeOnEmpty = true;
 
         internal DeflateStream(Stream stream, CompressionMode mode, long uncompressedSize) : this(stream, mode, leaveOpen: false, ZLibNative.Deflate_DefaultWindowBits, uncompressedSize)
         {
@@ -54,9 +54,9 @@ namespace System.IO.Compression
         }
 
         // internal constructor to use from ZipArchiveEntry
-        internal DeflateStream(Stream stream, CompressionLevel compressionLevel, bool leaveOpen, bool noFlushOnEmpty) : this(stream, compressionLevel, leaveOpen)
+        internal DeflateStream(Stream stream, CompressionLevel compressionLevel, bool leaveOpen, bool writeOnEmpty) : this(stream, compressionLevel, leaveOpen)
         {
-            _noFlushOnEmpty = noFlushOnEmpty;
+            _writeOnEmpty = writeOnEmpty;
         }
 
         /// <summary>
@@ -636,7 +636,7 @@ namespace System.IO.Compression
                 return;
 
             Debug.Assert(_deflater != null && _buffer != null);
-            if (_wroteBytes || !_noFlushOnEmpty)
+            if (_wroteBytes || _writeOnEmpty)
             {
                 // Compress any bytes left
                 WriteDeflaterOutput();
@@ -678,7 +678,7 @@ namespace System.IO.Compression
                 return;
 
             Debug.Assert(_deflater != null && _buffer != null);
-            if (_wroteBytes || !_noFlushOnEmpty)
+            if (_wroteBytes || _writeOnEmpty)
             {
                 // Compress any bytes left
                 await WriteDeflaterOutputAsync(default).ConfigureAwait(false);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -719,7 +719,7 @@ namespace System.IO.Compression
                 case CompressionMethodValues.Deflate:
                 case CompressionMethodValues.Deflate64:
                 default:
-                    compressorStream = new DeflateStream(backingStream, _compressionLevel, leaveBackingStreamOpen);
+                    compressorStream = new DeflateStream(backingStream, _compressionLevel, leaveBackingStreamOpen, true);
                     break;
 
             }
@@ -975,7 +975,6 @@ namespace System.IO.Compression
                 CompressionMethod = CompressionMethodValues.Stored;
                 compressedSizeTruncated = 0;
                 uncompressedSizeTruncated = 0;
-                Debug.Assert(_compressedSize == 0);
                 Debug.Assert(_uncompressedSize == 0);
                 Debug.Assert(_crc32 == 0);
             }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -719,7 +719,7 @@ namespace System.IO.Compression
                 case CompressionMethodValues.Deflate:
                 case CompressionMethodValues.Deflate64:
                 default:
-                    compressorStream = new DeflateStream(backingStream, _compressionLevel, leaveBackingStreamOpen, true);
+                    compressorStream = new DeflateStream(backingStream, _compressionLevel, leaveBackingStreamOpen, writeOnEmpty: false);
                     break;
 
             }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -709,23 +709,23 @@ namespace System.IO.Compression
                 || CompressionMethod == CompressionMethodValues.Stored);
 
             bool isIntermediateStream = true;
-            Stream compressorStream;
+            Func<Stream> compressorStreamFactory;
             switch (CompressionMethod)
             {
                 case CompressionMethodValues.Stored:
-                    compressorStream = backingStream;
+                    compressorStreamFactory = () => backingStream;
                     isIntermediateStream = false;
                     break;
                 case CompressionMethodValues.Deflate:
                 case CompressionMethodValues.Deflate64:
                 default:
-                    compressorStream = new DeflateStream(backingStream, _compressionLevel, leaveBackingStreamOpen, writeOnEmpty: false);
+                    compressorStreamFactory = () => new DeflateStream(backingStream, _compressionLevel, leaveBackingStreamOpen);
                     break;
 
             }
             bool leaveCompressorStreamOpenOnClose = leaveBackingStreamOpen && !isIntermediateStream;
             var checkSumStream = new CheckSumAndSizeWriteStream(
-                compressorStream,
+                compressorStreamFactory,
                 backingStream,
                 leaveCompressorStreamOpenOnClose,
                 this,

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -704,7 +704,7 @@ namespace System.IO.Compression
 
             // By default we compress with deflate, except if compression level
             // is set to NoCompression then stored is used.
-            // 
+            //
             // Stored is also used for empty files, but we can't know at this
             // point if user will write anything to the stream or not. For that
             // reason, we defer the instantiation of the compression stream

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
@@ -156,11 +156,13 @@ namespace System.IO.Compression
                                         break;
 
                                     case TestScenario.Read:
-                                        while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { }
+                                        ;
                                         break;
 
                                     case TestScenario.ReadAsync:
-                                        while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { }
+                                        ;
                                         break;
 
                                     case TestScenario.ReadByte:
@@ -217,6 +219,21 @@ namespace System.IO.Compression
             {
                 WriteArrayInvoked = true;
                 return base.WriteAsync(buffer, offset, count, cancellationToken);
+            }
+        }
+
+        [Fact]
+        public void EmptyDeflateStream_WritesOutput()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var deflateStream = new DeflateStream(ms, CompressionMode.Compress, leaveOpen: true))
+                {
+                    // Write nothing
+                }
+
+                // DeflateStream should now write output even for empty streams
+                Assert.True(ms.Length > 0, "Empty DeflateStream should write finalization data");
             }
         }
     }

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
@@ -157,12 +157,10 @@ namespace System.IO.Compression
 
                                     case TestScenario.Read:
                                         while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { }
-                                        ;
                                         break;
 
                                     case TestScenario.ReadAsync:
                                         while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { }
-                                        ;
                                         break;
 
                                     case TestScenario.ReadByte:

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
@@ -234,5 +234,22 @@ namespace System.IO.Compression
                 Assert.True(ms.Length > 0, "Empty DeflateStream should write finalization data");
             }
         }
+
+        [Fact]
+        public void EmptyStream_CanBeDecompressed()
+        {
+            // for compatibility reasons, an empty stream should be decompressible back to an empty stream
+            using (var ms = new MemoryStream())
+            {
+                ms.Position = 0;
+
+                using (var deflateStream = new DeflateStream(ms, CompressionMode.Decompress))
+                using (var reader = new StreamReader(deflateStream))
+                {
+                    string result = reader.ReadToEnd();
+                    Assert.Equal(string.Empty, result);
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -467,5 +467,21 @@ namespace System.IO.Compression
             }
         }
 
+        [Fact]
+        public void EmptyStream_CanBeDecompressed()
+        {
+            // For compatibility reasons, an empty stream should be decompressible back to an empty stream
+            using (var ms = new MemoryStream())
+            {
+                ms.Position = 0;
+
+                using (var deflateStream = new DeflateStream(ms, CompressionMode.Decompress))
+                using (var reader = new StreamReader(deflateStream))
+                {
+                    string result = reader.ReadToEnd();
+                    Assert.Equal(string.Empty, result);
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -126,7 +126,7 @@ namespace System.IO.Compression
         [InlineData(10, TestScenario.ReadAsync, 1000, 2000)]
         [InlineData(10, TestScenario.Copy, 1000, 2000)]
         [InlineData(10, TestScenario.CopyAsync, 1000, 2000)]
-        [InlineData(2, TestScenario.Copy, 1000, 0x2000-30)]
+        [InlineData(2, TestScenario.Copy, 1000, 0x2000 - 30)]
         [InlineData(2, TestScenario.CopyAsync, 1000, 0x2000 - 30)]
         [InlineData(1000, TestScenario.Read, 1, 1)]
         [InlineData(1000, TestScenario.ReadAsync, 1, 1)]
@@ -315,7 +315,7 @@ namespace System.IO.Compression
                     {
                         Assert.Throws<InvalidDataException>(() =>
                         {
-                            while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0);
+                            while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) ;
                         });
                     }
                 }
@@ -377,11 +377,13 @@ namespace System.IO.Compression
                                         break;
 
                                     case TestScenario.Read:
-                                        while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { }
+                                        ;
                                         break;
 
                                     case TestScenario.ReadAsync:
-                                        while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { }
+                                        ;
                                         break;
 
                                     case TestScenario.ReadByte:
@@ -441,5 +443,31 @@ namespace System.IO.Compression
                 return base.WriteAsync(buffer, offset, count, cancellationToken);
             }
         }
+
+        [Fact]
+        public void EmptyGZipStream_WritesHeaderAndFooter()
+        {
+            // Test that an empty GZip stream still writes the required headers and footers
+            using (var ms = new MemoryStream())
+            {
+                using (var gzipStream = new GZipStream(ms, CompressionMode.Compress, leaveOpen: true))
+                {
+                    // Write nothing
+                }
+
+                // At minimum it should have the GZip signature (0x1f 0x8b) and other required data
+                Assert.True(ms.Length > 0, "Empty GZip stream should write headers and footers");
+
+                // Verify the compressed data can be decompressed successfully
+                ms.Seek(0, SeekOrigin.Begin);
+                using (var decompressStream = new GZipStream(ms, CompressionMode.Decompress))
+                using (var resultStream = new MemoryStream())
+                {
+                    decompressStream.CopyTo(resultStream);
+                    Assert.Equal(0, resultStream.Length);
+                }
+            }
+        }
+
     }
 }

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -378,12 +378,10 @@ namespace System.IO.Compression
 
                                     case TestScenario.Read:
                                         while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { }
-                                        ;
                                         break;
 
                                     case TestScenario.ReadAsync:
                                         while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { }
-                                        ;
                                         break;
 
                                     case TestScenario.ReadByte:

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -820,7 +820,7 @@ namespace System.IO.Compression.Tests
         [MemberData(nameof(EmptyFiles))]
         public async Task ReadArchive_WithEmptyDeflatedFile(byte[] fileBytes, bool async)
         {
-            using (var testStream = new MemoryStream(fileBytes))
+            using (var testStream = new MemoryStream(fileBytes.ToArray()))
             {
                 const string ExpectedFileName = "xl/customProperty2.bin";
 
@@ -834,7 +834,7 @@ namespace System.IO.Compression.Tests
                 byte[] fileContent = testStream.ToArray();
 
                 // compression method should not have changed
-                Assert.Equal(firstEntryCompressionMethod, fileBytes[8]);
+                Assert.Equal(firstEntryCompressionMethod, fileContent[8]);
 
                 testStream.Seek(0, SeekOrigin.Begin);
                 // second attempt: open archive with zero-length file that is compressed (Deflate = 0x8)


### PR DESCRIPTION
Fixes #66449.

Ensure that DeflateStream writes necessary headers and footers even for empty input streams.

To preserve ZipArchive's functionality of storing 0-length bytes as Stored, we will now instantiate compression streams on the first write to the ZipArchiveEntry's stream, that way we avoid writing empty Deflate envelopes.