### PR TITLE
Remove `SR.Argument_NeedStructWithNoRefs`

### DIFF
--- a/src/libraries/System.Memory/src/Resources/Strings.resx
+++ b/src/libraries/System.Memory/src/Resources/Strings.resx
@@ -124,7 +124,7 @@
     <value>GetHashCode() on Span and ReadOnlySpan is not supported.</value>
   </data>
   <data name="Argument_TypeContainsReferences" xml:space="preserve">
-    <value>The type '{0}' is not supported because it contains references</value>
+    <value>The type '{0}' is not supported because it contains references.</value>
   </data>
   <data name="Argument_DestinationTooShort" xml:space="preserve">
     <value>Destination is too short.</value>

--- a/src/libraries/System.Memory/src/Resources/Strings.resx
+++ b/src/libraries/System.Memory/src/Resources/Strings.resx
@@ -123,8 +123,8 @@
   <data name="NotSupported_CannotCallGetHashCodeOnSpan" xml:space="preserve">
     <value>GetHashCode() on Span and ReadOnlySpan is not supported.</value>
   </data>
-  <data name="Argument_InvalidTypeWithPointersNotSupported" xml:space="preserve">
-    <value>Cannot use type '{0}'. Only value types without pointers or references are supported.</value>
+  <data name="Argument_NeedValueTypeWithNoRefs" xml:space="preserve">
+    <value>Type '{0}' must be a value type without references.</value>
   </data>
   <data name="Argument_DestinationTooShort" xml:space="preserve">
     <value>Destination is too short.</value>

--- a/src/libraries/System.Memory/src/Resources/Strings.resx
+++ b/src/libraries/System.Memory/src/Resources/Strings.resx
@@ -123,8 +123,8 @@
   <data name="NotSupported_CannotCallGetHashCodeOnSpan" xml:space="preserve">
     <value>GetHashCode() on Span and ReadOnlySpan is not supported.</value>
   </data>
-  <data name="Argument_NeedValueTypeWithNoRefs" xml:space="preserve">
-    <value>Type '{0}' must be a value type without references.</value>
+  <data name="Argument_TypeContainsReferences" xml:space="preserve">
+    <value>The type '{0}' is not supported because it contains references</value>
   </data>
   <data name="Argument_DestinationTooShort" xml:space="preserve">
     <value>Destination is too short.</value>

--- a/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
+++ b/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
@@ -138,8 +138,8 @@
   <data name="Argument_InvalidEnumValue" xml:space="preserve">
     <value>The value '{0}' is not valid for this usage of the type {1}.</value>
   </data>
-  <data name="Argument_NeedValueTypeWithNoRefs" xml:space="preserve">
-    <value>Type '{0}' must be a value type without references.</value>
+  <data name="Argument_TypeContainsReferences" xml:space="preserve">
+    <value>The type '{0}' is not supported because it contains references</value>
   </data>
   <data name="DestinationTooShort" xml:space="preserve">
     <value>Destination is too short.</value>

--- a/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
+++ b/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
@@ -139,7 +139,7 @@
     <value>The value '{0}' is not valid for this usage of the type {1}.</value>
   </data>
   <data name="Argument_TypeContainsReferences" xml:space="preserve">
-    <value>The type '{0}' is not supported because it contains references</value>
+    <value>The type '{0}' is not supported because it contains references.</value>
   </data>
   <data name="DestinationTooShort" xml:space="preserve">
     <value>Destination is too short.</value>

--- a/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
+++ b/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
@@ -138,8 +138,8 @@
   <data name="Argument_InvalidEnumValue" xml:space="preserve">
     <value>The value '{0}' is not valid for this usage of the type {1}.</value>
   </data>
-  <data name="Argument_InvalidTypeWithPointersNotSupported" xml:space="preserve">
-    <value>Cannot use type '{0}'. Only value types without pointers or references are supported.</value>
+  <data name="Argument_NeedValueTypeWithNoRefs" xml:space="preserve">
+    <value>Type '{0}' must be a value type without references.</value>
   </data>
   <data name="DestinationTooShort" xml:space="preserve">
     <value>Destination is too short.</value>

--- a/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
@@ -60,9 +60,9 @@ namespace System
         }
 
         [DoesNotReturn]
-        internal static void ThrowArgumentException_NeedValueTypeWithNoRefs(Type targetType)
+        internal static void ThrowArgument_TypeContainsReferences(Type targetType)
         {
-            throw new ArgumentException(SR.Format(SR.Argument_NeedValueTypeWithNoRefs, targetType));
+            throw new ArgumentException(SR.Format(SR.Argument_TypeContainsReferences, targetType));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
@@ -60,9 +60,9 @@ namespace System
         }
 
         [DoesNotReturn]
