### PR TITLE
Avoid `CollectionsMarshal.AsSpan` for derived `List<T>` in Linq

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
@@ -55,7 +55,7 @@ namespace System.Linq
             {
                 span = Unsafe.As<TSource[]>(source);
             }
-            else if (source.GetType() == typeof(List<TSource>))
+            else if (source.GetType() == typeof(List<TSource>)) // avoid accidentally bypassing a derived type's reimplementation of IEnumerable<T>
             {
                 span = CollectionsMarshal.AsSpan(Unsafe.As<List<TSource>>(source));
             }

--- a/src/libraries/System.Linq/src/System/Linq/Select.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using static System.Linq.Utilities;
 
 namespace System.Linq
@@ -52,9 +53,9 @@ namespace System.Linq
                     return new ArraySelectIterator<TSource, TResult>(array, selector);
                 }
 
-                if (source is List<TSource> list)
+                if (source.GetType() == typeof(List<TSource>)) // avoid accidentally bypassing a derived type's reimplementation of IEnumerable<T>
                 {
-                    return new ListSelectIterator<TSource, TResult>(list, selector);
+                    return new ListSelectIterator<TSource, TResult>(Unsafe.As<List<TSource>>(source), selector);
                 }
 
                 return new IListSelectIterator<TSource, TResult>(ilist, selector);

--- a/src/libraries/System.Linq/src/System/Linq/Where.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Where.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using static System.Linq.Utilities;
 
 namespace System.Linq
@@ -36,9 +37,9 @@ namespace System.Linq
                 return new ArrayWhereIterator<TSource>(array, predicate);
             }
 
-            if (source is List<TSource> list)
+            if (source.GetType() == typeof(List<TSource>))
             {
-                return new ListWhereIterator<TSource>(list, predicate);
+                return new ListWhereIterator<TSource>(Unsafe.As<List<TSource>>(source), predicate);
             }
 
             return new IEnumerableWhereIterator<TSource>(source, predicate);


### PR DESCRIPTION
`CollectionsMarshal.AsSpan` relies on the exact internal layout of `List<T>`. Passing a subclass is unsafe because a derived list may reimplement `IEnumerable<T>` with altered enumeration semantics.

Related: https://github.com/dotnet/runtime/pull/96574, https://github.com/dotnet/runtime/pull/85288