### PR TITLE
`OleAutBinder` needs to special case `DBNull`

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/Microsoft/Win32/OAVariantLib.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Microsoft/Win32/OAVariantLib.cs
@@ -28,9 +28,6 @@ namespace Microsoft.Win32
     {
         #region Constants
 
-        // Constants for VariantChangeType from OleAuto.h
-        public const int LocalBool = 0x10;
-
         private static readonly Dictionary<Type, VarEnum> ClassTypes = new Dictionary<Type, VarEnum>
         {
             { typeof(bool), VarEnum.VT_BOOL },
@@ -62,11 +59,8 @@ namespace Microsoft.Win32
          * Variant and the types that CLR supports explicitly in the
          * CLR Variant class.
          */
-        internal static object? ChangeType(object source, Type targetClass, short options, CultureInfo culture)
+        internal static object? ChangeType(object source, Type targetClass, CultureInfo culture)
         {
-            ArgumentNullException.ThrowIfNull(targetClass);
-            ArgumentNullException.ThrowIfNull(culture);
-
             object? result = null;
 
             if (Variant.IsSystemDrawingColor(targetClass))
@@ -88,7 +82,12 @@ namespace Microsoft.Win32
             ComVariant vOp = ToOAVariant(source);
             ComVariant ret = default;
 
-            int hr = Interop.OleAut32.VariantChangeTypeEx(&ret, &vOp, culture.LCID, options, (ushort)vt);
+            // Constants for VariantChangeTypeEx from OleAuto.h
+            const int VARIANT_LOCALBOOL = 0x10;
+
+            // Specify the VARIANT_LOCALBOOL flag to have BOOL values converted to local language rather
+            // than 0 or -1.
+            int hr = Interop.OleAut32.VariantChangeTypeEx(&ret, &vOp, culture.LCID, VARIANT_LOCALBOOL, (ushort)vt);
 
             using (vOp)
             using (ret)

--- a/src/coreclr/System.Private.CoreLib/src/System/OleAutBinder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/OleAutBinder.cs
@@ -3,15 +3,12 @@
 
 // This class represents the Ole Automation binder.
 
-// #define DISPLAY_DEBUG_INFO
-
 using System.Runtime.InteropServices;
 using Microsoft.Win32;
 using CultureInfo = System.Globalization.CultureInfo;
 
 namespace System
 {
-    // Made serializable in anticipation of this class eventually having state.
     internal sealed class OleAutBinder : DefaultBinder
     {
         // ChangeType
@@ -20,15 +17,8 @@ namespace System
         {
             cultureInfo ??= CultureInfo.CurrentCulture;
 
-#if DISPLAY_DEBUG_INFO
-            Console.WriteLine("In OleAutBinder::ChangeType converting variant of type: {0} to type: {1}", myValue.VariantType, type.Name);
-#endif
-
             if (type.IsByRef)
             {
-#if DISPLAY_DEBUG_INFO
-                Console.WriteLine("Stripping byref from the type to convert to.");
-#endif
                 type = type.GetElementType()!;
             }
 
@@ -36,9 +26,6 @@ namespace System
             // need the OLEAUT change type, we can just use the normal CLR mechanisms.
             if (!type.IsPrimitive && type.IsInstanceOfType(value))
             {
-#if DISPLAY_DEBUG_INFO
-                Console.WriteLine("Source variant can be assigned to destination type");
-#endif
                 return value;
             }
 
@@ -47,39 +34,36 @@ namespace System
             // Handle converting primitives to enums.
             if (type.IsEnum && srcType.IsPrimitive)
             {
-#if DISPLAY_DEBUG_INFO
-                Console.WriteLine("Converting primitive to enum");
-#endif
                 return Enum.Parse(type, value.ToString()!);
+            }
+
+            // Special case the conversion from DBNull.
+            if (srcType == typeof(DBNull))
+            {
+                // The requested type is a DBNull so no conversion is required.
+                if (type == typeof(DBNull))
+                    return value;
+
+                // The DBNull to null conversion is for compat with .NET Framework.
+                // We don't allow this when converting to a value class, since null
+                // doesn't make sense for these, or to object since this would change
+                // existing semantics.
+                if ((type.IsClass && type != typeof(object))
+                    || type.IsInterface)
+                {
+                    return null!;
+                }
             }
 
             // Use the OA variant lib to convert primitive types.
             try
             {
-#if DISPLAY_DEBUG_INFO
-                Console.WriteLine("Using OAVariantLib.ChangeType() to do the conversion");
-#endif
-                // Specify the LocalBool flag to have BOOL values converted to local language rather
-                // than 0 or -1.
-                object RetObj = OAVariantLib.ChangeType(value, type, OAVariantLib.LocalBool, cultureInfo)!;
-
-#if DISPLAY_DEBUG_INFO
-                Console.WriteLine("Object returned from ChangeType is of type: " + RetObj.GetType().Name);
-#endif
-
-                return RetObj;
+                return OAVariantLib.ChangeType(value, type, cultureInfo)!;
             }
-#if DISPLAY_DEBUG_INFO
-            catch (NotSupportedException e)
-#else
             catch (NotSupportedException)
-#endif
             {
-#if DISPLAY_DEBUG_INFO
-                Console.Write("Exception thrown: ");
-                Console.WriteLine(e);
-#endif
-                throw new COMException(SR.Interop_COM_TypeMismatch, unchecked((int)0x80020005));
+                const int DISP_E_TYPEMISMATCH = unchecked((int)0x80020005);
+                throw new COMException(SR.Interop_COM_TypeMismatch, DISP_E_TYPEMISMATCH);
             }
         }
     }

--- a/src/coreclr/vm/dispparammarshaler.cpp
+++ b/src/coreclr/vm/dispparammarshaler.cpp
@@ -220,7 +220,7 @@ void DispParamArrayMarshaler::MarshalNativeToManaged(VARIANT *pSrcVar, OBJECTREF
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(CheckPointer(pSrcVar));
-        PRECONDITION(CheckPointer(pDestObj) && *pDestObj == NULL);
+        PRECONDITION(CheckPointer(pDestObj));
     }
     CONTRACTL_END;
 
@@ -236,6 +236,7 @@ void DispParamArrayMarshaler::MarshalNativeToManaged(VARIANT *pSrcVar, OBJECTREF
 
     if (!pSafeArray)
     {
+        *pDestObj = NULL;
         return;
     }
 

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/OleAutBinderTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/OleAutBinderTests.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Reflection.Tests
+{
+    [PlatformSpecific(TestPlatforms.Windows)]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltInComEnabledWithOSAutomationSupport))]
+    public class OleAutBinderTests
+    {
+        [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
+        [return: UnsafeAccessorType("System.OleAutBinder")]
+        private static extern object CreateOleAutBinder();
+
+        private static Binder OleAutBinder => (Binder)CreateOleAutBinder();
+
+        [Theory]
+        [InlineData(-1, TestEnum.Value1)]
+        [InlineData(0, TestEnum.Value2)]
+        [InlineData(1, TestEnum.Value3)]
+        [InlineData(2, (TestEnum)2)]
+        public static void OleAutBinder_Enum(int value, TestEnum expected)
+        {
+            Assert.Equal(expected, OleAutBinder.ChangeType(value, typeof(TestEnum), null));
+        }
+
+        [Fact]
+        public static void OleAutBinder_DBNull()
+        {
+            Assert.Null(OleAutBinder.ChangeType(DBNull.Value, typeof(string), null));
+            Assert.Equal(DBNull.Value, OleAutBinder.ChangeType(DBNull.Value, typeof(object), null));
+            Assert.Equal(DBNull.Value, OleAutBinder.ChangeType(DBNull.Value, typeof(DBNull), null));
+            Assert.Throws<COMException>(() => OleAutBinder.ChangeType(DBNull.Value, typeof(Guid), null));
+        }
+
+        public static IEnumerable<object[]> OleAutBinder_Color_TestData()
+        {
+            yield return new object[] { 0, 0, 0, Color.Black };
+            yield return new object[] { 255, 255, 255, Color.White };
+            yield return new object[] { 128, 128, 128, Color.Gray };
+            yield return new object[] { 255, 0, 0, Color.Red };
+            yield return new object[] { 0, 128, 0, Color.Green };
+            yield return new object[] { 0, 0, 255, Color.Blue };
+        }
+
+        [Theory]
+        [MemberData(nameof(OleAutBinder_Color_TestData))]
+        public static void OleAutBinder_Color(int r, int g, int b, Color expected)
+        {
+            // Convert to OLE's COLORREF - https://learn.microsoft.com/windows/win32/gdi/colorref
+            int bgr = (b << 16) | (g << 8) | r;
+            Assert.Equal(expected, OleAutBinder.ChangeType(bgr, typeof(Color), null));
+        }
+
+        [Theory]
+        [InlineData(true, "True")]
+        [InlineData(false, "False")]
+        public static void OleAutBinder_Bool(bool value, string expected)
+        {
+            Assert.Equal(expected, OleAutBinder.ChangeType(value, typeof(string), null));
+        }
+    }
+
+    public enum TestEnum
+    {
+        Value1 = -1,
+        Value2 = 0,
+        Value3 = 1
+    }
+}

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/System.Reflection.Tests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="MethodInfoTests.cs" />
     <Compile Include="MethodInvokerTests.cs" />
     <Compile Include="ModuleTests.cs" />
+    <Compile Include="OleAutBinderTests.cs" />
     <Compile Include="Common.cs" />
     <Compile Include="ParameterInfoTests.cs" />
     <Compile Include="PropertyInfoTests.cs" />


### PR DESCRIPTION
This PR adds back the missing `DBNull` special case
that exists on .NET Framework.
Add some tests for `OleAutBinder`.

Fixes #96976 