### PR TITLE
Fix check for `host_runtime_contract` having `external_assembly_probe`

### DIFF
--- a/src/coreclr/vm/hostinformation.cpp
+++ b/src/coreclr/vm/hostinformation.cpp
@@ -45,7 +45,8 @@ bool HostInformation::GetProperty(_In_z_ const char* name, SString& value)
 
 bool HostInformation::HasExternalProbe()
 {
-    return s_hostContract.external_assembly_probe != nullptr;
+    size_t requiredSize = offsetof(host_runtime_contract, external_assembly_probe) + sizeof(s_hostContract.external_assembly_probe);
+    return s_hostContract.size >= requiredSize && s_hostContract.external_assembly_probe != nullptr;
 }
 
 bool HostInformation::ExternalAssemblyProbe(_In_ const SString& path, _Out_ void** data, _Out_ int64_t* size)


### PR DESCRIPTION
We should check the size of the contract to determine if it can have `external_assembly_probe`. In practice, we probably haven't hit this since `hostpolicy` ships next to `coreclr` - but any sort of patching such that `coreclr` is newer than `hostpolicy` could result in incorrectly determining that `external_assembly_probe` is set.

cc @AaronRobinsonMSFT @rcj1 