### PR TITLE
Serialize negative constants according to the operand type

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12644,27 +12644,34 @@ void emitter::emitDispConstant(const instrDesc* id, bool skipComma) const
         }
     }
 
-    switch (id->idOpSize())
+    if ((val > -1000) && (val < 1000))
     {
-        case EA_1BYTE:
-            printf("0x%X", static_cast<uint8_t>(val));
-            break;
+        printf("%d", static_cast<int>(val));
+    }
+    else
+    {
+        switch (id->idOpSize())
+        {
+            case EA_1BYTE:
+                printf("0x%X", static_cast<uint8_t>(val));
+                break;
 
-        case EA_2BYTE:
-            printf("0x%X", static_cast<uint16_t>(val));
-            break;
+            case EA_2BYTE:
+                printf("0x%X", static_cast<uint16_t>(val));
+                break;
 
-        case EA_4BYTE:
-            printf("0x%X", static_cast<uint32_t>(val));
-            break;
+            case EA_4BYTE:
+                printf("0x%X", static_cast<uint32_t>(val));
+                break;
 
-        case EA_8BYTE:
-            printf("0x%X", static_cast<uint64_t>(val));
-            break;
+            case EA_8BYTE:
+                printf("0x%X", static_cast<uint64_t>(val));
+                break;
 
-        default:
-            printf("0x%zX", (size_t)val);
-            break;
+            default:
+                printf("0x%zX", static_cast<size_t>(val));
+                break;
+        }
     }
 
     emitDispCommentForHandle(cnsVal.cnsVal, id->idDebugOnlyInfo()->idMemCookie, id->idDebugOnlyInfo()->idFlags);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12648,9 +12648,34 @@ void emitter::emitDispConstant(const instrDesc* id, bool skipComma) const
     {
         printf("%d", (int)val);
     }
-    else if ((val > 0) || (val < -0xFFFFFF))
+    else if (val > 0)
     {
         printf("0x%zX", (ssize_t)val);
+    }
+    else if (val < -0xFFFFFF)
+    {
+        switch (id->idOpSize())
+        {
+            case EA_1BYTE:
+                printf("0x%X", static_cast<int8_t>(val));
+                break;
+
+            case EA_2BYTE:
+                printf("0x%X", static_cast<int16_t>(val));
+                break;
+
+            case EA_4BYTE:
+                printf("0x%X", static_cast<int32_t>(val));
+                break;
+
+            case EA_8BYTE:
+                printf("0x%X", static_cast<int64_t>(val));
+                break;
+
+            default:
+                printf("0x%zX", (ssize_t)val);
+                break;
+        }
     }
     else
     {

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12644,43 +12644,27 @@ void emitter::emitDispConstant(const instrDesc* id, bool skipComma) const
         }
     }
 
-    if ((val > -1000) && (val < 1000))
+    switch (id->idOpSize())
     {
-        printf("%d", (int)val);
-    }
-    else if (val > 0)
-    {
-        printf("0x%zX", (ssize_t)val);
-    }
-    else if (val < -0xFFFFFF)
-    {
-        switch (id->idOpSize())
-        {
-            case EA_1BYTE:
-                printf("0x%X", static_cast<int8_t>(val));
-                break;
+        case EA_1BYTE:
+            printf("0x%X", static_cast<uint8_t>(val));
+            break;
 
-            case EA_2BYTE:
-                printf("0x%X", static_cast<int16_t>(val));
-                break;
+        case EA_2BYTE:
+            printf("0x%X", static_cast<uint16_t>(val));
+            break;
 
-            case EA_4BYTE:
-                printf("0x%X", static_cast<int32_t>(val));
-                break;
+        case EA_4BYTE:
+            printf("0x%X", static_cast<uint32_t>(val));
+            break;
 
-            case EA_8BYTE:
-                printf("0x%X", static_cast<int64_t>(val));
-                break;
+        case EA_8BYTE:
+            printf("0x%X", static_cast<uint64_t>(val));
+            break;
 
-            default:
-                printf("0x%zX", (ssize_t)val);
-                break;
-        }
-    }
-    else
-    {
-        // (val < 0)
-        printf("-0x%zX", (ssize_t)-val);
+        default:
+            printf("0x%zX", (ssize_t)val);
+            break;
     }
 
     emitDispCommentForHandle(cnsVal.cnsVal, id->idDebugOnlyInfo()->idMemCookie, id->idDebugOnlyInfo()->idFlags);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12663,7 +12663,7 @@ void emitter::emitDispConstant(const instrDesc* id, bool skipComma) const
             break;
 
         default:
-            printf("0x%zX", (ssize_t)val);
+            printf("0x%zX", (size_t)val);
             break;
     }
 


### PR DESCRIPTION
Prior to this patch, any negative constants smaller than -0xFFFFFF would
get serialized to 64-bit constants, so we would end up with assembly
statements like `imul eax, esi, 0xFFFFFFFFFEFFFFFF`, which is invalid
since the constant is larger than 32 bits, which is the size of `eax`
and `esi` registers.

This patch fixes the code so that for known 1-, 2, 4-, and 8-byte types,
we first truncate the constant to the correct number of bits before
printing it.

Fix #118813