### PR TITLE
[PQC] Update tests for latest Win11 Insiders

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Formats.Asn1;
 using System.Security.Cryptography.Asn1;
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 
@@ -373,16 +372,6 @@ namespace System.Security.Cryptography
                 {
                     key = CngKey.Import(pkcs8Source, CngKeyBlobFormat.Pkcs8PrivateBlob);
                 }
-                catch (CryptographicException)
-                {
-                    // TODO: Once Windows moves to new PKCS#8 format, we can remove this conversion.
-                    byte[] newPkcs8Source = MLDsaPkcs8.ConvertToOldChoicelessFormat(pkcs8Source);
-
-                    using (PinAndClear.Track(newPkcs8Source))
-                    {
-                        key = CngKey.Import(newPkcs8Source, CngKeyBlobFormat.Pkcs8PrivateBlob);
-                    }
-                }
                 catch (AsnContentException e)
                 {
                     throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
@@ -490,13 +479,6 @@ namespace System.Security.Cryptography
                 try
                 {
                     mldsaPrivateKeyAsn = MLDsaPrivateKeyAsn.Decode(privateKey, AsnEncodingRules.BER);
-                }
-                catch (CryptographicException)
-                {
-                    // TODO: Once Windows moves to new PKCS#8 format, we can remove this conversion.
-                    newPkcs8 = MLDsaPkcs8.ConvertFromOldChoicelessFormat(pkcs8);
-                    ReadOnlyMemory<byte> newPrivateKey = KeyFormatHelper.ReadPkcs8(KnownOids, newPkcs8, out _);
-                    mldsaPrivateKeyAsn = MLDsaPrivateKeyAsn.Decode(newPrivateKey, AsnEncodingRules.BER);
                 }
                 catch (AsnContentException e)
                 {

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaPkcs8.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaPkcs8.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
-using System.Diagnostics;
 using System.Formats.Asn1;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography.Asn1;
 
 namespace System.Security.Cryptography
@@ -69,75 +66,6 @@ namespace System.Security.Cryptography
                 if (rented is not null)
                 {
                     CryptoPool.Return(rented, written);
-                }
-            }
-        }
-
-        // TODO: Remove this once Windows moves to the new format.
-        internal static unsafe byte[] ConvertToOldChoicelessFormat(ReadOnlySpan<byte> pkcs8WithChoice)
-        {
-            fixed (byte* ptr = &MemoryMarshal.GetReference(pkcs8WithChoice))
-            {
-                using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, pkcs8WithChoice.Length))
-                {
-                    PrivateKeyInfoAsn privateKeyInfo = PrivateKeyInfoAsn.Decode(manager.Memory, AsnEncodingRules.BER);
-                    AlgorithmIdentifierAsn privateAlgorithm = privateKeyInfo.PrivateKeyAlgorithm;
-
-                    if (privateAlgorithm.Algorithm is not (Oids.MLDsa44 or Oids.MLDsa65 or Oids.MLDsa87))
-                    {
-                        Debug.Fail("Unexpected algorithm");
-                        throw new CryptographicException();
-                    }
-
-                    MLDsaPrivateKeyAsn mldsaPrivateKeyAsn = MLDsaPrivateKeyAsn.Decode(privateKeyInfo.PrivateKey, AsnEncodingRules.BER);
-                    privateKeyInfo.PrivateKey = mldsaPrivateKeyAsn.Seed
-                        ?? mldsaPrivateKeyAsn.ExpandedKey.GetValueOrDefault(); // Old format does not support having both
-
-                    AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-                    privateKeyInfo.Encode(writer);
-                    return writer.Encode();
-                }
-            }
-        }
-
-        // TODO: Remove this once Windows moves to the new format.
-        internal static unsafe byte[] ConvertFromOldChoicelessFormat(ReadOnlySpan<byte> pkcs8WithoutChoice)
-        {
-            fixed (byte* ptr = &MemoryMarshal.GetReference(pkcs8WithoutChoice))
-            {
-                using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, pkcs8WithoutChoice.Length))
-                {
-                    PrivateKeyInfoAsn privateKeyInfo = PrivateKeyInfoAsn.Decode(manager.Memory, AsnEncodingRules.BER);
-                    AlgorithmIdentifierAsn privateAlgorithm = privateKeyInfo.PrivateKeyAlgorithm;
-
-                    int seedSize = privateAlgorithm.Algorithm switch
-                    {
-                        Oids.MLDsa44 => MLDsaAlgorithm.MLDsa44.PrivateSeedSizeInBytes,
-                        Oids.MLDsa65 => MLDsaAlgorithm.MLDsa65.PrivateSeedSizeInBytes,
-                        Oids.MLDsa87 => MLDsaAlgorithm.MLDsa87.PrivateSeedSizeInBytes,
-                        _ => throw new CryptographicException(),
-                    };
-
-                    ReadOnlyMemory<byte> key = privateKeyInfo.PrivateKey;
-
-                    MLDsaPrivateKeyAsn mldsaPrivateKeyAsn = default;
-
-                    if (key.Length == seedSize)
-                    {
-                        mldsaPrivateKeyAsn.Seed = key;
-                    }
-                    else
-                    {
-                        mldsaPrivateKeyAsn.ExpandedKey = key;
-                    }
-
-                    AsnWriter writer = new(AsnEncodingRules.DER);
-                    mldsaPrivateKeyAsn.Encode(writer);
-                    privateKeyInfo.PrivateKey = writer.Encode();
-
-                    writer = new AsnWriter(AsnEncodingRules.DER);
-                    privateKeyInfo.Encode(writer);
-                    return writer.Encode();
                 }
             }
         }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaCngTests.Windows.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaCngTests.Windows.cs
