### PR TITLE
[clr-interp] allow modification of the this pointer in functions which use it as the generics context

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1285,7 +1285,7 @@ void InterpCompiler::BuildGCInfo(InterpMethod *pInterpMethod)
             ? (GcSlotFlags)GC_SLOT_UNTRACKED
             : (GcSlotFlags)(GC_SLOT_INTERIOR | GC_SLOT_PINNED);
 
-        // The this pointer may have a shadow copy or not, and if it does not
+        // The 'this' pointer may have a shadow copy, or it may not. If it does not have a shadow copy, handle accordingly below.
         if (m_shadowCopyOfThisPointerHasVar && !m_shadowCopyOfThisPointerActuallyNeeded)
         {
             // Don't report the original this pointer var, we'll report the shadow copy instead

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3971,7 +3971,7 @@ bool InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
 
     if (HasFlag(m_originalRetryFlags, InterpreterRetryFlags::RetryWithSavedThisPointer))
     {
-        // If this flag is set, then we need to handle the case where an IL instruction may change the 
+        // If this flag is set, then we need to handle the case where an IL instruction may change the
         // value of the this pointer during the execution of the method. We do that by operating on a
         // local copy of the this pointer instead of the original this pointer for most operations.
 

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3877,7 +3877,7 @@ void InterpCompiler::EmitStaticFieldAccess(InterpType interpFieldType, CORINFO_F
 
 void InterpCompiler::EmitLdLocA(int32_t var)
 {
-    // Check for the unusual case of storing to the this pointer variable within a generic method which uses the this pointer as a generic context arg
+    // Check for the unusual case of taking the address of the this pointer variable within a generic method which uses the this pointer as a generic context arg
     // and if doing so and the mitigation for this pointer changing is not enabled, restart the compile to enable it
     if (var == 0 && ((m_methodInfo->options & CORINFO_GENERICS_CTXT_MASK) == CORINFO_GENERICS_CTXT_FROM_THIS))
     {

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2219,7 +2219,6 @@ void InterpCompiler::EmitLoadVar(int32_t var)
 void InterpCompiler::EmitStoreVar(int32_t var)
 {
     // Check for the unusual case of storing to the this pointer variable within a generic method which uses the this pointer as a generic context arg
-    // and if doing so and the mitigation for this pointer changing is not enabled, restart the compile to enable it
     if (var == 0 && m_shadowCopyOfThisPointerHasVar)
     {
         m_shadowCopyOfThisPointerActuallyNeeded = true;
@@ -3877,7 +3876,6 @@ void InterpCompiler::EmitStaticFieldAccess(InterpType interpFieldType, CORINFO_F
 void InterpCompiler::EmitLdLocA(int32_t var)
 {
     // Check for the unusual case of taking the address of the this pointer variable within a generic method which uses the this pointer as a generic context arg
-    // and if doing so and the mitigation for this pointer changing is not enabled, restart the compile to enable it
     if (var == 0 && m_shadowCopyOfThisPointerHasVar)
     {
         m_shadowCopyOfThisPointerActuallyNeeded = true;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -6678,7 +6678,7 @@ DO_LDFTN:
     if (m_shadowCopyOfThisPointerActuallyNeeded)
     {
         InterpInst *pFirstIns = FirstRealIns(m_pEntryBB);
-        InterpInst *pMovInst = InsertIns(FirstRealIns(m_pEntryBB), INTOP_MOV_P);
+        InterpInst *pMovInst = InsertIns(pFirstIns, INTOP_MOV_P);
         // If this flag is set, then we need to handle the case where an IL instruction may change the
         // value of the this pointer during the execution of the method. We do that by operating on a
         // local copy of the this pointer instead of the original this pointer for most operations.

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1684,9 +1684,7 @@ void InterpCompiler::CreateILVars()
     if (HasFlag(m_originalRetryFlags, InterpreterRetryFlags::RetryWithSavedThisPointer))
     {
         hasThisPointerShadowCopyAsParamIndex = true;
-        if (hasParamArg)
-        {
-            BADCODE("Unexpected param arg in combination with mitigation for this pointer used as param arg");
+            BADCODE("Unexpected param arg in combination with this pointer mitigation");
         }
     }
     int paramArgIndex = hasParamArg ? hasThis ? 1 : 0 : INT_MAX;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1487,8 +1487,11 @@ static void FreeInterpreterStackMap(void *key, void *value, void *userdata)
 }
 
 InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
-                                CORINFO_METHOD_INFO* methodInfo)
+                               CORINFO_METHOD_INFO* methodInfo,
+                               InterpreterRetryFlags *pRetryFlags)
     : m_stackmapsByClass(FreeInterpreterStackMap)
+    , m_originalRetryFlags(*pRetryFlags)
+    , m_pRetryFlags(pRetryFlags)
     , m_pInitLocalsIns(nullptr)
     , m_hiddenArgumentVar(-1)
     , m_globalVarsWithRefsStackTop(0)
@@ -1522,15 +1525,22 @@ InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
 InterpMethod* InterpCompiler::CompileMethod()
 {
 #ifdef DEBUG
-    if (m_verbose || InterpConfig.InterpList())
+    if (m_verbose || (InterpConfig.InterpList() && m_originalRetryFlags == InterpreterRetryFlags::None))
     {
         printf("Interpreter compile method %s\n", m_methodName.GetUnderlyingArray());
+        if (m_verbose && m_originalRetryFlags != InterpreterRetryFlags::None)
+        {
+            printf("  with retry flags: %d\n", (int)m_originalRetryFlags);
+        }
     }
 #endif
 
     CreateILVars();
 
-    GenerateCode(m_methodInfo);
+    if (!GenerateCode(m_methodInfo))
+    {
+        return nullptr;
+    }
 
 #ifdef DEBUG
     if (m_verbose)
@@ -1670,6 +1680,15 @@ void InterpCompiler::CreateILVars()
 {
     bool hasThis = m_methodInfo->args.hasThis();
     bool hasParamArg = m_methodInfo->args.hasTypeArg();
+    bool hasThisPointerShadowCopyAsParamIndex = false;
+    if (HasFlag(m_originalRetryFlags, InterpreterRetryFlags::RetryWithSavedThisPointer))
+    {
+        hasThisPointerShadowCopyAsParamIndex = true;
+        if (hasParamArg)
+        {
+            BADCODE("Unexpected param arg in combination with mitigation for this pointer used as param arg");
+        }
+    }
     int paramArgIndex = hasParamArg ? hasThis ? 1 : 0 : INT_MAX;
     int32_t offset;
     int numArgs = hasThis + m_methodInfo->args.numArgs;
@@ -1679,7 +1698,7 @@ void InterpCompiler::CreateILVars()
     // add some starting extra space for new vars
     m_varsCapacity = m_numILVars + m_methodInfo->EHcount + 64;
     m_pVars = (InterpVar*)AllocTemporary0(m_varsCapacity * sizeof (InterpVar));
-    m_varsSize = m_numILVars + hasParamArg;
+    m_varsSize = m_numILVars + hasParamArg + (hasThisPointerShadowCopyAsParamIndex ? 1 : 0);
 
     offset = 0;
 
@@ -1700,7 +1719,12 @@ void InterpCompiler::CreateILVars()
     {
         CORINFO_CLASS_HANDLE argClass = m_compHnd->getMethodClass(m_methodInfo->ftn);
         InterpType interpType = m_compHnd->isValueClass(argClass) ? InterpTypeByRef : InterpTypeO;
-        CreateNextLocalVar(0, argClass, interpType, &offset);
+        if (hasThisPointerShadowCopyAsParamIndex)
+        {
+            assert(interpType == InterpTypeO);
+            m_paramArgIndex = m_varsSize - 1; // The param arg is stored after the IL locals in the m_pVars array
+        }
+        CreateNextLocalVar(hasThisPointerShadowCopyAsParamIndex ? m_paramArgIndex : 0, argClass, interpType, &offset);
         argIndexOffset++;
     }
 
@@ -1740,6 +1764,14 @@ void InterpCompiler::CreateILVars()
         // The param arg is stored after the IL locals in the m_pVars array
         assert(index == m_paramArgIndex);
         index++;
+    }
+
+    if (hasThisPointerShadowCopyAsParamIndex)
+    {
+        // This is the allocation of memory space for the shadow copy of the this pointer, operations like starg 0, and ldarga 0 will operate on this copy
+        CORINFO_CLASS_HANDLE argClass = m_compHnd->getMethodClass(m_methodInfo->ftn);
+        CreateNextLocalVar(0, argClass, InterpTypeO, &offset);
+        index++; // We need to account for the shadow copy in the variable index
     }
 
     offset = ALIGN_UP_TO(offset, INTERP_STACK_ALIGNMENT);
@@ -2189,6 +2221,13 @@ void InterpCompiler::EmitLoadVar(int32_t var)
 
 void InterpCompiler::EmitStoreVar(int32_t var)
 {
+    // Check for the unusual case of storing to the this pointer variable within a generic method which uses the this pointer as a generic context arg
+    // and if doing so and the mitigation for this pointer changing is not enabled, restart the compile to enable it
+    if (var == 0 && ((m_methodInfo->options & CORINFO_GENERICS_CTXT_MASK) == CORINFO_GENERICS_CTXT_FROM_THIS))
+    {
+        *m_pRetryFlags |= InterpreterRetryFlags::RetryWithSavedThisPointer;
+    }
+
     InterpType interpType = m_pVars[var].interpType;
     CHECK_STACK(1);
 
@@ -3840,6 +3879,13 @@ void InterpCompiler::EmitStaticFieldAccess(InterpType interpFieldType, CORINFO_F
 
 void InterpCompiler::EmitLdLocA(int32_t var)
 {
+    // Check for the unusual case of storing to the this pointer variable within a generic method which uses the this pointer as a generic context arg
+    // and if doing so and the mitigation for this pointer changing is not enabled, restart the compile to enable it
+    if (var == 0 && ((m_methodInfo->options & CORINFO_GENERICS_CTXT_MASK) == CORINFO_GENERICS_CTXT_FROM_THIS))
+    {
+        *m_pRetryFlags |= InterpreterRetryFlags::RetryWithSavedThisPointer;
+    }
+
     if (m_pCBB->clauseType == BBClauseFilter)
     {
         AddIns(INTOP_LOAD_FRAMEVAR);
@@ -3876,7 +3922,7 @@ void InterpCompiler::EmitBox(StackInfo* pStackInfo, const CORINFO_GENERICHANDLE_
     m_pStackPointer--;
 }
 
-void InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
+bool InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
 {
     bool readonly = false;
     bool tailcall = false;
@@ -3924,6 +3970,19 @@ void InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
     // Safepoint at each method entry. This could be done as part of a call, rather than
     // adding an opcode.
     AddIns(INTOP_SAFEPOINT);
+
+    if (HasFlag(m_originalRetryFlags, InterpreterRetryFlags::RetryWithSavedThisPointer))
+    {
+        // If this flag is set, then we need to handle the case where an IL instruction may change the 
+        // value of the this pointer during the execution of the method. We do that by operating on a
+        // local copy of the this pointer instead of the original this pointer for most operations.
+
+        // When this mitigation is enabled, the param arg is the actual input this pointer,
+        // and the arg 0 is the local copy of the this pointer.
+        AddIns(INTOP_MOV_P);
+        m_pLastNewIns->SetSVar(getParamArgIndex());
+        m_pLastNewIns->SetDVar(0);
+    }
 
     CORJIT_FLAGS corJitFlags;
     DWORD jitFlagsSize = m_compHnd->getJitFlags(&corJitFlags, sizeof(corJitFlags));
@@ -6634,6 +6693,9 @@ DO_LDFTN:
     }
 
     UnlinkUnreachableBBlocks();
+
+    // Detect if we have hit a condition which required a full restart of the compiler process
+    return m_originalRetryFlags == *m_pRetryFlags;
 }
 
 InterpBasicBlock *InterpCompiler::GenerateCodeForFinallyCallIslands(InterpBasicBlock *pNewBB, InterpBasicBlock *pPrevBB)

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -433,6 +433,14 @@ struct LeavesTableEntry
     InterpBasicBlock *pFinallyCallIslandBB;
 };
 
+enum class InterpreterRetryFlags
+{
+    support_use_as_flags = -1, // Magic value which in combination with enum_class_flags.h allows the use of bitwise operations and the HasFlag helper method
+
+    None = 0,
+    RetryWithSavedThisPointer = 1,
+};
+
 class InterpCompiler
 {
     friend class InterpIAllocator;
@@ -508,6 +516,9 @@ private:
 
     static int32_t InterpGetMovForType(InterpType interpType, bool signExtend);
 
+    InterpreterRetryFlags m_originalRetryFlags;
+    InterpreterRetryFlags *m_pRetryFlags;
+
     uint8_t* m_ip;
     uint8_t* m_pILCode;
     int32_t m_ILCodeSize;
@@ -543,7 +554,7 @@ private:
     int32_t GetMethodDataItemIndex(CORINFO_METHOD_HANDLE mHandle);
     int32_t GetDataForHelperFtn(CorInfoHelpFunc ftn);
 
-    void GenerateCode(CORINFO_METHOD_INFO* methodInfo);
+    bool GenerateCode(CORINFO_METHOD_INFO* methodInfo);
     InterpBasicBlock* GenerateCodeForFinallyCallIslands(InterpBasicBlock *pNewBB, InterpBasicBlock *pPrevBB);
     void PatchInitLocals(CORINFO_METHOD_INFO* methodInfo);
 
@@ -766,7 +777,7 @@ private:
     void PrintCompiledIns(const int32_t *ip, const int32_t *start);
 public:
 
-    InterpCompiler(COMP_HANDLE compHnd, CORINFO_METHOD_INFO* methodInfo);
+    InterpCompiler(COMP_HANDLE compHnd, CORINFO_METHOD_INFO* methodInfo, InterpreterRetryFlags *pRetryFlags);
 
     InterpMethod* CompileMethod();
     void BuildGCInfo(InterpMethod *pInterpMethod);

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -433,14 +433,6 @@ struct LeavesTableEntry
     InterpBasicBlock *pFinallyCallIslandBB;
 };
 
-enum class InterpreterRetryFlags
-{
-    support_use_as_flags = -1, // Magic value which in combination with enum_class_flags.h allows the use of bitwise operations and the HasFlag helper method
-
-    None = 0,
-    RetryWithSavedThisPointer = 1,
-};
-
 class InterpCompiler
 {
     friend class InterpIAllocator;
@@ -516,9 +508,6 @@ private:
 
     static int32_t InterpGetMovForType(InterpType interpType, bool signExtend);
 
-    InterpreterRetryFlags m_originalRetryFlags;
-    InterpreterRetryFlags *m_pRetryFlags;
-
     uint8_t* m_ip;
     uint8_t* m_pILCode;
     int32_t m_ILCodeSize;
@@ -554,7 +543,7 @@ private:
     int32_t GetMethodDataItemIndex(CORINFO_METHOD_HANDLE mHandle);
     int32_t GetDataForHelperFtn(CorInfoHelpFunc ftn);
 
-    bool GenerateCode(CORINFO_METHOD_INFO* methodInfo);
+    void GenerateCode(CORINFO_METHOD_INFO* methodInfo);
     InterpBasicBlock* GenerateCodeForFinallyCallIslands(InterpBasicBlock *pNewBB, InterpBasicBlock *pPrevBB);
     void PatchInitLocals(CORINFO_METHOD_INFO* methodInfo);
 
@@ -685,6 +674,8 @@ private:
     // For each catch or filter clause, we create a variable that holds the exception object.
     // This is the index of the first such variable.
     int32_t m_clauseVarsIndex = 0;
+    bool m_shadowCopyOfThisPointerActuallyNeeded = false;
+    bool m_shadowCopyOfThisPointerHasVar = false;
 
     int32_t CreateVarExplicit(InterpType interpType, CORINFO_CLASS_HANDLE clsHnd, int size);
 
@@ -777,7 +768,7 @@ private:
     void PrintCompiledIns(const int32_t *ip, const int32_t *start);
 public:
 
-    InterpCompiler(COMP_HANDLE compHnd, CORINFO_METHOD_INFO* methodInfo, InterpreterRetryFlags *pRetryFlags);
+    InterpCompiler(COMP_HANDLE compHnd, CORINFO_METHOD_INFO* methodInfo);
 
     InterpMethod* CompileMethod();
     void BuildGCInfo(InterpMethod *pInterpMethod);

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -106,32 +106,50 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
 
     try
     {
-        InterpCompiler compiler(compHnd, methodInfo);
-        InterpMethod *pMethod = compiler.CompileMethod();
-        int32_t IRCodeSize = 0;
-        int32_t *pIRCode = compiler.GetCode(&IRCodeSize);
+        bool tryCompilation = true;
+        InterpreterRetryFlags retryFlags = InterpreterRetryFlags::None;
 
-        uint32_t sizeOfCode = sizeof(InterpMethod*) + IRCodeSize * sizeof(int32_t);
-        uint8_t unwindInfo[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+        while (tryCompilation)
+        {
+            InterpCompiler compiler(compHnd, methodInfo, &retryFlags);
+            InterpMethod *pMethod = compiler.CompileMethod();
 
-        AllocMemArgs args {};
-        args.hotCodeSize = sizeOfCode;
-        args.coldCodeSize = 0;
-        args.roDataSize = 0;
-        args.xcptnsCount = 0;
-        args.flag = CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN;
-        compHnd->allocMem(&args);
+            if (pMethod == nullptr)
+            {
+                assert(retryFlags != InterpreterRetryFlags::None);
+                continue;
+            }
+            else
+            {
+                // Once we reach here, we're committed to trying to complete the compilation
+                tryCompilation = false;
+            }
 
-        // We store first the InterpMethod pointer as the code header, followed by the actual code
-        *(InterpMethod**)args.hotCodeBlockRW = pMethod;
-        memcpy ((uint8_t*)args.hotCodeBlockRW + sizeof(InterpMethod*), pIRCode, IRCodeSize * sizeof(int32_t));
+            int32_t IRCodeSize = 0;
+            int32_t *pIRCode = compiler.GetCode(&IRCodeSize);
 
-        *entryAddress = (uint8_t*)args.hotCodeBlock;
-        *nativeSizeOfCode = sizeOfCode;
+            uint32_t sizeOfCode = sizeof(InterpMethod*) + IRCodeSize * sizeof(int32_t);
+            uint8_t unwindInfo[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 
-        // We can't do this until we've called allocMem
-        compiler.BuildGCInfo(pMethod);
-        compiler.BuildEHInfo();
+            AllocMemArgs args {};
+            args.hotCodeSize = sizeOfCode;
+            args.coldCodeSize = 0;
+            args.roDataSize = 0;
+            args.xcptnsCount = 0;
+            args.flag = CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN;
+            compHnd->allocMem(&args);
+
+            // We store first the InterpMethod pointer as the code header, followed by the actual code
+            *(InterpMethod**)args.hotCodeBlockRW = pMethod;
+            memcpy ((uint8_t*)args.hotCodeBlockRW + sizeof(InterpMethod*), pIRCode, IRCodeSize * sizeof(int32_t));
+
+            *entryAddress = (uint8_t*)args.hotCodeBlock;
+            *nativeSizeOfCode = sizeOfCode;
+
+            // We can't do this until we've called allocMem
+            compiler.BuildGCInfo(pMethod);
+            compiler.BuildEHInfo();
+        }
     }
     catch(const InterpException& e)
     {

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -3398,6 +3398,10 @@ TypeHandle InterpreterJitManager::ResolveEHClause(EE_ILEXCEPTION_CLAUSE* pEHClau
                 _ASSERTE(paramContextType == GENERIC_PARAM_CONTEXT_THIS);
                 GCX_COOP();
                 declaringType = (TypeHandle)dac_cast<PTR_MethodTable>(pCf->GetExactGenericArgsToken());
+                if (declaringType.IsNull())
+                {
+                    COMPlusThrow(kNullReferenceException, W("NullReference_This"));
+                }
             }
 
             _ASSERTE(!declaringType.IsNull());


### PR DESCRIPTION
- When the this pointer is used as the generics context, if some code modifies the this pointer, do not allow that modification to affect the generics behavior of the function
- Implement this by making a shadow copy of the this pointer in this situation
- To avoid doing this ALL of the time, I've made a scheme where we reserve space for the shadow copy var during normal var processing, but we fill it only if needed, and otherwise bash the shadow copy var to point to its natural location.
- Also handle the case of a legitimate null this pointer when doing EH type resolution, and have it throw a NullReferenceException.

This is a new PR replacing #119338, since I fouled up a merge in that PR.