### PR TITLE
[clr-interp] More minimal tweak for enabling debug stack walking

### DIFF
--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -2878,6 +2878,11 @@ public:
         Init(codeAddress);
     }
 
+    EECodeInfo(PCODE codeAddress, ExecutionManager::ScanFlag scanFlag)
+    {
+        Init(codeAddress, scanFlag);
+    }
+
     // Explicit initialization
     void Init(PCODE codeAddress);
     void Init(PCODE codeAddress, ExecutionManager::ScanFlag scanFlag);

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -84,6 +84,12 @@ struct ThisPtrRetBufPrecode;
 typedef DPTR(class UMEntryThunk) PTR_UMEntryThunk;
 #define PRECODE_UMENTRY_THUNK_VALUE 0x7 // Define the value here and not in UMEntryThunk to avoid circular dependency with the dllimportcallback.h header
 
+#ifdef FEATURE_INTERPRETER
+struct InterpreterPrecode;
+
+typedef DPTR(InterpreterPrecode) PTR_InterpreterPrecode;
+#endif 
+
 // Regular precode
 struct StubPrecode
 {
@@ -121,6 +127,10 @@ struct StubPrecode
 #ifdef HAS_THISPTR_RETBUF_PRECODE
     ThisPtrRetBufPrecode* AsThisPtrRetBufPrecode();
 #endif // HAS_THISPTR_RETBUF_PRECODE
+
+#ifdef FEATURE_INTERPRETER
+    PTR_InterpreterPrecode AsInterpreterPrecode();
+#endif // FEATURE_INTERPRETER
 
 #ifndef DACCESS_COMPILE
     void SetSecretParam(TADDR secretParam)
@@ -340,7 +350,13 @@ struct InterpreterPrecode
     TADDR GetMethodDesc();
 };
 
-typedef DPTR(InterpreterPrecode) PTR_InterpreterPrecode;
+inline PTR_InterpreterPrecode StubPrecode::AsInterpreterPrecode()
+{
+    LIMITED_METHOD_CONTRACT;
+    SUPPORTS_DAC;
+
+    return dac_cast<PTR_InterpreterPrecode>(this);
+}
 
 #endif // FEATURE_INTERPRETER
 
@@ -509,10 +525,11 @@ inline TADDR StubPrecode::GetMethodDesc()
         case PRECODE_PINVOKE_IMPORT:
             return GetSecretParam();
 
-        case PRECODE_UMENTRY_THUNK:
 #ifdef FEATURE_INTERPRETER
         case PRECODE_INTERPRETER:
+            return AsInterpreterPrecode()->GetMethodDesc();
 #endif // FEATURE_INTERPRETER
+        case PRECODE_UMENTRY_THUNK:
 #ifdef FEATURE_STUBPRECODE_DYNAMIC_HELPERS
         case PRECODE_DYNAMIC_HELPERS:
 #endif // FEATURE_STUBPRECODE_DYNAMIC_HELPERS


### PR DESCRIPTION
- This just enables the StubPrecode::GetMethodDesc api, as well as ExecutionManager::GetCodeMethodDesc
- It is enough for !clrstack to work correctly