### PR TITLE
Check checksum when reading TAR archives

### DIFF
--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -190,6 +190,9 @@
   <data name="TarInvalidNumber" xml:space="preserve">
     <value>Unable to parse number.</value>
   </data>
+  <data name="TarInvalidChecksum" xml:space="preserve">
+    <value>Checksum validation failed. The archive might be corrupted.</value>
+  </data>
   <data name="TarEntryFieldExceedsMaxLength" xml:space="preserve">
     <value>The field '{0}' exceeds the maximum allowed length for this format.</value>
   </data>

--- a/src/libraries/System.Formats.Tar/src/System.Formats.Tar.csproj
+++ b/src/libraries/System.Formats.Tar/src/System.Formats.Tar.csproj
@@ -76,6 +76,7 @@
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)System.Collections\src\System.Collections.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Memory\src\System.Memory.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Numerics.Vectors\src\System.Numerics.Vectors.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\src\System.Runtime.InteropServices.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Threading\src\System.Threading.csproj" />

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -439,19 +439,13 @@ namespace System.Formats.Tar
             int calculatedChecksum = 0;
 
             // Process bytes before the checksum field
-            for (int i = 0; i < FieldLocations.Checksum; i++)
-            {
-                calculatedChecksum += buffer[i];
-            }
+            calculatedChecksum += Checksum(buffer.Slice(0, FieldLocations.Checksum));
 
             // For the checksum field, treat all bytes as spaces (ASCII 32)
             calculatedChecksum += (byte)' ' * FieldLengths.Checksum;
 
             // Process bytes after the checksum field
-            for (int i = FieldLocations.Checksum + FieldLengths.Checksum; i < TarHelpers.RecordSize; i++)
-            {
-                calculatedChecksum += buffer[i];
-            }
+            calculatedChecksum += Checksum(buffer.Slice(FieldLocations.Checksum + FieldLengths.Checksum, TarHelpers.RecordSize - (FieldLocations.Checksum + FieldLengths.Checksum)));
 
             return calculatedChecksum;
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -370,7 +370,6 @@ namespace System.Formats.Tar
             {
                 return null;
             }
-            
             int checksum = (int)TarHelpers.ParseOctal<uint>(spanChecksum);
             // Zero checksum means the whole header is empty
             if (checksum == 0)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -372,17 +372,17 @@ namespace System.Formats.Tar
             }
             int checksum = (int)TarHelpers.ParseOctal<uint>(spanChecksum);
 
+            // Zero checksum means the whole header is empty
+            if (checksum == 0)
+            {
+                return null;
+            }
+
             // Verify checksum by calculating it from the buffer
             int calculatedChecksum = CalculateHeaderChecksum(buffer);
             if (calculatedChecksum != checksum)
             {
                 throw new InvalidDataException(SR.TarInvalidChecksum);
-            }
-
-            // Zero checksum means the whole header is empty
-            if (checksum == 0)
-            {
-                return null;
             }
 
             long size = TarHelpers.ParseNumeric<long>(buffer.Slice(FieldLocations.Size, FieldLengths.Size));

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -370,8 +370,8 @@ namespace System.Formats.Tar
             {
                 return null;
             }
+            
             int checksum = (int)TarHelpers.ParseOctal<uint>(spanChecksum);
