### PR TITLE
Disable release assert on disallowed thread re-initialization for managed C++

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3744,10 +3744,19 @@ void SaveManagedCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv)
 #endif
 }
 
+static bool g_fIJWLoaded = false;
+
 void Module::SetIsIJWFixedUp()
 {
     LIMITED_METHOD_CONTRACT;
     InterlockedOr((LONG*)&m_dwTransientFlags, IS_IJW_FIXED_UP);
+    g_fIJWLoaded = true;
+}
+
+bool Module::HasAnyIJWBeenLoaded()
+{
+    LIMITED_METHOD_CONTRACT;
+    return g_fIJWLoaded;
 }
 #endif // !DACCESS_COMPILE
 

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1513,6 +1513,8 @@ public:
     BOOL IsIJWFixedUp() { return m_dwTransientFlags & IS_IJW_FIXED_UP; }
     void SetIsIJWFixedUp();
 
+    static bool HasAnyIJWBeenLoaded();
+
     BOOL IsBeingUnloaded() { return m_dwTransientFlags & IS_BEING_UNLOADED; }
     void   SetBeingUnloaded();
     void   StartUnload();

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1705,7 +1705,6 @@ static void OsAttachThread(void* thread)
         // Managed C++ may run managed code in DllMain (e.g. during DLL_PROCESS_DETACH to run global destructors). This is
         // not supported and unreliable. Historically, it happened to work most of the time. For backward compatibility,
         // suppress this assert in release builds if we have encountered any mixed mode binaries.
-        // compatibility.
         if (Module::HasAnyIJWBeenLoaded())
         {
             _ASSERTE(!"Attempt to execute managed code after the .NET runtime thread state has been destroyed.");

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1702,7 +1702,18 @@ static void OsAttachThread(void* thread)
 
     if (t_flsState == FLS_STATE_INVOKED)
     {
-        _ASSERTE_ALL_BUILDS(!"Attempt to execute managed code after the .NET runtime thread state has been destroyed.");
+        // Managed C++ may run managed code in DllMain (e.g. during DLL_PROCESS_DETACH to run global destructors). This is
+        // not supported and unreliable. Historically, it happened to work most of the time. For backward compatibility,
+        // suppress this assert in release builds if we have encountered any mixed mode binaries.
+        // compatibility.
+        if (Module::HasAnyIJWBeenLoaded())
+        {
+            _ASSERTE(!"Attempt to execute managed code after the .NET runtime thread state has been destroyed.");
+        }
+        else
+        {
+            _ASSERTE_ALL_BUILDS(!"Attempt to execute managed code after the .NET runtime thread state has been destroyed.");
+        }
     }
 
     t_flsState = FLS_STATE_ARMED;


### PR DESCRIPTION
This replaces deterministic fails with intermittent hangs and crashes for backward compatibility.

Contributes to #118741