### PR TITLE
Support IAT_PVALUE string literals in the interpreter

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3863,13 +3863,30 @@ retry_emit:
                 int32_t token = getI4LittleEndian(m_ip + 1);
                 void *str;
                 InfoAccessType accessType = m_compHnd->constructStringLiteral(m_compScopeHnd, token, &str);
-                DeclarePointerIsString(str);
-                assert(accessType == IAT_VALUE);
                 // str should be forever pinned, so we can include its ref inside interpreter code
                 AddIns(INTOP_LDPTR);
+                m_pLastNewIns->data[0] = GetDataItemIndex(str);
+
+                if (accessType == IAT_PVALUE)
+                {
+                    // IAT_PVALUE means str is a `ref string` not a `String` so the LDPTR produced an I
+                    PushInterpType(InterpTypeI, nullptr);
+                    int tempVar = m_pStackPointer[-1].var;
+                    m_pLastNewIns->SetDVar(tempVar);
+
+                    // Now we generate an LDIND_O to get the actual string out of the ref
+                    AddIns(INTOP_LDIND_O);
+                    m_pLastNewIns->SetSVar(tempVar);
+                    m_pStackPointer--;
+                }
+                else
+                {
+                    assert(accessType == IAT_VALUE);
+                    DeclarePointerIsString(str);
+                }
+
                 PushInterpType(InterpTypeO, m_compHnd->getBuiltinClass(CLASSID_STRING));
                 m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
-                m_pLastNewIns->data[0] = GetDataItemIndex(str);
                 m_ip += 5;
                 break;
             }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3876,6 +3876,8 @@ retry_emit:
 
                     // Now we generate an LDIND_O to get the actual string out of the ref
                     AddIns(INTOP_LDIND_O);
+                    // LDIND offset
+                    m_pLastNewIns->data[0] = 0;
                     m_pLastNewIns->SetSVar(tempVar);
                     m_pStackPointer--;
                 }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3874,8 +3874,8 @@ retry_emit:
                     int tempVar = m_pStackPointer[-1].var;
                     m_pLastNewIns->SetDVar(tempVar);
 
-                    // Now we generate an LDIND_O to get the actual string out of the ref
-                    AddIns(INTOP_LDIND_O);
+                    // Now we generate an LDIND_I to get the actual string out of the ref
+                    AddIns(INTOP_LDIND_I);
                     // LDIND offset
                     m_pLastNewIns->data[0] = 0;
                     m_pLastNewIns->SetSVar(tempVar);

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -338,7 +338,7 @@ OPDEF(INTOP_LDIND_I4, "ldind.i4", 4, 1, 1, InterpOpInt)
 OPDEF(INTOP_LDIND_I8, "ldind.i8", 4, 1, 1, InterpOpInt)
 OPDEF(INTOP_LDIND_R4, "ldind.r4", 4, 1, 1, InterpOpInt)
 OPDEF(INTOP_LDIND_R8, "ldind.r8", 4, 1, 1, InterpOpInt)
-OPDEF(INTOP_LDIND_O, "ldind.o", 4, 1, 1, InterpOpInt)
+// No LDIND_O, use LDIND_I
 OPDEF(INTOP_LDIND_VT, "ldind.vt", 5, 1, 1, InterpOpTwoInts)
 
 OPDEF(INTOP_STIND_I1, "stind.i1", 4, 0, 2, InterpOpInt)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1715,9 +1715,6 @@ MAIN_LOOP:
                 case INTOP_LDIND_R8:
                     LDIND(double, double);
                     break;
-                case INTOP_LDIND_O:
-                    LDIND(Object*, Object*);
-                    break;
                 case INTOP_LDIND_VT:
                 {
                     char *src = LOCAL_VAR(ip[2], char*);

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1715,6 +1715,9 @@ MAIN_LOOP:
                 case INTOP_LDIND_R8:
                     LDIND(double, double);
                     break;
+                case INTOP_LDIND_O:
+                    LDIND(Object*, Object*);
+                    break;
                 case INTOP_LDIND_VT:
                 {
                     char *src = LOCAL_VAR(ip[2], char*);


### PR DESCRIPTION
Adds support for IAT_PVALUE string literals and removes INTOP_LDIND_O. This fixes JIT\regression\jitblue\Runtime_100437