-
             // Zero checksum means the whole header is empty
             if (checksum == 0)
             {

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
@@ -283,11 +283,11 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        public async Task GarbageEntryChecksumZeroThrowsInvalidDataException()
+        public async Task GarbageEntryChecksumZeroReturnNullAsync()
         {
             await using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", "issue12435");
             await using TarReader reader = new TarReader(archiveStream);
-            await Assert.ThrowsAsync<InvalidDataException>(async () => await reader.GetNextEntryAsync());
+            Assert.Null(await reader.GetNextEntryAsync());
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
@@ -283,11 +283,20 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        public async Task GarbageEntryChecksumZeroReturnNullAsync()
+        public async Task GarbageEntryChecksumZeroThrowsInvalidDataException()
         {
             await using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", "issue12435");
             await using TarReader reader = new TarReader(archiveStream);
-            Assert.Null(await reader.GetNextEntryAsync());
+            await Assert.ThrowsAsync<InvalidDataException>(async () => await reader.GetNextEntryAsync());
+        }
+
+        [Fact]
+        public async Task InvalidChecksum_ThrowsInvalidDataException()
+        {
+            await using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "node-tar", "bad-cksum");
+            await using TarReader reader = new TarReader(archiveStream);
+            await reader.GetNextEntryAsync(); // first entry is okay
+            await Assert.ThrowsAsync<InvalidDataException>(async () => await reader.GetNextEntryAsync());
         }
 
         [Theory]

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -291,11 +291,20 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        public void GarbageEntryChecksumZeroReturnNull()
+        public void GarbageEntryChecksumZeroThrowsInvalidDataException()
         {
             using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", "issue12435");
             using TarReader reader = new TarReader(archiveStream);
-            Assert.Null(reader.GetNextEntry());
+            Assert.Throws<InvalidDataException>(() => reader.GetNextEntry());
+        }
+
+        [Fact]
+        public void InvalidChecksum_ThrowsInvalidDataException()
+        {
+            using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "node-tar", "bad-cksum");
+            using TarReader reader = new TarReader(archiveStream);
+            reader.GetNextEntry(); // first entry is okay
+            Assert.Throws<InvalidDataException>(() => reader.GetNextEntry());
         }
 
         [Theory]

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -291,11 +291,11 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        public void GarbageEntryChecksumZeroThrowsInvalidDataException()
+        public void GarbageEntryChecksumZeroReturnNull()
         {
             using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", "issue12435");
             using TarReader reader = new TarReader(archiveStream);
-            Assert.Throws<InvalidDataException>(() => reader.GetNextEntry());
+            Assert.Null(reader.GetNextEntry());
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
@@ -118,5 +118,58 @@ namespace System.Formats.Tar.Tests
                 Assert.Null(reader.GetNextEntry());
             }
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TarReader_InvalidChecksum_ThrowsException(bool corrupted)
+        {
+            // Create a simple tar file in memory
+            using MemoryStream ms = new MemoryStream();
+            using (TarWriter writer = new TarWriter(ms, TarEntryFormat.Ustar, leaveOpen: true))
+            {
+                UstarTarEntry entry = new UstarTarEntry(TarEntryType.RegularFile, "test.txt");
+                writer.WriteEntry(entry);
+            }
+
+            // Reset position and get the bytes
+            ms.Position = 0;
+            byte[] tarData = ms.ToArray();
+
+            // Corrupt the checksum field (starting at byte 148)
+            // The checksum is written as an octal number in ASCII
+            if (corrupted)
+            {
+                tarData[150] = (byte)'9'; // invalid digit
+            }
+            else
+            {
+                // increment the digit at position 150, wrapping around if necessary
+                if (tarData[150] == (byte)'7')
+                {
+                    tarData[150] = (byte)'0';
+                }
+                else
+                {
+                    tarData[150]++;
+                }
+            }
+
+            // Create a new stream with corrupted data
+            using MemoryStream corruptedStream = new MemoryStream(tarData);
+
+            // Verify that reading the corrupted tar file throws an InvalidDataException
+            using TarReader reader = new TarReader(corruptedStream);
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() => reader.GetNextEntry());
+
+            if (corrupted)
+            {
+                Assert.Contains("parse", exception.Message);
+            }
+            else
+            {
+                Assert.Contains("Checksum", exception.Message);
+            }
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
@@ -145,14 +145,9 @@ namespace System.Formats.Tar.Tests
             else
             {
                 // increment the digit at position 150, wrapping around if necessary
-                if (tarData[150] == (byte)'7')
-                {
-                    tarData[150] = (byte)'0';
-                }
-                else
-                {
-                    tarData[150]++;
-                }
+                byte digit = (byte)(tarData[150] - (byte)'0');
+                digit = (byte)((digit + 1) % 8);
+                tarData[150] = (byte)('0' + digit);
             }
 
             // Create a new stream with corrupted data

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -155,7 +155,6 @@ namespace System.Formats.Tar.Tests
 
         private static readonly string[] NodeTarTestCaseNames = new[]
         {
-            "bad-cksum",
             "body-byte-counts",
             "dir",
             "emptypax",

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
@@ -233,6 +233,12 @@ namespace System.Formats.Tar.Tests
             archiveStream.Seek(sizeLocation, SeekOrigin.Begin);
             archiveStream.Write(replacement);
 
+            // Also fixup checksum
+            int checksumLocation = 148;
+            ReadOnlySpan<byte> checksumReplacement = "04116\0\0\0"u8; // 2126 in octal
+            archiveStream.Seek(checksumLocation, SeekOrigin.Begin);
+            archiveStream.Write(checksumReplacement);
+
             archiveStream.Position = 0;
             using TarReader reader = new(archiveStream);
 
@@ -368,7 +374,7 @@ namespace System.Formats.Tar.Tests
             if (entryType is TarEntryType.RegularFile or TarEntryType.V7RegularFile)
             {
                 entry.DataStream = new MemoryStream();
-                byte[] buffer = [ 72, 101, 108, 108, 111 ]; // values don't matter, only length (5)
+                byte[] buffer = [72, 101, 108, 108, 111]; // values don't matter, only length (5)
 
                 // '00000000005\0' = 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 48 + 53 + 0 = 533
                 entry.DataStream.Write(buffer);


### PR DESCRIPTION
fixes #117455.

TarReader now throws when encountering checksum failures.

This PR also vectorizes checksum calculation already present on the Write path of the TarHeader, which seems to speed-up some benchmarks


<details>
<Summary>Benchmark data</Summary>

```
BenchmarkDotNet v0.14.1-nightly.20250107.205, Windows 11 (10.0.26100.6899)
Intel Core i9-10900K CPU 3.70GHz, 1 CPU, 20 logical and 10 physical cores
.NET SDK 10.0.100-rc.1.25451.107
  [Host]     : .NET 10.0.0 (10.0.25.45207), X64 RyuJIT AVX2
  Job-HZMVFR : .NET 10.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-ZKEGXV : .NET 10.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-BWJLCP : .NET 10.0.0 (42.42.42.42424), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=500ms  MaxIterationCount=100  
MinIterationCount=15  WarmupCount=1  
```

| Method                           | Job        | Toolchain              | Mean       | Error     | StdDev    | Median     | Min        | Max        | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|--------------------------------- |----------- |----------------------- |-----------:|----------:|----------:|-----------:|-----------:|-----------:|------:|--------:|-------:|----------:|------------:|
| CreateFromDirectory_Path         | Job-ZKEGXV | \main\corerun.exe      | 1,407.4 μs |  52.51 μs | 148.10 μs | 1,403.5 μs | 1,132.3 μs | 1,824.4 μs |  1.01 |    0.15 |      - |   8.21 KB |        1.00 |
| CreateFromDirectory_Path         | Job-BWJLCP | \opt-write\corerun.exe | 1,433.3 μs |  28.66 μs |  82.23 μs | 1,431.0 μs | 1,252.3 μs | 1,605.6 μs |  1.03 |    0.12 |      - |   8.21 KB |        1.00 |
|                                  |            |                        |            |           |           |            |            |            |       |         |        |           |             |
| CreateFromDirectory_Path_Async   | Job-ZKEGXV | \main\corerun.exe      | 1,646.2 μs |  32.42 μs |  71.16 μs | 1,644.6 μs | 1,529.1 μs | 1,854.2 μs |  1.00 |    0.06 |      - |  11.27 KB |        1.00 |
| CreateFromDirectory_Path_Async   | Job-BWJLCP | \opt-write\corerun.exe | 1,685.2 μs |  33.63 μs |  77.27 μs | 1,684.7 μs | 1,542.7 μs | 1,906.9 μs |  1.03 |    0.06 |      - |  11.27 KB |        1.00 |
|                                  |            |                        |            |           |           |            |            |            |       |         |        |           |             |
| ExtractToDirectory_Path          | Job-ZKEGXV | \main\corerun.exe      | 1,739.3 μs |  34.04 μs |  48.82 μs | 1,747.7 μs | 1,611.4 μs | 1,819.7 μs |  1.00 |    0.04 |      - |   8.64 KB |        1.00 |
| ExtractToDirectory_Path          | Job-BWJLCP | \opt-write\corerun.exe | 1,746.2 μs |  34.37 μs |  79.66 μs | 1,743.1 μs | 1,593.1 μs | 1,916.6 μs |  1.00 |    0.05 |      - |   8.63 KB |        1.00 |
|                                  |            |                        |            |           |           |            |            |            |       |         |        |           |             |
| ExtractToDirectory_Path_Async    | Job-ZKEGXV | \main\corerun.exe      | 1,768.3 μs |  34.78 μs |  67.02 μs | 1,773.2 μs | 1,641.4 μs | 1,899.2 μs |  1.00 |    0.05 |      - |  10.42 KB |        1.00 |
| ExtractToDirectory_Path_Async    | Job-BWJLCP | \opt-write\corerun.exe | 1,760.9 μs |  34.99 μs |  55.50 μs | 1,765.6 μs | 1,667.1 μs | 1,860.3 μs |  1.00 |    0.05 |      - |  10.42 KB |        1.00 |
|                                  |            |                        |            |           |           |            |            |            |       |         |        |           |             |
| CreateFromDirectory_Stream       | Job-ZKEGXV | \main\corerun.exe      |   767.1 μs |  14.97 μs |  14.00 μs |   770.6 μs |   739.9 μs |   788.5 μs |  1.00 |    0.03 |      - |  11.51 KB |        1.00 |
| CreateFromDirectory_Stream       | Job-BWJLCP | \opt-write\corerun.exe |   768.2 μs |   7.48 μs |   7.00 μs |   769.7 μs |   755.2 μs |   779.3 μs |  1.00 |    0.02 |      - |   11.5 KB |        1.00 |
|                                  |            |                        |            |           |           |            |            |            |       |         |        |           |             |
| CreateFromDirectory_Stream_Async | Job-ZKEGXV | \main\corerun.exe      |   838.3 μs |  12.84 μs |  12.01 μs |   837.7 μs |   816.8 μs |   858.2 μs |  1.00 |    0.02 | 1.5244 |  13.58 KB |        1.00 |
| CreateFromDirectory_Stream_Async | Job-BWJLCP | \opt-write\corerun.exe |   842.9 μs |  15.01 μs |  13.30 μs |   842.3 μs |   822.4 μs |   870.7 μs |  1.01 |    0.02 |      - |  13.57 KB |        1.00 |
|                                  |            |                        |            |           |           |            |            |            |       |         |        |           |             |
| ExtractToDirectory_Stream        | Job-ZKEGXV | \main\corerun.exe      | 1,708.4 μs |  33.93 μs |  71.58 μs | 1,689.1 μs | 1,575.4 μs | 1,860.3 μs |  1.00 |    0.06 |      - |   8.49 KB |        1.00 |
| ExtractToDirectory_Stream        | Job-BWJLCP | \opt-write\corerun.exe | 1,693.4 μs |  33.82 μs |  72.81 μs | 1,677.4 μs | 1,561.6 μs | 1,830.4 μs |  0.99 |    0.06 |      - |   8.49 KB |        1.00 |
|                                  |            |                        |            |           |           |            |            |            |       |         |        |           |             |
| ExtractToDirectory_Stream_Async  | Job-ZKEGXV | \main\corerun.exe      | 1,746.8 μs |  34.50 μs |  62.21 μs | 1,749.3 μs | 1,614.3 μs | 1,899.9 μs |  1.00 |    0.05 |      - |  10.15 KB |        1.00 |
| ExtractToDirectory_Stream_Async  | Job-BWJLCP | \opt-write\corerun.exe | 1,743.3 μs |  34.26 μs |  58.17 μs | 1,740.4 μs | 1,647.7 μs | 1,856.9 μs |  1.00 |    0.05 |      - |  10.17 KB |        1.00 |
|                                  |            |                        |            |           |           |            |            |            |       |         |        |           |             |
| V7TarEntry_WriteEntry          | Job-ZKEGXV | \main\corerun.exe      |   247.6 ns |  8.55 ns |  25.21 ns |   251.0 ns |   189.1 ns |   286.9 ns |  1.01 |    0.15 | 0.0249 |     264 B |        1.00 |
| V7TarEntry_WriteEntry          | Job-BWJLCP | \opt-write\corerun.exe |   248.3 ns | 12.10 ns |  35.69 ns |   254.4 ns |   177.8 ns |   335.8 ns |  1.01 |    0.18 | 0.0250 |     264 B |        1.00 |
|                                |            |                        |            |          |           |            |            |            |       |         |        |           |             |
| V7TarEntry_WriteEntry_Async    | Job-ZKEGXV | \main\corerun.exe      |   344.4 ns | 11.38 ns |  33.56 ns |   353.6 ns |   259.9 ns |   397.4 ns |  1.01 |    0.15 | 0.0249 |     264 B |        1.00 |
| V7TarEntry_WriteEntry_Async    | Job-BWJLCP | \opt-write\corerun.exe |   270.7 ns |  2.23 ns |   2.09 ns |   270.1 ns |   266.2 ns |   274.6 ns |  0.79 |    0.08 | 0.0248 |     264 B |        1.00 |
|                                |            |                        |            |          |           |            |            |            |       |         |        |           |             |
| UstarTarEntry_WriteEntry       | Job-ZKEGXV | \main\corerun.exe      |   258.6 ns |  8.21 ns |  24.20 ns |   263.6 ns |   186.6 ns |   291.5 ns |  1.01 |    0.14 | 0.0251 |     264 B |        1.00 |
| UstarTarEntry_WriteEntry       | Job-BWJLCP | \opt-write\corerun.exe |   192.6 ns |  1.95 ns |   1.82 ns |   192.8 ns |   190.3 ns |   195.7 ns |  0.75 |    0.08 | 0.0250 |     264 B |        1.00 |
|                                |            |                        |            |          |           |            |            |            |       |         |        |           |             |
| UstarTarEntry_WriteEntry_Async | Job-ZKEGXV | \main\corerun.exe      |   364.1 ns | 10.49 ns |  30.92 ns |   369.7 ns |   276.3 ns |   413.6 ns |  1.01 |    0.13 | 0.0248 |     264 B |        1.00 |
| UstarTarEntry_WriteEntry_Async | Job-BWJLCP | \opt-write\corerun.exe |   286.0 ns |  2.36 ns |   2.21 ns |   285.8 ns |   282.8 ns |   289.7 ns |  0.79 |    0.08 | 0.0252 |     264 B |        1.00 |
|                                |            |                        |            |          |           |            |            |            |       |         |        |           |             |
| PaxTarEntry_WriteEntry         | Job-ZKEGXV | \main\corerun.exe      | 1,565.0 ns | 51.03 ns | 150.48 ns | 1,592.7 ns | 1,204.0 ns | 1,800.2 ns |  1.01 |    0.14 | 0.1873 |    1983 B |        1.00 |
| PaxTarEntry_WriteEntry         | Job-BWJLCP | \opt-write\corerun.exe | 1,244.5 ns |  3.69 ns |   3.08 ns | 1,245.0 ns | 1,239.4 ns | 1,249.5 ns |  0.80 |    0.08 | 0.1892 |    1983 B |        1.00 |
|                                |            |                        |            |          |           |            |            |            |       |         |        |           |             |
| PaxTarEntry_WriteEntry_Async   | Job-ZKEGXV | \main\corerun.exe      | 1,825.4 ns | 56.38 ns | 166.24 ns | 1,843.4 ns | 1,397.5 ns | 2,107.6 ns |  1.01 |    0.13 | 0.1881 |    1983 B |        1.00 |
| PaxTarEntry_WriteEntry_Async   | Job-BWJLCP | \opt-write\corerun.exe | 1,458.5 ns | 21.53 ns |  20.14 ns | 1,456.9 ns | 1,412.5 ns | 1,492.9 ns |  0.81 |    0.08 | 0.1879 |    1983 B |        1.00 |
|                                |            |                        |            |          |           |            |            |            |       |         |        |           |             |
| GnuTarEntry_WriteEntry         | Job-ZKEGXV | \main\corerun.exe      |   271.8 ns |  8.80 ns |  25.95 ns |   273.5 ns |   199.3 ns |   306.7 ns |  1.01 |    0.14 | 0.0248 |     264 B |        1.00 |
| GnuTarEntry_WriteEntry         | Job-BWJLCP | \opt-write\corerun.exe |   206.2 ns |  1.16 ns |   1.03 ns |   206.5 ns |   203.3 ns |   207.4 ns |  0.77 |    0.08 | 0.0250 |     264 B |        1.00 |
|                                |            |                        |            |          |           |            |            |            |       |         |        |           |             |
| GnuTarEntry_WriteEntry_Async   | Job-ZKEGXV | \main\corerun.exe      |   376.9 ns | 12.04 ns |  35.49 ns |   382.4 ns |   287.3 ns |   438.2 ns |  1.01 |    0.14 | 0.0247 |     264 B |        1.00 |
| GnuTarEntry_WriteEntry_Async   | Job-BWJLCP | \opt-write\corerun.exe |   305.5 ns |  2.11 ns |   1.97 ns |   305.8 ns |   302.6 ns |   309.1 ns |  0.82 |    0.08 | 0.0252 |     264 B |        1.00 |


</details>