### PR TITLE
Revert "Increase cost of ARR_LENGTH node to match IND(ADD(..,CNS)) #117531

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5541,9 +5541,9 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 case GT_MDARR_LOWER_BOUND:
                     level++;
 
-                    // Array meta-data access should be the same as an IND(ADD(ADDR, SMALL_CNS)).
-                    costEx = IND_COST_EX + 1;
-                    costSz = 2 * 2;
+                    // Array meta-data access should be the same as an indirection, which has a costEx of IND_COST_EX.
+                    costEx = IND_COST_EX - 1;
+                    costSz = 2;
                     break;
 
                 case GT_BLK:


### PR DESCRIPTION
This reverts commit 5c170368ac8a8d28f39166ed96514b8d1f72c220.

Fixes https://github.com/dotnet/runtime/issues/117938 regression

Despite having a large PerfScore improvements only 1 benchmark improved and 5 regressed.