### PR TITLE
JIT: Handle more unsupported argument conversion cases

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1562,8 +1562,6 @@ void Lowering::LowerArg(GenTreeCall* call, CallArg* callArg)
 
     if (varTypeIsLong(arg))
     {
-        assert(callArg->AbiInfo.CountRegsAndStackSlots() == 2);
-
         noway_assert(arg->OperIs(GT_LONG));
         GenTreeFieldList* fieldList = new (comp, GT_FIELD_LIST) GenTreeFieldList();
         fieldList->AddFieldLIR(comp, arg->gtGetOp1(), 0, TYP_INT);
@@ -5177,11 +5175,13 @@ bool Lowering::IsFieldListCompatibleWithRegisters(GenTreeFieldList*   fieldList,
                 return false;
             }
 
-            // All SIMDs insertions are not yet supported
-            if (varTypeIsSIMD(regType) && ((fieldStart != regStart) || (fieldEnd != regEnd)))
+            // int -> float is currently only supported if we can do it as a single bitcast (i.e. without insertions
+            // required)
+            if (varTypeUsesIntReg(use->GetNode()) && varTypeUsesFloatReg(regType) &&
+                (genTypeSize(regType) > TARGET_POINTER_SIZE))
             {
-                JITDUMP("it is not; field [%06u] requires an insertion into SIMD register %u\n",
-                        Compiler::dspTreeID(use->GetNode()), i);
+                JITDUMP("it is not; field [%06u] requires an insertion into float register %u of size %d\n",
+                        Compiler::dspTreeID(use->GetNode()), i, genTypeSize(regType));
                 return false;
             }
 


### PR DESCRIPTION
On 32-bit platforms we can end up with long operands to a function taking a parameter in a double register. We would try to create bitcasts for this case, which is not supported for 32 bit.

Generalize a condition to properly detect this unsupported case.

Fix #119062