### PR TITLE
ILLink.RoslynAnalyzer: fix hole for new constraint

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using ILLink.RoslynAnalyzer.TrimAnalysis;
+using ILLink.RoslynAnalyzer.DataFlow;
 using ILLink.Shared;
 using ILLink.Shared.TrimAnalysis;
 using ILLink.Shared.TypeSystemProxy;
@@ -143,10 +144,10 @@ namespace ILLink.RoslynAnalyzer
 
                     var typeNameResolver = new TypeNameResolver(context.Compilation);
                     if (type.BaseType is INamedTypeSymbol baseType)
-                        GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(typeNameResolver, location, baseType, context.ReportDiagnostic);
+                        GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(dataFlowAnalyzerContext, FeatureContext.None, typeNameResolver, type, location, baseType, context.ReportDiagnostic);
 
                     foreach (var interfaceType in type.Interfaces)
-                        GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(typeNameResolver, location, interfaceType, context.ReportDiagnostic);
+                        GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(dataFlowAnalyzerContext, FeatureContext.None, typeNameResolver, type, location, interfaceType, context.ReportDiagnostic);
 
                     DynamicallyAccessedMembersTypeHierarchy.ApplyDynamicallyAccessedMembersToTypeHierarchy(typeNameResolver, location, type, context.ReportDiagnostic);
                 }, SymbolKind.NamedType);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -143,11 +143,12 @@ namespace ILLink.RoslynAnalyzer
                     var location = GetPrimaryLocation(type.Locations);
 
                     var typeNameResolver = new TypeNameResolver(context.Compilation);
+                    var genericArgumentDataFlow = new GenericArgumentDataFlow(dataFlowAnalyzerContext, FeatureContext.None, typeNameResolver, type, location, context.ReportDiagnostic);
                     if (type.BaseType is INamedTypeSymbol baseType)
-                        GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(dataFlowAnalyzerContext, FeatureContext.None, typeNameResolver, type, location, baseType, context.ReportDiagnostic);
+                        genericArgumentDataFlow.ProcessGenericArgumentDataFlow(baseType);
 
                     foreach (var interfaceType in type.Interfaces)
-                        GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(dataFlowAnalyzerContext, FeatureContext.None, typeNameResolver, type, location, interfaceType, context.ReportDiagnostic);
+                        genericArgumentDataFlow.ProcessGenericArgumentDataFlow(interfaceType);
 
                     DynamicallyAccessedMembersTypeHierarchy.ApplyDynamicallyAccessedMembersToTypeHierarchy(typeNameResolver, location, type, context.ReportDiagnostic);
                 }, SymbolKind.NamedType);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -74,56 +74,6 @@ namespace ILLink.RoslynAnalyzer
                     CheckMatchingAttributesInInterfaces(symbolAnalysisContext, typeSymbol);
                 }, SymbolKind.NamedType);
 
-                context.RegisterSyntaxNodeAction(syntaxNodeAnalysisContext =>
-                {
-                    var model = syntaxNodeAnalysisContext.SemanticModel;
-                    if (syntaxNodeAnalysisContext.ContainingSymbol is not ISymbol containingSymbol || containingSymbol.IsInRequiresScope(RequiresAttributeName, out _))
-                        return;
-
-                    GenericNameSyntax genericNameSyntaxNode = (GenericNameSyntax)syntaxNodeAnalysisContext.Node;
-                    var typeParams = ImmutableArray<ITypeParameterSymbol>.Empty;
-                    var typeArgs = ImmutableArray<ITypeSymbol>.Empty;
-                    switch (model.GetSymbolInfo(genericNameSyntaxNode).Symbol)
-                    {
-                        case INamedTypeSymbol typeSymbol:
-                            typeParams = typeSymbol.TypeParameters;
-                            typeArgs = typeSymbol.TypeArguments;
-                            break;
-
-                        case IMethodSymbol methodSymbol:
-                            typeParams = methodSymbol.TypeParameters;
-                            typeArgs = methodSymbol.TypeArguments;
-                            break;
-
-                        default:
-                            return;
-                    }
-
-                    for (int i = 0; i < typeParams.Length; i++)
-                    {
-                        var typeParam = typeParams[i];
-                        var typeArg = typeArgs[i];
-                        if (!typeParam.HasConstructorConstraint ||
-                            typeArg is not INamedTypeSymbol { InstanceConstructors: { } typeArgCtors })
-                            continue;
-
-                        foreach (var instanceCtor in typeArgCtors)
-                        {
-                            if (instanceCtor.Arity > 0)
-                                continue;
-
-                            if (instanceCtor.DoesMemberRequire(RequiresAttributeName, out var requiresAttribute) &&
-                                VerifyAttributeArguments(requiresAttribute))
-                            {
-                                syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(RequiresDiagnosticRule,
-                                    syntaxNodeAnalysisContext.Node.GetLocation(),
-                                    instanceCtor.GetDisplayName(),
-                                    (string)requiresAttribute.ConstructorArguments[0].Value!,
-                                    GetUrlFromAttribute(requiresAttribute)));
-                            }
-                        }
-                    }
-                }, SyntaxKind.GenericName);
 
                 foreach (var extraSyntaxNodeAction in ExtraSyntaxNodeActions)
                     context.RegisterSyntaxNodeAction(extraSyntaxNodeAction.Action, extraSyntaxNodeAction.SyntaxKind);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
