### PR TITLE
Update `.editorconfig` to specify `indent_size` for `.json` files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -183,8 +183,8 @@ indent_size = 2
 [*.{props,targets,config,nuspec}]
 indent_size = 2
 
-# YAML config files
-[*.{yml,yaml}]
+# Data serialization
+[*.{json,yaml,yml}]
 indent_size = 2
 
 # Shell scripts


### PR DESCRIPTION
The default settings specify an `indent_size` of `4`, however most `.json` files in the repository use `2`.