### PR TITLE
[NativeAOT] Streamline GetAssemblyCount

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/AssemblyBinder.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/AssemblyBinder.cs
@@ -33,5 +33,6 @@ namespace Internal.Reflection.Core
         public abstract bool Bind(RuntimeAssemblyName refName, bool cacheMissedLookups, out AssemblyBindResult result, out Exception exception);
 
         public abstract IList<AssemblyBindResult> GetLoadedAssemblies();
+        public abstract int GetLoadedAssembliesCount();
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Assembly.NativeAot.cs
@@ -35,13 +35,9 @@ namespace System.Reflection
         }
 
         // Performance metric to count the number of assemblies
-        // Caching since in NativeAOT, the number will be the same
-        private static uint s_assemblyCount;
         internal static uint GetAssemblyCount()
         {
-            if (s_assemblyCount == 0)
-                s_assemblyCount = (uint)Internal.Reflection.Core.Execution.ReflectionCoreExecution.ExecutionEnvironment.AssemblyBinder.GetLoadedAssemblies().Count;
-            return s_assemblyCount;
+            return (uint)Internal.Reflection.Core.Execution.ReflectionCoreExecution.ExecutionEnvironment.AssemblyBinder.GetLoadedAssembliesCount();
         }
 
         [Obsolete("Assembly.LoadWithPartialName has been deprecated. Use Assembly.Load() instead.")]

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
@@ -94,6 +94,11 @@ namespace Internal.Reflection.Execution
             return loadedAssemblies;
         }
 
+        public sealed override int GetLoadedAssembliesCount()
+        {
+            return ScopeGroups.Length;
+        }
+
         //
         // Encapsulates the assembly ref->def matching policy.
         //


### PR DESCRIPTION
Avoid unnecessary code and allocations