-        internal static void ThrowInvalidTypeWithPointersNotSupported(Type targetType)
+        internal static void ThrowArgumentException_NeedValueTypeWithNoRefs(Type targetType)
         {
-            throw new ArgumentException(SR.Format(SR.Argument_InvalidTypeWithPointersNotSupported, targetType));
+            throw new ArgumentException(SR.Format(SR.Argument_NeedValueTypeWithNoRefs, targetType));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1376,7 +1376,7 @@
     <value>The name of the type is invalid.</value>
   </data>
   <data name="Argument_TypeContainsReferences" xml:space="preserve">
-    <value>The type '{0}' is not supported because it contains references</value>
+    <value>The type '{0}' is not supported because it contains references.</value>
   </data>
   <data name="Argument_InvalidUnity" xml:space="preserve">
     <value>Type '{0}' is not deserializable.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1456,9 +1456,6 @@
   <data name="Argument_NeedNonGenericType" xml:space="preserve">
     <value>The specified Type must not be a generic type.</value>
   </data>
-  <data name="Argument_NeedStructWithNoRefs" xml:space="preserve">
-    <value>The specified Type must be a struct containing no references.</value>
-  </data>
   <data name="Argument_NegativeFieldOffsetNotPermitted" xml:space="preserve">
     <value>Negative field offset is not allowed.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1375,8 +1375,8 @@
   <data name="Argument_InvalidTypeName" xml:space="preserve">
     <value>The name of the type is invalid.</value>
   </data>
-  <data name="Argument_NeedValueTypeWithNoRefs" xml:space="preserve">
-    <value>Type '{0}' must be a value type without references.</value>
+  <data name="Argument_TypeContainsReferences" xml:space="preserve">
+    <value>The type '{0}' is not supported because it contains references</value>
   </data>
   <data name="Argument_InvalidUnity" xml:space="preserve">
     <value>Type '{0}' is not deserializable.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1375,8 +1375,8 @@
   <data name="Argument_InvalidTypeName" xml:space="preserve">
     <value>The name of the type is invalid.</value>
   </data>
-  <data name="Argument_InvalidTypeWithPointersNotSupported" xml:space="preserve">
-    <value>Cannot use type '{0}'. Only value types without pointers or references are supported.</value>
+  <data name="Argument_NeedValueTypeWithNoRefs" xml:space="preserve">
+    <value>Type '{0}' must be a value type without references.</value>
   </data>
   <data name="Argument_InvalidUnity" xml:space="preserve">
     <value>Type '{0}' is not deserializable.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -103,7 +103,7 @@ namespace System
         public unsafe ReadOnlySpan(void* pointer, int length)
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -103,7 +103,7 @@ namespace System
         public unsafe ReadOnlySpan(void* pointer, int length)
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -31,7 +31,7 @@ namespace System.Runtime.InteropServices
             where T : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
 
             return new Span<byte>(
                 ref Unsafe.As<T, byte>(ref GetReference(span)),
@@ -54,7 +54,7 @@ namespace System.Runtime.InteropServices
             where T : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
 
             return new ReadOnlySpan<byte>(
                 ref Unsafe.As<T, byte>(ref GetReference(span)),
@@ -116,9 +116,9 @@ namespace System.Runtime.InteropServices
             where TTo : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TFrom>())
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(TFrom));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(TFrom));
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(TTo));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(TTo));
 
             // Use unsigned integers - unsigned division by constant (especially by power of 2)
             // and checked casts are faster and smaller.
@@ -171,9 +171,9 @@ namespace System.Runtime.InteropServices
             where TTo : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TFrom>())
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(TFrom));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(TFrom));
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(TTo));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(TTo));
 
             // Use unsigned integers - unsigned division by constant (especially by power of 2)
             // and checked casts are faster and smaller.
@@ -470,7 +470,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
             }
             if (sizeof(T) > source.Length)
             {
@@ -489,7 +489,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
             }
             if (sizeof(T) > (uint)source.Length)
             {
@@ -509,7 +509,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
             }
             if ((uint)sizeof(T) > (uint)destination.Length)
             {
@@ -528,7 +528,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
             }
             if (sizeof(T) > (uint)destination.Length)
             {
@@ -551,7 +551,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
             }
             if (sizeof(T) > (uint)span.Length)
             {
@@ -573,7 +573,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
             }
             if (sizeof(T) > (uint)span.Length)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -31,7 +31,7 @@ namespace System.Runtime.InteropServices
             where T : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
 
             return new Span<byte>(
                 ref Unsafe.As<T, byte>(ref GetReference(span)),
@@ -54,7 +54,7 @@ namespace System.Runtime.InteropServices
             where T : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
 
             return new ReadOnlySpan<byte>(
                 ref Unsafe.As<T, byte>(ref GetReference(span)),
@@ -116,9 +116,9 @@ namespace System.Runtime.InteropServices
             where TTo : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TFrom>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TFrom));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(TFrom));
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TTo));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(TTo));
 
             // Use unsigned integers - unsigned division by constant (especially by power of 2)
             // and checked casts are faster and smaller.
