### PR TITLE
Disable canonicalization tests with native AOT

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -513,7 +513,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Json\tests\ReflectionOnly\System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Json\tests\System.Runtime.Serialization.Json.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Schema\tests\System.Runtime.Serialization.Schema.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\tests\Canonicalization\System.Runtime.Serialization.Xml.Canonicalization.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\Canonicalization\System.Runtime.Serialization.Xml.Canonicalization.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\ReflectionOnly\System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\System.Runtime.Serialization.Xml.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Dynamic.Runtime.Tests\System.Dynamic.Runtime.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -513,6 +513,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Json\tests\ReflectionOnly\System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Json\tests\System.Runtime.Serialization.Json.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Schema\tests\System.Runtime.Serialization.Schema.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\tests\Canonicalization\System.Runtime.Serialization.Xml.Canonicalization.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\ReflectionOnly\System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\System.Runtime.Serialization.Xml.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Dynamic.Runtime.Tests\System.Dynamic.Runtime.Tests.csproj" />


### PR DESCRIPTION
These are all incompatible with trimming and break native AOT outerloop runs. E.g.

```
[FAIL] System.Runtime.Serialization.Xml.Canonicalization.Tests.XmlCanonicalizationTest.TestC14NInclusivePrefixes
System.TypeInitializationException : A type initializer threw an exception. To determine which type, inspect the InnerException's StackTrace property.
---- System.InvalidOperationException : There is an error in XML document (0, 0).
-------- System.InvalidOperationException : There was an error reflecting type 'TestCasesConfig'.
------------ System.InvalidOperationException : You must implement a default accessor on System.Collections.Generic.List`1[[TestCase, System.Runtime.Serialization.Xml.Canonicalization.Tests, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51]] because it inherits from ICollection.
   at System.Runtime.CompilerServices.ClassConstructorRunner.EnsureClassConstructorRun(StaticClassConstructionContext*) + 0x16c
   at System.Runtime.CompilerServices.ClassConstructorRunner.CheckStaticClassConstructionReturnNonGCStaticBase(StaticClassConstructionContext*, IntPtr) + 0x14
   at System.Runtime.Serialization.Xml.Canonicalization.Tests.XmlCanonicalizationTest.TestC14NInclusivePrefixes() + 0x80c
   at System.Runtime.Serialization.Xml.Canonicalization!<BaseAddress>+0x720cdc
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) + 0x114
----- Inner Stack Trace -----
   at System.Xml.Serialization.XmlSerializer.Deserialize(XmlReader, String, XmlDeserializationEvents) + 0x1f8
   at System.Xml.Serialization.XmlSerializer.Deserialize(Stream) + 0x9c
   at TestConfigHelper.LoadAllTests(String path) + 0x78
   at System.Runtime.CompilerServices.ClassConstructorRunner.EnsureClassConstructorRun(StaticClassConstructionContext*) + 0xbc
----- Inner Stack Trace -----
   at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping(TypeModel, String, XmlReflectionImporter.ImportContext, String, XmlAttributes, Boolean, Boolean, RecursionLimiter) + 0x59c
   at System.Xml.Serialization.XmlReflectionImporter.ImportElement(TypeModel, XmlRootAttribute, String, RecursionLimiter) + 0xa0
   at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping(Type, XmlRootAttribute, String) + 0x8c
   at System.Xml.Serialization.XmlSerializer.GetMapping() + 0x58
   at System.Xml.Serialization.XmlSerializer.Deserialize(XmlReader, String, XmlDeserializationEvents) + 0x6c
----- Inner Stack Trace -----
   at System.Xml.Serialization.TypeScope.GetDefaultIndexer(Type, String) + 0x284
   at System.Xml.Serialization.TypeScope.ImportTypeDesc(Type, MemberInfo, Boolean) + 0x66c
   at System.Xml.Serialization.TypeScope.GetTypeDesc(Type, MemberInfo, Boolean, Boolean) + 0x100
   at System.Xml.Serialization.StructModel.GetFieldModel(FieldInfo) + 0x78
   at System.Xml.Serialization.StructModel.GetFieldModel(MemberInfo) + 0x68
   at System.Xml.Serialization.XmlReflectionImporter.InitializeStructMembers(StructMapping, StructModel, Boolean, String, RecursionLimiter) + 0x5d4
   at System.Xml.Serialization.XmlReflectionImporter.ImportStructLikeMapping(StructModel, String, Boolean, XmlAttributes, RecursionLimiter) + 0x228
   at System.Xml.Serialization.XmlReflectionImporter.ImportTypeMapping(TypeModel, String, XmlReflectionImporter.ImportContext, String, XmlAttributes, Boolean, Boolean, RecursionLimiter) + 0x218
```

Cc @dotnet/ilc-contrib 