### PR TITLE
Delay computing display names of type system entities

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/AttributeDataFlow.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/AttributeDataFlow.cs
@@ -102,7 +102,7 @@ namespace ILCompiler.Dataflow
                 if (parameterValue.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None)
                 {
                     MultiValue value = GetValueForCustomAttributeArgument(arguments[parameter.MetadataIndex]);
-                    RequireDynamicallyAccessedMembers(_diagnosticContext, value, parameterValue, method.GetDisplayName(), ref result);
+                    RequireDynamicallyAccessedMembers(_diagnosticContext, value, parameterValue, method, ref result);
                 }
             }
         }
@@ -114,7 +114,7 @@ namespace ILCompiler.Dataflow
                 && fieldValue.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None)
             {
                 MultiValue valueNode = GetValueForCustomAttributeArgument(value);
-                RequireDynamicallyAccessedMembers(_diagnosticContext, valueNode, fieldValue, field.GetDisplayName(), ref result);
+                RequireDynamicallyAccessedMembers(_diagnosticContext, valueNode, fieldValue, field, ref result);
             }
         }
 
@@ -132,7 +132,7 @@ namespace ILCompiler.Dataflow
             in DiagnosticContext diagnosticContext,
             in MultiValue value,
             ValueWithDynamicallyAccessedMembers targetValue,
-            string reason,
+            TypeSystemEntity reason,
             ref DependencyList? result)
         {
             var reflectionMarker = new ReflectionMarker(_logger, _factory, _annotations, typeHierarchyDataFlowOrigin: null, enabled: true);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/GenericArgumentDataFlow.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/GenericArgumentDataFlow.cs
@@ -93,7 +93,7 @@ namespace ILCompiler.Dataflow
                     var genericParameterValue = reflectionMarker.Annotations.GetGenericParameterValue(genericParameter);
                     Debug.Assert(genericParameterValue.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None);
                     MultiValue genericArgumentValue = reflectionMarker.Annotations.GetTypeValueFromGenericArgument(genericArgument);
-                    var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction(reflectionMarker, diagnosticContext, genericParameter.GetDisplayName());
+                    var requireDynamicallyAccessedMembersAction = new RequireDynamicallyAccessedMembersAction(reflectionMarker, diagnosticContext, genericParameter);
                     requireDynamicallyAccessedMembersAction.Invoke(genericArgumentValue, genericParameterValue);
                 }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/HandleCallAction.cs
@@ -28,7 +28,7 @@ namespace ILLink.Shared.TrimAnalysis
         private readonly ReflectionMarker _reflectionMarker;
         private ILOpcode _operation;
         private readonly MethodDesc _callingMethod;
-        private readonly string _reason;
+        private readonly MethodDesc _reason;
 
         public HandleCallAction(
             FlowAnnotations annotations,
@@ -36,7 +36,7 @@ namespace ILLink.Shared.TrimAnalysis
             ReflectionMarker reflectionMarker,
             in DiagnosticContext diagnosticContext,
             MethodDesc callingMethod,
-            string reason)
+            MethodDesc reason)
         {
             _reflectionMarker = reflectionMarker;
             _operation = operation;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -171,7 +171,7 @@ namespace ILCompiler.Dataflow
                 // Apply any annotations that didn't exist on the base type to the base type.
                 // This may produce redundant warnings when the annotation is DAMT.All or DAMT.PublicConstructors and the base already has a
                 // subset of those annotations.
-                reflectionMarker.MarkTypeForDynamicallyAccessedMembers(origin, type.BaseType, annotationToApplyToBase, type.GetDisplayName(), declaredOnly: false);
+                reflectionMarker.MarkTypeForDynamicallyAccessedMembers(origin, type.BaseType, annotationToApplyToBase, type, declaredOnly: false);
             }
 
             // Most of the DynamicallyAccessedMemberTypes don't select members on interfaces. We only need to apply
@@ -186,14 +186,14 @@ namespace ILCompiler.Dataflow
 
                     // Apply All or Interfaces to the interface type.
                     // DAMT.All may produce redundant warnings from implementing types, when the interface type already had some annotations.
-                    reflectionMarker.MarkTypeForDynamicallyAccessedMembers(origin, iface, annotationToApplyToInterfaces, type.GetDisplayName(), declaredOnly: false);
+                    reflectionMarker.MarkTypeForDynamicallyAccessedMembers(origin, iface, annotationToApplyToInterfaces, type, declaredOnly: false);
                 }
             }
 
             // The annotations this type inherited from its base types or interfaces should not produce
             // warnings on the respective base/interface members, since those are already covered by applying
             // the annotations to those types. So we only need to handle the members directly declared on this type.
-            reflectionMarker.MarkTypeForDynamicallyAccessedMembers(new MessageOrigin(type), type, annotation, type.GetDisplayName(), declaredOnly: true);
+            reflectionMarker.MarkTypeForDynamicallyAccessedMembers(new MessageOrigin(type), type, annotation, type, declaredOnly: true);
             return reflectionMarker.Dependencies;
         }
 
@@ -235,7 +235,7 @@ namespace ILCompiler.Dataflow
             return _annotations.GetFieldValue(field);
         }
 
