### PR TITLE
Disable async test assert with race condition

### DIFF
--- a/src/tests/async/synchronization-context/synchronization-context.cs
+++ b/src/tests/async/synchronization-context/synchronization-context.cs
@@ -40,8 +40,11 @@ public class Async2SynchronizationContext
         await WrappedYieldToThreadPool(suspend: false).ConfigureAwait(false);
         Assert.Same(context, SynchronizationContext.Current);
 
-        await WrappedYieldToThreadPool(suspend: true).ConfigureAwait(false);
-        Assert.Null(SynchronizationContext.Current);
+        // Currently disabled since ConfigureAwait does not become a runtime async call,
+        // and this has a race condition until it does (where the callee finishes before
+        // we check IsCompleted on the awaiter).
+        //await WrappedYieldToThreadPool(suspend: true).ConfigureAwait(false);
+        //Assert.Null(SynchronizationContext.Current);
 
         await WrappedYieldToThreadWithCustomSyncContext();
         Assert.Null(SynchronizationContext.Current);


### PR DESCRIPTION
We should be able to enable this testing once we switch to a Roslyn that emits this as a runtime async call.