### PR TITLE
[browser] Hard fingerprint user JavaScript files in `wasmbrowser` template

### DIFF
--- a/src/mono/wasm/templates/templates/browser/browser.0.csproj
+++ b/src/mono/wasm/templates/templates/browser/browser.0.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <StaticWebAssetFingerprintPattern Include="JS" Pattern="*.js" />
+    <StaticWebAssetFingerprintPattern Include="JS" Pattern="*.js" Expression="#[.{fingerprint}]!" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Use "hard" fingerprinting for user JavaScript files in `wasmbrowser` template. For this template we consider all user JavaScript files as modules, that's why we have the custom `StaticWebAssetFingerprintPattern`. Missing the expression for making the files "hard" fingerprinted instead of "soft" was a mistake from updating the template

Related to https://github.com/dotnet/aspnetcore/issues/62211#issuecomment-3146544516