### PR TITLE
[interp] Disable tiered compilation if the interpreter is enabled

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -305,6 +305,7 @@ RETAIL_CONFIG_STRING_INFO(EXTERNAL_AltJitExcludeAssemblies, W("AltJitExcludeAsse
 RETAIL_CONFIG_STRING_INFO(EXTERNAL_InterpreterName, W("InterpreterName"), "Primary interpreter to use")
 CONFIG_STRING_INFO(INTERNAL_InterpreterPath, W("InterpreterPath"), "Full path to the interpreter to use")
 RETAIL_CONFIG_STRING_INFO(EXTERNAL_Interpreter, W("Interpreter"), "Enables Interpreter and selectively limits it to the specified methods.")
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_InterpMode, W("InterpMode"), 0, "Enables Interpreter for a subset of all methods depending on the specified mode.")
 #endif // FEATURE_INTERPRETER
 
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_JitHostMaxSlabCache, W("JitHostMaxSlabCache"), 0x1000000, "Sets jit host max slab cache size, 16MB default")

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -643,12 +643,10 @@ HRESULT EEConfig::sync()
         IfFailThrow(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_Interpreter, &pwzInterpreterMaybe));
         if (pwzInterpreterMaybe && pwzInterpreterMaybe[0] != 0)
         {
-            printf("Disabling tiered compilation because DOTNET_Interpreter is set.\n");
             fTieredCompilation = false;
         }
         else if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_InterpMode) != 0)
         {
-            printf("Disabling tiered compilation because DOTNET_InterpMode is set.\n");
             fTieredCompilation = false;
         }
     }

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -639,6 +639,8 @@ HRESULT EEConfig::sync()
 #if defined(FEATURE_INTERPRETER)
     if (fTieredCompilation)
     {
+        // Disable tiered compilation for interpreter testing. Tiered compilation and interpreter 
+        // do not work well together currently.
         LPWSTR pwzInterpreterMaybe;
         IfFailThrow(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_Interpreter, &pwzInterpreterMaybe));
         if (pwzInterpreterMaybe && pwzInterpreterMaybe[0] != 0)

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -635,6 +635,25 @@ HRESULT EEConfig::sync()
 
 #if defined(FEATURE_TIERED_COMPILATION)
     fTieredCompilation = Configuration::GetKnobBooleanValue(W("System.Runtime.TieredCompilation"), CLRConfig::EXTERNAL_TieredCompilation);
+
+#if defined(FEATURE_INTERPRETER)
+    if (fTieredCompilation)
+    {
+        LPWSTR pwzInterpreterMaybe;
+        IfFailThrow(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_Interpreter, &pwzInterpreterMaybe));
+        if (pwzInterpreterMaybe && pwzInterpreterMaybe[0] != 0)
+        {
+            printf("Disabling tiered compilation because DOTNET_Interpreter is set.\n");
+            fTieredCompilation = false;
+        }
+        else if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_InterpMode) != 0)
+        {
+            printf("Disabling tiered compilation because DOTNET_InterpMode is set.\n");
+            fTieredCompilation = false;
+        }
+    }
+#endif
+
     if (fTieredCompilation)
     {
         fTieredCompilation_QuickJit =


### PR DESCRIPTION
When I run JIT\directed\tailcall\more_tailcalls in the debugger it crashes in this helper because pCallStub is NULL. I'm not sure why it's only broken in the debugger. I think @kotlarmilos has hit this problem before, this is not my first time seeing it. It manifests as an AV reading the address 0x10.

EDIT: This PR disables tiered compilation if DOTNET_Interpreter or DOTNET_InterpMode are in use.