### PR TITLE
Switch to OSX.13.Amd64.Open queues

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -117,9 +117,9 @@ jobs:
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - OSX.1200.Amd64.Open
+        - OSX.13.Amd64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - OSX.1200.Amd64
+        - OSX.13.Amd64
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:

--- a/eng/pipelines/installer/helix-queues-setup.yml
+++ b/eng/pipelines/installer/helix-queues-setup.yml
@@ -52,7 +52,7 @@ jobs:
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
-      - OSX.1200.Amd64.Open
+      - OSX.13.Amd64.Open
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -85,7 +85,7 @@ jobs:
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
-      - OSX.1200.Amd64.Open
+      - OSX.13.Amd64.Open
 
     # Android
     - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:


### PR DESCRIPTION
macOS 12 is out of support.

I ended up here because the host tests are hitting a crash on 12 that doesn't seem to happen on newer versions. Since 12 is EOL and I believe the helix queues are slated to be removed, I expect we want to update runtime and libraries tests too.

Resolves https://github.com/dotnet/runtime/issues/118904.
