### PR TITLE
Revert the update to the dotnet/runtime/eng/common file 

### DIFF
--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -95,8 +95,7 @@ try {
         if ($targetDirectory) {
           # Binskim crashes due to specific PDBs. GitHub issue: https://github.com/microsoft/binskim/issues/924.
           # We are excluding all `_.pdb` files from the scan.
-		  # SuperfileCheck uses two external LLVM libraries (llvm-mca.exe and FileCheck.exe) that we don't build. Excluding them to supporess BA2008. 
-          $tool.Args += "`"Target < $TargetDirectory\**;-:file|$TargetDirectory\**\_.pdb;-:file|$TargetDirectory\**\llvm-mca.exe;-:file|$TargetDirectory\**\FileCheck.exe`""
+          $tool.Args += "`"Target < $TargetDirectory\**;-:file|$TargetDirectory\**\_.pdb`""
         }
         $tool.Args += $BinskimAdditionalRunConfigParams
       }


### PR DESCRIPTION
Changing the files in dotnet/runtime/eng/common does not suppress binskim scans because they are overridden on the next arcade update. 
So, reverting the change in https://github.com/dotnet/runtime/pull/119376. 
Instead, I will put up a new PR that will update https://github.com/dotnet/dotnet/blob/main/eng/pipelines/official.yml#L96-L102.