### PR TITLE
Don't preinitialize fields that are never read

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
@@ -19,7 +19,7 @@ namespace ILCompiler
         protected DevirtualizationManager _devirtualizationManager = new DevirtualizationManager();
         protected InlinedThreadStatics _inlinedThreadStatics = new InlinedThreadStatics();
         protected MethodImportationErrorProvider _methodImportationErrorProvider = new MethodImportationErrorProvider();
-        protected ReadOnlyFieldPolicy _readOnlyFieldPolicy = new ReadOnlyFieldPolicy();
+        protected FieldPolicy _fieldPolicy = new FieldPolicy();
         protected IInliningPolicy _inliningPolicy;
         protected MethodBodyFoldingMode _methodBodyFolding;
         protected InstructionSetSupport _instructionSetSupport;
@@ -112,9 +112,9 @@ namespace ILCompiler
             return this;
         }
 
-        public CompilationBuilder UseReadOnlyFieldPolicy(ReadOnlyFieldPolicy policy)
+        public CompilationBuilder UseFieldPolicy(FieldPolicy policy)
         {
-            _readOnlyFieldPolicy = policy;
+            _fieldPolicy = policy;
             return this;
         }
 
@@ -139,7 +139,7 @@ namespace ILCompiler
         protected PreinitializationManager GetPreinitializationManager()
         {
             if (_preinitializationManager == null)
-                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), new TypePreinit.DisabledPreinitializationPolicy(), new StaticReadOnlyFieldPolicy(), null);
+                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), new TypePreinit.DisabledPreinitializationPolicy(), new FieldPolicyWithStaticInitOnly(), null);
             return _preinitializationManager;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -385,6 +385,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new NotReadOnlyFieldNode(field);
             });
 
