### PR TITLE
Make the InvalidSysctl exception more descriptive

### DIFF
--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -76,7 +76,7 @@ internal static partial class Interop
         static void ThrowInvalidSysctlException(ReadOnlySpan<int> name, nint errno)
         {
             throw new InvalidOperationException(SR.Format(SR.InvalidSysctl,
-                                                          string.Join(",", name.ToArray())
+                                                          string.Join(",", name.ToArray()),
                                                           errno));
         }
     }

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -29,7 +29,7 @@ internal static partial class Interop
                 if (autoSize)
                 {
                     // do one try to see how much data we need
-                    ret = Sysctl(name, name_len, value, &bytesLength);
+                    ret = Sysctl(name_ptr, name_len, value, &bytesLength);
                     if (ret != 0)
                     {
                         ThrowInvalidSysctlException(name, Marshal.GetLastPInvokeError());
@@ -37,7 +37,7 @@ internal static partial class Interop
                     value = (byte*)NativeMemory.Alloc(bytesLength);
                 }
 
-                ret = Sysctl(name, name_len, value, &bytesLength);
+                ret = Sysctl(name_ptr, name_len, value, &bytesLength);
                 while (autoSize && ret != 0 && GetLastErrorInfo().Error == Error.ENOMEM)
                 {
                     // Do not realloc here: we don't care about

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 
-using size_t = System.IntPtr;
-
 // This implements shim for sysctl calls.
 // They are available on BSD systems - FreeBSD, OSX and others.
 // Linux has sysctl() but it is deprecated as well as it is missing sysctlbyname()
@@ -17,68 +15,69 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_Sysctl", SetLastError = true)]
-        private static unsafe partial int Sysctl(int* name, int namelen, void* value, size_t* len);
+        private static unsafe partial int Sysctl(int* name, uint namelen, void* value, nuint* len);
 
-        // This is 'raw' sysctl call, only wrapped to allocate memory if needed
-        // caller always needs to free returned buffer using  Marshal.FreeHGlobal()
-
-        internal static unsafe void Sysctl(ReadOnlySpan<int> name, ref byte* value, ref int len)
+        private static unsafe void Sysctl(ReadOnlySpan<int> name, ref byte* value, ref uint len)
         {
-            fixed (int* ptr = &MemoryMarshal.GetReference(name))
+            fixed (int* name_ptr = &MemoryMarshal.GetReference(name))
             {
-                Sysctl(ptr, name.Length, ref value, ref len);
+                uint name_len = (uint)name.Length;
+                nuint bytesLength = len;
+                int ret;
+                bool autoSize = (value == null && len == 0);
+
+                if (autoSize)
+                {
+                    // do one try to see how much data we need
+                    ret = Sysctl(name, name_len, value, &bytesLength);
+                    if (ret != 0)
+                    {
+                        ThrowInvalidSysctlException(name, Marshal.GetLastPInvokeError());
+                    }
+                    value = (byte*)NativeMemory.Alloc(bytesLength);
+                }
+
+                ret = Sysctl(name, name_len, value, &bytesLength);
+                while (autoSize && ret != 0 && GetLastErrorInfo().Error == Error.ENOMEM)
+                {
+                    // Do not realloc here: we don't care about
+                    // previous contents, and proper checking of value returned
+                    // will make code more complex.
+                    NativeMemory.Free(value);
+                    if ((int)bytesLength == int.MaxValue)
+                    {
+                        throw new OutOfMemoryException();
+                    }
+                    if ((int)bytesLength >= int.MaxValue / 2)
+                    {
+                        bytesLength = int.MaxValue;
+                    }
+                    else
+                    {
+                        bytesLength *= 2;
+                    }
+                    value = (byte*)NativeMemory.Alloc(bytesLength);
+                    ret = Sysctl(name, name_len, value, &bytesLength);
+                }
+                if (ret != 0)
+                {
+                    nint errno = Marshal.GetLastPInvokeError();
+                    if (autoSize)
+                    {
+                        NativeMemory.Free(value);
+                    }
+                    ThrowInvalidSysctlException(name, errno);
+                }
+
+                len = (uint)bytesLength;
             }
         }
 
-        private static unsafe void Sysctl(int* name, int name_len, ref byte* value, ref int len)
+        static void ThrowInvalidSysctlException(ReadOnlySpan<int> name, nint errno)
         {
-            nint bytesLength = len;
-            int ret = -1;
-            bool autoSize = (value == null && len == 0);
-
-            if (autoSize)
-            {
-                // do one try to see how much data we need
-                ret = Sysctl(name, name_len, value, &bytesLength);
-                if (ret != 0)
-                {
-                    throw new InvalidOperationException(SR.Format(SR.InvalidSysctl, *name, Marshal.GetLastPInvokeError()));
-                }
-                value = (byte*)Marshal.AllocHGlobal((int)bytesLength);
-            }
-
-            ret = Sysctl(name, name_len, value, &bytesLength);
-            while (autoSize && ret != 0 && GetLastErrorInfo().Error == Error.ENOMEM)
-            {
-                // Do not use ReAllocHGlobal() here: we don't care about
-                // previous contents, and proper checking of value returned
-                // will make code more complex.
-                Marshal.FreeHGlobal((IntPtr)value);
-                if ((int)bytesLength == int.MaxValue)
-                {
-                    throw new OutOfMemoryException();
-                }
-                if ((int)bytesLength >= int.MaxValue / 2)
-                {
-                    bytesLength = int.MaxValue;
-                }
-                else
-                {
-                    bytesLength = (int)bytesLength * 2;
-                }
-                value = (byte*)Marshal.AllocHGlobal(bytesLength);
-                ret = Sysctl(name, name_len, value, &bytesLength);
-            }
-            if (ret != 0)
-            {
-                if (autoSize)
-                {
-                    Marshal.FreeHGlobal((IntPtr)value);
-                }
-                throw new InvalidOperationException(SR.Format(SR.InvalidSysctl, *name, Marshal.GetLastPInvokeError()));
-            }
-
-            len = (int)bytesLength;
+            throw new InvalidOperationException(SR.Format(SR.InvalidSysctl,
+                                                          string.Join(",", name.ToArray())
+                                                          errno));
         }
     }
 }

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -38,7 +38,7 @@ internal static partial class Interop
                 }
 
                 ret = Sysctl(name_ptr, name_len, value, &bytesLength);
