### PR TITLE
Add explanation for DeflateStream byte differences

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -11,6 +11,14 @@ using static System.IO.Compression.ZLibNative;
 
 namespace System.IO.Compression
 {
+    /// <remarks>
+    /// The exact compressed byte sequence returned by DeflateStream can vary
+    /// between.NET releases, platforms, or underlying compression engines.
+    /// Changes in zlib versions, algorithm tweaks, or performance optimizations
+    /// may produce different outputs for the same input data.
+    /// Despite these variations, any data compressed by DeflateStream
+    /// can always be decompressed to its original form without loss.
+    /// </remarks>
     public partial class DeflateStream : Stream
     {
         private const int DefaultBufferSize = 8192;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -13,7 +13,7 @@ namespace System.IO.Compression
 {
     /// <remarks>
     /// The exact compressed byte sequence returned by DeflateStream can vary
-    /// between.NET releases, platforms, or underlying compression engines.
+    /// between .NET releases, platforms, or underlying compression engines.
     /// Changes in zlib versions, algorithm tweaks, or performance optimizations
     /// may produce different outputs for the same input data.
     /// Despite these variations, any data compressed by DeflateStream


### PR DESCRIPTION
Small documentation update to explain possible differences in deflate stream byte sequence on different .net versions or operating systems.

Fixes #81043