### PR TITLE
Mark Marvin.ComputeHash32 as noinlining

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Marvin.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Marvin.cs
@@ -25,6 +25,7 @@ namespace System
         /// <summary>
         /// Compute a Marvin hash and collapse it into a 32-bit hash.
         /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static int ComputeHash32(ref byte data, uint count, uint p0, uint p1)
         {
             // Control flow of this method generally flows top-to-bottom, trying to


### PR DESCRIPTION
Recent changes to the JIT's inliner may lead to this method but not all of its callees being inlined, which is not good for performance.

There is not much benefit to be had by inlining this method, so mark it as noinline.

Fixes (part of) #118739.