### PR TITLE
Use `UnmanagedCallersOnly` in `AssemblyDependencyResolver`.

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
+++ b/src/libraries/Common/src/Interop/Interop.HostPolicy.cs
@@ -4,17 +4,12 @@
 using System;
 using System.Runtime.InteropServices;
 
+using unsafe ErrorWriterCallback = delegate* unmanaged[Cdecl]<nint, void>;
+
 internal static partial class Interop
 {
-    internal static partial class HostPolicy
+    internal static unsafe partial class HostPolicy
     {
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void corehost_resolve_component_dependencies_result_fn(IntPtr assemblyPaths,
-            IntPtr nativeSearchPaths, IntPtr resourceSearchPaths);
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void corehost_error_writer_fn(IntPtr message);
-
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
 #if TARGET_WINDOWS
         [LibraryImport(Libraries.HostPolicy, StringMarshalling = StringMarshalling.Utf16)]
@@ -23,11 +18,11 @@ internal static partial class Interop
 #endif
         [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
         internal static partial int corehost_resolve_component_dependencies(string componentMainAssemblyPath,
-            corehost_resolve_component_dependencies_result_fn result);
+            delegate* unmanaged[Cdecl]<nint, nint, nint, void> result);
 
         [LibraryImport(Libraries.HostPolicy)]
         [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        internal static partial IntPtr corehost_set_error_writer(IntPtr errorWriter);
+        internal static partial ErrorWriterCallback corehost_set_error_writer(ErrorWriterCallback errorWriter);
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
     }
 }


### PR DESCRIPTION
This PR updates the bindings to the `hostpolicy` library to use function pointers for the callback parameters. This enables us to use `UnmanagedCallersOnly` for the callback functions in `AssemblyDependencyResolver`.

Because the callbacks in the `hostpolicy` APIs do not take an opaque `void*` parameter, we use a thread-local variable to store the callbacks' state. This is safe to do because:

1. The callback passed to `corehost_set_error_writer` is documented to be per-thread.
2. The callback passed to `corehost_resolve_component_dependencies` [gets called only once at the end](https://github.com/dotnet/runtime/blob/bf795cbcc2639460f2f2cc7a90eaee20985aa232/src/native/corehost/hostpolicy/hostpolicy.cpp#L994-L997).

If you prefer to add new `hostpolicy` APIs, let me know.