### PR TITLE
JIT: fix crash in LSRA seen on VMR build on AVX-512 machines

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -13097,8 +13097,12 @@ void LinearScan::RegisterSelection::try_SPILL_COST()
         {
             continue;
         }
-        else if (assignedInterval != nullptr)
 #endif
+        if (assignedInterval == nullptr)
+        {
+            continue;
+        }
+
         {
             if ((linearScan->getNextIntervalRef(spillCandidateRegNum, regType) == thisLocation) &&
                 !assignedInterval->getNextRefPosition()->RegOptional())
@@ -13140,16 +13144,6 @@ void LinearScan::RegisterSelection::try_SPILL_COST()
                 }
             }
         }
-#ifdef TARGET_ARM64
-        else
-        {
-            // Ideally we should not be seeing this candidate because it is not assigned to
-            // any interval. But it is possible for certain scenarios. One of them is that
-            // `refPosition` needs consecutive registers and we decided to pick a mix of free+busy
-            // registers. This candidate is part of that set and is free and hence is not assigned
-            // to any interval.
-        }
-#endif // TARGET_ARM64
 
         // Only consider spillCost if we were not able to calculate weight of reloadRefPosition.
         if (currentSpillWeight == 0)


### PR DESCRIPTION
During the second stage bootstrap build VMR on an AVX-512 capable machine, we end up in `try_SPILL_COST` looking at a K-reg spill candidate without an assigned interval,  and crash.

The code was already handling this sort of thing for ARM64; so we now extend it to cover all architectures.

Fixes the crash seen in #119070.