### PR TITLE
Fix bad deallocate for zero-length allocations in jit allocator

### DIFF
--- a/src/coreclr/jit/alloc.h
+++ b/src/coreclr/jit/alloc.h
@@ -316,6 +316,9 @@ public:
     // Frees the block of memory pointed to by p.
     virtual void Free(void* p) override
     {
+        if (p == &m_zeroLenAllocTarg)
+            return;
+
         m_alloc.deallocate(p);
     }
 };


### PR DESCRIPTION
I think this is a bug.