### PR TITLE
library testhost modify `deps.json` to match actual release

### DIFF
--- a/src/tasks/installer.tasks/GenerateTestSharedFrameworkDepsFile.cs
+++ b/src/tasks/installer.tasks/GenerateTestSharedFrameworkDepsFile.cs
@@ -50,8 +50,8 @@ namespace Microsoft.DotNet.Build.Tasks
                 ".xml"
             };
 
-            List<RuntimeFile> runtimeFiles = new List<RuntimeFile>();
-            List<RuntimeFile> nativeFiles = new List<RuntimeFile>();
+            List<RuntimeFile> runtimeFiles = [];
+            List<RuntimeFile> nativeFiles = [];
 
             foreach (string filePath in Directory.EnumerateFiles(SharedFrameworkDirectory))
             {
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 string fileName = Path.GetFileName(filePath);
                 string fileVersion = FileUtilities.GetFileVersion(filePath)?.ToString() ?? string.Empty;
                 Version assemblyVersion = FileUtilities.GetAssemblyName(filePath)?.Version;
-                if (assemblyVersion == null)
+                if (assemblyVersion is null)
                 {
                     RuntimeFile nativeFile = new RuntimeFile(fileName, null, fileVersion);
                     nativeFiles.Add(nativeFile);

--- a/src/tasks/installer.tasks/GenerateTestSharedFrameworkDepsFile.cs
+++ b/src/tasks/installer.tasks/GenerateTestSharedFrameworkDepsFile.cs
@@ -50,12 +50,28 @@ namespace Microsoft.DotNet.Build.Tasks
                 ".xml"
             };
 
-            var isAssemblyTofileNames = Directory.EnumerateFiles(SharedFrameworkDirectory)
-                .Where(file => !ignoredExtensions.Contains(Path.GetExtension(file)))
-                .ToLookup(file => IsManagedAssembly(file), file => Path.GetFileName(file));
+            List<RuntimeFile> runtimeFiles = new List<RuntimeFile>();
+            List<RuntimeFile> nativeFiles = new List<RuntimeFile>();
 
-            var managedFileNames = isAssemblyTofileNames[true];
-            var nativeFileNames = isAssemblyTofileNames[false];
+            foreach (string filePath in Directory.EnumerateFiles(SharedFrameworkDirectory))
+            {
+                if (ignoredExtensions.Contains(Path.GetExtension(filePath)))
+                    continue;
+
+                string fileName = Path.GetFileName(filePath);
+                string fileVersion = FileUtilities.GetFileVersion(filePath)?.ToString() ?? string.Empty;
+                Version assemblyVersion = FileUtilities.GetAssemblyName(filePath)?.Version;
+                if (assemblyVersion == null)
+                {
+                    RuntimeFile nativeFile = new RuntimeFile(fileName, null, fileVersion);
+                    nativeFiles.Add(nativeFile);
+                }
+                else
+                {
+                    RuntimeFile runtimeFile = new RuntimeFile(fileName, assemblyVersion.ToString(), fileVersion);
+                    runtimeFiles.Add(runtimeFile);
+                }
+            }
 
             var runtimeLibraries = new[]
             {
@@ -64,8 +80,8 @@ namespace Microsoft.DotNet.Build.Tasks
                     name: sharedFxName,
                     version: sharedFxVersion,
                     hash: "hash",
-                    runtimeAssemblyGroups: new[] { new RuntimeAssetGroup(string.Empty, managedFileNames.Select(f => $"runtimes/{rid}/lib/{tfm}/{f}")) },
-                    nativeLibraryGroups: new[] { new RuntimeAssetGroup(string.Empty, nativeFileNames.Select(f => $"runtimes/{rid}/native/{f}")) },
+                    runtimeAssemblyGroups: new[] { new RuntimeAssetGroup(string.Empty, runtimeFiles) },
+                    nativeLibraryGroups: new[] { new RuntimeAssetGroup(string.Empty, nativeFiles) },
                     resourceAssemblies: Enumerable.Empty<ResourceAssembly>(),
                     dependencies: Enumerable.Empty<Dependency>(),
                     serviceable: true)
@@ -88,22 +104,6 @@ namespace Microsoft.DotNet.Build.Tasks
             }
 
             return !Log.HasLoggedErrors;
