### PR TITLE
[WASI] Continuable WASI SDK download using `curl` on Windows

### DIFF
--- a/eng/AcquireWasiSdk.targets
+++ b/eng/AcquireWasiSdk.targets
@@ -37,7 +37,7 @@
     <RemoveDir Directories="$(_RuntimeLocalWasiSdkPath)" />
     <MakeDir Directories="$(_RuntimeLocalWasiSdkPath)" />
 
-    <Exec Command="curl -L -o wasi-sdk-$(_WasiSdkVersion).tar.gz $(_WasiSdkUrl) &amp;&amp; tar --strip-components=1 -xzmf wasi-sdk-$(_WasiSdkVersion).tar.gz -C $(_RuntimeLocalWasiSdkPath)"
+    <Exec Command="curl --silent -L -o wasi-sdk-$(_WasiSdkVersion).tar.gz $(_WasiSdkUrl) &amp;&amp; tar --strip-components=1 -xzmf wasi-sdk-$(_WasiSdkVersion).tar.gz -C $(_RuntimeLocalWasiSdkPath)"
           Condition="'$(HostOS)' != 'windows'"
           WorkingDirectory="$(ArtifactsObjDir)"
           IgnoreStandardErrorWarningFormat="true" />

--- a/eng/download-wasi-sdk.ps1
+++ b/eng/download-wasi-sdk.ps1
@@ -13,7 +13,7 @@ $ProgressPreference = 'SilentlyContinue'
 $ContinueArgs = @()
 for ($i = 0; $i -lt 8; $i++)
 {
-    curl.exe -L -o wasi-sdk-$WasiSdkVersion-x86_64-windows.tar.gz $WasiSdkUrl @ContinueArgs
+    curl.exe --silent -L -o wasi-sdk-$WasiSdkVersion-x86_64-windows.tar.gz $WasiSdkUrl @ContinueArgs
     if ($LastExitCode -eq 0)
     {
         break;

--- a/eng/download-wasi-sdk.ps1
+++ b/eng/download-wasi-sdk.ps1
@@ -8,9 +8,23 @@ param(
 )
 
 Set-StrictMode -version 2.0
-$ErrorActionPreference='Stop'
 $ProgressPreference = 'SilentlyContinue'
 
-Invoke-WebRequest -Uri $WasiSdkUrl -OutFile ./wasi-sdk-$WasiSdkVersion-x86_64-windows.tar.gz
+$ContinueArgs = @()
+for ($i = 0; $i -lt 8; $i++)
+{
+    curl.exe -L -o wasi-sdk-$WasiSdkVersion-x86_64-windows.tar.gz $WasiSdkUrl @ContinueArgs
+    if ($LastExitCode -eq 0)
+    {
+        break;
+    }
+    if ($LastExitCode -ne 18) # "end of response with <number> bytes missing"
+    {
+        exit $LastExitCode
+    }
+    $ContinueArgs = "--continue-at", "-"
+}
+
+$ErrorActionPreference='Stop'
 tar --strip-components=1 -xzmf ./wasi-sdk-$WasiSdkVersion-x86_64-windows.tar.gz -C $WasiSdkPath
 Remove-Item ./wasi-sdk-$WasiSdkVersion-x86_64-windows.tar.gz -fo

--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -213,6 +213,8 @@ jobs:
       include:
       - eng/Version.Details.xml
       - eng/Versions.props
+      - eng/AcquireWasiSdk.targets
+      - eng/download-wasi-sdk.ps1
       - eng/testing/scenarios/BuildWasiAppsJobsList.txt
       - eng/testing/scenarios/BuildWasmAppsJobsList.txt
       - eng/testing/tests.browser.targets


### PR DESCRIPTION
See discussion here: https://github.com/dotnet/runtime/pull/119253#discussion_r2318551771.

Tested locally to indeed resolve the corruption/partial download issue.