### PR TITLE
Fix issues with interpreted EH

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -979,8 +979,10 @@ namespace System.Runtime
         private static void DebugVerifyHandlingFrame(UIntPtr handlingFrameSP)
         {
             Debug.Assert(handlingFrameSP != MaxSP, "Handling frame must have an SP value");
+#if !FEATURE_INTERPRETER
             Debug.Assert(((UIntPtr*)handlingFrameSP) > &handlingFrameSP,
                 "Handling frame must have a valid stack frame pointer");
+#endif
         }
 
         // Caclulate the code offset from the start of the method as if the hot and cold regions were

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -68,8 +68,9 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, GetSP());
         _ASSERTE(pRD->pCurrentContext->Rip == GetReturnAddress());
+        _ASSERTE(pRD->pCurrentContext->Rsp == GetSP());
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/arm/stubs.cpp
+++ b/src/coreclr/vm/arm/stubs.cpp
@@ -1243,7 +1243,7 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, GetSP());
         _ASSERTE(pRD->pCurrentContext->Pc == GetReturnAddress());
     }
 #endif // DACCESS_COMPILE

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -198,7 +198,7 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, GetSP());
         _ASSERTE(pRD->pCurrentContext->Pc == GetReturnAddress());
     }
 #endif // DACCESS_COMPILE

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -2233,7 +2233,9 @@ void InterpreterCodeManager::ResumeAfterCatch(CONTEXT *pContext, size_t targetSS
     }
     while (GetSP(pContext) != targetSP);
 
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
     targetSSP = pInterpreterFrame->GetInterpExecMethodSSP();
+#endif    
     ExecuteFunctionBelowContext((PCODE)ThrowResumeAfterCatchException, pContext, targetSSP, resumeSP, resumeIP);
 }
 

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -2211,53 +2211,30 @@ void InterpreterCodeManager::ResumeAfterCatch(CONTEXT *pContext, size_t targetSS
 
     ClrCaptureContext(pContext);
 
-    // Unwind to the caller of the Ex.RhThrowEx / Ex.RhThrowHwEx
-    Thread::VirtualUnwindToFirstManagedCallFrame(pContext);
+    TADDR targetSP = pInterpreterFrame->GetInterpExecMethodSP();
 
-#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
-    targetSSP = GetSSPForFrameOnCurrentStack(GetIP(pContext));
-#endif // HOST_AMD64 && HOST_WINDOWS
-
-    CONTEXT firstNativeContext;
-    size_t firstNativeSSP;
-
-    // Find the native frames chain that contains the resumeSP
+    // We are resuming in interpreter frame. So we need to skip all native, JIT and AOT generated frames until we reach
+    // the resumeSP
     do
     {
-        // Skip all managed frames upto a native frame
-        while (ExecutionManager::IsManagedCode(GetIP(pContext)))
+        if (ExecutionManager::IsManagedCode(GetIP(pContext)))
         {
+            // JIT / AOT generated managed code
             Thread::VirtualUnwindCallFrame(pContext);
-#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
-            if (targetSSP != 0)
-            {
-                targetSSP += sizeof(size_t);
-            }
-#endif
         }
-
-        // Save the first native context after managed frames. This will be the context where we throw the resume after catch exception from.
-        firstNativeContext = *pContext;
-        firstNativeSSP = targetSSP;
-        // Move over all native frames until we move over the resumeSP
-        while ((GetSP(pContext) < resumeSP) && !ExecutionManager::IsManagedCode(GetIP(pContext)))
+        else
         {
 #ifdef TARGET_UNIX
             PAL_VirtualUnwind(pContext, NULL);
 #else
             Thread::VirtualUnwindCallFrame(pContext);
 #endif
-#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
-            if (targetSSP != 0)
-            {
-                targetSSP += sizeof(size_t);
-            }
-#endif
         }
     }
-    while (GetSP(pContext) < resumeSP);
+    while (GetSP(pContext) != targetSP);
 
-    ExecuteFunctionBelowContext((PCODE)ThrowResumeAfterCatchException, &firstNativeContext, firstNativeSSP, resumeSP, resumeIP);
+    targetSSP = pInterpreterFrame->GetInterpExecMethodSSP();
+    ExecuteFunctionBelowContext((PCODE)ThrowResumeAfterCatchException, pContext, targetSSP, resumeSP, resumeIP);
 }
 
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -308,7 +308,8 @@ void ExInfo::UpdateNonvolatileRegisters(CONTEXT *pContextRecord, REGDISPLAY *pRe
     // ProcessCLRException leaves us with the original exception context. Thus we
     // rely solely on our frames and managed code unwinding. This also means that
     // if we pass through InlinedCallFrame we end up with empty context pointers.
-#if defined(TARGET_UNIX) || defined(TARGET_X86)
+    // With the interpreter enabled, we may also get NULL context pointers.
+#if defined(TARGET_UNIX) || defined(TARGET_X86) || defined(FEATURE_INTERPRETER)
 #define HANDLE_NULL_CONTEXT_POINTER
 #else // TARGET_UNIX || TARGET_X86
 #define HANDLE_NULL_CONTEXT_POINTER _ASSERTE(false)

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2505,6 +2505,7 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_SSP;
     }
