### PR TITLE
Suppress BinSkim BA2008 warning for llvm-mca.exe and FileCheck.exe

### DIFF
--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -95,6 +95,7 @@ try {
         if ($targetDirectory) {
           # Binskim crashes due to specific PDBs. GitHub issue: https://github.com/microsoft/binskim/issues/924.
           # We are excluding all `_.pdb` files from the scan.
+		  # SuperfileCheck uses two external LLVM libraries (llvm-mca.exe and FileCheck.exe) that we don't build. Excluding them to supporess BA2008. 
           $tool.Args += "`"Target < $TargetDirectory\**;-:file|$TargetDirectory\**\_.pdb;-:file|$TargetDirectory\**\llvm-mca.exe;-:file|$TargetDirectory\**\FileCheck.exe`""
         }
         $tool.Args += $BinskimAdditionalRunConfigParams

--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -95,7 +95,7 @@ try {
         if ($targetDirectory) {
           # Binskim crashes due to specific PDBs. GitHub issue: https://github.com/microsoft/binskim/issues/924.
           # We are excluding all `_.pdb` files from the scan.
-          $tool.Args += "`"Target < $TargetDirectory\**;-:file|$TargetDirectory\**\_.pdb`""
+          $tool.Args += "`"Target < $TargetDirectory\**;-:file|$TargetDirectory\**\_.pdb;-:file|$TargetDirectory\**\llvm-mca.exe;-:file|$TargetDirectory\**\FileCheck.exe`""
         }
         $tool.Args += $BinskimAdditionalRunConfigParams
       }


### PR DESCRIPTION
Suppressing BinSkim BA2008 warnings for two external libarries that SuperFileCheck uses.
