### PR TITLE
[RISC-V] Compressed mnemonics in disassembly

### DIFF
--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -105,7 +105,9 @@ inline ResultType ThumbCodeToDataPointer(SourceType pCode)
 
 inline bool Is32BitInstruction(WORD opcode)
 {
-    return (opcode & 0b11) == 0b11;
+    bool is32 = ((opcode & 0b11) == 0b11);
+    assert(!is32 || ((opcode & 0b11111) != 0b11111)); // 48-bit and larger instructions unsupported
+    return is32;
 }
 
 #endif

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -4833,7 +4833,7 @@ void emitter::emitDispInsName(
             unsigned rs2    = (code >> 2) & 0x1f;
             if (funct4 == 0b1001 && rdRs1 != REG_R0 && rs2 != REG_R0)
             {
-                if (JitConfig.JitDisasmWithCompressedNames())
+                if (emitComp->opts.disCodeBytes)
                 {
                     printf("c.add          %s, %s\n", RegNames[rdRs1], RegNames[rs2]);
                 }
@@ -4844,7 +4844,7 @@ void emitter::emitDispInsName(
             }
             else if (funct4 == 0b1000 && rdRs1 != REG_R0 && rs2 != REG_R0)
             {
-                const char* name = JitConfig.JitDisasmWithCompressedNames() ? "c.mv" : "mv  ";
+                const char* name = emitComp->opts.disCodeBytes ? "c.mv" : "mv  ";
                 printf("%s           %s, %s\n", name, RegNames[rdRs1], RegNames[rs2]);
             }
             else
@@ -4890,7 +4890,7 @@ void emitter::emitDispInsName(
                 emitDispIllegalInstruction(code);
             }
 
-            if (JitConfig.JitDisasmWithCompressedNames())
+            if (emitComp->opts.disCodeBytes)
             {
                 printf("c.%s         %s, %s\n", name, RegNames[rdRs1], RegNames[rs2]);
             }

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -162,9 +162,8 @@ enum class MajorOpcode
     /*        01 */ Store,  StoreFp, Custom1,  Amo,     Op,     Lui,   Op32,         Encoding64Bit,
     /*        11 */ MAdd,   MSub,    NmSub,    NmAdd,   OpFp,   OpV,   Custom2Rv128, Encoding48Bit2,
     /*        11 */ Branch, Jalr,    Reserved, Jal,     System, OpVe,  Custom3Rv128, Encoding80Bit,
-    // clang-format on
 
-    // clang-format off
+    // Compressed (RVC) instructions
     // inst[15:13]  000,      001,   010,  011,         100,         101,   110,  111
     /* inst[1:0] */
     /*        00 */ Addi4Spn, Fld,   Lw,   Ld,          Reserved2,   Fsd,   Sw,   Sd,
@@ -177,7 +176,7 @@ enum class MajorOpcode
 // GetMajorOpcode: extracts major opcode from an instruction
 //
 // Arguments:
-//    instr - instruction encoded in 32-bit format
+//    instr - instruction code
 //
 // Return Value:
 //    Major opcode

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -345,6 +345,11 @@ CONFIG_INTEGER(JitDisasmSpilled, "JitDisasmSpilled", 0)
 // Print the process address next to each instruction of the disassembly
 CONFIG_INTEGER(JitDasmWithAddress, "JitDasmWithAddress", 0)
 
+#ifdef TARGET_RISCV64
+// Print the "c.*" mnemonics for compressed (RVC) instructions instead of normalized names in the disassembly
+RELEASE_CONFIG_INTEGER(JitDisasmWithCompressedNames, "JitDisasmWithCompressedNames", 0)
+#endif
+
 RELEASE_CONFIG_STRING(JitStdOutFile, "JitStdOutFile") // If set, sends JIT's stdout output to this file.
 
 RELEASE_CONFIG_INTEGER(RichDebugInfo, "RichDebugInfo", 0) // If 1, keep rich debug info and report it back to the EE

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -345,11 +345,6 @@ CONFIG_INTEGER(JitDisasmSpilled, "JitDisasmSpilled", 0)
 // Print the process address next to each instruction of the disassembly
 CONFIG_INTEGER(JitDasmWithAddress, "JitDasmWithAddress", 0)
 
-#ifdef TARGET_RISCV64
-// Print the "c.*" mnemonics for compressed (RVC) instructions instead of normalized names in the disassembly
-RELEASE_CONFIG_INTEGER(JitDisasmWithCompressedNames, "JitDisasmWithCompressedNames", 0)
-#endif
-
 RELEASE_CONFIG_STRING(JitStdOutFile, "JitStdOutFile") // If set, sends JIT's stdout output to this file.
 
 RELEASE_CONFIG_INTEGER(RichDebugInfo, "RichDebugInfo", 0) // If 1, keep rich debug info and report it back to the EE


### PR DESCRIPTION
Display `c.*` mnemonics when `DOTNET_JitDisasmWithCodeBytes=1`.

Also fix printing code bytes for RVC and potential reading instruction out of bounds in `emitDispIns`.

Part of #84834, cc @dotnet/samsung