### PR TITLE
[cDAC] fix reference to relative value

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.ReadyToRunJitManager.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.ReadyToRunJitManager.cs
@@ -51,7 +51,7 @@ internal partial class ExecutionManagerCore<T> : IExecutionManager
                 {
                     // If the address is in the cold part, the relative offset is the size of the
                     // hot part plus the offset from the address to the start of the cold part
-                    uint hotSize = _runtimeFunctions.GetFunctionLength(function);
+                    uint hotSize = _runtimeFunctions.GetFunctionLength(imageBase, function);
                     relativeOffset = new TargetNUInt(hotSize + addr - coldStart);
                 }
             }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/RuntimeFunctionLookup.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/Helpers/RuntimeFunctionLookup.cs
@@ -19,12 +19,12 @@ internal sealed class RuntimeFunctionLookup
         _runtimeFunctionSize = target.GetTypeInfo(DataType.RuntimeFunction).Size!.Value;
     }
 
-    public uint GetFunctionLength(Data.RuntimeFunction function)
+    public uint GetFunctionLength(TargetPointer imageBase, Data.RuntimeFunction function)
     {
         if (function.EndAddress.HasValue)
             return function.EndAddress.Value - function.BeginAddress;
 
-        Data.UnwindInfo unwindInfo = _target.ProcessedData.GetOrAdd<Data.UnwindInfo>(function.UnwindData);
+        Data.UnwindInfo unwindInfo = _target.ProcessedData.GetOrAdd<Data.UnwindInfo>(imageBase + function.UnwindData);
         if (unwindInfo.FunctionLength.HasValue)
             return unwindInfo.FunctionLength.Value;
 

--- a/src/native/managed/cdac/tests/ExecutionManager/RuntimeFunctionTests.cs
+++ b/src/native/managed/cdac/tests/ExecutionManager/RuntimeFunctionTests.cs
@@ -44,7 +44,7 @@ public class RuntimeFunctionTests
                 : MockDescriptors.RuntimeFunctions.DefaultFunctionLength;
 
             Data.RuntimeFunction function = lookup.GetRuntimeFunction(addr, i);
-            uint functionLength = lookup.GetFunctionLength(function);
+            uint functionLength = lookup.GetFunctionLength(new(0), function);
             Assert.Equal(expectedFunctionLength, functionLength);
         }
     }


### PR DESCRIPTION
The `UnwindInfo` stores `uint` sized pointers which are relative to the module base.