### PR TITLE
[release/10.0] Propagate DynamicallyAccessedMembers annotations to auto-properties only

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
@@ -523,7 +524,7 @@ namespace ILLink.Shared.TrimAnalysis
                             // Look for the compiler generated backing field. If it doesn't work out simply move on. In such case we would still
                             // propagate the annotation to the setter/getter and later on when analyzing the setter/getter we will warn
                             // that the field (which ever it is) must be annotated as well.
-                            ScanMethodBodyForFieldAccess(methodBody, write: true, out backingFieldFromSetter);
+                            backingFieldFromSetter = GetAutoPropertyCompilerGeneratedField(methodBody, isWriteAccessor: true);
                         }
 
                         MethodAnnotations? setterAnnotation = null;
@@ -560,16 +561,14 @@ namespace ILLink.Shared.TrimAnalysis
                     MethodDesc getMethod = property.GetMethod;
                     if (getMethod != null)
                     {
-
-                        // Abstract property backing field propagation doesn't make sense, and any derived property will be validated
-                        // to have the exact same annotations on getter/setter, and thus if it has a detectable backing field that will be validated as well.
+                        // Look only at compiler-generated accessors
                         MethodIL methodBody = _ilProvider.GetMethodIL(getMethod);
                         if (methodBody != null)
                         {
                             // Look for the compiler generated backing field. If it doesn't work out simply move on. In such case we would still
                             // propagate the annotation to the setter/getter and later on when analyzing the setter/getter we will warn
                             // that the field (which ever it is) must be annotated as well.
-                            ScanMethodBodyForFieldAccess(methodBody, write: false, out backingFieldFromGetter);
+                            backingFieldFromGetter = GetAutoPropertyCompilerGeneratedField(methodBody, isWriteAccessor: false);
                         }
 
                         MethodAnnotations? getterAnnotation = null;
@@ -593,27 +592,41 @@ namespace ILLink.Shared.TrimAnalysis
                         }
                     }
 
-                    FieldDesc? backingField;
-                    if (backingFieldFromGetter != null && backingFieldFromSetter != null &&
-                        backingFieldFromGetter != backingFieldFromSetter)
+                    if (IsAutoProperty(property))
                     {
-                        _logger.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersCouldNotFindBackingField, property.GetDisplayName());
-                        backingField = null;
-                    }
-                    else
-                    {
-                        backingField = backingFieldFromGetter ?? backingFieldFromSetter;
-                    }
-
-                    if (backingField != null)
-                    {
-                        if (annotatedFields.Any(a => a.Field == backingField))
+                        FieldDesc? backingField = null;
+                        if ((property.SetMethod is not null
+                                && property.SetMethod.HasCustomAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute")
+                                && backingFieldFromSetter is null)
+                            || (property.GetMethod is not null
+                                && property.GetMethod.HasCustomAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute")
+                                && backingFieldFromGetter is null))
                         {
-                            _logger.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
+                            // We failed to find the backing field of an auto-property accessor
+                            _logger.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersCouldNotFindBackingField, property.GetDisplayName());
+                        }
+                        else if (backingFieldFromGetter is not null && backingFieldFromSetter is not null
+                            && backingFieldFromSetter != backingFieldFromGetter)
+                        {
+                            // We found two different backing fields for the getter and the setter
+                            _logger.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersCouldNotFindBackingField, property.GetDisplayName());
                         }
                         else
                         {
-                            annotatedFields.Add(new FieldAnnotation(backingField, annotation));
+                            // We either have a single auto-property accessor or both accessors point to the same backing field
+                            backingField = backingFieldFromSetter ?? backingFieldFromGetter;
+                        }
+
+                        if (backingField != null)
+                        {
+                            if (annotatedFields.Any(a => a.Field == backingField))
+                            {
+                                _logger.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
+                            }
+                            else
+                            {
+                                annotatedFields.Add(new FieldAnnotation(backingField, annotation));
+                            }
                         }
                     }
                 }
@@ -651,13 +664,33 @@ namespace ILLink.Shared.TrimAnalysis
                 return attrs;
             }
 
