### PR TITLE
Don't try to offer a conversion to SG COM when properties are involved

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
@@ -64,6 +64,10 @@ namespace Microsoft.Interop.Analyzers
 
                     foreach (var method in type.GetMembers().OfType<IMethodSymbol>().Where(m => !m.IsStatic && m.IsAbstract))
                     {
+                        // Non-ordinary methods (e.g., property/event accessors) are not supported by the COM generator.
+                        if (method.MethodKind != MethodKind.Ordinary)
+                            return;
+
                         // Ignore types with methods with unsupported returns
                         if (method.ReturnsByRef || method.ReturnsByRefReadonly)
                             return;

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ConvertToGeneratedComInterfaceTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ConvertToGeneratedComInterfaceTests.cs
@@ -479,5 +479,26 @@ namespace ComInterfaceGenerator.Unit.Tests
 
             await VerifyCS.VerifyCodeFixAsync(source, source);
         }
+
+        [Fact]
+        public async Task Event()
+        {
+            // Events are not supported at this time.
+            // Make sure we don't offer a fix in this scenario.
+            string source = """
+               using System;
+               using System.Runtime.InteropServices;
+
+               [ComImport]
+               [Guid("5DA39CDF-DCAD-447A-836E-EA80DB34D81B")]
+               [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+               public interface I
+               {
+                   event Action Evt;
+               }
+               """;
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ConvertToGeneratedComInterfaceTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ConvertToGeneratedComInterfaceTests.cs
@@ -161,7 +161,7 @@ namespace ComInterfaceGenerator.Unit.Tests
             string fixedSource = """
                 using System.Runtime.InteropServices;
                 using System.Runtime.InteropServices.Marshalling;
-                
+
                 [GeneratedComInterface(StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(BStrStringMarshaller))]
                 [Guid("5DA39CDF-DCAD-447A-836E-EA80DB34D81B")]
                 [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
@@ -408,7 +408,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                    [return: MarshalAs(UnmanagedType.Error)]
                    HResult Foo();
                }
-               
+
                [StructLayout(LayoutKind.Sequential)]
                public struct HResult
                {
@@ -453,6 +453,29 @@ namespace ComInterfaceGenerator.Unit.Tests
                  {
                  }
                  """;
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task Property()
+        {
+            // Properties are not supported at this time.
+            // Make sure we don't offer a fix in this scenario.
+            string source = """
+               using System.Runtime.InteropServices;
+
+               [ComImport]
+               [Guid("5DA39CDF-DCAD-447A-836E-EA80DB34D81B")]
+               [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+               public interface I
+               {
+                   int Prop
+                   {
+                       get;
+                   }
+               }
+               """;
 
             await VerifyCS.VerifyCodeFixAsync(source, source);
         }


### PR DESCRIPTION
Properties aren't supported and the analyzer was crashing on the cast to MethodDeclarationSyntax later due to this.
