### PR TITLE
[release/10.0] Add trim analyzer support for C# 14 extensions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -269,6 +269,10 @@
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true' OR '$(NuGetAuditWarnNotError)' == 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
     <!-- Warnings to always disable -->
     <NoWarn>$(NoWarn);CS8500;CS8969</NoWarn>
+    <!-- Don't warn about redundant equality -->
+    <NoWarn>$(NoWarn);IDE0100</NoWarn>
+    <!-- Don't warn about unused parameters -->
+    <NoWarn>$(NoWarn);IDE0060</NoWarn>
     <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors for private assemblies. -->
     <NoWarn Condition="'$(IsPrivateAssembly)' == 'true'">$(NoWarn);CS1591</NoWarn>
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,7 @@
       Source-build builds the product with the most recent previously source-built release. Thankfully, these two requirements line up nicely
       such that any version that satisfies the VS version requirement will also satisfy the .NET SDK version requirement because of how we ship.
     -->
-    <MicrosoftCodeAnalysisVersion_LatestVS>4.8.0</MicrosoftCodeAnalysisVersion_LatestVS>
+    <MicrosoftCodeAnalysisVersion_LatestVS>4.14.0</MicrosoftCodeAnalysisVersion_LatestVS>
     <!-- Some of the analyzer dependencies used by ILLink project -->
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.5-beta1.23270.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
   </PropertyGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ResultChecker.cs
@@ -202,6 +202,20 @@ namespace Mono.Linker.Tests.TestCasesRunner
             List<(ICustomAttributeProvider, CustomAttribute)> expectedNoWarningsAttributes = new();
             foreach (var attrProvider in GetAttributeProviders(original))
             {
+                if (attrProvider is IMemberDefinition attrMember &&
+                    attrMember is not TypeDefinition &&
+                    attrMember.DeclaringType is TypeDefinition declaringType &&
+                    declaringType.Name.StartsWith("<G>"))
+                {
+                    // Workaround: C# 14 extension members result in a compiler-generated type
+                    // that has a member for each extension member (this is in addition to the type
+                    // which contains the actual extension member implementation).
+                    // The generated members inherit attributes from the extension members, but
+                    // have empty implementations. We don't want to check inherited ExpectedWarningAttributes
+                    // for these members.
+                    continue;
+                }
+
                 foreach (var attr in attrProvider.CustomAttributes)
                 {
                     if (!IsProducedByNativeAOT(attr))

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -322,6 +322,11 @@ namespace ILLink.RoslynAnalyzer
                 || propertySymbol.GetDynamicallyAccessedMemberTypes() == DynamicallyAccessedMemberTypes.None)
                 return;
 
+            // For C# 14 extension properties, property-level DAM does not propagate to accessors
+            // and we do not consider property vs accessor conflicts meaningful. Skip conflict checks.
+            if (methodSymbol.HasExtensionParameterOnType())
+                return;
+
             // None on the return type of 'get' matches unannotated
             if (methodSymbol.MethodKind == MethodKind.PropertyGet
                 && methodSymbol.GetDynamicallyAccessedMemberTypesOnReturnType() != DynamicallyAccessedMemberTypes.None

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -10,7 +10,7 @@
     <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NoWarn);CS8524</NoWarn>
     <!-- Type conflicts with imported type. Silence this for source build to allow building with the latest
          source-included type name parser, instead of the one that comes with Roslyn. -->
-    <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NoWarn);CS0436</NoWarn>
+    <NoWarn>$(NoWarn);CS0436</NoWarn>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
     <!-- The analyzer needs to process deeply nested expressions in corelib.
          This can blow up the stack if using unoptimized code (due to large

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/IMethodSymbolExtensions.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/IMethodSymbolExtensions.cs
@@ -58,7 +58,7 @@ namespace ILLink.RoslynAnalyzer
         /// </summary>
         public static int GetMetadataParametersCount(this IMethodSymbol method)
         {
-            return method.Parameters.Length;
+            return method.Parameters.Length + (method.HasExtensionParameterOnType() ? 1 : 0);
         }
 
         /// <summary>
@@ -66,7 +66,15 @@ namespace ILLink.RoslynAnalyzer
         /// </summary>
         public static int GetParametersCount(this IMethodSymbol method)
         {
-            return method.Parameters.Length + (method.HasImplicitThis() ? 1 : 0);
+            return method.Parameters.Length + (method.HasImplicitThis() ? 1 : 0) + (method.HasExtensionParameterOnType() ? 1 : 0);
+        }
+
+        /// <summary>
+        /// Returns true if the method's containing type has an extension parameter
+        /// </summary>
+        public static bool HasExtensionParameterOnType(this IMethodSymbol method)
+        {
+            return method.ContainingType.ExtensionParameter != null;
         }
     }
 }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