@@ -145,7 +145,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsExportingPrivateKeyPkcs8))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118609", TestPlatforms.Windows)]
         public void ImportPrivateKey_Persisted()
         {
             CngKey key = PqcBlobHelpers.EncodeMLDsaBlob(

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaCngTests.Windows.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaCngTests.Windows.cs
@@ -144,7 +144,8 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsExportingPrivateKeyPkcs8))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118609", TestPlatforms.Windows)]
         public void ImportPrivateKey_Persisted()
         {
             CngKey key = PqcBlobHelpers.EncodeMLDsaBlob(

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
@@ -14,11 +14,8 @@ namespace System.Security.Cryptography.Tests
     {
         internal static bool MLDsaIsNotSupported => !MLDsa.IsSupported;
 
-        // TODO: Windows does not support draft 10 PKCS#8 format yet. Remove this and use MLDsa.IsSupported (or remove condition) when it does.
-        internal static bool SupportsDraft10Pkcs8 => MLDsa.IsSupported && !PlatformDetection.IsWindows;
-
-        // TODO: Windows does not support signing empty data. Remove this and use MLDsa.IsSupported (or remove condition) when it does.
-        internal static bool SigningEmptyDataIsSupported => MLDsa.IsSupported && !PlatformDetection.IsWindows;
+        // TODO: Windows currently does not support PKCS#8 export when imported as private key.
+        internal static bool SupportsExportingPrivateKeyPkcs8 => MLDsa.IsSupported && !PlatformDetection.IsWindows;
 
         internal static bool ExternalMuIsSupported => MLDsa.IsSupported && !PlatformDetection.IsWindows;
 
@@ -305,26 +302,9 @@ namespace System.Security.Cryptography.Tests
 
             AssertExportPkcs8PrivateKey(exportPkcs8 =>
                 indirectCallback(mldsa =>
-                    DecodeExpandedKey(
-                        mldsa,
+                    MLDsaPrivateKeyAsn.Decode(
                         PrivateKeyInfoAsn.Decode(
                             exportPkcs8(mldsa), AsnEncodingRules.DER).PrivateKey, AsnEncodingRules.DER).ExpandedKey?.ToArray()));
-        }
-
-        // TODO remove this when windows supports draft 10 PKCS#8 format
-        internal static MLDsaPrivateKeyAsn DecodeExpandedKey(MLDsa mldsa, ReadOnlyMemory<byte> encoded, AsnEncodingRules ruleSet)
-        {
-            try
-            {
-                return MLDsaPrivateKeyAsn.Decode(encoded, ruleSet);
-            }
-            catch (CryptographicException) when (!SupportsDraft10Pkcs8)
-            {
-                return new MLDsaPrivateKeyAsn
-                {
-                    ExpandedKey = (mldsa.Algorithm.PrivateKeySizeInBytes == encoded.Length) ? encoded : default(ReadOnlyMemory<byte>?),
-                };
-            }
         }
 
         internal static void AssertExportMLDsaPrivateSeed(Action<Func<MLDsa, byte[]>> callback) =>
@@ -341,26 +321,9 @@ namespace System.Security.Cryptography.Tests
 
             AssertExportPkcs8PrivateKey(exportPkcs8 =>
                 indirectCallback(mldsa =>
-                    DecodePrivateSeed(
-                        mldsa,
+                    MLDsaPrivateKeyAsn.Decode(
                         PrivateKeyInfoAsn.Decode(
                             exportPkcs8(mldsa), AsnEncodingRules.DER).PrivateKey, AsnEncodingRules.DER).Seed?.ToArray()));
-        }
-
-        // TODO remove this when windows supports draft 10 PKCS#8 format
-        internal static MLDsaPrivateKeyAsn DecodePrivateSeed(MLDsa mldsa, ReadOnlyMemory<byte> encoded, AsnEncodingRules ruleSet)
-        {
-            try
-            {
-                return MLDsaPrivateKeyAsn.Decode(encoded, ruleSet);
-            }
-            catch (CryptographicException) when (!SupportsDraft10Pkcs8)
-            {
-                return new MLDsaPrivateKeyAsn
-                {
-                    Seed = (mldsa.Algorithm.PrivateSeedSizeInBytes == encoded.Length) ? encoded : default(ReadOnlyMemory<byte>?),
-                };
-            }
         }
 
         internal static void AssertExportPkcs8PrivateKey(MLDsa mldsa, Action<byte[]> callback) =>

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography.Tests
     {
         internal static bool MLDsaIsNotSupported => !MLDsa.IsSupported;
 
-        // TODO: Windows currently does not support PKCS#8 export when imported as private key.
+        // TODO (https://github.com/dotnet/runtime/issues/118609): Windows currently does not support PKCS#8 export when imported as private key.
         internal static bool SupportsExportingPrivateKeyPkcs8 => MLDsa.IsSupported && !PlatformDetection.IsWindows;
 
         internal static bool ExternalMuIsSupported => MLDsa.IsSupported && !PlatformDetection.IsWindows;

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestsBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestsBase.cs
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Tests
             SignAndVerifyExternalMu(mldsa, data, context);
         }
 
-        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SigningEmptyDataIsSupported))]
+        [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/116461", TestPlatforms.Windows)]
         [MemberData(nameof(MLDsaTestsData.AllMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void GenerateSignVerifyEmptyMessageNoContext(MLDsaAlgorithm algorithm)
@@ -99,7 +99,7 @@ namespace System.Security.Cryptography.Tests
             ExerciseSuccessfulVerify(mldsa, [], signature, []);
         }
 
-        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SigningEmptyDataIsSupported))]
+        [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/116461", TestPlatforms.Windows)]
         [MemberData(nameof(MLDsaTestsData.AllMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void GenerateSignVerifyEmptyMessageWithContext(MLDsaAlgorithm algorithm)
@@ -110,9 +110,7 @@ namespace System.Security.Cryptography.Tests
             ExerciseSuccessfulVerify(mldsa, [], signature, context);
         }
 
-        [ConditionalTheory(
-            typeof(MLDsaTestHelpers),
-            [nameof(MLDsaTestHelpers.SigningEmptyDataIsSupported), nameof(MLDsaTestHelpers.ExternalMuIsSupported)])]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.ExternalMuIsSupported))]
         [MemberData(nameof(MLDsaTestsData.AllMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void GenerateSignVerifyEmptyMessageExternalMuNoContext(MLDsaAlgorithm algorithm)
         {
@@ -120,9 +118,7 @@ namespace System.Security.Cryptography.Tests
             SignAndVerifyExternalMu(mldsa, [], []);
         }
 
-        [ConditionalTheory(
-            typeof(MLDsaTestHelpers),
-            [nameof(MLDsaTestHelpers.SigningEmptyDataIsSupported), nameof(MLDsaTestHelpers.ExternalMuIsSupported)])]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.ExternalMuIsSupported))]
         [MemberData(nameof(MLDsaTestsData.AllMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void GenerateSignVerifyEmptyMessageExternalMuWithContext(MLDsaAlgorithm algorithm)
         {
@@ -228,7 +224,8 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsExportingPrivateKeyPkcs8))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118609", TestPlatforms.Windows)]
         public void ImportPrivateKey_CannotReconstructSeed()
         {
             byte[] privateKey;
@@ -295,7 +292,8 @@ namespace System.Security.Cryptography.Tests
             Assert.Equal(testCase.ShouldPass, mldsa.VerifyMu(testCase.Mu, testCase.Signature));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsExportingPrivateKeyPkcs8))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118609", TestPlatforms.Windows)]
         [MemberData(nameof(MLDsaTestsData.AllPureMLDsaNistTestCases), MemberType = typeof(MLDsaTestsData))]
         public void NistImportPrivateKeyVerifyExportsAndSignature(MLDsaNistTestCase testCase)
         {
@@ -332,7 +330,8 @@ namespace System.Security.Cryptography.Tests
                 export => AssertExportPkcs8FromPublicKey(() => export(mldsa)));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsExportingPrivateKeyPkcs8))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118609", TestPlatforms.Windows)]
         [MemberData(nameof(MLDsaTestsData.IetfMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void ImportPrivateKey_Export(MLDsaKeyInfo info)
         {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestsBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestsBase.cs
@@ -90,7 +90,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/116461", TestPlatforms.Windows)]
         [MemberData(nameof(MLDsaTestsData.AllMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void GenerateSignVerifyEmptyMessageNoContext(MLDsaAlgorithm algorithm)
         {
@@ -100,7 +99,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/116461", TestPlatforms.Windows)]
         [MemberData(nameof(MLDsaTestsData.AllMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void GenerateSignVerifyEmptyMessageWithContext(MLDsaAlgorithm algorithm)
         {
@@ -225,7 +223,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [ConditionalFact(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsExportingPrivateKeyPkcs8))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118609", TestPlatforms.Windows)]
         public void ImportPrivateKey_CannotReconstructSeed()
         {
             byte[] privateKey;
@@ -293,7 +290,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsExportingPrivateKeyPkcs8))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118609", TestPlatforms.Windows)]
         [MemberData(nameof(MLDsaTestsData.AllPureMLDsaNistTestCases), MemberType = typeof(MLDsaTestsData))]
         public void NistImportPrivateKeyVerifyExportsAndSignature(MLDsaNistTestCase testCase)
         {
@@ -331,7 +327,6 @@ namespace System.Security.Cryptography.Tests
         }
 
         [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsExportingPrivateKeyPkcs8))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118609", TestPlatforms.Windows)]
         [MemberData(nameof(MLDsaTestsData.IetfMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void ImportPrivateKey_Export(MLDsaKeyInfo info)
         {

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Formats.Asn1;
-using System.Linq;
 using System.Security.Cryptography.Tests;
 using System.Security.Cryptography.Dsa.Tests;
 using System.Security.Cryptography.EcDsa.Tests;
@@ -370,7 +368,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
             PbeParameters pbeParameters = new(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 32);
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, X509KeyStorageFlags.Exportable))
             {
                 byte[] pkcs12 = cert.ExportPkcs12(pbeParameters, password);
                 (int certs, int keys) = VerifyPkcs12(
@@ -382,7 +380,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(1, certs);
                 Assert.Equal(1, keys);
 
-                using (X509Certificate2 reLoaded = X509CertificateLoader.LoadPkcs12(pkcs12, password))
+                using (X509Certificate2 reLoaded = X509CertificateLoader.LoadPkcs12(pkcs12, password, X509KeyStorageFlags.Exportable))
                 using (MLKem kem = reLoaded.GetMLKemPrivateKey())
                 {
                     Assert.NotNull(kem);
@@ -392,15 +390,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsDraft10Pkcs8))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/116463", TestPlatforms.Windows)]
+        [ConditionalTheory(typeof(MLDsa), nameof(MLDsa.IsSupported))]
         [MemberData(nameof(MLDsaTestsData.IetfMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public static void ExportPkcs12_MLDsa_Generated_Roundtrip(MLDsaKeyInfo info)
         {
             string password = info.EncryptionPassword;
             PbeParameters pbeParameters = info.EncryptionParameters;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(info.Pfx_Seed, password))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(info.Pfx_Seed, password, X509KeyStorageFlags.Exportable))
             {
                 byte[] pkcs12 = cert.ExportPkcs12(pbeParameters, password);
                 (int certs, int keys) = VerifyPkcs12(
@@ -412,7 +409,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(1, certs);
                 Assert.Equal(1, keys);
 
-                using (X509Certificate2 reLoaded = X509CertificateLoader.LoadPkcs12(pkcs12, password))
+                using (X509Certificate2 reLoaded = X509CertificateLoader.LoadPkcs12(pkcs12, password, X509KeyStorageFlags.Exportable))
                 using (MLDsa mldsa = reLoaded.GetMLDsaPrivateKey())
                 {
                     Assert.NotNull(mldsa);
@@ -433,7 +430,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
             PbeParameters pbeParameters = new(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 32);
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, password))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, password, X509KeyStorageFlags.Exportable))
             {
                 byte[] pkcs12 = cert.ExportPkcs12(pbeParameters, password);
                 (int certs, int keys) = VerifyPkcs12(
@@ -445,7 +442,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(1, certs);
                 Assert.Equal(1, keys);
 
-                using (X509Certificate2 reLoaded = X509CertificateLoader.LoadPkcs12(pkcs12, password))
+                using (X509Certificate2 reLoaded = X509CertificateLoader.LoadPkcs12(pkcs12, password, X509KeyStorageFlags.Exportable))
                 using (SlhDsa slhDsa = reLoaded.GetSlhDsaPrivateKey())
                 {
                     Assert.NotNull(slhDsa);
@@ -462,7 +459,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string password = info.EncryptionPassword;
             PbeParameters pbeParameters = new(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 32);
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(info.SelfSignedCertificatePfx, password))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(info.SelfSignedCertificatePfx, password, X509KeyStorageFlags.Exportable))
             {
                 byte[] pkcs12 = cert.ExportPkcs12(pbeParameters, password);
                 (int certs, int keys) = VerifyPkcs12(
@@ -474,7 +471,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(1, certs);
                 Assert.Equal(1, keys);
 
-                using (X509Certificate2 reLoaded = X509CertificateLoader.LoadPkcs12(pkcs12, password))
+                using (X509Certificate2 reLoaded = X509CertificateLoader.LoadPkcs12(pkcs12, password, X509KeyStorageFlags.Exportable))
                 using (SlhDsa slhDsa = reLoaded.GetSlhDsaPrivateKey())
                 {
                     Assert.NotNull(slhDsa);

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
@@ -3,12 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Security.Cryptography.SLHDsa.Tests;
 using System.Security.Cryptography.Tests;
-using System.Text;
-using Microsoft.DotNet.RemoteExecutor;
-using Microsoft.DotNet.XUnitExtensions;
 using Test.Cryptography;
 using Xunit;
 
@@ -394,7 +390,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLKemTestData.IetfMlKem512PrivateKeySeedPfx;
             string pfxPassword = MLKemTestData.EncryptedPrivateKeyPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLKem kem = cert.GetMLKemPrivateKey())
             {
                 Assert.NotNull(kem);
@@ -411,7 +407,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLKemTestData.IetfMlKem512PrivateKeyExpandedKeyPfx;
             string pfxPassword = MLKemTestData.EncryptedPrivateKeyPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLKem kem = cert.GetMLKemPrivateKey())
             {
                 Assert.NotNull(kem);
@@ -431,7 +427,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLKemTestData.IetfMlKem512PrivateKeyBothPfx;
             string pfxPassword = MLKemTestData.EncryptedPrivateKeyPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLKem kem = cert.GetMLKemPrivateKey())
             {
                 Assert.NotNull(kem);
@@ -451,7 +447,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLKemTestData.IetfMlKem768PrivateKeySeedPfx;
             string pfxPassword = MLKemTestData.EncryptedPrivateKeyPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLKem kem = cert.GetMLKemPrivateKey())
             {
                 Assert.NotNull(kem);
@@ -468,7 +464,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLKemTestData.IetfMlKem768PrivateKeyExpandedKeyPfx;
             string pfxPassword = MLKemTestData.EncryptedPrivateKeyPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLKem kem = cert.GetMLKemPrivateKey())
             {
                 Assert.NotNull(kem);
@@ -488,7 +484,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLKemTestData.IetfMlKem768PrivateKeyBothPfx;
             string pfxPassword = MLKemTestData.EncryptedPrivateKeyPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLKem kem = cert.GetMLKemPrivateKey())
             {
                 Assert.NotNull(kem);
@@ -508,7 +504,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLKemTestData.IetfMlKem1024PrivateKeySeedPfx;
             string pfxPassword = MLKemTestData.EncryptedPrivateKeyPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLKem kem = cert.GetMLKemPrivateKey())
             {
                 Assert.NotNull(kem);
@@ -525,7 +521,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLKemTestData.IetfMlKem1024PrivateKeyExpandedKeyPfx;
             string pfxPassword = MLKemTestData.EncryptedPrivateKeyPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLKem kem = cert.GetMLKemPrivateKey())
             {
                 Assert.NotNull(kem);
@@ -545,7 +541,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLKemTestData.IetfMlKem1024PrivateKeyBothPfx;
             string pfxPassword = MLKemTestData.EncryptedPrivateKeyPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLKem kem = cert.GetMLKemPrivateKey())
             {
                 Assert.NotNull(kem);
@@ -641,7 +637,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // didn't actually load.
             if (PlatformDetection.IsWindows && keyStorageFlags != X509KeyStorageFlags.EphemeralKeySet)
             {
-                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags))
+                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
                 {
                     Assert.Throws<CryptographicException>(
                         () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, PfxPassword));
@@ -656,7 +652,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             else
             {
                 Assert.Throws<CryptographicException>(
-                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags));
+                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable));
 
                 Assert.Throws<CryptographicException>(
                     () => new X509Certificate2(pfxBytes, PfxPassword, keyStorageFlags));
@@ -670,15 +666,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             from ietfVector in ietfVectorWrapped
             select new object[] { storageFlag, ietfVector };
 
-        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsDraft10Pkcs8))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/116463", TestPlatforms.Windows)]
+        [ConditionalTheory(typeof(MLDsa), nameof(MLDsa.IsSupported))]
         [MemberData(nameof(ReadMLDsa_Pfx_Ietf_Data))]
         public static void ReadMLDsa512PrivateKey_Seed_Pfx(X509KeyStorageFlags keyStorageFlags, MLDsaKeyInfo info)
         {
             byte[] pfxBytes = info.Pfx_Seed;
             string pfxPassword = info.EncryptionPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLDsa mldsa = cert.GetMLDsaPrivateKey())
             {
                 Assert.NotNull(mldsa);
@@ -690,15 +685,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsDraft10Pkcs8))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/116463", TestPlatforms.Windows)]
+        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsExportingPrivateKeyPkcs8))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118609", TestPlatforms.Windows)]
         [MemberData(nameof(ReadMLDsa_Pfx_Ietf_Data))]
         public static void ReadMLDsa512PrivateKey_ExpandedKey_Pfx(X509KeyStorageFlags keyStorageFlags, MLDsaKeyInfo info)
         {
             byte[] pfxBytes = info.Pfx_Expanded;
             string pfxPassword = info.EncryptionPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLDsa mldsa = cert.GetMLDsaPrivateKey())
             {
                 Assert.NotNull(mldsa);
@@ -711,15 +706,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalTheory(typeof(MLDsaTestHelpers), nameof(MLDsaTestHelpers.SupportsDraft10Pkcs8))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/116463", TestPlatforms.Windows)]
+        [ConditionalTheory(typeof(MLDsa), nameof(MLDsa.IsSupported))]
         [MemberData(nameof(ReadMLDsa_Pfx_Ietf_Data))]
         public static void ReadMLDsa512PrivateKey_Both_Pfx(X509KeyStorageFlags keyStorageFlags, MLDsaKeyInfo info)
         {
             byte[] pfxBytes = info.Pfx_Both;
             string pfxPassword = info.EncryptionPassword;
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (MLDsa mldsa = cert.GetMLDsaPrivateKey())
             {
                 Assert.NotNull(mldsa);
@@ -746,7 +740,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // didn't actually load.
             if (PlatformDetection.IsWindows && keyStorageFlags != X509KeyStorageFlags.EphemeralKeySet)
             {
-                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
                 {
                     Assert.Throws<CryptographicException>(
                         () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, pfxPassword));
@@ -761,7 +755,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             else
             {
                 Assert.Throws<CryptographicException>(
-                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags));
+                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable));
 
                 Assert.Throws<CryptographicException>(
                     () => new X509Certificate2(pfxBytes, pfxPassword, keyStorageFlags));
@@ -775,7 +769,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = SlhDsaTestData.IetfSlhDsaSha2_128sCertificatePfx;
             string pfxPassword = "PLACEHOLDER";
 
-            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+            using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
             using (SlhDsa slhDsa = cert.GetSlhDsaPrivateKey())
             {
                 Assert.NotNull(slhDsa);
@@ -798,7 +792,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // didn't actually load.
             if (PlatformDetection.IsWindows && keyStorageFlags != X509KeyStorageFlags.EphemeralKeySet)
             {
-                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
+                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
                 {
                     Assert.Throws<CryptographicException>(
                         () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, pfxPassword));
@@ -813,7 +807,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             else
             {
                 Assert.Throws<CryptographicException>(
-                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags));
+                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable));
 
                 Assert.Throws<CryptographicException>(
                     () => new X509Certificate2(pfxBytes, pfxPassword, keyStorageFlags));

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
@@ -637,7 +637,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // didn't actually load.
             if (PlatformDetection.IsWindows && keyStorageFlags != X509KeyStorageFlags.EphemeralKeySet)
             {
-                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
+                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags))
                 {
                     Assert.Throws<CryptographicException>(
                         () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, PfxPassword));
@@ -652,7 +652,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             else
             {
                 Assert.Throws<CryptographicException>(
-                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable));
+                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags));
 
                 Assert.Throws<CryptographicException>(
                     () => new X509Certificate2(pfxBytes, PfxPassword, keyStorageFlags));
@@ -753,7 +753,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // didn't actually load.
             if (PlatformDetection.IsWindows && keyStorageFlags != X509KeyStorageFlags.EphemeralKeySet)
             {
-                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
+                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
                 {
                     Assert.Throws<CryptographicException>(
                         () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, pfxPassword));
@@ -768,7 +768,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             else
             {
                 Assert.Throws<CryptographicException>(
-                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable));
+                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags));
 
                 Assert.Throws<CryptographicException>(
                     () => new X509Certificate2(pfxBytes, pfxPassword, keyStorageFlags));
@@ -812,7 +812,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             // didn't actually load.
             if (PlatformDetection.IsWindows && keyStorageFlags != X509KeyStorageFlags.EphemeralKeySet)
             {
-                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable))
+                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
                 {
                     Assert.Throws<CryptographicException>(
                         () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, pfxPassword));
@@ -827,7 +827,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             else
             {
                 Assert.Throws<CryptographicException>(
-                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags | X509KeyStorageFlags.Exportable));
+                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags));
 
                 Assert.Throws<CryptographicException>(
                     () => new X509Certificate2(pfxBytes, pfxPassword, keyStorageFlags));


### PR DESCRIPTION
Windows 11 Insider Canary Channel build 27919 fixes #116463 and #116461 and introduces #118609.