-        }
-
-        private static bool IsManagedAssembly(string file)
-        {
-            bool result = false;
-            try
-            {
-                using (var peReader = new PEReader(File.OpenRead(file)))
-                {
-                    result = peReader.HasMetadata && peReader.GetMetadataReader().IsAssembly;
-                }
-            }
-            catch (BadImageFormatException)
-            { }
-
-            return result;
         }
 
         private static IEnumerable<RuntimeFallbacks> GetRuntimeFallbacks(string[] runtimeGraphFiles, string runtime)


### PR DESCRIPTION
The cDAC (`runtime-diagnostics`) pipeline has been failing due to a dependency lookup issue for several days:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=1125301&view=results

```
    Running Process: D:\a\_work\1\s\.dotnet-test\dotnet.exe D:\a\_work\1\s\artifacts\bin\dotnet-dump\Release\net8.0\publish\dotnet-dump.dll analyze D:\a\_work\1\s\artifacts\tmp\Release\dumps\ProjectK\10.0.0-rc.1.25411.106\net10.0\SOS.WebApp3.Heap.dmp
    Working Directory: 
    Additional Environment Variables: DOTNET_ROOT=D:\a\_work\1\s\.dotnet-test, DOTNET_ENABLE_CDAC=1, DOTNET_ENABLED_SOS_LOGGING=D:\a\_work\1\s\artifacts\TestResults\Release\sos.unittests_2025_08_18_07_01_38_5425\SOS.WebApp3.projectk.sdk.prebuilt.cdac.10.0.0-rc.1.25411.106.soslog, DOTNET_EnableWriteXorExecute=0, COMPlus_EnableWriteXorExecute=0
    {
        00:00.118: Loading core dump: D:\a\_work\1\s\artifacts\tmp\Release\dumps\ProjectK\10.0.0-rc.1.25411.106\net10.0\SOS.WebApp3.Heap.dmp ...
        00:00.205: Could not load file or assembly 'System.Diagnostics.DiagnosticSource, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified.
    }
    Process 3316 exited 1 (00:00.212 elapsed)
```
`dotnet-dump` can not find `System.Diagnostics.DiagnosticSource` `10.0.0`. This file exists but is skipped over because the `deps.json` file does not set a version. The resolver defaults to `-1` and this version does not override the `9.0.8` found with `dotnet-dump`.

This failure may have been caused by changes in https://github.com/dotnet/runtime/pull/118297. 

Updates `GenerateTestSharedFrameworkDepsFile.cs` to be more like https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.SharedFramework.Sdk/src/GenerateSharedFrameworkDepsFile.cs by including the file/assembly versions.

<details>
<summary>JSON Reference</summary>
Previous structure example:

