### PR TITLE
Disable DevDiv_255294 on crossgen lanes because it is eaten by the linux OOM killer

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -567,6 +567,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/forceinlining/PositiveCases/**">
             <Issue>https://github.com/dotnet/runtime/issues/109315</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_255294/**">
+            <Issue>https://github.com/dotnet/runtime/issues/106675</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Crossgen2 x86 specific excludes -->


### PR DESCRIPTION
Mitigates #106675 but does not fix it