@@ -171,9 +171,9 @@ namespace System.Runtime.InteropServices
             where TTo : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TFrom>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TFrom));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(TFrom));
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TTo));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(TTo));
 
             // Use unsigned integers - unsigned division by constant (especially by power of 2)
             // and checked casts are faster and smaller.
@@ -470,7 +470,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
             }
             if (sizeof(T) > source.Length)
             {
@@ -489,7 +489,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
             }
             if (sizeof(T) > (uint)source.Length)
             {
@@ -509,7 +509,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
             }
             if ((uint)sizeof(T) > (uint)destination.Length)
             {
@@ -528,7 +528,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
             }
             if (sizeof(T) > (uint)destination.Length)
             {
@@ -551,7 +551,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
             }
             if (sizeof(T) > (uint)span.Length)
             {
@@ -573,7 +573,7 @@ namespace System.Runtime.InteropServices
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
             }
             if (sizeof(T) > (uint)span.Length)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -403,7 +403,7 @@ namespace System.Runtime.InteropServices
         internal static uint SizeOf<T>() where T : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
 
             return (uint)sizeof(T);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -403,7 +403,7 @@ namespace System.Runtime.InteropServices
         internal static uint SizeOf<T>() where T : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
 
             return (uint)sizeof(T);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -403,7 +403,7 @@ namespace System.Runtime.InteropServices
         internal static uint SizeOf<T>() where T : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                throw new ArgumentException(SR.Argument_NeedStructWithNoRefs);
+                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
 
             return (uint)sizeof(T);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -108,7 +108,7 @@ namespace System
         public unsafe Span(void* pointer, int length)
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
+                ThrowHelper.ThrowArgument_TypeContainsReferences(typeof(T));
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -108,7 +108,7 @@ namespace System
         public unsafe Span(void* pointer, int length)
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
+                ThrowHelper.ThrowArgumentException_NeedValueTypeWithNoRefs(typeof(T));
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -78,12 +78,6 @@ namespace System
         }
 
         [DoesNotReturn]
-        internal static void ThrowInvalidTypeWithPointersNotSupported(Type targetType)
-        {
-            throw new ArgumentException(SR.Format(SR.Argument_InvalidTypeWithPointersNotSupported, targetType));
-        }
-
-        [DoesNotReturn]
         internal static void ThrowIndexOutOfRangeException()
         {
             throw new IndexOutOfRangeException();
@@ -135,6 +129,12 @@ namespace System
         internal static void ThrowArgumentException_TupleIncorrectType(object obj)
         {
             throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, obj.GetType()), "other");
+        }
+
+        [DoesNotReturn]
+        internal static void ThrowArgumentException_NeedValueTypeWithNoRefs(Type targetType)
+        {
+            throw new ArgumentException(SR.Format(SR.Argument_NeedValueTypeWithNoRefs, targetType));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -78,6 +78,12 @@ namespace System
         }
 
         [DoesNotReturn]
+        internal static void ThrowArgument_TypeContainsReferences(Type targetType)
+        {
+            throw new ArgumentException(SR.Format(SR.Argument_TypeContainsReferences, targetType));
+        }
+
+        [DoesNotReturn]
         internal static void ThrowIndexOutOfRangeException()
         {
             throw new IndexOutOfRangeException();
@@ -129,12 +135,6 @@ namespace System
         internal static void ThrowArgumentException_TupleIncorrectType(object obj)
         {
             throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, obj.GetType()), "other");
-        }
-
-        [DoesNotReturn]
-        internal static void ThrowArgumentException_NeedValueTypeWithNoRefs(Type targetType)
-        {
-            throw new ArgumentException(SR.Format(SR.Argument_NeedValueTypeWithNoRefs, targetType));
         }
 
         [DoesNotReturn]


### PR DESCRIPTION
This change removes the `SR.Argument_NeedStructWithNoRefs` resource string and updates the corresponding `ArgumentException` message to be more descriptive.

The old message was:

```
The specified Type must be a struct containing no references.
```

This has been replaced with:

```
The type '{0}' is not supported because it contains references.
```
