### PR TITLE
Limit doublemapper maximum size

### DIFF
--- a/src/coreclr/minipal/Unix/doublemapping.cpp
+++ b/src/coreclr/minipal/Unix/doublemapping.cpp
@@ -82,7 +82,7 @@ bool VMToOSInterface::CreateDoubleMemoryMapper(void** pHandle, size_t *pMaxExecu
         return false;
     }
 #endif
-    off_t maxDoubleMappedMemorySize = MaxDoubleMappedSize;
+    uint64_t maxDoubleMappedMemorySize = MaxDoubleMappedSize;
     
     // Set the maximum double mapped memory size to the size of the physical memory
     long pages = sysconf(_SC_PHYS_PAGES);
@@ -91,7 +91,7 @@ bool VMToOSInterface::CreateDoubleMemoryMapper(void** pHandle, size_t *pMaxExecu
         long pageSize = sysconf(_SC_PAGE_SIZE);
         if (pageSize != -1)
         {
-            long physicalMemorySize = (long)pages * pageSize;
+            uint64_t physicalMemorySize = (uint64_t)pages * pageSize;
             if (maxDoubleMappedMemorySize > physicalMemorySize)
             {
                 maxDoubleMappedMemorySize = physicalMemorySize;


### PR DESCRIPTION
The double mapping currently sets the maximum size of the double mapped memory to 2TB. However, that causes the runtime to fail to start if there is a rlimit for max file size set to a smaller value.

This change fixed the problem by clipping the max double mapped memory size by that rlimit and also uses much more conservative size even without the file size limit set. It is now set to the total amount of physical memory by default and also clipped by the virtual memory rlimit.

Close #117819