### PR TITLE
Elide redundant test instruction for signed comparison predicates

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -1464,7 +1464,9 @@ bool emitter::AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, GenCondition 
         return id->idOpSize() == opSize;
     }
 
-    if ((cond.GetCode() == GenCondition::NE) || (cond.GetCode() == GenCondition::EQ))
+    if ((cond.GetCode() == GenCondition::NE) || (cond.GetCode() == GenCondition::EQ) ||
+        (cond.GetCode() == GenCondition::SLE) || (cond.GetCode() == GenCondition::SLT) ||
+        (cond.GetCode() == GenCondition::SGE) || (cond.GetCode() == GenCondition::SGT))
     {
         if (DoesWriteZeroFlag(lastIns) && IsFlagsAlwaysModified(id))
         {

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -767,6 +767,7 @@ bool        IsDstSrcSrcAVXInstruction(instruction ins) const;
 bool        IsThreeOperandAVXInstruction(instruction ins) const;
 static bool HasRegularWideForm(instruction ins);
 static bool HasRegularWideImmediateForm(instruction ins);
+static bool DoesWriteOverflowFlag(instruction ins);
 static bool DoesWriteZeroFlag(instruction ins);
 static bool DoesWriteParityFlag(instruction ins);
 static bool DoesWriteSignFlag(instruction ins);


### PR DESCRIPTION
Prior to this patch, when emitting code for x64, if an instruction
updated the flags register and if the following instruction was an
equals or not-equals comparison with zero, the runtime elided the `test`
instruction for materializing the comparison.

Although correct, this is limiting, since it excludes the predicates
SGT, SGE, SLT, and SLE. This patch extends the optimization to allow the
omission of the `test` instruction for all signed integer comparisons.
We skip unsigned integer comparisons since unsigned comparisons with
zero can be evaluated earlier in the compilation process.

Fix #117866