### PR TITLE
[9.0] Preserve Lock ID Members

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -72,6 +72,11 @@
       <method name="GetActiveTaskFromId" />
     </type>
 
+    <type fullname="System.Threading.ThreadBlockingInfo">
+      <property name="LockOwnerManagedThreadId" />
+      <property name="LockOwnerOSThreadId" />
+    </type>
+
      <!-- methods used by hot reload -->
     <type fullname="System.Reflection.Metadata.MetadataUpdater">
       <method name="GetCapabilities" />


### PR DESCRIPTION
# Description

These members were meant to be preserved to enable utilization by other tools.

# Customer Impact

Features meant to be built on these properties don't function.

# Regression

No

# Testing

Local validation with the tooling built on these APIs.

# Risk

Low, only preserves members that were otherwise trimmed out.