### PR TITLE
Increase file descriptor limit in native AOT executables

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include <stdint.h>
+#include <minipal/descriptorlimit.h>
 
 #if defined(DEBUG) && defined(_WIN32)
 #include <process.h>
@@ -222,6 +223,8 @@ int main(int argc, char* argv[])
     int initval = InitializeRuntime();
     if (initval != 0)
         return initval;
+
+    minipal_increase_descriptor_limit();
 
 #if defined(DEBUG) && defined(_WIN32)
     // work around Debug UCRT shutdown issues: https://github.com/dotnet/runtime/issues/108640

--- a/src/coreclr/pal/src/CMakeLists.txt
+++ b/src/coreclr/pal/src/CMakeLists.txt
@@ -101,8 +101,6 @@ if(CLR_CMAKE_HOST_ARCH_ARM64 AND CLR_CMAKE_TARGET_LINUX AND NOT CLR_CMAKE_TARGET
 endif(CLR_CMAKE_HOST_ARCH_ARM64 AND CLR_CMAKE_TARGET_LINUX AND NOT CLR_CMAKE_TARGET_LINUX_MUSL)
 
 if(CLR_CMAKE_TARGET_LINUX_MUSL)
-  # Setting RLIMIT_NOFILE breaks debugging of coreclr on Alpine Linux for some reason
-  add_definitions(-DDONT_SET_RLIMIT_NOFILE)
   # On Alpine Linux, we need to ensure that the reported stack range for the primary thread is
   # larger than the initial committed stack size.
   add_definitions(-DENSURE_PRIMARY_STACK_SIZE)

--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -857,8 +857,6 @@ set(FULL_VERSION ${product_version_string})
 ######################################
 
 if(CLR_CMAKE_TARGET_LINUX_MUSL)
-  # Setting RLIMIT_NOFILE breaks debugging of coreclr on musl-libc for some reason
-  add_definitions(-DDONT_SET_RLIMIT_NOFILE)
   # On musl-libc, we need to ensure that the reported stack range for the primary thread is
   # larger than the initial committed stack size.
   add_definitions(-DENSURE_PRIMARY_STACK_SIZE)

--- a/src/native/minipal/CMakeLists.txt
+++ b/src/native/minipal/CMakeLists.txt
@@ -16,12 +16,6 @@ set(SOURCES
     log.c
 )
 
-# Setting RLIMIT_NOFILE breaks debugging of coreclr on Alpine Linux for some reason
-# Setting limits in Browser/WASI doesn't make sense
-if(CLR_CMAKE_TARGET_LINUX_MUSL OR CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
-  add_definitions(-DDONT_SET_RLIMIT_NOFILE)
-endif()
-
 # Provide an object library for scenarios where we ship static libraries
 include_directories(${CLR_SRC_NATIVE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/native/minipal/CMakeLists.txt
+++ b/src/native/minipal/CMakeLists.txt
@@ -2,6 +2,7 @@ include(configure.cmake)
 
 set(SOURCES
     cpufeatures.c
+    descriptorlimit.c
     memorybarrierprocesswide.c
     mutex.c
     guid.c
@@ -14,6 +15,12 @@ set(SOURCES
     xoshiro128pp.c
     log.c
 )
+
+# Setting RLIMIT_NOFILE breaks debugging of coreclr on Alpine Linux for some reason
+# Setting limits in Browser/WASI doesn't make sense
+if(CLR_CMAKE_TARGET_LINUX_MUSL OR CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
+  add_definitions(-DDONT_SET_RLIMIT_NOFILE)
+endif()
 
 # Provide an object library for scenarios where we ship static libraries
 include_directories(${CLR_SRC_NATIVE_DIR} ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/native/minipal/configure.cmake
+++ b/src/native/minipal/configure.cmake
@@ -5,6 +5,7 @@ include(CheckSymbolExists)
 check_include_files("windows.h;bcrypt.h" HAVE_BCRYPT_H)
 check_include_files("sys/auxv.h;asm/hwcap.h" HAVE_AUXV_HWCAP_H)
 check_include_files("asm/hwprobe.h" HAVE_HWPROBE_H)
+check_include_files("sys/resource.h" HAVE_RESOURCE_H)
 
 check_function_exists(sysctlbyname HAVE_SYSCTLBYNAME)
 check_function_exists(fsync HAVE_FSYNC)

--- a/src/native/minipal/descriptorlimit.c
+++ b/src/native/minipal/descriptorlimit.c
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "minipalconfig.h"
+
+#if HAVE_RESOURCE_H
+#include <sys/resource.h>
+#endif
+
+#include "descriptorlimit.h"
+
+bool minipal_increase_descriptor_limit(void)
+{
+#if HAVE_RESOURCE_H && !defined(DONT_SET_RLIMIT_NOFILE)
+    struct rlimit rlp;
+    int result;
+
+    result = getrlimit(RLIMIT_NOFILE, &rlp);
+    if (result != 0)
+    {
+        return false;
+    }
+    // Set our soft limit for file descriptors to be the same
+    // as the max limit.
+    rlp.rlim_cur = rlp.rlim_max;
+#ifdef __APPLE__
+    // Based on compatibility note in setrlimit(2) manpage for OSX,
+    // trim the limit to OPEN_MAX.
+    if (rlp.rlim_cur > OPEN_MAX)
+    {
+        rlp.rlim_cur = OPEN_MAX;
+    }
+#endif
+    result = setrlimit(RLIMIT_NOFILE, &rlp);
+    if (result != 0)
+    {
+        return false;
+    }
+#endif // HAVE_RESOURCE_H && !DONT_SET_RLIMIT_NOFILE
+    return true;
+}

--- a/src/native/minipal/descriptorlimit.c
+++ b/src/native/minipal/descriptorlimit.c
@@ -13,7 +13,11 @@
 
 bool minipal_increase_descriptor_limit(void)
 {
-#if HAVE_RESOURCE_H && !defined(DONT_SET_RLIMIT_NOFILE)
+#if TARGET_WASM
+    // WebAssembly cannot set limits
+#elif TARGET_LINUX_MUSL
+    // Setting RLIMIT_NOFILE breaks debugging of coreclr on Alpine Linux for some reason
+#elif HAVE_RESOURCE_H
     struct rlimit rlp;
     int result;
 
@@ -38,6 +42,6 @@ bool minipal_increase_descriptor_limit(void)
     {
         return false;
     }
-#endif // HAVE_RESOURCE_H && !DONT_SET_RLIMIT_NOFILE
+#endif
     return true;
 }

--- a/src/native/minipal/descriptorlimit.c
+++ b/src/native/minipal/descriptorlimit.c
@@ -7,6 +7,8 @@
 #include <sys/resource.h>
 #endif
 
+#include <limits.h>
+
 #include "descriptorlimit.h"
 
 bool minipal_increase_descriptor_limit(void)

--- a/src/native/minipal/descriptorlimit.h
+++ b/src/native/minipal/descriptorlimit.h
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef HAVE_MINIPAL_DESCRIPTORLIMIT_H
+#define HAVE_MINIPAL_DESCRIPTORLIMIT_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+bool minipal_increase_descriptor_limit(void);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // HAVE_MINIPAL_DESCRIPTORLIMIT_H

--- a/src/native/minipal/minipalconfig.h.in
+++ b/src/native/minipal/minipalconfig.h.in
@@ -4,6 +4,7 @@
 #cmakedefine01 HAVE_ARC4RANDOM_BUF
 #cmakedefine01 HAVE_AUXV_HWCAP_H
 #cmakedefine01 HAVE_HWPROBE_H
+#cmakedefine01 HAVE_RESOURCE_H
 #cmakedefine01 HAVE_O_CLOEXEC
 #cmakedefine01 HAVE_SYSCTLBYNAME
 #cmakedefine01 HAVE_CLOCK_MONOTONIC


### PR DESCRIPTION
Fixes #82719

Cc @dotnet/ilc-contrib 