### PR TITLE
[clr-interp] Change size type from `size_t` to `uint32_t` in `INTOP_CPBLK`

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2084,7 +2084,7 @@ CALL_INTERP_METHOD:
                 {
                     void* dst = LOCAL_VAR(ip[1], void*);
                     void* src = LOCAL_VAR(ip[2], void*);
-                    size_t size = LOCAL_VAR(ip[3], size_t);
+                    uint32_t size = LOCAL_VAR(ip[3], uint32_t);
                     if (size && (!dst || !src))
                         COMPlusThrow(kNullReferenceException);
                     else


### PR DESCRIPTION
## Description

According to https://learn.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.cpblk?view=net-9.0, the size is an unsigned 32-bit integer. This change fixes the startup path on macOS arm64.