### PR TITLE
Update Android Codespace

### DIFF
--- a/.devcontainer/android/Dockerfile
+++ b/.devcontainer/android/Dockerfile
@@ -28,10 +28,10 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 SHELL ["/bin/bash", "-c"]
 
-ENV NDK_VER=r23c
-ENV SDK_VER=9123335_latest
-ENV SDK_API_LEVEL=33
-ENV SDK_BUILD_TOOLS=33.0.1
+ENV NDK_VER=r27c
+ENV SDK_VER=13114758_latest
+ENV SDK_API_LEVEL=35
+ENV SDK_BUILD_TOOLS=35.0.0
 ENV HOST_OS=linux
 ENV HOST_OS_SHORT=linux
 ENV ANDROID_NDK_ROOT=/android/android-ndk-${NDK_VER}
@@ -43,7 +43,7 @@ RUN curl -sSL --tlsv1.2 https://dl.google.com/android/repository/android-ndk-${N
     curl -sSL --tlsv1.2 https://dl.google.com/android/repository/commandlinetools-${HOST_OS_SHORT}-${SDK_VER}.zip -L --output /tmp/asdk.zip
 
 # Check hashes of downloads
-RUN (echo "6ce94604b77d28113ecd588d425363624a5228d9662450c48d2e4053f8039242 /tmp/andk.zip"; echo "0bebf59339eaa534f4217f8aa0972d14dc49e7207be225511073c661ae01da0a /tmp/asdk.zip") | cat | sha256sum -c
+RUN (echo "59c2f6dc96743b5daf5d1626684640b20a6bd2b1d85b13156b90333741bad5cc /tmp/andk.zip"; echo "7ec965280a073311c339e571cd5de778b9975026cfcbe79f2b1cdcb1e15317ee /tmp/asdk.zip") | cat | sha256sum -c
 
 # Unpack the NDK and SDK
 RUN mkdir -p ${ANDROID_NDK_ROOT} && unzip /tmp/andk.zip -d $(dirname ${ANDROID_NDK_ROOT}) && rm -f /tmp/andk.zip && \

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -31,7 +31,7 @@ case "$opt" in
 
     android)
         # prebuild the repo for Mono, so it is ready for development
-        ./build.sh mono+libs -os android
+        ./build.sh mono+libs+clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.packages -os android
         # restore libs tests so that the project is ready to be loaded by OmniSharp
         ./build.sh libs.tests -restore
     ;;


### PR DESCRIPTION
* Build the CoreCLR so the tests can be run with either the mono or coreclr runtime flavors.
* Update the NDK and Android SDK.