### PR TITLE
[MONO] Partially revert "Add TypeName APIs to simplify metadata lookup"

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
@@ -509,6 +509,26 @@ namespace System.Tests
             Assert.Equal(expectedType, Type.GetType(typeName.ToLower(), throwOnError: false, ignoreCase: true));
         }
 
+        public static IEnumerable<object[]> GetTypeByName_InvalidElementType()
+        {
+            Type expectedException = PlatformDetection.IsMonoRuntime
+                ? typeof(ArgumentException) // https://github.com/dotnet/runtime/issues/45033
+                : typeof(TypeLoadException);
+
+            yield return new object[] { "System.Int32&&", expectedException, true };
+            yield return new object[] { "System.Int32&*", expectedException, true };
+            yield return new object[] { "System.Int32&[]", expectedException, true };
+            yield return new object[] { "System.Int32&[*]", expectedException, true };
+            yield return new object[] { "System.Int32&[,]", expectedException, true };
+
+            // https://github.com/dotnet/runtime/issues/45033
+            if (!PlatformDetection.IsMonoRuntime)
+            {
+                yield return new object[] { "System.Void[]", expectedException, true };
+                yield return new object[] { "System.TypedReference[]", expectedException, true };
+            }
+        }
+
         [Theory]
         [InlineData("system.nullable`1[system.int32]", typeof(TypeLoadException), false)]
         [InlineData("System.NonExistingType", typeof(TypeLoadException), false)]
@@ -519,13 +539,7 @@ namespace System.Tests
         [InlineData(".System.Int32", typeof(TypeLoadException), false)]
         [InlineData("..Outside`1", typeof(TypeLoadException), false)]
         [InlineData(".Outside`1+.Inside`1", typeof(TypeLoadException), false)]
-        [InlineData("System.Int32&&", typeof(TypeLoadException), true)]
-        [InlineData("System.Int32&*", typeof(TypeLoadException), true)]
-        [InlineData("System.Int32&[]", typeof(TypeLoadException), true)]
-        [InlineData("System.Int32&[*]", typeof(TypeLoadException), true)]
-        [InlineData("System.Int32&[,]", typeof(TypeLoadException), true)]
-        [InlineData("System.Void[]", typeof(TypeLoadException), true)]
-        [InlineData("System.TypedReference[]", typeof(TypeLoadException), true)]
+        [MemberData(nameof(GetTypeByName_InvalidElementType))]
         public void GetTypeByName_Invalid(string typeName, Type expectedException, bool alwaysThrowsException)
         {
             if (!alwaysThrowsException)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
@@ -524,7 +524,8 @@ namespace System.Tests
             // https://github.com/dotnet/runtime/issues/45033
             if (!PlatformDetection.IsMonoRuntime)
             {
-                yield return new object[] { "..Outside`1", typeof(TypeLoadException), false };
+                yield return new object[] { "..Outside`1", expectedException, false };
+                yield return new object[] { ".Outside`1+.Inside`1", expectedException, false };
 
                 yield return new object[] { "System.Void[]", expectedException, true };
                 yield return new object[] { "System.TypedReference[]", expectedException, true };
@@ -539,7 +540,6 @@ namespace System.Tests
         [InlineData("Outside`2", typeof(TypeLoadException), false)]
         [InlineData("Outside`1[System.Boolean, System.Int32]", typeof(ArgumentException), true)]
         [InlineData(".System.Int32", typeof(TypeLoadException), false)]
-        [InlineData(".Outside`1+.Inside`1", typeof(TypeLoadException), false)]
         [MemberData(nameof(GetTypeByName_InvalidElementType))]
         public void GetTypeByName_Invalid(string typeName, Type expectedException, bool alwaysThrowsException)
         {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
@@ -524,6 +524,8 @@ namespace System.Tests
             // https://github.com/dotnet/runtime/issues/45033
             if (!PlatformDetection.IsMonoRuntime)
             {
+                yield return new object[] { "..Outside`1", typeof(TypeLoadException), false };
+
                 yield return new object[] { "System.Void[]", expectedException, true };
                 yield return new object[] { "System.TypedReference[]", expectedException, true };
             }
@@ -537,7 +539,6 @@ namespace System.Tests
         [InlineData("Outside`2", typeof(TypeLoadException), false)]
         [InlineData("Outside`1[System.Boolean, System.Int32]", typeof(ArgumentException), true)]
         [InlineData(".System.Int32", typeof(TypeLoadException), false)]
-        [InlineData("..Outside`1", typeof(TypeLoadException), false)]
         [InlineData(".Outside`1+.Inside`1", typeof(TypeLoadException), false)]
         [MemberData(nameof(GetTypeByName_InvalidElementType))]
         public void GetTypeByName_Invalid(string typeName, Type expectedException, bool alwaysThrowsException)

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.Mono.cs
@@ -18,7 +18,6 @@ namespace System.Reflection
         private Func<Assembly?, string, bool, Type?>? _typeResolver;
         private bool _throwOnError;
         private bool _ignoreCase;
-        private bool _extensibleParser;
         private ref StackCrawlMark _stackMark;
 
         [RequiresUnreferencedCode("The type might be removed")]
@@ -28,7 +27,6 @@ namespace System.Reflection
             Func<Assembly?, string, bool, Type?>? typeResolver,
             bool throwOnError,
             bool ignoreCase,
-            bool extensibleParser,
             ref StackCrawlMark stackMark)
         {
             ArgumentNullException.ThrowIfNull(typeName);
@@ -54,7 +52,6 @@ namespace System.Reflection
                 _typeResolver = typeResolver,
                 _throwOnError = throwOnError,
                 _ignoreCase = ignoreCase,
-                _extensibleParser = extensibleParser,
                 _stackMark = ref stackMark
             }.Resolve(parsed);
         }
@@ -115,8 +112,7 @@ namespace System.Reflection
                     {
                         throw new TypeLoadException(assembly is null ?
                             SR.Format(SR.TypeLoad_ResolveType, escapedTypeName) :
-                            SR.Format(SR.TypeLoad_ResolveTypeFromAssembly, escapedTypeName, assembly.FullName),
-                            typeName: escapedTypeName);
+                            SR.Format(SR.TypeLoad_ResolveTypeFromAssembly, escapedTypeName, assembly.FullName));
                     }
                     return null;
                 }
