### PR TITLE
Avoid `CollectionsMarshal.AsSpan` for derived `List<T>`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -784,19 +784,19 @@ namespace System
 
         public static string Join(string? separator, IEnumerable<string?> values)
         {
-            if (values is List<string?> valuesList)
+            if (values is null)
             {
-                return JoinCore(separator.AsSpan(), CollectionsMarshal.AsSpan(valuesList));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.values);
+            }
+
+            if (values.GetType() == typeof(List<string?>)) // avoid accidentally bypassing a derived type's reimplementation of IEnumerable<T>
+            {
+                return JoinCore(separator.AsSpan(), CollectionsMarshal.AsSpan((List<string?>)values));
             }
 
             if (values is string?[] valuesArray)
             {
                 return JoinCore(separator.AsSpan(), new ReadOnlySpan<string?>(valuesArray));
-            }
-
-            if (values == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.values);
             }
 
             using (IEnumerator<string?> en = values.GetEnumerator())


### PR DESCRIPTION
* `Task.WaitAll`
* `Task.Whenall`
* `string.Join`

As per:
https://github.com/dotnet/runtime/blob/a693af397e4c626686c05a655801a86bae2bcffa/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs#L925

Related: https://github.com/dotnet/runtime/pull/118682