### PR TITLE
Tweaks to warning formatting

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/MessageContainer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/MessageContainer.cs
@@ -271,7 +271,7 @@ namespace ILCompiler.Logging
 
         public string ToMSBuildString()
         {
-            const string originApp = "ILC";
+            const string originApp = "ILC "; // extra space for MSBuild sake: https://github.com/dotnet/runtime/issues/118788
             string origin = Origin?.ToString() ?? originApp;
 
             StringBuilder sb = new StringBuilder();

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -222,7 +222,7 @@ namespace ILCompiler
                     Logger.LogWarning(method, DiagnosticId.COMInteropNotSupportedInFullAOT);
                 }
                 if ((_compilationOptions & RyuJitCompilationOptions.UseResilience) != 0)
-                    Logger.LogMessage($"Method '{method}' in assembly '{owningAssembly}' will always throw because: {exception.Message}");
+                    Logger.LogMessage($"Method '{method}' in assembly will always throw because: {exception.Message}");
                 else
                     Logger.LogError($"Method in '{owningAssembly}' will always throw because: {exception.Message}", 1005, method, MessageSubCategory.AotAnalysis);
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -222,7 +222,7 @@ namespace ILCompiler
                     Logger.LogWarning(method, DiagnosticId.COMInteropNotSupportedInFullAOT);
                 }
                 if ((_compilationOptions & RyuJitCompilationOptions.UseResilience) != 0)
-                    Logger.LogMessage($"Method '{method}' in assembly will always throw because: {exception.Message}");
+                    Logger.LogMessage($"Method '{method}' will always throw because: {exception.Message}");
                 else
                     Logger.LogError($"Method in '{owningAssembly}' will always throw because: {exception.Message}", 1005, method, MessageSubCategory.AotAnalysis);
 

--- a/src/tools/illink/src/linker/Linker/MessageContainer.cs
+++ b/src/tools/illink/src/linker/Linker/MessageContainer.cs
@@ -293,7 +293,8 @@ namespace Mono.Linker
         public string ToMSBuildString()
         {
             const string originApp = Constants.ILLink;
-            string origin = Origin?.ToString() ?? originApp;
+            string origin = Origin?.ToString()
+                ?? $"{originApp} "; // extra space for MSBuild sake: https://github.com/dotnet/runtime/issues/118788
 
             StringBuilder sb = new StringBuilder();
             sb.Append(origin).Append(':');


### PR DESCRIPTION
Fixes #118788

Sample output after this change:

```
ILC : AOT analysis error IL1005: TestGenericLdtoken.Main(): Method in 'repro' will always throw because: Failed to load type 'F`1' from assembly 'repro, Version=10.0.0.0, Culture=neutral, PublicKey=null' because generic types cannot have explicit layout
```

Note that the error message is only reachable if the `--resilient` argument is missing. Otherwise this prints a non-error/non-warning message that already includes the assembly name

```
ILC : Method '[repro]TestGenericLdtoken.Main()' will always throw because: Failed to load type 'F`1' from assembly 'repro, Version=10.0.0.0, Culture=neutral, PublicKey=null' because generic types cannot have explicit layout
```

`--resilient` is passed by default and there is an undocumented opt out.

Cc @dotnet/ilc-contrib 