### PR TITLE
Fix Equals for cryptographic wrappers

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAFactoryTests.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
-        public static void ECDsaCreate_Equals_DifferentInstance_FalseForSameKeyMaterial()
+        public static void DsaCreate_Equals_DifferentInstance_FalseForSameKeyMaterial()
         {
             using DSA dsa1 = DSAFactory.Create();
             using DSA dsa2 = DSAFactory.Create();

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAFactoryTests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Dsa.Tests
+{
+    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, "Not supported on Browser/iOS/tvOS/MacCatalyst")]
+    public partial class DSAFactoryTests
+    {
+        [Fact]
+        public static void DSACreateDefault_Equals_SameInstance()
+        {
+            using DSA dsa = DSAFactory.Create();
+            dsa.ImportParameters(DSATestData.GetDSA1024Params());
+            AssertExtensions.TrueExpression(dsa.Equals(dsa));
+        }
+
+        [Fact]
+        public static void DSACreateKeySize_Equals_SameInstance()
+        {
+            using DSA dsa = DSAFactory.Create(1024);
+            AssertExtensions.TrueExpression(dsa.Equals(dsa));
+        }
+
+        [Fact]
+        public static void ECDsaCreate_Equals_DifferentInstance_FalseForSameKeyMaterial()
+        {
+            using DSA dsa1 = DSAFactory.Create();
+            using DSA dsa2 = DSAFactory.Create();
+            dsa1.ImportParameters(DSATestData.GetDSA1024Params());
+            dsa2.ImportParameters(DSATestData.GetDSA1024Params());
+            AssertExtensions.FalseExpression(dsa1.Equals(dsa2));
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanFactoryTests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography.Tests;
+using Xunit;
+
+namespace System.Security.Cryptography.EcDiffieHellman.Tests
+{
+    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
+    public static class ECDiffieHellmanFactoryTests
+    {
+        [Fact]
+        public static void ECDiffieHellmanCreateDefault_Equals_SameInstance()
+        {
+            using ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create();
+            AssertExtensions.TrueExpression(ecdh.Equals(ecdh));
+        }
+
+        [Fact]
+        public static void ECDiffieHellmanCreateKeySize_Equals_SameInstance()
+        {
+            using ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create(256);
+            AssertExtensions.TrueExpression(ecdh.Equals(ecdh));
+        }
+
+        [Fact]
+        public static void ECDiffieHellmanCreateKeySize_Equals_DifferentInstance_FalseForSameKeyMaterial()
+        {
+            using ECDiffieHellman ecdh1 = ECDiffieHellmanFactory.Create();
+            using ECDiffieHellman ecdh2 = ECDiffieHellmanFactory.Create();
+            ecdh1.ImportParameters(EccTestData.GetNistP256ReferenceKey());
+            ecdh2.ImportParameters(EccTestData.GetNistP256ReferenceKey());
+            AssertExtensions.FalseExpression(ecdh1.Equals(ecdh2));
+        }
+
+#if NET
+        [Fact]
+        public static void ECDiffieHellmanCreateCurve_Equals_SameInstance()
+        {
+            using ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create(ECCurve.NamedCurves.nistP256);
+            AssertExtensions.TrueExpression(ecdh.Equals(ecdh));
+        }
+#endif
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaFactoryTests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography.Tests;
+using Xunit;
+
+namespace System.Security.Cryptography.EcDsa.Tests
+{
+    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
+    public static class ECDsaFactoryTests
+    {
+        [Fact]
+        public static void ECDsaCreateDefault_Equals_SameInstance()
+        {
+            using ECDsa ecdsa = ECDsaFactory.Create();
+            AssertExtensions.TrueExpression(ecdsa.Equals(ecdsa));
+        }
+
+        [Fact]
+        public static void ECDsaCreateKeySize_Equals_SameInstance()
+        {
+            using ECDsa ecdsa = ECDsaFactory.Create(256);
+            AssertExtensions.TrueExpression(ecdsa.Equals(ecdsa));
+        }
+
+        [Fact]
+        public static void ECDsaCreateKeySize_Equals_DifferentInstance_FalseForSameKeyMaterial()
+        {
+            using ECDsa ecdsa1 = ECDsaFactory.Create();
+            using ECDsa ecdsa2 = ECDsaFactory.Create();
+            ecdsa1.ImportParameters(EccTestData.GetNistP256ReferenceKey());
+            ecdsa2.ImportParameters(EccTestData.GetNistP256ReferenceKey());
+            AssertExtensions.FalseExpression(ecdsa1.Equals(ecdsa2));
+        }
+
+#if NET
+        [Fact]
+        public static void ECDsaCreateCurve_Equals_SameInstance()
+        {
+            using ECDsa ecdsa = ECDsaFactory.Create(ECCurve.NamedCurves.nistP256);
+            AssertExtensions.TrueExpression(ecdsa.Equals(ecdsa));
+        }
+#endif
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactoryTests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography.Tests;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Rsa.Tests
+{
+    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
+    public static class RSAFactoryTests
+    {
+        [Fact]
+        public static void RSACreateDefault_Equals_SameInstance()
+        {
+            using RSA rsa = RSAFactory.Create();
+            AssertExtensions.TrueExpression(rsa.Equals(rsa));
+        }
+
+        [Fact]
+        public static void RSACreateKeySize_Equals_SameInstance()
+        {
+            using RSA rsa = RSAFactory.Create(1024);
+            AssertExtensions.TrueExpression(rsa.Equals(rsa));
+        }
+
+        [Fact]
+        public static void RSACreateParameters_Equals_SameInstance()
+        {
+            using RSA rsa = RSAFactory.Create(TestData.RSA2048Params);
+            AssertExtensions.TrueExpression(rsa.Equals(rsa));
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactoryTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Security.Cryptography.Tests;
-using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.Rsa.Tests
@@ -20,7 +18,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void RSACreateKeySize_Equals_SameInstance()
         {
-            using RSA rsa = RSAFactory.Create(1024);
+            using RSA rsa = RSAFactory.Create(2048);
             AssertExtensions.TrueExpression(rsa.Equals(rsa));
         }
 
@@ -29,6 +27,14 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             using RSA rsa = RSAFactory.Create(TestData.RSA2048Params);
             AssertExtensions.TrueExpression(rsa.Equals(rsa));
+        }
+
+        [Fact]
+        public static void RSACreateParameters_Equals_DifferentInstance_FalseForSameKeyMaterial()
+        {
+            using RSA rsa1 = RSAFactory.Create(TestData.RSA2048Params);
+            using RSA rsa2 = RSAFactory.Create(TestData.RSA2048Params);
+            AssertExtensions.FalseExpression(rsa1.Equals(rsa2));
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -54,6 +54,8 @@
     <Compile Include="ECDsaCngProvider.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaStub.cs"

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -73,6 +73,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSATestHelpers.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSATestHelpers.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs"

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -37,6 +37,8 @@
     <Compile Include="ECDiffieHellmanCngProvider.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs"
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CngKeyWrapper.cs"

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -99,6 +99,8 @@
              Link="CommonTest\System\Security\Cryptography\AsymmetricSignatureFormatter.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DsaFamilySignatureFormatTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DsaFamilySignatureFormatTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs"

--- a/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -64,6 +64,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DsaFamilySignatureFormatTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DsaFamilySignatureFormatTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs"

--- a/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -32,6 +32,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSATestHelpers.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSATestHelpers.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -91,6 +91,8 @@
              Link="CommonTest\System\Security\Cryptography\AsymmetricSignatureFormatter.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DsaFamilySignatureFormatTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DsaFamilySignatureFormatTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAImportExport.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -66,6 +66,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSATestHelpers.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSATestHelpers.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -46,6 +46,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaSignatureFormatTests.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -28,6 +28,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs"

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAWrapper.cs
@@ -150,8 +150,6 @@ namespace System.Security.Cryptography
 
         public override byte[] ExportSubjectPublicKeyInfo() => _wrapped.ExportSubjectPublicKeyInfo();
 
-        public override bool Equals(object? obj) => _wrapped.Equals(obj);
-
         public override int GetHashCode() => _wrapped.GetHashCode();
 
         public override string ToString() => _wrapped.ToString()!;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAWrapper.cs
@@ -150,8 +150,6 @@ namespace System.Security.Cryptography
 
         public override byte[] ExportSubjectPublicKeyInfo() => _wrapped.ExportSubjectPublicKeyInfo();
 
-        public override int GetHashCode() => _wrapped.GetHashCode();
-
         public override string ToString() => _wrapped.ToString()!;
 
         protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanWrapper.cs
@@ -152,8 +152,6 @@ namespace System.Security.Cryptography
 
         public override byte[] ExportSubjectPublicKeyInfo() => _wrapped.ExportSubjectPublicKeyInfo();
 
-        public override int GetHashCode() => _wrapped.GetHashCode();
-
         public override string ToString() => _wrapped.ToString()!;
 
         private static ECDiffieHellmanPublicKey Unwrap(ECDiffieHellmanPublicKey otherPartyPublicKey)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanWrapper.cs
@@ -152,8 +152,6 @@ namespace System.Security.Cryptography
 
         public override byte[] ExportSubjectPublicKeyInfo() => _wrapped.ExportSubjectPublicKeyInfo();
 
-        public override bool Equals(object? obj) => obj is ECDiffieHellmanWrapper wrapper && _wrapped.Equals(wrapper._wrapped);
-
         public override int GetHashCode() => _wrapped.GetHashCode();
 
         public override string ToString() => _wrapped.ToString()!;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanWrapper.cs
@@ -152,7 +152,7 @@ namespace System.Security.Cryptography
 
         public override byte[] ExportSubjectPublicKeyInfo() => _wrapped.ExportSubjectPublicKeyInfo();
 
-        public override bool Equals(object? obj) => _wrapped.Equals(obj);
+        public override bool Equals(object? obj) => obj is ECDiffieHellmanWrapper wrapper && _wrapped.Equals(wrapper._wrapped);
 
         public override int GetHashCode() => _wrapped.GetHashCode();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaWrapper.cs
@@ -175,8 +175,6 @@ namespace System.Security.Cryptography
         public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature) =>
             _wrapped.VerifyHash(hash, signature);
 
-        public override int GetHashCode() => _wrapped.GetHashCode();
-
         public override string ToString() => _wrapped.ToString()!;
 
         protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaWrapper.cs
@@ -175,8 +175,6 @@ namespace System.Security.Cryptography
         public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature) =>
             _wrapped.VerifyHash(hash, signature);
 
-        public override bool Equals(object? obj) => obj is ECDsaWrapper wrapper && _wrapped.Equals(wrapper._wrapped);
-
         public override int GetHashCode() => _wrapped.GetHashCode();
 
         public override string ToString() => _wrapped.ToString()!;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaWrapper.cs
@@ -175,7 +175,7 @@ namespace System.Security.Cryptography
         public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature) =>
             _wrapped.VerifyHash(hash, signature);
 
-        public override bool Equals(object? obj) => _wrapped.Equals(obj);
+        public override bool Equals(object? obj) => obj is ECDsaWrapper wrapper && _wrapped.Equals(wrapper._wrapped);
 
         public override int GetHashCode() => _wrapped.GetHashCode();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAWrapper.cs
@@ -215,7 +215,7 @@ namespace System.Security.Cryptography
             base.Dispose(disposing);
         }
 
-        public override bool Equals(object? obj) => _wrapped.Equals(obj);
+        public override bool Equals(object? obj) => obj is RSAWrapper wrapper && _wrapped.Equals(wrapper._wrapped);
 
         public override int GetHashCode() => _wrapped.GetHashCode();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAWrapper.cs
@@ -215,8 +215,6 @@ namespace System.Security.Cryptography
             base.Dispose(disposing);
         }
 
-        public override bool Equals(object? obj) => obj is RSAWrapper wrapper && _wrapped.Equals(wrapper._wrapped);
-
         public override int GetHashCode() => _wrapped.GetHashCode();
 
         public override string ToString() => _wrapped.ToString()!;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAWrapper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAWrapper.cs
@@ -215,8 +215,6 @@ namespace System.Security.Cryptography
             base.Dispose(disposing);
         }
 
-        public override int GetHashCode() => _wrapped.GetHashCode();
-
         public override string ToString() => _wrapped.ToString()!;
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -339,6 +339,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanKeyPemTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Hash.cs"

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -299,6 +299,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DesTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DSAFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DsaFamilySignatureFormatTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DSA\DsaFamilySignatureFormatTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DSA\DSASignatureFormatter.cs"

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -357,6 +357,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanTests.Xml.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaImportExport.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\ECDsa\ECDsaKeyFileTests.cs"

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -413,6 +413,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\KeyGeneration.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactory.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAFactoryTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyExchangeFormatter.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\RSAKeyFileTests.cs"


### PR DESCRIPTION
The internal cryptographic wrapper, ECDsaWrapper, RSAWrapper, ECDiffieHellmanWrapper, and DSAWrapper implemented `Equals` in such a way that it was never going to be true. It delegated equals to "what was wrapped", but since you can't get what is wrapped out, you would end up comparing a wrapper to a wrapped.

This violated FDG 8.9.1

> DO comply with the contract defined for Object.Equals when overriding the method.
For convenience, the contract taken directly from the System.Object documentation is provided here.

> * x.Equals(x) returns true.

> Excerpt From
> Framework Design Guidelines

Instead, let's let wrappers compare what is being wrapped.

Fixes #118701