### PR TITLE
Allow disabling runtime versions via an environment variable

### DIFF
--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolution.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolution.cs
@@ -104,6 +104,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         }
 
         [Theory]
+        [InlineData("6.1.0", "", "6.1.3")]      // Roll forward to 6.1.3 - empty value has no effect on resolution
+        [InlineData("6.1.0", "   ", "6.1.3")]   // Roll forward to 6.1.3 - whitespace value has no effect on resolution
         [InlineData("6.1.0", "6.1.2", "6.1.3")] // Roll forward to 6.1.3 when 6.1.2 is disabled
         [InlineData("6.1.0", "6.1.3", "6.1.2")] // Roll forward to 6.1.2 when 6.1.3 is disabled
         [InlineData("6.1.3", "6.1.3", ResolvedFramework.NotFound)] // Fail when the only matching version is disabled
@@ -115,8 +117,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithRuntimeConfigCustomizer(rc => rc.WithFramework(MicrosoftNETCoreApp, requestedVersion))
                     .WithEnvironment(Constants.DisableRuntimeVersions.EnvironmentVariable, disabledVersion));
 
-            result.ShouldHaveResolvedFrameworkOrFailToFind(MicrosoftNETCoreApp, expectedResolution)
-                .And.HaveStdErrContaining($"Ignoring disabled version [{disabledVersion}]");
+            result.ShouldHaveResolvedFrameworkOrFailToFind(MicrosoftNETCoreApp, expectedResolution);
+            if (string.IsNullOrWhiteSpace(disabledVersion))
+            {
+                result.Should().NotHaveStdErrContaining($"Ignoring disabled version");
+            }
+            else
+            { 
+                result.Should().HaveStdErrContaining($"Ignoring disabled version [{disabledVersion}]");
+            }
         }
 
         [Fact]

--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -241,6 +241,22 @@ namespace HostActivation.Tests
                 .And.HaveStdOut(expectedOutput);
         }
 
+        [Fact]
+        public void ListRuntimes_DisabledVersions()
+        {
+            // Verify exact match of command output. The output of --list-runtimes is intended to be machine-readable
+            // and must not change in a way that breaks existing parsing.
+            string disabledVersion = SharedState.InstalledVersions[0];
+            string[] expectedVersions = SharedState.InstalledVersions[1..];
+            string expectedOutput = GetListRuntimesOutput(SharedState.DotNet.BinPath, expectedVersions);
+            SharedState.DotNet.Exec("--list-runtimes")
+                .CaptureStdOut()
+                .EnvironmentVariable(Constants.DisableRuntimeVersions.EnvironmentVariable, disabledVersion)
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOut(expectedOutput);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/installer/tests/TestUtils/Constants.cs
+++ b/src/installer/tests/TestUtils/Constants.cs
@@ -35,6 +35,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
             public const string Disable = "Disable";
         }
 
+        public static class DisableRuntimeVersions
+        {
+            public const string EnvironmentVariable = "DOTNET_DISABLE_RUNTIME_VERSIONS";
+        }
+
         public static class FxVersion
         {
             public const string CommandLineArgument = "--fx-version";

--- a/src/native/corehost/fxr/framework_info.cpp
+++ b/src/native/corehost/fxr/framework_info.cpp
@@ -37,6 +37,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
     const pal::string_t& dotnet_dir,
     const pal::char_t* fx_name,
     bool disable_multilevel_lookup,
+    bool include_disabled_versions,
     std::vector<framework_info>* framework_infos)
 {
     std::vector<pal::string_t> hive_dir;
@@ -94,7 +95,8 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
                     continue;
                 }
 
-                if (std::find(disabled_versions.begin(), disabled_versions.end(), ver) != disabled_versions.end())
+                bool is_disabled = std::find(disabled_versions.begin(), disabled_versions.end(), ver) != disabled_versions.end();
+                if (is_disabled && !include_disabled_versions)
                 {
                     trace::verbose(_X("Ignoring disabled version [%s]"), ver.c_str());
                     continue;
@@ -102,7 +104,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
 
                 trace::verbose(_X("Found FX version [%s]"), ver.c_str());
 
-                framework_info info(fx_name_local, fx_dir, parsed, hive_depth);
+                framework_info info(fx_name_local, fx_dir, parsed, hive_depth, is_disabled);
                 framework_infos->push_back(info);
             }
         }
@@ -118,7 +120,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
     assert(leading_whitespace != nullptr);
 
     std::vector<framework_info> framework_infos;
