### PR TITLE
[interp] Fixes for Vector3 Interop test

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5513,8 +5513,8 @@ retry_emit:
                         if (m_pStackPointer[-1].type == StackTypeI4)
                         {
                             // The localloc instruction allocates size (type native unsigned int or U4) bytes from the local dynamic memory pool ...
-                            // So the size is currently U4 and needs to be promoted to I8
-                            EmitConv(m_pStackPointer - 1, StackTypeI8, INTOP_CONV_I8_U4);
+                            // So the size is currently U4 and needs to be promoted to U8
+                            EmitConv(m_pStackPointer - 1, StackTypeI8, INTOP_CONV_U8_U4);
                             m_pStackPointer[-1].type = StackTypeI8;
                         }
 #endif

--- a/src/coreclr/interpreter/intops.def
+++ b/src/coreclr/interpreter/intops.def
@@ -397,6 +397,7 @@ OPDEF(INTOP_GENERICLOOKUP, "generic", 4, 1, 1, InterpOpGenericLookup)
 OPDEF(INTOP_CALL_FINALLY, "call.finally", 2, 0, 0, InterpOpBranch)
 
 OPDEF(INTOP_ZEROBLK_IMM, "zeroblk.imm", 3, 0, 1, InterpOpInt)
+OPDEF(INTOP_INITBLK, "initblk", 4, 0, 3, InterpOpNoArgs)
 OPDEF(INTOP_CPBLK, "cpblk", 4, 0, 3, InterpOpNoArgs)
 OPDEF(INTOP_LOCALLOC, "localloc", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_BREAKPOINT, "breakpoint", 1, 0, 0, InterpOpNoArgs)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2172,6 +2172,18 @@ CALL_INTERP_METHOD:
                     ip += 4;
                     break;
                 }
+                case INTOP_INITBLK:
+                {
+                    void* dst = LOCAL_VAR(ip[1], void*);
+                    uint8_t value = LOCAL_VAR(ip[2], uint8_t);
+                    uint32_t size = LOCAL_VAR(ip[3], uint32_t);
+                    if (size && !dst)
+                        COMPlusThrow(kNullReferenceException);
+                    else
+                        memset(dst, value, size);
+                    ip += 4;
+                    break;
+                }
                 case INTOP_LOCALLOC:
                 {
                     size_t len = LOCAL_VAR(ip[2], size_t);

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1957,10 +1957,7 @@ unsigned CEEInfo::getClassAlignmentRequirement(CORINFO_CLASS_HANDLE type, bool f
 
 unsigned CEEInfo::getClassAlignmentRequirementStatic(TypeHandle clsHnd)
 {
-    CONTRACTL {
-        THROWS;
-        GC_TRIGGERS;
-    } CONTRACTL_END;
+    STANDARD_VM_CONTRACT;
 
     // Default alignment is sizeof(void*)
     unsigned result = TARGET_POINTER_SIZE;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1920,15 +1920,15 @@ bool CEEInfo::canAllocateOnStack(CORINFO_CLASS_HANDLE clsHnd)
 unsigned CEEInfo::getClassAlignmentRequirement(CORINFO_CLASS_HANDLE type, bool fDoubleAlignHint)
 {
     CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
+        THROWS; // Due to GetNativeLayoutInfo() call in getClassAlignmentRequirementStatic
+        GC_TRIGGERS; // Due to InitializeNativeLayoutFieldMetadataThrowing() call in GetNativeLayoutInfo
         MODE_PREEMPTIVE;
     } CONTRACTL_END;
 
     // Default alignment is sizeof(void*)
     unsigned result = TARGET_POINTER_SIZE;
 
-    JIT_TO_EE_TRANSITION_LEAF();
+    JIT_TO_EE_TRANSITION();
 
     TypeHandle clsHnd(type);
 
@@ -1950,7 +1950,7 @@ unsigned CEEInfo::getClassAlignmentRequirement(CORINFO_CLASS_HANDLE type, bool f
         result = getClassAlignmentRequirementStatic(clsHnd);
     }
 
-    EE_TO_JIT_TRANSITION_LEAF();
+    EE_TO_JIT_TRANSITION();
 
     return result;
 }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1920,8 +1920,8 @@ bool CEEInfo::canAllocateOnStack(CORINFO_CLASS_HANDLE clsHnd)
 unsigned CEEInfo::getClassAlignmentRequirement(CORINFO_CLASS_HANDLE type, bool fDoubleAlignHint)
 {
     CONTRACTL {
-        THROWS; // Due to GetNativeLayoutInfo() call in getClassAlignmentRequirementStatic
-        GC_TRIGGERS; // Due to InitializeNativeLayoutFieldMetadataThrowing() call in GetNativeLayoutInfo
+        THROWS;
+        GC_TRIGGERS;
         MODE_PREEMPTIVE;
     } CONTRACTL_END;
 
@@ -1957,7 +1957,10 @@ unsigned CEEInfo::getClassAlignmentRequirement(CORINFO_CLASS_HANDLE type, bool f
 
 unsigned CEEInfo::getClassAlignmentRequirementStatic(TypeHandle clsHnd)
 {
-    LIMITED_METHOD_CONTRACT;
+    CONTRACTL {
+        THROWS;
+        GC_TRIGGERS;
+    } CONTRACTL_END;
 
     // Default alignment is sizeof(void*)
     unsigned result = TARGET_POINTER_SIZE;


### PR DESCRIPTION
With these fixes and the fixes from https://github.com/dotnet/runtime/pull/119020, JIT\SIMD\Vector3Interop_ro\Vector3Interop_ro gets to `All PInvoke testcases passed` now. The reverse p/invoke test cases don't pass yet, still.

* Fix some check failures in getClassAlignmentRequirement
* Implement CPOBJ
* Implement INITBLK