### PR TITLE
Disable UnhandledExceptionHandler tests with native components on `llvmfullaot`

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2199,6 +2199,12 @@
         <ExcludeList Include = "$(XunitTestBinBase)/Exceptions/ForeignThread/ForeignThreadExceptions/**">
             <Issue>llvmfullaot: EH problem</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/baseservices/exceptions/UnhandledExceptionHandler/Foreign/**">
+            <Issue>llvmfullaot: EH problem</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/baseservices/exceptions/UnhandledExceptionHandler/PInvoke/**">
+            <Issue>llvmfullaot: EH problem</Issue>
+        </ExcludeList>
 
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Directed/nullabletypes/Desktop/boxunboxvaluetype_*/**">
             <Issue>https://github.com/dotnet/runtime/issues/57353</Issue>


### PR DESCRIPTION
Fixes: #118981

These tests load a native .dll/.so , which starts threads, enters the runtime, runs managed code, throws unhandled exceptions...

We have other similar tests. They are marked as incompatible with `llvmfullaot`. 
I guess, these should be marked incompatible as well.