-                while (autoSize && ret != 0 && Marshal.GetLastPInvokeError() == Error.ENOMEM)
+                while (autoSize && ret != 0 && Interop.Sys.GetLastError() == Error.ENOMEM)
                 {
                     // Do not realloc here: we don't care about
                     // previous contents, and proper checking of value returned

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -71,7 +71,6 @@ internal static partial class Interop
 
                 len = (uint)bytesLength;
             }
-        }
 
             static void ThrowInvalidSysctlException(ReadOnlySpan<int> name, nint errno)
             {

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -38,7 +38,7 @@ internal static partial class Interop
                 }
 
                 ret = Sysctl(name_ptr, name_len, value, &bytesLength);
-                while (autoSize && ret != 0 && GetLastErrorInfo().Error == Error.ENOMEM)
+                while (autoSize && ret != 0 && Marshal.GetLastPInvokeError() == Error.ENOMEM)
                 {
                     // Do not realloc here: we don't care about
                     // previous contents, and proper checking of value returned

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_Sysctl", SetLastError = true)]
         private static unsafe partial int Sysctl(int* name, uint namelen, void* value, nuint* len);
 
-        private static unsafe void Sysctl(ReadOnlySpan<int> name, ref byte* value, ref uint len)
+        internal static unsafe void Sysctl(ReadOnlySpan<int> name, ref byte* value, ref uint len)
         {
             fixed (int* name_ptr = &MemoryMarshal.GetReference(name))
             {

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -73,11 +73,12 @@ internal static partial class Interop
             }
         }
 
-        static void ThrowInvalidSysctlException(ReadOnlySpan<int> name, nint errno)
-        {
-            throw new InvalidOperationException(SR.Format(SR.InvalidSysctl,
-                                                          string.Join(",", name.ToArray()),
-                                                          errno));
+            static void ThrowInvalidSysctlException(ReadOnlySpan<int> name, nint errno)
+            {
+                throw new InvalidOperationException(SR.Format(SR.InvalidSysctl,
+                                                              string.Join(",", name.ToArray()),
+                                                              errno));
+            }
         }
     }
 }

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -57,7 +57,7 @@ internal static partial class Interop
                         bytesLength *= 2;
                     }
                     value = (byte*)NativeMemory.Alloc(bytesLength);
