### PR TITLE
Simplify Uri IsNotSafeForUnescape checks

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3424,7 +3424,7 @@ namespace System
                     origIdx = index == -1 ? _originalUnicodeString.Length : (index + origIdx);
                 }
 
-                _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Path);
+                _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, isQuery: false);
 
                 length = _string.Length;
                 // We need to be sure that there isn't a '?' separated from the path by spaces.
@@ -3554,7 +3554,7 @@ namespace System
                         origIdx = _originalUnicodeString.Length;
                     }
 
-                    _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Query);
+                    _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, isQuery: true);
 
                     length = _string.Length;
                     // We need to be sure that there isn't a '#' separated from the query by spaces.
@@ -3605,7 +3605,7 @@ namespace System
                 {
                     origIdx = _originalUnicodeString.Length;
 
-                    _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Fragment);
+                    _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, isQuery: false);
 
                     length = _string.Length;
                     // we don't need to check _originalUnicodeString == _string because # is last part
@@ -3876,7 +3876,7 @@ namespace System
                         if (hasUnicode)
                         {
                             // Normalize user info
-                            newHost += IriHelper.EscapeUnescapeIri(pString, startInput, start + 1, UriComponents.UserInfo);
+                            newHost += IriHelper.EscapeUnescapeIri(pString, startInput, start + 1, isQuery: false);
                         }
                         ++start;
                         ch = pString[start];

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -202,8 +202,7 @@ namespace System
                 if (hasUnicode)
                 {
                     // Iri'ze and then normalize relative uris
-                    _string = EscapeUnescapeIri(_originalUnicodeString, 0, _originalUnicodeString.Length,
-                                                (UriComponents)0);
+                    _string = EscapeUnescapeIri(_originalUnicodeString, 0, _originalUnicodeString.Length, isQuery: false);
                 }
             }
             else
@@ -721,11 +720,11 @@ namespace System
         // b) Bidi chars are stripped
         //
         // should be called only if IRI parsing is switched on
-        internal unsafe string EscapeUnescapeIri(string input, int start, int end, UriComponents component)
+        internal unsafe string EscapeUnescapeIri(string input, int start, int end, bool isQuery)
         {
             fixed (char* pInput = input)
             {
-                return IriHelper.EscapeUnescapeIri(pInput, start, end, component);
+                return IriHelper.EscapeUnescapeIri(pInput, start, end, isQuery);
             }
         }
 

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -440,8 +440,7 @@ namespace System
                                 next += 2;
                                 continue;
                             }
-                            else if (iriParsing && ((ch <= '\x9F' && IsNotSafeForUnescape(ch)) ||
-                                                    (ch > '\x9F' && !IriHelper.CheckIriUnicodeRange(ch, isQuery))))
+                            else if (iriParsing && (ch <= '\x9F' ? IsNotSafeForUnescape(ch) : !IriHelper.CheckIriUnicodeRange(ch, isQuery)))
                             {
                                 // check if unenscaping gives a char outside iri range
                                 // if it does then keep it escaped
@@ -547,38 +546,29 @@ namespace System
             return (char)((a << 4) | b);
         }
 
-        internal const string RFC3986ReservedMarks = @";/?:@&=+$,#[]!'()*";
-        private const string AdditionalUnsafeToUnescape = @"%\#"; // While not specified as reserved, these are still unsafe to unescape.
-
         // When unescaping in safe mode, do not unescape the RFC 3986 reserved set:
+        // reserved    = gen-delims / sub-delims
         // gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
         // sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
         //             / "*" / "+" / "," / ";" / "="
         //
         // In addition, do not unescape the following unsafe characters:
         // excluded    = "%" / "\"
-        //
-        // This implementation used to use the following variant of the RFC 2396 reserved set.
-        // That behavior is now disabled by default, and is controlled by a UriSyntax property.
-        // reserved    = ";" | "/" | "?" | "@" | "&" | "=" | "+" | "$" | ","
-        // excluded    = control | "#" | "%" | "\"
-        internal static bool IsNotSafeForUnescape(char ch)
-        {
-            if (ch <= '\x1F' || (ch >= '\x7F' && ch <= '\x9F'))
-            {
-                return true;
-            }
+        internal static bool IsNotSafeForUnescape(char ch) =>
+            s_notSafeForUnescapeChars.Contains(ch);
 
-            const string NotSafeForUnescape = RFC3986ReservedMarks + AdditionalUnsafeToUnescape;
+        private static readonly SearchValues<char> s_notSafeForUnescapeChars = SearchValues.Create(
+            "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000A\u000B\u000C\u000D\u000E\u000F" +
+            "\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F" +
+            ";/?:@&=+$,#[]!'()*" + "%\\" + "\u007F" +
+            "\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F" +
+            "\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F");
 
-            return NotSafeForUnescape.Contains(ch);
-        }
-
-        // true for all ASCII letters and digits, as well as the RFC3986 unreserved marks '-', '_', '.', and '~'
+        /// <summary>All ASCII letters and digits, as well as the RFC3986 unreserved marks '-', '_', '.', and '~'.</summary>
         public static readonly SearchValues<char> Unreserved =
             SearchValues.Create("-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~");
 
