### PR TITLE
ValueStringBuilder.Append("") should be a noop

### DIFF
--- a/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
+++ b/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
@@ -146,7 +146,7 @@ namespace System.Text
 
         public void Insert(int index, string? s)
         {
-            if (s == null)
+            if (s == null || s == "")
             {
                 return;
             }


### PR DESCRIPTION
This is useful for example for `string.Join`, where most people would do `string.Join("", blabla)` to join strings without any delimiter, but it has a small performance penalty compared to `string.Join(null, blabla)`