### PR TITLE
Fixes trying to create a module using a trash as the address of the module

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -11708,6 +11708,7 @@ treatAllValuesAsBoxed:
             res->ClassTypeData.metadataToken = th.GetCl();
             DebuggerModule * pModule = LookupOrCreateModule(th.GetModule());
             res->ClassTypeData.vmDomainAssembly.SetRawPtr((pModule ? pModule->GetDomainAssembly() : NULL));
+            res->ClassTypeData.vmModule.SetRawPtr(NULL);
             _ASSERTE(!res->ClassTypeData.vmDomainAssembly.IsNull());
             break;
         }


### PR DESCRIPTION
In this PR https://github.com/dotnet/runtime/pull/118414, this code was changed:

FROM: 
`pModule = m_modules.GetBase(vmDomainAssembly.IsNull() ? VmPtrToCookie(vmModule) : mPtrToCookie(vmDomainAssembly));`
TO:
`pModule = m_modules.GetBase(VmPtrToCookie(vmModule));`

But vmModule can contain trash value so it will not find a module in m_module and this will make it try to create a new module using this trash address in the CordbModule constructor.

I don't know if this needs to be fixed in other places, but this place for sure is causing issues. Not sure how it was not detected on other platforms, I detected it on android.