### PR TITLE
Revert "JIT: Remove side effect detection quirk in loop hoisting (#118463)" with some improvements

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4296,7 +4296,7 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
             assert(!m_canHoistSideEffects || (block == m_loop->GetHeader()));
             // After visiting the first block (which is expected to always be
             // the loop header) we can no longer hoist out side effecting trees
-            // as the next blocks could be unconditionally executed.
+            // as the next blocks could be conditionally executed.
             m_canHoistSideEffects = false;
         }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_119061/Runtime_119061.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_119061/Runtime_119061.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_119061
+{
+    private static C1 s_6 = new C1();
+    
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        s_6.F8 = new S0(-1);
+        var vr4 = s_6.F8.F0;
+        Vector128<short> vr6 = default(Vector128<short>);
+        M3(vr4, vr6);
+    }
+
+    private static ushort M3(int arg1, Vector128<short> arg2)
+    {
+        bool[] var0 = new bool[]
+        {
+            false
+        };
+        for (sbyte lvar1 = 10; lvar1 < 12; lvar1++)
+        {
+            if (var0[0])
+            {
+                var vr2 = (uint)(3329109910U / (-9223372036854775808L / (arg1 | 1)));
+                var vr1 = (short)BitOperations.LeadingZeroCount(vr2);
+                arg2 = Vector128.CreateScalar(vr1);
+            }
+        }
+
+        C0 vr8 = new C0();
+        return vr8.F1;
+    }
+
+    private struct S0
+    {
+        public int F0;
+        public S0(int f0) : this()
+        {
+            F0 = f0;
+        }
+    }
+
+    private class C0
+    {
+        public ushort F1;
+    }
+
+    private class C1
+    {
+        public S0 F8;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_119061/Runtime_119061.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_119061/Runtime_119061.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This reverts commit https://github.com/dotnet/runtime/commit/e0b14e9589c453ad4a4daeddb853eb652abd05ac. That change is not correct as it removes the safe guard that prevents hoisting throwing expressions out of conditionally executed blocks.

Also renames `m_beforeSideEffect` to `m_canHoistSideEffects` to capture more precisely what it represents and why the conditionality of the blocks play a role. Also adds a test.

Fix #119061