### PR TITLE
Enable GetMemberWithSameMetadataDefinitionAs test on native AOT

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
@@ -1700,7 +1700,6 @@ namespace System.Reflection.Tests
         }
 
         [Theory, MemberData(nameof(GetMemberWithSameMetadataDefinitionAsData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69244", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void GetMemberWithSameMetadataDefinitionAs(Type openGenericType, Type closedGenericType, bool checkDeclaringType)
         {
             BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;


### PR DESCRIPTION
The repro case in #69244 now works, so maybe the test now works too. CI will find out.

Resolves #69244