### PR TITLE
Fix missing cleanup of cached last used code heap

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -3541,12 +3541,12 @@ void EECodeGenManager::RemoveCodeHeapFromDomainList(CodeHeap *pHeap, LoaderAlloc
             {
                 pAllocator->m_pLastUsedDynamicCodeHeap = NULL;
             }
-
+#ifdef FEATURE_INTERPRETER
             if (pAllocator->m_pLastUsedInterpreterDynamicCodeHeap == ((void *) pHeapList))
             {
                 pAllocator->m_pLastUsedInterpreterDynamicCodeHeap = NULL;
             }
-
+#endif // FEATURE_INTERPRETER
             break;
         }
     }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -3542,6 +3542,11 @@ void EECodeGenManager::RemoveCodeHeapFromDomainList(CodeHeap *pHeap, LoaderAlloc
                 pAllocator->m_pLastUsedDynamicCodeHeap = NULL;
             }
 
+            if (pAllocator->m_pLastUsedInterpreterDynamicCodeHeap == ((void *) pHeapList))
+            {
+                pAllocator->m_pLastUsedInterpreterDynamicCodeHeap = NULL;
+            }
+
             break;
         }
     }


### PR DESCRIPTION
I've started to hit a problem with the interpreter when a CodeHeap pointer obtained from the m_pLastUsedInterpreterDynamicCodeHeap was invalid.
This issue is that we were missing cleanup of that cached code heap pointer when the code heap was destroyed.

This change adds the cleanup in the same way it is done for non-interpreter dynamic code heap.