### PR TITLE
Set of interpreter related fixes for coreclr tests

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1140,19 +1140,39 @@ void InterpCompiler::BuildEHInfo()
 
     INTERP_DUMP("EH info:\n");
 
-    if (m_methodInfo->EHcount == 0)
+    unsigned int nativeEHCount = 0;
+    for (unsigned int i = 0; i < m_methodInfo->EHcount; i++)
+    {
+        CORINFO_EH_CLAUSE clause;
+
+        m_compHnd->getEHinfo(m_methodInfo->ftn, i, &clause);
+        if (m_ppOffsetToBB[clause.TryOffset] != NULL)
+        {
+            nativeEHCount++;
+        }
+    }
+
+    if (nativeEHCount == 0)
     {
         INTERP_DUMP("  None\n");
         return;
     }
 
-    m_compHnd->setEHcount(m_methodInfo->EHcount);
+    m_compHnd->setEHcount(nativeEHCount);
+
+    unsigned int nativeEHIndex = 0;
     for (unsigned int i = 0; i < m_methodInfo->EHcount; i++)
     {
         CORINFO_EH_CLAUSE clause;
         CORINFO_EH_CLAUSE nativeClause;
 
         m_compHnd->getEHinfo(m_methodInfo->ftn, i, &clause);
+
+        if (m_ppOffsetToBB[clause.TryOffset] == NULL)
+        {
+            INTERP_DUMP("  Unreachable try region at IL offset %x\n", clause.TryOffset);
+            continue;
+        }
 
         int32_t tryStartNativeOffset;
         int32_t tryEndNativeOffset;
@@ -1188,7 +1208,7 @@ void InterpCompiler::BuildEHInfo()
             nativeClause.Flags = (CORINFO_EH_CLAUSE_FLAGS)((int)nativeClause.Flags | COR_ILEXCEPTION_CLAUSE_SAMETRY);
         }
 
-        m_compHnd->setEHinfo(i, &nativeClause);
+        m_compHnd->setEHinfo(nativeEHIndex++, &nativeClause);
 
         INTERP_DUMP("  try [IR_%04x(%x), IR_%04x(%x)) ", tryStartNativeOffset, clause.TryOffset, tryEndNativeOffset, clause.TryOffset + clause.TryLength);
         if (clause.Flags == CORINFO_EH_CLAUSE_FILTER)
@@ -3355,7 +3375,7 @@ void InterpCompiler::EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORI
         }
         default:
             // TODO
-            assert(0);
+            assert(!"Unsupported (yet) static field accessor");
             break;
     }
 
@@ -5476,6 +5496,10 @@ DO_LDFTN:
             {
                 int32_t ilOffset = (int32_t)(m_ip - m_pILCode);
                 int32_t target = (opcode == CEE_LEAVE) ? ilOffset + 5 + *(int32_t*)(m_ip + 1) : (ilOffset + 2 + (int8_t)m_ip[1]);
+                if (target < 0 || target >= m_ILCodeSize)
+                {
+                    BADCODE("Invalid leave target");
+                }
                 InterpBasicBlock *pTargetBB = m_ppOffsetToBB[target];
 
                 m_pStackPointer = m_pStackBase;

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -48,6 +48,7 @@
 #endif // FEATURE_COMINTEROP
 
 #include "eventtrace.h"
+#include "interpexec.h"
 
 namespace
 {
@@ -5643,6 +5644,15 @@ PCODE JitILStub(MethodDesc* pStubMD)
             //
 
             pCode = pStubMD->PrepareInitialCode();
+#ifdef FEATURE_INTERPRETER
+            // Interpreter-TODO: Figure out how to create the call stub for the IL stub only when it is
+            // needed, like we do for the regular methods.
+            InterpByteCodeStart *pInterpreterCode = pStubMD->GetInterpreterCode();
+            if (pInterpreterCode != NULL)
+            {
+                CreateNativeToInterpreterCallStub(pInterpreterCode->Method);
+            }
+#endif // FEATURE_INTERPRETER
 
             _ASSERTE(pCode == pStubMD->GetNativeCode());
         }

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -5646,7 +5646,7 @@ PCODE JitILStub(MethodDesc* pStubMD)
             //
 
             pCode = pStubMD->PrepareInitialCode();
-#ifdef FEATURE_INTERPRETER
+#if defined(FEATURE_INTERPRETER) && defined(FEATURE_JIT)
             // Interpreter-TODO: Figure out how to create the call stub for the IL stub only when it is
             // needed, like we do for the regular methods.
             InterpByteCodeStart *pInterpreterCode = pStubMD->GetInterpreterCode();
@@ -5654,7 +5654,7 @@ PCODE JitILStub(MethodDesc* pStubMD)
             {
                 CreateNativeToInterpreterCallStub(pInterpreterCode->Method);
             }
-#endif // FEATURE_INTERPRETER
+#endif // FEATURE_INTERPRETER && FEATURE_JIT
 
             _ASSERTE(pCode == pStubMD->GetNativeCode());
         }

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -48,7 +48,9 @@
 #endif // FEATURE_COMINTEROP
 
 #include "eventtrace.h"
