### PR TITLE
JIT: Include kmov instructions in an encoding assert

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -5391,6 +5391,8 @@ UNATIVE_OFFSET emitter::emitInsSizeAM(instrDesc* id, code_t code)
                || (attrSize == EA_16BYTE) || (attrSize == EA_32BYTE) || (attrSize == EA_64BYTE) // only for x64
                || (ins == INS_movzx) || (ins == INS_movsx) ||
                (ins == INS_cmpxchg)
+               // kmov instructions reach this path with EA_8BYTE size, even on x86
+               || IsKMOVInstruction(ins)
                // The prefetch instructions are always 3 bytes and have part of their modr/m byte hardcoded
                || isPrefetch(ins));
 


### PR DESCRIPTION
We can get here for kmov instructions. On x64 the above check for `EA_PTRSIZE` will make the assert pass, but for x86 the assert fails.

This just includes the kmov instructions like @tannergooding suggested here: https://github.com/dotnet/runtime/issues/118921#issuecomment-3275471354

I verified that the produced codegen looks reasonable: we see `kmovq k1, qword ptr [eax+0x10]` and corresponding `kmovq qword ptr [eax+0x10], k1` when moving the mask local between heap and local because of the async suspension.

Fix #118921