### PR TITLE
[browser] Emit hosting messages expected by debug proxy launcher

### DIFF
--- a/src/mono/browser/debugger/BrowserDebugHost/DebugProxyHost.cs
+++ b/src/mono/browser/debugger/BrowserDebugHost/DebugProxyHost.cs
@@ -53,7 +53,6 @@ public static class DebugProxyHost
             .ConfigureServices(services =>
             {
                 services.AddSingleton(loggerFactory);
-                services.AddLogging(configure => configure.AddSimpleConsole().AddFilter(null, LogLevel.Information));
                 services.AddSingleton(Options.Create(options));
                 services.AddRouting();
             })

--- a/src/mono/browser/debugger/BrowserDebugHost/Program.cs
+++ b/src/mono/browser/debugger/BrowserDebugHost/Program.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 
 #nullable enable
 
@@ -23,13 +24,16 @@ namespace Microsoft.WebAssembly.Diagnostics
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
             {
-                builder.AddSimpleConsole(options =>
-                        {
-                            options.TimestampFormat = "[HH:mm:ss] ";
-                        })
-                        .AddFilter("DevToolsProxy", LogLevel.Information)
-                        .AddFilter("FirefoxMonoProxy", LogLevel.Information)
-                        .AddFilter(null, LogLevel.Warning);
+                builder
+                    .AddSimpleConsole(options =>
+                    {
+                        options.ColorBehavior = LoggerColorBehavior.Disabled;
+                        options.IncludeScopes = false;
+                    })
+                    .AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Information)
+                    .AddFilter("DevToolsProxy", LogLevel.Information)
+                    .AddFilter("FirefoxMonoProxy", LogLevel.Information)
+                    .AddFilter(null, LogLevel.Warning);
             });
 
             await DebugProxyHost.RunDebugProxyAsync(options, args, loggerFactory, CancellationToken.None);


### PR DESCRIPTION
Without the log messages, debug proxy launcher don't get the URLs it needs to connect to.