### PR TITLE
Include suspend time on minipal ticks for Unix-like systems

### DIFF
--- a/src/native/minipal/time.c
+++ b/src/native/minipal/time.c
@@ -76,7 +76,7 @@ int64_t minipal_hires_tick_frequency(void)
 int64_t minipal_hires_ticks(void)
 {
 #if HAVE_CLOCK_GETTIME_NSEC_NP
-    return (int64_t)clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+    return (int64_t)clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
 #elif HAVE_CLOCK_MONOTONIC
     struct timespec ts;
     int result = clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -94,7 +94,7 @@ int64_t minipal_hires_ticks(void)
 int64_t minipal_lowres_ticks(void)
 {
 #if HAVE_CLOCK_GETTIME_NSEC_NP
-    return  (int64_t)clock_gettime_nsec_np(CLOCK_UPTIME_RAW) / (int64_t)(tccMilliSecondsToNanoSeconds);
+    return  (int64_t)clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW_APPROX) / (int64_t)(tccMilliSecondsToNanoSeconds);
 #elif HAVE_CLOCK_MONOTONIC
     struct timespec ts;
 


### PR DESCRIPTION
On macOS, this uses `CLOCK_MONOTONIC_RAW` (and `CLOCK_MONOTONIC_RAW_APPROX` for low-res ticks as a mini-optimization here) and on Linux uses `CLOCK_BOOTTIME` when available now.

[Emscripten](https://github.com/emscripten-core/emscripten/blob/80ca182d92aa33f874acd2f25718143ce8848f37/system/lib/llvm-libc/src/__support/time/gpu/clock_gettime.cpp) only fully implements `CLOCK_MONOTONIC` on all platforms, so leave it at that.

Of note is that this loses the optimization done in https://github.com/dotnet/coreclr/pull/2293, since there is no `CLOCK_BOOTTIME_COARSE`; however, as of Linux 5.0, all of `CLOCK_BOOTTIME`, `CLOCK_MONOTONIC`, and `CLOCK_MONOTONIC_COARSE` are handled via a fast path in vDSO on at least x86/arm64 in the low nanosecond range.

On my arm64 machine with kernel 6.15.6, I couldn't even measure a meaningful difference between any of these three at least.

Fixes #77945 and #119437