### PR TITLE
[clr-interp] Fix performance of compiling huge methods

### DIFF
--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -649,6 +649,9 @@ private:
     InterpBasicBlock**  m_ppOffsetToBB;
 
     ICorDebugInfo::OffsetMapping* m_pILToNativeMap = NULL;
+#ifdef DEBUG
+    int32_t* m_pNativeMapIndexToILOffset = NULL;
+#endif
     int32_t m_ILToNativeMapSize = 0;
 
     InterpBasicBlock*   AllocBB(int32_t ilOffset);
@@ -781,15 +784,25 @@ public:
  *  Uses the compiler's AllocMemPool0, which will eventually free automatically at the end of compilation (doesn't yet).
  */
 
- inline void* operator new(size_t sz, InterpCompiler* compiler)
- {
+inline void* operator new(size_t sz, InterpCompiler* compiler)
+{
     return compiler->AllocMemPool0(sz);
 }
 
- inline void* operator new[](size_t sz, InterpCompiler* compiler)
- {
-     return compiler->AllocMemPool0(sz);
- }
+inline void* operator new[](size_t sz, InterpCompiler* compiler)
+{
+    return compiler->AllocMemPool0(sz);
+}
+
+inline void operator delete(void* ptr, InterpCompiler* compiler)
+{
+    // Nothing to do, memory will be freed when the compiler is destroyed
+}
+
+inline void operator delete[](void* ptr, InterpCompiler* compiler)
+{
+    // Nothing to do, memory will be freed when the compiler is destroyed
+}
 
 template<typename T>
 int32_t InterpDataItemIndexMap::GetDataItemIndexForT(const T& lookup)

--- a/src/coreclr/interpreter/compileropt.cpp
+++ b/src/coreclr/interpreter/compileropt.cpp
@@ -137,7 +137,7 @@ void InterpCompiler::InitializeGlobalVars()
 void InterpCompiler::EndActiveCall(InterpInst *call)
 {
     // Remove call from array
-    m_pActiveCalls->Remove(call);
+    m_pActiveCalls->Remove_ArrayIsBag(call);
 
     // Push active call that should be resolved onto the stack
     if (m_pActiveCalls->GetSize())
@@ -211,7 +211,7 @@ void InterpCompiler::CompactActiveVars(int32_t *pCurrentOffset)
         if (m_pVars[var].alive)
             return;
         *pCurrentOffset = m_pVars[var].offset;
-        m_pActiveVars->RemoveAt(i);
+        m_pActiveVars->RemoveAt_ArrayIsBag(i);
         i--;
     }
 }

--- a/src/coreclr/interpreter/compileropt.cpp
+++ b/src/coreclr/interpreter/compileropt.cpp
@@ -137,7 +137,7 @@ void InterpCompiler::InitializeGlobalVars()
 void InterpCompiler::EndActiveCall(InterpInst *call)
 {
     // Remove call from array
-    m_pActiveCalls->Remove_ArrayIsBag(call);
+    m_pActiveCalls->RemoveFirstUnordered(call);
 
     // Push active call that should be resolved onto the stack
     if (m_pActiveCalls->GetSize())
@@ -211,7 +211,7 @@ void InterpCompiler::CompactActiveVars(int32_t *pCurrentOffset)
         if (m_pVars[var].alive)
             return;
         *pCurrentOffset = m_pVars[var].offset;
-        m_pActiveVars->RemoveAt_ArrayIsBag(i);
+        m_pActiveVars->RemoveAtUnordered(i);
         i--;
     }
 }
@@ -219,8 +219,8 @@ void InterpCompiler::CompactActiveVars(int32_t *pCurrentOffset)
 void InterpCompiler::AllocOffsets()
 {
     InterpBasicBlock *pBB;
-    m_pActiveVars = new TArray<int32_t>();
-    m_pActiveCalls = new TArray<InterpInst*>();
+    m_pActiveVars = new TArray<int32_t, MemPoolAllocator>(GetMemPoolAllocator());
+    m_pActiveCalls = new TArray<InterpInst*, MemPoolAllocator>(GetMemPoolAllocator());
     m_pDeferredCalls = NULL;
 
     InitializeGlobalVars();

--- a/src/coreclr/interpreter/datastructs.h
+++ b/src/coreclr/interpreter/datastructs.h
@@ -130,6 +130,12 @@ public:
         return m_array[index];
     }
 
