### PR TITLE
Allow using UTF-8 in CompilerGeneratedNames

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedCallGraph.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedCallGraph.cs
@@ -30,7 +30,7 @@ namespace ILCompiler.Dataflow
         {
             Debug.Assert(fromMethod.IsTypicalMethodDefinition);
             Debug.Assert(toMethod.IsTypicalMethodDefinition);
-            Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(toMethod.GetName()));
+            Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(toMethod.Name));
             TrackCallInternal(fromMethod, toMethod);
         }
 
@@ -38,7 +38,7 @@ namespace ILCompiler.Dataflow
         {
             Debug.Assert(fromMethod.IsTypicalMethodDefinition);
             Debug.Assert(toType.IsTypeDefinition);
-            Debug.Assert(CompilerGeneratedNames.IsStateMachineType(toType.GetName()));
+            Debug.Assert(CompilerGeneratedNames.IsStateMachineType(toType.Name));
             TrackCallInternal(fromMethod, toType);
         }
 
@@ -46,8 +46,8 @@ namespace ILCompiler.Dataflow
         {
             Debug.Assert(fromType.IsTypeDefinition);
             Debug.Assert(toMethod.IsTypicalMethodDefinition);
-            Debug.Assert(CompilerGeneratedNames.IsStateMachineType(fromType.GetName()));
-            Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(toMethod.GetName()));
+            Debug.Assert(CompilerGeneratedNames.IsStateMachineType(fromType.Name));
+            Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(toMethod.Name));
             TrackCallInternal(fromType, toMethod);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
@@ -111,7 +111,7 @@ namespace ILCompiler.Dataflow
             internal TypeCache(MetadataType type, ILProvider ilProvider)
             {
                 Debug.Assert(type == type.GetTypeDefinition());
-                Debug.Assert(!CompilerGeneratedNames.IsStateMachineOrDisplayClass(type.GetName()));
+                Debug.Assert(!CompilerGeneratedNames.IsStateMachineOrDisplayClass(type.Name));
 
                 Type = type;
 
@@ -132,8 +132,8 @@ namespace ILCompiler.Dataflow
                 {
                     Debug.Assert(method == method.GetTypicalMethodDefinition());
 
-                    bool isStateMachineMember = CompilerGeneratedNames.IsStateMachineType(((MetadataType)method.OwningType).GetName());
-                    if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(method.GetName()))
+                    bool isStateMachineMember = CompilerGeneratedNames.IsStateMachineType(((MetadataType)method.OwningType).Name);
+                    if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(method.Name))
                     {
                         if (!isStateMachineMember)
                         {
@@ -177,7 +177,7 @@ namespace ILCompiler.Dataflow
                                             referencedMethod.OwningType is MetadataType generatedType &&
                                             // Don't consider calls in the same/nested type, like inside a static constructor
                                             !IsSameOrNestedType(method.OwningType, generatedType) &&
-                                            CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.GetName()))
+                                            CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.Name))
                                         {
                                             Debug.Assert(generatedType.IsTypeDefinition);
 
@@ -190,7 +190,7 @@ namespace ILCompiler.Dataflow
                                             continue;
                                         }
 
-                                        if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(referencedMethod.GetName()))
+                                        if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(referencedMethod.Name))
                                             continue;
 
                                         if (isStateMachineMember)
