### PR TITLE
Fix unicode tests for ios/tvOs

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -333,6 +333,20 @@ namespace System.IO.Compression.Tests
             await ItemEqual(actualList, expectedList, isFile: true);
             await ItemEqual(actualFolders, expectedList, isFile: false);
         }
+        public static void NormalizeFileNames(string folder)
+        {
+            foreach (var entry in Directory.GetFileSystemEntries(folder, "*", SearchOption.AllDirectories))
+            {
+                string parent = Path.GetDirectoryName(entry)!;
+                string normalized = Path.GetFileName(entry).Normalize(NormalizationForm.FormC);
+                string newPath = Path.Combine(parent, normalized);
+
+                if (entry != newPath)
+                {
+                    File.Move(entry, newPath);
+                }
+            }
+        }
 
         public static void DirFileNamesEqual(string actual, string expected)
         {

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -341,6 +341,7 @@ namespace System.IO.Compression.Tests
 
             if (PlatformDetection.IstvOS || PlatformDetection.IsiOS)
             {
+                // iOS/tvOS filesystems use NFD by default for non-ASCII characters, so we normalize to NFC for cross-platform comparison
                 actualEntries = actualEntries.Select(Path.GetFileName).Select(name => name.Normalize(NormalizationForm.FormC)).Order();
             }
             else

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -339,9 +339,17 @@ namespace System.IO.Compression.Tests
             IEnumerable<string> actualEntries = Directory.EnumerateFileSystemEntries(actual, "*", SearchOption.AllDirectories).Select(Path.GetFileName);
             IEnumerable<string> expectedEntries = Directory.EnumerateFileSystemEntries(expected, "*", SearchOption.AllDirectories).Select(Path.GetFileName);
 
-            // iOS/tvOS filesystems use NFD by default for non-ASCII characters, so we normalize to NFC for cross-platform comparison
-            actualEntries = actualEntries.Select(name => name.Normalize(NormalizationForm.FormC)).Order();
-            expectedEntries = expectedEntries.Select(name => name.Normalize(NormalizationForm.FormC)).Order();
+            if (PlatformDetection.IsiOS || PlatformDetection.IstvOS)
+            {
+                // iOS/tvOS filesystems use NFD by default for non-ASCII characters, so we normalize to NFC for cross-platform comparison
+                actualEntries = actualEntries.Select(name => name.Normalize(NormalizationForm.FormC)).Order();
+                expectedEntries = expectedEntries.Select(name => name.Normalize(NormalizationForm.FormC)).Order();
+            }
+            else
+            {
+                actualEntries = actualEntries.Order();
+                expectedEntries = expectedEntries.Order();
+            }
 
             AssertExtensions.SequenceEqual(actualEntries.ToArray(), expectedEntries.ToArray());
         }

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -336,21 +336,10 @@ namespace System.IO.Compression.Tests
 
         public static void DirFileNamesEqual(string actual, string expected)
         {
-            IEnumerable<string> actualEntries = Directory.EnumerateFileSystemEntries(actual, "*", SearchOption.AllDirectories);
-            IEnumerable<string> expectedEntries = Directory.EnumerateFileSystemEntries(expected, "*", SearchOption.AllDirectories);
+            IOrderedEnumerable<string> actualEntries = Directory.EnumerateFileSystemEntries(actual, "*", SearchOption.AllDirectories).Order();
+            IOrderedEnumerable<string> expectedEntries = Directory.EnumerateFileSystemEntries(expected, "*", SearchOption.AllDirectories).Order();
 
-            if (PlatformDetection.IstvOS || PlatformDetection.IsiOS)
-            {
-                // iOS/tvOS filesystems use NFD by default for non-ASCII characters, so we normalize to NFC for cross-platform comparison
-                actualEntries = actualEntries.Select(Path.GetFileName).Select(name => name.Normalize(NormalizationForm.FormC)).Order();
-            }
-            else
-            {
-                actualEntries = actualEntries.Select(Path.GetFileName).Order();
-            }
-            expectedEntries = expectedEntries.Select(Path.GetFileName).Order();
-
-            AssertExtensions.SequenceEqual(expectedEntries.ToArray(), actualEntries.ToArray());
+            Assert.True(actualEntries.SequenceEqual(expectedEntries, StringComparer.InvariantCulture));
         }
 
         private static async Task ItemEqual(string[] actualList, List<FileData> expectedList, bool isFile)

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -339,11 +339,14 @@ namespace System.IO.Compression.Tests
             IEnumerable<string> actualEntries = Directory.EnumerateFileSystemEntries(actual, "*", SearchOption.AllDirectories);
             IEnumerable<string> expectedEntries = Directory.EnumerateFileSystemEntries(expected, "*", SearchOption.AllDirectories);
 