-            private static bool ScanMethodBodyForFieldAccess(MethodIL body, bool write, out FieldDesc? found)
+            /// <summary>
+            /// Returns true if the property has a single accessor which is compiler generated,
+            /// indicating that it is an auto-property.
+            /// </summary>
+            /// <remarks>
+            /// Ideally this would be tightened to only return true if both accessors are auto-property accessors,
+            /// but it allows for either for back compatibility with existing behavior.
+            /// </remarks>
+            private static bool IsAutoProperty(PropertyPseudoDesc property)
+            {
+                return property.SetMethod?.HasCustomAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute") == true
+                    || property.GetMethod?.HasCustomAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute") == true;
+            }
+
+            private static FieldDesc? GetAutoPropertyCompilerGeneratedField(MethodIL body, bool isWriteAccessor)
             {
                 // Tries to find the backing field for a property getter/setter.
                 // Returns true if this is a method body that we can unambiguously analyze.
                 // The found field could still be null if there's no backing store.
-                found = null;
 
+                // Only analyze compiler-generated accessors
+                if (!body.OwningMethod.HasCustomAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute"))
+                {
+                    return null;
+                }
+
+                FieldDesc? found = null;
                 ILReader ilReader = new ILReader(body.GetILBytes());
 
                 while (ilReader.HasNext)
@@ -665,45 +698,35 @@ namespace ILLink.Shared.TrimAnalysis
                     ILOpcode opcode = ilReader.ReadILOpcode();
                     switch (opcode)
                     {
-                        case ILOpcode.ldsfld when !write:
-                        case ILOpcode.ldfld when !write:
-                        case ILOpcode.stsfld when write:
-                        case ILOpcode.stfld when write:
+                        case ILOpcode.ldsfld when !isWriteAccessor:
+                        case ILOpcode.ldfld when !isWriteAccessor:
+                        case ILOpcode.stsfld when isWriteAccessor:
+                        case ILOpcode.stfld when isWriteAccessor:
+                        {
+                            // Multiple field accesses - ambiguous, fail
+                            if (found != null)
                             {
-                                // This writes/reads multiple fields - can't guess which one is the backing store.
-                                // Return failure.
-                                if (found != null)
-                                {
-                                    found = null;
-                                    return false;
-                                }
-                                found = (FieldDesc)body.GetObject(ilReader.ReadILToken());
+                                return null;
                             }
+                            found = (FieldDesc)body.GetObject(ilReader.ReadILToken());
                             break;
+                        }
                         default:
                             ilReader.Skip(opcode);
                             break;
                     }
                 }
 
-                if (found == null)
-                {
-                    // Doesn't access any fields. Could be e.g. "Type Foo => typeof(Bar);"
-                    // Return success.
-                    return true;
-                }
-
-                if (found.OwningType != body.OwningMethod.OwningType ||
+                if (found is null ||
+                    found.OwningType != body.OwningMethod.OwningType ||
                     found.IsStatic != body.OwningMethod.Signature.IsStatic ||
                     !found.HasCustomAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute"))
                 {
-                    // A couple heuristics to make sure we got the right field.
-                    // Return failure.
-                    found = null;
-                    return false;
+                    // Heuristics failed - not a backing field
+                    return null;
                 }
 
-                return true;
+                return found;
             }
         }
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/IPropertySymbolExtensions.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/IPropertySymbolExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ILLink.RoslynAnalyzer
 {
@@ -29,6 +30,38 @@ namespace ILLink.RoslynAnalyzer
                     break;
             }
             return setMethod;
+        }
+
+        public static bool IsAutoProperty(this IPropertySymbol property)
+        {
+            if (property.IsAbstract)
+                return false;
+
+            return (property.GetMethod?.IsAutoAccessor() ?? false) || (property.SetMethod?.IsAutoAccessor() ?? false);
+        }
+
+        private static bool IsAutoAccessor(this IMethodSymbol method)
+        {
+            if (method == null || method.IsAbstract)
+                return false;
+
+            foreach (var decl in method.DeclaringSyntaxReferences)
+            {
+                var syntax = decl.GetSyntax();
+                // Auto property accessors have no body in their syntax
+                switch (syntax)
+                {
+                    case AccessorDeclarationSyntax a:
+                        if (a.Body is not null)
+                            return false;
+                        if (a.ExpressionBody is not null)
+                            return false;
+                        return true;
+                    default:
+                        break;
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
@@ -117,6 +117,13 @@ namespace ILLink.Shared.TrimAnalysis
             if (!field.OriginalDefinition.Type.IsTypeInterestingForDataflow(isByRef: field.RefKind is not RefKind.None))
                 return DynamicallyAccessedMemberTypes.None;
 
+            if (field.AssociatedSymbol is IPropertySymbol property)
+            {
+                // If this is an auto property, we get the property annotation
+                if (property.IsAutoProperty())
+                    return property.GetDynamicallyAccessedMemberTypes();
+            }
+
             return field.GetDynamicallyAccessedMemberTypes();
         }
 

--- a/src/tools/illink/src/linker/Linker/MethodDefinitionExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/MethodDefinitionExtensions.cs
@@ -146,5 +146,20 @@ namespace Mono.Linker
             int implicitThisOffset = method.HasImplicitThis() ? 1 : 0;
             return new ParameterProxyEnumerable(implicitThisOffset, method.Parameters.Count + implicitThisOffset, method);
         }
+
+        public static bool IsCompilerGenerated(this MethodDefinition field)
+        {
+            if (!field.HasCustomAttributes)
+                return false;
+
+            foreach (var ca in field.CustomAttributes)
+            {
+                var caType = ca.AttributeType;
+                if (caType.Name == "CompilerGeneratedAttribute" && caType.Namespace == "System.Runtime.CompilerServices")
+                    return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -198,6 +198,12 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task FieldKeyword()
+        {
+            return RunTest();
+        }
+
+        [Fact]
         public Task FileScopedClasses()
         {
             return RunTest();

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/ReferenceCompatibilityTestUtils.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/ReferenceCompatibilityTestUtils.cs
@@ -42,7 +42,7 @@ namespace ILLink.RoslynAnalyzer.Tests
                 var refs = SourceGenerators.Tests.LiveReferencePack.GetMetadataReferences();
                 var referencedCompilation = CSharpCompilation.Create(
                     "ReferencedAssembly",
-                    new[] { SyntaxFactory.ParseSyntaxTree(referencedSource) },
+                    new[] { SyntaxFactory.ParseSyntaxTree(referencedSource, new CSharpParseOptions(languageVersion: LanguageVersion.Preview)) },
                     refs,
                     new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
                 var referencedImage = new MemoryStream();

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestCaseCompilation.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestCaseCompilation.cs
@@ -30,7 +30,7 @@ namespace ILLink.RoslynAnalyzer.Tests
             IEnumerable<MetadataReference>? additionalReferences = null,
             IEnumerable<SyntaxTree>? additionalSources = null,
             IEnumerable<AdditionalText>? additionalFiles = null)
-            => CreateCompilation(CSharpSyntaxTree.ParseText(src), consoleApplication, globalAnalyzerOptions, additionalReferences, additionalSources, additionalFiles);
+            => CreateCompilation(CSharpSyntaxTree.ParseText(src, new CSharpParseOptions(LanguageVersion.Preview)), consoleApplication, globalAnalyzerOptions, additionalReferences, additionalSources, additionalFiles);
 
         public static (CompilationWithAnalyzers Compilation, SemanticModel SemanticModel, List<Diagnostic> ExceptionDiagnostics) CreateCompilation(
             SyntaxTree src,
@@ -58,7 +58,7 @@ namespace ILLink.RoslynAnalyzer.Tests
                 Path.Combine(sharedDir, "RequiresDynamicCodeAttribute.cs"),
             };
 
-            sources.AddRange(commonSourcePaths.Select(p => CSharpSyntaxTree.ParseText(File.ReadAllText(p), path: p)));
+            sources.AddRange(commonSourcePaths.Select(p => CSharpSyntaxTree.ParseText(File.ReadAllText(p), new CSharpParseOptions(languageVersion: LanguageVersion.Preview), path: p)));
             var comp = CSharpCompilation.Create(
                 assemblyName: "test",
                 syntaxTrees: sources,

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -61,11 +61,14 @@ namespace ILLink.RoslynAnalyzer.Tests
             Assert.True(File.Exists(testPath), $"{testPath} should exist");
             var tree = SyntaxFactory.ParseSyntaxTree(
                 SourceText.From(File.OpenRead(testPath), Encoding.UTF8),
+                new CSharpParseOptions(languageVersion: LanguageVersion.Preview),
                 path: testPath);
 
             var testDependenciesSource = GetTestDependencies(testCaseDir, tree)
                 .Where(f => Path.GetExtension(f) == ".cs")
-                .Select(f => SyntaxFactory.ParseSyntaxTree(SourceText.From(File.OpenRead(f))));
+                .Select(f => SyntaxFactory.ParseSyntaxTree(SourceText.From(
+                    File.OpenRead(f)),
+                    new CSharpParseOptions(languageVersion: LanguageVersion.Preview)));
             var additionalFiles = GetAdditionalFiles(rootSourceDir, tree);
 
             var (comp, model, exceptionDiagnostics) = TestCaseCompilation.CreateCompilation(

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestChecker.cs
@@ -234,7 +234,8 @@ namespace ILLink.RoslynAnalyzer.Tests
                 case nameof(UnexpectedWarningAttribute):
                 case nameof(LogContainsAttribute):
                     var args = LinkerTestBase.GetAttributeArguments(attribute);
-                    if (args.TryGetValue("ProducedBy", out var producedBy))
+                    if (args.TryGetValue("ProducedBy", out var producedBy)
+                        || args.TryGetValue("producedBy", out producedBy))
                     {
                         // Skip if this warning is not expected to be produced by any of the analyzers that we are currently testing.
                         return GetProducedBy(producedBy).HasFlag(Tool.Analyzer);

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
@@ -8,6 +8,12 @@ namespace ILLink.RoslynAnalyzer.Tests
     {
 
         [Fact]
+        public Task DataflowFailsToConverge()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task ExponentialDataFlow()
         {
             return RunTest(allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -234,7 +234,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             {
             }
 
-            // DynamicDependency is not supported yet in the analyzer 
+            // DynamicDependency is not supported yet in the analyzer
             [ExpectedWarning("IL2111", nameof(MethodWithSingleAnnotatedParameter), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/83080")]
             [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(AnnotatedMethodParameters))]
             static void DynamicDependency()
@@ -247,7 +247,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             {
             }
 
-            // DynamicDependency is not supported yet in the analyzer 
+            // DynamicDependency is not supported yet in the analyzer
             [ExpectedWarning("IL2111", nameof(MethodWithSingleAnnotatedParameter), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/83080")]
             [DynamicDependency(nameof(MethodWithSingleAnnotatedParameter), typeof(AnnotatedMethodParameters))]
             static void DynamicDependencyByName()
@@ -681,14 +681,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 typeof(AnnotatedProperty).RequiresAll();
             }
 
-            // Analyzer doesn't produce this warning 
-            [ExpectedWarning("IL2110", nameof(Property1WithAnnotation), Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/2628")]
+            // Analyzer doesn't produce this warning
+            [ExpectedWarning("IL2110", nameof(Property1WithAnnotation))]
             static void DynamicallyAccessedFields()
             {
                 typeof(AnnotatedProperty).RequiresNonPublicFields();
             }
 
-            // Analyzer doesn't recognize Linq.Expressions 
+            // Analyzer doesn't recognize Linq.Expressions
             [ExpectedWarning("IL2111", nameof(Property1WithAnnotation) + ".set", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/101148")]
             static void LdToken()
             {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FieldKeyword.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FieldKeyword.cs
@@ -1,0 +1,147 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+    [ExpectedNoWarnings]
+    [Kept]
+    public class FieldKeyword
+    {
+        [Kept]
+        public static void Main()
+        {
+            WithMethods = typeof(FieldKeyword);
+            WithFields = typeof(FieldKeyword);
+            _ = WithNone;
+            WithNone = null;
+            _ = WithFields;
+            _ = WithMethods;
+            _ = MismatchAssignedFromField;
+            _ = MismatchAssignedFromField_FieldAnnotated;
+            _ = MismatchAssignedToField;
+            _ = MismatchAssignedToField_FieldAnnotated;
+            MismatchAssignedFromValue = null;
+            AssignNoneToMethods();
+        }
+
+        [Kept]
+        [KeptBackingField]
+        static Type WithNone { [Kept] get => field; [Kept] set => field = value; }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods),
+            KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+        [Kept]
+        [KeptBackingField]
+        static Type WithMethods
+        {
+            [Kept]
+            [ExpectedWarning("IL2078", "return value", nameof(WithMethods), "BackingField")]
+            get => field;
+            [Kept]
+            set => field = value;
+        }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields),
+            KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+        [Kept]
+        [KeptBackingField]
+        static Type WithFields
+        {
+            [Kept]
+            [ExpectedWarning("IL2078", "return value", nameof(WithFields), "BackingField")]
+            get => field;
+            [Kept]
+            set => field = value;
+        }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields),
+            KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+        [Kept]
+        [KeptBackingField]
+        static Type MismatchAssignedToField
+        {
+            [ExpectedWarning("IL2078", "return value", nameof(MismatchAssignedToField))]
+            [Kept]
+            get
+            {
+                field = WithNone;
+                return field;
+            }
+        }
+
+        [field: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields),
+            KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+        [Kept]
+        [KeptBackingField]
+        static Type MismatchAssignedToField_FieldAnnotated
+        {
+            [ExpectedWarning("IL2074", nameof(WithNone))]
+            [Kept]
+            [return: KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+            get
+            {
+                field = WithNone;
+                return field;
+            }
+        }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields),
+            KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+        [Kept]
+        [KeptBackingField]
+        static Type MismatchAssignedFromField
+        {
+            [Kept]
+            [ExpectedWarning("IL2077", nameof(MismatchAssignedFromField), nameof(WithMethods))]
+            [ExpectedWarning("IL2078", "return value")]
+            get
+            {
+                WithMethods = field;
+                return field;
+            }
+        }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields),
+            KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+        [field: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        [Kept]
+        [KeptBackingField]
+        static Type MismatchAssignedFromField_FieldAnnotated
+        {
+            [Kept]
+            [ExpectedWarning("IL2077", nameof(MismatchAssignedFromField), nameof(WithMethods))]
+            get
+            {
+                WithMethods = field;
+                return field;
+            }
+        }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields),
+            KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
+        [Kept]
+        [KeptBackingField]
+        static Type MismatchAssignedFromValue
+        {
+            [ExpectedWarning("IL2067", nameof(WithMethods))]
+            [Kept]
+            set
+            {
+                WithMethods = value;
+                field = value;
+            }
+        }
+
+        [ExpectedWarning("IL2072")]
+        [Kept]
+        static void AssignNoneToMethods()
+        {
+            WithMethods = WithNone;
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -50,6 +50,10 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             ImplicitIndexerAccess.Test();
 
             AnnotationOnUnsupportedType.Test();
+            AutoPropertyUnrecognizedField.Test();
+
+            OneAutoPropAccessor.Test();
+            AutoPropertySyntaxVariations.Test();
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
@@ -242,6 +246,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 // See above comment about fake compiler generated backing fields - this warning is expected from the analyzer
                 [ExpectedWarning("IL2078", nameof(TestAutomaticPropagationType) + "." + nameof(PropertyWhichLooksLikeCompilerGenerated) + ".get",
                     nameof(TestAutomaticPropagationType) + "." + nameof(PropertyWhichLooksLikeCompilerGenerated_Field), Tool.Analyzer, "")]
+                [CompilerGenerated]
                 get
                 {
                     return PropertyWhichLooksLikeCompilerGenerated_Field;
@@ -284,7 +289,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
             // Analyzer doesn't try to detect backing fields of properties: https://github.com/dotnet/linker/issues/2273
             [ExpectedWarning("IL2042",
-                "Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow.TestAutomaticPropagationType.PropertyWithDifferentBackingFields", Tool.Trimmer | Tool.NativeAot, "")]
+                "Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow.TestAutomaticPropagationType.PropertyWithDifferentBackingFields", Tool.Trimmer | Tool.NativeAot, "Requires IL")]
             [ExpectedWarning("IL2078",
                 nameof(TestAutomaticPropagationType) + "." + nameof(PropertyWithDifferentBackingFields) + ".get",
                 "Type", Tool.Analyzer, "")]
@@ -293,11 +298,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             {
                 [ExpectedWarning("IL2078",
                     nameof(TestAutomaticPropagationType) + "." + nameof(PropertyWithDifferentBackingFields) + ".get", Tool.Trimmer | Tool.NativeAot, "")]
+                [CompilerGenerated]
                 get
                 {
                     return PropertyWithDifferentBackingFields_GetterField;
                 }
 
+                [CompilerGenerated]
                 set
                 {
                     PropertyWithDifferentBackingFields_SetterField = value;
@@ -324,11 +331,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
                 [ExpectedWarning("IL2043", "PropertyWithExistingAttributes", "PropertyWithExistingAttributes.get", Tool.Trimmer | Tool.NativeAot, "")]
                 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+                [CompilerGenerated]
                 get { return PropertyWithExistingAttributes_Field; }
 
                 // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
                 [ExpectedWarning("IL2043", "PropertyWithExistingAttributes", "PropertyWithExistingAttributes.set", Tool.Trimmer | Tool.NativeAot, "")]
                 [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+                [CompilerGenerated]
                 set { PropertyWithExistingAttributes_Field = value; }
             }
 
@@ -360,11 +369,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
                 [ExpectedWarning("IL2043", "PropertyWithConflictingAttributes", "PropertyWithConflictingAttributes.get", Tool.Trimmer | Tool.NativeAot, "")]
                 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+                [CompilerGenerated]
                 get { return PropertyWithConflictingAttributes_Field; }
 
                 // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
                 [ExpectedWarning("IL2043", "PropertyWithConflictingAttributes", "PropertyWithConflictingAttributes.set", Tool.Trimmer | Tool.NativeAot, "")]
                 [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+                [CompilerGenerated]
                 set { PropertyWithConflictingAttributes_Field = value; }
             }
 
@@ -393,9 +404,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 [ExpectedWarning("IL2078", nameof(TestAutomaticPropagationType) + "." + nameof(PropertyWithConflictingNoneAttributes) + ".get",
                     nameof(TestAutomaticPropagationType) + "." + nameof(PropertyWithConflictingNoneAttributes_Field), Tool.Analyzer, "")]
                 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.None)]
+                [CompilerGenerated]
                 get { return PropertyWithConflictingNoneAttributes_Field; }
 
                 [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.None)]
+                [CompilerGenerated]
                 set { PropertyWithConflictingNoneAttributes_Field = value; }
             }
 
@@ -936,6 +949,273 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 StringRefProperty.Test();
                 _ = UnsupportedPropertyAnnotationMismatch;
                 UnsupportedPropertyAnnotationMismatch = null;
+            }
+        }
+
+        class AutoPropertyUnrecognizedField
+        {
+            // Simulate an auto-property with unrecognizeable accessor behavior
+            [CompilerGenerated]
+            private Type Property_BackingField;
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
+            public Type Property
+            {
+                [CompilerGenerated]
+                [ExpectedWarning("IL2078", "return value", nameof(Property_BackingField))]
+                get
+                {
+                    // tools cannot find backing field when there are two loads in a getter
+                    _ = Property_BackingField;
+                    return Property_BackingField;
+                }
+                [CompilerGenerated]
+                set
+                {
+                    // tools cannot find backing field when there are two stores in a setter
+                    Property_BackingField = null;
+                    Property_BackingField = value;
+                }
+            }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
+            public Type PropertyAutoSet
+            {
+                [CompilerGenerated]
+                [ExpectedWarning("IL2078", "return value", nameof(Property_BackingField))]
+                get
+                {
+                    // tools cannot find backing field when there are two loads in a getter
+                    _ = Property_BackingField;
+                    return Property_BackingField;
+                }
+                set;
+            }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
+            public Type PropertyAutoGet
+            {
+                [ExpectedWarning("IL2078", ["return value", nameof(PropertyAutoGet), "BackingField"], producedBy: Tool.NativeAot | Tool.Trimmer, "Requires IL")]
+                get;
+                [CompilerGenerated]
+                set
+                {
+                    // tools cannot find backing field when there are two stores in a setter
+                    Property_BackingField = null;
+                    Property_BackingField = value;
+                }
+            }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
+            public Type PropertyManualSet
+            {
+                [CompilerGenerated]
+                [ExpectedWarning("IL2078", "return value", nameof(Property_BackingField))]
+                get
+                {
+                    // tools cannot find backing field when there are two loads in a getter
+                    _ = Property_BackingField;
+                    return Property_BackingField;
+                }
+                set => Property_BackingField = value;
+            }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
+            public Type PropertyManualGet
+            {
+                [ExpectedWarning("IL2078", "return value", nameof(Property_BackingField))]
+                get => Property_BackingField;
+                [CompilerGenerated]
+                set
+                {
+                    // tools cannot find backing field when there are two stores in a setter
+                    Property_BackingField = null;
+                    Property_BackingField = value;
+                }
+            }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
+            public Type PropertyOnlyGet
+            {
+                [CompilerGenerated]
+                [ExpectedWarning("IL2078", "return value", nameof(Property_BackingField))]
+                get
+                {
+                    // tools cannot find backing field when there are two loads in a getter
+                    _ = Property_BackingField;
+                    return Property_BackingField;
+                }
+            }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            [ExpectedWarning("IL2042", nameof(PropertyOnlySet), Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
+            public Type PropertyOnlySet
+            {
+                [CompilerGenerated]
+                set
+                {
+                    // tools cannot find backing field when there are two stores in a setter
+                    Property_BackingField = null;
+                    Property_BackingField = value;
+                }
+            }
+
+            public static void Test()
+            {
+                var instance = new AutoPropertyUnrecognizedField();
+                // No warning since annotation is not propagated
+                instance.Property_BackingField = GetUnknownType();
+
+                TestProperty();
+                TestPropertyAutoSet();
+                TestPropertyAutoGet();
+                TestPropertyOnlySet();
+                TestPropertyOnlyGet();
+                TestPropertyManualGet();
+                TestPropertyManualSet();
+            }
+
+            [ExpectedWarning("IL2072", nameof(Property), nameof(GetUnknownType))]
+            [ExpectedWarning("IL2072", "RequiresAll", nameof(Property))]
+            public static void TestProperty()
+            {
+                var instance = new AutoPropertyUnrecognizedField();
+                instance.Property = GetUnknownType();
+                instance.Property = GetTypeWithPublicConstructors();
+                instance.Property.RequiresPublicConstructors();
+                instance.Property.RequiresAll();
+            }
+
+            [ExpectedWarning("IL2072", nameof(PropertyAutoSet), nameof(GetUnknownType))]
+            [ExpectedWarning("IL2072", "RequiresAll", nameof(PropertyAutoSet))]
+            public static void TestPropertyAutoSet()
+            {
+                var instance = new AutoPropertyUnrecognizedField();
+                instance.PropertyAutoSet = GetUnknownType();
+                instance.PropertyAutoSet = GetTypeWithPublicConstructors();
+                instance.PropertyAutoSet.RequiresPublicConstructors();
+                instance.PropertyAutoSet.RequiresAll();
+            }
+
+            [ExpectedWarning("IL2072", nameof(PropertyAutoGet), nameof(GetUnknownType))]
+            [ExpectedWarning("IL2072", "RequiresAll", nameof(PropertyAutoGet))]
+            public static void TestPropertyAutoGet()
+            {
+                var instance = new AutoPropertyUnrecognizedField();
+                instance.PropertyAutoGet = GetUnknownType();
+                instance.PropertyAutoGet = GetTypeWithPublicConstructors();
+                instance.PropertyAutoGet.RequiresPublicConstructors();
+                instance.PropertyAutoGet.RequiresAll();
+            }
+
+            [ExpectedWarning("IL2072", nameof(PropertyOnlySet), nameof(GetUnknownType))]
+            public static void TestPropertyOnlySet()
+            {
+                var instance = new AutoPropertyUnrecognizedField();
+                instance.PropertyOnlySet = GetUnknownType();
+                instance.PropertyOnlySet = GetTypeWithPublicConstructors();
+            }
+
+            [ExpectedWarning("IL2072", "RequiresAll", nameof(PropertyOnlyGet))]
+            public static void TestPropertyOnlyGet()
+            {
+                var instance = new AutoPropertyUnrecognizedField();
+                instance.PropertyOnlyGet.RequiresPublicConstructors();
+                instance.PropertyOnlyGet.RequiresAll();
+            }
+
+            [ExpectedWarning("IL2072", nameof(PropertyManualGet), nameof(GetUnknownType))]
+            [ExpectedWarning("IL2072", "RequiresAll", nameof(PropertyManualGet))]
+            public static void TestPropertyManualGet()
+            {
+                var instance = new AutoPropertyUnrecognizedField();
+                instance.PropertyManualGet.RequiresPublicConstructors();
+                instance.PropertyManualGet.RequiresAll();
+                instance.PropertyManualGet = GetTypeWithPublicConstructors();
+                instance.PropertyManualGet = GetUnknownType();
+            }
+
+            [ExpectedWarning("IL2072", nameof(PropertyManualSet), nameof(GetUnknownType))]
+            [ExpectedWarning("IL2072", "RequiresAll", nameof(PropertyManualSet))]
+            public static void TestPropertyManualSet()
+            {
+                var instance = new AutoPropertyUnrecognizedField();
+                instance.PropertyManualSet.RequiresPublicConstructors();
+                instance.PropertyManualSet.RequiresAll();
+                instance.PropertyManualSet = GetTypeWithPublicConstructors();
+                instance.PropertyManualSet = GetUnknownType();
+            }
+        }
+
+        // Validate that auto-property accessors are recognized and annotation is propagated to backing field
+        // Even when there is only one auto-property accessor and the other is manually implemented.
+        class OneAutoPropAccessor
+        {
+            private Type Property_BackingField;
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            public Type AutoGet
+            {
+                get;
+                set { field = value; }
+            }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            public Type AutoSet
+            {
+                // Annotation does propagate to the backing field, so no warning
+                get { return field; }
+                set;
+            }
+
+            [ExpectedWarning("IL2072", nameof(AutoSet), nameof(GetUnknownType))]
+            [ExpectedWarning("IL2072", nameof(AutoGet), nameof(GetUnknownType))]
+            public static void Test()
+            {
+                var instance = new OneAutoPropAccessor();
+                instance.AutoGet = GetUnknownType();
+                _ = instance.AutoGet;
+                instance.AutoSet = GetUnknownType();
+                _ = instance.AutoSet;
+            }
+        }
+
+        // Validates a number of different auto-property syntax variations to ensure that they are all recognized and the annotation is propagated
+        class AutoPropertySyntaxVariations
+        {
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            public Type BodySetter
+            {
+                get;
+                [ExpectedWarning("IL2074", nameof(BodySetter), nameof(GetUnknownType))]
+                set { field = GetUnknownType(); }
+            }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            public Type ExpressionSetter
+            {
+                get;
+                [ExpectedWarning("IL2074", nameof(ExpressionSetter), nameof(GetUnknownType))]
+                set => field = GetUnknownType();
+            }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            public Type BodyGetter { get { return field; } set; }
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+            public Type ExpressionGetter { get => field; set; }
+
+            public static void Test()
+            {
+                var instance = new AutoPropertySyntaxVariations();
+                instance.BodySetter = instance.BodyGetter;
+                instance.ExpressionSetter = instance.ExpressionGetter;
             }
         }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -941,8 +941,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
             [KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))]
             [KeptBaseType(typeof(BaseWithField))]
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicFields)]
-            [ExpectedWarning("IL2115", nameof(BaseWithField), nameof(BaseWithField.CompilerGeneratedProperty),
-                Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/2628")]
+            [ExpectedWarning("IL2115", nameof(BaseWithField), nameof(BaseWithField.CompilerGeneratedProperty))]
             public class DerivedWithAnnotation : BaseWithField
             {
             }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/119329 to release/10.0

In the trimmer and ILC, we searched for backing fields with heuristics that validated a backing field had a `CompilerGeneratedAttribute`. In C# 14, the `field` keyword / semi-auto property feature means that some properties will have a compiler-generated field, but a user-written accessor. This can cause holes and unexpected behavior with the current heuristics. The semi-auto property accessors do not have `CompilerGeneratedAttribute`, so we can tighten the heuristic to only find backing fields when all accessors _and_ the found backing field have `CompilerGeneratedAttribute`. This should apply backing field propagation heuristics to properties with at least one auto accessor (e.g. `int Prop { get => field; set; }`) only (and also warns when it is unable to find the backing field for these). For all other properties, it is possible to annotate the backing field and accessors to achieve the same behavior.

The best way to unify behavior is to only propagate the annotation from the property to the field when one of the accessors is an auto-property accessor (`get;` or `set;`). Trying to find the compiler-generated backing field in all possible cases with semi-auto properties (with the `field` keyword) would be fragile

Additional context: https://github.com/dotnet/runtime/pull/117072#discussion_r2284034486 and https://github.com/dotnet/runtime/pull/117072#discussion_r2317324985

## Customer Impact

Properties annotated with `[DynamicallyAccessedMembers]` that use the new `field` keyword could have extra compile time warnings that don't show up when trimming.

```
void ValidateValue(
  [DynamicallyAccessedMembers(PublicMethods)]
  Type param)
{ }

[DynamicallyAccessedMembers(PublicMethod)]
Type MyType {
  get
  {
    return field; // "Field does not have PublicFields annotation" warning in analyzer, not in trimmer/ilc
  }
  set
  {
    field = value;
    ValidateValue(field); // "Field does not have PublicFields annotation" warning in analyzer, not in trimmer/ilc
  }
}
```

## Regression
No. This only affects new code patterns in C# 14.


## Testing
Tests were added to validate warning behavior for different patterns of semi and auto properties with annotations on the property.

## Risk
Low.
The tightening of the heuristic for finding backing fields only excludes properties using the new patterns of C# 14. It shouldn't affect existing code in any way.