### PR TITLE
Change some tests to be conditional on the availability of SCOSSL

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactory.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 #endif
         bool IsCurveValid(Oid oid);
         bool ExplicitCurvesSupported { get; }
-        bool ExplicitCurvesSupportFailOnUseOnly => PlatformDetection.IsAzureLinux;
+        bool ExplicitCurvesSupportFailOnUseOnly => PlatformDetection.IsSymCryptOpenSsl;
         bool CanDeriveNewPublicKey { get; }
         bool SupportsRawDerivation { get; }
         bool SupportsSha3 { get; }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactory.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 #endif
         bool IsCurveValid(Oid oid);
         bool ExplicitCurvesSupported { get; }
-        bool ExplicitCurvesSupportFailOnUseOnly => PlatformDetection.IsAzureLinux;
+        bool ExplicitCurvesSupportFailOnUseOnly => PlatformDetection.IsSymCryptOpenSsl;
     }
 
     public static partial class ECDsaFactory

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
@@ -8,13 +8,13 @@ namespace System.Security.Cryptography.Rsa.Tests
     [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public class KeyGeneration
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAzureLinux))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotSymCryptOpenSsl))]
         public static void GenerateMinKey()
         {
             GenerateKey(rsa => GetMin(rsa.LegalKeySizes));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAzureLinux))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotSymCryptOpenSsl))]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(rsa => GetSecondMin(rsa.LegalKeySizes));

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -56,7 +56,7 @@ namespace System
         public static bool IsOpenSsl3_4 => IsOpenSslVersionAtLeast(s_openssl3_4Version);
         public static bool IsOpenSsl3_5 => IsOpenSslVersionAtLeast(s_openssl3_5Version);
 
-        private static readonly Lazy<bool> s_IsSymCryptOpenSsl = new(() =>
+        private static readonly Lazy<bool> s_isSymCryptOpenSsl = new(() =>
         {
             return IsAzureLinux &&
                 (
@@ -65,7 +65,7 @@ namespace System
                 );
         });
 
-        public static bool IsSymCryptOpenSsl => s_IsSymCryptOpenSsl.Value;
+        public static bool IsSymCryptOpenSsl => s_isSymCryptOpenSsl.Value;
         public static bool IsNotSymCryptOpenSsl => !IsSymCryptOpenSsl;
 
         /// <summary>

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -34,7 +34,6 @@ namespace System
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
         public static bool IsQemuLinux => IsLinux && Environment.GetEnvironmentVariable("DOTNET_RUNNING_UNDER_QEMU") != null;
         public static bool IsNotQemuLinux => !IsQemuLinux;
-        public static bool IsNotAzureLinux => !IsAzureLinux;
 
         // OSX family
         public static bool IsApplePlatform => IsOSX || IsiOS || IstvOS || IsMacCatalyst;
@@ -56,6 +55,18 @@ namespace System
         public static bool IsOpenSsl3 => IsOpenSslVersionAtLeast(s_openssl3Version);
         public static bool IsOpenSsl3_4 => IsOpenSslVersionAtLeast(s_openssl3_4Version);
         public static bool IsOpenSsl3_5 => IsOpenSslVersionAtLeast(s_openssl3_5Version);
+
+        private static readonly Lazy<bool> s_IsSymCryptOpenSsl = new(() =>
+        {
+            return IsAzureLinux &&
+                (
+                    File.Exists("/usr/lib/ossl-modules/symcryptprovider.so") ||
+                    File.Exists("/usr/lib64/ossl-modules/symcryptprovider.so")
+                );
+        });
+
+        public static bool IsSymCryptOpenSsl => s_IsSymCryptOpenSsl.Value;
+        public static bool IsNotSymCryptOpenSsl => !IsSymCryptOpenSsl;
 
         /// <summary>
         /// If gnulibc is available, returns the release, such as "stable".

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslProvider.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslProvider.cs
@@ -46,13 +46,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
             return false;
         }
 
-        public bool ExplicitCurvesSupported
-        {
-            get
-            {
-                return !PlatformDetection.IsAzureLinux;
-            }
-        }
+        public bool ExplicitCurvesSupported => PlatformDetection.IsNotSymCryptOpenSsl;
     }
 
     public partial class ECDsaFactory

--- a/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
@@ -478,7 +478,7 @@ namespace System.Security.Cryptography.Tests
                 // CryptoKit is supported on macOS 10.15+, which is our minimum target. On iOS/tvOS, it was added in 13.0 but we can expect that version in our testing environments.
                 expectedIsSupported = true;
             }
-            else if (PlatformDetection.IsSymCryptOpenSsl)
+            else if (PlatformDetection.IsAzureLinux)
             {
                 // Though Azure Linux uses OpenSSL, they build OpenSSL without ChaCha20-Poly1305.
                 expectedIsSupported = false;

--- a/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
@@ -478,7 +478,7 @@ namespace System.Security.Cryptography.Tests
                 // CryptoKit is supported on macOS 10.15+, which is our minimum target. On iOS/tvOS, it was added in 13.0 but we can expect that version in our testing environments.
                 expectedIsSupported = true;
             }
