### PR TITLE
[HTTP] Stress fix for docker compose

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -63,6 +63,7 @@ extends:
             export STRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 3.0"
             mkdir -p $DUMPS_SHARE
             docker-compose up --abort-on-container-exit --no-color
+            docker-compose down
           timeoutInMinutes: 35 # In case the HTTP/3.0 run hangs, we timeout shortly after the expected 30 minute run
           displayName: Run HttpStress - HTTP 3.0
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
@@ -73,6 +74,7 @@ extends:
             export STRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 2.0"
             mkdir -p $DUMPS_SHARE
             docker-compose up --abort-on-container-exit --no-color
+            docker-compose down
           displayName: Run HttpStress - HTTP 2.0
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
@@ -82,6 +84,7 @@ extends:
             export STRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 1.1"
             mkdir -p $DUMPS_SHARE
             docker-compose up --abort-on-container-exit --no-color
+            docker-compose down
           displayName: Run HttpStress - HTTP 1.1
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -63,7 +63,6 @@ extends:
             export STRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 3.0"
             mkdir -p $DUMPS_SHARE
             docker-compose up --abort-on-container-exit --no-color
-            docker-compose down
           timeoutInMinutes: 35 # In case the HTTP/3.0 run hangs, we timeout shortly after the expected 30 minute run
           displayName: Run HttpStress - HTTP 3.0
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
@@ -73,8 +72,8 @@ extends:
             export STRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 2.0"
             export STRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 2.0"
             mkdir -p $DUMPS_SHARE
-            docker-compose up --abort-on-container-exit --no-color
             docker-compose down
+            docker-compose up --abort-on-container-exit --no-color
           displayName: Run HttpStress - HTTP 2.0
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
@@ -83,8 +82,8 @@ extends:
             export STRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 1.1"
             export STRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 1.1"
             mkdir -p $DUMPS_SHARE
-            docker-compose up --abort-on-container-exit --no-color
             docker-compose down
+            docker-compose up --abort-on-container-exit --no-color
           displayName: Run HttpStress - HTTP 1.1
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 


### PR DESCRIPTION
Wind down docker compose between individual runs in HTTP stress.

See logs for error: https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_apis/build/builds/1136356/logs/18
And test run of my branch that passed: https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_apis/build/builds/1137026/logs/17