### PR TITLE
Fix unloadability issue

### DIFF
--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -405,7 +405,7 @@ LoaderAllocator * LoaderAllocator::GCLoaderAllocators_RemoveAssemblies(AppDomain
                 }
             }
         }
-#endif ENABLE_LOG_LOADER_ALLOCATOR_CLEANUP
+#endif // ENABLE_LOG_LOADER_ALLOCATOR_CLEANUP
 
         i = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(
             kIncludeExecution | kIncludeLoaded | kIncludeCollected));

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -358,45 +358,42 @@ LoaderAllocator * LoaderAllocator::GCLoaderAllocators_RemoveAssemblies(AppDomain
     // List of LoaderAllocators being deleted
     LoaderAllocator * pFirstDestroyedLoaderAllocator = NULL;
 
-#if 0
-    // Debug logic for debugging the loader allocator gc.
-    {
-        /* Iterate through every loader allocator, and print its current state */
-        AppDomain::AssemblyIterator iData;
-        iData = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(
-            kIncludeExecution | kIncludeLoaded | kIncludeCollected));
-        CollectibleAssemblyHolder<Assembly *> pAssembly;
-
-        while (iData.Next_Unlocked(pAssembly.This()))
-        {
-            if (pAssembly != NULL)
-            {
-                LoaderAllocator * pLoaderAllocator = pAssembly->GetLoaderAllocator();
-                if (pLoaderAllocator->IsCollectible())
-                {
-                    minipal_log_print_info("LA %p ReferencesTo %d\n", pLoaderAllocator, pLoaderAllocator->m_cReferences);
-                    LoaderAllocatorSet::Iterator iter = pLoaderAllocator->m_LoaderAllocatorReferences.Begin();
-                    while (iter != pLoaderAllocator->m_LoaderAllocatorReferences.End())
-                    {
-                        LoaderAllocator * pAllocator = *iter;
-                        minipal_log_print_info("LARefTo: %p\n", pAllocator);
-                        iter++;
-                    }
-                }
-            }
-        }
-    }
-#endif //0
-
     AppDomain::AssemblyIterator i;
     {
         // Iterate through every loader allocator, marking as we go
         CrstHolder chLoaderAllocatorReferencesLock(pAppDomain->GetLoaderAllocatorReferencesLock());
         CrstHolder chAssemblyListLock(pAppDomain->GetAssemblyListLock());
 
+        CollectibleAssemblyHolder<Assembly *> pAssembly;
+
+#if 0
+        // Debug logic for debugging the loader allocator gc.
+        /* Iterate through every loader allocator, and print its current state */
         i = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(
             kIncludeExecution | kIncludeLoaded | kIncludeCollected));
-        CollectibleAssemblyHolder<Assembly *> pAssembly;
+
+        while (i.Next_Unlocked(pAssembly.This()))
+        {
+            if (pAssembly != NULL)
+            {
+                LoaderAllocator * pLoaderAllocator = pAssembly->GetLoaderAllocator();
+                if (pLoaderAllocator->IsCollectible())
+                {
+                    minipal_log_print_info("LA %d(%p) ReferencesTo %d\n", pLoaderAllocator->m_nLoaderAllocator, pLoaderAllocator, pLoaderAllocator->m_cReferences.Load());
+                    LoaderAllocatorSet::Iterator iter = pLoaderAllocator->m_LoaderAllocatorReferences.Begin();
+                    while (iter != pLoaderAllocator->m_LoaderAllocatorReferences.End())
+                    {
+                        LoaderAllocator * pAllocator = *iter;
+                        minipal_log_print_info("LARefTo: %d(%p)\n", pAllocator->m_nLoaderAllocator, pAllocator);
+                        iter++;
+                    }
+                }
+            }
+        }
+#endif //0
+
+        i = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(
+            kIncludeExecution | kIncludeLoaded | kIncludeCollected));
 
         while (i.Next_Unlocked(pAssembly.This()))
         {
@@ -406,7 +403,12 @@ LoaderAllocator * LoaderAllocator::GCLoaderAllocators_RemoveAssemblies(AppDomain
                 if (pLoaderAllocator->IsCollectible())
                 {
                     if (pLoaderAllocator->IsAlive())
+                    {
+                        // This mark is a deep mark, it will mark all LoaderAllocators that this one references too (recursively),
+                        // even ones that are not alive. Note that the caller of the current function has decremented reference count
+                        // of the loader allocator we are going to release and also all of its dependencies.
                         pLoaderAllocator->Mark();
+                    }
                 }
             }
         }