```json
{
  "runtimeTarget": {
    "name": ".NETCoreApp,Version=v0.0/rid",
    "signature": "runtimeSignature"
  },
  "compilationOptions": {},
  "targets": {
    ".NETCoreApp,Version=v0.0": {},
    ".NETCoreApp,Version=v0.0/rid": {
      "Microsoft.NETCore.App/10.0.0": {
        "runtime": {
          "runtimes/rid/lib/netcoreapp0.0/Microsoft.CSharp.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/Microsoft.VisualBasic.Core.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/Microsoft.VisualBasic.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/Microsoft.Win32.Primitives.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/Microsoft.Win32.Registry.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/mscorlib.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/netstandard.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.AppContext.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Buffers.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Collections.Concurrent.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Collections.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Collections.Immutable.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Collections.NonGeneric.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Collections.Specialized.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ComponentModel.Annotations.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ComponentModel.DataAnnotations.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ComponentModel.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ComponentModel.EventBasedAsync.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ComponentModel.Primitives.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ComponentModel.TypeConverter.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Configuration.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Console.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Core.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Data.Common.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Data.DataSetExtensions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Data.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.Contracts.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.Debug.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.DiagnosticSource.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.FileVersionInfo.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.Process.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.StackTrace.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.TextWriterTraceListener.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.Tools.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.TraceSource.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Diagnostics.Tracing.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Drawing.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Drawing.Primitives.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Dynamic.Runtime.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Formats.Asn1.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Formats.Tar.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Globalization.Calendars.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Globalization.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Globalization.Extensions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.Compression.Brotli.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.Compression.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.Compression.FileSystem.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.Compression.ZipFile.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.FileSystem.AccessControl.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.FileSystem.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.FileSystem.DriveInfo.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.FileSystem.Primitives.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.FileSystem.Watcher.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.IsolatedStorage.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.MemoryMappedFiles.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.Pipelines.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.Pipes.AccessControl.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.Pipes.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.IO.UnmanagedMemoryStream.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Linq.AsyncEnumerable.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Linq.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Linq.Expressions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Linq.Parallel.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Linq.Queryable.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Memory.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.Http.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.Http.Json.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.HttpListener.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.Mail.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.NameResolution.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.NetworkInformation.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.Ping.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.Primitives.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.Quic.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.Requests.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.Security.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.ServerSentEvents.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.ServicePoint.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.Sockets.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.WebClient.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.WebHeaderCollection.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.WebProxy.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.WebSockets.Client.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Net.WebSockets.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Numerics.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Numerics.Vectors.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ObjectModel.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Private.CoreLib.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Private.DataContractSerialization.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Private.Uri.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Private.Xml.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Private.Xml.Linq.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Reflection.DispatchProxy.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Reflection.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Reflection.Emit.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Reflection.Emit.ILGeneration.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Reflection.Emit.Lightweight.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Reflection.Extensions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Reflection.Metadata.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Reflection.Primitives.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Reflection.TypeExtensions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Resources.Reader.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Resources.ResourceManager.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Resources.Writer.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.CompilerServices.Unsafe.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.CompilerServices.VisualC.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Extensions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Handles.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.InteropServices.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.InteropServices.JavaScript.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.InteropServices.RuntimeInformation.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Intrinsics.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Loader.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Numerics.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Serialization.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Serialization.Formatters.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Serialization.Json.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Serialization.Primitives.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Runtime.Serialization.Xml.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.AccessControl.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Claims.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Cryptography.Algorithms.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Cryptography.Cng.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Cryptography.Csp.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Cryptography.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Cryptography.Encoding.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Cryptography.OpenSsl.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Cryptography.Primitives.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Cryptography.X509Certificates.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Principal.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.Principal.Windows.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Security.SecureString.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ServiceModel.Web.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ServiceProcess.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Text.Encoding.CodePages.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Text.Encoding.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Text.Encoding.Extensions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Text.Encodings.Web.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Text.Json.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Text.RegularExpressions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.AccessControl.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.Channels.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.Overlapped.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.Tasks.Dataflow.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.Tasks.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.Tasks.Extensions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.Tasks.Parallel.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.Thread.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.ThreadPool.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Threading.Timer.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Transactions.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Transactions.Local.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.ValueTuple.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Web.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Web.HttpUtility.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Windows.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Xml.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Xml.Linq.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Xml.ReaderWriter.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Xml.Serialization.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Xml.XDocument.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Xml.XmlDocument.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Xml.XmlSerializer.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Xml.XPath.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/System.Xml.XPath.XDocument.dll": {},
          "runtimes/rid/lib/netcoreapp0.0/WindowsBase.dll": {}
        },
        "native": {
          "runtimes/rid/native/clretwrc.dll": {},
          "runtimes/rid/native/clrgc.dll": {},
          "runtimes/rid/native/clrgcexp.dll": {},
          "runtimes/rid/native/clrjit.dll": {},
          "runtimes/rid/native/coreclr.dll": {},
          "runtimes/rid/native/coredistools.dll": {},
          "runtimes/rid/native/corerun.exe": {},
          "runtimes/rid/native/createdump.exe": {},
          "runtimes/rid/native/hostfxr.dll": {},
          "runtimes/rid/native/hostpolicy.dll": {},
          "runtimes/rid/native/mscordaccore.dll": {},
          "runtimes/rid/native/mscordaccore_amd64_amd64_42.42.42.42424.dll": {},
          "runtimes/rid/native/mscordaccore_universal.dll": {},
          "runtimes/rid/native/mscordbi.dll": {},
          "runtimes/rid/native/mscorrc.dll": {},
          "runtimes/rid/native/msquic.dll": {},
          "runtimes/rid/native/System.Globalization.Native-Static.lib": {},
          "runtimes/rid/native/System.Globalization.Native.lib": {},
          "runtimes/rid/native/System.IO.Compression.Native-Static.lib": {},
          "runtimes/rid/native/System.IO.Compression.Native.dll": {},
          "runtimes/rid/native/System.IO.Compression.Native.lib": {}
        }
      }
    }
  },
  "libraries": {
    "Microsoft.NETCore.App/10.0.0": {
      "type": "package",
      "serviceable": true,
      "sha512": "hash"
    }
  },
  "runtimes": {
    "win-x64": [
      "win",
      "any",
      "base"
    ],
    "win-x64-aot": [
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ],
    "win10-x64": [
      "win10",
      "win81-x64",
      "win81",
      "win8-x64",
      "win8",
      "win7-x64",
      "win7",
      "win-x64",
      "win",
      "any",
      "base"
    ],
    "win10-x64-aot": [
      "win10-aot",
      "win10-x64",
      "win10",
      "win81-x64-aot",
      "win81-aot",
      "win81-x64",
      "win81",
      "win8-x64-aot",
      "win8-aot",
      "win8-x64",
      "win8",
      "win7-x64-aot",
      "win7-aot",
      "win7-x64",
      "win7",
      "win-x64-aot",
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ],
    "win7-x64": [
      "win7",
      "win-x64",
      "win",
      "any",
      "base"
    ],
    "win7-x64-aot": [
      "win7-aot",
      "win7-x64",
      "win7",
      "win-x64-aot",
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ],
    "win8-x64": [
      "win8",
      "win7-x64",
      "win7",
      "win-x64",
      "win",
      "any",
      "base"
    ],
    "win8-x64-aot": [
      "win8-aot",
      "win8-x64",
      "win8",
      "win7-x64-aot",
      "win7-aot",
      "win7-x64",
      "win7",
      "win-x64-aot",
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ],
    "win81-x64": [
      "win81",
      "win8-x64",
      "win8",
      "win7-x64",
      "win7",
      "win-x64",
      "win",
      "any",
      "base"
    ],
    "win81-x64-aot": [
      "win81-aot",
      "win81-x64",
      "win81",
      "win8-x64-aot",
      "win8-aot",
      "win8-x64",
      "win8",
      "win7-x64-aot",
      "win7-aot",
      "win7-x64",
      "win7",
      "win-x64-aot",
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ]
  }
}
```