-            else if (PlatformDetection.IsAzureLinux)
+            else if (PlatformDetection.IsSymCryptOpenSsl)
             {
                 // Though Azure Linux uses OpenSSL, they build OpenSSL without ChaCha20-Poly1305.
                 expectedIsSupported = false;

--- a/src/libraries/System.Security.Cryptography/tests/DefaultECDiffieHellmanProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultECDiffieHellmanProvider.Unix.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         {
             get
             {
-                if (PlatformDetection.IsApplePlatform || PlatformDetection.IsAzureLinux)
+                if (PlatformDetection.IsApplePlatform || PlatformDetection.IsSymCryptOpenSsl)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Unix.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             get
             {
-                if (PlatformDetection.IsApplePlatform || PlatformDetection.IsAzureLinux)
+                if (PlatformDetection.IsApplePlatform || PlatformDetection.IsSymCryptOpenSsl)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HKDFTests.cs
@@ -14,8 +14,8 @@ namespace System.Security.Cryptography.Tests
         protected abstract byte[] Expand(HashAlgorithmName hash, byte[] prk, int outputLength, byte[] info);
         protected abstract byte[] DeriveKey(HashAlgorithmName hash, byte[] ikm, int outputLength, byte[] salt, byte[] info);
 
-        internal static bool MD5Supported => !PlatformDetection.IsBrowser && !PlatformDetection.IsAzureLinux;
-        internal static bool EmptyKeysSupported => !PlatformDetection.IsAzureLinux;
+        internal static bool MD5Supported => !PlatformDetection.IsBrowser && !PlatformDetection.IsSymCryptOpenSsl;
+        internal static bool EmptyKeysSupported => !PlatformDetection.IsSymCryptOpenSsl;
 
         [Theory]
         [MemberData(nameof(GetHkdfTestCases))]

--- a/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacMD5Tests.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography.Tests
     {
         public sealed class Traits : IHmacTrait
         {
-            public static bool IsSupported => !PlatformDetection.IsAzureLinux && !PlatformDetection.IsBrowser;
+            public static bool IsSupported => !PlatformDetection.IsSymCryptOpenSsl && !PlatformDetection.IsBrowser;
             public static int HashSizeInBytes => HMACMD5.HashSizeInBytes;
         }
 

--- a/src/libraries/System.Security.Cryptography/tests/KmacTestDriver.cs
+++ b/src/libraries/System.Security.Cryptography/tests/KmacTestDriver.cs
@@ -95,7 +95,7 @@ namespace System.Security.Cryptography.Tests
         public static bool IsSupported => TKmacTrait.IsSupported;
         public static bool IsNotSupported => !IsSupported;
         public static KeySizes? PlatformKeySizeRequirements { get; } =
-            PlatformDetection.IsOpenSslSupported && !PlatformDetection.IsAzureLinux ? new KeySizes(4, 512, 1) : null;
+            PlatformDetection.IsOpenSslSupported && !PlatformDetection.IsSymCryptOpenSsl ? new KeySizes(4, 512, 1) : null;
 
         public static int? PlatformMaxOutputSize { get; } = PlatformDetection.IsOpenSslSupported ? 0xFFFFFF / 8 : null;
         public static int? PlatformMaxCustomizationStringSize { get; } = PlatformDetection.IsOpenSslSupported ? 512 : null;


### PR DESCRIPTION
Some of our cryptography tests are conditioned on whether or not they are running on Azure Linux, which by default uses SCOSSL for cryptographic algorithms. This is not guaranteed though - using vanilla OpenSSL on Azure Linux is possible simply by uninstalling the SymCrypt-OpenSSL package.

In this case, our tests would fail because they are assuming the environment is using SCOSSL when it is really using OpenSSL.

n.b. not _all_ of our tests can be conditioned on if SCOSSL is the default OpenSSL provider. Azure Linux itself applies some patches when building OpenSSL. A notable example is they compile OpenSSL with `-no-chacha`. That means that regardless of the OpenSSL provider, ChaCha20Poly1305 will not be available. So some tests remain conditioned on `IsAzureLinux`, not `IsSymCryptOpenSsl`.

With `SymCrypt-OpenSSL` package present:
<img width="1177" height="112" alt="yes-scossl" src="https://github.com/user-attachments/assets/6475ea40-8f61-4c81-b9ee-3c9ab18744b9" />

Without `SymCrypt-OpenSSL` package present:
<img width="1209" height="132" alt="no-scossl" src="https://github.com/user-attachments/assets/031064e9-4921-48cc-847b-186b5617ed83" />

Fixes https://github.com/dotnet/runtime/issues/118656
