### PR TITLE
Fix type parameter mapping for static closures

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
@@ -175,8 +175,8 @@ namespace ILCompiler.Dataflow
                                         // Find calls to state machine constructors that occur outside the type
                                         if (referencedMethod.IsConstructor &&
                                             referencedMethod.OwningType is MetadataType generatedType &&
-                                            // Don't consider calls in the same type, like inside a static constructor
-                                            method.OwningType != generatedType &&
+                                            // Don't consider calls in the same/nested type, like inside a static constructor
+                                            !IsSameOrNestedType(method.OwningType, generatedType) &&
                                             CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.Name))
                                         {
                                             Debug.Assert(generatedType.IsTypeDefinition);
@@ -216,8 +216,8 @@ namespace ILCompiler.Dataflow
                                         field = field.GetTypicalFieldDefinition();
 
                                         if (field.OwningType is MetadataType generatedType &&
-                                            // Don't consider field accesses in the same type, like inside a static constructor
-                                            method.OwningType != generatedType &&
+                                            // Don't consider field accesses in the same/nested type, like inside a static constructor
+                                            !IsSameOrNestedType(method.OwningType, generatedType) &&
                                             CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.Name))
                                         {
                                             Debug.Assert(generatedType.IsTypeDefinition);
@@ -258,6 +258,22 @@ namespace ILCompiler.Dataflow
                         // Already warned above if multiple methods map to the same type
                         // Fill in null for argument providers now, the real providers will be filled in later
                         generatedTypeToTypeArgs[stateMachineType] = new TypeArgumentInfo(method, null);
+                    }
+
+                    static bool IsSameOrNestedType(TypeDesc type, TypeDesc potentialOuterType)
+                    {
+                        do
+                        {
+                            if (type == potentialOuterType)
+                                return true;
+
+                            if (type is not EcmaType ecmaType)
+                                return false;
+
+                            type = ecmaType.ContainingType;
+                        } while (type != null);
+
+                        return false;
                     }
                 }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
@@ -48,6 +48,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             CapturingLocalFunctionInsideIterator<int>();
             LambdaInsideAsync<int>();
             LocalFunctionInsideAsync<int>();
+            NestedAsyncLambda.Test<int>();
+            NestedAsyncLocalFunction.Test<int>();
             NestedStaticLambda.Test<int>();
         }
 
@@ -421,6 +423,50 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             void LocalFunction() => typeof(T).GetMethods();
             await Task.Delay(0);
             LocalFunction();
+        }
+
+        class NestedAsyncLambda
+        {
+            public static async void Test<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>()
+            {
+                var outer = async () =>
+                {
+                    var inner =
+                    [ExpectedWarning("IL2090", "T", nameof(DynamicallyAccessedMemberTypes.PublicProperties))]
+                    () =>
+                    {
+                        _ = typeof(T).GetMethods();
+                        _ = typeof(T).GetProperties();
+                    };
+
+                    inner();
+                };
+
+                outer().Wait();
+            }
+        }
+
+        class NestedAsyncLocalFunction
+        {
+            public static void Test<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>()
+            {
+                Local1();
+
+#if INCLUDE_UNEXPECTED_LOWERING_WARNINGS
+                [UnexpectedWarning("IL2091", "T", nameof(DynamicallyAccessedMemberTypes.PublicMethods), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/roslyn/issues/79333", CompilerGeneratedCode = true)]
+#endif
+                static async Task Local1()
+                {
+                    Local2();
+
+                    [ExpectedWarning("IL2090", "T", nameof(DynamicallyAccessedMemberTypes.PublicProperties))]
+                    static void Local2()
+                    {
+                        _ = typeof(T).GetMethods();
+                        _ = typeof(T).GetProperties();
+                    };
+                };
+            }
         }
 
         class NestedStaticLambda


### PR DESCRIPTION
Roslyn can generate code (specifically for nested async lambda state machines) where a static closure environment is referenced from a nested type of the display class. Handle this case by detecting nested classes, and never tracking type parameter instantiations from nested classes to outer classes. This fixes the reported stack overflow in ILLink and ILC.

Fixes https://github.com/dotnet/runtime/issues/117153