### PR TITLE
Adjust so that we only require FEAT_LSE for osx-arm64 and maccatalyst, not for iOS or tvOS

### DIFF
--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -182,7 +182,7 @@ bool DetectCPUFeatures()
     {
 #if defined(HOST_X86) || defined(HOST_AMD64)
         PalPrintFatalError("\nThe current CPU is missing one or more of the following instruction sets: SSE, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, POPCNT\n");
-#elif defined(HOST_ARM64) && (defined(HOST_WINDOWS) || defined(HOST_APPLE))
+#elif defined(HOST_ARM64) && (defined(HOST_WINDOWS) || defined(HOST_OSX) || defined(HOST_MACCATALYST))
         PalPrintFatalError("\nThe current CPU is missing one or more of the following instruction sets: AdvSimd, LSE\n");
 #elif defined(HOST_ARM64)
         PalPrintFatalError("\nThe current CPU is missing one or more of the following instruction sets: AdvSimd\n");

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -44,9 +44,19 @@ namespace System.CommandLine
             }
             else if (targetArchitecture == TargetArchitecture.ARM64)
             {
-                if (targetOS == TargetOS.OSX)
+                if ((targetOS == TargetOS.OSX) || (targetOS == TargetOS.MacCatalyst))
                 {
-                    // For osx-arm64 we know that apple-m1 is the baseline
+                    // Apple has six targets today:
+                    // * OSX
+                    // * MacCatalyst
+                    // * iOS
+                    // * iOSSimulator
+                    // * tvOS
+                    // * tvOSSimulator
+                    //
+                    // For osx-arm64 and maccatalyst, we know that the baseline is apple-m1
+                    // For iOS, tvOS, and the simulator variants it can be older
+
                     instructionSetSupportBuilder.AddSupportedInstructionSet("apple-m1");
                 }
                 else if (isReadyToRun)

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1184,7 +1184,7 @@ void EEJitManager::SetCpuInfo()
     {
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
         EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("\nThe current CPU is missing one or more of the following instruction sets: SSE, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, POPCNT\n"));
-#elif defined(TARGET_ARM64) && (defined(TARGET_WINDOWS) || defined(TARGET_APPLE))
+#elif defined(TARGET_ARM64) && (defined(TARGET_WINDOWS) || defined(TARGET_OSX) || defined(TARGET_MACCATALYST))
         EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("\nThe current CPU is missing one or more of the following instruction sets: AdvSimd, LSE\n"));
 #elif defined(TARGET_ARM64)
         EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("\nThe current CPU is missing one or more of the following instruction sets: AdvSimd\n"));


### PR DESCRIPTION
This resolves #119008 