### PR TITLE
Improve codegen for `MemoryExtensions.Replace`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -4420,6 +4420,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void Replace<T>(this Span<T> span, T oldValue, T newValue) where T : IEquatable<T>?
         {
+            uint length = (uint)span.Length;
+
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (sizeof(T) == sizeof(byte))
@@ -4430,7 +4432,7 @@ namespace System
                         ref src,
                         Unsafe.BitCast<T, byte>(oldValue),
                         Unsafe.BitCast<T, byte>(newValue),
-                        (uint)span.Length);
+                        length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(ushort))
@@ -4442,7 +4444,7 @@ namespace System
                         ref src,
                         Unsafe.BitCast<T, ushort>(oldValue),
                         Unsafe.BitCast<T, ushort>(newValue),
-                        (uint)span.Length);
+                        length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(int))
@@ -4453,7 +4455,7 @@ namespace System
                         ref src,
                         Unsafe.BitCast<T, int>(oldValue),
                         Unsafe.BitCast<T, int>(newValue),
-                        (uint)span.Length);
+                        length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(long))
@@ -4464,13 +4466,13 @@ namespace System
                         ref src,
                         Unsafe.BitCast<T, long>(oldValue),
                         Unsafe.BitCast<T, long>(newValue),
-                        (uint)span.Length);
+                        length);
                     return;
                 }
             }
 
             ref T src2 = ref MemoryMarshal.GetReference(span);
-            SpanHelpers.Replace(ref src2, ref src2, oldValue, newValue, (uint)span.Length);
+            SpanHelpers.Replace(ref src2, ref src2, oldValue, newValue, length);
         }
 
         /// <summary>
@@ -4577,12 +4579,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void Replace<T>(this ReadOnlySpan<T> source, Span<T> destination, T oldValue, T newValue) where T : IEquatable<T>?
         {
-            if (source.Length == 0)
+            uint length = (uint)source.Length;
+            if (length == 0)
             {
                 return;
             }
 
-            if (source.Length > destination.Length)
+            if (length > (uint)destination.Length)
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
@@ -4607,7 +4610,7 @@ namespace System
                         ref Unsafe.As<T, byte>(ref dst),
                         Unsafe.BitCast<T, byte>(oldValue),
                         Unsafe.BitCast<T, byte>(newValue),
-                        (uint)source.Length);
+                        length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(ushort))
@@ -4618,7 +4621,7 @@ namespace System
                         ref Unsafe.As<T, ushort>(ref dst),
                         Unsafe.BitCast<T, ushort>(oldValue),
                         Unsafe.BitCast<T, ushort>(newValue),
-                        (uint)source.Length);
+                        length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(int))
@@ -4628,7 +4631,7 @@ namespace System
                         ref Unsafe.As<T, int>(ref dst),
                         Unsafe.BitCast<T, int>(oldValue),
                         Unsafe.BitCast<T, int>(newValue),
-                        (uint)source.Length);
+                        length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(long))
@@ -4638,12 +4641,12 @@ namespace System
                         ref Unsafe.As<T, long>(ref dst),
                         Unsafe.BitCast<T, long>(oldValue),
                         Unsafe.BitCast<T, long>(newValue),
-                        (uint)source.Length);
+                        length);
                     return;
                 }
             }
 
-            SpanHelpers.Replace(ref src, ref dst, oldValue, newValue, (uint)source.Length);
+            SpanHelpers.Replace(ref src, ref dst, oldValue, newValue, length);
         }
 
         /// <summary>
@@ -4660,12 +4663,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void Replace<T>(this ReadOnlySpan<T> source, Span<T> destination, T oldValue, T newValue, IEqualityComparer<T>? comparer = null)
         {
-            if (source.Length == 0)
+            uint length = (uint)source.Length;
+            if (length == 0)
             {
                 return;
             }
 
-            if (source.Length > destination.Length)
+            if (length > (uint)destination.Length)
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
@@ -4692,7 +4696,7 @@ namespace System
                             ref Unsafe.As<T, byte>(ref dst),
                             Unsafe.BitCast<T, byte>(oldValue),
                             Unsafe.BitCast<T, byte>(newValue),
-                            (uint)source.Length);
+                            length);
                         return;
                     }
                     else if (sizeof(T) == sizeof(ushort))
@@ -4703,7 +4707,7 @@ namespace System
                             ref Unsafe.As<T, ushort>(ref dst),
                             Unsafe.BitCast<T, ushort>(oldValue),
                             Unsafe.BitCast<T, ushort>(newValue),
-                            (uint)source.Length);
+                            length);
                         return;
                     }
                     else if (sizeof(T) == sizeof(int))
@@ -4713,7 +4717,7 @@ namespace System
                             ref Unsafe.As<T, int>(ref dst),
                             Unsafe.BitCast<T, int>(oldValue),
                             Unsafe.BitCast<T, int>(newValue),
-                            (uint)source.Length);
+                            length);
                         return;
                     }
                     else if (sizeof(T) == sizeof(long))
@@ -4723,7 +4727,7 @@ namespace System
                             ref Unsafe.As<T, long>(ref dst),
                             Unsafe.BitCast<T, long>(oldValue),
                             Unsafe.BitCast<T, long>(newValue),
