### PR TITLE
Improve compat for low rights users loading CAPI machine keys via PFX

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
@@ -375,7 +375,18 @@ namespace System.Security.Cryptography.X509Certificates
 
                     if (ProviderNameIsRelevant)
                     {
-                        if (!loaderLimits.PreserveStorageProvider)
+                        const X509KeyStorageFlags EphemeralKeySet =
+#if NET
+                            X509KeyStorageFlags.EphemeralKeySet;
+#else
+                            (X509KeyStorageFlags)0x20;
+#endif
+
+                        if ((bagState.StorageFlags & EphemeralKeySet) != 0)
+                        {
+                            // Ephemeral loads have to go into CNG, but also won't get access denied.
+                        }
+                        else if (!loaderLimits.PreserveStorageProvider)
                         {
                             providerName = DetermineStorageProvider(
                                 bag.BagAttributes,

--- a/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
@@ -751,7 +751,7 @@ namespace System.Security.Cryptography.X509Certificates
                 }
                 finally
                 {
-                    cngKey?.Dispose();
+                    cngKey?.Delete();
                 }
 #else
                 // The netstandard builds shouldn't ever execute on a relevant configuration,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Windows.cs
@@ -281,7 +281,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             Debug.Assert((keyStorageFlags & KeyStorageFlagsAll) == keyStorageFlags);
 
-            Interop.Crypt32.PfxCertStoreFlags pfxCertStoreFlags = Interop.Crypt32.PfxCertStoreFlags.PKCS12_PREFER_CNG_KSP;
+            Interop.Crypt32.PfxCertStoreFlags pfxCertStoreFlags = 0;
 
             if ((keyStorageFlags & X509KeyStorageFlags.UserKeySet) == X509KeyStorageFlags.UserKeySet)
                 pfxCertStoreFlags |= Interop.Crypt32.PfxCertStoreFlags.CRYPT_USER_KEYSET;
@@ -299,7 +299,6 @@ namespace System.Security.Cryptography.X509Certificates
             // complexity of pointer interpretation.
             if ((keyStorageFlags & X509KeyStorageFlags.EphemeralKeySet) == X509KeyStorageFlags.EphemeralKeySet)
             {
-                pfxCertStoreFlags &= ~Interop.Crypt32.PfxCertStoreFlags.PKCS12_PREFER_CNG_KSP;
                 pfxCertStoreFlags |= Interop.Crypt32.PfxCertStoreFlags.PKCS12_NO_PERSIST_KEY | Interop.Crypt32.PfxCertStoreFlags.PKCS12_ALWAYS_CNG_KSP;
             }
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
@@ -25,6 +25,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         public static bool Pkcs12PBES2Supported => !PlatformDetection.IsWindows || PlatformDetection.IsWindows10Version1703OrGreater;
         public static bool MLKemIsNotSupported => !MLKem.IsSupported;
 
+        private static readonly Oid s_keyProviderNameOid =
+            new Oid("1.3.6.1.4.1.311.17.1", "szOID_PKCS_12_KEY_PROVIDER_NAME_ATTR");
+
         public static IEnumerable<object[]> BrainpoolCurvesPfx
         {
             get
@@ -1033,10 +1036,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
                         writer.WriteCharacterString(UniversalTagNumber.BMPString, StrongProv);
 
-                        keyBag.Attributes.Add(
-                            new AsnEncodedData(
-                                new Oid("1.3.6.1.4.1.311.17.1", "1.3.6.1.4.1.311.17.1"),
-                                writer.Encode()));
+                        keyBag.Attributes.Add(new AsnEncodedData(s_keyProviderNameOid, writer.Encode()));
 
                         builder.AddSafeContentsUnencrypted(keyContents);
                         builder.SealWithMac("", HashAlgorithmName.SHA1, 10);
@@ -1164,10 +1164,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                     foreach (Pkcs12SafeBag bag in safeContents.GetBags())
                     {
-                        bag.Attributes.Add(
-                            new AsnEncodedData(
-                                new Oid("1.3.6.1.4.1.311.17.1", "1.3.6.1.4.1.311.17.1"),
-                                writer.Encode()));
+                        bag.Attributes.Add(new AsnEncodedData(s_keyProviderNameOid, writer.Encode()));
 
                         newContents.AddSafeBag(bag);
                     }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Formats.Asn1;
 using System.Linq;
+using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.SLHDsa.Tests;
 using System.Security.Cryptography.Tests;
 using Test.Cryptography;
@@ -632,31 +634,26 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 AQkVMRYEFAoeq6T+1m3SxQcSi9MLIHgD+izRMDEwITAJBgUrDgMCGgUABBSkzDq8UAiqd5YK7p1i
                 YwIgZfxAsAQIG3eE/Gomu/ECAgfQ");
 
+            Assert.Throws<CryptographicException>(
+               () => X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags));
+
+            // This particular PFX does not specify a provider for the private key, therefore
             // Windows when using non-ephemeral delays throwing no private key and instead acts as it the
             // keyset does not exist. Exporting it again to PFX forces Windows to reconcile the fact the key
             // didn't actually load.
             if (PlatformDetection.IsWindows && keyStorageFlags != X509KeyStorageFlags.EphemeralKeySet)
             {
-                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags))
-                {
-                    Assert.Throws<CryptographicException>(
-                        () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, PfxPassword));
-                }
-
                 using (X509Certificate2 cert = new(pfxBytes, PfxPassword, keyStorageFlags))
                 {
                     Assert.Throws<CryptographicException>(
                         () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, PfxPassword));
                 }
