### PR TITLE
Increase minimum storage requirements for building the runtime (again)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	"hostRequirements": {
 		"cpus": 4,
 		"memory": "8gb",
-		"storage": "32gb"
+		"storage": "64gb"
 	},
 
 	"features": {

--- a/.devcontainer/libraries/devcontainer.json
+++ b/.devcontainer/libraries/devcontainer.json
@@ -10,7 +10,7 @@
 	"hostRequirements": {
 		"cpus": 4,
 		"memory": "8gb",
-		"storage": "32gb"
+		"storage": "64gb"
 	},
 
 	"features": {


### PR DESCRIPTION
The PR https://github.com/dotnet/runtime/pull/119610 was increasing the minimum storage to 32GB, it was already 32 GB. We really wanted 64 GB.