### PR TITLE
[WIP][Android][CoreCLR] Filter legacy TimeZone IDs using ICU if `tzlookup.xml` isn't available

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.TimeZoneInfo.cs
+++ b/src/libraries/Common/src/Interop/Interop.TimeZoneInfo.cs
@@ -21,5 +21,8 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_IanaIdToWindowsId", StringMarshalling = StringMarshalling.Utf16)]
         internal static unsafe partial int IanaIdToWindowsId(string ianaId, char* windowsId, int windowsIdLength);
+
+        [LibraryImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetCanonicalTimeZoneId", StringMarshalling = StringMarshalling.Utf16)]
+        internal static unsafe partial int GetCanonicalTimeZoneId(string timeZoneId, char* canonicalId, int canonicalIdLength);
     }
 }

--- a/src/native/libs/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/native/libs/System.Globalization.Native/pal_icushim_internal.h
@@ -95,6 +95,7 @@ extern ucol_safeClone_func ucol_safeClone_ptr;
     PER_FUNCTION_BLOCK(ucal_close, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_get, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_getAttribute, libicui18n, true) \
+    PER_FUNCTION_BLOCK(ucal_getCanonicalTimeZoneID, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_getKeywordValuesForLocale, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_getLimit, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_getNow, libicui18n, true) \
@@ -232,6 +233,7 @@ FOR_ALL_ICU_FUNCTIONS
 #define ucal_close(...) ucal_close_ptr(__VA_ARGS__)
 #define ucal_get(...) ucal_get_ptr(__VA_ARGS__)
 #define ucal_getAttribute(...) ucal_getAttribute_ptr(__VA_ARGS__)
+#define ucal_getCanonicalTimeZoneID(...) ucal_getCanonicalTimeZoneID_ptr(__VA_ARGS__)
 #define ucal_getKeywordValuesForLocale(...) ucal_getKeywordValuesForLocale_ptr(__VA_ARGS__)
 #define ucal_getLimit(...) ucal_getLimit_ptr(__VA_ARGS__)
 #define ucal_getNow(...) ucal_getNow_ptr(__VA_ARGS__)

--- a/src/native/libs/System.Globalization.Native/pal_icushim_internal_android.h
+++ b/src/native/libs/System.Globalization.Native/pal_icushim_internal_android.h
@@ -448,6 +448,7 @@ void ucal_add(UCalendar * cal, UCalendarDateFields field, int32_t amount, UError
 void ucal_close(UCalendar * cal);
 int32_t ucal_get(const UCalendar * cal, UCalendarDateFields field, UErrorCode * status);
 int32_t ucal_getAttribute(const UCalendar * cal, UCalendarAttribute attr);
+int32_t ucal_getCanonicalTimeZoneID(const UChar * id, int32_t len, UChar * result, int32_t resultCapacity, UBool * isSystemID, UErrorCode * status);
 UEnumeration * ucal_getKeywordValuesForLocale(const char * key, const char * locale, UBool commonlyUsed, UErrorCode * status);
 int32_t ucal_getLimit(const UCalendar * cal, UCalendarDateFields field, UCalendarLimitType type, UErrorCode * status);
 UDate ucal_getNow(void);

--- a/src/native/libs/System.Globalization.Native/pal_timeZoneInfo.c
+++ b/src/native/libs/System.Globalization.Native/pal_timeZoneInfo.c
@@ -5,7 +5,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h>
 
 #include "pal_errors_internal.h"
 #include "pal_locale_internal.h"

--- a/src/native/libs/System.Globalization.Native/pal_timeZoneInfo.c
+++ b/src/native/libs/System.Globalization.Native/pal_timeZoneInfo.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include "pal_errors_internal.h"
 #include "pal_locale_internal.h"
@@ -335,4 +336,22 @@ ResultCode GlobalizationNative_GetTimeZoneDisplayName(const UChar* localeName, c
     }
 
     return GetResultCode(err);
+}
+
+/*
+Get the canonical timezone ID for a given timezone ID.
+*/
+int32_t GlobalizationNative_GetCanonicalTimeZoneId(const UChar* timeZoneId, UChar* canonicalId, int32_t canonicalIdLength)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    UBool isSystemID = 0;
+
+    int32_t actualLength = ucal_getCanonicalTimeZoneID(timeZoneId, -1, canonicalId, canonicalIdLength, &isSystemID, &status);
+
+    if (U_SUCCESS(status))
+    {
+        return actualLength;
+    }
+
+    return 0;
 }

--- a/src/native/libs/System.Globalization.Native/pal_timeZoneInfo.h
+++ b/src/native/libs/System.Globalization.Native/pal_timeZoneInfo.h
@@ -23,6 +23,7 @@ typedef enum
 PALEXPORT int32_t GlobalizationNative_WindowsIdToIanaId(const UChar* windowsId, const char* region, UChar* ianaId, int32_t ianaIdLength);
 PALEXPORT int32_t GlobalizationNative_IanaIdToWindowsId(const UChar* ianaId, UChar* windowsId, int32_t windowsIdLength);
 PALEXPORT ResultCode GlobalizationNative_GetTimeZoneDisplayName(const UChar* localeName, const UChar* timeZoneId, TimeZoneDisplayNameType type, UChar* result, int32_t resultLength);
+PALEXPORT int32_t GlobalizationNative_GetCanonicalTimeZoneId(const UChar* timeZoneId, UChar* canonicalId, int32_t canonicalIdLength);
 #if defined(APPLE_HYBRID_GLOBALIZATION)
 PALEXPORT int32_t GlobalizationNative_GetTimeZoneDisplayNameNative(const uint16_t* localeName, int32_t lNameLength, const uint16_t* timeZoneId, int32_t timeZoneIdLength,
                                                                    TimeZoneDisplayNameType type, uint16_t* result, int32_t resultLength);


### PR DESCRIPTION
## Goal

Tries to fix #90269.

## Issue summary

On Android, there are legacy TimeZones that have the same display name as non-legacy TimeZones. If developers get a list of all TimeZones and show them in UI, it can look like there are duplicate TimeZones based on the display name.

The fix we have for Android API > 25 is to use `tzlookup.xml` to filter out the legacy TimeZone IDs.

The problem is that for API <= 25, the `tzlookup.xml` file isn't available.

## PR Description

- This PR tries to detect legacy TimeZones by using the [ucal_getCanonicalTimeZoneID](https://devdoc.net/linux/icu4c-64_2-docs/ucal_8h.html#a84f79f30804a091f5436ac4e29be0c37) function from the ICU library.
- A canonical TimeZone ID is a "normalized" ID - basically we are able to pass a legacy ID and get the corresponding non-legacy ID (passing non-legacy ID works as well, in that case the returned value is an identity).

## Problem with the PR

- Sample program

```cs
using System;
using System.Collections.Generic;
using System.Collections.ObjectModel;
using System.Globalization;

public static class Program
{
    public static int Main(string[] args)
    {
        ReadOnlyCollection<TimeZoneInfo> tzCollection = TimeZoneInfo.GetSystemTimeZones();
        return 42;
    }
}
```

- In `pal_timeZoneInfo.cs` when we call `ucal_getCanonicalTimeZoneID` function in `GlobalizationNative_GetCanonicalTimeZoneId` method, the app crashes
