### PR TITLE
Reuse characteristic mechanism for IDynIntfCastable trimming

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
@@ -113,6 +113,10 @@ namespace System.Runtime
             return result;
         }
 
+        [Intrinsic]
+        [AnalysisCharacteristic]
+        private static extern bool DynamicInterfaceCastablePresent();
+
         private static unsafe IntPtr RhResolveDispatchWorker(object pObject, void* cell, ref DispatchCellInfo cellInfo)
         {
             // Type of object we're dispatching on.
@@ -125,7 +129,7 @@ namespace System.Runtime
                                                                               cellInfo.InterfaceSlot,
                                                                               flags: default,
                                                                               ppGenericContext: null);
-                if (pTargetCode == IntPtr.Zero && pInstanceType->IsIDynamicInterfaceCastable)
+                if (DynamicInterfaceCastablePresent() && pTargetCode == IntPtr.Zero && pInstanceType->IsIDynamicInterfaceCastable)
                 {
                     // Dispatch not resolved through normal dispatch map, try using the IDynamicInterfaceCastable
                     // This will either give us the appropriate result, or throw.

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/ThrowHelpers.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/ThrowHelpers.cs
@@ -57,10 +57,5 @@ namespace Internal.Runtime.CompilerHelpers
             // exception doesn't exist in MRT: throw PlatformNotSupportedException() instead
             throw new PlatformNotSupportedException();
         }
-
-        private static void ThrowFeatureBodyRemoved()
-        {
-            throw new NotSupportedException();
-        }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -240,6 +240,7 @@
     <Compile Include="System\ValueType.cs" />
     <Compile Include="System\Runtime\RuntimeExportAttribute.cs" />
     <Compile Include="System\Runtime\RuntimeImportAttribute.cs" />
+    <Compile Include="System\Runtime\CompilerServices\AnalysisCharacteristicAttribute.cs" />
     <Compile Include="System\Runtime\CompilerServices\ClassConstructorRunner.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeHelpers.NativeAot.cs" />
   </ItemGroup>

--- a/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
@@ -212,6 +212,7 @@
     <Compile Include="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System\Runtime\InteropServices\IDynamicInterfaceCastable.cs">
       <Link>Common\System\Runtime\InteropServices\IDynamicInterfaceCastable.cs</Link>
     </Compile>
+    <Compile Include="..\..\System.Private.CoreLib\src\System\Runtime\CompilerServices\AnalysisCharacteristicAttribute.cs" />
     <Compile Include="Internal\Runtime\MethodTable.Runtime.cs" />
     <Compile Include="System\Runtime\CompilerServices\CastCache.cs" />
     <Compile Include="System\Runtime\CompilerServices\ClassConstructorRunner.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -28,6 +28,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             DependencyList dependencyList = base.ComputeNonRelocationBasedDependencies(factory);
 
+            if (_type.IsIDynamicInterfaceCastable)
+            {
+                dependencyList.Add(factory.AnalysisCharacteristic("DynamicInterfaceCastablePresent"), "Implements IDynamicInterfaceCastable");
+            }
+
             // Ensure that we track the metadata type symbol if we are working with a constructed type symbol.
             // The emitter will ensure we don't emit both, but this allows us assert that we only generate
             // relocs to nodes we emit.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -150,7 +150,6 @@ namespace ILCompiler
             _dependencyGraph.AddRoot(GetHelperEntrypoint(ReadyToRunHelper.CheckInstanceInterface), "Not tracked by scanner");
             _dependencyGraph.AddRoot(GetHelperEntrypoint(ReadyToRunHelper.CheckInstanceClass), "Not tracked by scanner");
             _dependencyGraph.AddRoot(GetHelperEntrypoint(ReadyToRunHelper.IsInstanceOfException), "Not tracked by scanner");
-            _dependencyGraph.AddRoot(_nodeFactory.MethodEntrypoint(_nodeFactory.TypeSystemContext.GetHelperEntryPoint("ThrowHelpers", "ThrowFeatureBodyRemoved")), "Substitution for methods removed based on scanning");
 
             _dependencyGraph.ComputeMarkedNodes();
 
@@ -275,34 +274,6 @@ namespace ILCompiler
         public ReadOnlyFieldPolicy GetReadOnlyFieldPolicy()
         {
             return new ScannedReadOnlyPolicy(MarkedNodes);
-        }
-
-        public BodyAndFieldSubstitutions GetBodyAndFieldSubstitutions()
-        {
-            Dictionary<MethodDesc, BodySubstitution> bodySubstitutions = [];
-
-            bool hasIDynamicInterfaceCastableType = false;
-
-            foreach (var type in ConstructedEETypes)
-            {
-                if (type.IsIDynamicInterfaceCastable)
-                {
-                    hasIDynamicInterfaceCastableType = true;
-                    break;
-                }
-            }
-
-            if (!hasIDynamicInterfaceCastableType)
-            {
-                // We can't easily trim out some of the IDynamicInterfaceCastable infrastructure because
-                // the callers do type checks based on flags on the MethodTable instead of an actual type cast.
-                // Trim out the logic that we can't do easily here.
-                TypeDesc iDynamicInterfaceCastableType = _factory.TypeSystemContext.SystemModule.GetKnownType("System.Runtime.InteropServices", "IDynamicInterfaceCastable");
-                MethodDesc getDynamicInterfaceImplementationMethod = iDynamicInterfaceCastableType.GetKnownMethod("GetDynamicInterfaceImplementation", null);
-                bodySubstitutions.Add(getDynamicInterfaceImplementationMethod, BodySubstitution.ThrowingBody);
-            }
-
-            return new BodyAndFieldSubstitutions(bodySubstitutions, []);
         }
 
         public TypeMapManager GetTypeMapManager()

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -530,10 +530,6 @@ namespace ILCompiler
 
                 interopStubManager = scanResults.GetInteropStubManager(interopStateManager, pinvokePolicy);
 
-                substitutions.AppendFrom(scanResults.GetBodyAndFieldSubstitutions());
-
-                substitutionProvider = new SubstitutionProvider(logger, featureSwitches, substitutions);
-
                 ilProvider = new SubstitutedILProvider(unsubstitutedILProvider, substitutionProvider, devirtualizationManager, metadataManager, scanResults.GetAnalysisCharacteristics());
 
                 // Use a more precise IL provider that uses whole program analysis for dead branch elimination


### PR DESCRIPTION
Implements suggestion from https://github.com/dotnet/runtime/pull/118769#issuecomment-3192084645.

We could probably replace `CanHaveDynamicInterfaceImplementations` with this too, but we'd need to make it so that characteristics are available in `Compilation` class. They are currently hidden in `SubstitutionILProvider`.