@@ -144,16 +140,7 @@ namespace System.Reflection
                 if (_ignoreCase)
                     bindingFlags |= BindingFlags.IgnoreCase;
 
-                if (type is RuntimeType rt)
-                {
-                    // Compat: Non-extensible parser allows ambiguous matches with ignore case lookup
-                    bool ignoreAmbiguousMatch = !_extensibleParser && _ignoreCase;
-                    type = rt.GetNestedType(nestedTypeNames[i], bindingFlags, ignoreAmbiguousMatch);
-                }
-                else
-                {
-                    type = type.GetNestedType(nestedTypeNames[i], bindingFlags);
-                }
+                type = type.GetNestedType(nestedTypeNames[i], bindingFlags);
 
                 if (type is null)
                 {

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.Mono.cs
@@ -112,7 +112,8 @@ namespace System.Reflection
                     {
                         throw new TypeLoadException(assembly is null ?
                             SR.Format(SR.TypeLoad_ResolveType, escapedTypeName) :
-                            SR.Format(SR.TypeLoad_ResolveTypeFromAssembly, escapedTypeName, assembly.FullName));
+                            SR.Format(SR.TypeLoad_ResolveTypeFromAssembly, escapedTypeName, assembly.FullName),
+                            typeName: escapedTypeName);
                     }
                     return null;
                 }

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -679,17 +679,21 @@ namespace System
             return candidates;
         }
 
