### PR TITLE
Add `AggressiveInlining` to `SizeOf` methods in `SafeBuffer`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -386,6 +386,7 @@ namespace System.Runtime.InteropServices
         /// value that sizeof(T) returns! Since the primary use case is to parse memory mapped files, we cannot change this algorithm as this defines a de-facto serialization format.
         /// Throws if T contains GC references.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static uint AlignedSizeOf<T>() where T : struct
         {
             uint size = SizeOf<T>();
@@ -400,6 +401,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Returns same value as sizeof(T) but throws if T contains GC references.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static uint SizeOf<T>() where T : struct
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())


### PR DESCRIPTION
https://github.com/MihuBot/runtime-utils/issues/1459:

```log
Found 82 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 41696249
Total bytes of diff: 41694880
Total bytes of delta: -1369 (-0.00 % of base)
Total relative delta: -9.18
    diff is an improvement.
    relative diff is an improvement.
```