### PR TITLE
Drop size of hello world to 745 kB

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
@@ -81,7 +81,7 @@ namespace Internal.Runtime.CompilerHelpers
         [SupportedOSPlatform("windows")]
         private static void InitializeApartmentState(ApartmentState state)
         {
-            Thread.CurrentThread.SetApartmentStateUnchecked(state, throwOnError: true);
+            Thread.CurrentThread.SetApartmentState(state);
         }
 #endif
     }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/StartupCode/StartupCodeHelpers.Extensions.cs
@@ -81,7 +81,7 @@ namespace Internal.Runtime.CompilerHelpers
         [SupportedOSPlatform("windows")]
         private static void InitializeApartmentState(ApartmentState state)
         {
-            Thread.CurrentThread.SetApartmentState(state);
+            Thread.CurrentThread.SetApartmentStateUnchecked(state, throwOnError: true);
         }
 #endif
     }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/MethodTable.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/MethodTable.Runtime.cs
@@ -37,7 +37,7 @@ namespace Internal.Runtime
 
                 // Generic type definitions that return true for IsPrimitive are type definitions of generic enums.
                 // Otherwise check the base type.
-                return IsPrimitive && (IsGenericTypeDefinition || NonArrayBaseType == MethodTable.Of<Enum>());
+                return IsPrimitive && (IsGenericTypeDefinition || NonArrayBaseType != MethodTable.Of<ValueType>());
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
@@ -764,7 +764,7 @@ namespace System
 
         /// <summary>Gets garbage collection memory information.</summary>
         /// <returns>An object that contains information about the garbage collector's memory usage.</returns>
-        public static GCMemoryInfo GetGCMemoryInfo() => GetGCMemoryInfo(GCKind.Any);
+        public static GCMemoryInfo GetGCMemoryInfo() => GetGCMemoryInfoUnchecked(GCKind.Any);
 
         /// <summary>Gets garbage collection memory information.</summary>
         /// <param name="kind">The kind of collection for which to retrieve memory information.</param>
@@ -780,6 +780,11 @@ namespace System
                                           GCKind.Background));
             }
 
+            return GetGCMemoryInfoUnchecked(kind);
+        }
+
+        private static GCMemoryInfo GetGCMemoryInfoUnchecked(GCKind kind)
+        {
             var data = new GCMemoryInfoData();
             RuntimeImports.RhGetMemoryInfo(ref data.GetRawData(), kind);
             return new GCMemoryInfo(data);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
@@ -246,7 +246,7 @@ namespace System.Threading
             }
         }
 
-        internal bool SetApartmentStateUnchecked(ApartmentState state, bool throwOnError)
+        private bool SetApartmentStateUnchecked(ApartmentState state, bool throwOnError)
         {
             ApartmentState retState;
 
@@ -289,6 +289,8 @@ namespace System.Threading
             {
                 if (throwOnError)
                 {
+                    // NOTE: We do the enum stringification manually to avoid introducing a dependency
+                    // on enum stringification in small apps. We set apartment state in the startup path.
                     string msg = SR.Format(SR.Thread_ApartmentState_ChangeFailed, retState switch
                     {
                         ApartmentState.MTA => "MTA",

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
@@ -246,7 +246,7 @@ namespace System.Threading
             }
         }
 
-        private bool SetApartmentStateUnchecked(ApartmentState state, bool throwOnError)
+        internal bool SetApartmentStateUnchecked(ApartmentState state, bool throwOnError)
         {
             ApartmentState retState;
 
@@ -289,7 +289,12 @@ namespace System.Threading
             {
                 if (throwOnError)
                 {
-                    string msg = SR.Format(SR.Thread_ApartmentState_ChangeFailed, retState);
+                    string msg = SR.Format(SR.Thread_ApartmentState_ChangeFailed, retState switch
+                    {
+                        ApartmentState.MTA => "MTA",
+                        ApartmentState.STA => "STA",
+                        _ => "Unknown"
+                    });
                     throw new InvalidOperationException(msg);
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -626,7 +626,7 @@ namespace System.Globalization
             invariant._iFirstWeekOfYear = 0;                      // first week of year
 
             // all available calendar type(s).  The first one is the default calendar
-            invariant._waCalendars = [CalendarId.GREGORIAN];
+            invariant._waCalendars = (CalendarId[])(object)new ushort[] { (ushort)CalendarId.GREGORIAN };
 
             if (!GlobalizationMode.InvariantNoLoad)
             {


### PR DESCRIPTION
(With `StackTraceSupport=false`, `OptimizationPreference=Size`, `UseSystemResourceKeys=true`)

I don't know if we want it in this form, but it is tempting. The thing that makes the difference is that we are no longer boxing enums and we can get rid of the super expensive enum stringification logic.

Not boxing enums also means that #118640 can fully kick in because enums are the last remaining place that looks at custom attributes (looking for `FlagsAttribute`).

Cc @dotnet/ilc-contrib 