### PR TITLE
Fix validating constraints with `Nullable<T>`

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidator.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidator.cs
@@ -55,7 +55,7 @@ namespace Internal.Reflection.Execution
                     continue;
 
                 // if a concrete type can be cast to the constraint, then this constraint will be satisfied
-                if (!AreTypesAssignable(typeArg, instantiatedTypeConstraint))
+                if (!AreTypesAssignableInternal(typeArg, instantiatedTypeConstraint, fBoxedSource: true, fAllowSizeEquivalence: false))
                     return false;
             }
 

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/TypeCast.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/TypeCast.cs
@@ -209,27 +209,6 @@ namespace Internal.Reflection.Execution
             return true;
         }
 
-        //
-        // Determines if a value of the source type can be assigned to a location of the target type.
-        // It does not handle IDynamicInterfaceCastable, and cannot since we do not have an actual object instance here.
-        // This routine assumes that the source type is boxed, i.e. a value type source is presumed to be
-        // compatible with Object and ValueType and an enum source is additionally compatible with Enum.
-        //
-        private static bool AreTypesAssignable(Type pSourceType, Type pTargetType)
-        {
-            // Special case: T can be cast to Nullable<T> (where T is a value type). Call this case out here
-            // since this is only applicable if T is boxed, which is not true for any other callers of
-            // AreTypesAssignableInternal, so no sense making all the other paths pay the cost of the check.
-            if (pTargetType.IsNullable() && pSourceType.IsValueType && !pSourceType.IsNullable())
-            {
-                Type pNullableType = pTargetType.GetNullableType();
-
-                return AreTypesEquivalentInternal(pSourceType, pNullableType);
-            }
-
-            return AreTypesAssignableInternal(pSourceType, pTargetType, true, false);
-        }
-
         // Internally callable version of the export method above. Has two additional parameters:
         //  fBoxedSource            : assume the source type is boxed so that value types and enums are
         //                            compatible with Object, ValueType and Enum (if applicable)

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemConstraintsHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemConstraintsHelpers.cs
@@ -62,6 +62,11 @@ namespace Internal.TypeSystem
                 if (CanCastConstraint(ref instantiatedConstraints, instantiatedType))
                     continue;
 
+                // CanCastTo below assumes thisType is boxed and that allows additional cases
+                // to be considered castable. But int is not castable to Nullable<int> and neither are enums.
+                if (instantiationParam.IsValueType && instantiatedType.IsValueType && !instantiationParam.IsEquivalentTo(instantiatedType))
+                    return false;
+
                 if (!instantiationParam.CanCastTo(instantiatedType))
                     return false;
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
@@ -82,7 +82,8 @@ namespace ILLink.Shared.TrimAnalysis
 
                                             if (isExact)
                                             {
-                                                _reflectionMarker.MarkType(_diagnosticContext.Origin, typeInstantiated, "MakeGenericType");
+                                                if (typeInstantiated.CheckConstraints())
+                                                    _reflectionMarker.MarkType(_diagnosticContext.Origin, typeInstantiated, "MakeGenericType");
                                             }
                                             else
                                             {
@@ -154,7 +155,8 @@ namespace ILLink.Shared.TrimAnalysis
 
                                             if (isExact)
                                             {
-                                                _reflectionMarker.MarkMethod(_diagnosticContext.Origin, methodInstantiated, "MakeGenericMethod");
+                                                if (methodInstantiated.CheckConstraints())
+                                                    _reflectionMarker.MarkMethod(_diagnosticContext.Origin, methodInstantiated, "MakeGenericMethod");
                                             }
                                             else
                                             {

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
@@ -611,7 +611,6 @@ namespace System.Reflection.Tests
         static volatile object s_boxedInt32;
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67568", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void IsAssignableNullable()
         {
             Type nubInt = typeof(Nullable<int>);


### PR DESCRIPTION
* Constraint validation was taking codepaths that assume boxed `this`; however constraint validation run on half-boxed this (casting struct and `object`/`ValueType`/`Enum`/interfaces is fine, casting `T` and `Nullable<T>` is not).
* This was a bug in the compiler and runtime refection too.
* Additional compiler bug was that we didn't check constraints when we saw `MakeGenericType`

Fixes #67568

Cc @dotnet/ilc-contrib 