-        // true for all ASCII letters and digits, as well as the RFC3986 reserved characters, unreserved characters, and hash
+        /// <summary>All ASCII letters and digits, as well as the RFC3986 reserved and unreserved marks.</summary>
         public static readonly SearchValues<char> UnreservedReserved =
             SearchValues.Create("!#$&'()*+,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~");
 
@@ -587,14 +577,6 @@ namespace System
 
         public static readonly SearchValues<char> UnreservedReservedExceptQuestionMarkHash =
             SearchValues.Create("!$&'()*+,-./0123456789:;=@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~");
-
-        //
-        // Is this a gen delim char from RFC 3986
-        //
-        internal static bool IsGenDelim(char ch)
-        {
-            return (ch == ':' || ch == '/' || ch == '?' || ch == '#' || ch == '[' || ch == ']' || ch == '@');
-        }
 
         internal static readonly char[] s_WSchars = new char[] { ' ', '\n', '\r', '\t' };
 

--- a/src/libraries/System.Private.Uri/tests/UnitTests/IriEscapeUnescapeTest.cs
+++ b/src/libraries/System.Private.Uri/tests/UnitTests/IriEscapeUnescapeTest.cs
@@ -158,52 +158,17 @@ namespace System.Net.Test.Uri.IriTest
 
         private void EscapeUnescapeAllUriComponentsInDifferentCultures(string uriInput)
         {
-            UriComponents[] components = new UriComponents[]
-            {
-                UriComponents.AbsoluteUri,
-                UriComponents.Fragment,
-                UriComponents.Host,
-                UriComponents.HostAndPort,
-                UriComponents.HttpRequestUrl,
-                UriComponents.KeepDelimiter,
-                UriComponents.NormalizedHost,
-                UriComponents.Path,
-                UriComponents.PathAndQuery,
-                UriComponents.Port,
-                UriComponents.Query,
-                UriComponents.Scheme,
-                UriComponents.SchemeAndServer,
-                UriComponents.SerializationInfoString,
-                UriComponents.StrongAuthority,
-                UriComponents.StrongPort,
-                UriComponents.UserInfo,
-            };
-
-            string[] results_en = new string[components.Length];
-            string[] results_zh = new string[components.Length];
-
-            for (int i = 0; i < components.Length; i++)
-            {
-                results_en[i] = EscapeUnescapeTestComponent(uriInput, components[i]);
-            }
+            string result_en_query = EscapeUnescapeTestComponent(uriInput, true);
+            string result_en_nonQuery = EscapeUnescapeTestComponent(uriInput, false);
 
             using (new ThreadCultureChange("zh-cn"))
             {
-                for (int i = 0; i < components.Length; i++)
-                {
-                    results_zh[i] = EscapeUnescapeTestComponent(uriInput, components[i]);
-                }
-
-                for (int i = 0; i < components.Length; i++)
-                {
-                    Assert.True(
-                        0 == string.CompareOrdinal(results_en[i], results_zh[i]),
-                        "Detected locale differences when processing UriComponents." + components[i]);
-                }
+                Assert.Equal(result_en_query, EscapeUnescapeTestComponent(uriInput, true));
+                Assert.Equal(result_en_nonQuery, EscapeUnescapeTestComponent(uriInput, false));
             }
         }
 
-        private string EscapeUnescapeTestComponent(string uriInput, UriComponents component)
+        private string EscapeUnescapeTestComponent(string uriInput, bool isQuery)
         {
             string? ret = null;
             HeapCheck hc = new HeapCheck(uriInput);
@@ -212,7 +177,7 @@ namespace System.Net.Test.Uri.IriTest
             {
                 fixed (char* pInput = hc.Buffer)
                 {
-                    ret = IriHelper.EscapeUnescapeIri(pInput + HeapCheck.PaddingLength, 0, uriInput.Length, component);
+                    ret = IriHelper.EscapeUnescapeIri(pInput + HeapCheck.PaddingLength, 0, uriInput.Length, isQuery);
                 }
             }
 


### PR DESCRIPTION
`ch == '%' || CheckIsReserved(ch, component) || UriHelper.IsNotSafeForUnescape(ch)`
can be simplified to just `IsNotSafeForUnescape` since the latter already contains `%` and is also a strict superset of `CheckIsReserved`.

Instead of calling into `string.Contains` for every character we can also use `SearchValues` instead, which uses a check that can be inlined.

```c#
public class UriUnescape
{
    private static readonly string s_escapedLetters = string.Concat(Enumerable.Range('a', 26).Select(i => $"%{i:X2}"));
    private static readonly string s_uriString = $"http://host/{s_escapedLetters}";

    [Benchmark] public Uri Ctor() => new Uri(s_uriString);
}
```

| Method | Toolchain         | Mean     | Error   | Ratio |
|------- |------------------ |---------:|--------:|------:|
| Ctor   | \main\corerun.exe | 294.6 ns | 4.34 ns |  1.00 |
| Ctor   | \pr\corerun.exe   | 197.6 ns | 2.17 ns |  0.67 |