### PR TITLE
[clr-interp] Fix null checking callvirt IL instruction behavior

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3443,26 +3443,39 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             else
             {
                 // Normal call
-                if (callInfo.nullInstanceCheck)
-                {
-                    // If the call is a normal call, we need to check for null instance
-                    // before the call.
-                    // TODO: Add null checking behavior somewhere here!
-                }
+                InterpOpcode opcode;
                 if (isDelegateInvoke)
                 {
                     assert(!isPInvoke && !isMarshaledPInvoke);
-                    AddIns(INTOP_CALLDELEGATE);
+                    opcode = INTOP_CALLDELEGATE;
                 }
                 else if (tailcall)
                 {
                     assert(!isPInvoke && !isMarshaledPInvoke);
-                    AddIns(INTOP_CALL_TAIL);
+                    opcode = INTOP_CALL_TAIL;
                 }
                 else
                 {
-                    AddIns((isPInvoke && !isMarshaledPInvoke) ? INTOP_CALL_PINVOKE : INTOP_CALL);
+                    opcode = (isPInvoke && !isMarshaledPInvoke) ? INTOP_CALL_PINVOKE : INTOP_CALL;
                 }
+
+                if (callInfo.nullInstanceCheck)
+                {
+                    // If the call is a normal call, we need to check for null instance
+                    // before the call.
+                    if (opcode == INTOP_CALL)
+                    {
+                        // There is an optimized form of this for the INTOP_CALL opcode as it is so very common
+                        opcode = INTOP_CALL_NULLCHECK;
+                    }
+                    else
+                    {
+                        // Otherwise, insert an explicit null check instruction
+                        AddIns(INTOP_NULLCHECK);
+                        m_pLastNewIns->SetSVar(callArgs[0]);
+                    }
+                }
+                AddIns(opcode);
                 m_pLastNewIns->data[0] = GetMethodDataItemIndex(callInfo.hMethod);
                 if (isPInvoke && !isMarshaledPInvoke)
                 {
@@ -3486,7 +3499,8 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             {
                 // If the call is a normal call, we need to check for null instance
                 // before the call.
-                // TODO: Add null checking behavior somewhere here!
+                AddIns(INTOP_NULLCHECK);
+                m_pLastNewIns->SetSVar(callArgs[0]);
             }
 
             EmitPushCORINFO_LOOKUP(callInfo.codePointerLookup);

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -23,7 +23,7 @@ OPDEF(INTOP_LDC_R8, "ldc.r8", 4, 1, 0, InterpOpDouble)
 
 OPDEF(INTOP_LDPTR, "ldptr", 3, 1, 0, InterpOpLdPtr)
 OPDEF(INTOP_LDPTR_DEREF, "ldptr.deref", 3, 1, 0, InterpOpLdPtr)
-OPDEF(INTOP_NULLCHECK, "nullcheck", 2, 1, 0, InterpOpNoArgs)
+OPDEF(INTOP_NULLCHECK, "nullcheck", 2, 0, 1, InterpOpNoArgs)
 OPDEF(INTOP_NEWARR, "newarr", 5, 1, 1, InterpOpPointerHelperFtn)
 OPDEF(INTOP_NEWARR_GENERIC, "newarr.generic", 6, 1, 2, InterpOpGenericHelperFtn)
 OPDEF(INTOP_NEWMDARR, "newmdarr", 5, 1, 1, InterpOpPointerInt)
@@ -357,6 +357,7 @@ OPDEF(INTOP_LDFLDA, "ldflda", 4, 1, 1, InterpOpInt)
 
 // Calls
 OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_CALL_NULLCHECK, "call.nullcheck", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLDELEGATE, "call.delegate", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLI, "calli", 6, 1, 2, InterpOpLdPtr)
 OPDEF(INTOP_CALLVIRT, "callvirt", 4, 1, 1, InterpOpMethodHandle)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2259,8 +2259,7 @@ MAIN_LOOP:
                 case INTOP_CALL_NULLCHECK:
                     // Check the target this pointer in the call for null
                     NULL_CHECK(LOCAL_VAR(ip[2], void*));
-                __fallthrough;
-                    // fall through
+                    FALLTHROUGH;
                 case INTOP_CALL_TAIL:
                 case INTOP_CALL:
                 {

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2256,6 +2256,11 @@ MAIN_LOOP:
                     break;
                 }
 
+                case INTOP_CALL_NULLCHECK:
+                    // Check the target this pointer in the call for null
+                    NULL_CHECK(LOCAL_VAR(ip[2], void*));
+                __fallthrough;
+                    // fall through
                 case INTOP_CALL_TAIL:
                 case INTOP_CALL:
                 {


### PR DESCRIPTION
- When calling a non-virtual instance function via the callvirt instruction, ECMA 335 specifies that a null check must be performed on the this pointer
- This change does that, and since this case is so common, adds a new INTOP that behaves just like INTOP_CALL, except it throws for a null this pointer
- Also it fixes the definition of INTOP_NULLCHECK so that it works correctly