### PR TITLE
[browser] Generate source maps as hidden in Release configuration

### DIFF
--- a/src/mono/browser/runtime/rollup.config.js
+++ b/src/mono/browser/runtime/rollup.config.js
@@ -173,7 +173,7 @@ const loaderConfig = {
             banner,
             intro: "/*! bundlerFriendlyImports */",
             plugins,
-            sourcemap: true,
+            sourcemap: isDebug ? true : "hidden",
             sourcemapPathTransform,
         }
     ],


### PR DESCRIPTION
Follow the pattern from Blazor https://github.com/dotnet/aspnetcore/pull/62558.

Although having the link in the JavaScript files don't cause any requests and so failures until the DevTools are opened, producing such errors/warnings into the console of user applications might cause confusion.

Fixes https://github.com/dotnet/runtime/issues/98288