### PR TITLE
Update MemoryStream max capacity

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1944,7 +1944,7 @@
     <value>startIndex cannot be larger than length of string.</value>
   </data>
   <data name="ArgumentOutOfRange_StreamLength" xml:space="preserve">
-    <value>Stream length must be non-negative and less than 2^31 - 1 - origin.</value>
+    <value>Stream length must be non-negative and less than the maximum array length (0x7FFFFFC7) - origin.</value>
   </data>
   <data name="ArgumentOutOfRange_UIntPtrMax" xml:space="preserve">
     <value>The length of the buffer must be less than the maximum UIntPtr value for your platform.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -34,8 +34,7 @@ namespace System.IO
 
         private CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
 
-        // Max array length allowed by CLR for byte[]
-        private const int MemStreamMaxLength = 0x7FFFFFC7;
+        private static int MemStreamMaxLength => Array.MaxLength;
 
         public MemoryStream()
             : this(0)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -543,7 +543,7 @@ namespace System.IO
         // into the MemoryStream constructor.  The upper bounds prevents any
         // situations where a stream may be created on top of an array then
         // the stream is made longer than the maximum possible length of the
-        // array (MemStreamMaxLength
+        // array (MemStreamMaxLength).
         //
         public override void SetLength(long value)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
@@ -34,7 +34,8 @@ namespace System.IO
 
         private CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
 
-        private const int MemStreamMaxLength = int.MaxValue;
+        // Max array length allowed by CLR for byte[]
+        private const int MemStreamMaxLength = 0x7FFFFFC7;
 
         public MemoryStream()
             : this(0)
@@ -536,24 +537,24 @@ namespace System.IO
 
         // Sets the length of the stream to a given value.  The new
         // value must be nonnegative and less than the space remaining in
-        // the array, int.MaxValue - origin
+        // the array, MemStreamMaxLength - origin
         // Origin is 0 in all cases other than a MemoryStream created on
         // top of an existing array and a specific starting offset was passed
         // into the MemoryStream constructor.  The upper bounds prevents any
         // situations where a stream may be created on top of an array then
         // the stream is made longer than the maximum possible length of the
-        // array (int.MaxValue).
+        // array (MemStreamMaxLength
         //
         public override void SetLength(long value)
         {
-            if (value < 0 || value > int.MaxValue)
+            if (value < 0 || value > MemStreamMaxLength)
                 throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_StreamLength);
 
             EnsureWriteable();
 
             // Origin wasn't publicly exposed above.
