### PR TITLE
[NativeAOT] Fix floating pointer register unwinding on Arm32

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.cpp
@@ -354,8 +354,8 @@ struct Registers_REGDISPLAY : REGDISPLAY
     uint32_t    getRegister(int num) const;
     void        setRegister(int num, uint32_t value, uint32_t location);
 
-    double      getFloatRegister(int num) const;
-    void        setFloatRegister(int num, double value);
+    unw_fpreg_t getFloatRegister(int num) const;
+    void        setFloatRegister(int num, unw_fpreg_t value);
 
     libunwind::v128    getVectorRegister(int num) const { abort(); }
     void        setVectorRegister(int num, libunwind::v128 value) { abort(); }
@@ -516,13 +516,13 @@ void Registers_REGDISPLAY::setRegister(int num, uint32_t value, uint32_t locatio
     }
 }
 
-double Registers_REGDISPLAY::getFloatRegister(int num) const
+unw_fpreg_t Registers_REGDISPLAY::getFloatRegister(int num) const
 {
     assert(validFloatRegister(num));
-    return unwindhelpers_bitcast<double>(D[num - UNW_ARM_D8]);
+    return unwindhelpers_bitcast<unw_fpreg_t>(D[num - UNW_ARM_D8]);
 }
 
-void Registers_REGDISPLAY::setFloatRegister(int num, double value)
+void Registers_REGDISPLAY::setFloatRegister(int num, unw_fpreg_t value)
 {
     assert(validFloatRegister(num));
     D[num - UNW_ARM_D8] = unwindhelpers_bitcast<uint64_t>(value);

--- a/src/tests/Exceptions/UnwindFpBleedTest/UnwindFpBleedTest.cs
+++ b/src/tests/Exceptions/UnwindFpBleedTest/UnwindFpBleedTest.cs
@@ -4,6 +4,9 @@ using Xunit;
 
 public class Program
 {
+    // Make sure that the JIT doesn't optimize away the loops.
+    static volatile int iterations = 10;
+
     [Fact]
     public static int TestEntryPoint()
     {
@@ -18,7 +21,7 @@ public class Program
         double a8 = 9.0;
         double a9 = 10.0;
 
-        for (int i = 1; i < 10; i++)
+        for (int i = 1; i < iterations; i++)
         {
             a0 *= 1.0;
             a1 *= 2.0;
@@ -32,19 +35,31 @@ public class Program
             a9 *= 10.0;
         }
 
+        a0 += 0.1;
+        a1 += 0.2;
+        a2 += 0.3;
+        a3 += 0.4;
+        a4 += 0.5;
+        a5 += 0.6;
+        a6 += 0.7;
+        a7 += 0.8;
+        a8 += 0.9;
+        a9 += 1.1;
+
+
         EHMethod();
 
         bool isExpectedValue =
-            a0 == 1.0
-            && a1 == Math.Pow(2, 10)
-            && a2 == Math.Pow(3, 10)
-            && a3 == Math.Pow(4, 10)
-            && a4 == Math.Pow(5, 10)
-            && a5 == Math.Pow(6, 10)
-            && a6 == Math.Pow(7, 10)
-            && a7 == Math.Pow(8, 10)
-            && a8 == Math.Pow(9, 10)
-            && a9 == Math.Pow(10, 10);
+            a0 == 1.1
+            && a1 == Math.Pow(2, 10) + 0.2
+            && a2 == Math.Pow(3, 10) + 0.3
+            && a3 == Math.Pow(4, 10) + 0.4
+            && a4 == Math.Pow(5, 10) + 0.5
+            && a5 == Math.Pow(6, 10) + 0.6
+            && a6 == Math.Pow(7, 10) + 0.7
+            && a7 == Math.Pow(8, 10) + 0.8
+            && a8 == Math.Pow(9, 10) + 0.9
+            && a9 == Math.Pow(10, 10) + 1.1;
 
         return isExpectedValue ? 100 : 1;
     }
@@ -71,14 +86,21 @@ public class Program
         double a24 = 1, a25 = 2, a26 = 3, a27 = 4, a28 = 5, a29 = 6, a30 = 7, a31 = 8;
 
         // Some busy math to prevent easy optimizations and folding.
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < iterations; i++)
         {
             a0 -= 1; a1 -= 2; a2 -= 3; a3 -= 4; a4 -= 5; a5 -= 6; a6 -= 7; a7 -= 8;
             a8 -= 9; a9 -= 10; a10 -= 11; a11 -= 12; a12 -= 13; a13 -= 14; a14 -= 15; a15 -= 16;
             a16 -= 17; a17 -= 18; a18 -= 19; a19 -= 20; a20 -= 21; a21 -= 22; a22 -= 23; a23 -= 24;
             a24 -= 25; a25 -= 26; a26 -= 27; a27 -= 28; a28 -= 29; a29 -= 30; a30 -= 31; a31 -= 32;
-        }
 
-        throw new Exception();
+            if (i == 7)
+            {
+                throw new Exception(
+                    (a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 +
+                    a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15 +
+                    a16 + a17 + a19 + a20 + a21 + a22 + a23 +
+                    a24 + a25 + a26 + a27 + a28 + a29 + a30 + a31).ToString());
+            }
+        }
     }
 }

--- a/src/tests/Exceptions/UnwindFpBleedTest/UnwindFpBleedTest.csproj
+++ b/src/tests/Exceptions/UnwindFpBleedTest/UnwindFpBleedTest.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="UnwindFpBleedTest.cs" />
   </ItemGroup>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -232,9 +232,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_590771/DevDiv_590771/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Exceptions/UnwindFpBleedTest/UnwindFpBleedTest/*">
-          <Issue>Windows's unwinder in ARM64v8 queue doesn't contain FP unwind fix</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows all architecture excludes -->


### PR DESCRIPTION
NativeAOT specific register window implementation has to match the one in libunwind.

Fixes https://github.com/dotnet/runtime/issues/118942.