### PR TITLE
Fix registry key handle leak in EventLogEntry.

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
@@ -377,7 +377,8 @@ namespace System.Diagnostics
             try
             {
                 eventKey = EventLog.GetEventLogRegKey(machineName, false);
-                return eventKey?.OpenSubKey(logName ?? "Application", /*writable*/false)?.OpenSubKey(source, /*writeable*/false);
+                logKey = eventKey?.OpenSubKey(logName ?? "Application", /*writable*/false);
+                return logKey?.OpenSubKey(source, /*writeable*/false);
             }
             finally
             {


### PR DESCRIPTION
Fix registry key handle leak in EventLogEntry.

Found by Linux Verification Center (linuxtesting.org) with SVACE.