### PR TITLE
[DAC] fix dac_gc_heap marshalling

### DIFF
--- a/src/coreclr/debug/daccess/request_svr.cpp
+++ b/src/coreclr/debug/daccess/request_svr.cpp
@@ -225,7 +225,9 @@ HRESULT
 ClrDataAccess::ServerGCInterestingInfoData(CLRDATA_ADDRESS addr, DacpGCInterestingInfoData *interestingInfoData)
 {
 #ifdef GC_CONFIG_DRIVEN
-    dac_gc_heap *pHeap = __DPtr<dac_gc_heap>(TO_TADDR(addr));
+    TADDR heapAddress = TO_TADDR(addr);
+    dac_gc_heap heap = LoadGcHeapData(heapAddress);
+    dac_gc_heap* pHeap = &heap;
 
     size_t* dataPoints = (size_t*)&(pHeap->interesting_data_per_heap);
     for (int i = 0; i < NUM_GC_DATA_POINTS; i++)


### PR DESCRIPTION
Found while working on https://github.com/dotnet/runtime/pull/119324

This API was giving different data from the cDAC, I manually inspected the data structure in WinDBG and found that the DAC was giving incorrect data.
It looks like this is the only API to marshal a `dac_gc_heap` without `LoadGcHeapData`. I think it was reading the class as if it were laid out sequentially in memory as opposed to using the offsets in `g_gcDacGlobals->gc_heap_field_offsets`.

I modified the API to use `LoadGcHeapData` in the same way as other APIs.

Adding test to the diagnostics repo https://github.com/dotnet/diagnostics/pull/5562

diagnostics pipeline with failures on main: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1140784&view=results
runtime-diagnostics leg running with new test: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1140803&view=results