-        private ListBuilder<Type> GetNestedTypeCandidates(string? name, BindingFlags bindingAttr, bool allowPrefixLookup)
+        private ListBuilder<Type> GetNestedTypeCandidates(string? fullname, BindingFlags bindingAttr, bool allowPrefixLookup)
         {
+            bool prefixLookup;
             bindingAttr &= ~BindingFlags.Static;
-            FilterHelper(bindingAttr, ref name, allowPrefixLookup, out bool prefixLookup, out _, out MemberListType listType);
+            string? name, ns;
+            MemberListType listType;
+            SplitName(fullname, out name, out ns);
+            FilterHelper(bindingAttr, ref name, allowPrefixLookup, out prefixLookup, out _, out listType);
 
             RuntimeType[] cache = GetNestedTypes_internal(name, bindingAttr, listType);
             ListBuilder<Type> candidates = new ListBuilder<Type>(cache.Length);
             for (int i = 0; i < cache.Length; i++)
             {
                 RuntimeType nestedClass = cache[i];
-                if (FilterApplyType(nestedClass, bindingAttr, name, prefixLookup, null))
+                if (FilterApplyType(nestedClass, bindingAttr, name, prefixLookup, ns))
                 {
                     candidates.Add(nestedClass);
                 }
@@ -1000,37 +1004,31 @@ namespace System
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
-        internal Type? GetNestedType([MaybeNull] string name, BindingFlags bindingAttr, bool ignoreAmbiguousMatch)
+        public override Type? GetNestedType(string fullname, BindingFlags bindingAttr)
         {
-            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(fullname);
 
             bindingAttr &= ~BindingFlags.Static;
-            FilterHelper(bindingAttr, ref name, out _, out MemberListType listType);
+            string? name, ns;
+            MemberListType listType;
+            SplitName(fullname, out name, out ns);
+            FilterHelper(bindingAttr, ref name, out _, out listType);
             RuntimeType[] cache = GetNestedTypes_internal(name, bindingAttr, listType);
             RuntimeType? match = null;
 
             for (int i = 0; i < cache.Length; i++)
             {
                 RuntimeType nestedType = cache[i];
-                if (FilterApplyType(nestedType, bindingAttr, name, false, null))
+                if (FilterApplyType(nestedType, bindingAttr, name, false, ns))
                 {
                     if (match != null)
                         throw ThrowHelper.GetAmbiguousMatchException(match);
 
                     match = nestedType;
-
-                    if (ignoreAmbiguousMatch)
-                        break;
                 }
             }
 
             return match;
-        }
-
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
-        public override Type? GetNestedType(string name, BindingFlags bindingAttr)
-        {
-            return GetNestedType(name, bindingAttr, ignoreAmbiguousMatch: false);
         }
 
         [DynamicallyAccessedMembers(GetAllMembers)]
@@ -1685,8 +1683,7 @@ namespace System
 
         [Flags]
         // Types of entries cached in TypeCache
-        private enum TypeCacheEntries
-        {
+        private enum TypeCacheEntries {
             IsGenericTypeDef = 1,
             IsDelegate = 2,
             IsValueType = 4,

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1683,7 +1683,8 @@ namespace System
 
         [Flags]
         // Types of entries cached in TypeCache
-        private enum TypeCacheEntries {
+        private enum TypeCacheEntries
+        {
             IsGenericTypeDef = 1,
             IsDelegate = 2,
             IsValueType = 4,

--- a/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
@@ -30,7 +30,7 @@ namespace System
         public static Type? GetType(string typeName, bool throwOnError, bool ignoreCase)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return GetType(typeName, null, null, throwOnError, ignoreCase, false, ref stackMark);
+            return RuntimeType.GetType(typeName, throwOnError, ignoreCase, ref stackMark);
         }
 
         [RequiresUnreferencedCode("The type might be removed")]
@@ -38,7 +38,7 @@ namespace System
         public static Type? GetType(string typeName, bool throwOnError)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return GetType(typeName, null, null, throwOnError, false, false, ref stackMark);
+            return RuntimeType.GetType(typeName, throwOnError, false, ref stackMark);
         }
 
         [RequiresUnreferencedCode("The type might be removed")]
@@ -46,7 +46,7 @@ namespace System
         public static Type? GetType(string typeName)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return GetType(typeName, null, null, false, false, false, ref stackMark);
+            return RuntimeType.GetType(typeName, false, false, ref stackMark);
         }
 
         [RequiresUnreferencedCode("The type might be removed")]
@@ -54,7 +54,7 @@ namespace System
         public static Type? GetType(string typeName, Func<AssemblyName, Assembly?>? assemblyResolver, Func<Assembly?, string, bool, Type?>? typeResolver)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return GetType(typeName, assemblyResolver, typeResolver, false, false, true, ref stackMark);
+            return GetType(typeName, assemblyResolver, typeResolver, false, false, ref stackMark);
         }
 
         [RequiresUnreferencedCode("The type might be removed")]
@@ -62,7 +62,7 @@ namespace System
         public static Type? GetType(string typeName, Func<AssemblyName, Assembly?>? assemblyResolver, Func<Assembly?, string, bool, Type?>? typeResolver, bool throwOnError)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return GetType(typeName, assemblyResolver, typeResolver, throwOnError, false, true, ref stackMark);
+            return GetType(typeName, assemblyResolver, typeResolver, throwOnError, false, ref stackMark);
         }
 
         [RequiresUnreferencedCode("The type might be removed")]
@@ -70,13 +70,13 @@ namespace System
         public static Type? GetType(string typeName, Func<AssemblyName, Assembly?>? assemblyResolver, Func<Assembly?, string, bool, Type?>? typeResolver, bool throwOnError, bool ignoreCase)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, true, ref stackMark);
+            return GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, ref stackMark);
         }
 
         [RequiresUnreferencedCode("The type might be removed")]
-        private static Type? GetType(string typeName, Func<AssemblyName, Assembly?>? assemblyResolver, Func<Assembly?, string, bool, Type?>? typeResolver, bool throwOnError, bool ignoreCase, bool extensibleParser, ref StackCrawlMark stackMark)
+        private static Type? GetType(string typeName, Func<AssemblyName, Assembly?>? assemblyResolver, Func<Assembly?, string, bool, Type?>? typeResolver, bool throwOnError, bool ignoreCase, ref StackCrawlMark stackMark)
         {
-            return TypeNameResolver.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, extensibleParser, ref stackMark);
+            return TypeNameResolver.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, ref stackMark);
         }
 
         public static Type? GetTypeFromHandle(RuntimeTypeHandle handle)


### PR DESCRIPTION
Mono specific changes in #111598 regressed Mono runtime performance significantly. Reverting the changes for now.

Fixes #112763