### PR TITLE
Add a lock to GetNewThunksBlock

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ThunkPool.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ThunkPool.cs
@@ -294,7 +294,7 @@ namespace System.Runtime
     {
         private static IntPtr[] s_currentlyMappedThunkBlocks = new IntPtr[Constants.NumThunkBlocksPerMapping];
         private static int s_currentlyMappedThunkBlocksIndex = Constants.NumThunkBlocksPerMapping;
-        private static Lock s_lock = new Lock();
+        private static Lock s_lock = new Lock(useTrivialWaits: true);
 
         public static unsafe IntPtr GetNewThunksBlock()
         {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ThunkPool.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ThunkPool.cs
@@ -36,6 +36,7 @@
 
 using System.Diagnostics;
 using System.Numerics;
+using System.Threading;
 
 namespace System.Runtime
 {
@@ -293,9 +294,12 @@ namespace System.Runtime
     {
         private static IntPtr[] s_currentlyMappedThunkBlocks = new IntPtr[Constants.NumThunkBlocksPerMapping];
         private static int s_currentlyMappedThunkBlocksIndex = Constants.NumThunkBlocksPerMapping;
+        private static Lock s_lock = new Lock();
 
         public static unsafe IntPtr GetNewThunksBlock()
         {
+            using Lock.Scope scope = s_lock.EnterScope();
+
             IntPtr nextThunksBlock;
 
             // Check the most recently mapped thunks block. Each mapping consists of multiple


### PR DESCRIPTION
Fixes #116089.

The method accesses shared static state, locking is needed.

Cc @dotnet/ilc-contrib 