### PR TITLE
Restore calls to CreateFatalHandshakeAlertToken on Android

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
@@ -21,7 +21,11 @@ namespace System.Net.Security
 
         internal const bool StartMutualAuthAsAnonymous = false;
         internal const bool CanEncryptEmptyMessage = false;
-        internal const bool CanGenerateCustomAlerts = false;
+
+        // There is no API to generate custom alerts on Android, but the interop layer currently
+        // depends on SslStream calling HandshakeInternal one last time when tearing down the connection
+        // due to handshake failures.
+        internal const bool CanGenerateCustomAlerts = true;
 
         public static void VerifyPackageInfo()
         {
@@ -231,7 +235,6 @@ namespace System.Net.Security
         {
             // There doesn't seem to be an exposed API for writing an alert.
             // The API seems to assume that all alerts are generated internally.
-            Debug.Assert(CanGenerateCustomAlerts);
             return new SecurityStatusPal(SecurityStatusPalErrorCode.OK);
         }
 


### PR DESCRIPTION
Fixes #118118
Fixes #117963
Fixes #118350

https://github.com/dotnet/runtime/pull/117428 Introduced some PAL constants to adjust SslStream behavior with regards to sending custom alerts. The PR assumed that since SslStreamPal.ApplyAlertToken is a no-op (due to no API for creating custom alert being available), the entire SslStream.CreateFatalHandshakeAlertToken would be no-op as well. This was the case on Linux and OSX, but not so on Android.

To avoid a regression in .NET 10, this PR restores the call to CreateFatalHandshakeAlertToken, but ideally, the code should be examined as to why the last call to SslStream.HandshakeInternal is needed (as any internally generated alerts should've been returned as part of the previous call).