### PR TITLE
Put different arches in different yml for NativeAOT Android pipelines

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -126,7 +126,6 @@ jobs:
     buildConfig: Release
     runtimeFlavor: coreclr
     platforms:
-    - android_x64
     - android_arm64
     variables:
       # map dependencies variables to local variables

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -164,7 +164,6 @@ jobs:
     isAndroidEmulatorOnlyBuild: ${{ parameters.isAndroidEmulatorOnlyBuild }}
     platforms:
     - android_x64
-    - android_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange


### PR DESCRIPTION
Should fix https://github.com/dotnet/runtime/issues/118621

runtime-extra-platforms pulls in both runtime-android and runtime-androidemulator. NativeAOT has runs for the same arches in both of those, creating duplicates. This follows the CoreCLR pattern and runs one arch in runtime-android and one in tuneim-androidemulator.