+#ifdef FEATURE_INTERPRETER
 #include "interpexec.h"
+#endif // FEATURE_INTERPRETER
 
 namespace
 {

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1916,7 +1916,7 @@ void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 {
     SyncRegDisplayToCurrentContext(pRD);
     TransitionFrame::UpdateRegDisplay_Impl(pRD, updateFloats);
-#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
     // Update the SSP to match the updated regdisplay
     size_t *targetSSP = (size_t *)GetInterpExecMethodSSP();
     if (targetSSP != NULL)
@@ -1927,7 +1927,7 @@ void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
         _ASSERTE(targetSSP != NULL);
         pRD->SSP = (TADDR)targetSSP;
     }
-#endif // HOST_AMD64 && HOST_WINDOWS
+#endif // TARGET_AMD64 && TARGET_WINDOWS
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1916,7 +1916,7 @@ void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 {
     SyncRegDisplayToCurrentContext(pRD);
     TransitionFrame::UpdateRegDisplay_Impl(pRD, updateFloats);
-
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
     // Update the SSP to match the updated regdisplay
     size_t *targetSSP = (size_t *)GetInterpExecMethodSSP();
     if (targetSSP != NULL)
@@ -1927,6 +1927,7 @@ void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
         _ASSERTE(targetSSP != NULL);
         pRD->SSP = (TADDR)targetSSP;
     }
+#endif // HOST_AMD64 && HOST_WINDOWS
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1916,6 +1916,17 @@ void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 {
     SyncRegDisplayToCurrentContext(pRD);
     TransitionFrame::UpdateRegDisplay_Impl(pRD, updateFloats);
+
+    // Update the SSP to match the updated regdisplay
+    size_t *targetSSP = (size_t *)GetInterpExecMethodSSP();
+    if (targetSSP != NULL)
+    {
+        while (*targetSSP++ != pRD->ControlPC)
+        {
+        }
+        _ASSERTE(targetSSP != NULL);
+        pRD->SSP = (TADDR)targetSSP;
+    }
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -458,6 +458,44 @@ void* DoGenericLookup(void* genericVarAsPtr, InterpGenericLookup* pLookup)
     return result;
 }
 
+// Filter to ignore SEH exceptions representing C++ exceptions.
+LONG IgnoreCppExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo, PVOID pv)
+{
+    return (pExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_MSVC)
+        ? EXCEPTION_CONTINUE_SEARCH
+        : EXCEPTION_EXECUTE_HANDLER;
+}
+
+// Wrapper around MethodDesc::PrepareInitialCode to handle possible managed exceptions thrown by it.
+void PrepareInitialCode(MethodDesc *pMD)
+{
+    STANDARD_VM_CONTRACT;
+
+    struct Param
+    {
+        MethodDesc *pMethodDesc;
+    }
+    param = { pMD };
+
+    PAL_TRY(Param *, pParam, &param)
+    {
+        pParam->pMethodDesc->PrepareInitialCode(CallerGCMode::Coop);
+    }
+    PAL_EXCEPT_FILTER(IgnoreCppExceptionFilter)
+    {
+        // There can be both C++ (thrown by the COMPlusThrow) and managed exceptions thrown
+        // from the PrepareInitialCode call chain.
+        // We need to process only managed ones here, the C++ ones are handled by the
+        // INSTALL_/UNINSTALL_UNWIND_AND_CONTINUE_HANDLER in the InterpExecMethod.
+        // The managed ones are represented by SEH exception, which cannot be handled there
+        // because it is not possible to handle both SEH and C++ exceptions in the same frame.
+        GCX_COOP_NO_DTOR();
+        OBJECTREF ohThrowable = GET_THREAD()->LastThrownObject();
+        DispatchManagedException(ohThrowable);
+    }
+    PAL_ENDTRY
+}
+
 void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFrame *pFrame, InterpThreadContext *pThreadContext, ExceptionClauseArgs *pExceptionClauseArgs)
 {
     CONTRACTL
@@ -1886,6 +1924,9 @@ MAIN_LOOP:
                     CallStubHeader *pCallStub = (CallStubHeader*)pMethod->pDataItems[calliCookie];
                     ip += 5;
 
+                    // Save current execution state for when we return from called method
+                    pFrame->ip = ip;
+
                     InvokeCalliStub(LOCAL_VAR(calliFunctionPointerVar, PCODE), pCallStub, stack + callArgsOffset, stack + returnOffset);
                     break;
                 }
