### PR TITLE
Fix benchmarksgame tests to be able to resolve the embedded resources

### DIFF
--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/harness-helpers.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/harness-helpers.cs
@@ -25,14 +25,14 @@ namespace BenchmarksGame
                 expectedCountLetter = new int[] { 302923, 301375, 198136, 197566 };
                 expectedCountPairs = new int[] { 91779, 91253, 91225, 90837, 60096, 60030, 59889, 59795, 59756, 59713, 59572, 59557, 39203, 39190, 39081, 39023 };
                 expectedCountFragments = new int[] { 11765, 3572, 380, 7, 7 };
-                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName)}.knucleotide-input-big.txt";
+                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName).Replace('-', '_')}.knucleotide-input-big.txt";
             }
             else
             {
                 expectedCountLetter = new int[] { 1576, 1480, 974, 970 };
                 expectedCountPairs = new int[] { 496, 480, 470, 420, 316, 315, 310, 302, 298, 292, 273, 272, 202, 201, 185, 167 };
                 expectedCountFragments = new int[] { 54, 24, 4, 0, 0 };
-                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName)}.knucleotide-input.txt";
+                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName).Replace('-', '_')}.knucleotide-input.txt";
             }
             expectedFrequencies = new int[][] { expectedCountLetter, expectedCountPairs };
         }

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-1.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-1.cs
@@ -83,7 +83,6 @@ namespace BenchmarksGame
     {
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118475")]
         public static int TestEntryPoint()
         {
             var helpers = new TestHarnessHelpers(bigInput: false);

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-9.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-9.cs
@@ -254,7 +254,6 @@ namespace BenchmarksGame
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118475")]
         public static int TestEntryPoint()
         {
             var helpers = new TestHarnessHelpers(bigInput: false);

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/harness-helpers.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/harness-helpers.cs
@@ -20,12 +20,12 @@ namespace BenchmarksGame
             if (bigInput)
             {
                 ExpectedLength = 136381;
-                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName)}.regexdna-input25000.txt";
+                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName).Replace('-', '_')}.regexdna-input25000.txt";
             }
             else
             {
                 ExpectedLength = 152;
-                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName)}.regexdna-input25.txt";
+                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName).Replace('-', '_')}.regexdna-input25.txt";
             }
         }
 

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-1.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-1.cs
@@ -24,7 +24,6 @@ namespace BenchmarksGame
     public class RegexRedux_1
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118475")]
         public static int TestEntryPoint()
         {
             var helpers = new TestHarnessHelpers(bigInput: false);

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-5.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-5.cs
@@ -8,7 +8,7 @@
 
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
- 
+
    Regex-Redux by Josh Goldfoot
    order variants by execution time by Anthony Lloyd
 */
@@ -38,7 +38,6 @@ namespace BenchmarksGame
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118475")]
         public static int TestEntryPoint()
         {
             var helpers = new TestHarnessHelpers(bigInput: false);

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/harness-helpers.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/harness-helpers.cs
@@ -22,13 +22,13 @@ namespace BenchmarksGame
             {
                 FileLength = 254245;
                 CheckSum = "61-A4-CC-6D-15-8D-26-77-88-93-4F-E2-29-A2-8D-FB";
-                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName)}.revcomp-input25000.txt";
+                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName).Replace('-', '_')}.revcomp-input25000.txt";
             }
             else
             {
                 FileLength = 333;
                 CheckSum = "62-45-8E-09-2E-89-A0-69-8C-17-F5-D8-C7-63-5B-50";
-                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName)}.revcomp-input25.txt";
+                resourceName = $"{Path.GetFileNameWithoutExtension(csFileName).Replace('-', '_')}.revcomp-input25.txt";
             }
         }
 

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/reverse-complement-1.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/reverse-complement-1.cs
@@ -46,7 +46,6 @@ namespace BenchmarksGame
         const byte Lf = (byte)'\n';
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118475")]
         public static int TestEntryPoint()
         {
             var helpers = new TestHarnessHelpers(bigInput: false);

--- a/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/reverse-complement-6.cs
+++ b/src/tests/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/reverse-complement-6.cs
@@ -229,7 +229,6 @@ namespace BenchmarksGame
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118475")]
         public static int TestEntryPoint()
         {
             var helpers = new TestHarnessHelpers(bigInput: false);


### PR DESCRIPTION
This resolves #118475 

There's still some discussion happening on if the SDK change here needs a breaking change doc or more consideration, but this ensures the tests are running in the interim.