@@ -514,7 +516,7 @@ void LoaderAllocator::GCLoaderAllocators(LoaderAllocator* pOriginalLoaderAllocat
     AppDomain* pAppDomain = AppDomain::GetCurrentDomain();
 
     // Collect all LoaderAllocators that don't have anymore DomainAssemblies alive
-    // Note: that it may not collect our pOriginalLoaderAllocator in case this
+    // Note: that it will not collect our pOriginalLoaderAllocator in case this
     // LoaderAllocator hasn't loaded any DomainAssembly. We handle this case in the next loop.
     // Note: The removed LoaderAllocators are not reachable outside of this function anymore, because we
     // removed them from the assembly list
@@ -550,7 +552,7 @@ void LoaderAllocator::GCLoaderAllocators(LoaderAllocator* pOriginalLoaderAllocat
         pDomainLoaderAllocatorDestroyIterator = pDomainLoaderAllocatorDestroyIterator->m_pLoaderAllocatorDestroyNext;
     }
 
-    // If the original LoaderAllocator was not processed, it is most likely a LoaderAllocator without any loaded DomainAssembly
+    // If the original LoaderAllocator was not processed, it is a LoaderAllocator without any loaded DomainAssembly
     // But we still want to collect it so we add it to the list of LoaderAllocator to destroy
     if (!isOriginalLoaderAllocatorFound && !pOriginalLoaderAllocator->IsAlive())
     {

--- a/src/coreclr/vm/loaderallocator.hpp
+++ b/src/coreclr/vm/loaderallocator.hpp
@@ -229,7 +229,7 @@ public:
     LoaderAllocatorID(LoaderAllocatorType laType=LAT_Invalid, VOID* value = 0)
     {
         m_type = laType;
-        m_pValue = 0;
+        m_pValue = value;
     };
     VOID Init();
     bool HasAttachedDynamicAssemblies()

--- a/src/coreclr/vm/loaderallocator.hpp
+++ b/src/coreclr/vm/loaderallocator.hpp
@@ -229,9 +229,17 @@ public:
     LoaderAllocatorID(LoaderAllocatorType laType=LAT_Invalid, VOID* value = 0)
     {
         m_type = laType;
-        m_pValue = value;
+        m_pValue = 0;
     };
     VOID Init();
+    bool HasAttachedDynamicAssemblies()
+    {
+        if (m_type == LAT_Assembly && m_pDomainAssembly != NULL)
+        {
+            return true;
+        }
+        return false;
+    }
     LoaderAllocatorType GetType();
     VOID AddDomainAssembly(DomainAssembly* pDomainAssembly);
     DomainAssemblyIterator GetDomainAssemblyIterator();

--- a/src/tests/Regressions/coreclr/GitHub_116953/AssemblyA.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116953/AssemblyA.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ClassA.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_116953/AssemblyB.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116953/AssemblyB.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ClassB.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="AssemblyA.csproj" />
+    <ProjectReference Include="AssemblyC.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_116953/AssemblyC.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116953/AssemblyC.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ClassC.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_116953/ClassA.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116953/ClassA.cs
@@ -1,0 +1,7 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace AssemblyA;
+
+public class ClassA
+{
+}

--- a/src/tests/Regressions/coreclr/GitHub_116953/ClassB.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116953/ClassB.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using AssemblyC;
+
+namespace AssemblyB;
+
+public class ClassB
+{
+    public string GetMessage()
+    {
+        var b = new GenericClass<AssemblyA.ClassA>();
+        var c = new ClassC();
+        return $"Hello from Assembly B! -> {c.GetMessage()} -> {b.ToString()}";
+    }
+}
+
+public class GenericClass<T>
+{
+}

--- a/src/tests/Regressions/coreclr/GitHub_116953/ClassC.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116953/ClassC.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace AssemblyC;
+
+public class ClassC
+{
+    public string GetMessage()
+    {
+        return "Hello from Assembly C!";
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_116953/test116953.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116953/test116953.cs
@@ -68,7 +68,7 @@ public class Test116953
 
         // Load assembly B (depends on assemblies A and C)
         Assembly assemblyB = LoadAssembly(alcB, "AssemblyB");
-	Log($"AssemblyB: {assemblyB}");
+            Log($"AssemblyB: {assemblyB}");
 
         // Call method in assembly B
         Log("\nTesting call to method in assembly B:");

--- a/src/tests/Regressions/coreclr/GitHub_116953/test116953.cs
+++ b/src/tests/Regressions/coreclr/GitHub_116953/test116953.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.IO;
+using System.Threading;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using Xunit;
+
+// ALC For AssemblyB
+public class AssemblyLoadContextB : AssemblyLoadContext
+{
+    public AssemblyLoadContextB(string name, bool isCollectible) : base(name, isCollectible)
+    {
+    }
+
+    protected override Assembly Load(AssemblyName assemblyName)
+    {
+        if (assemblyName.Name == "AssemblyC")
+        {
+            Test116953.Log($"AssemblyB is resolving C");
+            return Test116953.AssemblyC;
+        }
+
+        if (assemblyName.Name == "AssemblyA")
+        {
+            Test116953.Log($"AssemblyB is resolving A");
+            return Test116953.AssemblyA;
+        }
+
+        return null;
+    }
+}
+
+public class Test116953
+{
+    public static Assembly AssemblyA;
+    public static Assembly AssemblyC;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            Log($"Test #{i}");
+            RunOneTest();
+        }
+    }
+
+    private static void RunOneTest()
+    {
+        // Create three collectible ALCs
+        var alcB = new AssemblyLoadContextB("ALC_B", isCollectible: true);
+        var alcC = new AssemblyLoadContext("ALC_C", isCollectible: true);
+        var alcA = new AssemblyLoadContext("ALC_A", isCollectible: true);
+
+        // Track ALCs with weak references
+        WeakReference alcCRef = new WeakReference(alcC, trackResurrection: true);
+        WeakReference alcBRef = new WeakReference(alcB, trackResurrection: true);
+        WeakReference alcARef = new WeakReference(alcA, trackResurrection: true);
+
+        // Load assembly A
+        AssemblyA = LoadAssembly(alcA, "AssemblyA");
+
+        // Load assembly C
+        AssemblyC = LoadAssembly(alcC, "AssemblyC");
+
+        // Load assembly B (depends on assemblies A and C)
+        Assembly assemblyB = LoadAssembly(alcB, "AssemblyB");
+	Log($"AssemblyB: {assemblyB}");
+
+        // Call method in assembly B
+        Log("\nTesting call to method in assembly B:");
+        Type? typeBClass = assemblyB.GetType("AssemblyB.ClassB");
+        if (typeBClass != null)
+        {
+            object bInstance = Activator.CreateInstance(typeBClass)!;
+            string resultB = (string)typeBClass.GetMethod("GetMessage").Invoke(bInstance, null);
+            Log($"B method returns: {resultB}");
+        }
+        else
+        {
+            Log("AssemblyB.ClassB not found!");
+        }
+
+        AssemblyA = null;
+        AssemblyC = null;
+
+        // Unload the three ALCs
+        Log("\nStarting to unload ALCs...");
+
+        alcA.Unload();
+        alcC.Unload();
+        alcB.Unload();
+
+        alcA = null;
+        alcB = null;
+        alcC = null;
+
+        for (int i = 0; i < 100 && (alcARef.IsAlive || alcBRef.IsAlive || alcCRef.IsAlive); i++)
+        {
+            Thread.Sleep(1);
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Log($"ALC_A status: {(alcARef.IsAlive ? "still in memory" : "unloaded")}");
+        Log($"ALC_B status: {(alcBRef.IsAlive ? "still in memory" : "unloaded")}");
+        Log($"ALC_C status: {(alcCRef.IsAlive ? "still in memory" : "unloaded")}");
+
+        Log("Test completed");
+    }
+
+    private static Assembly LoadAssembly(AssemblyLoadContext alc, string assemblyName)
+    {
+        string assemblyDir = Assembly.GetExecutingAssembly().Location;
+        assemblyDir = Path.GetDirectoryName(assemblyDir)!;
+        return alc.LoadFromAssemblyPath(Path.Combine(assemblyDir, $"{assemblyName}.dll"));
+    }
+
+    public static void Log(string message)
+    {
+        Console.WriteLine(message);
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_116953/test116953.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_116953/test116953.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test116953.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="AssemblyA.csproj" />
+    <ProjectReference Include="AssemblyB.csproj" />
+    <ProjectReference Include="AssemblyC.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There is a rare case when attempt to unload an assembly load context in multi-assembly load context scenario leads to access violation in the runtime.

The crash is caused by a DomainAssembly pointer in the AppDomain assembly list not being removed while the DomainAssembly was deleted. The fix is to defer deletion of the DomainAssembly until after all dependencies on the LoaderAllocator have notified the runtime that they are freed. Notably, the fix is to adjust a bit of logic where we were forcing the original LoaderAllocator to be cleaned up even if it wasn't found as free-able during the GCLoaderAllocator's logic. That needed to exist to handle the case of a LoaderAllocator without any associated DomainAssembly objects, but we can special case that specific scenario.

There is a detailed analysis in the https://github.com/dotnet/runtime/issues/116953.

This change fixes it and adds a regression test that is a repro app provided in the issue converted to coreclr test.

Close https://github.com/dotnet/runtime/issues/116953