### PR TITLE
Remove unreliable assertions around Query and Fragment offsets

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -177,8 +177,8 @@ namespace System
                         Debug.Assert(offset.Path >= offset.Host);
                     }
 
-                    Debug.Assert(offset.Query == 0);
-                    Debug.Assert(offset.Fragment == 0);
+                    // We can't check that Query and Fragment offsets are 0 here as a different thread may have called
+                    // ParseRemaining after we've checked InFact(Flags.AllUriInfoSet).
                 }
             }
             else


### PR DESCRIPTION
Fixes #119547

https://github.com/dotnet/runtime/issues/119547#issuecomment-3276679791
> We have asserts that `Query` and `Fragment` offsets aren't populated if `Flags.AllUriInfoSet` isn't set (as we haven't finished parsing yet).
> 
> [runtime/src/libraries/System.Private.Uri/src/System/Uri.cs](https://github.com/dotnet/runtime/blob/80dbb9f0579493dafc685f6cb99f12e58a8b9b0c/src/libraries/System.Private.Uri/src/System/Uri.cs#L180-L181)
> 
> Lines 180 to 181 in [80dbb9f](/dotnet/runtime/commit/80dbb9f0579493dafc685f6cb99f12e58a8b9b0c)
> 
>  Debug.Assert(offset.Query == 0); 
>  Debug.Assert(offset.Fragment == 0); 
> The asserts have a race condition since a different thread may have done the parsing between us checking the flag and reading the offsets. Introduced in [#117287](https://github.com/dotnet/runtime/pull/117287).
> 
> Might have to backport that to 10.0 as well if it creates too much CI noise.

