### PR TITLE
Update MicrosoftCodeAnalysisVersion_LatestVS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -269,6 +269,10 @@
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true' OR '$(NuGetAuditWarnNotError)' == 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
     <!-- Warnings to always disable -->
     <NoWarn>$(NoWarn);CS8500;CS8969</NoWarn>
+    <!-- Don't warn about redundant equality -->
+    <NoWarn>$(NoWarn);IDE0100</NoWarn>
+    <!-- Don't warn about unused parameters -->
+    <NoWarn>$(NoWarn);IDE0060</NoWarn>
     <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors for private assemblies. -->
     <NoWarn Condition="'$(IsPrivateAssembly)' == 'true'">$(NoWarn);CS1591</NoWarn>
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,7 @@
       Source-build builds the product with the most recent previously source-built release. Thankfully, these two requirements line up nicely
       such that any version that satisfies the VS version requirement will also satisfy the .NET SDK version requirement because of how we ship.
     -->
-    <MicrosoftCodeAnalysisVersion_LatestVS>4.8.0</MicrosoftCodeAnalysisVersion_LatestVS>
+    <MicrosoftCodeAnalysisVersion_LatestVS>4.14.0</MicrosoftCodeAnalysisVersion_LatestVS>
     <!-- Some of the analyzer dependencies used by ILLink project -->
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.5-beta1.23270.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
   </PropertyGroup>

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -10,7 +10,7 @@
     <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NoWarn);CS8524</NoWarn>
     <!-- Type conflicts with imported type. Silence this for source build to allow building with the latest
          source-included type name parser, instead of the one that comes with Roslyn. -->
-    <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NoWarn);CS0436</NoWarn>
+    <NoWarn>$(NoWarn);CS0436</NoWarn>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
     <!-- The analyzer needs to process deeply nested expressions in corelib.
          This can blow up the stack if using unoptimized code (due to large


### PR DESCRIPTION
To 4.14.0.

Silence the warnings for now to avoid introducing a bunch of code changes that are unnecessary for .NET 10.