### PR TITLE
JIT: Only look for integer temp regs in prolog generation

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5035,7 +5035,7 @@ void CodeGen::genFnProlog()
     const bool isOSRx64Root = false;
 #endif // TARGET_AMD64
 
-    regMaskTP tempMask = initRegs & ~excludeMask & ~regSet.rsMaskResvd;
+    regMaskTP tempMask = initRegs & RBM_ALLINT & ~excludeMask & ~regSet.rsMaskResvd;
 
     if (tempMask != RBM_NONE)
     {


### PR DESCRIPTION
Otherwise we may end up with mask registers in this mask, and passing that to `genFindLowestBit` hits asserts. We are in any case only interested in integer registers here, so limit it to that.

Fix #118925