### PR TITLE
Clear TS_GCSuspendRedirected at the end of thread redirection

### DIFF
--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2713,6 +2713,11 @@ void __stdcall Thread::RedirectedHandledJITCase(RedirectReason reason)
         GCX_PREEMP_NO_DTOR_END();
     }
 
+#if defined(FEATURE_HIJACK) && !defined(TARGET_UNIX)
+    // Make sure that this is cleared to enable redirects again
+    pThread->ResetThreadState(Thread::TS_GCSuspendRedirected);
+#endif
+
     // Once we get here the suspension is over!
     // We will restore the state as it was at the point of redirection
     // and continue normal execution.


### PR DESCRIPTION
TS_GCSuspendRedirected is normally cleared in the slow path of pulsing GC mode (RareDisablePreemptiveGC). The problem is that we may not even get to that slow path if the thread gets rescheduled right after we switch to preemptive mode and gets scheduled back only after the GC completes and resumes execution. This change clears it explicitly.

Fixes #119149