### PR TITLE
[clr-interp] Fix issue where we are implementing an intrinsic incorrectly

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2401,6 +2401,11 @@ bool InterpCompiler::EmitNamedIntrinsicCall(NamedIntrinsic ni, CORINFO_CLASS_HAN
         }
         case NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference:
         {
+            if (sig.sigInst.methInstCount != 1)
+            {
+                assert(!mustExpand);
+                return false;
+            }
             CHECK_STACK(1);
 
             m_pStackPointer--;


### PR DESCRIPTION
GetArrayDataReference should only be an intrinsic for the generic version of this api. (The non-generic version needs to handle multidimensional arrays, and is somewhat different.