### PR TITLE
[NativeAOT] Use AssemblyNameInfo.Name instead of AssemblyNameInfo.FullName

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/AssemblyNameInfo.Dummy.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/AssemblyNameInfo.Dummy.cs
@@ -6,6 +6,6 @@ namespace Internal.TypeSystem
     // Dummy implementation of AssemlyNameInfo for runtime type system
     public abstract class AssemblyNameInfo
     {
-        public abstract string FullName { get; }
+        public abstract string Name { get; }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/ThrowHelper.Common.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ThrowHelper.Common.cs
@@ -65,7 +65,7 @@ namespace Internal.TypeSystem
                 IAssemblyDesc assembly = module as IAssemblyDesc;
                 if (assembly != null)
                 {
-                    return assembly.GetName().FullName;
+                    return assembly.GetName().Name;
                 }
                 else
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -183,7 +183,7 @@ namespace ILCompiler
                     if (callsiteModule != null)
                     {
                         Debug.Assert(callsiteModule is IAssemblyDesc, "Multi-module assemblies");
-                        return _typeGetTypeMethodThunks.GetHelper(intrinsicMethod, ((IAssemblyDesc)callsiteModule).GetName().FullName);
+                        return _typeGetTypeMethodThunks.GetHelper(intrinsicMethod, ((IAssemblyDesc)callsiteModule).GetName().Name);
                     }
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ModuleMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ModuleMetadataNode.cs
@@ -63,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName(NodeFactory factory)
         {
-            return "Reflectable module: " + ((IAssemblyDesc)_module).GetName().FullName;
+            return "Reflectable module: " + ((IAssemblyDesc)_module).GetName().Name;
         }
 
         public override bool InterestingForDynamicDependencyAnalysis => false;


### PR DESCRIPTION
AssemblyNameInfo.FullName includes full public key and other details that leads to very long error messages like: `Method will always throw because: Failed to load type 'NonExistent' from assembly 'System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKey=00240000048000009400000006020000002400005253413100040000010001008d56c76f9e8649383049f383c44be0ec204181822a6c31cf5eb7ef486944d032188ea1d3920763712ccb12d75fb77e9811149e6148e5d32fbaab37611c1878ddc19e20ef135d0cb2cff2bfec3d115810c3d9069638fe4be215dbf795861920e5ab6f7db2e2ceef136ac23d5dd2bf031700aec232f6c6b1c785b4305c123b37ab'

Use AssemblyNameInfo.Name instead where possible.