### PR TITLE
[runtime-diagnostics] allowing targeting any diagnostics branch

### DIFF
--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -12,7 +12,7 @@ resources:
       type: github
       endpoint: public
       name: dotnet/diagnostics
-      ref: $(diagnosticsBranch)
+      ref:  ${{ parameters.diagnosticsBranch }}
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -1,9 +1,10 @@
 trigger: none
 
-variables:
-  - template: /eng/pipelines/common/variables.yml
-  - name: diagnosticsBranch
-    value: main
+parameters:
+- name: diagnosticsBranch
+  displayName: Diagnostics Branch
+  type: string
+  default: main
 
 resources:
   repositories:
@@ -12,6 +13,9 @@ resources:
       endpoint: public
       name: dotnet/diagnostics
       ref: $(diagnosticsBranch)
+
+variables:
+  - template: /eng/pipelines/common/variables.yml
 
 schedules:
 - cron: "30 2 * * *"

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -1,14 +1,17 @@
 trigger: none
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+  - name: diagnosticsBranch
+    value: main
+
 resources:
   repositories:
     - repository: diagnostics
       type: github
-      name: dotnet/diagnostics
       endpoint: public
-
-variables:
-  - template: /eng/pipelines/common/variables.yml
+      name: dotnet/diagnostics
+      ref: $(diagnosticsBranch)
 
 schedules:
 - cron: "30 2 * * *"


### PR DESCRIPTION
Allows selecting specific diagnostics branch to run on.

Can select a pr in the diagnostics repo using `refs/pull/<num>/head`
