### PR TITLE
Add dotnet-linker-tests to build analysis

### DIFF
--- a/eng/build-analysis-configuration.json
+++ b/eng/build-analysis-configuration.json
@@ -1,28 +1,32 @@
 {
-    "PipelinesToAnalyze":[
-       {
-          "PipelineId": 129,
-          "PipelineName": "runtime"
-       },
-       {
-         "PipelineId": 133,
-         "PipelineName": "runtime-dev-innerloop"
-       },
-       {
-         "PipelineId": 154,
-         "PipelineName": "runtime-extra-platforms"
-       },
-       {
-         "PipelineId": 157,
-         "PipelineName": "runtime-llvm"
-       },
-       {
-         "PipelineId": 265,
-         "PipelineName": "runtime-nativeaot-outerloop"
-       },
-       {
-         "PipelineId": 108,
-         "PipelineName": "runtime-coreclr outerloop"
-       }
-    ]
+  "PipelinesToAnalyze": [
+    {
+      "PipelineId": 129,
+      "PipelineName": "runtime"
+    },
+    {
+      "PipelineId": 133,
+      "PipelineName": "runtime-dev-innerloop"
+    },
+    {
+      "PipelineId": 139,
+      "PipelineName": "dotnet-linker-tests"
+    },
+    {
+      "PipelineId": 154,
+      "PipelineName": "runtime-extra-platforms"
+    },
+    {
+      "PipelineId": 157,
+      "PipelineName": "runtime-llvm"
+    },
+    {
+      "PipelineId": 265,
+      "PipelineName": "runtime-nativeaot-outerloop"
+    },
+    {
+      "PipelineId": 108,
+      "PipelineName": "runtime-coreclr outerloop"
+    }
+  ]
 }


### PR DESCRIPTION
We want this pipeline to block auto-merge (see https://github.com/dotnet/runtime/issues/119364).