+#endif // HOST_AMD64 && HOST_WINDOWS
 
     void SetInterpExecMethodSP(TADDR sp)
     {
@@ -2517,7 +2518,6 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_SP;
     }
-#endif // HOST_AMD64 && HOST_WINDOWS
 
     void SetIsFaulting(bool isFaulting)
     {

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -592,7 +592,7 @@ protected:
 
 #ifndef DACCESS_COMPILE
 #if !defined(TARGET_X86) || defined(TARGET_UNIX)
-    static void UpdateFloatingPointRegisters(const PREGDISPLAY pRD);
+    static void UpdateFloatingPointRegisters(const PREGDISPLAY pRD, TADDR targetSP);
 #endif // !TARGET_X86 || TARGET_UNIX
 #endif // DACCESS_COMPILE
 
@@ -2210,6 +2210,17 @@ public:
         return PTR_MethodDesc(*PTR_TADDR(addr));
     }
 
+#ifndef DACCESS_COMPILE
+#if !defined(TARGET_X86) || defined(TARGET_UNIX)
+    void UpdateFloatingPointRegisters(const PREGDISPLAY pRD);
+#endif // !TARGET_X86 || TARGET_UNIX
+#endif // DACCESS_COMPILE
+
+#ifdef FEATURE_INTERPRETER
+    // Check if the InlinedCallFrame is in the interpreter code
+    BOOL IsInInterpreter();
+#endif
+
     void UpdateRegDisplay_Impl(const PREGDISPLAY, bool updateFloats = false);
 
     // m_Datum contains PInvokeMethodDesc ptr or
@@ -2494,6 +2505,18 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_SSP;
     }
+
+    void SetInterpExecMethodSP(TADDR sp)
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_SP = sp;
+    }
+
+    TADDR GetInterpExecMethodSP()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_SP;
+    }
 #endif // HOST_AMD64 && HOST_WINDOWS
 
     void SetIsFaulting(bool isFaulting)
@@ -2512,6 +2535,7 @@ private:
     // Saved SSP of the InterpExecMethod for resuming after catch into interpreter frames.
     TADDR m_SSP;
 #endif // HOST_AMD64 && HOST_WINDOWS
+    TADDR m_SP;
 };
 
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -580,6 +580,9 @@ void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFr
     bool isTailcall = false;
     MethodDesc* targetMethod;
 