-                    ret = Sysctl(name, name_len, value, &bytesLength);
+                    ret = Sysctl(name_ptr, name_len, value, &bytesLength);
                 }
                 if (ret != 0)
                 {

--- a/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.GetProcInfo.cs
+++ b/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.GetProcInfo.cs
@@ -191,14 +191,14 @@ internal static partial class Interop
                 [CTL_KERN, KERN_PROC, KERN_PROC_PID | (threads ? KERN_PROC_INC_THREAD : 0), pid]; // get specific process, possibly with threads
 
             byte* pBuffer = null;
-            int bytesLength = 0;
+            uint bytesLength = 0;
             Interop.Sys.Sysctl(sysctlName, ref pBuffer, ref bytesLength);
 
             kinfo_proc* kinfo = (kinfo_proc*)pBuffer;
 
             Debug.Assert(kinfo->ki_structsize == sizeof(kinfo_proc));
 
-            count = (int)bytesLength / sizeof(kinfo_proc);
+            count = (int)(bytesLength / sizeof(kinfo_proc));
 
             // Buffer ownership transferred to the caller
             return kinfo;

--- a/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.cs
+++ b/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.cs
@@ -79,12 +79,12 @@ internal static partial class Interop
         {
             ReadOnlySpan<int> sysctlName = [CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, pid];
             byte* pBuffer = null;
-            int bytesLength = 0;
+            uint bytesLength = 0;
 
             try
             {
                 Interop.Sys.Sysctl(sysctlName, ref pBuffer, ref bytesLength);
-                return System.Text.Encoding.UTF8.GetString(pBuffer, bytesLength - 1);
+                return System.Text.Encoding.UTF8.GetString(pBuffer, (int)bytesLength - 1);
             }
             finally
             {

--- a/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -331,7 +331,7 @@
     <value>Not all processes in process tree could be terminated.</value>
   </data>
   <data name="InvalidSysctl" xml:space="preserve">
-    <value>sysctl {0} failed with {1} error.</value>
+    <value>sysctl ({0}) failed with {1} error.</value>
   </data>
   <data name="InvalidPerfData" xml:space="preserve">
     <value>Invalid performance counter data with type '{0}'.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3861,7 +3861,7 @@
     <value>The returned enumerator does not implement IEnumVARIANT.</value>
   </data>
   <data name="InvalidSysctl" xml:space="preserve">
-    <value>sysctl {0} failed with {1} error.</value>
+    <value>sysctl ({0}) failed with {1} error.</value>
   </data>
   <data name="Argument_StructArrayTooLarge" xml:space="preserve">
     <value>Array size exceeds addressing limitations.</value>


### PR DESCRIPTION
The parameter being acted on by sysctl() call is determined by an arbitrarily sized array of integers called MIB. The current version of the code only prints the first element of the MIB, which isn't descriptive at all. This change tries to print 4 elements, which should be enough for most of sysctls in the wild.

While there, make type signatures of low-level functions match their C versions.

The problem was raised by a FreeBSD user:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289022