### PR TITLE
Fix case-insensitive URI matching

### DIFF
--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
@@ -654,6 +654,7 @@ namespace System.IO.Packaging
             #endregion IEquatable Methods
 
             #region Overrides
+
             public override bool Equals(object? obj)
             {
                 if (obj is ValidatedPartUri other)
@@ -666,7 +667,7 @@ namespace System.IO.Packaging
                 return StringComparer.OrdinalIgnoreCase.GetHashCode(NormalizedPartUriString);
             }
 
-            #endregion Object Overrides
+            #endregion Overrides
 
             #region Internal Properties
 

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
@@ -601,9 +601,7 @@ namespace System.IO.Packaging
         /// to reduce the parsing and number of allocations for Strings and Uris
         /// we cache the results after parsing.
         /// </summary>
-#pragma warning disable CA1067 // Override Equals because it implements IEquatable<T>; not overriding to avoid possible regressions in code that's working
         internal sealed class ValidatedPartUri : Uri, IComparable<ValidatedPartUri>, IEquatable<ValidatedPartUri>
-#pragma warning restore CA1067
         {
             //------------------------------------------------------
             //

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -601,7 +602,7 @@ namespace System.IO.Packaging
         /// to reduce the parsing and number of allocations for Strings and Uris
         /// we cache the results after parsing.
         /// </summary>
- #pragma warning disable CA1067 // Override Equals because it implements IEquatable<T>; not overriding to avoid possible regressions in code that's working
+#pragma warning disable CA1067 // Override Equals because it implements IEquatable<T>; not overriding to avoid possible regressions in code that's working
         internal sealed class ValidatedPartUri : Uri, IComparable<ValidatedPartUri>, IEquatable<ValidatedPartUri>
 #pragma warning restore CA1067
         {
@@ -841,7 +842,11 @@ namespace System.IO.Packaging
                     return 1;
 
                 //Compare the normalized uri strings for the two part uris.
-                return string.CompareOrdinal(NormalizedPartUriString, otherPartUri.NormalizedPartUriString);
+                return string.Compare(
+                    NormalizedPartUriString,
+                    otherPartUri.NormalizedPartUriString,
+                    StringComparison.OrdinalIgnoreCase
+                );
             }
 
             //------------------------------------------------------

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
@@ -653,6 +653,21 @@ namespace System.IO.Packaging
 
             #endregion IEquatable Methods
 
+            #region Overrides
+            public override bool Equals(object? obj)
+            {
+                if (obj is ValidatedPartUri other)
+                    return Compare(other) == 0;
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(NormalizedPartUriString);
+            }
+
+            #endregion Object Overrides
+
             #region Internal Properties
 
             //------------------------------------------------------

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;

--- a/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
@@ -327,6 +327,27 @@ namespace System.IO.Packaging.Tests
         }
 
         [Fact]
+        public void PartNamesAreCaseInsensitive()
+        {
+            using var ms = new MemoryStream();
+
+            using (var zipPackage = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite))
+            {
+                zipPackage.CreatePart(new Uri("/part", UriKind.Relative), "text/plain");
+            }
+            ms.Position = 0;
+            using (var zipPackage = Package.Open(ms, FileMode.Open, FileAccess.Read))
+            {
+                var lowerPart = zipPackage.GetPart(new Uri("/part", UriKind.Relative));
+                var upperPart = zipPackage.GetPart(new Uri("/PART", UriKind.Relative));
+
+                Assert.Same(lowerPart, upperPart);
+                Assert.Equal(lowerPart.Uri, upperPart.Uri);
+                Assert.Equal(lowerPart.ContentType, upperPart.ContentType);
+            }
+        }
+
+        [Fact]
         public void CanCreateAtomicPart()
         {
             using var ms = new MemoryStream();

--- a/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
@@ -15,7 +15,7 @@ namespace System.IO.Packaging.Tests
     public class PartPieceTests : FileCleanupTestBase
     {
         private delegate byte[] FileContentsGenerator(PartConstructionParameters pcp, int totalLength);
-        private record class PartConstructionParameters (string FullPath, bool CreateAsAtomic, bool CreateAsValidPieceSequence, bool UppercaseFileName, bool ShufflePieces, int[] PieceLengths, FileContentsGenerator PieceGenerator)
+        private record class PartConstructionParameters(string FullPath, bool CreateAsAtomic, bool CreateAsValidPieceSequence, bool UppercaseFileName, bool ShufflePieces, int[] PieceLengths, FileContentsGenerator PieceGenerator)
         { }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
@@ -85,7 +85,7 @@ namespace System.IO.Packaging.Tests
         {
             var bytes = new byte[totalLength];
 
-            for(int i = 0; i < totalLength; i++)
+            for (int i = 0; i < totalLength; i++)
             {
                 bytes[i] = (byte)(i % 255);
             }
@@ -209,7 +209,7 @@ namespace System.IO.Packaging.Tests
 
             Assert.NotNull(s_ZipPackagePartPieceType);
             Assert.NotNull(s_TryParseZipPackagePartPiece);
-            Assert.False((bool)s_TryParseZipPackagePartPiece.Invoke(null, [ partPieceEntry, null ]));
+            Assert.False((bool)s_TryParseZipPackagePartPiece.Invoke(null, [partPieceEntry, null]));
         }
 
         [Theory]
@@ -344,6 +344,18 @@ namespace System.IO.Packaging.Tests
                 Assert.Same(lowerPart, upperPart);
                 Assert.Equal(lowerPart.Uri, upperPart.Uri);
                 Assert.Equal(lowerPart.ContentType, upperPart.ContentType);
+            }
+        }
+
+        [Fact]
+        public void DuplicatePartsDifferingOnlyByCaseAreNotAllowed()
+        {
+            using var ms = new MemoryStream();
+            using (var zipPackage = Package.Open(ms, FileMode.Create, FileAccess.ReadWrite))
+            {
+                zipPackage.CreatePart(new Uri("/part", UriKind.Relative), "text/plain");
+                Assert.Throws<InvalidOperationException>(() =>
+                    zipPackage.CreatePart(new Uri("/PART", UriKind.Relative), "text/plain"));
             }
         }
 


### PR DESCRIPTION
The package lookup fails when part names differ only by ASCII case, because the comparer is doing a case-sensitive match.

This PR updates the URI comparer logic to validate equal case-insensitive strings.

Fixes #112783