### PR TITLE
[NativeAOT] Adjust SSP to match RSP of the throw site

### DIFF
--- a/src/coreclr/nativeaot/Runtime/amd64/ExceptionHandling.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/ExceptionHandling.asm
@@ -130,6 +130,10 @@ NESTED_ENTRY RhpThrowEx, _TEXT
 
         alloc_stack     SIZEOF_XmmSaves + 8h    ;; reserve stack for the xmm saves (+8h to realign stack)
         rdsspq  r8                              ;; nop if SSP is not implemented, 0 if not enabled
+        test    r8, r8
+        je      @f
+        add     r8, 8                           ;; Move SSP to match RSP of the throw site
+    @@:
         push_vol_reg    r8                      ;; SSP
         xor     r8, r8
         push_nonvol_reg r15
@@ -226,6 +230,10 @@ NESTED_ENTRY RhpRethrow, _TEXT
 
         alloc_stack     SIZEOF_XmmSaves + 8h    ;; reserve stack for the xmm saves (+8h to realign stack)
         rdsspq  r8                              ;; nop if SSP is not implemented, 0 if not enabled
+        test    r8, r8
+        je      @f
+        add     r8, 8                           ;; Move SSP to match RSP of the throw site
+    @@:
         push_vol_reg    r8                      ;; SSP
         xor     r8, r8
         push_nonvol_reg r15

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1024,13 +1024,6 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- NativeAOT ControlFlowGuard specific -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr' and '$(ControlFlowGuard)' == 'Guard'">
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314/**">
-            <Issue>https://github.com/dotnet/runtime/issues/107418</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
     <!-- run.proj finds all the *.cmd/*.sh scripts in a test folder and creates corresponding test methods.
          Exclude these scripts to avoid creating such methods for the superpmicollect dependent test projects
          and running them separately from superpmicollect test. These should be excluded regardless of RuntimeFlavor/os/arch-->


### PR DESCRIPTION
This fixes unbounded shadow stack growth that leads to stack overflow exception when exceptions are thrown and caught in a loop.

Fixes #118913
Fixes #107418