### PR TITLE
Use `MetadataTypeSymbol` in interop type maps

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AnalyzedExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AnalyzedExternalTypeMapNode.cs
@@ -21,7 +21,7 @@ namespace ILCompiler.DependencyAnalysis
             foreach ((string key, TypeDesc type) in entries)
             {
                 Vertex keyVertex = writer.GetStringConstant(key);
-                Vertex valueVertex = writer.GetUnsignedConstant(externalReferences.GetIndex(factory.MaximallyConstructableType(type)));
+                Vertex valueVertex = writer.GetUnsignedConstant(externalReferences.GetIndex(factory.MetadataTypeSymbol(type)));
                 Vertex entry = writer.GetTuple(keyVertex, valueVertex);
                 typeMapHashTable.Append((uint)TypeHashingAlgorithms.ComputeNameHashCode(key), section.Place(entry));
             }
@@ -37,7 +37,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             foreach (TypeDesc targetType in entries.Values)
             {
-                yield return new DependencyListEntry(context.MaximallyConstructableType(targetType), "Analyzed external type map entry target type");
+                yield return new DependencyListEntry(context.MetadataTypeSymbol(targetType), "Analyzed external type map entry target type");
             }
         }
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => [];

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AnalyzedProxyTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AnalyzedProxyTypeMapNode.cs
@@ -21,7 +21,7 @@ namespace ILCompiler.DependencyAnalysis
             foreach ((TypeDesc key, TypeDesc type) in entries)
             {
                 Vertex keyVertex = writer.GetUnsignedConstant(externalReferences.GetIndex(factory.MaximallyConstructableType(key)));
-                Vertex valueVertex = writer.GetUnsignedConstant(externalReferences.GetIndex(factory.MaximallyConstructableType(type)));
+                Vertex valueVertex = writer.GetUnsignedConstant(externalReferences.GetIndex(factory.MetadataTypeSymbol(type)));
                 Vertex entry = writer.GetTuple(keyVertex, valueVertex);
                 typeMapHashTable.Append((uint)key.GetHashCode(), section.Place(entry));
             }
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
             foreach (var (sourceType, proxyType) in entries)
             {
                 yield return new DependencyListEntry(context.MaximallyConstructableType(sourceType), "Analyzed proxy type map entry source type");
-                yield return new DependencyListEntry(context.MaximallyConstructableType(proxyType), "Analyzed proxy type map entry proxy type");
+                yield return new DependencyListEntry(context.MetadataTypeSymbol(proxyType), "Analyzed proxy type map entry proxy type");
             }
         }
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => [];

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (trimmingTargetType is not null)
                 {
                     yield return new CombinedDependencyListEntry(
-                        context.MaximallyConstructableType(targetType),
+                        context.MetadataTypeSymbol(targetType),
                         context.NecessaryTypeSymbol(trimmingTargetType),
                         "Type in external type map is cast target");
                 }
@@ -54,7 +54,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (trimmingTargetType is null)
                 {
                     yield return new DependencyListEntry(
-                        context.MaximallyConstructableType(targetType),
+                        context.MetadataTypeSymbol(targetType),
                         "External type map entry target type");
                 }
             }
@@ -80,7 +80,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (trimmingTargetType is null
                     || factory.NecessaryTypeSymbol(trimmingTargetType).Marked)
                 {
-                    IEETypeNode targetNode = factory.MaximallyConstructableType(targetType);
+                    IEETypeNode targetNode = factory.MetadataTypeSymbol(targetType);
                     Debug.Assert(targetNode.Marked);
                     yield return (entry.Key, targetNode);
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ProxyTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ProxyTypeMapNode.cs
@@ -43,7 +43,7 @@ namespace ILCompiler.DependencyAnalysis
             foreach (var (key, value) in _mapEntries)
             {
                 yield return new CombinedDependencyListEntry(
-                    context.MaximallyConstructableType(value),
+                    context.MetadataTypeSymbol(value),
                     context.MaximallyConstructableType(key),
                     "Proxy type map entry");
             }
@@ -60,7 +60,7 @@ namespace ILCompiler.DependencyAnalysis
                 IEETypeNode keyNode = factory.MaximallyConstructableType(key);
                 if (keyNode.Marked)
                 {
-                    IEETypeNode valueNode = factory.MaximallyConstructableType(value);
+                    IEETypeNode valueNode = factory.MetadataTypeSymbol(value);
                     Debug.Assert(valueNode.Marked);
                     yield return (keyNode, valueNode);
                 }


### PR DESCRIPTION
We guarantee the type can be found but not that it can be passed to e.g. `RuntimeHelpers.GetUninitializedObject`. The `MetadataTypeSymbol` node didn't exist when interop type map was added.

Cc @dotnet/ilc-contrib 