### PR TITLE
Avoid marking types as reflected on in CreateSpan

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -27,18 +27,6 @@ namespace System.Runtime.CompilerServices
             throw new PlatformNotSupportedException();
         }
 
-        private static unsafe ref byte GetSpanDataFrom(
-            RuntimeFieldHandle fldHandle,
-            RuntimeTypeHandle targetTypeHandle,
-            out int count)
-        {
-            // We only support this intrinsic when it occurs within a well-defined IL sequence.
-            // If a call to this method occurs within the recognized sequence, codegen must expand the IL sequence completely.
-            // For any other purpose, the API is currently unsupported.
-            // https://github.com/dotnet/corert/issues/364
-            throw new PlatformNotSupportedException();
-        }
-
         [RequiresUnreferencedCode("Trimmer can't guarantee existence of class constructor")]
         public static void RunClassConstructor(RuntimeTypeHandle type)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -151,7 +151,15 @@ namespace System.Runtime.CompilerServices
         /// <remarks>This method is intended for compiler use rather than use directly in code. T must be one of byte, sbyte, bool, char, short, ushort, int, uint, long, ulong, float, or double.</remarks>
         [Intrinsic]
         public static ReadOnlySpan<T> CreateSpan<T>(RuntimeFieldHandle fldHandle)
+#if NATIVEAOT
+            // We only support this intrinsic when it occurs within a well-defined IL sequence.
+            // If a call to this method occurs within the recognized sequence, codegen must expand the IL sequence completely.
+            // For any other purpose, the API is currently unsupported.
+            // We shortcut this here as opposed in GetSpanDataFrom to avoid `typeof(T)` below marking T target of reflection.
+            => throw new PlatformNotSupportedException();
+#else
             => new ReadOnlySpan<T>(ref Unsafe.As<byte, T>(ref GetSpanDataFrom(fldHandle, typeof(T).TypeHandle, out int length)), length);
+#endif
 
 
         // The following intrinsics return true if input is a compile-time constant

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -155,7 +155,7 @@ namespace System.Runtime.CompilerServices
             // We only support this intrinsic when it occurs within a well-defined IL sequence.
             // If a call to this method occurs within the recognized sequence, codegen must expand the IL sequence completely.
             // For any other purpose, the API is currently unsupported.
-            // We shortcut this here as opposed in GetSpanDataFrom to avoid `typeof(T)` below marking T target of reflection.
+            // We shortcut this here instead of in `GetSpanDataFrom` to avoid `typeof(T)` below marking T target of reflection.
             => throw new PlatformNotSupportedException();
 #else
             => new ReadOnlySpan<T>(ref Unsafe.As<byte, T>(ref GetSpanDataFrom(fldHandle, typeof(T).TypeHandle, out int length)), length);


### PR DESCRIPTION
This seems to be the only reason why Hello World on Linux still needs support for boxed enums. `CreateSpan` is used with an enum type in Unix System.Console, which brings a boxed enum into whole program view and we can't undo the damage this causes to the whole program view during compilation anymore (even though we no longer need the `typeof` then because RyuJIT always expands `CreateSpan`).

| Project | Size before | Size after | Difference |
|---------|-------------|------------|------------|
| hello-linux | [ 1221600 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/17031801595/artifacts/3785529058) | [ 1151440 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/17031801595/artifacts/3785529165) | -70160 |
| hello-minimal-linux | [ 1069896 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/17031801595/artifacts/3785532297) | [ 999736 ](https://github.com/MichalStrehovsky/rt-sz/actions/runs/17031801595/artifacts/3785529629) | -70160 |
