### PR TITLE
[Mono][Browser] Fix bitwise operations in cuint64 module

### DIFF
--- a/src/mono/browser/runtime/cuint64.ts
+++ b/src/mono/browser/runtime/cuint64.ts
@@ -21,17 +21,18 @@ export function fromBigInt (x: bigint): CUInt64 {
 }
 
 export function dangerousToNumber (x: CUInt64): number {
-    return x[0] | x[1] << 32;
+    return x[0] + x[1] * 0x100000000;
 }
 
 export function fromNumber (x: number): CUInt64 {
     if (x < 0)
         throw new Error(`${x} is not a valid 64 bit integer`);
-    if ((x >> 32) > 0xFFFFFFFF)
-        throw new Error(`${x} is not a valid 64 bit integer`);
     if (Math.trunc(x) != x)
         throw new Error(`${x} is not a valid 64 bit integer`);
-    return [x & 0xFFFFFFFF, x >> 32];
+    const high = Math.floor(x / 0x100000000);
+    if (high > 0xFFFFFFFF)
+        throw new Error(`${x} is not a valid 64 bit integer`);
+    return [x & 0xFFFFFFFF, high];
 }
 
 export function pack32 (lo: number, hi: number): CUInt64 {


### PR DESCRIPTION
- Fix dangerousToNumber function: replace bitwise left shift with multiplication to avoid 32-bit overflow
- Fix fromNumber function: replace bitwise right shift with division to correctly handle numbers > 32-bit

JavaScript bitwise operators are limited to 32-bit signed integers, causing incorrect results when working with 64-bit values. This change ensures proper handling of 64-bit integers in the browser runtime.