### PR TITLE
[interp] Implement STELEM_U1 and STELEM_U2

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2425,6 +2425,16 @@ do {                                                                           \
                     STELEM(int64_t, int64_t);
                     break;
                 }
+                case INTOP_STELEM_U1:
+                {
+                    STELEM(int32_t, uint8_t);
+                    break;
+                }
+                case INTOP_STELEM_U2:
+                {
+                    STELEM(int32_t, uint16_t);
+                    break;
+                }
                 case INTOP_STELEM_R4:
                 {
                     STELEM(float, float);


### PR DESCRIPTION
Fixes JIT\SIMD\VectorConvert_ro_Target_64Bit and its kin