New structure example:

```json
{
  "runtimeTarget": {
    "name": ".NETCoreApp,Version=v0.0/rid",
    "signature": "runtimeSignature"
  },
  "compilationOptions": {},
  "targets": {
    ".NETCoreApp,Version=v0.0": {},
    ".NETCoreApp,Version=v0.0/rid": {
      "Microsoft.NETCore.App/10.0.0": {
        "runtime": {
          "Microsoft.CSharp.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "Microsoft.VisualBasic.Core.dll": {
            "assemblyVersion": "15.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "Microsoft.VisualBasic.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "Microsoft.Win32.Primitives.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "Microsoft.Win32.Registry.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "mscorlib.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "netstandard.dll": {
            "assemblyVersion": "2.1.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.AppContext.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Buffers.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Collections.Concurrent.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Collections.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Collections.Immutable.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Collections.NonGeneric.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Collections.Specialized.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ComponentModel.Annotations.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ComponentModel.DataAnnotations.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ComponentModel.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ComponentModel.EventBasedAsync.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ComponentModel.Primitives.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ComponentModel.TypeConverter.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Configuration.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Console.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Core.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Data.Common.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Data.DataSetExtensions.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Data.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.Contracts.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.Debug.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.DiagnosticSource.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.FileVersionInfo.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.Process.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.StackTrace.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.TextWriterTraceListener.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.Tools.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.TraceSource.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Diagnostics.Tracing.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Drawing.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Drawing.Primitives.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Dynamic.Runtime.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Formats.Asn1.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Formats.Tar.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Globalization.Calendars.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Globalization.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Globalization.Extensions.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.Compression.Brotli.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.Compression.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.Compression.FileSystem.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.Compression.ZipFile.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.FileSystem.AccessControl.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.FileSystem.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.FileSystem.DriveInfo.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.FileSystem.Primitives.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.FileSystem.Watcher.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.IsolatedStorage.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.MemoryMappedFiles.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.Pipelines.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.Pipes.AccessControl.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.Pipes.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.UnmanagedMemoryStream.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Linq.AsyncEnumerable.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Linq.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Linq.Expressions.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Linq.Parallel.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Linq.Queryable.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Memory.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.Http.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.Http.Json.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.HttpListener.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.Mail.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.NameResolution.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.NetworkInformation.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.Ping.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.Primitives.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.Quic.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.Requests.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.Security.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.ServerSentEvents.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.ServicePoint.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.Sockets.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.WebClient.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.WebHeaderCollection.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.WebProxy.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.WebSockets.Client.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Net.WebSockets.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Numerics.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Numerics.Vectors.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ObjectModel.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Private.CoreLib.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Private.DataContractSerialization.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Private.Uri.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Private.Xml.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Private.Xml.Linq.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Reflection.DispatchProxy.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Reflection.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Reflection.Emit.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Reflection.Emit.ILGeneration.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Reflection.Emit.Lightweight.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Reflection.Extensions.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Reflection.Metadata.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Reflection.Primitives.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Reflection.TypeExtensions.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Resources.Reader.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Resources.ResourceManager.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Resources.Writer.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.CompilerServices.Unsafe.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.CompilerServices.VisualC.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Extensions.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Handles.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.InteropServices.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.InteropServices.JavaScript.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.InteropServices.RuntimeInformation.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Intrinsics.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Loader.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Numerics.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Serialization.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Serialization.Formatters.dll": {
            "assemblyVersion": "8.1.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Serialization.Json.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Serialization.Primitives.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Runtime.Serialization.Xml.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.AccessControl.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Claims.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Cryptography.Algorithms.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Cryptography.Cng.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Cryptography.Csp.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Cryptography.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Cryptography.Encoding.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Cryptography.OpenSsl.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Cryptography.Primitives.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Cryptography.X509Certificates.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Principal.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.Principal.Windows.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Security.SecureString.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ServiceModel.Web.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ServiceProcess.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Text.Encoding.CodePages.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Text.Encoding.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Text.Encoding.Extensions.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Text.Encodings.Web.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Text.Json.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Text.RegularExpressions.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.AccessControl.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.Channels.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.Overlapped.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.Tasks.Dataflow.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.Tasks.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.Tasks.Extensions.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.Tasks.Parallel.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.Thread.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.ThreadPool.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Threading.Timer.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Transactions.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Transactions.Local.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.ValueTuple.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Web.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Web.HttpUtility.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Windows.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Xml.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Xml.Linq.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Xml.ReaderWriter.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Xml.Serialization.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Xml.XDocument.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Xml.XmlDocument.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Xml.XmlSerializer.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Xml.XPath.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "System.Xml.XPath.XDocument.dll": {
            "assemblyVersion": "10.0.0.0",
            "fileVersion": "42.42.42.42424"
          },
          "WindowsBase.dll": {
            "assemblyVersion": "4.0.0.0",
            "fileVersion": "42.42.42.42424"
          }
        },
        "native": {
          "clretwrc.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "clrgc.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "clrgcexp.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "clrjit.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "coreclr.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "coredistools.dll": {
            "fileVersion": "20.1.0.0"
          },
          "corerun.exe": {
            "fileVersion": "42.42.42.42424"
          },
          "createdump.exe": {
            "fileVersion": "42.42.42.42424"
          },
          "hostfxr.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "hostpolicy.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "mscordaccore.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "mscordaccore_amd64_amd64_42.42.42.42424.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "mscordaccore_universal.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "mscordbi.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "mscorrc.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "msquic.dll": {
            "fileVersion": "2.4.8.0"
          },
          "System.Globalization.Native-Static.lib": {
            "fileVersion": "0.0.0.0"
          },
          "System.Globalization.Native.lib": {
            "fileVersion": "0.0.0.0"
          },
          "System.IO.Compression.Native-Static.lib": {
            "fileVersion": "0.0.0.0"
          },
          "System.IO.Compression.Native.dll": {
            "fileVersion": "42.42.42.42424"
          },
          "System.IO.Compression.Native.lib": {
            "fileVersion": "0.0.0.0"
          }
        }
      }
    }
  },
  "libraries": {
    "Microsoft.NETCore.App/10.0.0": {
      "type": "package",
      "serviceable": true,
      "sha512": "hash"
    }
  },
  "runtimes": {
    "win-x64": [
      "win",
      "any",
      "base"
    ],
    "win-x64-aot": [
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ],
    "win10-x64": [
      "win10",
      "win81-x64",
      "win81",
      "win8-x64",
      "win8",
      "win7-x64",
      "win7",
      "win-x64",
      "win",
      "any",
      "base"
    ],
    "win10-x64-aot": [
      "win10-aot",
      "win10-x64",
      "win10",
      "win81-x64-aot",
      "win81-aot",
      "win81-x64",
      "win81",
      "win8-x64-aot",
      "win8-aot",
      "win8-x64",
      "win8",
      "win7-x64-aot",
      "win7-aot",
      "win7-x64",
      "win7",
      "win-x64-aot",
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ],
    "win7-x64": [
      "win7",
      "win-x64",
      "win",
      "any",
      "base"
    ],
    "win7-x64-aot": [
      "win7-aot",
      "win7-x64",
      "win7",
      "win-x64-aot",
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ],
    "win8-x64": [
      "win8",
      "win7-x64",
      "win7",
      "win-x64",
      "win",
      "any",
      "base"
    ],
    "win8-x64-aot": [
      "win8-aot",
      "win8-x64",
      "win8",
      "win7-x64-aot",
      "win7-aot",
      "win7-x64",
      "win7",
      "win-x64-aot",
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ],
    "win81-x64": [
      "win81",
      "win8-x64",
      "win8",
      "win7-x64",
      "win7",
      "win-x64",
      "win",
      "any",
      "base"
    ],
    "win81-x64-aot": [
      "win81-aot",
      "win81-x64",
      "win81",
      "win8-x64-aot",
      "win8-aot",
      "win8-x64",
      "win8",
      "win7-x64-aot",
      "win7-aot",
      "win7-x64",
      "win7",
      "win-x64-aot",
      "win-aot",
      "win-x64",
      "win",
      "aot",
      "any",
      "base"
    ]
  }
}
```
</details/>