-            }
-            else
-            {
-                Assert.Throws<CryptographicException>(
-                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, PfxPassword, keyStorageFlags));
 
-                Assert.Throws<CryptographicException>(
-                    () => new X509Certificate2(pfxBytes, PfxPassword, keyStorageFlags));
+                pfxBytes = RepackWithCsp(pfxBytes, PfxPassword);
             }
+
+            Assert.Throws<CryptographicException>(
+                () => new X509Certificate2(pfxBytes, PfxPassword, keyStorageFlags));
         }
 
         public static IEnumerable<object[]> ReadMLDsa_Pfx_Ietf_Data =>
@@ -748,31 +745,26 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = MLDsaTestsData.IetfMLDsa_Pfx_Pbes1;
             string pfxPassword = "PLACEHOLDER";
 
+            Assert.Throws<CryptographicException>(
+                () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags));
+
+            // This particular PFX does not specify a provider for the private key, therefore
             // Windows when using non-ephemeral delays throwing no private key and instead acts as it the
             // keyset does not exist. Exporting it again to PFX forces Windows to reconcile the fact the key
             // didn't actually load.
             if (PlatformDetection.IsWindows && keyStorageFlags != X509KeyStorageFlags.EphemeralKeySet)
             {
-                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
-                {
-                    Assert.Throws<CryptographicException>(
-                        () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, pfxPassword));
-                }
-
                 using (X509Certificate2 cert = new(pfxBytes, pfxPassword, keyStorageFlags))
                 {
                     Assert.Throws<CryptographicException>(
                         () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, pfxPassword));
                 }
-            }
-            else
-            {
-                Assert.Throws<CryptographicException>(
-                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags));
 
-                Assert.Throws<CryptographicException>(
-                    () => new X509Certificate2(pfxBytes, pfxPassword, keyStorageFlags));
+                pfxBytes = RepackWithCsp(pfxBytes, pfxPassword);
             }
+
+            Assert.Throws<CryptographicException>(
+                () => new X509Certificate2(pfxBytes, pfxPassword, keyStorageFlags));
         }
 
         [ConditionalTheory(typeof(SlhDsa), nameof(SlhDsa.IsSupported))]
@@ -807,31 +799,26 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes = SlhDsaTestData.IetfSlhDsaSha2_128sCertificatePfx_Pbes1;
             string pfxPassword = "PLACEHOLDER";
 
