### PR TITLE
[browser] Append uniqueness to webcil temp path & move instead of copy

### DIFF
--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -280,6 +280,28 @@ internal static class Utils
         return areDifferent;
     }
 
+    public static bool MoveIfDifferent(string src, string dst)
+    {
+        if (!File.Exists(src))
+            throw new ArgumentException($"Cannot find {src} file to copy", nameof(src));
+
+        bool areDifferent = !File.Exists(dst) || !ContentEqual(src, dst);
+        if (areDifferent)
+        {
+
+#if NET
+            File.Move(src, dst, true);
+#else
+            if (File.Exists(dst))
+                File.Delete(dst);
+
+            File.Move(src, dst);
+#endif
+        }
+
+        return areDifferent;
+    }
+
     private static string ToBase64SafeString(byte[] data)
     {
         if (data.Length == 0)

--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -283,7 +283,7 @@ internal static class Utils
     public static bool MoveIfDifferent(string src, string dst)
     {
         if (!File.Exists(src))
-            throw new ArgumentException($"Cannot find {src} file to copy", nameof(src));
+            throw new ArgumentException($"Cannot find {src} file to move", nameof(src));
 
         bool areDifferent = !File.Exists(dst) || !ContentEqual(src, dst);
         if (areDifferent)

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
@@ -45,7 +45,7 @@ public class ConvertDllsToWebCil : Task
         if (!Directory.Exists(OutputPath))
             Directory.CreateDirectory(OutputPath);
 
-        string tmpDir = IntermediateOutputPath;
+        string tmpDir = Path.Combine(IntermediateOutputPath, Guid.NewGuid().ToString("N"));
         if (!Directory.Exists(tmpDir))
             Directory.CreateDirectory(tmpDir);
 
@@ -72,6 +72,8 @@ public class ConvertDllsToWebCil : Task
             }
         }
 
+        Directory.Delete(tmpDir, true);
+
         WebCilCandidates = webCilCandidates.ToArray();
         return true;
     }
@@ -96,7 +98,7 @@ public class ConvertDllsToWebCil : Task
             if (!Directory.Exists(candidatePath))
                 Directory.CreateDirectory(candidatePath);
 
-            if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
+            if (Utils.MoveIfDifferent(tmpWebcil, finalWebcil))
                 Log.LogMessage(MessageImportance.Low, $"Generated {finalWebcil} .");
             else
                 Log.LogMessage(MessageImportance.Low, $"Skipped generating {finalWebcil} as the contents are unchanged.");


### PR DESCRIPTION
- Append unique guid for every execution of `ConvertDllsToWebcil` to the temp files path
- Use "move" filesystem operation instead of "copy" if temp file is different than the final one

Contributes to https://github.com/dotnet/aspnetcore/issues/61987