### PR TITLE
Fix System.Net.Http.Functional.Tests.*.NoCallback_RevokedCertificate_RevocationChecking_Fails

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ServerCertificates.cs
@@ -246,6 +246,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task NoCallback_RevokedCertificate_RevocationChecking_Fails()
         {
             HttpClientHandler handler = CreateHttpClientHandler();
+            handler.CheckCertificateRevocationList = true;
             using (HttpClient client = CreateHttpClient(handler))
             {
                 await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(Configuration.Http.RevokedCertRemoteServer));


### PR DESCRIPTION
Adds back change that was missed in #118456.