### PR TITLE
Avoid leaking pthread flags from zlib-ng.cmake

### DIFF
--- a/src/native/external/zlib-ng.cmake
+++ b/src/native/external/zlib-ng.cmake
@@ -26,8 +26,8 @@ if (CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
 
   # zlib-ng uses atomics, so we need to enable threads when requested for browser/wasi, otherwise the wasm target won't have thread support.
   if (CMAKE_USE_PTHREADS)
-      add_compile_options(-pthread)
-      add_linker_flag(-pthread)
+      target_compile_options(zlib PRIVATE -pthread)
+      target_link_options(zlib PRIVATE -pthread)
   endif()
 endif()
 

--- a/src/native/external/zlib-ng.cmake
+++ b/src/native/external/zlib-ng.cmake
@@ -23,12 +23,6 @@ endif()
 if (CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
   # 'aligned_alloc' is not available in browser/wasi, yet it is set by zlib-ng/CMakeLists.txt.
   set(HAVE_ALIGNED_ALLOC FALSE CACHE BOOL "have aligned_alloc" FORCE)
-
-  # zlib-ng uses atomics, so we need to enable threads when requested for browser/wasi, otherwise the wasm target won't have thread support.
-  if (CMAKE_USE_PTHREADS)
-      target_compile_options(zlib PRIVATE -pthread)
-      target_link_options(zlib PRIVATE -pthread)
-  endif()
 endif()
 
 if (MSVC)
@@ -48,5 +42,13 @@ target_compile_options(zlib PRIVATE $<$<COMPILE_LANG_AND_ID:C,Clang,AppleClang>:
 target_compile_options(zlib PRIVATE $<$<COMPILE_LANG_AND_ID:C,Clang,AppleClang>:-Wno-logical-op-parentheses>) # place parentheses around the '&&' expression to silence this warning
 target_compile_options(zlib PRIVATE $<$<COMPILE_LANG_AND_ID:C,MSVC>:/wd4127>) # warning C4127: conditional expression is constant
 target_compile_options(zlib PRIVATE $<$<COMPILE_LANG_AND_ID:C,MSVC>:/guard:cf>) # Enable CFG always for zlib-ng so we don't need to build two flavors.
+
+if (CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
+  # zlib-ng uses atomics, so we need to enable threads when requested for browser/wasi, otherwise the wasm target won't have thread support.
+  if (CMAKE_USE_PTHREADS)
+    target_compile_options(zlib PRIVATE -pthread)
+    target_link_options(zlib PRIVATE -pthread)
+  endif()
+endif()
 
 set_target_properties(zlib PROPERTIES DEBUG_POSTFIX "") # Workaround: zlib's debug lib name is zlibd.lib


### PR DESCRIPTION
See comment at the start of the file, add_compile_options() and add_linker_flag() will leak to the cmake projects which include zlib-ng.cmake.