### PR TITLE
Use XOR instead of subtraction for constant-time equality checks.

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptographicOperations.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptographicOperations.cs
@@ -47,14 +47,13 @@ namespace System.Security.Cryptography
             }
 
             int length = left.Length;
-            int accum = 0;
-
+            int diff = 0;
             for (int i = 0; i < length; i++)
             {
-                accum |= left[i] - right[i];
+                diff |= left[i] ^ right[i];
             }
 
-            return accum == 0;
+            return diff == 0;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]


### PR DESCRIPTION
Changes `FixedTimeEquals` to use `XOR` instead of `SUB`.

XOR directly expresses the statement "are these bytes different"; the use of subtraction changes that to "what is the difference between these bytes". 
The agreed implementation for constant-time security is to avoid arithmetic that may introduce timing variations between platform/processor/compiler. XOR operations `a ^ b` produces a non-zero result, only when bits differ, and benefits from being its own inverse without requiring extra-information like carry bits or sign bits. XOR is cheaper at a CPU level (realitically not a huge factor unless your on certain low speed asics) though I mention this more for fun than "this would have a huge impact on perf"; Theoretically that difference can matter in side-channel-attacks that utilise differential power analysis; but again not the biggest driver for change vs consistency and agreed approach. 

* XOR usage makes this consistent with:
  * Windows SymCrypt https://github.com/microsoft/SymCrypt/blob/6d019cefafb3fefe3c53b0de3bba6f8c86e2d48a/lib/equal.c
  * GoLang std FIPS140 https://cs.opensource.google/go/go/+/master:src/crypto/internal/fips140/subtle/constant_time.go;l=72?q=ConstantTimeEq&ss=go%2Fgo
  * JDK https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/security/MessageDigest.java#L473C1-L486C6
  * Rust https://github.com/cesarb/constant_time_eq/blob/main/src/generic.rs#L158
  * OpenBSD https://sources.debian.org/src/openssh/1%3A10.0p1-6/openbsd-compat/timingsafe_bcmp.c/#L30


```
BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.4946/24H2/2024Update/HudsonValley)
AMD Ryzen 9 9900X 4.40GHz, 1 CPU, 24 logical and 12 physical cores
.NET SDK 9.0.304
  [Host]     : .NET 9.0.8 (9.0.825.36511), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  DefaultJob : .NET 9.0.8 (9.0.825.36511), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
```

| Method                             | Mean        | BranchInstructions/Op | Code Size |
|----------------------------------- |------------:|----------------------:|----------:|
| XOR_WithVariance          | 3,396.70 ns |                 8,335 |     377 B |
| FixedTimeEquals_WithVariance       | 3,337.46 ns |                 8,338 |     381 B |
| XOR_ExtremeValues         | 3,474.97 ns |                11,403 |     339 B |
| FixedTimeEquals_ExtremeValues      | 3,385.70 ns |                11,418 |     343 B |
| XOR_RealisticShaValues    |    88.68 ns |                   237 |     275 B |
| FixedTimeEquals_RealisticShaValues |    87.80 ns |                   237 |     279 B |