-#if OS_IOS || OS_TVOS
-            actualEntries = actualEntries.Select(Path.GetFileName).Select(name => name.Normalize(NormalizationForm.FormC)).Order();
-#else
-            actualEntries = actualEntries.Select(Path.GetFileName).Order();
-#endif
+            if (PlatformDetection.IstvOS || PlatformDetection.IsiOS)
+            {
+                actualEntries = actualEntries.Select(Path.GetFileName).Select(name => name.Normalize(NormalizationForm.FormC)).Order();
+            }
+            else
+            {
+                actualEntries = actualEntries.Select(Path.GetFileName).Order();
+            }
             expectedEntries = expectedEntries.Select(Path.GetFileName).Order();
 
             AssertExtensions.SequenceEqual(expectedEntries.ToArray(), actualEntries.ToArray());

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.Stream.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.Stream.cs
@@ -79,7 +79,6 @@ public class ZipFile_Extract_Stream : ZipFileTestBase
 
     [Theory]
     [MemberData(nameof(Get_Booleans_Data))]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/72951", TestPlatforms.iOS | TestPlatforms.tvOS)]
     public async Task ExtractToDirectoryUnicode(bool async)
     {
         FileStream source = CreateFileStreamRead(async, zfile("unicode.zip"));

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.Stream.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.Stream.cs
@@ -85,7 +85,6 @@ public class ZipFile_Extract_Stream : ZipFileTestBase
         string folderName = zfolder("unicode");
         using TempDirectory tempFolder = new TempDirectory(GetTestFilePath());
         await CallZipFileExtractToDirectory(async, source, tempFolder.Path);
-        NormalizeFileNames(tempFolder.Path);
         DirFileNamesEqual(tempFolder.Path, folderName);
         await DisposeStream(async, source);
     }

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.Stream.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.Stream.cs
@@ -85,6 +85,7 @@ public class ZipFile_Extract_Stream : ZipFileTestBase
         string folderName = zfolder("unicode");
         using TempDirectory tempFolder = new TempDirectory(GetTestFilePath());
         await CallZipFileExtractToDirectory(async, source, tempFolder.Path);
+        NormalizeFileNames(tempFolder.Path);
         DirFileNamesEqual(tempFolder.Path, folderName);
         await DisposeStream(async, source);
     }

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -44,7 +44,6 @@ namespace System.IO.Compression.Tests
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72951", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public async Task ExtractToDirectoryUnicode(bool async)
         {
             string zipFileName = zfile("unicode.zip");

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -51,6 +51,7 @@ namespace System.IO.Compression.Tests
             using (var tempFolder = new TempDirectory(GetTestFilePath()))
             {
                 await CallZipFileExtractToDirectory(async, zipFileName, tempFolder.Path);
+                NormalizeFileNames(tempFolder.Path);
                 DirFileNamesEqual(tempFolder.Path, folderName);
             }
         }

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -51,7 +51,6 @@ namespace System.IO.Compression.Tests
             using (var tempFolder = new TempDirectory(GetTestFilePath()))
             {
                 await CallZipFileExtractToDirectory(async, zipFileName, tempFolder.Path);
-                NormalizeFileNames(tempFolder.Path);
                 DirFileNamesEqual(tempFolder.Path, folderName);
             }
         }

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Extract.cs
@@ -32,7 +32,6 @@ namespace System.IO.Compression.Tests
 
             string tempFolder = GetTestFilePath();
             await CallZipFileExtensionsExtractToDirectory(async, archive, tempFolder);
-            NormalizeFileNames(tempFolder);
             DirFileNamesEqual(tempFolder, zfolder("unicode"));
 
             await DisposeZipArchive(async, archive);

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Extract.cs
@@ -24,7 +24,6 @@ namespace System.IO.Compression.Tests
             await DisposeZipArchive(async, archive);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72951", TestPlatforms.iOS | TestPlatforms.tvOS)]
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
         public async Task ExtractToDirectoryExtension_Unicode(bool async)

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Extract.cs
@@ -32,6 +32,7 @@ namespace System.IO.Compression.Tests
 
             string tempFolder = GetTestFilePath();
             await CallZipFileExtensionsExtractToDirectory(async, archive, tempFolder);
+            NormalizeFileNames(tempFolder);
             DirFileNamesEqual(tempFolder, zfolder("unicode"));
 
             await DisposeZipArchive(async, archive);


### PR DESCRIPTION
Fixes #72951

Normalize extra ascii characters to perform correct matching on apple platforms 