### PR TITLE
Disable MSBuild wrapping more thoroughly

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -340,6 +340,8 @@ if ($env:TreatWarningsAsErrors -eq 'false') {
 
 # disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
 $arguments += " /tl:false"
+# disable line wrapping so that C&P from the console works well
+$arguments += " /clp:ForceNoAlign"
 
 # Disable targeting pack caching as we reference a partially constructed targeting pack and update it later.
 # The later changes are ignored when using the cache.

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -571,6 +571,8 @@ fi
 
 # disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
 arguments+=("-tl:false")
+# disable line wrapping so that C&P from the console works well
+arguments+=("-clp:ForceNoAlign")
 
 initDistroRid "$os" "$arch" "$crossBuild"
 


### PR DESCRIPTION
It turns out that https://github.com/dotnet/runtime/pull/119282 is not enough to disable the wrapping when invoking the top-level `./build.[cmd|sh]` script (it works as expected when `dotnet build`ing projects manually).

Why?

Because the top-level build uses a project from the Nuget cache, outside of the runtime source tree.
<details>
<summary>Example command line</summary>

```
"C:\Users\Accretion\source\dotnet\runtime\.dotnet\dotnet.exe" msbuild /m /nologo /clp:Summary /v:minimal /nr:True /p:ContinuousIntegrationBuild=False /p:TreatWarningsAsErrors=false "C:\Users\Accretion\.nuget\packages\microsoft.dotnet.arcade.sdk\10.0.0-beta.25420.121\tools\Build.proj" "/p:Configuration=Debug" "/p:RepoRoot=C:\Users\Accretion\source\dotnet\runtime\\" "/p:Restore=True" "/p:DeployDeps=False" "/p:Build=True" "/p:Rebuild=False" "/p:Deploy=False" "/p:Test=False" "/p:Pack=False" "/p:DotNetBuild=False" "/p:DotNetBuildFromVMR=False" "/p:IntegrationTest=False" "/p:PerformanceTest=False" "/p:Sign=False" "/p:Publish=False" "/p:RestoreStaticGraphEnableBinaryLogger=False" "/p:TargetArchitecture=wasm" "/p:TargetOS=browser" "/p:Ninja=false" "/p:subset=libs.native" "/tl:false"
```
</details>