### PR TITLE
Make wasm corerun build regular

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -178,7 +178,7 @@
     <_subset>$(_subset.Replace('+host+', '+$(DefaultHostSubsets)+'))</_subset>
     <_subset>$(_subset.Replace('+packs+', '+$(DefaultPacksSubsets)+'))</_subset>
     <_subset>$(_subset.Replace('+bootstrap+', '+bootstrap+$(BootstrapSubsets)+'))</_subset>
-    <_subset Condition="'$(TargetOS)' == 'browser'">$(_subset.Replace('+clr.runtime+', '+mono.emsdk+clr.runtime+'))</_subset>
+    <_subset Condition="'$(TargetOS)' == 'browser'">$(_subset.Replace('+clr.runtime+', '+mono.emsdk+clr.corelib+clr.runtime+'))</_subset>
 
     <!-- Surround _subset in dashes to simplify checks below -->
     <_subset>+$(_subset.Trim('+'))+</_subset>

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -110,10 +110,6 @@ if(CLR_CMAKE_HOST_UNIX)
     endif()
 
     add_subdirectory(pal)
-
-    if(NOT CLR_CMAKE_HOST_MACCATALYST AND NOT CLR_CMAKE_HOST_IOS AND NOT CLR_CMAKE_HOST_TVOS)
-      add_subdirectory(hosts)
-    endif()
 else()
     if(CLR_CMAKE_TARGET_UNIX)
         add_subdirectory(${CLR_SRC_NATIVE_DIR}/external/libunwind_extras ${CLR_ARTIFACTS_OBJ_DIR}/external/libunwind)
@@ -311,8 +307,5 @@ endif()
 
 if(NOT CLR_CMAKE_HOST_MACCATALYST AND NOT CLR_CMAKE_HOST_IOS AND NOT CLR_CMAKE_HOST_TVOS)
   add_subdirectory(tools)
-endif(NOT CLR_CMAKE_HOST_MACCATALYST AND NOT CLR_CMAKE_HOST_IOS AND NOT CLR_CMAKE_HOST_TVOS)
-
-if(CLR_CMAKE_HOST_WIN32)
   add_subdirectory(hosts)
-endif(CLR_CMAKE_HOST_WIN32)
+endif(NOT CLR_CMAKE_HOST_MACCATALYST AND NOT CLR_CMAKE_HOST_IOS AND NOT CLR_CMAKE_HOST_TVOS)

--- a/src/coreclr/hosts/corewasmrun/CMakeLists.txt
+++ b/src/coreclr/hosts/corewasmrun/CMakeLists.txt
@@ -18,12 +18,12 @@ endif (EXISTS "${_WASM_PRELOAD_DIR}")
 target_compile_options(corewasmrun PRIVATE -fwasm-exceptions)
 target_link_options(corewasmrun PRIVATE -fwasm-exceptions -sEXIT_RUNTIME=1 -sINITIAL_MEMORY=134217728 -sFORCE_FILESYSTEM=1 ${_WASM_PRELOAD_FILE} -Wl,-error-limit=0)
 
-target_link_libraries(corewasmrun PRIVATE coreclr_static)
-target_link_libraries(corewasmrun PRIVATE clrinterpreter)
-
-target_link_libraries(corewasmrun PRIVATE icuuc)
-target_link_libraries(corewasmrun PRIVATE icui18n)
-target_link_libraries(corewasmrun PRIVATE icudata)
+target_link_libraries(corewasmrun PRIVATE
+  coreclr_static
+  clrinterpreter
+  icuuc
+  icui18n
+  icudata)
 
 # The corerun version for wasm is being installed in its own directory
 # because it is an executable that comes with an index.html and we

--- a/src/coreclr/hosts/corewasmrun/CMakeLists.txt
+++ b/src/coreclr/hosts/corewasmrun/CMakeLists.txt
@@ -25,4 +25,8 @@ target_link_libraries(corewasmrun PRIVATE icuuc)
 target_link_libraries(corewasmrun PRIVATE icui18n)
 target_link_libraries(corewasmrun PRIVATE icudata)
 
-install_clr(TARGETS corewasmrun DESTINATIONS . COMPONENT hosts)
+# The corerun version for wasm is being installed in its own directory
+# because it is an executable that comes with an index.html and we
+# want to avoid clashes.
+install_clr(TARGETS corewasmrun DESTINATIONS corewasmrun COMPONENT hosts)
+install(FILES index.html DESTINATION corewasmrun COMPONENT hosts)

--- a/src/coreclr/inc/bundle.h
+++ b/src/coreclr/inc/bundle.h
@@ -11,7 +11,7 @@
 #define _BUNDLE_H_
 
 #include <sstring.h>
-#include "coreclrhost.h"
+#include <coreclrhost.h>
 
 class Bundle;
 

--- a/src/coreclr/inc/pinvokeoverride.h
+++ b/src/coreclr/inc/pinvokeoverride.h
@@ -10,7 +10,7 @@
 #ifndef _PINVOKEOVERRIDE_H_
 #define _PINVOKEOVERRIDE_H_
 
-#include "coreclrhost.h"
+#include <coreclrhost.h>
 
 class PInvokeOverride
 {


### PR DESCRIPTION
This PR updates the current wasm build for `corewasmrun`, which is wasm's version of `corerun`, and places all artifacts in the correct bin location like other `corerun` scenarios. The work flow for `corewasmrun` is now much simpler.

1) `./build.sh -os browser -c Debug --subset clr.runtime+libs`
2) `./dotnet.sh build -c Release src/mono/sample/wasm/simple-server`
3) Navigate to the build output - (for example, `artifacts/bin/coreclr/browser.wasm.Debug/corewasmrun`)
4) Launch the simpler-server, `./src/mono/sample/wasm/simple-server/bin/Release/net8.0/HttpServer`, in the `corewasmrun` directory.
