### PR TITLE
DRAFT- Fix assert in the where accessing a Signature can fail on a MethodDesc

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -812,7 +812,12 @@ void DacDbiInterfaceImpl::InitFrameData(StackFrameIterator *   pIter,
         // Strictly speaking, we can do this in CordbJITILFrame::Init(), but it's just easier and more
         // efficiently to do it here.  CordbJITILFrame::Init() will initialize the other vararg-related
         // fields.  We don't have the native var info here to fully initialize everything.
-        pFrameData->v.fVarArgs = (pMD->IsVarArg() == TRUE);
+        BOOL isVarArg = FALSE;
+        HRESULT hr = pMD->IsVarArgDAC(&isVarArg);
+        if (FAILED(hr))
+            ThrowHR(hr);
+
+        pFrameData->v.fVarArgs = (isVarArg == TRUE);
 
         pFrameData->v.fNoMetadata = (pMD->IsNoMetadata() == TRUE);
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -828,7 +828,6 @@ public:
     BOOL IsVarArg();
 #ifdef DACCESS_COMPILE
     HRESULT IsVarArgDAC(BOOL *isVarArg);
-    HRESULT GetSignatureDAC(Signature *pSignature);
 #endif // DACCESS_COMPILE
 
     BOOL IsVoid();
@@ -921,7 +920,9 @@ public:
     // Convenience methods for common signature wrapper types.
     SigPointer GetSigPointer();
     Signature GetSignature();
-
+#ifdef DACCESS_COMPILE
+    HRESULT GetSignatureDAC(Signature *pSignature);
+#endif // DACCESS_COMPILE
 
     void GetSigFromMetadata(IMDInternalImport * importer,
                             PCCOR_SIGNATURE   * ppSig,

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -826,6 +826,11 @@ public:
     // About the signature.
 
     BOOL IsVarArg();
+#ifdef DACCESS_COMPILE
+    HRESULT IsVarArgDAC(BOOL *isVarArg);
+    HRESULT GetSignatureDAC(Signature *pSignature);
+#endif // DACCESS_COMPILE
+
     BOOL IsVoid();
     BOOL HasRetBuffArg();
 


### PR DESCRIPTION
This provides a path that the DAC can use which won't assert, but instead will fail. And of course a spot where it is used.

This hasn't been verified to work reliably, so its DRAFT.