### PR TITLE
Normalizing slashes in entrynames

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.cs
@@ -106,6 +106,8 @@ namespace System.IO.Compression
 
             FileStream fs = new FileStream(sourceFileName, FileMode.Open, FileAccess.Read, FileShare.Read, ZipFile.FileStreamBufferSize, useAsync);
 
+            entryName = entryName.TrimStart('/', '\\').Replace('\\', '/');
+
             ZipArchiveEntry entry = compressionLevel.HasValue ?
                                     destination.CreateEntry(entryName, compressionLevel.Value) :
                                     destination.CreateEntry(entryName);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -388,6 +388,7 @@ namespace System.IO.Compression
 
             ThrowIfDisposed();
 
+            entryName = entryName.TrimStart('/', '\\').Replace('\\', '/');
 
             ZipArchiveEntry entry = compressionLevel.HasValue ?
                 new ZipArchiveEntry(this, entryName, compressionLevel.Value) :

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers.Binary;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO.Pipelines;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -424,7 +422,7 @@ namespace System.IO.Compression.Tests
         public void CreateEntry_NormalizesPaths()
         {
             var sourceContent = "file content";
-            var sourceBytes = System.Text.Encoding.UTF8.GetBytes(sourceContent);
+            var sourceBytes = Encoding.UTF8.GetBytes(sourceContent);
 
             using (var zipStream = new MemoryStream())
             {
@@ -432,20 +430,23 @@ namespace System.IO.Compression.Tests
                 {
                     var entry1 = archive.CreateEntry(@"dir1\dir2\file.txt");
                     using (var entryStream = entry1.Open())
+                    using (var sourceStream = new MemoryStream(sourceBytes))
                     {
-                        new MemoryStream(sourceBytes).CopyTo(entryStream);
+                        sourceStream.CopyTo(entryStream);
                     }
 
                     var entry2 = archive.CreateEntry("dirA/dirB/file.txt");
                     using (var entryStream = entry2.Open())
+                    using (var sourceStream = new MemoryStream(sourceBytes))
                     {
-                        new MemoryStream(sourceBytes).CopyTo(entryStream);
+                        sourceStream.CopyTo(entryStream);
                     }
 
                     var entry3 = archive.CreateEntry(@"dirX/dirY\file.txt");
                     using (var entryStream = entry3.Open())
+                    using (var sourceStream = new MemoryStream(sourceBytes))
                     {
-                        new MemoryStream(sourceBytes).CopyTo(entryStream);
+                        sourceStream.CopyTo(entryStream);
                     }
                 }
 


### PR DESCRIPTION
Fix ZipFileExtensions.CreateEntryFromFile writing backslashes (\) into ZipArchive entries.

Per the ZIP spec, file paths stored in the central directory MUST use forward slashes (/). Using backslashes causes interoperability issues with some tools (Java, PHP).

This change normalizes entry names to use / only when creating new entries.

Fixes #41914