### PR TITLE
[cDAC] IXCLRDataMethodInstance::GetILAddressMap verification fix

### DIFF
--- a/src/native/managed/cdac/mscordaccore_universal/Legacy/ClrDataMethodInstance.cs
+++ b/src/native/managed/cdac/mscordaccore_universal/Legacy/ClrDataMethodInstance.cs
@@ -270,19 +270,20 @@ internal sealed unsafe partial class ClrDataMethodInstance : IXCLRDataMethodInst
             uint mapNeededLocal;
             ClrDataILAddressMap[]? mapsLocal = mapLen > 0 ? new ClrDataILAddressMap[mapLen] : null;
             int hrLocal = _legacyImpl.GetILAddressMap(mapLen, &mapNeededLocal, mapsLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.Assert(hrLocal == hr, $"HResult - cDAC: {hr:x}, DAC: {hrLocal:x}");
 
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(mapNeeded == null || *mapNeeded == mapNeededLocal);
                 if (mapsLocal is not null)
                 {
-                    for (int i = 0; i < mapsLocal.Length; i++)
+                    int countToCheck = Math.Min(mapsLocal.Length, (int)mapNeededLocal);
+                    for (int i = 0; i < countToCheck; i++)
                     {
-                        Debug.Assert(mapsLocal[i].ilOffset == maps![i].ilOffset, $"cDAC: {maps[i].ilOffset:x}, DAC: {mapsLocal[i].ilOffset:x}");
-                        Debug.Assert(mapsLocal[i].startAddress == maps[i].startAddress, $"cDAC: {maps[i].startAddress:x}, DAC: {mapsLocal[i].startAddress:x}");
-                        Debug.Assert(mapsLocal[i].endAddress == maps[i].endAddress, $"cDAC: {maps[i].endAddress:x}, DAC: {mapsLocal[i].endAddress:x}");
-                        Debug.Assert(mapsLocal[i].type == maps[i].type, $"cDAC: {maps[i].type:x}, DAC: {mapsLocal[i].type:x}");
+                        Debug.Assert(mapsLocal[i].ilOffset == maps![i].ilOffset, $"ILOffset - cDAC: {maps[i].ilOffset:x}, DAC: {mapsLocal[i].ilOffset:x}");
+                        Debug.Assert(mapsLocal[i].startAddress == maps[i].startAddress, $"StartAddress - cDAC: {maps[i].startAddress:x}, DAC: {mapsLocal[i].startAddress:x}");
+                        Debug.Assert(mapsLocal[i].endAddress == maps[i].endAddress, $"EndAddress - cDAC: {maps[i].endAddress:x}, DAC: {mapsLocal[i].endAddress:x}");
+                        Debug.Assert(mapsLocal[i].type == maps[i].type, $"Type - cDAC: {maps[i].type:x}, DAC: {mapsLocal[i].type:x}");
                     }
                 }
             }


### PR DESCRIPTION
We've been seeing some test failures due to verification on this API (https://dev.azure.com/dnceng-public/public/_build/results?buildId=1144777&view=ms.vss-test-web.build-test-results-tab&runId=31577242&resultId=100277&paneView=attachments)


```
        STDERROR: 00:03.632: cDAC: bab00000, DAC: 0
        STDERROR: 00:03.632:    at System.Diagnostics.DebugProvider.Fail(String, String) + 0x49
        STDERROR: 00:03.632:    at System.Diagnostics.Debug.Fail(String, String) + 0x58
        STDERROR: 00:03.632:    at System.Diagnostics.Debug.Assert(Boolean, String, String) + 0x2d
        STDERROR: 00:03.632:    at System.Diagnostics.Debug.Assert(Boolean, String) + 0x28
        STDERROR: 00:03.632:    at System.Diagnostics.Debug.Assert(Boolean, Debug.AssertInterpolatedStringHandler&) + 0x3a
        STDERROR: 00:03.632:    at Microsoft.Diagnostics.DataContractReader.Legacy.ClrDataMethodInstance.Microsoft.Diagnostics.DataContractReader.Legacy.IXCLRDataMethodInstance.GetILAddressMap(UInt32, UInt32*, ClrDataILAddressMap[]) + 0x8a7
        STDERROR: 00:03.632:    at <Microsoft_Diagnostics_DataContractReader_Legacy_IXCLRDataMethodInstance>F2EDE1EC1C5EEAE9ED371311EF29C492A086AC9D53E48B83CA31DCA14CDE62126__InterfaceImplementation.ABI_GetILAddressMap(ComWrappers.ComInterfaceDispatch*, UInt32, UInt32*, ClrDataILAddressMap*) + 0x143
```

I believe this is due to the caller passing in an array that is not entirely filled in by the method. The verification block would then compare the 0-allocated managed list with some random values from the native allocation. I modified the verification to only check up to the amount filled in.

Additionally, I added more information to the verification printing to get a better understanding of what is occurring if it happens again.