### PR TITLE
[release/10.0][Android] Avoid calling membarrier on older Android versions

### DIFF
--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2826,6 +2826,17 @@ InitializeFlushProcessWriteBuffers()
     _ASSERTE(s_flushUsingMemBarrier == 0);
 
 #if defined(__linux__) || HAVE_SYS_MEMBARRIER_H
+
+#ifdef TARGET_ANDROID
+    // Avoid calling membarrier on older Android versions where membarrier
+    // may be barred by seccomp causing the process to be killed.
+    int apiLevel = android_get_device_api_level();
+    if (apiLevel < __ANDROID_API_Q__)
+    {
+        return TRUE;
+    }
+#endif
+
     // Starting with Linux kernel 4.14, process memory barriers can be generated
     // using MEMBARRIER_CMD_PRIVATE_EXPEDITED.
     int mask = membarrier(MEMBARRIER_CMD_QUERY, 0, 0);

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2831,23 +2831,21 @@ InitializeFlushProcessWriteBuffers()
     // Avoid calling membarrier on older Android versions where membarrier
     // may be barred by seccomp causing the process to be killed.
     int apiLevel = android_get_device_api_level();
-    if (apiLevel < __ANDROID_API_Q__)
-    {
-        return TRUE;
-    }
+    if (apiLevel >= __ANDROID_API_Q__)
 #endif
-
-    // Starting with Linux kernel 4.14, process memory barriers can be generated
-    // using MEMBARRIER_CMD_PRIVATE_EXPEDITED.
-    int mask = membarrier(MEMBARRIER_CMD_QUERY, 0, 0);
-    if (mask >= 0 &&
-        mask & MEMBARRIER_CMD_PRIVATE_EXPEDITED)
     {
-        // Register intent to use the private expedited command.
-        if (membarrier(MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED, 0, 0) == 0)
+        // Starting with Linux kernel 4.14, process memory barriers can be generated
+        // using MEMBARRIER_CMD_PRIVATE_EXPEDITED.
+        int mask = membarrier(MEMBARRIER_CMD_QUERY, 0, 0);
+        if (mask >= 0 &&
+            mask & MEMBARRIER_CMD_PRIVATE_EXPEDITED)
         {
-            s_flushUsingMemBarrier = TRUE;
-            return TRUE;
+            // Register intent to use the private expedited command.
+            if (membarrier(MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED, 0, 0) == 0)
+            {
+                s_flushUsingMemBarrier = TRUE;
+                return TRUE;
+            }
         }
     }
 #endif


### PR DESCRIPTION
Fixes #115480 in .NET 10 RC2, supersedes #118984.

This fix was part of #118161 but it wasn't ready before the RC snap. This PR includes only the necessary changes to fix the Android startup crash.

/cc @jkotas 

## Customer Impact

- [ ] Customer reported
- [X] Found internally

In .NET 10, we are shipping experimental support for CoreCLR on Android. On older Android versions, the `membarrier` syscall is disallowed. Without this change, customers will not be able to test Android CoreCLR on devices running API 28 and earlier which are still supported by .NET.

## Regression

- [ ] Yes
- [X] No

## Testing

Manual testing on Android emulators running a wide range of API levels.

## Risk

Low. The fix is scoped to the Android target. It is based on the existing code in [`gcenv.unix.cpp`](https://github.com/dotnet/runtime/blob/release/10.0/src/coreclr/gc/unix/gcenv.unix.cpp#L143-L155).