@@ -218,7 +218,7 @@ namespace ILCompiler.Dataflow
                                         if (field.OwningType is MetadataType generatedType &&
                                             // Don't consider field accesses in the same/nested type, like inside a static constructor
                                             !IsSameOrNestedType(method.OwningType, generatedType) &&
-                                            CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.GetName()))
+                                            CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.Name))
                                         {
                                             Debug.Assert(generatedType.IsTypeDefinition);
 
@@ -243,7 +243,7 @@ namespace ILCompiler.Dataflow
                     if (TryGetStateMachineType(method, out MetadataType? stateMachineType))
                     {
                         Debug.Assert(stateMachineType.ContainingType == type ||
-                            (CompilerGeneratedNames.IsStateMachineOrDisplayClass(stateMachineType.ContainingType.GetName()) &&
+                            (CompilerGeneratedNames.IsStateMachineOrDisplayClass(stateMachineType.ContainingType.Name) &&
                              stateMachineType.ContainingType.ContainingType == type));
                         Debug.Assert(stateMachineType == stateMachineType.GetTypeDefinition());
 
@@ -319,7 +319,7 @@ namespace ILCompiler.Dataflow
                         switch (compilerGeneratedMember)
                         {
                             case MethodDesc nestedFunction:
-                                Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(nestedFunction.GetName()));
+                                Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(nestedFunction.Name));
                                 // Nested functions get suppressions from the user method only.
                                 _compilerGeneratedMethodToUserCodeMethod ??= new Dictionary<MethodDesc, MethodDesc>();
                                 if (!_compilerGeneratedMethodToUserCodeMethod.TryAdd(nestedFunction, userDefinedMethod))
@@ -334,7 +334,7 @@ namespace ILCompiler.Dataflow
                                 // are represented by the state machine type itself.
                                 // We are already tracking the association of the state machine type to the user code method
                                 // above, so no need to track it here.
-                                Debug.Assert(CompilerGeneratedNames.IsStateMachineType(stateMachineType.GetName()));
+                                Debug.Assert(CompilerGeneratedNames.IsStateMachineType(stateMachineType.Name));
                                 break;
                             default:
                                 throw new InvalidOperationException();
@@ -386,7 +386,7 @@ namespace ILCompiler.Dataflow
                     MetadataType generatedType,
                     Dictionary<MetadataType, TypeArgumentInfo> generatedTypeToTypeArgs)
                 {
-                    Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.GetName()));
+                    Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.Name));
                     Debug.Assert(generatedType == generatedType.GetTypeDefinition());
 
                     var typeInfo = generatedTypeToTypeArgs[generatedType];