+    void Set(int32_t index, T value)
+    {
+        assert(index < m_size);
+        m_array[index] = value;
+    }
+
     int32_t Find(T element)
     {
         for (int i = 0; i < m_size; i++)
@@ -140,8 +146,32 @@ public:
         return -1;
     }
 
-    // Assumes elements are unique
     void RemoveAt(int32_t index)
+    {
+        assert(index < m_size);
+        for (int32_t iCopy = index + 1; iCopy < m_size; iCopy++)
+        {
+            m_array[iCopy - 1] = m_array[iCopy];
+        }
+        m_size--;
+    }
+
+    void InsertAt(int32_t index, T newValue)
+    {
+        assert(index < m_size);
+        if (m_size == m_capacity)
+            Grow();
+
+        for (int32_t iCopy = index; iCopy < m_size; iCopy++)
+        {
+            m_array[iCopy + 1] = m_array[iCopy];
+        }
+        m_array[index] = newValue;
+        m_size++;
+    }
+
+    // Assumes elements are unique, and order of items in the array is unimportant
+    void RemoveAt_ArrayIsBag(int32_t index)
     {
         assert(index < m_size);
         m_size--;
@@ -150,14 +180,14 @@ public:
             m_array[index] = m_array[m_size];
     } 
 
-    // Assumes elements are unique
-    void Remove(T element)
+    // Assumes elements are unique, and order of items in the array is unimportant
+    void Remove_ArrayIsBag(T element)
     {
         for (int32_t i = 0; i < m_size; i++)
         {
             if (element == m_array[i])
             {
-                RemoveAt(i);
+                RemoveAt_ArrayIsBag(i);
                 break;
             }
         }

--- a/src/coreclr/interpreter/datastructs.h
+++ b/src/coreclr/interpreter/datastructs.h
@@ -4,25 +4,42 @@
 #ifndef _DATASTRUCTS_H_
 #define _DATASTRUCTS_H_
 
-template <typename T>
+struct MallocAllocator
+{
+    MallocAllocator() {}
+    void* Alloc(size_t sz) const;
+    void Free(void* ptr) const;
+};
+
+inline MallocAllocator GetMallocAllocator() { return MallocAllocator(); }
+
+template <typename T, typename Allocator>
 class TArray
 {
 private:
     int32_t m_size, m_capacity;
     T *m_array;
+    Allocator const m_allocator;
 
     void Grow()
     {
+        int32_t oldCapacity = m_capacity;
+
         if (m_capacity)
             m_capacity *= 2;
         else
             m_capacity = 16;
 
-        m_array = (T*)realloc(m_array, m_capacity * sizeof(T));
+        T* newArray = (T*)m_allocator.Alloc(m_capacity * sizeof(T));
+        memcpy(newArray, m_array, oldCapacity * sizeof(T));
+        m_allocator.Free(m_array);
+        m_array = newArray;
     }
 
     void Grow(int32_t minNewCapacity)
     {
+        int32_t oldCapacity = m_capacity;
+
         if (m_capacity)
             m_capacity *= 2;
         else
@@ -30,10 +47,13 @@ private:
 
         m_capacity = (m_capacity > minNewCapacity) ? m_capacity : minNewCapacity;
 
-        m_array = (T*)realloc(m_array, m_capacity * sizeof(T));
+        T* newArray = (T*)m_allocator.Alloc(m_capacity * sizeof(T));
+        memcpy(newArray, m_array, oldCapacity * sizeof(T));
+        m_allocator.Free(m_array);
+        m_array = newArray;
     }
 public:
-    TArray()
+    TArray(Allocator allocator) : m_allocator(allocator)
     {
         m_size = 0;
         m_capacity = 0;
@@ -41,10 +61,11 @@ public:
     }
 
     // Implicit copies are not permitted to prevent accidental allocation of large arrays.
-    TArray(const TArray<T> &other) = delete;
-    TArray<T>& operator=(const TArray<T> &other) = delete;
+    TArray(const TArray<T,Allocator> &other) = delete;
+    TArray<T, Allocator>& operator=(const TArray<T,Allocator> &other) = delete;
 
-    TArray(TArray<T> &&other)
+    TArray(TArray<T,Allocator> &&other)
+        : m_allocator(other.m_allocator)
     {
         m_size = other.m_size;
         m_capacity = other.m_capacity;
@@ -54,13 +75,12 @@ public:
         other.m_capacity = 0;
         other.m_array = NULL;
     }
-    TArray<T>& operator=(TArray<T> &&other)
+    TArray<T,Allocator>& operator=(TArray<T,Allocator> &&other)
     {
         if (this != &other)
         {
-            if (m_capacity > 0)
-                free(m_array);
-
+            if (m_array != nullptr)
+                m_allocator.Free(m_array);
             m_size = other.m_size;
             m_capacity = other.m_capacity;
             m_array = other.m_array;
@@ -74,8 +94,8 @@ public:
 
     ~TArray()
     {
-        if (m_capacity > 0)
-            free(m_array);
+        if (m_array != nullptr)
+            m_allocator.Free(m_array);
     }
 
     int32_t GetSize() const
@@ -124,7 +144,7 @@ public:
         return m_array;
     }
 
-    T Get(int32_t index)
+    T Get(int32_t index) const
     {
         assert(index < m_size);
         return m_array[index];
@@ -136,7 +156,7 @@ public:
         m_array[index] = value;
     }
 
-    int32_t Find(T element)
+    int32_t Find(T element) const
     {
         for (int i = 0; i < m_size; i++)
         {
@@ -158,36 +178,36 @@ public:
 
     void InsertAt(int32_t index, T newValue)
     {
-        assert(index < m_size);
+        assert(index <= m_size);
         if (m_size == m_capacity)
             Grow();
 
-        for (int32_t iCopy = index; iCopy < m_size; iCopy++)
+        for (int32_t iCopy = m_size; iCopy > index; iCopy--)
         {
-            m_array[iCopy + 1] = m_array[iCopy];
+            m_array[iCopy] = m_array[iCopy - 1];
         }
         m_array[index] = newValue;
         m_size++;
     }
 
-    // Assumes elements are unique, and order of items in the array is unimportant
-    void RemoveAt_ArrayIsBag(int32_t index)
+    // Assumes order of items in the array is unimportant, as it will reorder the array
+    void RemoveAtUnordered(int32_t index)
     {
         assert(index < m_size);
         m_size--;
         // Since this entry is removed, move the last entry into it
         if (m_size > 0 && index < m_size)
             m_array[index] = m_array[m_size];
-    } 
+    }
 
-    // Assumes elements are unique, and order of items in the array is unimportant
-    void Remove_ArrayIsBag(T element)
+    // Assumes order of items in the array is unimportant, as it will reorder the array
+    void RemoveFirstUnordered(T element)
     {
         for (int32_t i = 0; i < m_size; i++)
         {
             if (element == m_array[i])
             {
-                RemoveAt_ArrayIsBag(i);
+                RemoveAtUnordered(i);
                 break;
             }
         }

--- a/src/coreclr/interpreter/methodset.cpp
+++ b/src/coreclr/interpreter/methodset.cpp
@@ -155,7 +155,7 @@ bool MethodSet::contains(COMP_HANDLE comp,
         return false;
     }
 
-    TArray<char> printer;
+    TArray<char, MallocAllocator> printer(GetMallocAllocator());
     MethodName*   prevPattern = nullptr;
 
     for (MethodName* name = m_names; name != nullptr; name = name->m_next)

--- a/src/coreclr/interpreter/naming.cpp
+++ b/src/coreclr/interpreter/naming.cpp
@@ -3,11 +3,11 @@
 
 #include "interpreter.h"
 
-void AppendType(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation);
-void AppendCorInfoType(TArray<char>* printer, CorInfoType corInfoType);
-void AppendTypeOrJitAlias(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation);
+void AppendType(COMP_HANDLE comp, TArray<char, MallocAllocator>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation);
+void AppendCorInfoType(TArray<char, MallocAllocator>* printer, CorInfoType corInfoType);
+void AppendTypeOrJitAlias(COMP_HANDLE comp, TArray<char, MallocAllocator>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation);
 
-void AppendString(TArray<char>* array, const char* str)
+void AppendString(TArray<char, MallocAllocator>* array, const char* str)
 {
     if (str != nullptr)
     {
@@ -16,7 +16,7 @@ void AppendString(TArray<char>* array, const char* str)
     }
 }
 
-void AppendCorInfoTypeWithModModifiers(TArray<char>* printer, CorInfoTypeWithMod corInfoTypeWithMod)
+void AppendCorInfoTypeWithModModifiers(TArray<char, MallocAllocator>* printer, CorInfoTypeWithMod corInfoTypeWithMod)
 {
     if ((corInfoTypeWithMod & CORINFO_TYPE_MOD_PINNED) == CORINFO_TYPE_MOD_PINNED)
     {
@@ -28,7 +28,7 @@ void AppendCorInfoTypeWithModModifiers(TArray<char>* printer, CorInfoTypeWithMod
     }
 }
 
-void AppendCorInfoType(TArray<char>* printer, CorInfoType corInfoType)
+void AppendCorInfoType(TArray<char, MallocAllocator>* printer, CorInfoType corInfoType)
 {
     static const char* preciseVarTypeMap[CORINFO_TYPE_COUNT] = {
         // see the definition of enum CorInfoType in file inc/corinfo.h
@@ -66,7 +66,7 @@ void AppendCorInfoType(TArray<char>* printer, CorInfoType corInfoType)
     printer->Append(corInfoTypeName, static_cast<int32_t>(strlen(corInfoTypeName)));
 }
 
-void AppendTypeOrJitAlias(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation)
+void AppendTypeOrJitAlias(COMP_HANDLE comp, TArray<char, MallocAllocator>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation)
 {
     CorInfoType typ = comp->asCorInfoType(clsHnd);
     if ((typ == CORINFO_TYPE_CLASS) || (typ == CORINFO_TYPE_VALUECLASS))
@@ -79,7 +79,7 @@ void AppendTypeOrJitAlias(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS
     }
 }
 
-void AppendType(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation)
+void AppendType(COMP_HANDLE comp, TArray<char, MallocAllocator>* printer, CORINFO_CLASS_HANDLE clsHnd, bool includeInstantiation)
 {
     unsigned arrayRank = comp->getArrayRank(clsHnd);
     if (arrayRank > 0)
@@ -141,7 +141,7 @@ void AppendType(COMP_HANDLE comp, TArray<char>* printer, CORINFO_CLASS_HANDLE cl
 }
 
 void AppendMethodName(COMP_HANDLE comp,
-                            TArray<char>* printer,
+                            TArray<char, MallocAllocator>* printer,
                             CORINFO_CLASS_HANDLE  clsHnd,
                             CORINFO_METHOD_HANDLE methHnd,
                             CORINFO_SIG_INFO*     sig,
@@ -153,7 +153,7 @@ void AppendMethodName(COMP_HANDLE comp,
                             bool                  includeReturnType,
                             bool                  includeThisSpecifier)
 {
-    TArray<char> result;
+    TArray<char, MallocAllocator> result(GetMallocAllocator());
 
     if (includeAssembly)
     {
@@ -273,7 +273,7 @@ void AppendMethodName(COMP_HANDLE comp,
     }
 }
 
-TArray<char> PrintMethodName(COMP_HANDLE comp,
+TArray<char, MallocAllocator> PrintMethodName(COMP_HANDLE comp,
                             CORINFO_CLASS_HANDLE  clsHnd,
                             CORINFO_METHOD_HANDLE methHnd,
                             CORINFO_SIG_INFO*     sig,
@@ -285,7 +285,7 @@ TArray<char> PrintMethodName(COMP_HANDLE comp,
                             bool                  includeReturnType,
                             bool                  includeThisSpecifier)
 {
-    TArray<char> printer;
+    TArray<char, MallocAllocator> printer(GetMallocAllocator());
     AppendMethodName(comp, &printer, clsHnd, methHnd, sig,
                      includeAssembly, includeClass,
                      includeClassInstantiation, includeMethodInstantiation,


### PR DESCRIPTION
- Remove O(n) algorithm in InterpCompiler::EmitCodeIns which was debug only, replace with O(1) algorithm
- The new conservative range computuation code also has an O(N^2) algorithm for ranges, and this is replaced with an O(n*logN) algorithm with better constant factors (Binary search in an array instead of linear scan of a linked list)
- Adjust apis on TArray so that the RemoveAt and Remove functions don't re-order the array. Change the names of the existing apis to have a Unordered suffix, and add more typical implementations of RemoveAt and InsertAt