-                            (uint)source.Length);
+                            length);
                         return;
                     }
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -4420,8 +4420,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void Replace<T>(this Span<T> span, T oldValue, T newValue) where T : IEquatable<T>?
         {
-            nuint length = (uint)span.Length;
-
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (sizeof(T) == sizeof(byte))
@@ -4432,7 +4430,7 @@ namespace System
                         ref src,
                         Unsafe.BitCast<T, byte>(oldValue),
                         Unsafe.BitCast<T, byte>(newValue),
-                        length);
+                        (uint)span.Length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(ushort))
@@ -4444,7 +4442,7 @@ namespace System
                         ref src,
                         Unsafe.BitCast<T, ushort>(oldValue),
                         Unsafe.BitCast<T, ushort>(newValue),
-                        length);
+                        (uint)span.Length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(int))
@@ -4455,7 +4453,7 @@ namespace System
                         ref src,
                         Unsafe.BitCast<T, int>(oldValue),
                         Unsafe.BitCast<T, int>(newValue),
-                        length);
+                        (uint)span.Length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(long))
@@ -4466,13 +4464,13 @@ namespace System
                         ref src,
                         Unsafe.BitCast<T, long>(oldValue),
                         Unsafe.BitCast<T, long>(newValue),
-                        length);
+                        (uint)span.Length);
                     return;
                 }
             }
 
             ref T src2 = ref MemoryMarshal.GetReference(span);
-            SpanHelpers.Replace(ref src2, ref src2, oldValue, newValue, length);
+            SpanHelpers.Replace(ref src2, ref src2, oldValue, newValue, (uint)span.Length);
         }
 
         /// <summary>
@@ -4579,13 +4577,12 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void Replace<T>(this ReadOnlySpan<T> source, Span<T> destination, T oldValue, T newValue) where T : IEquatable<T>?
         {
-            nuint length = (uint)source.Length;
-            if (length == 0)
+            if (source.Length == 0)
             {
                 return;
             }
 
-            if (length > (uint)destination.Length)
+            if (source.Length > destination.Length)
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
@@ -4610,7 +4607,7 @@ namespace System
                         ref Unsafe.As<T, byte>(ref dst),
                         Unsafe.BitCast<T, byte>(oldValue),
                         Unsafe.BitCast<T, byte>(newValue),
-                        length);
+                        (uint)source.Length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(ushort))
@@ -4621,7 +4618,7 @@ namespace System
                         ref Unsafe.As<T, ushort>(ref dst),
                         Unsafe.BitCast<T, ushort>(oldValue),
                         Unsafe.BitCast<T, ushort>(newValue),
-                        length);
+                        (uint)source.Length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(int))
@@ -4631,7 +4628,7 @@ namespace System
                         ref Unsafe.As<T, int>(ref dst),
                         Unsafe.BitCast<T, int>(oldValue),
                         Unsafe.BitCast<T, int>(newValue),
-                        length);
+                        (uint)source.Length);
                     return;
                 }
                 else if (sizeof(T) == sizeof(long))
@@ -4641,12 +4638,12 @@ namespace System
                         ref Unsafe.As<T, long>(ref dst),
                         Unsafe.BitCast<T, long>(oldValue),
                         Unsafe.BitCast<T, long>(newValue),
-                        length);
+                        (uint)source.Length);
                     return;
                 }
             }
 
-            SpanHelpers.Replace(ref src, ref dst, oldValue, newValue, length);
+            SpanHelpers.Replace(ref src, ref dst, oldValue, newValue, (uint)source.Length);
         }
 
         /// <summary>
@@ -4663,13 +4660,12 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void Replace<T>(this ReadOnlySpan<T> source, Span<T> destination, T oldValue, T newValue, IEqualityComparer<T>? comparer = null)
         {
-            nuint length = (uint)source.Length;
-            if (length == 0)
+            if (source.Length == 0)
             {
                 return;
             }
 
-            if (length > (uint)destination.Length)
+            if (source.Length > destination.Length)
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
@@ -4696,7 +4692,7 @@ namespace System
                             ref Unsafe.As<T, byte>(ref dst),
                             Unsafe.BitCast<T, byte>(oldValue),
                             Unsafe.BitCast<T, byte>(newValue),
-                            length);
+                            (uint)source.Length);
                         return;
                     }
                     else if (sizeof(T) == sizeof(ushort))
@@ -4707,7 +4703,7 @@ namespace System
                             ref Unsafe.As<T, ushort>(ref dst),
                             Unsafe.BitCast<T, ushort>(oldValue),
                             Unsafe.BitCast<T, ushort>(newValue),
-                            length);
+                            (uint)source.Length);
                         return;
                     }
                     else if (sizeof(T) == sizeof(int))
@@ -4717,7 +4713,7 @@ namespace System
                             ref Unsafe.As<T, int>(ref dst),
                             Unsafe.BitCast<T, int>(oldValue),
                             Unsafe.BitCast<T, int>(newValue),
-                            length);
+                            (uint)source.Length);
                         return;
                     }
                     else if (sizeof(T) == sizeof(long))
@@ -4727,7 +4723,7 @@ namespace System
                             ref Unsafe.As<T, long>(ref dst),
                             Unsafe.BitCast<T, long>(oldValue),
                             Unsafe.BitCast<T, long>(newValue),
-                            length);
+                            (uint)source.Length);
                         return;
                     }
                 }


### PR DESCRIPTION
These changes show significant improvements in codegen, see https://github.com/MihuBot/runtime-utils/issues/1456.