### PR TITLE
[browser] Apply COOP/COEP headers only when threads are enabled

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -34,7 +34,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_RunWorkingDirectory Condition="'$(_RunWorkingDirectory)' != '' and !$([System.IO.Path]::IsPathRooted($(_RunWorkingDirectory)))">$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(_RunWorkingDirectory)))</_RunWorkingDirectory>
     <_RuntimeConfigJsonPath>$([MSBuild]::NormalizePath($(_RunWorkingDirectory), '$(AssemblyName).runtimeconfig.json'))</_RuntimeConfigJsonPath>
 
-    <RunArguments>exec &quot;$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll'))&quot; --use-staticwebassets --runtime-config &quot;$(_RuntimeConfigJsonPath)&quot; $(WasmHostArguments)</RunArguments>
+    <_RunExtraArguments Condition="'$(WasmEnableThreads)' == 'true'">--apply-cop-headers</_RunExtraArguments>
+    <RunArguments>exec &quot;$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll'))&quot; --use-staticwebassets --runtime-config &quot;$(_RuntimeConfigJsonPath)&quot; $(_RunExtraArguments) $(WasmHostArguments)</RunArguments>
     <RunWorkingDirectory>$(_RunWorkingDirectory)</RunWorkingDirectory>
   </PropertyGroup>
 

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -240,7 +240,8 @@
     <RunCommand Condition="'$(RunCommand)' == ''">dotnet</RunCommand>
 
     <_RuntimeConfigJsonPath>$([MSBuild]::NormalizePath($(_AppBundleDirForRunCommand), '$(AssemblyName).runtimeconfig.json'))</_RuntimeConfigJsonPath>
-    <RunArguments Condition="'$(RunArguments)' == ''">exec &quot;$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll'))&quot; --runtime-config &quot;$(_RuntimeConfigJsonPath)&quot; $(WasmHostArguments)</RunArguments>
+    <_RunExtraArguments Condition="'$(WasmEnableThreads)' == 'true'">--apply-cop-headers</_RunExtraArguments>
+    <RunArguments Condition="'$(RunArguments)' == ''">exec &quot;$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll'))&quot; --runtime-config &quot;$(_RuntimeConfigJsonPath)&quot; $(_RunExtraArguments) $(WasmHostArguments)</RunArguments>
     <RunWorkingDirectory Condition="'$(RunWorkingDirectory)' == ''">$(_AppBundleDirForRunCommand)</RunWorkingDirectory>
   </PropertyGroup>
 

--- a/src/mono/wasm/host/BrowserHost.cs
+++ b/src/mono/wasm/host/BrowserHost.cs
@@ -118,16 +118,16 @@ internal sealed class BrowserHost
         }
 
         // Otherwise for old template, use web server
-        WebServerOptions webServerOptions = CreateWebServerOptions(urls, args.CommonConfig.AppPath, onConsoleConnected);
+        WebServerOptions webServerOptions = CreateWebServerOptions(args, urls, onConsoleConnected);
         return await WebServer.StartAsync(webServerOptions, _logger, token);
     }
 
-    private static WebServerOptions CreateWebServerOptions(string[] urls, string appPath, Func<WebSocket, Task>? onConsoleConnected) => new
+    private static WebServerOptions CreateWebServerOptions(BrowserArguments args, string[] urls, Func<WebSocket, Task>? onConsoleConnected) => new
     (
         OnConsoleConnected: onConsoleConnected,
-        ContentRootPath: Path.GetFullPath(appPath),
+        ContentRootPath: Path.GetFullPath(args.CommonConfig.AppPath),
         WebServerUseCors: true,
-        WebServerUseCrossOriginPolicy: true,
+        WebServerUseCrossOriginPolicy: args.CommonConfig.ApplyCopHeaders,
         Urls: urls
     );
 
