### PR TITLE
Fix GCStress regression

### DIFF
--- a/src/coreclr/vm/amd64/PInvokeStubs.asm
+++ b/src/coreclr/vm/amd64/PInvokeStubs.asm
@@ -113,10 +113,11 @@ NESTED_ENTRY VarargPInvokeGenILStub, _TEXT
         mov             r13, PINVOKE_CALLI_SIGTOKEN_REGISTER
 
         ;
-        ; VarargPInvokeStubWorker(TransitionBlock* pTransitionBlock, VASigCookie* pVASigCookie)
+        ; VarargPInvokeStubWorker(TransitionBlock * pTransitionBlock, VASigCookie *pVASigCookie, MethodDesc *pMD)
         ;
         lea             rcx, [rsp + __PWTB_TransitionBlock]     ; pTransitionBlock*
         mov             rdx, PINVOKE_CALLI_SIGTOKEN_REGISTER    ; pVASigCookie
+        mov             r8, METHODDESC_REGISTER                 ; pMD
         call            VarargPInvokeStubWorker
 
         ;

--- a/src/coreclr/vm/amd64/pinvokestubs.S
+++ b/src/coreclr/vm/amd64/pinvokestubs.S
@@ -109,10 +109,11 @@ NESTED_ENTRY VarargPInvokeGenILStub, _TEXT, NoHandler
         mov             r13, PINVOKE_CALLI_SIGTOKEN_REGISTER
 
         //
-        // VarargPInvokeStubWorker(TransitionBlock* pTransitionBlock, VASigCookie* pVASigCookie)
+        // VarargPInvokeStubWorker(TransitionBlock * pTransitionBlock, VASigCookie *pVASigCookie, MethodDesc *pMD)
         //
         lea             rdi, [rsp + __PWTB_TransitionBlock]     // pTransitionBlock*
         mov             rsi, PINVOKE_CALLI_SIGTOKEN_REGISTER    // pVASigCookie
+        mov             rdx, METHODDESC_REGISTER                // pMD
         call            C_FUNC(VarargPInvokeStubWorker)
 
         //

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4197,13 +4197,12 @@ static bool MethodSignatureContainsGenericVariables(SigParser& sp)
 //==========================================================================
 // Enregisters a VASig.
 //==========================================================================
-VASigCookie *Module::GetVASigCookie(Signature vaSignature, MethodDesc* pMD, const SigTypeContext* typeContext)
+VASigCookie *Module::GetVASigCookie(Signature vaSignature, const SigTypeContext* typeContext)
 {
     CONTRACT(VASigCookie*)
     {
         INSTANCE_CHECK;
         STANDARD_VM_CHECK;
-        PRECONDITION(pMD == NULL || pMD->IsPInvoke()); // Only PInvoke methods are embedded in VASig cookies.
         POSTCONDITION(CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM());
     }
@@ -4236,17 +4235,16 @@ VASigCookie *Module::GetVASigCookie(Signature vaSignature, MethodDesc* pMD, cons
 #endif
     }
 
-    VASigCookie *pCookie = GetVASigCookieWorker(this, pLoaderModule, pMD, vaSignature, typeContext);
+    VASigCookie *pCookie = GetVASigCookieWorker(this, pLoaderModule, vaSignature, typeContext);
 
     RETURN pCookie;
 }
 
