### PR TITLE
Run IsAssignableNullable test on native AOT

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
@@ -611,7 +611,6 @@ namespace System.Reflection.Tests
         static volatile object s_boxedInt32;
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67568", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void IsAssignableNullable()
         {
             Type nubInt = typeof(Nullable<int>);


### PR DESCRIPTION
Based on what is in #67568, we fixed this in #112986. Didn't try locally, the CI will decide.

Resolves #67568.