### PR TITLE
Optimize ImmutableArray<T>.ElementAtOrDefault

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -315,12 +315,12 @@ namespace System.Linq
         /// <typeparam name="T">The type of element contained by the collection.</typeparam>
         public static T? ElementAtOrDefault<T>(this ImmutableArray<T> immutableArray, int index)
         {
-            if (index < 0 || index >= immutableArray.Length)
+            if ((uint)index < (uint)immutableArray.Length)
             {
-                return default;
+                return immutableArray[index];
             }
 
-            return immutableArray[index];
+            return default;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR optimizes the bounds checking logic for index validation in `ImmutableArray<T>.ElementAtOrDefault`.  
The current implementation uses `index < 0 || index >= immutableArray.Length`, but I replaced this with unsigned comparison `(uint)index >= (uint)immutableArray.Length` to reduce bounds checks.
This pattern is already used in `Enumerable.ElementAtOrDefault`, making this change safe and consistent.