### PR TITLE
[release/10.0] Allow disabling runtime versions via an environment variable

### DIFF
--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -241,6 +241,22 @@ namespace HostActivation.Tests
                 .And.HaveStdOut(expectedOutput);
         }
 
+        [Fact]
+        public void ListRuntimes_DisabledVersions()
+        {
+            // Verify exact match of command output. The output of --list-runtimes is intended to be machine-readable
+            // and must not change in a way that breaks existing parsing.
+            string disabledVersion = SharedState.InstalledVersions[0];
+            string[] expectedVersions = SharedState.InstalledVersions[1..];
+            string expectedOutput = GetListRuntimesOutput(SharedState.DotNet.BinPath, expectedVersions);
+            SharedState.DotNet.Exec("--list-runtimes")
+                .CaptureStdOut()
+                .EnvironmentVariable(Constants.DisableRuntimeVersions.EnvironmentVariable, disabledVersion)
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOut(expectedOutput);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -353,26 +353,10 @@ namespace HostActivation.Tests
             string expectedSdkVersions = string.Join(";", f.LocalSdks);
             string expectedSdkPaths = string.Join(';', f.LocalSdkPaths);
 
-            string expectedFrameworkNames = string.Join(';', new[]
-            {
-                "HostFxr.Test.B",
-                "HostFxr.Test.B",
-                "HostFxr.Test.C"
-            });
-
-            string expectedFrameworkVersions = string.Join(';', new[]
-            {
-                "4.0.0",
-                "5.6.7-A",
-                "3.0.0"
-            });
-
-            string expectedFrameworkPaths = string.Join(';', new[]
-            {
-                Path.Combine(f.LocalFrameworksDir, "HostFxr.Test.B"),
-                Path.Combine(f.LocalFrameworksDir, "HostFxr.Test.B"),
-                Path.Combine(f.LocalFrameworksDir, "HostFxr.Test.C")
-            });
+            IEnumerable<(string Name, string Version)> frameworks = f.LocalFrameworks.SelectMany(fw => fw.fwVersions.Select(v => (fw.fwName, v)));
+            string expectedFrameworkNames = string.Join(';', frameworks.Select(fw => fw.Name));
+            string expectedFrameworkVersions = string.Join(';', frameworks.Select(fw => fw.Version));
+            string expectedFrameworkPaths = string.Join(';', frameworks.Select(fw => Path.Combine(f.LocalFrameworksDir, fw.Name)));
 
             string api = ApiNames.hostfxr_get_dotnet_environment_info;
             TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
@@ -429,6 +413,41 @@ namespace HostActivation.Tests
                 .And.HaveStdOutContaining($"{api} framework names:[{expectedFrameworkNames}]")
                 .And.HaveStdOutContaining($"{api} framework versions:[{expectedFrameworkVersions}]")
                 .And.HaveStdOutContaining($"{api} framework paths:[{expectedFrameworkPaths}]");
+        }
+
+        [Fact]
+        public void Hostfxr_get_dotnet_environment_info_DisabledVersions()
+        {
+            var f = sharedTestState.SdkAndFrameworkFixture;
+            string expectedSdkVersions = string.Join(";", f.LocalSdks);
+            string expectedSdkPaths = string.Join(';', f.LocalSdkPaths);
+
+            string[] disabledVersions = ["4.0.0", "3.0.0"];
+            IEnumerable<(string Name, string Version)> frameworks = f.LocalFrameworks
+                .SelectMany(fw => fw.fwVersions
+                    .Where(v => !disabledVersions.Contains(v))
+                    .Select(v => (fw.fwName, v)));
+            string expectedFrameworkNames = string.Join(';', frameworks.Select(fw => fw.Name));
+            string expectedFrameworkVersions = string.Join(';', frameworks.Select(fw => fw.Version));
+            string expectedFrameworkPaths = string.Join(';', frameworks.Select(fw => Path.Combine(f.LocalFrameworksDir, fw.Name)));
+
+            string api = ApiNames.hostfxr_get_dotnet_environment_info;
+            var result = TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
+                .EnableTracingAndCaptureOutputs()
+                .EnvironmentVariable(Constants.DisableRuntimeVersions.EnvironmentVariable, string.Join(';', disabledVersions))
+                .Execute();
+            result.Should().Pass()
+                .And.ReturnStatusCode(api, Constants.ErrorCode.Success)
+                .And.HaveStdOutContaining($"{api} sdk versions:[{expectedSdkVersions}]")
+                .And.HaveStdOutContaining($"{api} sdk paths:[{expectedSdkPaths}]")
+                .And.HaveStdOutContaining($"{api} framework names:[{expectedFrameworkNames}]")
+                .And.HaveStdOutContaining($"{api} framework versions:[{expectedFrameworkVersions}]")
+                .And.HaveStdOutContaining($"{api} framework paths:[{expectedFrameworkPaths}]");
+
+            foreach (string version in disabledVersions)
+            {
+                result.Should().HaveStdErrContaining($"Ignoring disabled version [{version}]");
+            }
         }
 
         [Fact]

--- a/src/installer/tests/TestUtils/Constants.cs
+++ b/src/installer/tests/TestUtils/Constants.cs
@@ -35,6 +35,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
             public const string Disable = "Disable";
         }
 
