### PR TITLE
System.Runtime.Serialization.Xml: throw SerializationException on malformed prefix

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializer.cs
@@ -363,6 +363,10 @@ namespace System.Runtime.Serialization
             {
                 throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorDeserializing, GetDeserializeType(), ex), ex);
             }
+            catch (ArgumentException ex)
+            {
+                throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorDeserializing, GetDeserializeType(), ex), ex);
+            }
         }
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
@@ -380,6 +384,10 @@ namespace System.Runtime.Serialization
                 throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorIsStartObject, GetDeserializeType(), ex), ex);
             }
             catch (FormatException ex)
+            {
+                throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorIsStartObject, GetDeserializeType(), ex), ex);
+            }
+            catch (ArgumentException ex)
             {
                 throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorIsStartObject, GetDeserializeType(), ex), ex);
             }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializer.cs
@@ -363,10 +363,6 @@ namespace System.Runtime.Serialization
             {
                 throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorDeserializing, GetDeserializeType(), ex), ex);
             }
-            catch (ArgumentException ex)
-            {
-                throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorDeserializing, GetDeserializeType(), ex), ex);
-            }
         }
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
@@ -384,10 +380,6 @@ namespace System.Runtime.Serialization
                 throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorIsStartObject, GetDeserializeType(), ex), ex);
             }
             catch (FormatException ex)
-            {
-                throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorIsStartObject, GetDeserializeType(), ex), ex);
-            }
-            catch (ArgumentException ex)
             {
                 throw XmlObjectSerializer.CreateSerializationException(GetTypeInfoError(SR.ErrorIsStartObject, GetDeserializeType(), ex), ex);
             }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextReader.cs
@@ -653,6 +653,11 @@ namespace System.Xml
 
         private void VerifyNCName(string s)
         {
+            if (string.IsNullOrEmpty(s))
+            {
+                XmlExceptionHelper.ThrowXmlException(this, SR.InvalidLocalNameEmpty, null);
+            }
+
             try
             {
                 XmlConvert.VerifyNCName(s);

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -4606,21 +4606,26 @@ public static partial class DataContractSerializerTests
         Assert.Throws<System.Runtime.Serialization.SerializationException>(() => { dcs.ReadObject(reader); });
     }
 
-    [Fact]
-    public static void DCS_ReadObject_MalformedPrefix_EmptyLocalName_ThrowsSerializationException()
+    [Theory]
+    [InlineData("<s:")]
+    [InlineData("<s:1")]
+    public static void DCS_ReadObject_MalformedPrefix_InvalidLocalName_ThrowsSerializationException(string malformedElement)
     {
-        // Regression for https://github.com/dotnet/runtime/issues/1409
-        // Uses the original repro payload that triggers an empty local-name via an unfinished prefixed element.
-        string xml = @"<Program.Obj xmlns=""http://schemas.datacontract.org/2004/07/CoreFX.Fuzz""><s:";
-        byte[] bytes = Encoding.UTF8.GetBytes(xml);
-        using (MemoryStream stream = new MemoryStream(bytes))
-        {
-            var serializer = new DataContractSerializer(typeof(CoreFX.Fuzz.Program.Obj));
-            var ex = Assert.Throws<SerializationException>(() => serializer.ReadObject(stream));
-            Assert.NotNull(ex.InnerException);
-            Assert.IsType<ArgumentException>(ex.InnerException);
-            Assert.Equal("name", ((ArgumentException)ex.InnerException).ParamName);
-        }
+        var serializer = new DataContractSerializer(typeof(MalformedPrefixObject));
+
+        SerializationException ex = Assert.Throws<SerializationException>(() => serializer.ReadObject(CreateMalformedPrefixStream(malformedElement)));
+        Assert.IsType<XmlException>(ex.InnerException);
+    }
+
+    private static MemoryStream CreateMalformedPrefixStream(string malformedElement)
+    {
+        string xml = $@"<Program.Obj xmlns=""http://schemas.datacontract.org/2004/07/CoreFX.Fuzz"">{malformedElement}";
+        return new MemoryStream(Encoding.UTF8.GetBytes(xml));
+    }
+
+    [DataContract(Name = "Program.Obj", Namespace = "http://schemas.datacontract.org/2004/07/CoreFX.Fuzz")]
+    private sealed class MalformedPrefixObject
+    {
     }
 
     private static T DeserializeString<T>(string stringToDeserialize, bool shouldReportDeserializationExceptions = true, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null)
@@ -4678,15 +4683,5 @@ public static partial class DataContractSerializerTests
         var deserializedDesktopObject = DeserializeString<T>(desktopPayload, settings: settings);
         Assert.NotNull(deserializedDesktopObject);
         SerializationTestTypes.ComparisonHelper.CompareRecursively(value, deserializedDesktopObject);
-    }
-}
-
-// Test helper type
-namespace CoreFX.Fuzz
-{
-    public class Program
-    {
-        [DataContract]
-        public class Obj { }
     }
 }

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -4606,6 +4606,23 @@ public static partial class DataContractSerializerTests
         Assert.Throws<System.Runtime.Serialization.SerializationException>(() => { dcs.ReadObject(reader); });
     }
 
+    [Fact]
+    public static void DCS_ReadObject_MalformedPrefix_EmptyLocalName_ThrowsSerializationException()
+    {
+        // Regression for https://github.com/dotnet/runtime/issues/1409
+        // Uses the original repro payload that triggers an empty local-name via an unfinished prefixed element.
+        string xml = @"<Program.Obj xmlns=""http://schemas.datacontract.org/2004/07/CoreFX.Fuzz""><s:";
+        byte[] bytes = Encoding.UTF8.GetBytes(xml);
+        using (MemoryStream stream = new MemoryStream(bytes))
+        {
+            var serializer = new DataContractSerializer(typeof(CoreFX.Fuzz.Program.Obj));
+            var ex = Assert.Throws<SerializationException>(() => serializer.ReadObject(stream));
+            Assert.NotNull(ex.InnerException);
+            Assert.IsType<ArgumentException>(ex.InnerException);
+            Assert.Equal("name", ((ArgumentException)ex.InnerException).ParamName);
+        }
+    }
+
     private static T DeserializeString<T>(string stringToDeserialize, bool shouldReportDeserializationExceptions = true, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null)
     {
         DataContractSerializer dcs;
@@ -4661,5 +4678,15 @@ public static partial class DataContractSerializerTests
         var deserializedDesktopObject = DeserializeString<T>(desktopPayload, settings: settings);
         Assert.NotNull(deserializedDesktopObject);
         SerializationTestTypes.ComparisonHelper.CompareRecursively(value, deserializedDesktopObject);
+    }
+}
+
+// Test helper type
+namespace CoreFX.Fuzz
+{
+    public class Program
+    {
+        [DataContract]
+        public class Obj { }
     }
 }


### PR DESCRIPTION
When parsing an unfinished prefixed element ("<s:"), ReadObject previously surfaced ArgumentException (param "name"). Now it wraps the error in SerializationException per serializer contract.

Add regression test:
- DataContractSerializer.cs: DCS_ReadObject_MalformedPrefix_EmptyLocalName_ThrowsSerializationException

Fixes #1409.