+    // Save the lowest SP in the current method so that we can identify it by that during stackwalk
+    pInterpreterFrame->SetInterpExecMethodSP(GetCurrentSP());
+
 MAIN_LOOP:
     try
     {
@@ -2109,6 +2112,8 @@ CALL_INTERP_METHOD:
                                 pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
                                 pChildFrame->pNext = NULL;
                                 pFrame->pNext = pChildFrame;
+                                // Save the lowest SP in the current method so that we can identify it by that during stackwalk
+                                pInterpreterFrame->SetInterpExecMethodSP(GetCurrentSP());
                             }
                             pChildFrame->ReInit(pFrame, targetIp, stack + returnOffset, stack + callArgsOffset);
                             pFrame = pChildFrame;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2717,6 +2717,8 @@ do                                                                      \
                             pChildFrame = (InterpMethodContextFrame*)alloca(sizeof(InterpMethodContextFrame));
                             pChildFrame->pNext = NULL;
                             pFrame->pNext = pChildFrame;
+                            // Save the lowest SP in the current method so that we can identify it by that during stackwalk
+                            pInterpreterFrame->SetInterpExecMethodSP((TADDR)GetCurrentSP());
                         }
                         // Set the frame to the same values as the caller frame.
                         pChildFrame->ReInit(pFrame, pFrame->startIp, pFrame->pRetVal, pFrame->pStack);

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -581,7 +581,7 @@ void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFr
     MethodDesc* targetMethod;
 
     // Save the lowest SP in the current method so that we can identify it by that during stackwalk
-    pInterpreterFrame->SetInterpExecMethodSP(GetCurrentSP());
+    pInterpreterFrame->SetInterpExecMethodSP((TADDR)GetCurrentSP());
 
 MAIN_LOOP:
     try
@@ -2113,7 +2113,7 @@ CALL_INTERP_METHOD:
                                 pChildFrame->pNext = NULL;
                                 pFrame->pNext = pChildFrame;
                                 // Save the lowest SP in the current method so that we can identify it by that during stackwalk
-                                pInterpreterFrame->SetInterpExecMethodSP(GetCurrentSP());
+                                pInterpreterFrame->SetInterpExecMethodSP((TADDR)GetCurrentSP());
                             }
                             pChildFrame->ReInit(pFrame, targetIp, stack + returnOffset, stack + callArgsOffset);
                             pFrame = pChildFrame;

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -268,7 +268,7 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, GetSP());
         _ASSERTE(pRD->pCurrentContext->Pc == GetReturnAddress());
     }
 #endif // DACCESS_COMPILE

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -222,7 +222,7 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, GetSP());
         _ASSERTE(pRD->pCurrentContext->Pc == GetReturnAddress());
     }
 #endif // DACCESS_COMPILE

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2877,11 +2877,10 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                     SyncRegDisplayToCurrentContext(pRD);
                 }
             }
