### PR TITLE
Throttle finalization a bit when doing GC stress.

### DIFF
--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -177,23 +177,23 @@ Again:
         return NULL;
 
 #ifdef _DEBUG
-        if (g_pConfig->GetGCStressLevel() > 1)
-        {
-            // Throttle finalizing to one item per msec, or so, when running GC stress.
-            // This is to prevent cases where finalizers rearm themselves and
-            // do allocations or whatever else that triggers GC under stress.
-            // As a result couple of such things can occupy finalizer loop continuously
-            // while rearming and finalizing the same objects, which adds little
-            // to the coverage, but makes everything else move slower.
-            // NOTE: under GC stress most allocations of finalizable objects
-            //       would trigger a GC, thus 1 item/msec should not be too slow for
-            //       regular not re-arming finalizables.
-            GetFinalizerThread()->m_GCOnTransitionsOK = FALSE;
-            GetFinalizerThread()->EnablePreemptiveGC();
-            ClrSleepEx(1, false);
-            GetFinalizerThread()->DisablePreemptiveGC();
-            GetFinalizerThread()->m_GCOnTransitionsOK = TRUE;
-        }
+    if (g_pConfig->GetGCStressLevel() > 1)
+    {
+        // Throttle finalizing to one item per msec, or so, when running GC stress.
+        // This is to prevent cases where finalizers rearm themselves and
+        // do allocations or whatever else that triggers GC under stress.
+        // As a result couple of such things can occupy finalizer loop continuously
+        // while rearming and finalizing the same objects, which adds little
+        // to the coverage, but makes everything else move slower.
+        // NOTE: under GC stress most allocations of finalizable objects
+        //       would trigger a GC, thus 1 item/msec should not be too slow for
+        //       regular not re-arming finalizables.
+        GetFinalizerThread()->m_GCOnTransitionsOK = FALSE;
+        GetFinalizerThread()->EnablePreemptiveGC();
+        ClrSleepEx(1, false);
+        GetFinalizerThread()->DisablePreemptiveGC();
+        GetFinalizerThread()->m_GCOnTransitionsOK = TRUE;
+    }
 #endif //_DEBUG
 
     OBJECTREF obj = ObjectToOBJECTREF(GCHeapUtilities::GetGCHeap()->GetNextFinalizable());

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -176,6 +176,26 @@ Again:
     if (fQuitFinalizer)
         return NULL;
 
+#ifdef _DEBUG
+        if (g_pConfig->GetGCStressLevel() > 1)
+        {
+            // Throttle finalizing to one item per msec, or so, when running GC stress.
+            // This is to prevent cases where finalizers rearm themselves and
+            // do allocations or whatever else that triggers GC under stress.
+            // As a result couple of such things can occupy finalizer loop continuously
+            // while rearming and finalizing the same objects, which adds little
+            // to the coverage, but makes everything else move slower.
+            // NOTE: under GC stress most allocations of finalizable objects
+            //       would trigger a GC, thus 1 item/msec should not be too slow for
+            //       regular not re-arming finalizables.
+            GetFinalizerThread()->m_GCOnTransitionsOK = FALSE;
+            GetFinalizerThread()->EnablePreemptiveGC();
+            ClrSleepEx(1, false);
+            GetFinalizerThread()->DisablePreemptiveGC();
+            GetFinalizerThread()->m_GCOnTransitionsOK = TRUE;
+        }
+#endif //_DEBUG
+
     OBJECTREF obj = ObjectToOBJECTREF(GCHeapUtilities::GetGCHeap()->GetNextFinalizable());
     if (obj == NULL)
         return NULL;
@@ -431,27 +451,6 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
         JitHost::Reclaim();
 
         GetFinalizerThread()->DisablePreemptiveGC();
-
-#ifdef _DEBUG
-        // <TODO> workaround.  make finalization very lazy for gcstress 3 or 4.
-        // only do finalization if the system is quiescent</TODO>
-        if (g_pConfig->GetGCStressLevel() > 1)
-        {
-            size_t last_gc_count;
-            DWORD dwSwitchCount = 0;
-
-            do
-            {
-                last_gc_count = GCHeapUtilities::GetGCHeap()->CollectionCount(0);
-                GetFinalizerThread()->m_GCOnTransitionsOK = FALSE;
-                GetFinalizerThread()->EnablePreemptiveGC();
-                __SwitchToThread (0, ++dwSwitchCount);
-                GetFinalizerThread()->DisablePreemptiveGC();
-                // If no GCs happened, then we assume we are quiescent
-                GetFinalizerThread()->m_GCOnTransitionsOK = TRUE;
-            } while (GCHeapUtilities::GetGCHeap()->CollectionCount(0) - last_gc_count > 0);
-        }
-#endif //_DEBUG
 
         // we might want to do some extra work on the finalizer thread
         // check and do it


### PR DESCRIPTION
Re: https://github.com/dotnet/runtime/issues/114581

It looks like under GC stress a couple of self-rearming GC-finalizer callbacks can keep finalizer loop continuously occupied by re-arming each other and causing a GC. That adds very little to the coverage, but can consume considerable resources through frequent GCs and make everything else slower. 

Throttling finalization rate to 1 item/msec when running with GC stress reduces the rate of uninteresting GCs and makes the tests move faster.