### PR TITLE
Fix using obsolete WebHostBuilder in wasm DevServer/DebugProxy

### DIFF
--- a/src/mono/browser/debugger/BrowserDebugHost/DebugProxyHost.cs
+++ b/src/mono/browser/debugger/BrowserDebugHost/DebugProxyHost.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -43,7 +44,8 @@ public static class DebugProxyHost
     public static async Task RunDevToolsProxyAsync(ProxyOptions options, string[] args, ILoggerFactory loggerFactory, CancellationToken token)
     {
         string proxyUrl = $"http://127.0.0.1:{options.DevToolsProxyPort}";
-        IWebHost host = new WebHostBuilder()
+        IHost host = new HostBuilder().ConfigureWebHost(webHostBuilder =>
+            webHostBuilder
             .UseSetting("UseIISIntegration", false.ToString())
             .UseKestrel()
             .UseContentRoot(Directory.GetCurrentDirectory())
@@ -60,7 +62,7 @@ public static class DebugProxyHost
                 config.AddCommandLine(args);
             })
             .UseUrls(proxyUrl)
-            .Build();
+        ).Build();
 
         if (token.CanBeCanceled)
             token.Register(async () => await host.StopAsync());

--- a/src/mono/wasm/host/BrowserHost.cs
+++ b/src/mono/wasm/host/BrowserHost.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.WebAssembly.AppHost.DevServer;
 using Microsoft.WebAssembly.Diagnostics;
@@ -80,7 +81,7 @@ internal sealed class BrowserHost
                             ? aspnetUrls.Split(';', StringSplitOptions.RemoveEmptyEntries)
                             : new string[] { $"http://127.0.0.1:{_args.CommonConfig.HostProperties.WebServerPort}", "https://127.0.0.1:0" };
 
-        (ServerURLs serverURLs, IWebHost host) = await StartWebServerAsync(_args,
+        (ServerURLs serverURLs, IHost host) = await StartWebServerAsync(_args,
                                                                            urls,
                                                                            token);
 
@@ -100,7 +101,7 @@ internal sealed class BrowserHost
         await host.WaitForShutdownAsync(token);
     }
 
-    private async Task<(ServerURLs, IWebHost)> StartWebServerAsync(BrowserArguments args, string[] urls, CancellationToken token)
+    private async Task<(ServerURLs, IHost)> StartWebServerAsync(BrowserArguments args, string[] urls, CancellationToken token)
     {
         Func<WebSocket, Task>? onConsoleConnected = null;
         if (args.ForwardConsoleOutput ?? false)

--- a/src/mono/wasm/host/DevServer/DevServer.cs
+++ b/src/mono/wasm/host/DevServer/DevServer.cs
@@ -17,11 +17,12 @@ namespace Microsoft.WebAssembly.AppHost.DevServer;
 
 internal static class DevServer
 {
-    internal static async Task<(ServerURLs, IWebHost)> StartAsync(DevServerOptions options, ILogger logger, CancellationToken token)
+    internal static async Task<(ServerURLs, IHost)> StartAsync(DevServerOptions options, ILogger logger, CancellationToken token)
     {
         TaskCompletionSource<ServerURLs> realUrlsAvailableTcs = new();
 
-        IWebHostBuilder builder = new WebHostBuilder()
+        IHostBuilder builder = new HostBuilder().ConfigureWebHost(webHostBuilder =>
+            webHostBuilder
             .UseConfiguration(ConfigureHostConfiguration(options))
             .UseKestrel()
             .UseStaticWebAssets()
@@ -47,10 +48,10 @@ internal static class DevServer
                 services.AddSingleton(realUrlsAvailableTcs);
                 services.AddRouting();
             })
-            .UseUrls(options.Urls);
+            .UseUrls(options.Urls));
 
 
-        IWebHost? host = builder.Build();
+        IHost? host = builder.Build();
         await host.StartAsync(token);
 
         if (token.CanBeCanceled)

--- a/src/mono/wasm/host/WebServer.cs
+++ b/src/mono/wasm/host/WebServer.cs
@@ -21,11 +21,12 @@ namespace Microsoft.WebAssembly.AppHost;
 
 public class WebServer
 {
-    internal static async Task<(ServerURLs, IWebHost)> StartAsync(WebServerOptions options, ILogger logger, CancellationToken token)
+    internal static async Task<(ServerURLs, IHost)> StartAsync(WebServerOptions options, ILogger logger, CancellationToken token)
     {
         TaskCompletionSource<ServerURLs> realUrlsAvailableTcs = new();
 
-        IWebHostBuilder builder = new WebHostBuilder()
+        IHostBuilder builder = new HostBuilder().ConfigureWebHost(webHostBuilder =>
+            webHostBuilder
             .UseKestrel()
             .UseStartup<WebServerStartup>()
             .ConfigureLogging(logging =>
@@ -49,12 +50,12 @@ public class WebServer
                 services.AddSingleton(realUrlsAvailableTcs);
                 services.AddRouting();
             })
-            .UseUrls(options.Urls);
+            .UseUrls(options.Urls));
 
         if (options.ContentRootPath != null)
             builder.UseContentRoot(options.ContentRootPath);
 
-        IWebHost? host = builder.Build();
+        IHost? host = builder.Build();
         await host.StartAsync(token);
 
         if (token.CanBeCanceled)


### PR DESCRIPTION
It was obsoleted in https://github.com/dotnet/aspnetcore/pull/62785

Switch to `new HostBuilder().ConfigureWebHost` instead.