### PR TITLE
Add more info for StdErrAfter assertion in host tests

### DIFF
--- a/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Linq;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -154,18 +153,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
-        public string GetDiagnosticsInfo()
-            => $"""
-
-                File Name: {Result.StartInfo.FileName}
-                Arguments: {Result.StartInfo.Arguments}
-                Environment:
-                {string.Join(Environment.NewLine, Result.StartInfo.Environment.Where(i => i.Key.StartsWith(Constants.DotnetRoot.EnvironmentVariable)).Select(i => $"  {i.Key} = {i.Value}"))}
-                Exit Code: 0x{Result.ExitCode:x}
-                StdOut:
-                {Result.StdOut}
-                StdErr:
-                {Result.StdErr}
-                """;
+        public string GetDiagnosticsInfo() => Result.GetDiagnosticsInfo();
     }
 }

--- a/src/installer/tests/TestUtils/Assertions/CommandResultExtensions.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultExtensions.cs
@@ -4,7 +4,6 @@
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.DotNet.Cli.Build.Framework;
-using System;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
@@ -20,10 +19,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             int i = commandResult.StdErr.IndexOf(pattern);
             i.Should().BeGreaterThanOrEqualTo(
                 0,
-                "Trying to filter StdErr after '{0}', but such string can't be found in the StdErr.{1}{2}",
-                pattern,
-                Environment.NewLine,
-                commandResult.StdErr);
+                $"'{pattern}' should be in StdErr - cannot filter StdErr to after expected string.{commandResult.GetDiagnosticsInfo()}");
             string filteredStdErr = commandResult.StdErr.Substring(i);
 
             return new CommandResult(commandResult.StartInfo, commandResult.ProcessId, commandResult.ExitCode, commandResult.StdOut, filteredStdErr);

--- a/src/installer/tests/TestUtils/CommandResult.cs
+++ b/src/installer/tests/TestUtils/CommandResult.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
                 File Name: {StartInfo.FileName}
                 Arguments: {StartInfo.Arguments}
                 Environment:
-                {string.Join(Environment.NewLine, StartInfo.Environment.Where(i => i.Key.StartsWith("DOTNET_")).Select(i => $"  {i.Key} = {i.Value}"))}
+                {string.Join(Environment.NewLine, StartInfo.Environment.Where(i => i.Key.StartsWith("DOTNET_", OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)).Select(i => $"  {i.Key} = {i.Value}"))}
                 Exit Code: 0x{ExitCode:x}
                 StdOut:
                 {StdOut}

--- a/src/installer/tests/TestUtils/CommandResult.cs
+++ b/src/installer/tests/TestUtils/CommandResult.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Text;
 using System.Diagnostics;
+using System.Linq;
+using System.Text;
 
 namespace Microsoft.DotNet.Cli.Build.Framework
 {
@@ -23,5 +24,19 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             StdOut = stdOut;
             StdErr = stdErr;
         }
+
+        internal string GetDiagnosticsInfo()
+            => $"""
+
+                File Name: {StartInfo.FileName}
+                Arguments: {StartInfo.Arguments}
+                Environment:
+                {string.Join(Environment.NewLine, StartInfo.Environment.Where(i => i.Key.StartsWith("DOTNET_")).Select(i => $"  {i.Key} = {i.Value}"))}
+                Exit Code: 0x{ExitCode:x}
+                StdOut:
+                {StdOut}
+                StdErr:
+                {StdErr}
+                """;
     }
 }


### PR DESCRIPTION
The assertion only ended up printing stderr, but it would be useful to have all the information about the command that was run (the exit code, stdout). Without it, we have no insight into issues like #118170, especially since it does not seem to repro easily (first time we've seen it, hasn't been hit again).

Resolves #118170 - while this wouldn't actually fix whatever happened there, it will give us insight into any similar issues that happen again.

cc @dotnet/appmodel @AaronRobinsonMSFT 