### PR TITLE
Fix character/byte confusion in `System.Diagnostics.EventLog`

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
@@ -387,8 +387,7 @@ namespace System.Diagnostics.Eventing.Reader
 
         public override string ToXml()
         {
-            char[] renderBuffer = GC.AllocateUninitializedArray<char>(2000);
-            return NativeWrapper.EvtRenderXml(EventLogHandle.Zero, Handle, renderBuffer);
+            return NativeWrapper.EvtRenderXml(EventLogHandle.Zero, Handle);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/UnsafeNativeMethods.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/UnsafeNativeMethods.cs
@@ -673,26 +673,15 @@ namespace Microsoft.Win32
                                 string[] valuePaths,
                             EvtRenderContextFlags flags);
 
-        [LibraryImport(Interop.Libraries.Wevtapi, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        [LibraryImport(Interop.Libraries.Wevtapi, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool EvtRender(
                             EventLogHandle context,
                             EventLogHandle eventHandle,
                             EvtRenderFlags flags,
-                            int buffSize,
-                            [Out] char[]? buffer,
-                            out int buffUsed,
-                            out int propCount);
-
-        [LibraryImport(Interop.Libraries.Wevtapi, EntryPoint = "EvtRender", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool EvtRender(
-                            EventLogHandle context,
-                            EventLogHandle eventHandle,
-                            EvtRenderFlags flags,
-                            int buffSize,
+                            uint buffSize,
                             IntPtr buffer,
-                            out int buffUsed,
+                            out uint buffUsed,
                             out int propCount);
 
 #if NET


### PR DESCRIPTION
Also removed use of `GC.AllocateUninitializedArray` since this API is not supported in .NET Standard.

Related: https://github.com/dotnet/runtime/pull/61990

cc:@elinor-fung
