### PR TITLE
Fix CustomAttributeTypedArgument.ToString() throwing an exception on Mono

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/CustomAttributeTypedArgument.cs
@@ -56,7 +56,11 @@ namespace System.Reflection
 
             if (ArgumentType.IsArray)
             {
+#if !MONO
                 IList<CustomAttributeTypedArgument> array = (IList<CustomAttributeTypedArgument>)Value!;
+#else
+                IList array = (IList)Value!;
+#endif
                 Type elementType = ArgumentType.GetElementType()!;
 
                 var result = new ValueStringBuilder(stackalloc char[256]);
@@ -73,7 +77,11 @@ namespace System.Reflection
                     {
                         result.Append(", ");
                     }
+#if !MONO
                     result.Append(array[i].ToString(elementType != typeof(object)));
+#else
+                    result.Append(array[i]!.ToString());
+#endif
                 }
 
                 result.Append(" }");


### PR DESCRIPTION
CustomAttributeTypedArgument is structured differently in Mono and CoreClr and the function ToString() only takes into consideration how CoreClr's CustomAttributeTypedArgument is implemented and does a cast accordingly which causes it to fail with an InvalidCastException on Mono. So the casts should be runtime specific for it to not throw an InvalidCastException.

For Example, this is a standalone program which throws an InvalidCastException on Mono but not on CoreClr:

```
using System;
using System.Collections;
using System.Reflection;

using System.Runtime.InteropServices;

var attr = typeof(C).CustomAttributes.Single(d => d.AttributeType == typeof(A));
var arg = attr.ConstructorArguments.Single();
Console.WriteLine(arg.ToString());
class A : Attribute
{
    public unsafe A(params B<delegate*<void>[]>.E[] a) { }
} 

class B<T>
{
    public enum E { }
}

[A(new B<delegate*<void>[]>.E())]
unsafe class C { }
```

Output on Mono without the fix:
```
Unhandled Exception:
System.InvalidCastException: Specified cast is not valid.
   at System.Reflection.CustomAttributeTypedArgument.ToString(Boolean typed)
   at System.Reflection.CustomAttributeTypedArgument.ToString()
   at Program.<Main>$(String[] args) in /home/venkad/extracts/Program.cs:line 9
[ERROR] FATAL UNHANDLED EXCEPTION: System.InvalidCastException: Specified cast is not valid.
   at System.Reflection.CustomAttributeTypedArgument.ToString(Boolean typed)
   at System.Reflection.CustomAttributeTypedArgument.ToString()
   at Program.<Main>$(String[] args) in /home/venkad/extracts/Program.cs:line 9

```

Output on CoreClr:

```
new B`1+E[[System.Void()[], System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][1] { 0 }
```

Output on Mono with the fix:
```
new B`1+E[[System.Void()[], System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][1] { 0 }
```