### PR TITLE
Fix elfreader for android

### DIFF
--- a/src/coreclr/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/debug/dbgutil/elfreader.cpp
@@ -128,8 +128,7 @@ ElfReader::PopulateForSymbolLookup(uint64_t baseAddress)
     if (!EnumerateProgramHeaders(
         baseAddress,
 #if defined(TARGET_LINUX_MUSL) || defined(TARGET_RISCV64) || defined(HOST_ANDROID)
-        // On musl based platforms (Alpine) and RISCV64 (VisionFive2 board),
-        // the below dynamic entries for hash,
+        // On some platforms, the below dynamic entries for hash,
         // string table, etc. are RVAs instead of absolute address like on all
         // other Linux distros. Get the "loadbias" (basically the base address
         // of the module) and add to these RVAs.

--- a/src/coreclr/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/debug/dbgutil/elfreader.cpp
@@ -127,7 +127,7 @@ ElfReader::PopulateForSymbolLookup(uint64_t baseAddress)
     // Enumerate program headers searching for the PT_DYNAMIC header, etc.
     if (!EnumerateProgramHeaders(
         baseAddress,
-#if defined(TARGET_LINUX_MUSL) || defined(TARGET_RISCV64)
+#if defined(TARGET_LINUX_MUSL) || defined(TARGET_RISCV64) || defined(HOST_ANDROID)
         // On musl based platforms (Alpine) and RISCV64 (VisionFive2 board),
         // the below dynamic entries for hash,
         // string table, etc. are RVAs instead of absolute address like on all

--- a/src/coreclr/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/debug/dbgutil/elfreader.cpp
@@ -127,7 +127,7 @@ ElfReader::PopulateForSymbolLookup(uint64_t baseAddress)
     // Enumerate program headers searching for the PT_DYNAMIC header, etc.
     if (!EnumerateProgramHeaders(
         baseAddress,
-#if defined(TARGET_LINUX_MUSL) || defined(TARGET_RISCV64) || defined(HOST_ANDROID)
+#if defined(TARGET_LINUX_MUSL) || defined(TARGET_RISCV64) || defined(TARGET_ANDROID)
         // On some platforms, the below dynamic entries for hash,
         // string table, etc. are RVAs instead of absolute address like on all
         // other Linux distros. Get the "loadbias" (basically the base address


### PR DESCRIPTION
This PR fixes an issue with the ELF reader on Android by extending a conditional compilation block to include Android platforms. The change addresses how dynamic entries are handled on Android, treating them as relative virtual addresses (RVAs) rather than absolute addresses.