### PR TITLE
[browser] Don't write webcil to temp files

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -286,11 +286,10 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_WasmBuildWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'webcil'))</_WasmBuildWebCilPath>
-      <_WasmBuildTmpWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'tmp-webcil'))</_WasmBuildTmpWebCilPath>
       <_WasmBuildOuputPath>$([MSBuild]::NormalizeDirectory('$(OutputPath)', 'wwwroot'))</_WasmBuildOuputPath>
     </PropertyGroup>
 
-    <ConvertDllsToWebCil Candidates="@(_BuildAssetsCandidates)" IntermediateOutputPath="$(_WasmBuildTmpWebCilPath)" OutputPath="$(_WasmBuildWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
+    <ConvertDllsToWebCil Candidates="@(_BuildAssetsCandidates)" OutputPath="$(_WasmBuildWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
       <Output TaskParameter="WebCilCandidates" ItemName="_WebCilAssetsCandidates" />
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ConvertDllsToWebCil>
@@ -637,10 +636,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <_WasmPublishWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'webcil', 'publish'))</_WasmPublishWebCilPath>
-      <_WasmPublishTmpWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'tmp-webcil', 'publish'))</_WasmPublishTmpWebCilPath>
     </PropertyGroup>
 
-    <ConvertDllsToWebCil Candidates="@(_NewWasmPublishStaticWebAssets)" IntermediateOutputPath="$(_WasmPublishTmpWebCilPath)" OutputPath="$(_WasmPublishWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
+    <ConvertDllsToWebCil Candidates="@(_NewWasmPublishStaticWebAssets)" OutputPath="$(_WasmPublishWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
       <Output TaskParameter="WebCilCandidates" ItemName="_NewWebCilPublishStaticWebAssetsCandidates" />
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ConvertDllsToWebCil>

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
@@ -19,9 +19,6 @@ public class ConvertDllsToWebCil : Task
     public string OutputPath { get; set; }
 
     [Required]
-    public string IntermediateOutputPath { get; set; }
-
-    [Required]
     public bool IsEnabled { get; set; }
 
     [Output]

--- a/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
+++ b/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
@@ -45,7 +45,7 @@ public class WebcilConverter
 
     public bool WrapInWebAssembly { get; set; } = true;
 
-    private WebcilConverter(string inputPath, string outputPath = string.Empty)
+    private WebcilConverter(string inputPath, string outputPath)
     {
         _inputPath = inputPath;
         _outputPath = outputPath;
@@ -93,10 +93,11 @@ public class WebcilConverter
             GatherInfo(peReader, out wcInfo, out peInfo);
         }
 
-        using var outputStream = new MemoryStream(checked((int)inputStream.Length));
         if (!WrapInWebAssembly)
         {
+            using var outputStream = new MemoryStream(checked((int)inputStream.Length));
             WriteConversionTo(outputStream, inputStream, peInfo, wcInfo);
+            return outputStream.ToArray();
         }
         else
         {
@@ -108,9 +109,11 @@ public class WebcilConverter
             memoryStream.Flush();
             var wrapper = new WebcilWasmWrapper(memoryStream);
             memoryStream.Seek(0, SeekOrigin.Begin);
+            
+            using var outputStream = new MemoryStream();
             wrapper.WriteWasmWrappedWebcil(outputStream);
+            return outputStream.ToArray();
         }
-        return outputStream.ToArray();
     }
 
     public void WriteConversionTo(Stream outputStream, FileStream inputStream, PEFileInfo peInfo, WCFileInfo wcInfo)

--- a/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
+++ b/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
@@ -109,7 +109,7 @@ public class WebcilConverter
             memoryStream.Flush();
             var wrapper = new WebcilWasmWrapper(memoryStream);
             memoryStream.Seek(0, SeekOrigin.Begin);
-            
+
             using var outputStream = new MemoryStream();
             wrapper.WriteWasmWrappedWebcil(outputStream);
             return outputStream.ToArray();

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -142,7 +142,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
             if (UseWebcil)
             {
                 using TempFileName tmpWebcil = new();
-                var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: assembly, outputPath: tmpWebcil.Path, logger: logAdapter);
+                var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(logger: logAdapter, inputPath: assembly, outputPath: tmpWebcil.Path);
                 webcilWriter.ConvertToWebcil();
                 var finalWebcil = Path.Combine(runtimeAssetsPath, Path.ChangeExtension(Path.GetFileName(assembly), Utils.WebcilInWasmExtension));
                 if (Utils.CopyIfDifferent(tmpWebcil.Path, finalWebcil, useHash: true))
@@ -249,7 +249,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
             if (UseWebcil)
             {
                 using TempFileName tmpWebcil = new();
-                var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: args.fullPath, outputPath: tmpWebcil.Path, logger: logAdapter);
+                var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(logger: logAdapter, inputPath: args.fullPath, outputPath: tmpWebcil.Path);
                 webcilWriter.ConvertToWebcil();
                 var finalWebcil = Path.Combine(cultureDirectory, Path.ChangeExtension(name, Utils.WebcilInWasmExtension));
                 if (Utils.CopyIfDifferent(tmpWebcil.Path, finalWebcil, useHash: true))

--- a/src/tasks/WasmAppBuilder/WebcilConverter.cs
+++ b/src/tasks/WasmAppBuilder/WebcilConverter.cs
@@ -31,7 +31,7 @@ public class WebcilConverter
         Log = logger;
     }
 
-    public static WebcilConverter FromPortableExecutable(LogAdapter logger, string inputPath, string outputPath = string.Empty)
+    public static WebcilConverter FromPortableExecutable(LogAdapter logger, string inputPath, string outputPath = "")
     {
         var converter = NET.WebAssembly.Webcil.WebcilConverter.FromPortableExecutable(inputPath, outputPath);
         return new WebcilConverter(converter, inputPath, outputPath, logger);

--- a/src/tasks/WasmAppBuilder/WebcilConverter.cs
+++ b/src/tasks/WasmAppBuilder/WebcilConverter.cs
@@ -31,7 +31,7 @@ public class WebcilConverter
         Log = logger;
     }
 
-    public static WebcilConverter FromPortableExecutable(string inputPath, string outputPath, LogAdapter logger)
+    public static WebcilConverter FromPortableExecutable(LogAdapter logger, string inputPath, string outputPath = string.Empty)
     {
         var converter = NET.WebAssembly.Webcil.WebcilConverter.FromPortableExecutable(inputPath, outputPath);
         return new WebcilConverter(converter, inputPath, outputPath, logger);
@@ -43,4 +43,9 @@ public class WebcilConverter
         _converter.ConvertToWebcil();
     }
 
+    public byte[] ConvertToWebcilBytes()
+    {
+        Log.LogMessage(MessageImportance.Low, $"Converting to Webcil: input {_inputPath}");
+        return _converter.ConvertToWebcilBytes();
+    }
 }


### PR DESCRIPTION
Use `ArtifactsWriter` to check if the dll converted to webcil/wasm changed in memory, instead of writing to temp files, and if it does, write to the final destination only. Because of how `WebcilWasmWrapper` works, we now have two MemoryStreams per assembly instead of one, but I assume that won't be a problem.

Contributes to https://github.com/dotnet/aspnetcore/issues/61987