### PR TITLE
[Android][Testing] Fix detection of supported TLS versions on Android

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -569,10 +569,16 @@ namespace System
 #pragma warning disable SYSLIB0039 // TLS versions 1.0 and 1.1 have known vulnerabilities
         private static bool GetTls10Support()
         {
-            // on macOS and Android TLS 1.0 is supported.
-            if ((IsApplePlatform && !IsNetworkFrameworkEnabled()) || IsAndroid)
+            // on macOS TLS 1.0 is supported.
+            if (IsApplePlatform && !IsNetworkFrameworkEnabled())
             {
                 return true;
+            }
+
+            // on Android TLS 1.0 support depends on API level
+            if (IsAndroid)
+            {
+                return AndroidGetSslProtocolSupport(SslProtocols.Tls);
             }
 
             // Windows depend on registry, enabled by default on all supported versions.
@@ -597,10 +603,15 @@ namespace System
                 // It is enabled on other versions unless explicitly disabled.
                 return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: true) && !IsWindows10Version20348OrGreater;
             }
-            // on macOS and Android TLS 1.1 is supported.
-            else if ((IsApplePlatform && !IsNetworkFrameworkEnabled()) || IsAndroid)
+            // on macOS TLS 1.1 is supported.
+            else if (IsApplePlatform && !IsNetworkFrameworkEnabled())
             {
                 return true;
+            }
+            // on Android TLS 1.1 support depends on API level
+            else if (IsAndroid)
+            {
+                return AndroidGetSslProtocolSupport(SslProtocols.Tls11);
             }
 
             return IsOpenSslSupported && OpenSslGetTlsSupport(SslProtocols.Tls11);


### PR DESCRIPTION
Starting in Android API 35, TLS 1.0 and 1.1 are not supported:

> Android 15 restricts the usage of TLS versions 1.0 and 1.1. These versions had previously been deprecated in Android, but are now disallowed for apps targeting Android 15.
-- [Behavior changes: Apps targeting Android 15 or higher (developer.android.com)](https://developer.android.com/about/versions/15/behavior-changes-15#restricted-tls-versions)

Our tests assumed that these protocol versions are supported across all Android versions. We need to change the `PlatformDetection` implementation going forward.

Fixes #119016