### PR TITLE
Check for truncation when writing R2R PE images

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -254,7 +254,7 @@ namespace ILCompiler.PEWriter
 
             _sectionBuilder.RelocateOutputFile(outputPeFile, Header.ImageBase, outputStream);
 
-            UpdateSectionRVAs(outputStream);
+            int sizeOfImage = UpdateSectionRVAs(outputStream);
 
             if (_customPESectionAlignment != 0)
                 SetPEHeaderSectionAlignment(outputStream, _customPESectionAlignment);
@@ -265,6 +265,10 @@ namespace ILCompiler.PEWriter
                 SetPEHeaderTimeStamp(outputStream, timeDateStamp.Value);
 
             _written = true;
+
+            Console.WriteLine($"R2RPEBuilder wrote {outputStream.Length} byte(s)");
+            if (outputStream.Length != sizeOfImage)
+                throw new BadImageFormatException("R2R image was truncated during writing");
         }
 
         /// <summary>
@@ -345,7 +349,8 @@ namespace ILCompiler.PEWriter
         /// we're performing the same transformation on Windows where it is a no-op.
         /// </summary>
         /// <param name="outputStream"></param>
-        private void UpdateSectionRVAs(Stream outputStream)
+        /// <returns>Computed SizeOfImage value</returns>
+        private int UpdateSectionRVAs(Stream outputStream)
         {
             int peHeaderSize =
                 OffsetOfChecksum +
@@ -416,6 +421,7 @@ namespace ILCompiler.PEWriter
             byte[] sizeOfImageBytes = BitConverter.GetBytes(sizeOfImage);
             Debug.Assert(sizeOfImageBytes.Length == sizeof(int));
             outputStream.Write(sizeOfImageBytes, 0, sizeOfImageBytes.Length);
+            return sizeOfImage;
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -268,7 +268,7 @@ namespace ILCompiler.PEWriter
 
             Console.WriteLine($"R2RPEBuilder wrote {outputStream.Length} byte(s)");
             if (outputStream.Length != sizeOfImage)
-                throw new BadImageFormatException("R2R image was truncated during writing");
+                throw new BadImageFormatException($"R2R image was truncated during writing. Expected {sizeOfImage} bytes but wrote {outputStream.Length} bytes.");
         }
 
         /// <summary>


### PR DESCRIPTION
We have a failure mode on CI where the R2R image appears to have been truncated, and the file is much shorter than the SizeOfImage indicates. R2RDump gets unhappy about these images and sometimes they cause failures at runtime too. This adds a simple check to R2RPEBuilder.cs to verify that we wrote the amount of bytes we should have written.