### PR TITLE
Change Markdownlint action to use latest node LTS version

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 'lts/*'
     - name: Run Markdownlint
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"


### PR DESCRIPTION
Rather than pin this to a specific Node LTS version, change the action to set up with the latest LTS every time.