### PR TITLE
allow file overwrite when extracting release bits for superpmi collect script

### DIFF
--- a/eng/pipelines/common/download-artifact-step.yml
+++ b/eng/pipelines/common/download-artifact-step.yml
@@ -4,6 +4,7 @@ parameters:
   artifactFileName: ''
   artifactName: ''
   displayName: ''
+  overwriteExistingFiles: false
 
 steps:
   # Download artifact
@@ -23,3 +24,4 @@ steps:
       archiveFilePatterns: $(Build.SourcesDirectory)/__download__/${{ parameters.artifactName }}/**/${{ parameters.artifactFileName }}
       destinationFolder: ${{ parameters.unpackFolder }}
       cleanDestinationFolder: ${{ parameters.cleanUnpackFolder }}
+      overwriteExistingFiles: ${{ parameters.overwriteExistingFiles }}

--- a/eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-collect-job.yml
@@ -67,6 +67,7 @@ jobs:
         artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_Release
         displayName: 'Release runtime build artifacts'
         cleanUnpackFolder: false
+        overwriteExistingFiles: true
 
     # Unzip individual test projects
     - ${{ if eq(parameters.collectionName, 'libraries_tests') }}:


### PR DESCRIPTION
There seem to be a few release built files in a checked build, and this causes a zip collision. Allow the release unzip to overwrite.

