### PR TITLE
Mark UrlDecodeInternal noinline to work around inliner limitation

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
@@ -443,7 +443,12 @@ namespace System.Net
 
         #region UrlDecode implementation
 
+        // Marking UriDecodeInternal noinline to work around
+        // a jit issue where inlining this method may cause
+        // key inlinees to not be inlined
+        //
         [return: NotNullIfNotNull(nameof(value))]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static string? UrlDecodeInternal(string? value, Encoding encoding)
         {
             if (string.IsNullOrEmpty(value))
@@ -506,7 +511,12 @@ namespace System.Net
             return helper.GetString();
         }
 
+        // Marking UriDecodeInternal noinline to work around
+        // a jit issue where inlining this method may cause
+        // key inlinees to not be inlined
+        //
         [return: NotNullIfNotNull(nameof(bytes))]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static byte[]? UrlDecodeInternal(byte[]? bytes, int offset, int count)
         {
             if (!ValidateUrlEncodingParameters(bytes, offset, count))

--- a/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
@@ -443,7 +443,7 @@ namespace System.Net
 
         #region UrlDecode implementation
 
-        // Marking UriDecodeInternal noinline to work around
+        // Marking UrlDecodeInternal noinline to work around
         // a jit issue where inlining this method may cause
         // key inlinees to not be inlined
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
@@ -511,7 +511,7 @@ namespace System.Net
             return helper.GetString();
         }
 
-        // Marking UriDecodeInternal noinline to work around
+        // Marking UrlDecodeInternal noinline to work around
         // a jit issue where inlining this method may cause
         // key inlinees to not be inlined
         //


### PR DESCRIPTION
If this method is inlined, the JIT may be unable to inline some of its callees, leading to a perf regression.

See #114996.