### PR TITLE
Flip logic for enabling VXSort in the GC

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -71,8 +71,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <EventPipeName Condition="'$(EventSourceSupport)' == 'true'">libeventpipe-enabled</EventPipeName>
 
       <LinkStandardCPlusPlusLibrary Condition="'$(LinkStandardCPlusPlusLibrary)' == '' and '$(_IsiOSLikePlatform)' == 'true' and '$(InvariantGlobalization)' != 'true'">true</LinkStandardCPlusPlusLibrary>
-      <VxSortSupportName>libRuntime.VxsortEnabled</VxSortSupportName>
-      <VxSortSupportName Condition="'$(OptimizationPreference)' == 'Size' or '$(IlcDisableVxsort)' == 'true'">libRuntime.VxsortDisabled</VxSortSupportName>
+      <VxSortSupportName>libRuntime.VxsortDisabled</VxSortSupportName>
+      <VxSortSupportName Condition="'$(OptimizationPreference)' == 'Speed' or '$(IlcEnableVxsort)' == 'true'">libRuntime.VxsortEnabled</VxSortSupportName>
       <StandaloneGCSupportName>libstandalonegc-disabled</StandaloneGCSupportName>
       <StandaloneGCSupportName Condition="'$(IlcStandaloneGCSupport)' == 'true'">libstandalonegc-enabled</StandaloneGCSupportName>
     </PropertyGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -22,8 +22,8 @@ The .NET Foundation licenses this file to you under the MIT license.
     <FullRuntimeName Condition="'$(ServerGarbageCollection)' == 'true' or '$(IlcLinkServerGC)' == 'true'">Runtime.ServerGC</FullRuntimeName>
     <BootstrapperName>bootstrapper</BootstrapperName>
     <BootstrapperName Condition="'$(NativeLib)' != '' or '$(CustomNativeMain)' == 'true'">bootstrapperdll</BootstrapperName>
-    <VxSortSupportName>Runtime.VxsortEnabled</VxSortSupportName>
-    <VxSortSupportName Condition="'$(OptimizationPreference)' == 'Size' or '$(IlcDisableVxsort)' == 'true'">Runtime.VxsortDisabled</VxSortSupportName>
+    <VxSortSupportName>Runtime.VxsortDisabled</VxSortSupportName>
+    <VxSortSupportName Condition="'$(OptimizationPreference)' == 'Speed' or '$(IlcEnableVxsort)' == 'true'">Runtime.VxsortEnabled</VxSortSupportName>
     <StandaloneGCSupportName>standalonegc-disabled</StandaloneGCSupportName>
     <StandaloneGCSupportName Condition="'$(IlcStandaloneGCSupport)' == 'true'">standalonegc-enabled</StandaloneGCSupportName>
     <EntryPointSymbol Condition="'$(EntryPointSymbol)' == ''">wmainCRTStartup</EntryPointSymbol>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
@@ -21,8 +21,8 @@ unsafe class Program
         Console.WriteLine("****************************************************");
 
         long lowerBound, upperBound;
-        lowerBound = 1200 * 1024; // ~1.2 MB
-        upperBound = 1600 * 1024; // ~1.6 MB
+        lowerBound = 1100 * 1024; // ~1.1 MB
+        upperBound = 1500 * 1024; // ~1.5 MB
 
         if (fileSize < lowerBound || fileSize > upperBound)
         {


### PR DESCRIPTION
For native AOT we [document](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/optimizing) three build modes: a blended default, optimized for size, and optimized for speed.

Typically, optimize for speed is needed to get as closed as possible to CoreCLR-JIT performance (e.g. optimize for speed is the only mode that enables Tier-1 inliner in the JIT). The blended default gets close, but this gives an extra percent or two in throughput at the cost of more size.

The VXSort code and table costs 115,712 bytes.

We currently compile with VXSort enabled in blended mode and when we optimize for speed. We link out VXSort when optimizing for size. Maybe this is not something that should be part of the blended default.

* When you do `dotnet new console --aot` and `dotnet publish` the hello world, 11% of the output binary is VXSort (!)
* Even in more significant apps (e.g. a simple Kestrel host), VxSort is still a single-digit percentage of the app.
* I was not able to measure improvement with VxSort on real world apps that I tried (native AOT compiled ILC, benchmarks we use in ASP.NET labs). I'm sure there's apps in hyperscale environments that benefit, but maybe those would choose Speed optimized without even trying anything else.

I'm leaning towards disabling this on blended builds.

Our default guidance if someone is not happy with native AOT TP is to switch to Speed optimized builds, so if there's a problem because of this being off, our default guidance would resolve this right away without even having to profile and root cause the problem to sorting. I think using VxSort in the Speed optimization mode only is the right default.

Cc @dotnet/ilc-contrib @dotnet/gc 