### PR TITLE
Fix runtime-linker-tests pipeline

### DIFF
--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -85,7 +85,7 @@ extends:
             # Build libs.sfx subset first so that Roslyn analyzer tests can use live ref pack
             buildArgs: -s libs.sfx -c $(_BuildConfig)
             postBuildSteps:
-            - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) -s tools.illinktests -test -c $(_BuildConfig) $(crossArg) $(_officialBuildParameter)
+            - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch $(archType) $(_osParameter) -s tools.illinktests -test -c $(_BuildConfig) $(crossArg) $(_officialBuildParameter)
               displayName: Run ILLink Tests
 
       #


### PR DESCRIPTION
I broke runtime-linker-tests.yml in https://github.com/dotnet/runtime/pull/118180
but didn't notice because .yml errors don't surface in github.