@@ -165,8 +165,7 @@ namespace ILLink.Shared.TrimAnalysis
 
             var damt = parameter.GetDynamicallyAccessedMemberTypes();
 
-            var parameterMethod = (IMethodSymbol)parameter.ContainingSymbol;
-            Debug.Assert(parameterMethod != null);
+            IMethodSymbol parameterMethod = param.Method.Method;
 
             // If there are conflicts between the setter and the property annotation,
             // the setter annotation wins. (But DAMT.None is ignored)
@@ -174,7 +173,9 @@ namespace ILLink.Shared.TrimAnalysis
             // Is this a property setter `value` parameter?
             if (parameterMethod!.MethodKind == MethodKind.PropertySet
                 && damt == DynamicallyAccessedMemberTypes.None
-                && parameter.Ordinal == parameterMethod.Parameters.Length - 1)
+                && parameter.Ordinal == parameterMethod.Parameters.Length - 1
+                // Do not propagate property-level DAM for C# 14 extension properties
+                && !parameterMethod.HasExtensionParameterOnType())
             {
                 var property = (IPropertySymbol)parameterMethod.AssociatedSymbol!;
                 Debug.Assert(property != null);
@@ -194,7 +195,10 @@ namespace ILLink.Shared.TrimAnalysis
             // Is this a property getter?
             // If there are conflicts between the getter and the property annotation,
             // the getter annotation wins. (But DAMT.None is ignored)
-            if (method.MethodKind is MethodKind.PropertyGet && returnDamt == DynamicallyAccessedMemberTypes.None)
+            if (method.MethodKind is MethodKind.PropertyGet
+                && returnDamt == DynamicallyAccessedMemberTypes.None
+                // Do not propagate property-level DAM for C# 14 extension properties]
+                && !method.HasExtensionParameterOnType())
             {
                 var property = (IPropertySymbol)method.AssociatedSymbol!;
                 Debug.Assert(property != null);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodParameterValue.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/MethodParameterValue.cs
@@ -9,11 +9,6 @@ namespace ILLink.Shared.TrimAnalysis
 {
     internal partial record MethodParameterValue
     {
-        public MethodParameterValue(IParameterSymbol parameterSymbol)
-            : this(new ParameterProxy(parameterSymbol)) { }
-        public MethodParameterValue(IMethodSymbol methodSymbol, ParameterIndex parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
-            : this(new(new(methodSymbol), parameterIndex), dynamicallyAccessedMemberTypes) { }
-
         public MethodParameterValue(ParameterProxy parameter)
             : this(parameter, FlowAnnotations.GetMethodParameterAnnotation(parameter)) { }
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -137,18 +137,8 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
         public override MultiValue VisitParameterReference(IParameterReferenceOperation paramRef, StateValue state)
         {
-            IParameterSymbol parameter = paramRef.Parameter;
-
-            if (parameter.ContainingSymbol is not IMethodSymbol)
-            {
-                // TODO: Extension members allows parameters to be on types, rather than methods.
-                // For example: `extension<T>(ref T value) { }` will enumerate `value` where
-                // the containing symbol is a `NonErrorNamedTypeSymbol`
-                return TopValue;
-            }
-
             // Reading from a parameter always returns the same annotated value. We don't track modifications.
-            return GetParameterTargetValue(parameter);
+            return GetParameterTargetValue(paramRef.Parameter);
         }
 
         public override MultiValue VisitInstanceReference(IInstanceReferenceOperation instanceRef, StateValue state)
@@ -162,7 +152,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             // It can also happen that we see this for a static method - for example a delegate creation
             // over a local function does this, even thought the "this" makes no sense inside a static scope.
             if (OwningSymbol is IMethodSymbol method && !method.IsStatic)
-                return new MethodParameterValue(method, (ParameterIndex)0, FlowAnnotations.GetMethodParameterAnnotation(new ParameterProxy(new(method), (ParameterIndex)0)));
+                return new MethodParameterValue(new ParameterProxy(new(method), (ParameterIndex)0));
 
             return TopValue;
         }
@@ -265,7 +255,9 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 
         public override MultiValue GetParameterTargetValue(IParameterSymbol parameter)
-            => new MethodParameterValue(parameter);
+        {
+            return new MethodParameterValue(new ParameterProxy(parameter, parameter.ContainingSymbol as IMethodSymbol ?? (IMethodSymbol)OwningSymbol));
+        }
 
         public override void HandleAssignment(MultiValue source, MultiValue target, IOperation operation, in FeatureContext featureContext)
         {

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -168,6 +168,18 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task ExtensionsDataFlow()
+        {
+            return RunTest();
+        }
+
+        [Fact]
+        public Task ExtensionMembersDataFlow()
+        {
+            return RunTest();
+        }
+
+        [Fact]
         public Task FeatureCheckDataFlow()
         {
             return RunTest();

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
@@ -110,6 +110,12 @@ namespace ILLink.RoslynAnalyzer.Tests
             CheckMember(node);
         }
 
+        public override void VisitOperatorDeclaration(OperatorDeclarationSyntax node)
+        {
+            base.VisitOperatorDeclaration(node);
+            CheckMember(node);
+        }
+
         public override void VisitEventDeclaration(EventDeclarationSyntax node)
         {
             base.VisitEventDeclaration(node);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExtensionMembersDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExtensionMembersDataFlow.cs
@@ -1,0 +1,291 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+    [SkipKeptItemsValidation]
+    [IgnoreTestCase("NativeAOT sometimes emits duplicate IL2041: https://github.com/dotnet/runtime/issues/119155", IgnoredBy = Tool.NativeAot)]
+    [ExpectedNoWarnings]
+    public class ExtensionMembersDataFlow
+    {
+        public static void Main()
+        {
+            TestExtensionMethod();
+            TestExtensionMethodMismatch();
+            TestExtensionMethodRequires();
+            TestExtensionMethodWithParams();
+            TestExtensionMethodWithParamsMismatch();
+            TestExtensionStaticMethodRequires();
+            TestExtensionMethodAnnotation();
+            TestExtensionStaticMethodAnnotation();
+            TestExtensionProperty();
+            TestExtensionPropertyMismatch();
+            TestExtensionPropertyAnnotatedAccessor();
+            TestExtensionPropertyAnnotatedAccessorMismatch();
+            TestExtensionPropertyRequires();
+            TestExtensionPropertyConflict();
+            TestExtensionOperators();
+            TestExtensionOperatorsMismatch();
+        }
+
+        static void TestExtensionMethod()
+        {
+            GetWithFields().ExtensionMembersMethod();
+        }
+
+        [ExpectedWarning("IL2072", nameof(GetWithMethods), nameof(ExtensionMembers.ExtensionMembersMethod))]
+        static void TestExtensionMethodMismatch()
+        {
+            GetWithMethods().ExtensionMembersMethodMismatch();
+        }
+
+        [ExpectedWarning("IL2026", nameof(ExtensionMembers.ExtensionMembersMethodRequires))]
+        static void TestExtensionMethodRequires()
+        {
+            GetWithFields().ExtensionMembersMethodRequires();
+        }
+
+        static void TestExtensionMethodWithParams()
+        {
+            GetWithFields().ExtensionMembersMethodWithParams(GetWithMethods());
+        }
+
+        [ExpectedWarning("IL2072", nameof(GetWithMethods), nameof(ExtensionMembers.ExtensionMembersMethodWithParams))]
+        [ExpectedWarning("IL2072", nameof(GetWithFields), nameof(ExtensionMembers.ExtensionMembersMethodWithParams))]
+        static void TestExtensionMethodWithParamsMismatch()
+        {
+            GetWithMethods().ExtensionMembersMethodWithParamsMismatch(GetWithFields());
+        }
+
+        [ExpectedWarning("IL2026", nameof(ExtensionMembers.ExtensionMembersStaticMethodRequires))]
+        static void TestExtensionStaticMethodRequires()
+        {
+            ExtensionMembers.ExtensionMembersStaticMethodRequires();
+        }
+
+        static void TestExtensionMethodAnnotation()
+        {
+            GetWithFields().ExtensionMembersMethodAnnotation();
+        }
+
+        static void TestExtensionStaticMethodAnnotation()
+        {
+            ExtensionMembers.ExtensionMembersStaticMethodAnnotation();
+        }
+
+        [ExpectedWarning("IL2072", "ExtensionMembersProperty", nameof(DataFlowTypeExtensions.RequiresPublicMethods))]
+        static void TestExtensionProperty()
+        {
+            var instance = GetWithFields();
+            instance.ExtensionMembersProperty.RequiresPublicMethods();
+            instance.ExtensionMembersProperty = GetWithMethods();
+        }
+
+        [ExpectedWarning("IL2072", nameof(GetWithMethods), "ExtensionMembersPropertyMismatch")]
+        [ExpectedWarning("IL2072", nameof(GetWithMethods), "ExtensionMembersPropertyMismatch")]
+        [ExpectedWarning("IL2072", "ExtensionMembersPropertyMismatch", nameof(DataFlowTypeExtensions.RequiresPublicFields))]
+        static void TestExtensionPropertyMismatch()
+        {
+            var instance = GetWithMethods();
+            instance.ExtensionMembersPropertyMismatch.RequiresPublicFields();
+            instance.ExtensionMembersPropertyMismatch = GetWithFields();
+        }
+
+        [UnexpectedWarning("IL2072", "ExtensionMembersPropertyAnnotatedAccessor", nameof(DataFlowTypeExtensions.RequiresPublicMethods), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/roslyn/issues/80017")]
+        static void TestExtensionPropertyAnnotatedAccessor()
+        {
+            var instance = GetWithFields();
+            instance.ExtensionMembersPropertyAnnotatedAccessor.RequiresPublicMethods();
+            instance.ExtensionMembersPropertyAnnotatedAccessor = GetWithMethods();
+        }
+
+        [ExpectedWarning("IL2072", nameof(GetWithMethods), "ExtensionMembersPropertyAnnotatedAccessorMismatch")]
+        [ExpectedWarning("IL2072", nameof(GetWithMethods), "ExtensionMembersPropertyAnnotatedAccessorMismatch")]
+        [ExpectedWarning("IL2072", "ExtensionMembersPropertyAnnotatedAccessorMismatch", nameof(DataFlowTypeExtensions.RequiresPublicFields))]
+        [ExpectedWarning("IL2072", "ExtensionMembersPropertyAnnotatedAccessorMismatch", nameof(GetWithFields))]
+        static void TestExtensionPropertyAnnotatedAccessorMismatch()
+        {
+            var instance = GetWithMethods();
+            instance.ExtensionMembersPropertyAnnotatedAccessorMismatch.RequiresPublicFields();
+            instance.ExtensionMembersPropertyAnnotatedAccessorMismatch = GetWithFields();
+        }
+
+        [ExpectedWarning("IL2026", "ExtensionMembersPropertyRequires")]
+        static void TestExtensionPropertyRequires()
+        {
+            _ = GetWithFields().ExtensionMembersPropertyRequires;
+        }
+
+        [UnexpectedWarning("IL2072", "ExtensionMembersPropertyConflict", nameof(DataFlowTypeExtensions.RequiresPublicFields), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/roslyn/issues/80017")]
+        static void TestExtensionPropertyConflict()
+        {
+            var instance = GetWithFields();
+            instance.ExtensionMembersPropertyConflict.RequiresPublicFields();
+            instance.ExtensionMembersPropertyConflict = GetWithFields();
+        }
+
+        [UnexpectedWarning("IL2072", nameof(ExtensionMembers.op_Addition), nameof(DataFlowTypeExtensions.RequiresPublicFields), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/roslyn/issues/80017")]
+        [UnexpectedWarning("IL2062", nameof(DataFlowTypeExtensions.RequiresPublicFields), Tool.Analyzer, "https://github.com/dotnet/runtime/issues/119110")]
+        static void TestExtensionOperators()
+        {
+            var a = GetWithFields();
+            var b = GetWithFields();
+            var c = a + b;
+            c.RequiresPublicFields();
+        }
+
+        [ExpectedWarning("IL2072", nameof(GetWithMethods), nameof(ExtensionMembers.op_Subtraction), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/119110")]
+        [ExpectedWarning("IL2072", nameof(GetWithMethods), nameof(ExtensionMembers.op_Subtraction), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/119110")]
+        [ExpectedWarning("IL2072", nameof(ExtensionMembers.op_Subtraction), nameof(DataFlowTypeExtensions.RequiresPublicFields), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/119110")]
+        [UnexpectedWarning("IL2062", nameof(DataFlowTypeExtensions.RequiresPublicFields), Tool.Analyzer, "https://github.com/dotnet/runtime/issues/119110")]
+        static void TestExtensionOperatorsMismatch()
+        {
+            var a = GetWithMethods();
+            var b = GetWithMethods();
+            var c = a - b;
+            c.RequiresPublicFields();
+        }
+
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        public static Type GetWithFields() => null;
+
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        public static Type GetWithMethods() => null;
+    }
+
+    [ExpectedNoWarnings]
+    public static class ExtensionMembers
+    {
+        extension([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
+        {
+            public void ExtensionMembersMethod() => type.RequiresPublicFields();
+
+            [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions.RequiresPublicMethods))]
+            public void ExtensionMembersMethodMismatch() => type.RequiresPublicMethods();
+
+            [RequiresUnreferencedCode(nameof(ExtensionMembersMethodRequires))]
+            public void ExtensionMembersMethodRequires() { }
+
+            public void ExtensionMembersMethodWithParams([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type typeParam)
+            {
+                type.RequiresPublicFields();
+                typeParam.RequiresPublicMethods();
+            }
+
+            [ExpectedWarning("IL2067", "type", nameof(DataFlowTypeExtensions.RequiresPublicMethods))]
+            [ExpectedWarning("IL2067", "typeParam", nameof(DataFlowTypeExtensions.RequiresPublicFields))]
+            public void ExtensionMembersMethodWithParamsMismatch([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type typeParam)
+            {
+                type.RequiresPublicMethods();
+                typeParam.RequiresPublicFields();
+            }
+
+            [RequiresUnreferencedCode(nameof(ExtensionMembersStaticMethodRequires))]
+            public static void ExtensionMembersStaticMethodRequires() { }
+
+            [ExpectedWarning("IL2041")]
+            [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions.RequiresPublicMethods))]
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+            public void ExtensionMembersMethodAnnotation()
+            {
+                type.RequiresPublicFields();
+                type.RequiresPublicMethods();
+            }
+
+            [ExpectedWarning("IL2041")]
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+            public static void ExtensionMembersStaticMethodAnnotation()
+            {
+            }
+
+            // Annotations on extension properties have no effect:
+            // https://github.com/dotnet/runtime/issues/119113
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+            public Type ExtensionMembersProperty
+            {
+                get => ExtensionMembersDataFlow.GetWithMethods();
+
+                [ExpectedWarning("IL2067", "value", nameof(DataFlowTypeExtensions.RequiresPublicMethods))]
+                set => value.RequiresPublicMethods();
+            }
+
+            // Annotations on extension properties have no effect:
+            // https://github.com/dotnet/runtime/issues/119113
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+            public Type ExtensionMembersPropertyMismatch
+            {
+                get => ExtensionMembersDataFlow.GetWithFields();
+
+                [ExpectedWarning("IL2067", "value", nameof(DataFlowTypeExtensions.RequiresPublicFields))]
+                set => value.RequiresPublicFields();
+            }
+
+            public Type ExtensionMembersPropertyAnnotatedAccessor
+            {
+                [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+                get => ExtensionMembersDataFlow.GetWithMethods();
+                [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+                set => value.RequiresPublicMethods();
+            }
+
+            public Type ExtensionMembersPropertyAnnotatedAccessorMismatch
+            {
+                [ExpectedWarning("IL2073", nameof(ExtensionMembersDataFlow.GetWithFields), Tool.Analyzer, "https://github.com/dotnet/roslyn/issues/80017")]
+                [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+                get => ExtensionMembersDataFlow.GetWithFields();
+
+                [ExpectedWarning("IL2067", "value", nameof(DataFlowTypeExtensions.RequiresPublicFields))]
+                [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+                set => value.RequiresPublicFields();
+            }
+
+            public Type ExtensionMembersPropertyRequires
+            {
+                [RequiresUnreferencedCode("ExtensionMembersPropertyRequires")]
+                get => null;
+            }
+
+            // Annotations on extension properties have no effect:
+            // https://github.com/dotnet/runtime/issues/119113
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+            public Type ExtensionMembersPropertyConflict
+            {
+                [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+                get => ExtensionMembersDataFlow.GetWithFields();
+
+                [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+                set => value.RequiresPublicFields();
+            }
+
+            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+            public static Type operator +(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type left,
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type right)
+            {
+                left.RequiresPublicFields();
+                right.RequiresPublicFields();
+                return ExtensionMembersDataFlow.GetWithFields();
+            }
+
+            [ExpectedWarning("IL2067", "left", nameof(DataFlowTypeExtensions.RequiresPublicMethods))] 
+            [ExpectedWarning("IL2067", "right", nameof(DataFlowTypeExtensions.RequiresPublicMethods))] 
+            [ExpectedWarning("IL2073", nameof(ExtensionMembersDataFlow.GetWithMethods), Tool.Analyzer, "https://github.com/dotnet/roslyn/issues/80017")] 
+            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+            public static Type operator -(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type left,
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type right)
+            {
+                left.RequiresPublicMethods();
+                right.RequiresPublicMethods();
+                return ExtensionMembersDataFlow.GetWithMethods();
+            }
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExtensionsDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExtensionsDataFlow.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+    [SkipKeptItemsValidation]
+    [ExpectedNoWarnings]
+    public class ExtensionsDataFlow
+    {
+        public static void Main()
+        {
+            TestExtensionMethod();
+            TestExtensionMethodMismatch();
+            TestExtensionMethodRequires();
+        }
+
+        [ExpectedWarning("IL2072", "GetWithMethods", nameof(Extensions.ExtensionMethod))]
+        static void TestExtensionMethod()
+        {
+            GetWithFields().ExtensionMethod();
+            GetWithMethods().ExtensionMethod();
+        }
+
+        static void TestExtensionMethodMismatch()
+        {
+            GetWithFields().ExtensionMethodMismatch();
+        }
+
+        [ExpectedWarning("IL2026", nameof(Extensions.ExtensionMethodRequires))]
+        static void TestExtensionMethodRequires()
+        {
+            GetWithFields().ExtensionMethodRequires();
+        }
+
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        static Type GetWithFields() => null;
+
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        static Type GetWithMethods() => null;
+    }
+
+    [ExpectedNoWarnings]
+    public static class Extensions
+    {
+        public static void ExtensionMethod([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] this Type type)
+        {
+            type.RequiresPublicFields();
+        }
+
+        [ExpectedWarning("IL2067", "RequiresPublicMethods")]
+        public static void ExtensionMethodMismatch([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] this Type type)
+        {
+            type.RequiresPublicMethods();
+        }
+
+        [RequiresUnreferencedCode(nameof(ExtensionMethodRequires))]
+        public static void ExtensionMethodRequires([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] this Type type)
+        {
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -52,8 +52,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         }
 
         // Validate the error message when annotated parameter is passed to another annotated parameter
-    [ExpectedWarning("IL2067", "'sourceType'", "PublicParameterlessConstructorParameter(Type)", "'type'", nameof(DataFlowTypeExtensions.RequiresPublicConstructors) + "(Type)")]
-    [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions) + "." + nameof(DataFlowTypeExtensions.RequiresNonPublicConstructors))]
+        [ExpectedWarning("IL2067", "'sourceType'", "PublicParameterlessConstructorParameter(Type)", "'type'", nameof(DataFlowTypeExtensions.RequiresPublicConstructors) + "(Type)")]
+        [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions) + "." + nameof(DataFlowTypeExtensions.RequiresNonPublicConstructors))]
         private static void PublicParameterlessConstructorParameter(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
             Type sourceType)
@@ -73,8 +73,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             type.RequiresNonPublicConstructors();
         }
 
-    [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions) + "." + nameof(DataFlowTypeExtensions.RequiresPublicParameterlessConstructor))]
-    [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions) + "." + nameof(DataFlowTypeExtensions.RequiresPublicConstructors))]
+        [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions) + "." + nameof(DataFlowTypeExtensions.RequiresPublicParameterlessConstructor))]
+        [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions) + "." + nameof(DataFlowTypeExtensions.RequiresPublicConstructors))]
         private static void NonPublicConstructorsParameter(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
             Type type)
@@ -84,7 +84,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             type.RequiresNonPublicConstructors();
         }
 
-    [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions) + "." + nameof(DataFlowTypeExtensions.RequiresPublicConstructors))]
+        [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions) + "." + nameof(DataFlowTypeExtensions.RequiresPublicConstructors))]
         private void InstanceMethod(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
             Type type)
@@ -161,7 +161,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         }
 
         // Validate the error message for the case of unannotated method return value passed to an annotated parameter.
-    [ExpectedWarning("IL2067", "'type'", "NoAnnotation(Type)", "'type'", nameof(DataFlowTypeExtensions.RequiresPublicParameterlessConstructor) + "(Type)")]
+        [ExpectedWarning("IL2067", "'type'", "NoAnnotation(Type)", "'type'", nameof(DataFlowTypeExtensions.RequiresPublicParameterlessConstructor) + "(Type)")]
         private void NoAnnotation(Type type)
         {
             type.RequiresPublicParameterlessConstructor();

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -909,6 +909,20 @@ namespace Mono.Linker.Tests.TestCasesRunner
             List<string> unexpectedMessageWarnings = [];
             foreach (var attrProvider in GetAttributeProviders(original))
             {
+                if (attrProvider is IMemberDefinition attrMember &&
+                    attrMember is not TypeDefinition &&
+                    attrMember.DeclaringType is TypeDefinition declaringType &&
+                    declaringType.Name.StartsWith("<G>"))
+                {
+                    // Workaround: C# 14 extension members result in a compiler-generated type
+                    // that has a member for each extension member (this is in addition to the type
+                    // which contains the actual extension member implementation).
+                    // The generated members inherit attributes from the extension members, but
+                    // have empty implementations. We don't want to check inherited ExpectedWarningAttributes
+                    // for these members.
+                    continue;
+                }
+
                 foreach (var attr in attrProvider.CustomAttributes)
                 {
                     if (!IsProducedByLinker(attr))


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/119017 to release/10.0

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Reported in https://github.com/dotnet/runtime/issues/115949 and https://github.com/dotnet/runtime/issues/118025 as an analyzer crash when analyzing code with C# 14 extension members.

A temporary fix was put in place to avoid the crash, but it did not include support for analyzing extension members. The impact is missing or unexpected warnings when adding trim annotations for extension members.

## Regression

- [ ] Yes
- [x] No

## Testing

Added testcases to cover annotations for extension members.

## Risk

Low. Analyzer-only fix. Note that it does include an update to Microsoft.CodeAnalysis, which needs to remain compatible with the version that ships with VS. Confirmed with @jkoritzinsky that this version is OK for .NET 10.