### PR TITLE
Use DllImportSearchPath.AssemblyDirectory for loading jitinterface library

### DIFF
--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -105,7 +105,7 @@ namespace System.CommandLine
                 }
 
                 string jitInterfaceLibrary = "jitinterface_" + RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-                nint libHandle = NativeLibrary.Load(jitInterfaceLibrary, System.Reflection.Assembly.GetExecutingAssembly(), DllImportSearchPath.ApplicationDirectory);
+                nint libHandle = NativeLibrary.Load(jitInterfaceLibrary, System.Reflection.Assembly.GetExecutingAssembly(), DllImportSearchPath.AssemblyDirectory);
                 int cpuFeatures;
                 unsafe
                 {


### PR DESCRIPTION
`DllImportSearchPath.ApplicationDirectory` doesn't mean anything on non-Windows. Switch to using `DllImportSearchPath.AssemblyDirectory`, which will search next to the specified assembly or next to the application for single-file applications.

See https://github.com/dotnet/runtime/issues/118999