### PR TITLE
Fix outdated comments on SocketAsyncEventArgs.Windows

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -695,18 +695,17 @@ namespace System.Net.Sockets
                     {
                         if (spe?.FilePath != null)
                         {
-                            // Create a FileStream to open the file.
+                            // Open the file and get its handle.
                             _sendPacketsFileHandles[index] =
                                 File.OpenHandle(spe.FilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
 
-                            // Get the file handle from the stream.
                             index++;
                         }
                     }
                 }
                 catch
                 {
-                    // Got an exception opening a file - close any open streams, then throw.
+                    // Got an exception opening a file - close any open files, then throw.
                     for (int i = index - 1; i >= 0; i--)
                         _sendPacketsFileHandles[i].Dispose();
                     _sendPacketsFileHandles = null;


### PR DESCRIPTION
related: https://github.com/dotnet/runtime/commit/61ea22a0fe4c35aa43ec3d5e99914a961b0f35b6, https://github.com/dotnet/runtime/commit/6d00aae0e21b324fe85c24de65e496d70bafe953