-            else if (InlinedCallFrame::FrameHasActiveCall(m_crawl.pFrame) &&
-                     (m_crawl.pFrame->PtrNextFrame() != FRAME_TOP) &&
-                     (m_crawl.pFrame->PtrNextFrame()->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame))
+            else if (InlinedCallFrame::FrameHasActiveCall(m_crawl.pFrame) && ((PTR_InlinedCallFrame)m_crawl.pFrame)->IsInInterpreter())
             {
-                // There is an active inlined call frame and the next frame is the interpreter frame. This is a special case where we need to save the current context registers that the interpreter frames walking reuses.
+                // There is an active inlined call frame localed in the interpreter code. This is a special case where we need
+                // to save the current context registers that the interpreter frames walking reuses.
                 m_interpExecMethodIP = GetIP(pRD->pCurrentContext);
                 m_interpExecMethodSP = GetSP(pRD->pCurrentContext);
                 m_interpExecMethodFP = GetFP(pRD->pCurrentContext);

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -2416,25 +2416,6 @@ public class InterpreterTest
         // Test marshaling wrappers
         writeToStdout("Hello world from pinvoke.dll!writeToStdout\n");
 
-        /* fails, with output:
-            Assert failure(PID 32748 [0x00007fec], Thread: 24256 [0x5ec0]): pMD == codeInfo.GetMethodDesc()
-
-            CORECLR! AppendExceptionStackFrame + 0x331 (0x00007ff9`85879b71)
-            SYSTEM.PRIVATE.CORELIB! <no symbol> + 0x0 (0x00007ff9`80d91f30)
-            SYSTEM.PRIVATE.CORELIB! <no symbol> + 0x0 (0x00007ff9`80d926b7)
-            SYSTEM.PRIVATE.CORELIB! <no symbol> + 0x0 (0x00007ff9`80d92289)
-            CORECLR! CallDescrWorkerInternal + 0x83 (0x00007ff9`859811c3)
-            CORECLR! CallDescrWorkerWithHandler + 0x130 (0x00007ff9`854755c0)
-            CORECLR! DispatchCallSimple + 0x26C (0x00007ff9`8547655c)
-            CORECLR! DispatchManagedException + 0x388 (0x00007ff9`85872998)
-            CORECLR! DispatchManagedException + 0x67 (0x00007ff9`858725a7)
-            CORECLR! UnwindAndContinueRethrowHelperAfterCatch + 0x1F8 (0x00007ff9`851be5e8)
-            File: Z:\runtime\src\coreclr\vm\exceptionhandling.cpp:3032
-            Image: Z:\runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\corerun.exe
-
-            pMD is TestPInvoke (correct) and codeInfo.GetMethodDesc() is Main (wrong)
-        */
-        /*
         bool caught = false;
         try {
             Console.WriteLine("calling missingPInvoke");
@@ -2447,28 +2428,7 @@ public class InterpreterTest
 
         if (!caught)
             return false;
-        */
 
-        /* fails, with output:
-            calling missingPInvokeWithMarshaling
-            caught #2
-
-            Assert failure(PID 59772 [0x0000e97c], Thread: 24864 [0x6120]): ohThrowable
-
-            CORECLR! PreStubWorker$catch$10 + 0x93 (0x00007ff9`580972b3)
-            CORECLR! CallSettingFrame_LookupContinuationIndex + 0x20 (0x00007ff9`57f32e70)
-            CORECLR! _FrameHandler4::CxxCallCatchBlock + 0x1DE (0x00007ff9`57f1e83e)
-            NTDLL! RtlCaptureContext2 + 0x4A6 (0x00007ffa`b7e46606)
-            CORECLR! PreStubWorker + 0x4F8 (0x00007ff9`5789dd78)
-            CORECLR! ThePreStub + 0x55 (0x00007ff9`57ec29c5)
-            CORECLR! CallJittedMethodRetVoid + 0x14 (0x00007ff9`57ec0f34)
-            CORECLR! InvokeCompiledMethod + 0x5D7 (0x00007ff9`57afaf67)
-            CORECLR! InterpExecMethod + 0x84BB (0x00007ff9`57af68cb)
-            CORECLR! ExecuteInterpretedMethod + 0x11B (0x00007ff9`5789c77b)
-            File: Z:\runtime\src\coreclr\vm\prestub.cpp:1965
-            Image: Z:\runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\corerun.exe
-        */
-        /*
         bool caught2 = false;
         try {
             Console.WriteLine("calling missingPInvokeWithMarshaling");
@@ -2481,7 +2441,6 @@ public class InterpreterTest
 
         if (!caught2)
             return false;
-        */
 
         return true;
     }


### PR DESCRIPTION
The exception handling with interpreter enabled was not working properly when the managed code exception handling code was interpreted too. There were couple of places where we try to unwind to the first managed frame using native unwind that obviously doesn't work for fully interpreted code.
There is also an assert in the ExceptionHandling.cs that checks sanity of the handling frame SP, but it assumes that managed locals are stored on the processor stack. This is not the case for interpreted code.

This change fixes those places, namely:
* Updating floating point registers for Frames. It now unwinds upto a specific SP instead of searching for managed frame except for InlinedCallFrame case when that frame is in JIT/AOT code.
* Resuming after catch is fixed and also simplified a lot.
* Disable the sanity assert when runtime is compiled with interpreter. I don't think there is much value in that assert.

It also enables two pinvoke tests that were fixed in the past already, but not enabled yet.