### PR TITLE
JIT: Always remove commas while splitting

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17162,6 +17162,17 @@ bool Compiler::gtSplitTree(BasicBlock* block,
             }
 #endif
 
+            if ((*use)->OperIs(GT_COMMA))
+            {
+                // We might as well get rid of the comma while we're at it. This avoids unnecessarily nested trees and
+                // also handles splitting some irregular nodes when nested under commas
+                // (like COMMA(op1, FIELD_LIST(...))).
+                SplitOutUse(UseInfo{&(*use)->AsOp()->gtOp1, *use}, false);
+                *use = (*use)->gtGetOp2();
+                SplitOutUse(useInf, userIsReturned);
+                return;
+            }
+
             if ((*use)->OperIs(GT_FIELD_LIST, GT_INIT_VAL))
             {
                 for (GenTree** operandUse : (*use)->UseEdges())

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17170,6 +17170,7 @@ bool Compiler::gtSplitTree(BasicBlock* block,
                 SplitOutUse(UseInfo{&(*use)->AsOp()->gtOp1, *use}, false);
                 *use = (*use)->gtGetOp2();
                 SplitOutUse(useInf, userIsReturned);
+                MadeChanges = true;
                 return;
             }
 


### PR DESCRIPTION
There is no reason to keep the commas around, and for some struct IR it results in illegal IR (e.g. when splitting COMMA(op1, FIELD_LIST(...))).

Fixes an issue I hit over in #118778