### PR TITLE
Add .NET 10.x and 8.x installation steps for MCP servers in Copilot setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -45,3 +45,18 @@ jobs:
 
       - name: Build clr+libs
         run: ./build.sh clr+libs -rc release
+
+      # For MCP servers like nuget's
+      - name: Install .NET 10.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.x
+          dotnet-quality: preview
+
+      # for MCP servers
+      - name: Install .NET 8.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.x 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -59,4 +59,4 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.x 
+            8.x


### PR DESCRIPTION
Matches what I did in aspire to make the NuGet MCP server run. It seemed like both were needed.

https://github.com/dotnet/aspire/blob/main/.github/workflows/copilot-setup-steps.yml