### PR TITLE
Skip generating debug info for deduplicated nodes

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
@@ -517,6 +517,13 @@ namespace ILCompiler.ObjectWriter
                         continue;
                     }
 
+                    ISymbolNode symbolNode = node as ISymbolNode;
+                    ISymbolNode deduplicatedSymbolNode = _nodeFactory.ObjectInterner.GetDeduplicatedSymbol(_nodeFactory, symbolNode);
+                    if (deduplicatedSymbolNode != symbolNode)
+                    {
+                        continue;
+                    }
+
                     // Ensure any allocated MethodTables have debug info
                     if (node is ConstructedEETypeNode methodTable)
                     {


### PR DESCRIPTION
Fixes #118236 

We have a check to prevent generating duplicated method bodies when emitting the bodies, but we were missing a check when generating the debug information. So we generated debug info for methods that don't exist.

We had this problem since method body folding was added in #101969 but it only started showing up as a problem now and only on x64 macOS.

Cc @dotnet/ilc-contrib 