### PR TITLE
Use a SafeHandle when duplicating a certificate context.

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/CertificateHelpers.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/CertificateHelpers.Windows.cs
@@ -25,6 +25,8 @@ namespace System.Security.Cryptography.X509Certificates
 
         private static partial int GuessKeySpec(CngProvider provider, string keyName, bool machineKey, CngAlgorithmGroup? algorithmGroup);
 
+        private static partial SafeCertContextHandle DuplicateCertificateHandle(TCertificate certificate);
+
 #if !SYSTEM_SECURITY_CRYPTOGRAPHY
         [SupportedOSPlatform("windows")]
 #endif
@@ -75,7 +77,7 @@ namespace System.Security.Cryptography.X509Certificates
         internal static T? GetPrivateKey<T>(TCertificate certificate, Func<CspParameters, T> createCsp, Func<CngKey, T?> createCng)
             where T : class, IDisposable
         {
-            using (SafeCertContextHandle certContext = Interop.Crypt32.CertDuplicateCertificateContext(certificate.Handle))
+            using (SafeCertContextHandle certContext = DuplicateCertificateHandle(certificate))
             {
                 SafeNCryptKeyHandle? ncryptKey = TryAcquireCngPrivateKey(certContext, out CngKeyHandleOpenOptions cngHandleOptions);
                 if (ncryptKey != null)

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateHelpers.Windows.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateHelpers.Windows.cs
@@ -42,5 +42,10 @@ namespace System.Security.Cryptography.X509Certificates
             return new SafeNCryptKeyHandle(handle, parentHandle);
 #endif
         }
+
+        private static partial SafeCertContextHandle DuplicateCertificateHandle(X509Certificate2 certificate)
+        {
+            return Interop.Crypt32.CertDuplicateCertificateContext(certificate.Handle);
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
@@ -50,6 +50,8 @@ namespace System.Security.Cryptography.X509Certificates
             get { return _certContext.DangerousGetHandle(); }
         }
 
+        internal SafeCertContextHandle? SafeHandle => _certContext;
+
         public string Issuer => GetIssuerOrSubject(issuer: true, reverse: true);
 
         public string Subject => GetIssuerOrSubject(issuer: false, reverse: true);


### PR DESCRIPTION
CertDuplicateCertificateContext does not ensure the CERT_CONTEXT pointer it is incrementing has not been freed. If the duplicate and dispose race, duplicating a disposed handle will lead to unspecified behavior.

For .NET 10, we can use the SafeHandle around the certificate before we duplicate the handle. For OOB, we don't have access to the internals, so we will continue to use the IntPtr Handle property.

Contributes to #119313