### PR TITLE
JIT: slightly increase the inline budget

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -11253,7 +11253,7 @@ public:
 
 #define DEFAULT_MAX_INLINE_DEPTH 20 // Methods at more than this level deep will not be inlined
 
-#define DEFAULT_INLINE_BUDGET 20 // Maximum estimated compile time increase via inlining
+#define DEFAULT_INLINE_BUDGET 22 // Maximum estimated compile time increase via inlining
 
 #define DEFAULT_MAX_FORCE_INLINE_DEPTH 1 // Methods at more than this level deep will not be force inlined
 


### PR DESCRIPTION
The inline budget is set by the root method being compiled. If we inline a large method into a small one, we sometimes run out of budget trying to inline the large method's callees.

Increase the budget from 20 to 22 to give us a bit more breathing room.

Fixes some regressions from #114996 / #116054