+            Assert.Throws<CryptographicException>(
+                () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags));
+
+            // This particular PFX does not specify a provider for the private key, therefore
             // Windows when using non-ephemeral delays throwing no private key and instead acts as it the
             // keyset does not exist. Exporting it again to PFX forces Windows to reconcile the fact the key
             // didn't actually load.
             if (PlatformDetection.IsWindows && keyStorageFlags != X509KeyStorageFlags.EphemeralKeySet)
             {
-                using (X509Certificate2 cert = X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags))
-                {
-                    Assert.Throws<CryptographicException>(
-                        () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, pfxPassword));
-                }
-
                 using (X509Certificate2 cert = new(pfxBytes, pfxPassword, keyStorageFlags))
                 {
                     Assert.Throws<CryptographicException>(
                         () => cert.ExportPkcs12(Pkcs12ExportPbeParameters.Pbes2Aes256Sha256, pfxPassword));
                 }
-            }
-            else
-            {
-                Assert.Throws<CryptographicException>(
-                    () => X509CertificateLoader.LoadPkcs12(pfxBytes, pfxPassword, keyStorageFlags));
 
-                Assert.Throws<CryptographicException>(
-                    () => new X509Certificate2(pfxBytes, pfxPassword, keyStorageFlags));
+                pfxBytes = RepackWithCsp(pfxBytes, pfxPassword);
             }
+
+            Assert.Throws<CryptographicException>(
+                () => new X509Certificate2(pfxBytes, pfxPassword, keyStorageFlags));
         }
 
 #if !NO_EPHEMERALKEYSET_AVAILABLE
@@ -1024,6 +1011,53 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             X509Certificate2 newC = new X509Certificate2(c.Handle);
             c.Dispose();
             return newC;
+        }
+
+        private static byte[] RepackWithCsp(byte[] pfxBytes, string pfxPassword)
+        {
+            // This method assumes a very specific format for the incoming data.
+            // An encrypted data segment containing the certificate,
+            // and an unencrypted segment consisting of one shrouded key,
+            // and that key already has attributes (LocalKeyId),
+            // and does not already have a provider name attribute.
+
+            Pkcs12Info pkcs12 = Pkcs12Info.Decode(pfxBytes, out _, skipCopy: true);
+
+            if (!pkcs12.VerifyMac(pfxPassword))
+            {
+                throw new InvalidOperationException();
+            }
+
+            Pkcs12Builder builder = new Pkcs12Builder();
+
+            foreach (Pkcs12SafeContents safeContents in pkcs12.AuthenticatedSafe)
+            {
+                if (safeContents.ConfidentialityMode != Pkcs12ConfidentialityMode.None)
+                {
+                    builder.AddSafeContentsUnencrypted(safeContents);
+                }
+                else
+                {
+                    Pkcs12SafeContents newContents = new Pkcs12SafeContents();
+                    AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+                    writer.WriteCharacterString(UniversalTagNumber.BMPString, CngProvider.MicrosoftSoftwareKeyStorageProvider.Provider);
+
+                    foreach (Pkcs12SafeBag bag in safeContents.GetBags())
+                    {
+                        bag.Attributes.Add(
+                            new AsnEncodedData(
+                                new Oid("1.3.6.1.4.1.311.17.1", "1.3.6.1.4.1.311.17.1"),
+                                writer.Encode()));
+
+                        newContents.AddSafeBag(bag);
+                    }
+
+                    builder.AddSafeContentsUnencrypted(newContents);
+                }
+            }
+
+            builder.SealWithMac(pfxPassword, HashAlgorithmName.SHA256, 25);
+            return builder.Encode();
         }
 
         internal delegate ulong GetIterationCountDelegate(ReadOnlySpan<byte> pkcs12, out int bytesConsumed);


### PR DESCRIPTION
1) Windows exhibits different behaviors between no provider attribute with PKCS12_PREFER_CNG_KSP than with specifying the KSP, so always specify the KSP instead of deleting the attribute.

2) Let's stop messing with provider attributes on non-Windows, since this change is making them more expensive.

3) If PreserveStorageProvider is false, the key would go to a machine store, the user can't write to the CNG machine store, and the key is from a known CAPI provider, don't upgrade it to CNG.

Fixes #117798.