### PR TITLE
Fix passing Vector3s from the interpreter to native code

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2848,6 +2848,9 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                 m_pLastNewIns->SetDVar(pThisStackInfo->var);
             }
         }
+
+        if (InterpConfig.InterpHaltOnCall().contains(m_compHnd, resolvedCallToken.hMethod, resolvedCallToken.hClass, nullptr))
+            assert(!"HaltOnCall");
     }
 
     if (newObj && (callInfo.classFlags & CORINFO_FLG_VAROBJSIZE))
@@ -5315,7 +5318,7 @@ retry_emit:
                 int byrefOfTypedRefVar = m_pStackPointer[-1].var;
                 m_pLastNewIns->SetDVar(byrefOfTypedRefVar);
                 m_pStackPointer--;
-                
+
                 AddIns(GetStindForType(InterpTypeByRef));
                 m_pLastNewIns->data[0] = OFFSETOF__CORINFO_TypedReference__dataPtr;
                 m_pLastNewIns->SetSVars2(byrefOfTypedRefVar, addressVar);
@@ -5380,7 +5383,7 @@ retry_emit:
                         m_pLastNewIns->data[2] = 0;
                         m_pLastNewIns->SetSVar(typedByRefVar);
                         m_pLastNewIns->SetDVar(classHandleVar);
-                        
+
                         AddIns(INTOP_CALL_HELPER_P_S);
                         m_pLastNewIns->data[0] = GetDataForHelperFtn(CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE_MAYBENULL);
                         m_pLastNewIns->SetSVar(classHandleVar);

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2849,8 +2849,10 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             }
         }
 
+#if DEBUG
         if (InterpConfig.InterpHaltOnCall().contains(m_compHnd, resolvedCallToken.hMethod, resolvedCallToken.hClass, nullptr))
             assert(!"HaltOnCall");
+#endif
     }
 
     if (newObj && (callInfo.classFlags & CORINFO_FLG_VAROBJSIZE))

--- a/src/coreclr/interpreter/interpconfigvalues.h
+++ b/src/coreclr/interpreter/interpconfigvalues.h
@@ -20,6 +20,7 @@
 #endif
 
 RELEASE_CONFIG_METHODSET(Interpreter, "Interpreter")
+CONFIG_METHODSET(InterpHaltOnCall, "InterpHaltOnCall"); // Assert in the compiler when compiling a call to these method(s)
 CONFIG_METHODSET(InterpHalt, "InterpHalt");
 CONFIG_METHODSET(InterpDump, "InterpDump");
 CONFIG_INTEGER(InterpList, "InterpList", 0); // List the methods which are compiled by the interpreter JIT

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1685,17 +1685,28 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
     // we always process single argument passed by reference using single routine.
     if (pArgIt != NULL && pArgIt->IsArgPassedByRef())
     {
+        int unalignedArgSize = pArgIt->GetArgSize();
+        // For the interpreter-to-native transition we need to make sure that we properly align the offsets
+        //  to interpreter stack slots. Otherwise a VT of i.e. size 12 will misalign the stack offset during
+        //  loads and we will start loading garbage into registers.
+        // We don't need to do this for native-to-interpreter transitions because the Store_Ref_xxx helpers
+        //  automatically do alignment of the stack offset themselves when updating the stack offset,
+        //  and if we were to pass them aligned sizes they would potentially read bytes past the end of the VT.
+        int alignedArgSize = m_interpreterToNative
+            ? (unalignedArgSize + 7) & ~7
+            : unalignedArgSize;
+
         if (argLocDesc.m_cGenReg == 1)
         {
             pRoutines[m_routineIndex++] = GetGPRegRefRoutine(argLocDesc.m_idxGenReg);
-            pRoutines[m_routineIndex++] = pArgIt->GetArgSize();
+            pRoutines[m_routineIndex++] = alignedArgSize;
             m_r1 = NoRange;
         }
         else
         {
             _ASSERTE(argLocDesc.m_byteStackIndex != -1);
             pRoutines[m_routineIndex++] = GetStackRefRoutine();
-            pRoutines[m_routineIndex++] = ((int64_t)pArgIt->GetArgSize() << 32) | argLocDesc.m_byteStackIndex;
+            pRoutines[m_routineIndex++] = ((int64_t)alignedArgSize << 32) | argLocDesc.m_byteStackIndex;
             m_s1 = NoRange;
         }
     }

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1693,7 +1693,7 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
         //  automatically do alignment of the stack offset themselves when updating the stack offset,
         //  and if we were to pass them aligned sizes they would potentially read bytes past the end of the VT.
         int alignedArgSize = m_interpreterToNative
-            ? (unalignedArgSize + 7) & ~7
+            ? ALIGN_UP(unalignedArgSize, 8)
             : unalignedArgSize;
 
         if (argLocDesc.m_cGenReg == 1)


### PR DESCRIPTION
Currently if you pass a VT argument with a size that is not a multiple of 8, the interp->native transition will misalign its stack offset and start loading garbage into registers after it processes the VT. The native->interp transition is handled correctly because the Store_Ref_XXX helpers already align offsets. The Load_Ref_Reg helpers don't do alignment, unlike Load_Stack_Ref which does.

This PR tweaks the callstub generator so that when generating a list of load routines, it aligns up the size of any VTs to maintain the alignment of the stack offsets. This is unnecessary for stack refs but harmless there. Store routines are left alone.

This PR also adds a new DOTNET_InterpHaltOnCall environment var that lets you make the interpreter assert when compiling calls to a specific method. It was helpful to have this when investigating this issue.

This fixes an issue in JIT\SIMD\Vector3Interop_ro\Vector3Interop_ro (but it still doesn't pass, due to a GC hole much later in the test)