### PR TITLE
Fix unloadability crash

### DIFF
--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -522,8 +522,6 @@ void LoaderAllocator::GCLoaderAllocators(LoaderAllocator* pOriginalLoaderAllocat
     // removed them from the assembly list
     pFirstDestroyedLoaderAllocator = GCLoaderAllocators_RemoveAssemblies(pAppDomain);
 
-    bool isOriginalLoaderAllocatorFound = false;
-
     // Iterate through free list, firing ETW events and notifying the debugger
     LoaderAllocator * pDomainLoaderAllocatorDestroyIterator = pFirstDestroyedLoaderAllocator;
     while (pDomainLoaderAllocatorDestroyIterator != NULL)

--- a/src/tests/Regressions/coreclr/GitHub_116953/AssemblyA.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116953/AssemblyA.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ClassA.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_116953/AssemblyB.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116953/AssemblyB.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ClassB.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="AssemblyA.csproj" />
+    <ProjectReference Include="AssemblyC.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_116953/AssemblyC.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116953/AssemblyC.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ClassC.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_116953/ClassA.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116953/ClassA.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace AssemblyA;
+
+public class ClassA
+{
+}

--- a/src/tests/Regressions/coreclr/GitHub_116953/ClassB.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116953/ClassB.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using AssemblyC;
+
+namespace AssemblyB;
+
+public class ClassB
+{
+    public string GetMessage()
+    {
+        var b = new GenericClass<AssemblyA.ClassA>();
+        var c = new ClassC();
+        return $"Hello from Assembly B! -> {c.GetMessage()} -> {b.ToString()}";
+    }
+}
+
+public class GenericClass<T>
+{
+}

--- a/src/tests/Regressions/coreclr/GitHub_116953/ClassC.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116953/ClassC.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace AssemblyC;
+
+public class ClassC
+{
+    public string GetMessage()
+    {
+        return "Hello from Assembly C!";
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_116953/test116953.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116953/test116953.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.IO;
+using System.Threading;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using Xunit;
+
+// ALC For AssemblyB
+public class AssemblyLoadContextB : AssemblyLoadContext
+{
+    public AssemblyLoadContextB(string name, bool isCollectible) : base(name, isCollectible)
+    {
+    }
+
+    protected override Assembly Load(AssemblyName assemblyName)
+    {
+        if (assemblyName.Name == "AssemblyC")
+        {
+            Test116953.Log($"AssemblyB is resolving C");
+            return Test116953.AssemblyC;
+        }
+
+        if (assemblyName.Name == "AssemblyA")
+        {
+            Test116953.Log($"AssemblyB is resolving A");
+            return Test116953.AssemblyA;
+        }
+
+        return null;
+    }
+}
+
+public class Test116953
+{
+    public static Assembly AssemblyA;
+    public static Assembly AssemblyC;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            Log($"Test #{i}");
+            RunOneTest();
+        }
+    }
+
+    private static void RunOneTest()
+    {
+        // Create three collectible ALCs
+        var alcB = new AssemblyLoadContextB("ALC_B", isCollectible: true);
+        var alcC = new AssemblyLoadContext("ALC_C", isCollectible: true);
+        var alcA = new AssemblyLoadContext("ALC_A", isCollectible: true);
+
+        // Track ALCs with weak references
+        WeakReference alcCRef = new WeakReference(alcC, trackResurrection: true);
+        WeakReference alcBRef = new WeakReference(alcB, trackResurrection: true);
+        WeakReference alcARef = new WeakReference(alcA, trackResurrection: true);
+
+        // Load assembly A
+        AssemblyA = LoadAssembly(alcA, "AssemblyA");
+
+        // Load assembly C
+        AssemblyC = LoadAssembly(alcC, "AssemblyC");
+
+        // Load assembly B (depends on assemblies A and C)
+        Assembly assemblyB = LoadAssembly(alcB, "AssemblyB");
+	Log($"AssemblyB: {assemblyB}");
+
+        // Call method in assembly B
+        Log("\nTesting call to method in assembly B:");
+        Type? typeBClass = assemblyB.GetType("AssemblyB.ClassB");
+        if (typeBClass != null)
+        {
+            object bInstance = Activator.CreateInstance(typeBClass)!;
+            string resultB = (string)typeBClass.GetMethod("GetMessage").Invoke(bInstance, null);
+            Log($"B method returns: {resultB}");
+        }
+        else
+        {
+            Log("AssemblyB.ClassB not found!");
+        }
+
+        AssemblyA = null;
+        AssemblyC = null;
+
+        // Unload the three ALCs
+        Log("\nStarting to unload ALCs...");
+
+        alcA.Unload();
+        alcC.Unload();
+        alcB.Unload();
+
+        alcA = null;
+        alcB = null;
+        alcC = null;
+
+        for (int i = 0; i < 100 && (alcARef.IsAlive || alcBRef.IsAlive || alcCRef.IsAlive); i++)
+        {
+            Thread.Sleep(1);
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Log($"ALC_A status: {(alcARef.IsAlive ? "still in memory" : "unloaded")}");
+        Log($"ALC_B status: {(alcBRef.IsAlive ? "still in memory" : "unloaded")}");
+        Log($"ALC_C status: {(alcCRef.IsAlive ? "still in memory" : "unloaded")}");
+
+        Log("Test completed");
+    }
+
+    private static Assembly LoadAssembly(AssemblyLoadContext alc, string assemblyName)
+    {
+        string assemblyDir = Assembly.GetExecutingAssembly().Location;
+        assemblyDir = Path.GetDirectoryName(assemblyDir)!;
+        return alc.LoadFromAssemblyPath(Path.Combine(assemblyDir, $"{assemblyName}.dll"));
+    }
+
+    public static void Log(string message)
+    {
+        Console.WriteLine(message);
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_116953/test116953.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116953/test116953.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test116953.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="AssemblyA.csproj" />
+    <ProjectReference Include="AssemblyB.csproj" />
+    <ProjectReference Include="AssemblyC.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There is a rare case when attempt to unload an assembly load context in multi-assembly load context scenario leads to access violation in the runtime.

The crash is caused by a DomainAssembly pointer in the AppDomain assembly list not being removed while the DomainAssembly was deleted.

There is a detailed analysis in the #116953.

This change fixes it and adds a regression test that is a repro app provided in the issue converted to coreclr test.

Close #116953