@@ -1906,6 +1947,9 @@ MAIN_LOOP:
                     PCODE callTarget = (flags & (int32_t)PInvokeCallFlags::Indirect)
                         ? *(PCODE *)pMethod->pDataItems[targetAddrSlot]
                         : (PCODE)pMethod->pDataItems[targetAddrSlot];
+
+                    // Save current execution state for when we return from called method
+                    pFrame->ip = ip;
 
                     InlinedCallFrame inlinedCallFrame;
                     inlinedCallFrame.m_pCallerReturnAddress = (TADDR)ip;
@@ -1942,6 +1986,9 @@ MAIN_LOOP:
                     OBJECTREF targetMethodObj = delegateObj->GetTarget();
                     LOCAL_VAR(callArgsOffset, OBJECTREF) = targetMethodObj;
 
+                    // Save current execution state for when we return from called method
+                    pFrame->ip = ip;
+
                     // TODO! Once we are investigating performance here, we may want to optimize this so that
                     // delegate calls to interpeted methods don't have to go through the native invoke here, but for
                     // now this should work well.
@@ -1959,6 +2006,9 @@ MAIN_LOOP:
 CALL_INTERP_SLOT:
                     targetMethod = (MethodDesc*)pMethod->pDataItems[methodSlot];
 CALL_INTERP_METHOD:
+                    // Save current execution state for when we return from called method
+                    pFrame->ip = ip;
+
                     InterpByteCodeStart* targetIp = targetMethod->GetInterpreterCode();
                     if (targetIp == NULL)
                     {
@@ -1975,7 +2025,7 @@ CALL_INTERP_METHOD:
                             // Attempt to setup the interpreter code for the target method.
                             if ((targetMethod->IsIL() || targetMethod->IsNoMetadata()) && !targetMethod->IsUnboxingStub())
                             {
-                                targetMethod->PrepareInitialCode(CallerGCMode::Coop);
+                                PrepareInitialCode(targetMethod);
                             }
                             targetIp = targetMethod->GetInterpreterCode();
                         }
@@ -1986,9 +2036,6 @@ CALL_INTERP_METHOD:
                             break;
                         }
                     }
-
-                    // Save current execution state for when we return from called method
-                    pFrame->ip = ip;
 
                     // Allocate child frame.
                     {
@@ -2587,7 +2634,14 @@ do                                                                      \
         // Unwind the interpreter stack upto the resume frame
         while (pFrame != pResumeFrame)
         {
-            assert(pFrame != NULL);
+            if (pFrame == NULL)
+            {
+                // In scenarios when the interpreted code ends up calling other interpreted code through the precode, there are two separate
+                // sequences of interpreted frames without any AOTed/JITted frames in between. In such case, the topmost native frame
+                // the ResumeAfterCatchException is thrown from may not be the one that corresponds to the target interpreted frame.
+                // Thus, we need to rethrow it to let it propagate further.
+                throw;
+            }
             pThreadContext->frameDataAllocator.PopInfo(pFrame);
             pFrame->ip = 0;
             pFrame = pFrame->pParent;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -469,7 +469,7 @@ LONG IgnoreCppExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo, PVOID pv)
 // Wrapper around MethodDesc::PrepareInitialCode to handle possible managed exceptions thrown by it.
 void PrepareInitialCode(MethodDesc *pMD)
 {
-    STANDARD_VM_CONTRACT;
+    STATIC_STANDARD_VM_CONTRACT;
 
     struct Param
     {


### PR DESCRIPTION
The changes in this PR were made to fix various issues uncovered by the coreclr tests.
* Handle case when a try block is eliminated because it can never be executed.
* Ensure call stubs are generated for IL stubs.
* Fix shadow stack updating during stack walk
* Fix handling managed exceptions thrown as SEH from managed code called by JIT / Interpreter compiler in interpreted code.
* Fix resuming after catch in interpreted code for cases when interpreted code calls another interpreted code via a prestub, which currently happens for delegates.
* Ensure that ip is saved to the pFrame->ip before calling native methods that can throw to make sure that the stack walk reports correct return IP.