### PR TITLE
Make DynamicGenerics test run faster

### DIFF
--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/Github118072.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/Github118072.cs
@@ -21,26 +21,22 @@ class GitHub118072
     [TestMethod]
     public static void RunTest()
     {
-        Type current = typeof(object);
-
         GetMI1().MakeGenericMethod(typeof(object)).Invoke(null, []);
-        current = FillCache(current);
+        FlushCache();
         GetMI2().MakeGenericMethod(typeof(object)).Invoke(null, []);
-        current = FillCache(current);
+        FlushCache();
         GetMI3().MakeGenericMethod(typeof(object)).Invoke(null, []);
-        current = FillCache(current);
+        FlushCache();
         GetMI4().MakeGenericMethod(typeof(object)).Invoke(null, []);
 
-        static Type FillCache(Type current)
+        static void FlushCache()
         {
-            for (int i = 0; i < 400; i++)
+            // Make sure the cached type loader contexts are flushed
+            for (int j = 0; j < 10; j++)
             {
-                Type next = typeof(MyClass<>).MakeGenericType(current);
-                Activator.CreateInstance(next);
-                current = next;
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
             }
-
-            return current;
         }
     }
 


### PR DESCRIPTION
This is a recently added test and the 40 second run time of it got old pretty fast. Turns out we already have a test that hopes to flush the type system context that does this differently:

https://github.com/dotnet/runtime/blob/ce10f6f9586177c15c4df76093abbea81decf042/src/tests/nativeaot/SmokeTests/DynamicGenerics/dictionaries.cs#L1516-L1521

Use the same approach here.

Cc @dotnet/ilc-contrib 