### PR TITLE
Fix eligibility check for WKS concurrent gen2 GC

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -24753,7 +24753,7 @@ void gc_heap::garbage_collect (int n)
                 }
             }
 #else
-            do_concurrent_p = (!!bgc_thread && commit_mark_array_bgc_init());
+            do_concurrent_p = (bgc_thread_running && commit_mark_array_bgc_init());
             if (do_concurrent_p)
             {
                 background_saved_lowest_address = lowest_address;


### PR DESCRIPTION
Existing behavior for workstation gen2 collections is allow background GC if the BGC thread is already running and has retrieved its thread handle. This creates a race condition when starting a new BGC thread that may result in a blocking gen2 collection if the BGC thread hasn't spun up in time.

This change removes the race condition and permits background GC as long as the BGC thread has been successfully started, regardless of how far into execution the BGC thread is at.

Fix #13238