### PR TITLE
Fix link to "com error codes" in inc/corerror.xml

### DIFF
--- a/src/coreclr/inc/corerror.xml
+++ b/src/coreclr/inc/corerror.xml
@@ -33,7 +33,7 @@
 <!--                                          -->
 <!-- These HRESULTs are used for mapping managed exceptions to COM error codes -->
 <!-- and vice versa through COM Interop.  For background on COM error codes see -->
-<!-- http://msdn.microsoft.com/library/default.asp?url=/library/en-us/com/error_9td2.asp. -->
+<!-- https://learn.microsoft.com/en-us/windows/win32/com/com-error-codes. -->
 
 <!-- The range (0x8013xxxx) and (0x13xxxx) is reserved for the .NET Framework SDK teams. -->
 <!-- Within that range, the following subranges have been allocated for different feature areas: -->

--- a/src/coreclr/inc/corerror.xml
+++ b/src/coreclr/inc/corerror.xml
@@ -33,7 +33,7 @@
 <!--                                          -->
 <!-- These HRESULTs are used for mapping managed exceptions to COM error codes -->
 <!-- and vice versa through COM Interop.  For background on COM error codes see -->
-<!-- https://learn.microsoft.com/en-us/windows/win32/com/com-error-codes. -->
+<!-- https://learn.microsoft.com/windows/win32/com/com-error-codes . -->
 
 <!-- The range (0x8013xxxx) and (0x13xxxx) is reserved for the .NET Framework SDK teams. -->
 <!-- Within that range, the following subranges have been allocated for different feature areas: -->


### PR DESCRIPTION
Old link to the com error codes was broken. I could not find the original content using the Wayback Machine or other resources, but I found a link that I believe references the old content.