+            _fieldReads = new NodeCache<FieldDesc, StaticFieldReadNode>(field =>
+            {
+                return new StaticFieldReadNode(field);
+            });
+
             _genericStaticBaseInfos = new NodeCache<MetadataType, GenericStaticBaseInfoNode>(type =>
             {
                 return new GenericStaticBaseInfoNode(type);
@@ -1229,6 +1234,12 @@ namespace ILCompiler.DependencyAnalysis
         public NotReadOnlyFieldNode NotReadOnlyField(FieldDesc field)
         {
             return _notReadOnlyFields.GetOrAdd(field);
+        }
+
+        private NodeCache<FieldDesc, StaticFieldReadNode> _fieldReads;
+        public StaticFieldReadNode StaticFieldRead(FieldDesc field)
+        {
+            return _fieldReads.GetOrAdd(field);
         }
 
         private NodeCache<MetadataType, GenericStaticBaseInfoNode> _genericStaticBaseInfos;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (!factory.Target.IsWindows)
                     return ObjectNodeSection.DataSection;
 
-                ReadOnlyFieldPolicy readOnlyPolicy = _preinitializationManager.ReadOnlyFieldPolicy;
+                FieldPolicy fieldPolicy = _preinitializationManager.FieldPolicy;
 
                 bool allFieldsReadOnly = true;
                 foreach (FieldDesc field in _type.GetFields())
@@ -53,7 +53,7 @@ namespace ILCompiler.DependencyAnalysis
                     if (!IsNonGcStaticField(field))
                         continue;
 
-                    allFieldsReadOnly = readOnlyPolicy.IsReadOnly(field);
+                    allFieldsReadOnly = fieldPolicy.IsReadOnly(field);
                     if (!allFieldsReadOnly)
                         break;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
@@ -43,6 +43,9 @@ namespace ILCompiler.DependencyAnalysis
                 return dependencies;
             }
 
+            if (_field.IsStatic)
+                dependencies.Add(factory.StaticFieldRead(_field), "Reflection readable static field");
+
             // readonly static fields are not reflection settable, the rest are
             if (!_field.IsInitOnly || !_field.IsStatic)
                 dependencies.Add(factory.NotReadOnlyField(_field), "Reflection writable field");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StaticFieldReadNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StaticFieldReadNode.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a field that that can be read programmatically at runtime.
+    /// </summary>
+    public class StaticFieldReadNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly FieldDesc _field;
+
+        public StaticFieldReadNode(FieldDesc field)
+        {
+            Debug.Assert(field.IsStatic);
+            Debug.Assert(!field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any)
+                || field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific) == field.OwningType);
+            _field = field;
+        }
+
+        public FieldDesc Field => _field;
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return "Static field that can be read at runtime: " + _field.ToString();
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/FieldPolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/FieldPolicy.cs
@@ -5,12 +5,13 @@ using Internal.TypeSystem;
 
 namespace ILCompiler
 {
-    public class ReadOnlyFieldPolicy
+    public class FieldPolicy
     {
         public virtual bool IsReadOnly(FieldDesc field) => field.IsInitOnly;
+        public virtual bool IsStaticFieldRead(FieldDesc field) => true;
     }
 
-    public sealed class StaticReadOnlyFieldPolicy : ReadOnlyFieldPolicy
+    public sealed class FieldPolicyWithStaticInitOnly : FieldPolicy
     {
         public override bool IsReadOnly(FieldDesc field) => field.IsStatic && field.IsInitOnly;
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
@@ -17,12 +17,12 @@ namespace ILCompiler
     {
         private readonly bool _supportsLazyCctors;
 
-        public ReadOnlyFieldPolicy ReadOnlyFieldPolicy => _preinitHashTable._readOnlyPolicy;
+        public FieldPolicy FieldPolicy => _preinitHashTable._fieldPolicy;
 
-        public PreinitializationManager(TypeSystemContext context, CompilationModuleGroup compilationGroup, ILProvider ilprovider, TypePreinit.TypePreinitializationPolicy policy, ReadOnlyFieldPolicy readOnlyPolicy, FlowAnnotations flowAnnotations)
+        public PreinitializationManager(TypeSystemContext context, CompilationModuleGroup compilationGroup, ILProvider ilprovider, TypePreinit.TypePreinitializationPolicy policy, FieldPolicy fieldPolicy, FlowAnnotations flowAnnotations)
         {
             _supportsLazyCctors = context.SystemModule.GetType("System.Runtime.CompilerServices", "ClassConstructorRunner", throwIfNotFound: false) != null;
-            _preinitHashTable = new PreinitializationInfoHashtable(compilationGroup, ilprovider, policy, readOnlyPolicy, flowAnnotations);
+            _preinitHashTable = new PreinitializationInfoHashtable(compilationGroup, ilprovider, policy, fieldPolicy, flowAnnotations);
         }
 
         /// <summary>
@@ -141,15 +141,15 @@ namespace ILCompiler
             private readonly CompilationModuleGroup _compilationGroup;
             private readonly ILProvider _ilProvider;
             internal readonly TypePreinit.TypePreinitializationPolicy _policy;
-            internal readonly ReadOnlyFieldPolicy _readOnlyPolicy;
+            internal readonly FieldPolicy _fieldPolicy;
             private readonly FlowAnnotations _flowAnnotations;
 
-            public PreinitializationInfoHashtable(CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinit.TypePreinitializationPolicy policy, ReadOnlyFieldPolicy readOnlyPolicy, FlowAnnotations flowAnnotations)
+            public PreinitializationInfoHashtable(CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinit.TypePreinitializationPolicy policy, FieldPolicy fieldPolicy, FlowAnnotations flowAnnotations)
             {
                 _compilationGroup = compilationGroup;
                 _ilProvider = ilProvider;
                 _policy = policy;
-                _readOnlyPolicy = readOnlyPolicy;
+                _fieldPolicy = fieldPolicy;
                 _flowAnnotations = flowAnnotations;
             }
 
@@ -160,7 +160,7 @@ namespace ILCompiler
 
             protected override TypePreinit.PreinitializationInfo CreateValueFromKey(MetadataType key)
             {
-                var info = TypePreinit.ScanType(_compilationGroup, _ilProvider, _policy, _readOnlyPolicy, _flowAnnotations, key);
+                var info = TypePreinit.ScanType(_compilationGroup, _ilProvider, _policy, _fieldPolicy, _flowAnnotations, key);
 
                 // We either successfully preinitialized or
                 // the type doesn't have a canonical form or

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -1066,6 +1066,17 @@ namespace Internal.IL
 
             _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, canonField);
 
+            if (field.IsStatic && (!write.HasValue || write == false))
+            {
+                FieldDesc fieldToReport = canonField;
+                DefType fieldOwningType = canonField.OwningType;
+                TypeDesc canonFieldOwningType = fieldOwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
+                if (fieldOwningType != canonFieldOwningType)
+                    fieldToReport = _factory.TypeSystemContext.GetFieldForInstantiatedType(fieldToReport.GetTypicalFieldDefinition(), (InstantiatedType)canonFieldOwningType);
+
+                _dependencies.Add(_factory.StaticFieldRead(fieldToReport), "Static field read");
+            }
+
             // `write` will be null for ld(s)flda. Consider address loads write unless they were
             // for initonly static fields. We'll trust the initonly that this is not a write.
             write ??= !field.IsInitOnly || !field.IsStatic;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -455,6 +455,7 @@
     <Compile Include="Compiler\DependencyAnalysis\VariantInterfaceMethodUseNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\CustomAttributeBasedDependencyAlgorithm.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FieldMetadataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\StaticFieldReadNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ILScanNodeFactory.cs" />
     <Compile Include="Compiler\DictionaryLayoutProvider.cs" />
     <Compile Include="Compiler\Disassembler.cs" />
@@ -631,7 +632,7 @@
     <Compile Include="Compiler\ObjectWriter\SectionData.cs" />
     <Compile Include="Compiler\ObjectWriter\SectionWriter.cs" />
     <Compile Include="Compiler\ObjectWriter\StringTableBuilder.cs" />
-    <Compile Include="Compiler\ReadOnlyFieldPolicy.cs" />
+    <Compile Include="Compiler\FieldPolicy.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_RiscV64\RiscV64JumpStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_RiscV64\RiscV64ReadyToRunHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_RiscV64\RiscV64ReadyToRunGenericHelperNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -27,7 +27,7 @@ namespace ILCompiler
         private readonly ProfileDataManager _profileDataManager;
         private readonly FileLayoutOptimizer _fileLayoutOptimizer;
         private readonly MethodImportationErrorProvider _methodImportationErrorProvider;
-        private readonly ReadOnlyFieldPolicy _readOnlyFieldPolicy;
+        private readonly FieldPolicy _fieldPolicy;
         private readonly int _parallelism;
 
         public InstructionSetSupport InstructionSetSupport { get; }
@@ -43,7 +43,7 @@ namespace ILCompiler
             InstructionSetSupport instructionSetSupport,
             ProfileDataManager profileDataManager,
             MethodImportationErrorProvider errorProvider,
-            ReadOnlyFieldPolicy readOnlyFieldPolicy,
+            FieldPolicy fieldPolicy,
             RyuJitCompilationOptions options,
             MethodLayoutAlgorithm methodLayoutAlgorithm,
             FileLayoutAlgorithm fileLayoutAlgorithm,
@@ -58,7 +58,7 @@ namespace ILCompiler
 
             _methodImportationErrorProvider = errorProvider;
 
-            _readOnlyFieldPolicy = readOnlyFieldPolicy;
+            _fieldPolicy = fieldPolicy;
 
             _parallelism = parallelism;
 
@@ -67,7 +67,7 @@ namespace ILCompiler
 
         public ProfileDataManager ProfileData => _profileDataManager;
 
-        public bool IsInitOnly(FieldDesc field) => _readOnlyFieldPolicy.IsReadOnly(field);
+        public bool IsInitOnly(FieldDesc field) => _fieldPolicy.IsReadOnly(field);
 
         public override IEETypeNode NecessaryTypeSymbolIfPossible(TypeDesc type)
         {

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -157,7 +157,7 @@ namespace ILCompiler
                 _instructionSetSupport,
                 _profileDataManager,
                 _methodImportationErrorProvider,
-                _readOnlyFieldPolicy,
+                _fieldPolicy,
                 options,
                 _methodLayoutAlgorithm,
                 _fileLayoutAlgorithm,

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -476,7 +476,7 @@ namespace ILCompiler
             TypePreinit.TypePreinitializationPolicy preinitPolicy = preinitStatics ?
                 new TypePreinit.TypeLoaderAwarePreinitializationPolicy() : new TypePreinit.DisabledPreinitializationPolicy();
 
-            var preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, preinitPolicy, new StaticReadOnlyFieldPolicy(), flowAnnotations);
+            var preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, preinitPolicy, new FieldPolicyWithStaticInitOnly(), flowAnnotations);
             builder
                 .UseILProvider(ilProvider)
                 .UsePreinitializationManager(preinitManager)
@@ -564,11 +564,11 @@ namespace ILCompiler
                 // has the whole program view.
                 if (preinitStatics)
                 {
-                    var readOnlyFieldPolicy = scanResults.GetReadOnlyFieldPolicy();
+                    var readOnlyFieldPolicy = scanResults.GetFieldPolicy();
                     preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, scanResults.GetPreinitializationPolicy(),
                         readOnlyFieldPolicy, flowAnnotations);
                     builder.UsePreinitializationManager(preinitManager)
-                        .UseReadOnlyFieldPolicy(readOnlyFieldPolicy);
+                        .UseFieldPolicy(readOnlyFieldPolicy);
                 }
 
                 // If we have a scanner, we can inline threadstatics storage using the information we collected at scanning time.


### PR DESCRIPTION
* Track whether a field is accessed outside preinitialized static initializers
* If it's not accessed, emit it as zero-initialized

Draft for rt-sz measurements. Not clear if this will have savings since RyuJIT is already pretty good at inlining the values of fields, which means we often eliminate entire static bases already.