@@ -426,7 +426,7 @@ namespace ILCompiler.Dataflow
                             else
                             {
                                 // Must be a type ref
-                                if (method.OwningType is not MetadataType owningType || !CompilerGeneratedNames.IsStateMachineOrDisplayClass(owningType.GetName()))
+                                if (method.OwningType is not MetadataType owningType || !CompilerGeneratedNames.IsStateMachineOrDisplayClass(owningType.Name))
                                 {
                                     userAttrs = param;
                                 }
@@ -567,7 +567,7 @@ namespace ILCompiler.Dataflow
         {
             foreach (var nestedType in type.GetNestedTypes())
             {
-                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(nestedType.GetName()))
+                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(nestedType.Name))
                     continue;
 
                 yield return nestedType;
@@ -579,14 +579,14 @@ namespace ILCompiler.Dataflow
 
         public static bool IsHoistedLocal(FieldDesc field)
         {
-            if (CompilerGeneratedNames.IsLambdaDisplayClass(field.OwningType.GetName()))
+            if (CompilerGeneratedNames.IsLambdaDisplayClass(field.OwningType.Name))
                 return true;
 
-            if (CompilerGeneratedNames.IsStateMachineType(field.OwningType.GetName()))
+            if (CompilerGeneratedNames.IsStateMachineType(field.OwningType.Name))
             {
                 // Don't track the "current" field which is used for state machine return values,
                 // because this can be expensive to track.
-                return !CompilerGeneratedNames.IsStateMachineCurrentField(field.GetName());
+                return !CompilerGeneratedNames.IsStateMachineCurrentField(field.Name);
             }
 
             return false;
@@ -595,13 +595,13 @@ namespace ILCompiler.Dataflow
         // "Nested function" refers to lambdas and local functions.
         public static bool IsNestedFunctionOrStateMachineMember(TypeSystemEntity member)
         {
-            if (member is MethodDesc method && CompilerGeneratedNames.IsLambdaOrLocalFunction(method.GetName()))
+            if (member is MethodDesc method && CompilerGeneratedNames.IsLambdaOrLocalFunction(method.Name))
                 return true;
 
             if (member.GetOwningType() is not MetadataType declaringType)
                 return false;
 
-            return CompilerGeneratedNames.IsStateMachineType(declaringType.GetName());
+            return CompilerGeneratedNames.IsStateMachineType(declaringType.Name);
         }
 
         public static bool TryGetStateMachineType(MethodDesc method, [NotNullWhen(true)] out MetadataType? stateMachineType)
@@ -631,7 +631,7 @@ namespace ILCompiler.Dataflow
             // State machines can be emitted into display classes, so we may also need to go one more level up.
             // To avoid depending on implementation details, we go up until we see a non-compiler-generated type.
             // This is the counterpart to GetCompilerGeneratedNestedTypes.
-            while (userType != null && CompilerGeneratedNames.IsStateMachineOrDisplayClass(userType.GetName()))
+            while (userType != null && CompilerGeneratedNames.IsStateMachineOrDisplayClass(userType.Name))
                 userType = userType.ContainingType as MetadataType;
 
             if (userType is null)
@@ -676,7 +676,7 @@ namespace ILCompiler.Dataflow
         public IReadOnlyList<GenericParameterDesc?>? GetGeneratedTypeAttributes(MetadataType type)
         {
             MetadataType generatedType = (MetadataType)type.GetTypeDefinition();
-            Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.GetName()));
+            Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.Name));
 
             // Avoid the heuristics for .NET10+, where DynamicallyAccessedMembers flows to generated code
             // because it is annotated with CompilerLoweringPreserveAttribute.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -655,7 +655,7 @@ namespace ILLink.Shared.TrimAnalysis
 
             private IReadOnlyList<GenericParameterDesc?>? GetGeneratedTypeAttributes(EcmaType typeDef)
             {
-                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(typeDef.GetName()))
+                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(typeDef.Name))
                 {
                     return null;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/InterproceduralState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/InterproceduralState.cs
@@ -78,7 +78,7 @@ namespace ILCompiler.Dataflow
             {
                 foreach (var stateMachineMethod in stateMachineType.GetMethods())
                 {
-                    Debug.Assert(!CompilerGeneratedNames.IsLambdaOrLocalFunction(stateMachineMethod.GetName()));
+                    Debug.Assert(!CompilerGeneratedNames.IsLambdaOrLocalFunction(stateMachineMethod.Name));
                     if (TryGetMethodBody(stateMachineMethod, out MethodIL? stateMachineMethodBody))
                     {
                         stateMachineMethodBody = GetInstantiatedMethodIL(stateMachineMethodBody);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
@@ -335,7 +335,7 @@ namespace ILCompiler.Dataflow
         {
             MethodDesc method = referencedMethod.GetTypicalMethodDefinition();
 
-            if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(method.GetName()))
+            if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(method.Name))
                 return;
 
             interproceduralState.TrackMethod(method);

--- a/src/tools/illink/src/ILLink.Shared/DataFlow/CompilerGeneratedNames.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/CompilerGeneratedNames.cs
@@ -1,11 +1,19 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Diagnostics;
+
 namespace ILLink.Shared.DataFlow
 {
     internal sealed class CompilerGeneratedNames
     {
         private static bool IsGeneratedMemberName(string memberName)
+        {
+            return memberName.Length > 0 && memberName[0] == '<';
+        }
+
+        private static bool IsGeneratedMemberName(ReadOnlySpan<byte> memberName)
         {
             return memberName.Length > 0 && memberName[0] == '<';
         }
@@ -20,7 +28,31 @@ namespace ILLink.Shared.DataFlow
             return className.StartsWith("<>c");
         }
 
+        internal static bool IsLambdaDisplayClass(ReadOnlySpan<byte> className)
+        {
+            if (!IsGeneratedMemberName(className))
+                return false;
+
+            // This is true for static lambdas (which are emitted into a class like <>c)
+            // and for instance lambdas (which are emitted into a class like <>c__DisplayClass1_0)
+            return className.StartsWith("<>c"u8);
+        }
+
         internal static bool IsStateMachineType(string typeName)
+        {
+            if (!IsGeneratedMemberName(typeName))
+                return false;
+
+            // State machines are generated into types with names like <OwnerMethodName>d__0
+            // Or if its nested in a local function the name will look like <<OwnerMethodName>g__Local>d and so on
+            int i = typeName.LastIndexOf('>');
+            if (i == -1)
+                return false;
+
+            return typeName.Length > i + 1 && typeName[i + 1] == 'd';
+        }
+
+        internal static bool IsStateMachineType(ReadOnlySpan<byte> typeName)
         {
             if (!IsGeneratedMemberName(typeName))
                 return false;
@@ -47,15 +79,45 @@ namespace ILLink.Shared.DataFlow
             return fieldName.Length > i + 1 && fieldName[i + 1] == '2';
         }
 
+        internal static bool IsStateMachineCurrentField(ReadOnlySpan<byte> fieldName)
+        {
+            if (!IsGeneratedMemberName(fieldName))
+                return false;
+
+            int i = fieldName.LastIndexOf('>');
+            if (i == -1)
+                return false;
+
+            // Current field is <>2__current
+            return fieldName.Length > i + 1 && fieldName[i + 1] == '2';
+        }
+
         internal static bool IsStateMachineOrDisplayClass(string name) => IsStateMachineType(name) || IsLambdaDisplayClass(name);
 
+        internal static bool IsStateMachineOrDisplayClass(ReadOnlySpan<byte> name) => IsStateMachineType(name) || IsLambdaDisplayClass(name);
+
         internal static bool IsLambdaOrLocalFunction(string methodName) => IsLambdaMethod(methodName) || IsLocalFunction(methodName);
+
+        internal static bool IsLambdaOrLocalFunction(ReadOnlySpan<byte> methodName) => IsLambdaMethod(methodName) || IsLocalFunction(methodName);
 
         // Lambda methods have generated names like "<UserMethod>b__0_1" where "UserMethod" is the name
         // of the original user code that contains the lambda method declaration.
         // The user method name may include a (potentially generic) interface type name for
         // explicitly implemented interface methods.
         internal static bool IsLambdaMethod(string methodName)
+        {
+            if (!IsGeneratedMemberName(methodName))
+                return false;
+
+            int i = methodName.LastIndexOf('>');
+            if (i == -1)
+                return false;
+
+            // Ignore the method ordinal/generation and lambda ordinal/generation.
+            return methodName.Length > i + 1 && methodName[i + 1] == 'b';
+        }
+
+        internal static bool IsLambdaMethod(ReadOnlySpan<byte> methodName)
         {
             if (!IsGeneratedMemberName(methodName))
                 return false;
@@ -84,6 +146,29 @@ namespace ILLink.Shared.DataFlow
 
             // Ignore the method ordinal/generation and local function ordinal/generation.
             return methodName.Length > i + 1 && methodName[i + 1] == 'g';
+        }
+
+        internal static bool IsLocalFunction(ReadOnlySpan<byte> methodName)
+        {
+            if (!IsGeneratedMemberName(methodName))
+                return false;
+
+            int i = methodName.LastIndexOf('>');
+            if (i == -1)
+                return false;
+
+            // Ignore the method ordinal/generation and local function ordinal/generation.
+            return methodName.Length > i + 1 && methodName[i + 1] == 'g';
+        }
+    }
+
+    file static class Extensions
+    {
+        public static int LastIndexOf(this ReadOnlySpan<byte> span, char ch)
+        {
+            // UTF-8 is byte-accurate, so searching for characters that fit under 0x80 means searching for the byte in valid UTF-8 strings.
+            Debug.Assert(ch < 0x80);
+            return span.LastIndexOf((byte)ch);
         }
     }
 }


### PR DESCRIPTION
The managed type system switched to UTF-8, The `CompilerGeneratedNames` class is forcing us to materialize hundreds of thousands of UTF-16 strings (in a `dotnet new webapiaot` sample). Add overloads that take UTF-8.

I was thinking to do some code reuse with clever use of structs and interfaces but this is one of the cases where simpler is just better, so a copy it is.

Before:

<img width="848" height="312" alt="image" src="https://github.com/user-attachments/assets/aabacda7-1e9c-479a-951c-48e2d1d91c83" />


After:

<img width="840" height="298" alt="image" src="https://github.com/user-attachments/assets/2123e536-5d28-479f-850c-794794c5924f" />


Cc @dotnet/ilc-contrib 