### PR TITLE
Fix null dereference in logging in Task

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -1677,11 +1677,12 @@ namespace System.Threading.Tasks
             if (s_asyncDebuggingEnabled)
                 AddToActiveTasks(this);
 
-            if (TplEventSource.Log.IsEnabled() && (Options & (TaskCreationOptions)InternalTaskOptions.ContinuationTask) == 0)
+            if (TplEventSource.Log.IsEnabled() &&
+                (Options & (TaskCreationOptions)InternalTaskOptions.ContinuationTask) == 0 &&
+                m_action is Delegate action)
             {
                 // For all other task than TaskContinuations we want to log. TaskContinuations log in their constructor
-                Debug.Assert(m_action != null, "Must have a delegate to be in ScheduleAndStart");
-                TplEventSource.Log.TraceOperationBegin(this.Id, "Task: " + m_action.GetMethodName(), 0);
+                TplEventSource.Log.TraceOperationBegin(this.Id, "Task: " + action.GetMethodName(), 0);
             }
 
             try


### PR DESCRIPTION
If Task.Start and Task.Wait are used concurrently, it's possible for Wait to execute the task as part of the inlining logic, causing the task's completion logic to null out its m_action during the call to Start. This isn't generally a functional issue, as synchronization ensures it's only ever invoked once, however EventSource-based tracing code may try to extract the method name from the delegate, and it can end up hitting an ArgumentNullException due to the race causing the delegate to be null.

Fixes https://github.com/dotnet/runtime/issues/119484