+        public static class DisableRuntimeVersions
+        {
+            public const string EnvironmentVariable = "DOTNET_DISABLE_RUNTIME_VERSIONS";
+        }
+
         public static class FxVersion
         {
             public const string CommandLineArgument = "--fx-version";

--- a/src/native/corehost/fxr/framework_info.cpp
+++ b/src/native/corehost/fxr/framework_info.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include "framework_info.h"
+#include "fx_resolver.h"
 #include "pal.h"
 #include "trace.h"
 #include "utils.h"
@@ -36,13 +37,15 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
     const pal::string_t& dotnet_dir,
     const pal::char_t* fx_name,
     bool disable_multilevel_lookup,
+    bool include_disabled_versions,
     std::vector<framework_info>* framework_infos)
 {
     std::vector<pal::string_t> hive_dir;
     get_framework_locations(dotnet_dir, disable_multilevel_lookup, &hive_dir);
 
-    int32_t hive_depth = 0;
+    std::vector<pal::string_t> disabled_versions = fx_resolver_t::get_disabled_versions();
 
+    int32_t hive_depth = 0;
     for (const pal::string_t& dir : hive_dir)
     {
         auto fx_shared_dir = dir;
@@ -92,9 +95,16 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
                     continue;
                 }
 
+                bool is_disabled = std::find(disabled_versions.begin(), disabled_versions.end(), ver) != disabled_versions.end();
+                if (is_disabled && !include_disabled_versions)
+                {
+                    trace::verbose(_X("Ignoring disabled version [%s]"), ver.c_str());
+                    continue;
+                }
+
                 trace::verbose(_X("Found FX version [%s]"), ver.c_str());
 
-                framework_info info(fx_name_local, fx_dir, parsed, hive_depth);
+                framework_info info(fx_name_local, fx_dir, parsed, hive_depth, is_disabled);
                 framework_infos->push_back(info);
             }
         }
@@ -110,7 +120,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
     assert(leading_whitespace != nullptr);
 
     std::vector<framework_info> framework_infos;
-    get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, &framework_infos);
+    get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, /*include_disabled_versions*/ false, &framework_infos);
     for (framework_info info : framework_infos)
     {
         trace::println(_X("%s%s %s [%s]"), leading_whitespace, info.name.c_str(), info.version.as_str().c_str(), info.path.c_str());

--- a/src/native/corehost/fxr/framework_info.h
+++ b/src/native/corehost/fxr/framework_info.h
@@ -9,16 +9,19 @@
 
 struct framework_info
 {
-    framework_info(pal::string_t name, pal::string_t path, fx_ver_t version, int32_t hive_depth)
+    framework_info(pal::string_t name, pal::string_t path, fx_ver_t version, int32_t hive_depth, bool disabled)
         : name(name)
         , path(path)
         , version(version)
-        , hive_depth(hive_depth) { }
+        , hive_depth(hive_depth)
+        , disabled(disabled)
+    { }
 
     static void get_all_framework_infos(
         const pal::string_t& dotnet_dir,
         const pal::char_t* fx_name,
         bool disable_multilevel_lookup,
+        bool include_disabled_versions,
         std::vector<framework_info>* framework_infos);
 
     static bool print_all_frameworks(const pal::string_t& dotnet_dir, const pal::char_t* leading_whitespace);
@@ -27,6 +30,7 @@ struct framework_info
     pal::string_t path;
     fx_ver_t version;
     int32_t hive_depth;
+    bool disabled;
 };
 
 #endif // __FRAMEWORK_INFO_H_

--- a/src/native/corehost/fxr/fx_resolver.h
+++ b/src/native/corehost/fxr/fx_resolver.h
@@ -40,11 +40,10 @@ public:
         const runtime_config_t& config,
         const std::unordered_map<pal::string_t, const fx_ver_t> &existing_framework_versions_by_name);
 
+    static std::vector<pal::string_t> get_disabled_versions();
+
 private:
-    fx_resolver_t(bool disable_multilevel_lookup, const runtime_config_t::settings_t& override_settings)
-        : m_disable_multilevel_lookup{disable_multilevel_lookup}
-        , m_override_settings{override_settings}
-    { }
+    fx_resolver_t(bool disable_multilevel_lookup, const runtime_config_t::settings_t& override_settings);
 
     void update_newest_references(
         const runtime_config_t& config);
@@ -97,6 +96,9 @@ private:
 
     bool m_disable_multilevel_lookup;
     const runtime_config_t::settings_t& m_override_settings;
+
+    // Disabled runtime versions
+    std::vector<pal::string_t> m_disabled_versions;
 };
 
 #endif // __FX_RESOLVER_H__

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -437,7 +437,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_dotnet_environment_info(
     }
 
     std::vector<framework_info> framework_infos;
-    framework_info::get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, &framework_infos);
+    framework_info::get_all_framework_infos(dotnet_dir, nullptr, /*disable_multilevel_lookup*/ true, /*include_disabled_versions*/ false, &framework_infos);
 
     std::vector<hostfxr_dotnet_environment_framework_info> environment_framework_infos;
     std::vector<pal::string_t> framework_versions;


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/119343
cc @dotnet/appmodel @AaronRobinsonMSFT 

## Customer Impact

- [ ] Customer reported
- [x] Found internally

Issue: https://github.com/dotnet/runtime/issues/118553

New versions of a runtime can have changes that cause issues and require investigation. For large-scale deployments, it can be expensive to roll back the installation of a new runtime. This change allows disabling specific runtime versions via an environment variable, which should be a faster mitigation for large deployments than uninstalling a specific version.

## Regression

- [ ] Yes
- [x] No

## Testing

Automated tests added.

## Risk

Medium-low. This is in a code path that affects the launch of every single application. However, for the vast majority of cases (where this environment variable is not set), the impact is checking an environment variable and allocating an empty vector, so the risk pretty contained.
