### PR TITLE
Raise MAX_METHODS limit in Multicore JIT

### DIFF
--- a/src/coreclr/vm/multicorejitimpl.h
+++ b/src/coreclr/vm/multicorejitimpl.h
@@ -33,7 +33,7 @@ const unsigned MODULE_MASK             = 0xffff;    // mask to get module index 
 const unsigned MODULE_LEVEL_OFFSET     = 16;        // offset of module load level
 const unsigned MAX_MODULE_LEVELS       = 0x100;     // maximum allowed number of module levels (2^8 values)
 
-const unsigned MAX_METHODS             = 0x4000;    // Maximum allowed number of methods (2^14 values) (in principle this is also limited by "unsigned short" counters)
+const unsigned MAX_METHODS             = 0xffff;    // Maximum allowed number of methods (2^16-1 max signature length)
 
 const unsigned SIGNATURE_LENGTH_MASK   = 0xffff;    // mask to get signature from packed data (2^16-1 max signature length)
 

--- a/src/coreclr/vm/multicorejitimpl.h
+++ b/src/coreclr/vm/multicorejitimpl.h
@@ -33,7 +33,7 @@ const unsigned MODULE_MASK             = 0xffff;    // mask to get module index 
 const unsigned MODULE_LEVEL_OFFSET     = 16;        // offset of module load level
 const unsigned MAX_MODULE_LEVELS       = 0x100;     // maximum allowed number of module levels (2^8 values)
 
-const unsigned MAX_METHODS             = 0xffff;    // Maximum allowed number of methods (2^16-1 values)
+const unsigned MAX_METHODS             = 0xffff;    // Maximum allowed number of methods (2^16-1 values) (in principle this is also limited by "unsigned short" counters)
 
 const unsigned SIGNATURE_LENGTH_MASK   = 0xffff;    // mask to get signature from packed data (2^16-1 max signature length)
 

--- a/src/coreclr/vm/multicorejitimpl.h
+++ b/src/coreclr/vm/multicorejitimpl.h
@@ -33,7 +33,7 @@ const unsigned MODULE_MASK             = 0xffff;    // mask to get module index 
 const unsigned MODULE_LEVEL_OFFSET     = 16;        // offset of module load level
 const unsigned MAX_MODULE_LEVELS       = 0x100;     // maximum allowed number of module levels (2^8 values)
 
-const unsigned MAX_METHODS             = 0xffff;    // Maximum allowed number of methods (2^16-1 max signature length)
+const unsigned MAX_METHODS             = 0xffff;    // Maximum allowed number of methods (2^16-1 values)
 
 const unsigned SIGNATURE_LENGTH_MASK   = 0xffff;    // mask to get signature from packed data (2^16-1 max signature length)
 


### PR DESCRIPTION
Increase the MAX_METHODS limit in Multicore JIT to support larger workloads. This prevents hitting the previous cap of 16384 methods and allows faster startup for large applications.