-    get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, &framework_infos);
+    get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, /*include_disabled_versions*/ false, &framework_infos);
     for (framework_info info : framework_infos)
     {
         trace::println(_X("%s%s %s [%s]"), leading_whitespace, info.name.c_str(), info.version.as_str().c_str(), info.path.c_str());

--- a/src/native/corehost/fxr/framework_info.cpp
+++ b/src/native/corehost/fxr/framework_info.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include "framework_info.h"
+#include "fx_resolver.h"
 #include "pal.h"
 #include "trace.h"
 #include "utils.h"
@@ -41,8 +42,9 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
     std::vector<pal::string_t> hive_dir;
     get_framework_locations(dotnet_dir, disable_multilevel_lookup, &hive_dir);
 
-    int32_t hive_depth = 0;
+    std::vector<pal::string_t> disabled_versions = fx_resolver_t::get_disabled_versions();
 
+    int32_t hive_depth = 0;
     for (const pal::string_t& dir : hive_dir)
     {
         auto fx_shared_dir = dir;
@@ -89,6 +91,12 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
                 if (!file_exists_in_dir(fx_version_dir, deps_file_name.c_str(), nullptr))
                 {
                     trace::verbose(_X("Ignoring FX version [%s] without .deps.json"), ver.c_str());
+                    continue;
+                }
+
+                if (std::find(disabled_versions.begin(), disabled_versions.end(), ver) != disabled_versions.end())
+                {
+                    trace::verbose(_X("Ignoring disabled version [%s]"), ver.c_str());
                     continue;
                 }
 

--- a/src/native/corehost/fxr/framework_info.h
+++ b/src/native/corehost/fxr/framework_info.h
@@ -9,16 +9,19 @@
 
 struct framework_info
 {
-    framework_info(pal::string_t name, pal::string_t path, fx_ver_t version, int32_t hive_depth)
+    framework_info(pal::string_t name, pal::string_t path, fx_ver_t version, int32_t hive_depth, bool disabled)
         : name(name)
         , path(path)
         , version(version)
-        , hive_depth(hive_depth) { }
+        , hive_depth(hive_depth)
+        , disabled(disabled)
+    { }
 
     static void get_all_framework_infos(
         const pal::string_t& dotnet_dir,
         const pal::char_t* fx_name,
         bool disable_multilevel_lookup,
+        bool include_disabled_versions,
         std::vector<framework_info>* framework_infos);
 
     static bool print_all_frameworks(const pal::string_t& dotnet_dir, const pal::char_t* leading_whitespace);
@@ -27,6 +30,7 @@ struct framework_info
     pal::string_t path;
     fx_ver_t version;
     int32_t hive_depth;
+    bool disabled;
 };
 
 #endif // __FRAMEWORK_INFO_H_

--- a/src/native/corehost/fxr/fx_resolver.cpp
+++ b/src/native/corehost/fxr/fx_resolver.cpp
@@ -332,19 +332,17 @@ std::vector<pal::string_t> fx_resolver_t::get_disabled_versions()
     size_t pos = 0;
     while ((pos = env_var.find(_X(';'), start)) != pal::string_t::npos)
     {
-        pal::string_t version = env_var.substr(start, pos - start);
-        if (!version.empty())
+        if (pos > start)
         {
-            disabled_versions.push_back(version);
+            disabled_versions.emplace_back(env_var, start, pos - start);
         }
         start = pos + 1;
     }
 
     // Add the last version (after the last semicolon or the only version if no semicolons)
-    pal::string_t last_version = env_var.substr(start);
-    if (!last_version.empty())
+    if (start < env_var.size())
     {
-        disabled_versions.push_back(last_version);
+        disabled_versions.emplace_back(env_var, start, env_var.size() - start);
     }
 
     return disabled_versions;

--- a/src/native/corehost/fxr/fx_resolver.cpp
+++ b/src/native/corehost/fxr/fx_resolver.cpp
@@ -188,7 +188,8 @@ namespace
         const fx_reference_t & fx_ref,
         const pal::string_t & oldest_requested_version,
         const pal::string_t & dotnet_dir,
-        const bool disable_multilevel_lookup)
+        const bool disable_multilevel_lookup,
+        const std::vector<pal::string_t>& disabled_versions)
     {
 #if defined(DEBUG)
         assert(!fx_ref.get_fx_name().empty());
@@ -236,6 +237,12 @@ namespace
                 append_path(&fx_dir, fx_ref.get_fx_version().c_str());
                 if (file_exists_in_dir(fx_dir, deps_file_name.c_str(), nullptr))
                 {
+                    if (std::find(disabled_versions.begin(), disabled_versions.end(), fx_ref.get_fx_version()) != disabled_versions.end())
+                    {
+                        trace::verbose(_X("Ignoring disabled version [%s]"), fx_ref.get_fx_version().c_str());
+                        continue;
+                    }
+
                     selected_fx_dir = fx_dir;
                     selected_fx_version = fx_ref.get_fx_version();
                     break;
@@ -252,6 +259,12 @@ namespace
                     fx_ver_t ver;
                     if (fx_ver_t::parse(version, &ver, false))
                     {
+                        if (std::find(disabled_versions.begin(), disabled_versions.end(), version) != disabled_versions.end())
+                        {
+                            trace::verbose(_X("Ignoring disabled version [%s]"), version.c_str());
+                            continue;
+                        }
+
                         version_list.push_back(ver);
                     }
                 }
@@ -305,7 +318,42 @@ namespace
 
         return std::unique_ptr<fx_definition_t>(new fx_definition_t(fx_ref.get_fx_name(), selected_fx_dir, oldest_requested_version, selected_fx_version));
     }
