### PR TITLE
Fix compile error in coreclr/vm/methodtable.cpp GetMethodDataHelper

### DIFF
--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -3120,6 +3120,10 @@ public:
         static void HolderRelease(MethodData *pEntry)
             { WRAPPER_NO_CONTRACT; if (pEntry != NULL) pEntry->Release(); }
 
+        static void* operator new(size_t size)
+        {
+            return ::operator new(size);
+        }
         static void operator delete(void* ptr)
         {
             ::operator delete(ptr);


### PR DESCRIPTION
I get this compile error when building for SunOS (#117023)
``` 
 $runtime/src/coreclr/vm/methodtable.cpp: In static member function 'static MethodTable::MethodData* MethodTable::GetMethodDataHelper(MethodTable*, MethodTable*, MethodDataComputeOptions)':
  $runtime/src/coreclr/vm/methodtable.cpp:7130:52: error: 'static void MethodTable::MethodDataInterface::operator delete(void*)' called on pointer returned from a mismatched allocation function [-Werror=mismatched-new-delete]
   7130 |             pData = new MethodDataInterface(pMTDecl);
        |                                                    ^
  $runtime/src/coreclr/vm/methodtable.cpp:7130:52: note: returned from 'void* operator new(std::size_t)'
   7130 |             pData = new MethodDataInterface(pMTDecl);
        |                                                    ^
```
It looks like maybe this was missed when #119112 was fixed?