@@ -148,17 +148,17 @@ internal sealed class BrowserHost
             var staticWebAssetsPath = Path.ChangeExtension(mainAssemblyPath, staticWebAssetsV2Extension);
             if (File.Exists(staticWebAssetsPath))
             {
-                devServerOptions = CreateDevServerOptions(urls, staticWebAssetsPath, endpointsManifest, onConsoleConnected);
+                devServerOptions = CreateDevServerOptions(args, urls, staticWebAssetsPath, endpointsManifest, onConsoleConnected);
             }
             else
             {
                 staticWebAssetsPath = Path.ChangeExtension(mainAssemblyPath, staticWebAssetsV1Extension);
                 if (File.Exists(staticWebAssetsPath))
-                    devServerOptions = CreateDevServerOptions(urls, staticWebAssetsPath, endpointsManifest, onConsoleConnected);
+                    devServerOptions = CreateDevServerOptions(args, urls, staticWebAssetsPath, endpointsManifest, onConsoleConnected);
             }
 
             if (devServerOptions == null)
-                devServerOptions = CreateDevServerOptions(urls, mainAssemblyPath, endpointsManifest, onConsoleConnected);
+                devServerOptions = CreateDevServerOptions(args, urls, mainAssemblyPath, endpointsManifest, onConsoleConnected);
         }
         else
         {
@@ -170,7 +170,7 @@ internal sealed class BrowserHost
             var endpointsManifest = FindFirstFileWithExtension(appPath, ".staticwebassets.endpoints.json");
 
             if (staticWebAssetsPath != null)
-                devServerOptions = CreateDevServerOptions(urls, staticWebAssetsPath, endpointsManifest, onConsoleConnected);
+                devServerOptions = CreateDevServerOptions(args, urls, staticWebAssetsPath, endpointsManifest, onConsoleConnected);
 
             if (devServerOptions == null)
                 throw new CommandLineException($"Please, provide mainAssembly in hostProperties of runtimeconfig. Alternatively leave the static web assets manifest ('*{staticWebAssetsV2Extension}') in the build output directory '{appPath}' .");
@@ -179,13 +179,13 @@ internal sealed class BrowserHost
         return devServerOptions;
     }
 
-    private static DevServerOptions CreateDevServerOptions(string[] urls, string staticWebAssetsPath, string? endpointsManifest, Func<WebSocket, Task>? onConsoleConnected) => new
+    private static DevServerOptions CreateDevServerOptions(BrowserArguments args, string[] urls, string staticWebAssetsPath, string? endpointsManifest, Func<WebSocket, Task>? onConsoleConnected) => new
     (
         OnConsoleConnected: onConsoleConnected,
         StaticWebAssetsPath: staticWebAssetsPath,
         StaticWebAssetsEndpointsPath: endpointsManifest,
         WebServerUseCors: true,
-        WebServerUseCrossOriginPolicy: true,
+        WebServerUseCrossOriginPolicy: args.CommonConfig.ApplyCopHeaders,
         Urls: urls
     );
 

--- a/src/mono/wasm/host/CommonConfiguration.cs
+++ b/src/mono/wasm/host/CommonConfiguration.cs
@@ -23,6 +23,7 @@ internal sealed class CommonConfiguration
     public IEnumerable<string> HostArguments { get; init; }
     public bool Silent { get; private set; } = true;
     public bool UseStaticWebAssets { get; private set; }
+    public bool ApplyCopHeaders { get; private set; }
     public string? RuntimeConfigPath { get; private set; }
 
     private string? hostArg;
@@ -46,7 +47,8 @@ internal sealed class CommonConfiguration
             { "runtime-config|r=", "runtimeconfig.json path for the app", v => RuntimeConfigPath = v },
             { "extra-host-arg=", "Extra argument to be passed to the host", hostArgsList.Add },
             { "no-silent", "Verbose output from WasmAppHost", _ => Silent = false },
-            { "use-staticwebassets", "Use static web assets, needed for projects targeting WebAssembly SDK", _ => UseStaticWebAssets = true }
+            { "use-staticwebassets", "Use static web assets, needed for projects targeting WebAssembly SDK", _ => UseStaticWebAssets = true },
+            { "apply-cop-headers", "Apply COOP/COEP headers, required for multi-threaded apps", _ => ApplyCopHeaders = true }
         };
 
         RemainingArgs = options.Parse(args);


### PR DESCRIPTION
Apply COOP/COEP headers only when `WasmEnableThreads=true` the same as Blazor's DevServer does.
Originally it was partially blocked by https://github.com/dotnet/sdk/issues/32551, but that is resolved as well.

Fixes https://github.com/dotnet/runtime/issues/109937