+
+    std::vector<pal::string_t> get_disabled_versions()
+    {
+        pal::string_t env_var;
+        if (!pal::getenv(_X("DOTNET_DISABLE_RUNTIME_VERSIONS"), &env_var) || env_var.empty())
+            return {};
+
+        std::vector<pal::string_t> disabled_versions;
+        size_t start = 0;
+        size_t pos = 0;
+        while ((pos = env_var.find(_X(';'), start)) != pal::string_t::npos)
+        {
+            pal::string_t version = env_var.substr(start, pos - start);
+            if (!version.empty())
+            {
+                disabled_versions.push_back(version);
+            }
+            start = pos + 1;
+        }
+
+        // Add the last version (after the last semicolon or the only version if no semicolons)
+        pal::string_t last_version = env_var.substr(start);
+        if (!last_version.empty())
+        {
+            disabled_versions.push_back(last_version);
+        }
+
+        return disabled_versions;
+    }
 }
+
+fx_resolver_t::fx_resolver_t(bool disable_multilevel_lookup, const runtime_config_t::settings_t& override_settings)
+    : m_disable_multilevel_lookup{disable_multilevel_lookup}
+    , m_override_settings{override_settings}
+    , m_disabled_versions{get_disabled_versions()}
+{ }
 
 // Reconciles two framework references into a new effective framework reference
 // This process is sometimes also called "soft roll forward" (soft as in no IO)
@@ -438,7 +486,7 @@ StatusCode fx_resolver_t::read_framework(
             m_effective_fx_references[fx_name] = new_effective_fx_ref;
 
             // Resolve the effective framework reference against the existing physical framework folders
-            std::unique_ptr<fx_definition_t> fx = resolve_framework_reference(new_effective_fx_ref, m_oldest_fx_references[fx_name].get_fx_version(), dotnet_root, m_disable_multilevel_lookup);
+            std::unique_ptr<fx_definition_t> fx = resolve_framework_reference(new_effective_fx_ref, m_oldest_fx_references[fx_name].get_fx_version(), dotnet_root, m_disable_multilevel_lookup, m_disabled_versions);
             if (fx == nullptr)
             {
                 resolution_failure.missing = std::move(new_effective_fx_ref);

--- a/src/native/corehost/fxr/fx_resolver.h
+++ b/src/native/corehost/fxr/fx_resolver.h
@@ -40,6 +40,8 @@ public:
         const runtime_config_t& config,
         const std::unordered_map<pal::string_t, const fx_ver_t> &existing_framework_versions_by_name);
 
+    static std::vector<pal::string_t> get_disabled_versions();
+
 private:
     fx_resolver_t(bool disable_multilevel_lookup, const runtime_config_t::settings_t& override_settings);
 

--- a/src/native/corehost/fxr/fx_resolver.h
+++ b/src/native/corehost/fxr/fx_resolver.h
@@ -41,10 +41,7 @@ public:
         const std::unordered_map<pal::string_t, const fx_ver_t> &existing_framework_versions_by_name);
 
 private:
-    fx_resolver_t(bool disable_multilevel_lookup, const runtime_config_t::settings_t& override_settings)
-        : m_disable_multilevel_lookup{disable_multilevel_lookup}
-        , m_override_settings{override_settings}
-    { }
+    fx_resolver_t(bool disable_multilevel_lookup, const runtime_config_t::settings_t& override_settings);
 
     void update_newest_references(
         const runtime_config_t& config);
@@ -97,6 +94,9 @@ private:
 
     bool m_disable_multilevel_lookup;
     const runtime_config_t::settings_t& m_override_settings;
+
+    // Disabled runtime versions
+    std::vector<pal::string_t> m_disabled_versions;
 };
 
 #endif // __FX_RESOLVER_H__

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -437,7 +437,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_dotnet_environment_info(
     }
 
     std::vector<framework_info> framework_infos;
-    framework_info::get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, &framework_infos);
+    framework_info::get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, /*include_disabled_versions*/ false, &framework_infos);
 
     std::vector<hostfxr_dotnet_environment_framework_info> environment_framework_infos;
     std::vector<pal::string_t> framework_versions;


### PR DESCRIPTION
Allow disabling specific runtime versions during framework resolution via an environment variable
- Read the `DOTNET_DISABLE_RUNTIME_VERSIONS` environment variable as one or more versions separated by semi-colons - for example, `9.0.7` or `9.0.2;9.0.7`
  - Must be the exact version string. An invalid or non-existent version has no effect.
  - Resolver reads and stores this when it is created
- Update the framework resolution logic to skip disabled versions when searching for compatible frameworks
  - If all matching versions are disabled, resolution fails

Resolves https://github.com/dotnet/runtime/issues/118553

cc @dotnet/appmodel @AaronRobinsonMSFT 