### PR TITLE
[nativeaot] Don't overwrite `$(LinkNativeDependsOn)` property

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -87,7 +87,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <IlcCompileOutput>$(NativeObject)</IlcCompileOutput>
 
-    <LinkNativeDependsOn>IlcCompile</LinkNativeDependsOn>
+    <LinkNativeDependsOn>IlcCompile;$(LinkNativeDependsOn)</LinkNativeDependsOn>
 
     <FrameworkLibPath Condition="'$(FrameworkLibPath)' == ''">$(NativeOutputPath)</FrameworkLibPath>
     <FrameworkObjPath Condition="'$(FrameworkObjPath)' == ''">$(NativeIntermediateOutputPath)</FrameworkObjPath>


### PR DESCRIPTION
The `$(LinkNativeDependsOn)` property is used by the `LinkNative` target to list its dependency targets. Unfortunately, its value is unconditionally overwritten in `Microsoft.NETCore.Native.targets`, making it impossible for 3rd parties to add custom dependency targets to the `LinkNative` target.

Change the code to make sure that previous value of the property is preserved.