### PR TITLE
Fix IList.Contains to work with multidimensional arrays

### DIFF
--- a/src/libraries/System.Linq/tests/OfTypeTests.cs
+++ b/src/libraries/System.Linq/tests/OfTypeTests.cs
@@ -255,7 +255,7 @@ namespace System.Linq.Tests
             // Contains
             foreach (string s in array)
             {
-                Assert.True(result.OfType<string>().Contains(s));
+                Assert.True(array.OfType<string>().Contains(s));
             }
         }
     }

--- a/src/libraries/System.Linq/tests/OfTypeTests.cs
+++ b/src/libraries/System.Linq/tests/OfTypeTests.cs
@@ -228,5 +228,35 @@ namespace System.Linq.Tests
                 Assert.Equal(i + 1, count);
             }
         }
+
+        [Fact]
+        public void MultiDimArray_OfType_Succeeds()
+        {
+            var array = new string[3, 4];
+            for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; j < 4; j++)
+                {
+                    array[i, j] = $"{i}{j}";
+                }
+            }
+
+            // ToArray
+            var result = array.OfType<string>().ToArray();
+            Assert.Equal(12, result.Length);
+            for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; j < 4; j++)
+                {
+                    Assert.Equal($"{i}{j}", result[i * 4 + j]);
+                }
+            }
+
+            // Contains
+            foreach (string s in array)
+            {
+                Assert.True(result.OfType<string>().Contains(s));
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1039,7 +1039,22 @@ namespace System
 
         bool IList.Contains(object? value)
         {
-            return IndexOf(this, value) >= this.GetLowerBound(0);
+            // IndexOf only works for single-dimensional arrays.
+            if (Rank == 1)
+            {
+                return IndexOf(this, value) >= GetLowerBound(0);
+            }
+
+            // For multi-dimensional arrays, fall back to enumeration.
+            foreach (object? element in this)
+            {
+                if (Equals(element, value))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         void IList.Clear()

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
@@ -81,7 +81,7 @@ namespace System.Tests
         [Fact]
         public static void Construction()
         {
-            // Check a number of the simple APIs on Array for dimensions up to 4.
+            // Check a number of the simple APIs on Array for dimensions up to 4, first with value types, then reference types.
             Array array = new int[] { 1, 2, 3 };
             VerifyArray(array, typeof(int), new int[] { 3 }, new int[1]);
 
@@ -93,6 +93,19 @@ namespace System.Tests
 
             array = new int[2, 3, 4, 5];
             VerifyArray(array, typeof(int), new int[] { 2, 3, 4, 5 }, new int[4]);
+
+            // Check a number of the simple APIs on Array for dimensions up to 4.
+            array = new string[] { "1", "2", "3" };
+            VerifyArray(array, typeof(string), new int[] { 3 }, new int[1]);
+
+            array = new string[,] { { "1", "2", "3" }, { "4", null, "6" } };
+            VerifyArray(array, typeof(string), new int[] { 2, 3 }, new int[2]);
+
+            array = new string[2, 3, 4];
+            VerifyArray(array, typeof(string), new int[] { 2, 3, 4 }, new int[3]);
+
+            array = new string[2, 3, 4, 5];
+            VerifyArray(array, typeof(string), new int[] { 2, 3, 4, 5 }, new int[4]);
         }
 
         [Fact]
@@ -4682,10 +4695,19 @@ namespace System.Tests
             }
             else
             {
-                Assert.Throws<RankException>(() => iList.Contains(null));
                 Assert.Throws<RankException>(() => iList.IndexOf(null));
                 AssertExtensions.Throws<ArgumentException>(null, () => iList[0]);
                 AssertExtensions.Throws<ArgumentException>(null, () => iList[0] = 1);
+
+                bool containsNull = false;
+                foreach (object? obj in array)
+                {
+                    containsNull |= obj is null;
+                    Assert.True(iList.Contains(obj), $"{obj} not found in {string.Join(",", array.Cast<object?>())}");
+                }
+
+                Assert.False(iList.Contains(new object()));
+                Assert.Equal(containsNull, iList.Contains(null));
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
@@ -94,7 +94,6 @@ namespace System.Tests
             array = new int[2, 3, 4, 5];
             VerifyArray(array, typeof(int), new int[] { 2, 3, 4, 5 }, new int[4]);
 
-            // Check a number of the simple APIs on Array for dimensions up to 4.
             array = new string[] { "1", "2", "3" };
             VerifyArray(array, typeof(string), new int[] { 3 }, new int[1]);
 


### PR DESCRIPTION
It currently fails because it uses IndexOf, but there's no fundamental reason this shouldn't work with multidimensional arrays, and it breaks expectations that it doesn't work. We can just fall back to enumerating if the Rank isn't 1.

Fixes https://github.com/dotnet/runtime/issues/119569

We need to fix the issue in 10, and fixing Array itself seems like the right answer. If there are objections to backporting this fix, please let me know. This is taking something that previously always threw an exception and now makes it work. (There are probably a couple more array interface implementations we could fix subsequently to work with multidimensional arrays, as well, e.g. CopyTo, a problem we've bumped into from LINQ as well in the past.)