### PR TITLE
JIT: fix crash in LSRA seen on VMR build on AVX-512 machines

### DIFF
--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -954,17 +954,7 @@ inline SingleTypeRegSet genSingleTypeFloatMask(regNumber reg ARM_ARG(var_types t
 inline SingleTypeRegSet genSingleTypeRegMask(regNumber reg)
 {
     assert((unsigned)reg < ArrLen(regMasks));
-#ifdef TARGET_AMD64
-    // shift is faster than a L1 hit on modern x86
-    // (L1 latency on sandy bridge is 4 cycles for [base] and 5 for [base + index*c] )
-    // the reason this is AMD-only is because the x86 BE will try to get reg masks for REG_STK
-    // and the result needs to be zero.
-    SingleTypeRegSet result = 1ULL << reg;
-    assert(result == regMasks[reg]);
-    return result;
-#else
     return regMasks[reg];
-#endif
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
During the second stage bootstrap build VMR on an AVX-512 capable machine, we end up in `try_SPILL_COST` looking at a K-reg spill candidate without an assigned interval,  and crash.

This happens because the preceding heuristic `try_REG_ORDER` fails to find a register when it should, because mask register numbers are greater than 63 and we shift 1ULL by this amount to build a mask, which is undefined behavior.

The fix is to always look up the mask via table fetch, which is set up to handle mask register numbers properly.

Fixes the crash seen in #119070.