### PR TITLE
Avoid confusion in Reflection with hidden members.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -170,7 +170,7 @@ namespace System.Reflection
             if (type.IsClass)
                 return CustomAttributeEncoding.Object;
 
-            if (type.IsInterface)
+            if (type.IsActualInterface)
                 return CustomAttributeEncoding.Object;
 
             if (type.IsActualValueType)
@@ -2263,7 +2263,7 @@ namespace System.Reflection
 
         internal static StructLayoutAttribute? GetStructLayoutCustomAttribute(RuntimeType type)
         {
-            if (type.IsInterface || type.HasElementType || type.IsGenericParameter)
+            if (type.IsActualInterface || type.HasElementType || type.IsGenericParameter)
                 return null;
 
             LayoutKind layoutKind = LayoutKind.Auto;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
@@ -105,7 +105,7 @@ namespace System.Reflection
 
         internal RuntimeMethodInfo? GetParentDefinition()
         {
-            if (!IsVirtual || m_declaringType.IsInterface)
+            if (!IsVirtual || m_declaringType.IsActualInterface)
                 return null;
 
             RuntimeType? parent = (RuntimeType?)m_declaringType.BaseType;
@@ -323,7 +323,7 @@ namespace System.Reflection
 
         public override MethodInfo GetBaseDefinition()
         {
-            if (!IsVirtual || IsStatic || m_declaringType == null || m_declaringType.IsInterface)
+            if (!IsVirtual || IsStatic || m_declaringType == null || m_declaringType.IsActualInterface)
                 return this;
 
             int slot = RuntimeMethodHandle.GetSlot(this);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/DynamicInterfaceCastableHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/DynamicInterfaceCastableHelpers.cs
@@ -30,7 +30,7 @@ namespace System.Runtime.InteropServices
                 throw new InvalidCastException(SR.Format(SR.InvalidCast_FromTo, castable.GetType(), interfaceType));
 
             RuntimeType implType = handle.GetRuntimeType();
-            if (!implType.IsInterface)
+            if (!implType.IsActualInterface)
                 throw new InvalidOperationException(SR.Format(SR.IDynamicInterfaceCastable_NotInterface, implType.ToString()));
 
             if (!implType.IsDefined(typeof(DynamicInterfaceCastableImplementationAttribute), inherit: false))

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -579,7 +579,7 @@ namespace System
                     RuntimeType declaringType = ReflectedType;
                     Debug.Assert(declaringType != null);
 
-                    if (declaringType.IsInterface)
+                    if (declaringType.IsActualInterface)
                     {
                         #region IsInterface
 
@@ -998,7 +998,7 @@ namespace System
                                     continue;
                             }
 
-                            Debug.Assert(interfaceType.IsInterface);
+                            Debug.Assert(interfaceType.IsActualInterface);
                             list.Add(interfaceType);
                         }
 
@@ -1028,7 +1028,7 @@ namespace System
                         for (int i = 0; i < constraints.Length; i++)
                         {
                             RuntimeType constraint = (RuntimeType)constraints[i];
-                            if (constraint.IsInterface)
+                            if (constraint.IsActualInterface)
                                 al.Add(constraint);
 
                             Type[] temp = constraint.GetInterfaces();
@@ -1113,7 +1113,7 @@ namespace System
                     RuntimeType declaringType = ReflectedType;
                     ListBuilder<RuntimeEventInfo> list = default;
 
-                    if (!declaringType.IsInterface)
+                    if (!declaringType.IsActualInterface)
                     {
                         while (RuntimeTypeHandle.IsGenericVariable(declaringType))
                             declaringType = declaringType.GetBaseType()!;
@@ -1206,7 +1206,7 @@ namespace System
 
                     ListBuilder<RuntimePropertyInfo> list = default;
 
-                    if (!declaringType.IsInterface)
+                    if (!declaringType.IsActualInterface)
                     {
                         while (RuntimeTypeHandle.IsGenericVariable(declaringType))
                             declaringType = declaringType.GetBaseType()!;
@@ -1258,8 +1258,8 @@ namespace System
 
                     int numVirtuals = RuntimeTypeHandle.GetNumVirtuals(declaringType);
 
-                    Debug.Assert((declaringType.IsInterface && isInterface && csPropertyInfos == null) ||
-                                 (!declaringType.IsInterface && !isInterface && usedSlots.Length >= numVirtuals));
+                    Debug.Assert((declaringType.IsActualInterface && isInterface && csPropertyInfos == null) ||
+                                 (!declaringType.IsActualInterface && !isInterface && usedSlots.Length >= numVirtuals));
 
                     for (int i = 0; i < tkProperties.Length; i++)
                     {
@@ -2697,7 +2697,7 @@ namespace System
 
             TypeHandle.VerifyInterfaceIsImplemented(ifaceRtTypeHandle);
             Debug.Assert(interfaceType.IsInterface);  // VerifyInterfaceIsImplemented enforces this invariant
-            Debug.Assert(!IsInterface); // VerifyInterfaceIsImplemented enforces this invariant
+            Debug.Assert(!IsActualInterface); // VerifyInterfaceIsImplemented enforces this invariant
 
             // SZArrays implement the methods on IList`1, IEnumerable`1, and ICollection`1 with
             // SZArrayHelper and some runtime magic. We don't have accurate interface maps for them.
@@ -2739,7 +2739,7 @@ namespace System
 
                 // If we resolved to an interface method, use the interface type as reflected type. Otherwise use `this`.
                 RuntimeType reflectedType = RuntimeMethodHandle.GetDeclaringType(classRtMethodHandle);
-                if (!reflectedType.IsInterface)
+                if (!reflectedType.IsActualInterface)
                     reflectedType = this;
 
                 // GetMethodBase will convert this to the instantiating/unboxing stub if necessary
@@ -3432,7 +3432,7 @@ namespace System
             }
         }
 
-        internal new unsafe bool IsInterface
+        internal unsafe bool IsActualInterface
         {
             get
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -186,7 +186,7 @@
     <Compile Include="System\MathF.NativeAot.cs" />
     <Compile Include="System\Object.NativeAot.cs" />
     <Compile Include="System\RuntimeArgumentHandle.cs" />
-    <Compile Include="System\RuntimeType.cs" />
+    <Compile Include="System\RuntimeType.NativeAot.cs" />
     <Compile Include="System\Runtime\ControlledExecution.NativeAot.cs" />
     <Compile Include="System\Runtime\DependentHandle.cs" />
     <Compile Include="System\Runtime\CompilerServices\EagerStaticClassConstructionAttribute.cs" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeType.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeType.NativeAot.cs
@@ -213,7 +213,7 @@ namespace System
             }
         }
 
-        internal new unsafe bool IsInterface
+        internal unsafe bool IsActualInterface
         {
             get
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -269,7 +269,7 @@ namespace System.Reflection.Emit
                     if (owner?.UnderlyingSystemType is RuntimeType rtOwner)
                     {
                         if (rtOwner.HasElementType || rtOwner.ContainsGenericParameters
-                            || rtOwner.IsGenericParameter || rtOwner.IsInterface)
+                            || rtOwner.IsGenericParameter || rtOwner.IsActualInterface)
                             throw new ArgumentException(SR.Argument_InvalidTypeForDynamicMethod);
 
                         _typeOwner = rtOwner;

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -297,7 +297,7 @@ namespace System
                 if (c.IsSubclassOf(this))
                     return true;
 
-                if (IsInterface)
+                if (IsActualInterface)
                 {
                     return c.ImplementInterface(this);
                 }
@@ -711,7 +711,7 @@ namespace System
         // `class G3<T,U> where T:U where U:Stream`: typeof(G3<,>).GetGenericArguments()[0].BaseType is Object (!)
         private RuntimeType? GetBaseType()
         {
-            if (IsInterface)
+            if (IsActualInterface)
                 return null;
 
             if (RuntimeTypeHandle.IsGenericVariable(this))
@@ -724,7 +724,7 @@ namespace System
                 {
                     RuntimeType constraint = (RuntimeType)constraints[i];
 
-                    if (constraint.IsInterface)
+                    if (constraint.IsActualInterface)
                         continue;
 
                     if (constraint.IsGenericParameter)

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -33,7 +33,7 @@ namespace System
             {
 #if !MONO
                 if (this is RuntimeType rt)
-                    return rt.IsInterface;
+                    return rt.IsActualInterface;
 #endif
                 return (GetAttributeFlagsImpl() & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface;
             }

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1321,6 +1321,8 @@ namespace System
             return res;
         }
 
+        internal bool IsActualInterface => IsInterface;
+
         // Returns true for actual value types only, ignoring generic parameter constraints.
         internal bool IsActualValueType => RuntimeTypeHandle.IsValueType(this);
 


### PR DESCRIPTION
On CoreCLR, the Reflection API was preemptively
filtering out members with the same name and signature.
This means that hidden private members in C# using
the new keyword in derived classes can make public
members in base classes inaccessible.

Add tests for properties and methods.

Fixes https://github.com/dotnet/runtime/issues/28056
Fixes https://github.com/dotnet/runtime/issues/98533
Fixes https://github.com/dotnet/runtime/issues/118677