### PR TITLE
add GC_CONFIG_DRIVEN define to standalone GC builds

### DIFF
--- a/src/coreclr/gc/CMakeLists.txt
+++ b/src/coreclr/gc/CMakeLists.txt
@@ -137,6 +137,7 @@ if(FEATURE_STANDALONE_GC)
 
   add_definitions(-DFX_VER_INTERNALNAME_STR=clrgc.dll)
   add_definitions(-DVERIFY_HEAP)
+  add_definitions(-DGC_CONFIG_DRIVEN)
   if(CLR_CMAKE_HOST_APPLE)
     # The implementation of GCToOSInterface on Apple platforms makes use of non-POSIX
     # pthreads APIs, which by default are not included in the pthreads header


### PR DESCRIPTION
Found while working on https://github.com/dotnet/runtime/pull/119324. `GC_CONFIG_DRIVEN` is always defined in the built-in GC, but not in standalone builds. 

Logic in the DAC checks this define. However, the define has different values in the GC and DAC which leads to unintended behavior.

Discussed with @jkotas and agreed that `GC_CONFIG_DRIVEN` not being defined in the standalone GC builds is most likely an oversight and it can always be defined.

Planning to add a test in the SOS test suite which invokes GC APIs on standalone GCs.