### PR TITLE
Disable MSBuild console output wrapping

### DIFF
--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,2 +1,4 @@
 # disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
 -tl:false
+# disable line wrapping so that C&P from the console works well
+-clp:ForceNoAlign

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -55,7 +55,6 @@ set __BuildTypeRelease=0
 set __PgoInstrument=0
 set __PgoOptimize=0
 set __EnforcePgo=0
-set __ConsoleLoggingParameters=/clp:ForceNoAlign;Summary
 
 REM __PassThroughArgs is a set of things that will be passed through to nested calls to build.cmd
 REM when using "all".
@@ -440,7 +439,7 @@ if %__BuildNative% EQU 1 (
     set "__MsbuildWrn=/flp1:WarningsOnly;LogFile=!__BuildWrn!"
     set "__MsbuildErr=/flp2:ErrorsOnly;LogFile=!__BuildErr!"
     set "__MsbuildBinLog=/bl:!__BinLog!"
-    set "__Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr! !__MsbuildBinLog! !__ConsoleLoggingParameters!"
+    set "__Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr! !__MsbuildBinLog!"
 
     set __CmakeBuildToolArgs=
     if %__Ninja% EQU 1 (


### PR DESCRIPTION
This changes the output from:
```
  Some/long/path/that
  /gets/broken/up
```
To:
```
  Some/long/path/that/gets/broken/up
```
Leaving wrapping up to the terminal and making C&P much easier.

See also https://github.com/dotnet/msbuild/issues/10578.