### PR TITLE
[H/3] Fix interop tests.

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -814,7 +814,6 @@ namespace System.Net.Http.Functional.Tests
             };
             using HttpResponseMessage response = await client.SendAsync(request).WaitAsync(TimeSpan.FromSeconds(20));
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(3, response.Version.Major);
         }
 
@@ -833,7 +832,6 @@ namespace System.Net.Http.Functional.Tests
             };
             using HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead).WaitAsync(TimeSpan.FromSeconds(20));
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(3, response.Version.Major);
 
             var content = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
Based on Kusto data, since 25.8., interop test against cloudflare has been failing on the response status check (whether it's 200 OK, it's not, it's 403 now). We can either disable the test and lose coverage or just ignore the status. I chose the later since the status code in not relevant in evaluating whether HTTP/3 is working or not.

And we'll need to backport to all active release branches.