-            Debug.Assert(MemStreamMaxLength == int.MaxValue);  // Check parameter validation logic in this method if this fails.
-            if (value > (int.MaxValue - _origin))
+            Debug.Assert(MemStreamMaxLength == 0x7FFFFFC7);  // Check parameter validation logic in this method if this fails.
+            if (value > (MemStreamMaxLength - _origin))
                 throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_StreamLength);
 
             int newLength = _origin + (int)value;

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/BinaryWriter/BinaryWriterTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/BinaryWriter/BinaryWriterTests.cs
@@ -91,8 +91,7 @@ namespace System.IO.Tests
         [Fact]
         public void BinaryWriter_SeekTests()
         {
-            // Max length allowed by CLR for byte[] is 0x7FFFFFC7
-            int[] iArrLargeValues = new int[] { 10000, 100000, int.MaxValue / 200, int.MaxValue / 1000, short.MaxValue, 0x7FFFFFC7, 0x7FFFFFC7 - 1, int.MaxValue / 2, int.MaxValue / 10, int.MaxValue / 100 };
+            int[] iArrLargeValues = new int[] { 10000, 100000, int.MaxValue / 200, int.MaxValue / 1000, short.MaxValue, Array.MaxLength, Array.MaxLength - 1, int.MaxValue / 2, int.MaxValue / 10, int.MaxValue / 100 };
 
             BinaryWriter dw2 = null;
             MemoryStream mstr = null;

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/BinaryWriter/BinaryWriterTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/BinaryWriter/BinaryWriterTests.cs
@@ -91,7 +91,8 @@ namespace System.IO.Tests
         [Fact]
         public void BinaryWriter_SeekTests()
         {
-            int[] iArrLargeValues = new int[] { 10000, 100000, int.MaxValue / 200, int.MaxValue / 1000, short.MaxValue, int.MaxValue, int.MaxValue - 1, int.MaxValue / 2, int.MaxValue / 10, int.MaxValue / 100 };
+            // Max length allowed by CLR for byte[] is 0x7FFFFFC7
+            int[] iArrLargeValues = new int[] { 10000, 100000, int.MaxValue / 200, int.MaxValue / 1000, short.MaxValue, 0x7FFFFFC7, 0x7FFFFFC7 - 1, int.MaxValue / 2, int.MaxValue / 10, int.MaxValue / 100 };
 
             BinaryWriter dw2 = null;
             MemoryStream mstr = null;

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
@@ -105,8 +105,8 @@ namespace System.IO.Tests
             byte[] buffer = new byte[bufferSize];
             using (MemoryStream ms = new MemoryStream(buffer, origin, buffer.Length - origin, true))
             {
-                Seek(mode, ms, 0x7FFFFFC7 - origin);
-                Assert.Throws<ArgumentOutOfRangeException>(() => Seek(mode, ms, (long)0x7FFFFFC7 - origin + 1));
+                Seek(mode, ms, Array.MaxLength - origin);
+                Assert.Throws<ArgumentOutOfRangeException>(() => Seek(mode, ms, (long)Array.MaxLength - origin + 1));
                 Assert.ThrowsAny<Exception>(() => Seek(mode, ms, long.MinValue + 1));
                 Assert.ThrowsAny<Exception>(() => Seek(mode, ms, long.MaxValue - 1));
             }
@@ -150,7 +150,7 @@ namespace System.IO.Tests
         [SkipOnCI("Skipping on CI due to large memory allocation")]
         public void MemoryStream_CapacityBoundaryChecks()
         {
-            const int MaxSupportedLength = 0x7FFFFFC7;
+            int MaxSupportedLength = Array.MaxLength;
 
             using (var ms = new MemoryStream())
             {

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
@@ -146,6 +146,21 @@ namespace System.IO.Tests
             Assert.True(s.ReadArrayInvoked);
         }
 
+        [Fact]
+        public void MemoryStream_CapacityBoundaryChecks()
+        {
+            const int MaxSupportedLength = 0x7FFFFFC7;
+
+            using (var ms = new MemoryStream())
+            {
+                ms.Capacity = MaxSupportedLength - 1;
+
+                Assert.Equal(MaxSupportedLength - 1, ms.Capacity);
+
+                Assert.ThrowsAny<Exception>(() => ms.Capacity = MaxSupportedLength + 1);
+            }
+        }
+
         private class ReadWriteOverridingMemoryStream : MemoryStream
         {
             public bool ReadArrayInvoked, WriteArrayInvoked;

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
@@ -105,8 +105,8 @@ namespace System.IO.Tests
             byte[] buffer = new byte[bufferSize];
             using (MemoryStream ms = new MemoryStream(buffer, origin, buffer.Length - origin, true))
             {
-                Seek(mode, ms, int.MaxValue - origin);
-                Assert.Throws<ArgumentOutOfRangeException>(() => Seek(mode, ms, (long)int.MaxValue - origin + 1));
+                Seek(mode, ms, 0x7FFFFFC7 - origin);
+                Assert.Throws<ArgumentOutOfRangeException>(() => Seek(mode, ms, (long)0x7FFFFFC7 - origin + 1));
                 Assert.ThrowsAny<Exception>(() => Seek(mode, ms, long.MinValue + 1));
                 Assert.ThrowsAny<Exception>(() => Seek(mode, ms, long.MaxValue - 1));
             }
@@ -147,6 +147,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnCI("Skipping on CI due to large memory allocation")]
         public void MemoryStream_CapacityBoundaryChecks()
         {
             const int MaxSupportedLength = 0x7FFFFFC7;
@@ -154,10 +155,14 @@ namespace System.IO.Tests
             using (var ms = new MemoryStream())
             {
                 ms.Capacity = MaxSupportedLength - 1;
-
                 Assert.Equal(MaxSupportedLength - 1, ms.Capacity);
 
-                Assert.ThrowsAny<Exception>(() => ms.Capacity = MaxSupportedLength + 1);
+                ms.Capacity = MaxSupportedLength;
+                Assert.Equal(MaxSupportedLength, ms.Capacity);
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => ms.Capacity = MaxSupportedLength + 1);
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => ms.Capacity = int.MaxValue);
             }
         }
 


### PR DESCRIPTION
Updates MemoryStream to cap capacity at 0x7FFFFFC7 (the true max byte array length) and adds a test to check:
- Capacity just under the max succeeds
- Capacity above the max throws

Fixes #43542