-VASigCookie *Module::GetVASigCookieWorker(Module* pDefiningModule, Module* pLoaderModule, MethodDesc* pMD, Signature vaSignature, const SigTypeContext* typeContext)
+VASigCookie *Module::GetVASigCookieWorker(Module* pDefiningModule, Module* pLoaderModule, Signature vaSignature, const SigTypeContext* typeContext)
 {
     CONTRACT(VASigCookie*)
     {
         STANDARD_VM_CHECK;
-        PRECONDITION(pMD == NULL || pMD->IsPInvoke());
         POSTCONDITION(CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM());
     }
@@ -4262,10 +4260,6 @@ VASigCookie *Module::GetVASigCookieWorker(Module* pDefiningModule, Module* pLoad
         for (UINT i = 0; i < pBlock->m_numCookies; i++)
         {
             VASigCookie* cookieMaybe = &pBlock->m_cookies[i];
-
-            // Check if the cookie targets the same MethodDesc.
-            if (cookieMaybe->pMethodDesc != pMD)
-                continue;
 
             // Check if the cookie has the same signature.
             if (cookieMaybe->signature.GetRawSig() == vaSignature.GetRawSig())
@@ -4355,7 +4349,6 @@ VASigCookie *Module::GetVASigCookieWorker(Module* pDefiningModule, Module* pLoad
             // Now, fill in the new cookie (assuming we had enough memory to create one.)
             pCookie->pModule = pDefiningModule;
             pCookie->pPInvokeILStub = (PCODE)NULL;
-            pCookie->pMethodDesc = pMD;
             pCookie->sizeOfArgs = sizeOfArgs;
             pCookie->signature = vaSignature;
             pCookie->pLoaderModule = pLoaderModule;

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -345,7 +345,6 @@ struct VASigCookie
     // so please keep this field first
     unsigned        sizeOfArgs;             // size of argument list
     Volatile<PCODE> pPInvokeILStub;         // will be use if target is PInvoke (tag == 0)
-    PTR_MethodDesc  pMethodDesc;            // Only non-null if this is a PInvoke method
     PTR_Module      pModule;
     PTR_Module      pLoaderModule;
     Signature       signature;
@@ -1398,9 +1397,9 @@ public:
     void NotifyEtwLoadFinished(HRESULT hr);
 
     // Enregisters a VASig.
-    VASigCookie *GetVASigCookie(Signature vaSignature, MethodDesc* pMD, const SigTypeContext* typeContext);
+    VASigCookie *GetVASigCookie(Signature vaSignature, const SigTypeContext* typeContext);
 private:
-    static VASigCookie *GetVASigCookieWorker(Module* pDefiningModule, Module* pLoaderModule, MethodDesc* pMD, Signature vaSignature, const SigTypeContext* typeContext);
+    static VASigCookie *GetVASigCookieWorker(Module* pDefiningModule, Module* pLoaderModule, Signature vaSignature, const SigTypeContext* typeContext);
 
 public:
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/cgensys.h
+++ b/src/coreclr/vm/cgensys.h
@@ -50,7 +50,7 @@ enum class CallerGCMode
 // Non-CPU-specific helper functions called by the CPU-dependent code
 extern "C" PCODE STDCALL PreStubWorker(TransitionBlock * pTransitionBlock, MethodDesc * pMD);
 
-extern "C" void STDCALL VarargPInvokeStubWorker(TransitionBlock* pTransitionBlock, VASigCookie* pVASigCookie);
+extern "C" void STDCALL VarargPInvokeStubWorker(TransitionBlock* pTransitionBlock, VASigCookie* pVASigCookie, MethodDesc* pMD);
 extern "C" void STDCALL VarargPInvokeStub(void);
 extern "C" void STDCALL VarargPInvokeStub_RetBuffArg(void);
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2941,7 +2941,7 @@ void EECodeGenManager::AllocCode(MethodDesc* pMD, size_t blockSize, size_t reser
 
             // If the IL Stub is a P/Invoke stub, set the CodeHeader's MethodDesc
             // to be the real target method and not the stub. This adjustment makes
-            // the stub frame show up with the P/Invoke method indentity in stack
+            // the stub frame show up with the P/Invoke method identity in stack
             // traces without any special handling in the stackwalker.
             if (pDMD->IsPInvokeStub())
                 pMDTarget = pDMD->GetILStubResolver()->GetStubTargetMethodDesc();

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2940,7 +2940,9 @@ void EECodeGenManager::AllocCode(MethodDesc* pMD, size_t blockSize, size_t reser
             DynamicMethodDesc* pDMD = pMD->AsDynamicMethodDesc();
 
             // If the IL Stub is a P/Invoke stub, set the CodeHeader's MethodDesc
-            // to be the real target method and not the stub.
+            // to be the real target method and not the stub. This adjustment makes
+            // the stub frame show up with the P/Invoke method indentity in stack
+            // traces without any special handling in the stackwalker.
             if (pDMD->IsPInvokeStub())
                 pMDTarget = pDMD->GetILStubResolver()->GetStubTargetMethodDesc();
         }

--- a/src/coreclr/vm/i386/asmhelpers.S
+++ b/src/coreclr/vm/i386/asmhelpers.S
@@ -384,6 +384,7 @@ LOCAL_LABEL(GoCallVarargWorker):
     // save pMD
     push        eax
 
+    push        eax                     // pMD
     push        dword ptr [esi + 4*7]   // pVaSigCookie
     push        esi                     // pTransitionBlock
 

--- a/src/coreclr/vm/i386/asmhelpers.asm
+++ b/src/coreclr/vm/i386/asmhelpers.asm
@@ -46,7 +46,7 @@ endif ; FEATURE_EH_FUNCLETS
 EXTERN __alloca_probe:PROC
 EXTERN _PInvokeImportWorker@4:PROC
 
-EXTERN _VarargPInvokeStubWorker@8:PROC
+EXTERN _VarargPInvokeStubWorker@12:PROC
 EXTERN _GenericPInvokeCalliStubWorker@12:PROC
 
 EXTERN _PreStubWorker@8:PROC
@@ -930,10 +930,11 @@ GoCallVarargWorker:
     ; save pMD
     push        eax
 
+    push        eax                     ; pMD
     push        dword ptr [esi + 4*7]   ; pVaSigCookie
     push        esi                     ; pTransitionBlock
 
-    call        _VarargPInvokeStubWorker@8
+    call        _VarargPInvokeStubWorker@12
 
     ; restore pMD
     pop     eax

--- a/src/coreclr/vm/ilstubcache.cpp
+++ b/src/coreclr/vm/ilstubcache.cpp
@@ -118,9 +118,12 @@ namespace
 
         switch (type)
         {
-            case DynamicMethodDesc::StubCLRToNativeInterop: return "IL_STUB_PInvoke";
+            case DynamicMethodDesc::StubPInvoke:
+            case DynamicMethodDesc::StubPInvokeDelegate:
+            case DynamicMethodDesc::StubPInvokeCalli:
+            case DynamicMethodDesc::StubPInvokeVarArg:      return "IL_STUB_PInvoke";
+            case DynamicMethodDesc::StubReversePInvoke:     return "IL_STUB_ReversePInvoke";
             case DynamicMethodDesc::StubCLRToCOMInterop:    return "IL_STUB_CLRtoCOM";
-            case DynamicMethodDesc::StubNativeToCLRInterop: return "IL_STUB_ReversePInvoke";
             case DynamicMethodDesc::StubCOMToCLRInterop:    return "IL_STUB_COMtoCLR";
             case DynamicMethodDesc::StubStructMarshalInterop: return "IL_STUB_StructMarshal";
             case DynamicMethodDesc::StubArrayOp:            return "IL_STUB_Array";
@@ -304,19 +307,26 @@ MethodDesc* ILStubCache::CreateNewMethodDesc(LoaderHeap* pCreationHeap, MethodTa
         // mark certain types of stub MDs with random flags so ILStubManager recognizes them
         if (SF_IsReverseStub(dwStubFlags))
         {
-            pMD->SetILStubType(DynamicMethodDesc::StubNativeToCLRInterop);
+            pMD->SetILStubType(DynamicMethodDesc::StubReversePInvoke);
         }
         else
         {
             if (SF_IsDelegateStub(dwStubFlags))
             {
-                pMD->SetFlags(DynamicMethodDesc::FlagIsDelegate);
+                pMD->SetILStubType(DynamicMethodDesc::StubPInvokeDelegate);
             }
             else if (SF_IsCALLIStub(dwStubFlags))
             {
-                pMD->SetFlags(DynamicMethodDesc::FlagIsCALLI);
+                pMD->SetILStubType(DynamicMethodDesc::StubPInvokeCalli);
             }
-            pMD->SetILStubType(DynamicMethodDesc::StubCLRToNativeInterop);
+            else if (SF_IsVarArgStub(dwStubFlags))
+            {
+                pMD->SetILStubType(DynamicMethodDesc::StubPInvokeVarArg);
+            }
+            else
+            {
+                pMD->SetILStubType(DynamicMethodDesc::StubPInvoke);
+            }
         }
     }
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -6166,13 +6166,7 @@ CORINFO_VARARGS_HANDLE CEEInfo::getVarArgsHandle(CORINFO_SIG_INFO *sig,
     Instantiation methodInst = Instantiation((TypeHandle*) sig->sigInst.methInst, sig->sigInst.methInstCount);
     SigTypeContext typeContext = SigTypeContext(classInst, methodInst);
 
-    MethodDesc* pMD = GetMethod(methHnd);
-    if (pMD != NULL && !pMD->IsPInvoke())
-    {
-        pMD = NULL;
-    }
-
-    result = CORINFO_VARARGS_HANDLE(module->GetVASigCookie(Signature(sig->pSig, sig->cbSig), pMD, &typeContext));
+    result = CORINFO_VARARGS_HANDLE(module->GetVASigCookie(Signature(sig->pSig, sig->cbSig), &typeContext));
 
     EE_TO_JIT_TRANSITION();
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2462,12 +2462,18 @@ MethodImpl *MethodDesc::GetMethodImpl()
 #ifndef DACCESS_COMPILE
 
 //*******************************************************************************
-BOOL MethodDesc::RequiresMDContextArg() const
+BOOL MethodDesc::RequiresMDContextArg()
 {
     LIMITED_METHOD_CONTRACT;
 
     // Interop marshaling is implemented using shared stubs
     if (IsCLRToCOMCall())
+        return TRUE;
+
+    // Interop marshalling of vararg needs MethodDesc calling convention
+    // to support ldftn <PInvoke method with varargs>. It is not possible
+    // to smugle the MethodDesc* via vararg cookie in this case.
+    if (IsPInvoke() && IsVarArg())
         return TRUE;
 
     return FALSE;
@@ -3497,7 +3503,7 @@ BOOL MethodDesc::HasUnmanagedCallersOnlyAttribute()
     {
         // Stubs generated for being called from native code are equivalent to
         // managed methods marked with UnmanagedCallersOnly.
-        return AsDynamicMethodDesc()->GetILStubType() == DynamicMethodDesc::StubNativeToCLRInterop;
+        return AsDynamicMethodDesc()->GetILStubType() == DynamicMethodDesc::StubReversePInvoke;
     }
 
     HRESULT hr = GetCustomAttribute(

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2470,7 +2470,7 @@ BOOL MethodDesc::RequiresMDContextArg()
     if (IsCLRToCOMCall())
         return TRUE;
 
-    // Interop marshalling of vararg needs MethodDesc calling convention
+    // Interop marshalling of varargs needs MethodDesc calling convention
     // to support ldftn <PInvoke method with varargs>. It is not possible
     // to smuggle the MethodDesc* via vararg cookie in this case.
     if (IsPInvoke() && IsVarArg())

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2472,7 +2472,7 @@ BOOL MethodDesc::RequiresMDContextArg()
 
     // Interop marshalling of vararg needs MethodDesc calling convention
     // to support ldftn <PInvoke method with varargs>. It is not possible
-    // to smugle the MethodDesc* via vararg cookie in this case.
+    // to smuggle the MethodDesc* via vararg cookie in this case.
     if (IsPInvoke() && IsVarArg())
         return TRUE;
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1720,7 +1720,7 @@ public:
     // The stub produced by prestub requires method desc to be passed
     // in dedicated register.
     // See HasMDContextArg() for the related stub version.
-    BOOL RequiresMDContextArg() const;
+    BOOL RequiresMDContextArg();
 
     // Returns true if the method has to have stable entrypoint always.
     BOOL RequiresStableEntryPoint();
@@ -2703,9 +2703,12 @@ public:
     enum ILStubType : DWORD
     {
         StubNotSet = 0,
-        StubCLRToNativeInterop,
+        StubPInvoke,
+        StubPInvokeDelegate,
+        StubPInvokeCalli,
+        StubPInvokeVarArg,
+        StubReversePInvoke,
         StubCLRToCOMInterop,
-        StubNativeToCLRInterop,
         StubCOMToCLRInterop,
         StubStructMarshalInterop,
         StubArrayOp,
@@ -2738,8 +2741,8 @@ public:
         FlagRequiresCOM         = 0x00002000,
         FlagIsLCGMethod         = 0x00004000,
         FlagIsILStub            = 0x00008000,
-        FlagIsDelegate          = 0x00010000,
-        FlagIsCALLI             = 0x00020000,
+        // unused               = 0x00010000,
+        // unused               = 0x00020000,
         FlagMask                = 0x0003f800,
         StackArgSizeMask        = 0xfffc0000, // native stack arg size for IL stubs
         ILStubTypeMask          = ~(FlagMask | StackArgSizeMask)
@@ -2833,7 +2836,7 @@ public:
         LIMITED_METHOD_DAC_CONTRACT;
         _ASSERTE(IsILStub());
         ILStubType type = GetILStubType();
-        return type == StubCOMToCLRInterop || type == StubNativeToCLRInterop;
+        return type == StubCOMToCLRInterop || type == StubReversePInvoke;
     }
 
     bool IsStepThroughStub() const
@@ -2855,21 +2858,37 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(IsILStub());
-        return !HasFlags(FlagStatic) && GetILStubType() == StubCLRToCOMInterop;
+        return GetILStubType() == StubCLRToCOMInterop;
     }
     bool IsCOMToCLRStub() const
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(IsILStub());
-        return !HasFlags(FlagStatic) && GetILStubType() == StubCOMToCLRInterop;
+        return GetILStubType() == StubCOMToCLRInterop;
     }
     bool IsPInvokeStub() const
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(IsILStub());
-        return HasFlags(FlagStatic)
-            && !HasFlags(FlagIsCALLI | FlagIsDelegate)
-            && GetILStubType() == StubCLRToNativeInterop;
+        return GetILStubType() == StubPInvoke;
+    }
+    bool IsPInvokeDelegateStub() const
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE(IsILStub());
+        return GetILStubType() == StubPInvokeDelegate;
+    }
+    bool IsPInvokeCalliStub() const
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE(IsILStub());
+        return GetILStubType() == StubPInvokeCalli;
+    }
+    bool IsPInvokeVarArgStub() const
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        _ASSERTE(IsILStub());
+        return GetILStubType() == StubPInvokeVarArg;
     }
 
     bool IsMulticastStub() const
@@ -2910,7 +2929,7 @@ public:
     bool HasMDContextArg() const
     {
         LIMITED_METHOD_CONTRACT;
-        return IsCLRToCOMStub();
+        return IsCLRToCOMStub() || IsPInvokeVarArgStub();
     }
 
     //

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -951,14 +951,15 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, COR_ILMETHOD_
 
         if (IsILStub())
         {
-            CodeHeader* pHdr = (CodeHeader*)(pCode - sizeof(CodeHeader));
+            CodeHeader* pHdr = ((CodeHeader*)PCODEToPINSTR(pCode)) - 1;
             MethodDesc* pActualMethodDesc = pHdr->GetMethodDesc();
 
             if (pActualMethodDesc != this)
             {
                 // Compensate for PInvoke MethodDesc adjustment done in EECodeGenManager::AllocCode.
                 // The GC stress instrumentation must save the non-instrumented version of the code
-                // on MethodDesc that matches CodeHeader so that it can be retrieved later.
+                // on MethodDesc that matches CodeHeader so that it can be retrieved later during
+                // GC stress interrupts.
                 _ASSERTE(pActualMethodDesc->IsPInvoke());
                 nativeCodeVersion = NativeCodeVersion(pActualMethodDesc);
             }

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -947,7 +947,24 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, COR_ILMETHOD_
             return pOtherCode;
         }
 
-        SetupGcCoverage(pConfig->GetCodeVersion(), (BYTE*)pCode);
+        NativeCodeVersion nativeCodeVersion = pConfig->GetCodeVersion();
+
+        if (IsILStub())
+        {
+            CodeHeader* pHdr = (CodeHeader*)(pCode - sizeof(CodeHeader));
+            MethodDesc* pActualMethodDesc = pHdr->GetMethodDesc();
+
+            if (pActualMethodDesc != this)
+            {
+                // Compensate for PInvoke MethodDesc adjustment done in EECodeGenManager::AllocCode.
+                // The GC stress instrumentation must save the non-instrumented version of the code
+                // on MethodDesc that matches CodeHeader so that it can be retrieved later.
+                _ASSERTE(pActualMethodDesc->IsPInvoke());
+                nativeCodeVersion = NativeCodeVersion(pActualMethodDesc);
+            }
+        }
+
+        SetupGcCoverage(nativeCodeVersion, (BYTE*)pCode);
     }
 #endif // HAVE_GCCOVER
 


### PR DESCRIPTION
GCStress is not able to find the original version of the code for PInvoke stubs after #117901. We need to compensate for the MethodDesc adjustment done for PInvoke stubs when storing the original version of the code during GC stress.