### PR TITLE
[wasm]  workaround for gsharedvt_out_sig of SymbolicRegexBuilder/NodeCacheKey:Equals

### DIFF
--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3319,7 +3319,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 	error_init (cfg->error);
 
 	if (cfg->compile_aot && !try_generic_shared && (method->is_generic || mono_class_is_gtd (method->klass) || method_is_gshared)) {
-		cfg->exception_type = MONO_EXCEPTION_GENERIC_SHARING_FAILED;
+		mono_cfg_set_exception (cfg, MONO_EXCEPTION_GENERIC_SHARING_FAILED);
 		return cfg;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/117557

The proper fix is probably too complex to be worth of the effort. 
Investigations described in the issue.
In short: this is generic nested struct with variable binary size depending on the size of the generic argument
On all other platforms this leads to JIT fallback at runtime.