### PR TITLE
[RISC-V] Always report call target in range

### DIFF
--- a/src/coreclr/jit/lowerriscv64.cpp
+++ b/src/coreclr/jit/lowerriscv64.cpp
@@ -38,8 +38,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 //
 bool Lowering::IsCallTargetInRange(void* addr)
 {
-    // TODO-RISCV64: using B/BL for optimization.
-    return false;
+    return true;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
`auipc + jalr` instruction combo has 32-bit range. Further calls are kept absolute by the same condition as x64:

https://github.com/dotnet/runtime/blob/a6740f49b59afca0dd1d1b2b6c8bdd01ece1fb88/src/coreclr/jit/lower.cpp#L6866-L6876

Part of #84834, cc @dotnet/samsung