### PR TITLE
[cDAC] Correct EnumMethodInstancesByAddress HResult

### DIFF
--- a/src/native/managed/cdac/mscordaccore_universal/Legacy/IXCLRData.cs
+++ b/src/native/managed/cdac/mscordaccore_universal/Legacy/IXCLRData.cs
@@ -206,7 +206,7 @@ internal unsafe partial interface IXCLRDataProcess
     int GetModuleByAddress(ClrDataAddress address, /*IXCLRDataModule*/ void** mod);
 
     [PreserveSig]
-    int StartEnumMethodInstancesByAddress(ulong address, /*IXCLRDataAppDomain*/ void* appDomain, ulong* handle);
+    int StartEnumMethodInstancesByAddress(ClrDataAddress address, /*IXCLRDataAppDomain*/ void* appDomain, ulong* handle);
     [PreserveSig]
     int EnumMethodInstanceByAddress(ulong* handle, out IXCLRDataMethodInstance? method);
     [PreserveSig]


### PR DESCRIPTION
Follow up to https://github.com/dotnet/runtime/pull/115131

Noticed some test failures in CI after merging. This should resolve those failures.

* Modifies `ulong` -> `ClrDataAddress`
* Handles read failures and returns proper error code