### PR TITLE
Refactor code so it doesn't hit mono aot limitation

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/IReadBufferState.cs
@@ -26,6 +26,9 @@ namespace System.Text.Json.Serialization
 
         public abstract void Advance(long bytesConsumed);
 
-        public abstract Utf8JsonReader GetReader(JsonReaderState jsonReaderState);
+        // This would normally be implemented as returning a Utf8JsonReader, but this pattern hits a limitation
+        // in mono aot that is not trivial to fix. For now use the alternative pattern of returning via an out
+        // argument. Tracking issue: https://github.com/dotnet/runtime/issues/118697
+        public abstract void GetReader(JsonReaderState jsonReaderState, out Utf8JsonReader reader);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
@@ -136,7 +136,7 @@ namespace System.Text.Json.Serialization.Metadata
             out T? value)
             where TReadBufferState : struct, IReadBufferState<TReadBufferState, TStream>
         {
-            Utf8JsonReader reader = bufferState.GetReader(jsonReaderState);
+            bufferState.GetReader(jsonReaderState, out Utf8JsonReader reader);
 
             try
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PipeReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PipeReadBufferState.cs
@@ -75,11 +75,11 @@ namespace System.Text.Json.Serialization
 
         public void Read(PipeReader utf8Json) => throw new NotImplementedException();
 
-        public Utf8JsonReader GetReader(JsonReaderState jsonReaderState)
+        public void GetReader(JsonReaderState jsonReaderState, out Utf8JsonReader reader)
         {
             if (_sequence.IsSingleSegment)
             {
-                return new Utf8JsonReader(
+                reader = new Utf8JsonReader(
 #if NET
                     _sequence.FirstSpan,
 #else
@@ -89,7 +89,7 @@ namespace System.Text.Json.Serialization
             }
             else
             {
-                return new Utf8JsonReader(_sequence, IsFinalBlock, jsonReaderState);
+                reader = new Utf8JsonReader(_sequence, IsFinalBlock, jsonReaderState);
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/StreamReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/StreamReadBufferState.cs
@@ -157,9 +157,9 @@ namespace System.Text.Json.Serialization
             _offset = 0;
         }
 
-        public Utf8JsonReader GetReader(JsonReaderState jsonReaderState)
+        public void GetReader(JsonReaderState jsonReaderState, out Utf8JsonReader reader)
         {
-            return new Utf8JsonReader(
+            reader = new Utf8JsonReader(
                 _buffer.AsSpan(_offset, _count),
                 IsFinalBlock,
                 jsonReaderState);


### PR DESCRIPTION
The previous code was hitting a mono aot gsharedvt limitation described in https://github.com/dotnet/runtime/issues/118697. This is not trivial and too risky to fix in time for .NET 10. The alternative easy fix is to pass the return byref.

This regressed after https://github.com/dotnet/runtime/pull/118408.

Fixes https://github.com/dotnet/runtime/issues/118576