-        private void HandleStoreValueWithDynamicallyAccessedMembers(MethodIL methodIL, int offset, ValueWithDynamicallyAccessedMembers targetValue, MultiValue sourceValue, int? parameterIndex, string reason)
+        private void HandleStoreValueWithDynamicallyAccessedMembers(MethodIL methodIL, int offset, ValueWithDynamicallyAccessedMembers targetValue, MultiValue sourceValue, int? parameterIndex, TypeSystemEntity reason)
         {
             if (targetValue.DynamicallyAccessedMemberTypes != 0)
             {
@@ -245,13 +245,13 @@ namespace ILCompiler.Dataflow
         }
 
         protected override void HandleStoreField(MethodIL methodIL, int offset, FieldValue field, MultiValue valueToStore, int? parameterIndex)
-            => HandleStoreValueWithDynamicallyAccessedMembers(methodIL, offset, field, valueToStore, parameterIndex, field.Field.GetDisplayName());
+            => HandleStoreValueWithDynamicallyAccessedMembers(methodIL, offset, field, valueToStore, parameterIndex, field.Field);
 
         protected override void HandleStoreParameter(MethodIL methodIL, int offset, MethodParameterValue parameter, MultiValue valueToStore, int? parameterIndex)
-            => HandleStoreValueWithDynamicallyAccessedMembers(methodIL, offset, parameter, valueToStore, parameterIndex, parameter.Parameter.Method.GetDisplayName());
+            => HandleStoreValueWithDynamicallyAccessedMembers(methodIL, offset, parameter, valueToStore, parameterIndex, parameter.Parameter.Method.Method);
 
         protected override void HandleReturnValue(MethodIL methodIL, int offset, MethodReturnValue returnValue, MultiValue valueToStore)
-            => HandleStoreValueWithDynamicallyAccessedMembers(methodIL, offset, returnValue, valueToStore, null, returnValue.Method.GetDisplayName());
+            => HandleStoreValueWithDynamicallyAccessedMembers(methodIL, offset, returnValue, valueToStore, null, returnValue.Method.Method);
 
         protected override void HandleTypeTokenAccess(MethodIL methodIL, int offset, TypeDesc accessedType)
         {
@@ -342,7 +342,7 @@ namespace ILCompiler.Dataflow
                 RequiresReflectionMethodBodyScannerForCallSite(reflectionMarker.Annotations, calledMethod) ||
                 annotatedMethodReturnValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.None);
 
-            var handleCallAction = new HandleCallAction(reflectionMarker.Annotations, operation, reflectionMarker, diagnosticContext, callingMethodDefinition, calledMethod.GetDisplayName());
+            var handleCallAction = new HandleCallAction(reflectionMarker.Annotations, operation, reflectionMarker, diagnosticContext, callingMethodDefinition, calledMethod);
             var intrinsicId = Intrinsics.GetIntrinsicIdForMethod(calledMethod);
             if (!handleCallAction.Invoke(calledMethod, instanceValue, argumentValues, intrinsicId, out MultiValue methodReturnValue))
                 throw new NotImplementedException($"Unhandled intrinsic {intrinsicId}");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/RequireDynamicallyAccessedMembersAction.cs
@@ -13,12 +13,12 @@ namespace ILLink.Shared.TrimAnalysis
     internal partial struct RequireDynamicallyAccessedMembersAction
     {
         private readonly ReflectionMarker _reflectionMarker;
-        private readonly string _reason;
+        private readonly TypeSystemEntity _reason;
 
         public RequireDynamicallyAccessedMembersAction(
             ReflectionMarker reflectionMarker,
             in DiagnosticContext diagnosticContext,
-            string reason)
+            TypeSystemEntity reason)
         {
             _reflectionMarker = reflectionMarker;
             _diagnosticContext = diagnosticContext;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/TrimAnalysisAssignmentPattern.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/TrimAnalysisAssignmentPattern.cs
@@ -7,6 +7,8 @@ using ILCompiler.Logging;
 using ILLink.Shared.DataFlow;
 using ILLink.Shared.TrimAnalysis;
 
+using Internal.TypeSystem;
+
 using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
 
 #nullable enable
@@ -22,9 +24,9 @@ namespace ILCompiler.Dataflow
         // For assignment of a method parameter, we store the parameter index to disambiguate
         // assignments from different out parameters of a single method call.
         public int? ParameterIndex { get; init; }
-        internal string Reason { get; init; }
+        internal TypeSystemEntity Reason { get; init; }
 
-        internal TrimAnalysisAssignmentPattern(MultiValue source, MultiValue target, MessageOrigin origin, int? parameterIndex, string reason)
+        internal TrimAnalysisAssignmentPattern(MultiValue source, MultiValue target, MessageOrigin origin, int? parameterIndex, TypeSystemEntity reason)
         {
             Source = source.DeepCopy();
             Target = target.DeepCopy();


### PR DESCRIPTION
Ran into this in the profiles for #119385 but it's orthogonal. We were trying to compute display names of things even though we don't need them - in particular, for every call the dataflow analysis sees, we were computing a display name of the called method and throwing it away most of the time.