### PR TITLE
[browser] Override boot config only when the content changes

### DIFF
--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Sdk.WebAssembly;
 

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Sdk.WebAssembly;
+
+public static class ArtifactWriter
+{
+    public static bool PersistFileIfChanged<T>(this Task task, T manifest, string artifactPath, JsonTypeInfo<T> serializer)
+    {
+        var data = JsonSerializer.SerializeToUtf8Bytes(manifest, serializer);
+        return PersistFileIfChanged(task, data, artifactPath);
+    }
+
+    public static bool PersistFileIfChanged(this Task task, byte[] data, string artifactPath)
+    {
+        var newHash = ComputeHash(data);
+        var fileExists = File.Exists(artifactPath);
+        var existingManifestHash = fileExists ? ComputeHash(artifactPath) : null;
+
+        if (!fileExists)
+        {
+            task.Log.LogMessage(MessageImportance.Low, $"Creating artifact because artifact file '{artifactPath}' does not exist.");
+            File.WriteAllBytes(artifactPath, data);
+            return true;
+        }
+        else if (!string.Equals(newHash, existingManifestHash, StringComparison.Ordinal))
+        {
+            task.Log.LogMessage(MessageImportance.Low, $"Updating artifact because artifact version '{newHash}' is different from existing artifact hash '{existingManifestHash}'.");
+            File.WriteAllBytes(artifactPath, data);
+            return true;
+        }
+        else
+        {
+            task.Log.LogMessage(MessageImportance.Low, $"Skipping artifact updated because artifact version '{existingManifestHash}' has not changed.");
+            return false;
+        }
+    }
+
+    private static string ComputeHash(string artifactPath) => ComputeHash(File.ReadAllBytes(artifactPath));
+
+    private static string ComputeHash(byte[] data)
+    {
+#if NET6_0_OR_GREATER
+        var hash = SHA256.HashData(data);
+        return Convert.ToBase64String(hash);
+#else
+        using var sha256 = SHA256.Create();
+        return Convert.ToBase64String(sha256.ComputeHash(data));
+#endif
+    }
+}

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
@@ -13,13 +13,13 @@ namespace Microsoft.NET.Sdk.WebAssembly;
 
 public static class ArtifactWriter
 {
-    public static bool PersistFileIfChanged<T>(this Task task, T manifest, string artifactPath, JsonTypeInfo<T> serializer)
+    public static bool PersistFileIfChanged<T>(TaskLoggingHelper log, T manifest, string artifactPath, JsonTypeInfo<T> serializer)
     {
         var data = JsonSerializer.SerializeToUtf8Bytes(manifest, serializer);
-        return PersistFileIfChanged(task, data, artifactPath);
+        return PersistFileIfChanged(log, data, artifactPath);
     }
 
-    public static bool PersistFileIfChanged(this Task task, byte[] data, string artifactPath)
+    public static bool PersistFileIfChanged(TaskLoggingHelper log, byte[] data, string artifactPath)
     {
         var newHash = ComputeHash(data);
         var fileExists = File.Exists(artifactPath);
@@ -27,19 +27,19 @@ public static class ArtifactWriter
 
         if (!fileExists)
         {
-            task.Log.LogMessage(MessageImportance.Low, $"Creating artifact because artifact file '{artifactPath}' does not exist.");
+            log.LogMessage(MessageImportance.Low, $"Creating artifact because artifact file '{artifactPath}' does not exist.");
             File.WriteAllBytes(artifactPath, data);
             return true;
         }
         else if (!string.Equals(newHash, existingManifestHash, StringComparison.Ordinal))
         {
-            task.Log.LogMessage(MessageImportance.Low, $"Updating artifact because artifact version '{newHash}' is different from existing artifact hash '{existingManifestHash}'.");
+            log.LogMessage(MessageImportance.Low, $"Updating artifact because artifact version '{newHash}' is different from existing artifact hash '{existingManifestHash}'.");
             File.WriteAllBytes(artifactPath, data);
             return true;
         }
         else
         {
-            task.Log.LogMessage(MessageImportance.Low, $"Skipping artifact updated because artifact version '{existingManifestHash}' has not changed.");
+            log.LogMessage(MessageImportance.Low, $"Skipping artifact updated because artifact version '{existingManifestHash}' has not changed.");
             return false;
         }
     }

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
@@ -87,7 +87,7 @@ namespace Microsoft.NET.Sdk.WebAssembly
                 output = $"export const config = /*json-start*/{output}/*json-end*/;";
             }
 
-            ArtifactWriter.PersistFileIfChanged(Encoding.UTF8.GetBytes(output), outputPath);
+            ArtifactWriter.PersistFileIfChanged(Log, Encoding.UTF8.GetBytes(output), outputPath);
         }
 
         private string ReplaceWithAssert(Regex regex, string content, string replacement, string errorMessage)

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
@@ -87,7 +87,7 @@ namespace Microsoft.NET.Sdk.WebAssembly
                 output = $"export const config = /*json-start*/{output}/*json-end*/;";
             }
 
-            File.WriteAllText(outputPath, output);
+            ArtifactWriter.PersistFileIfChanged(Encoding.UTF8.GetBytes(output), outputPath);
         }
 
         private string ReplaceWithAssert(Regex regex, string content, string replacement, string errorMessage)

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.csproj
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.csproj
@@ -21,6 +21,7 @@
     <Compile Include="..\Common\LogAsErrorException.cs" />
     <Compile Include="..\Common\TempFileName.cs" />
     <Compile Include="..\Common\JoinedString.cs" />
+    <Compile Include="..\Microsoft.NET.Sdk.WebAssembly.Pack.Tasks\ArtifactWriter.cs" />
     <Compile Include="..\Microsoft.NET.Sdk.WebAssembly.Pack.Tasks\BootJsonData.cs" />
     <Compile Include="..\Microsoft.NET.Sdk.WebAssembly.Pack.Tasks\BootJsonBuilderHelper.cs" />
   </ItemGroup>


### PR DESCRIPTION
- Include [ArtifactWriter](https://github.com/dotnet/sdk/blob/main/src/StaticWebAssetsSdk/Tasks/Utils/ArtifactWriter.cs) in Wasm SDK tasks.
- Use it when generating boot config to skip file write if the file is the same

```
PS samples WasmBuildBootIncremental> dotnet build .\BlazorWasm\ -bl -question
Restore complete (0.4s)
    info NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  BlazorWasm succeeded (1.3s) → BlazorWasm\bin\Debug\net10.0\wwwroot

Build succeeded in 2.2s
```

Fixes https://github.com/dotnet/aspnetcore/issues/63207