### PR TITLE
Simplify range validation in `Memory.Span`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Memory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Memory.cs
@@ -325,22 +325,15 @@ namespace System
                     // AV the process.
 
                     // We use 'nuint' because it gives us a free early zero-extension to 64 bits when running on a 64-bit platform.
-                    nuint desiredStartIndex = (uint)_index & (uint)ReadOnlyMemory<T>.RemoveFlagsBitMask;
+                    nuint desiredStartIndex = (uint)(_index & ReadOnlyMemory<T>.RemoveFlagsBitMask);
 
                     int desiredLength = _length;
 
-#if TARGET_64BIT
-                    // See comment in Span<T>.Slice for how this works.
-                    if ((ulong)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
+                    Debug.Assert((int)desiredStartIndex >= 0 && lengthOfUnderlyingSpan >= 0);
+                    if ((uint)desiredStartIndex + (uint)desiredLength > (uint)lengthOfUnderlyingSpan)
                     {
                         ThrowHelper.ThrowArgumentOutOfRangeException();
                     }
-#else
-                    if ((uint)desiredStartIndex > (uint)lengthOfUnderlyingSpan || (uint)desiredLength > (uint)lengthOfUnderlyingSpan - (uint)desiredStartIndex)
-                    {
-                        ThrowHelper.ThrowArgumentOutOfRangeException();
-                    }
-#endif
 
                     refToReturn = ref Unsafe.Add(ref refToReturn, desiredStartIndex);
                     lengthOfUnderlyingSpan = desiredLength;

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
@@ -247,22 +247,15 @@ namespace System
                     // AV the process.
 
                     // We use 'nuint' because it gives us a free early zero-extension to 64 bits when running on a 64-bit platform.
-                    nuint desiredStartIndex = (uint)_index & (uint)RemoveFlagsBitMask;
+                    nuint desiredStartIndex = (uint)(_index & RemoveFlagsBitMask);
 
                     int desiredLength = _length;
 
-#if TARGET_64BIT
-                    // See comment in Span<T>.Slice for how this works.
-                    if ((ulong)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
+                    Debug.Assert((int)desiredStartIndex >= 0 && lengthOfUnderlyingSpan >= 0);
+                    if ((uint)desiredStartIndex + (uint)desiredLength > (uint)lengthOfUnderlyingSpan)
                     {
                         ThrowHelper.ThrowArgumentOutOfRangeException();
                     }
-#else
-                    if ((uint)desiredStartIndex > (uint)lengthOfUnderlyingSpan || (uint)desiredLength > (uint)lengthOfUnderlyingSpan - (uint)desiredStartIndex)
-                    {
-                        ThrowHelper.ThrowArgumentOutOfRangeException();
-                    }
-#endif
 
                     refToReturn = ref Unsafe.Add(ref refToReturn, desiredStartIndex);
                     lengthOfUnderlyingSpan = desiredLength;


### PR DESCRIPTION
* `desiredStartIndex` cannot be negative as high order bit of `_index` has been removed.
* `desiredLength` cannot be negative as all public constructors validate `_length` is not negative.
* `lengthOfUnderlyingSpan` cannot be negative as `_object.Length` as the length property of an array, string, or span cannot be negative.