### PR TITLE
[DAC] ClrDataAccess::StartEnumMethodInstancesByAddress return S_FALSE on failure

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -4183,6 +4183,7 @@ ClrDataAccess::StartEnumMethodInstancesByAddress(
         methodDesc = ExecutionManager::GetCodeMethodDesc(taddr);
         if (!methodDesc)
         {
+            status = S_FALSE;
             goto Exit;
         }
 

--- a/src/native/managed/cdac/mscordaccore_universal/Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/mscordaccore_universal/Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -331,10 +331,8 @@ internal sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataPro
 
     int IXCLRDataProcess.StartEnumMethodInstancesByAddress(ClrDataAddress address, /*IXCLRDataAppDomain*/ void* appDomain, ulong* handle)
     {
-        int hr = HResults.S_OK;
-
+        int hr = HResults.S_FALSE;
         *handle = 0;
-        hr = HResults.S_FALSE;
 
         ulong handleLocal = default;
 #if DEBUG


### PR DESCRIPTION
Fixed a portion of this in https://github.com/dotnet/runtime/pull/115131, but caused a failure of getting a methodDesc to return `S_OK` instead of `S_FALSE`.

Clean up cDAC implementation.