### PR TITLE
Use fast hashing helpers for types with trailing padding

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 using ILCompiler.DependencyAnalysis;
 
+using Internal.IL.Stubs;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -26,8 +27,16 @@ namespace ILCompiler
 
         public bool CanFold(MethodDesc method)
         {
-            return this != Null
-                && (!_genericsOnly || method.HasInstantiation || method.OwningType.HasInstantiation);
+            if (this == Null)
+                return false;
+
+            if (!_genericsOnly || method.HasInstantiation || method.OwningType.HasInstantiation)
+                return true;
+
+            if (method.GetTypicalMethodDefinition() is ValueTypeGetFieldHelperMethodOverride)
+                return true;
+
+            return false;
         }
 
         private void EnsureMap(NodeFactory factory)


### PR DESCRIPTION
This is same as #111620 but with an extra thing: enable unconditional method body folding on `__GetFieldHelper` overrides (both the simplified ones that just return a negative number and normal ones).

Before this PR we considered valuetypes as byte-hashable/comparable only if the valuetype didn't have any trailing padding.

This fixes things up so that we can consider types with trailing padding byte-hashable/comparable if the other requirements still hold (such as no double/float fields, no GC references, etc.) and there is a trailing padding. In this case, we remember the number of bytes that we should be looking at and ignore the rest.

Since this doesn't seem to provide meaningful size savings according to rt-sz, this is a throughput improvement, not a size improvement.

```csharp
class Program
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    static object Get() => default(Helper);

    static void Main()
    {
        for (int i = 0; i < 10; i++)
        {
            var s = Stopwatch.StartNew();

            object o = Get();
            int acc = 0;

            for (int j = 0; j < 10000000; j++)
            {
                acc += o.GetHashCode();
            }

            Console.WriteLine($"{s.ElapsedMilliseconds} ({acc})");
        }
    }

    struct Helper
    {
        long _one;
        byte _two;
        byte _three;
        byte _four;
        byte _five;
    }
}
```

Before:

```
243 (-899317760)
243 (-899317760)
246 (-899317760)
244 (-899317760)
244 (-899317760)
245 (-899317760)
240 (-899317760)
240 (-899317760)
232 (-899317760)
248 (-899317760)
```

After:

```
229 (565863296)
229 (565863296)
228 (565863296)
229 (565863296)
233 (565863296)
228 (565863296)
229 (565863296)
230 (565863296)
228 (565863296)
230 (565863296)
```

Resolves #111542

Cc @dotnet/ilc-contrib 