@@ -169,8 +169,11 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
         {
             foreach (var typeParameter in typeParameters)
             {
+                if (typeParameter.HasConstructorConstraint)
+                    return true;
+
                 var genericParameterValue = new GenericParameterValue(typeParameter);
-                if (genericParameterValue.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None || typeParameter.HasConstructorConstraint)
+                if (genericParameterValue.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None)
                     return true;
             }
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericArgumentDataFlow.cs
@@ -76,10 +76,13 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
                     }
                 }
 
-                // TODO: avoid duplicate warnings for new() and DAMT.PublicParameterlessConstructor.
+                var parameterRequirements = typeParameter.GetDynamicallyAccessedMemberTypes();
+                // Avoid duplicate warnings for new() and DAMT.PublicParameterlessConstructor
+                if (typeParameter.HasConstructorConstraint)
+                    parameterRequirements &= ~DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
 
                 // Apply annotations to the generic argument
-                var genericParameterValue = new GenericParameterValue(typeParameter);
+                var genericParameterValue = new GenericParameterValue(typeParameter, parameterRequirements);
                 if (context.EnableTrimAnalyzer &&
                     !owningSymbol.IsInRequiresUnreferencedCodeAttributeScope(out _) &&
                     !featureContext.IsEnabled(RequiresUnreferencedCodeAnalyzer.FullyQualifiedRequiresUnreferencedCodeAttribute) &&

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
@@ -28,6 +28,8 @@ namespace ILLink.Shared.TrimAnalysis
         private ValueSetLattice<SingleValue> _multiValueLattice;
 
         public HandleCallAction(
+            DataFlowAnalyzerContext context,
+            FeatureContext featureContext,
             TypeNameResolver typeNameResolver,
             Location location,
             ISymbol owningSymbol,
@@ -41,7 +43,7 @@ namespace ILLink.Shared.TrimAnalysis
             _diagnosticContext = new DiagnosticContext(location, reportDiagnostic);
             _annotations = FlowAnnotations.Instance;
             _reflectionAccessAnalyzer = new(reportDiagnostic, typeNameResolver, typeHierarchyType: null);
-            _requireDynamicallyAccessedMembersAction = new(typeNameResolver, location, reportDiagnostic, _reflectionAccessAnalyzer);
+            _requireDynamicallyAccessedMembersAction = new(context, featureContext, typeNameResolver, location, reportDiagnostic, _reflectionAccessAnalyzer, _owningSymbol);
             _multiValueLattice = multiValueLattice;
         }
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -51,7 +51,10 @@ namespace ILLink.Shared.TrimAnalysis
             if (_reflectionAccessAnalyzer.TryResolveTypeNameAndMark(typeName, diagnosticContext, needsAssemblyName, out ITypeSymbol? foundType))
             {
                 if (foundType is INamedTypeSymbol namedType && namedType.IsGenericType)
-                    GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(_context, _featureContext, _typeNameResolver, _owningSymbol, _location, namedType, _reportDiagnostic);
+                {
+                    var genericArgumentDataFlow = new GenericArgumentDataFlow(_context, _featureContext, _typeNameResolver, _owningSymbol, _location, _reportDiagnostic);
+                    genericArgumentDataFlow.ProcessGenericArgumentDataFlow(namedType);
+                }
 
                 type = new TypeProxy(foundType);
                 return true;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -7,8 +7,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis;
 using ILLink.RoslynAnalyzer.TrimAnalysis;
+using ILLink.RoslynAnalyzer.DataFlow;
 using ILLink.Shared.TypeSystemProxy;
 using System.Collections.Immutable;
+using ILLink.RoslynAnalyzer;
 
 namespace ILLink.Shared.TrimAnalysis
 {
@@ -18,19 +20,28 @@ namespace ILLink.Shared.TrimAnalysis
         readonly Action<Diagnostic>? _reportDiagnostic;
         readonly ReflectionAccessAnalyzer _reflectionAccessAnalyzer;
         readonly TypeNameResolver _typeNameResolver;
+        readonly ISymbol _owningSymbol;
+        readonly DataFlowAnalyzerContext _context;
+        readonly FeatureContext _featureContext;
 #pragma warning disable CA1822 // Mark members as static - the other partial implementations might need to be instance methods
 #pragma warning disable IDE0060 // Unused parameters - should be removed once methods are actually implemented
 
         public RequireDynamicallyAccessedMembersAction(
+            DataFlowAnalyzerContext context,
+            FeatureContext featureContext,
             TypeNameResolver typeNameResolver,
             Location location,
             Action<Diagnostic>? reportDiagnostic,
-            ReflectionAccessAnalyzer reflectionAccessAnalyzer)
+            ReflectionAccessAnalyzer reflectionAccessAnalyzer,
+            ISymbol owningSymbol)
         {
+            _context = context;
+            _featureContext = featureContext;
             _typeNameResolver = typeNameResolver;
             _location = location;
             _reportDiagnostic = reportDiagnostic;
             _reflectionAccessAnalyzer = reflectionAccessAnalyzer;
+            _owningSymbol = owningSymbol;
             _diagnosticContext = new(location, reportDiagnostic);
         }
 
@@ -40,7 +51,7 @@ namespace ILLink.Shared.TrimAnalysis
             if (_reflectionAccessAnalyzer.TryResolveTypeNameAndMark(typeName, diagnosticContext, needsAssemblyName, out ITypeSymbol? foundType))
             {
                 if (foundType is INamedTypeSymbol namedType && namedType.IsGenericType)
-                    GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(_typeNameResolver, _location, namedType, _reportDiagnostic);
+                    GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(_context, _featureContext, _typeNameResolver, _owningSymbol, _location, namedType, _reportDiagnostic);
 
                 type = new TypeProxy(foundType);
                 return true;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
@@ -70,7 +70,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
                         var typeNameResolver = new TypeNameResolver(context.Compilation);
                         var reflectionAccessAnalyzer = new ReflectionAccessAnalyzer(reportDiagnostic, typeNameResolver, typeHierarchyType: null);
-                        var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction(typeNameResolver, location, reportDiagnostic, reflectionAccessAnalyzer);
+                        var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction(context, FeatureContext, typeNameResolver, location, reportDiagnostic, reflectionAccessAnalyzer, OwningSymbol);
                         requireDynamicallyAccessedMembersAction.Invoke(sourceValue, targetWithDynamicallyAccessedMembers);
                     }
                 }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisGenericInstantiationPattern.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisGenericInstantiationPattern.cs
@@ -49,19 +49,20 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
         {
             var location = Operation.Syntax.GetLocation();
             var typeNameResolver = new TypeNameResolver(context.Compilation);
+            var genericArgumentDataFlow = new GenericArgumentDataFlow(context, FeatureContext, typeNameResolver, OwningSymbol, location, reportDiagnostic);
 
             switch (GenericInstantiation)
             {
                 case INamedTypeSymbol type:
-                    GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(context, FeatureContext, typeNameResolver, OwningSymbol, location, type, reportDiagnostic);
+                    genericArgumentDataFlow.ProcessGenericArgumentDataFlow(type);
                     break;
 
                 case IMethodSymbol method:
-                    GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(context, FeatureContext, typeNameResolver, OwningSymbol, location, method, reportDiagnostic);
+                    genericArgumentDataFlow.ProcessGenericArgumentDataFlow(method);
                     break;
 
                 case IFieldSymbol field:
-                    GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(context, FeatureContext, typeNameResolver, OwningSymbol, location, field, reportDiagnostic);
+                    genericArgumentDataFlow.ProcessGenericArgumentDataFlow(field);
                     break;
             }
         }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
@@ -83,7 +83,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
                 !FeatureContext.IsEnabled(RequiresUnreferencedCodeAnalyzer.FullyQualifiedRequiresUnreferencedCodeAttribute))
             {
                 var typeNameResolver = new TypeNameResolver(context.Compilation);
-                TrimAnalysisVisitor.HandleCall(typeNameResolver, Operation, OwningSymbol, CalledMethod, Instance, Arguments, location, reportDiagnostic, default, out var _);
+                TrimAnalysisVisitor.HandleCall(context, FeatureContext, typeNameResolver, Operation, OwningSymbol, CalledMethod, Instance, Arguments, location, reportDiagnostic, default, out var _);
             }
             // For Requires, make the location the reference to the method, not the entire invocation.
             // The parameters are not part of the issue, and including them in the location can be misleading.

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -1407,8 +1407,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
             [ExpectedWarning("IL2026", "ClassWithRequires()", "--ClassWithRequires--")]
             class ClassWithWarningOnGenericArgumentConstructor : RequiresNew<ClassWithRequires>
             {
-                // Analyzer misses warning for implicit call to the base constructor, because the new constraint is not checked in dataflow.
-                [ExpectedWarning("IL2026", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/108507")]
+                [ExpectedWarning("IL2026", "--ClassWithRequires--")]
                 public ClassWithWarningOnGenericArgumentConstructor()
                 {
                 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -1347,6 +1347,10 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
             {
             }
 
+            class RequiresNewAndConstructors<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> where T : new()
+            {
+            }
+
             [RequiresUnreferencedCode("--ClassWithRequires--")]
             public class ClassWithRequires
             {
@@ -1413,6 +1417,17 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
                 }
             }
 
+            [ExpectedWarning("IL2026", "ClassWithRequires()", "--ClassWithRequires--")]
+            [ExpectedWarning("IL2026", "ClassWithRequires()", "--ClassWithRequires--", Tool.Trimmer, "https://github.com/dotnet/runtime/issues/119290")]
+            class ClassWithWarningOnGenericArgumentConstructor_NewAndAnnotation : RequiresNewAndConstructors<ClassWithRequires>
+            {
+                [ExpectedWarning("IL2026", "--ClassWithRequires--")]
+                [ExpectedWarning("IL2026", "--ClassWithRequires--", Tool.Trimmer, "https://github.com/dotnet/runtime/issues/119290")]
+                public ClassWithWarningOnGenericArgumentConstructor_NewAndAnnotation()
+                {
+                }
+            }
+
             [UnexpectedWarning("IL2026", Tool.All, "https://github.com/dotnet/runtime/issues/108507")]
             [RequiresUnreferencedCode("--ClassWithWarningOnGenericArgumentConstructorWithRequires--")]
             class ClassWithWarningOnGenericArgumentConstructorWithRequires : RequiresNew<ClassWithRequires>
@@ -1448,8 +1463,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
                 var g = new GenericClassWithWarningWithRequires<int>();
                 var h = new ClassWithWarningWithRequires();
                 var j = new ClassWithWarningOnGenericArgumentConstructor();
-                var k = new ClassWithWarningOnGenericArgumentConstructorWithRequires();
-                var l = new GenericAnnotatedWithWarningWithRequires<int>();
+                var k = new ClassWithWarningOnGenericArgumentConstructor_NewAndAnnotation();
+                var l = new ClassWithWarningOnGenericArgumentConstructorWithRequires();
+                var m = new GenericAnnotatedWithWarningWithRequires<int>();
             }
         }
 


### PR DESCRIPTION
The new constraint processing was happening in a separate code path from the other generic argument processing, and that code path didn't see the implicit call to the base ctor (because it didn't use the IOperation tree). This fixes it by moving the new constraint processing into `GenericArgumentDataFlow`.

Unlike ILC, the analyzer can't just treat `new()` the same as `PublicParameterlessConstructors`, because it needs to produce analysis warnings for `RequiresDynamicCode` or `RequiresAssemblyFiles` accessed via `new()` constraint, even when trim analysis is disabled (the annotation is treated as reflection access, but `new()` is not).

Fixes https://github.com/dotnet/runtime/issues/118869