### PR TITLE
[RISC-V] Fold OP-FP disasm

### DIFF
--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -4576,7 +4576,6 @@ void emitter::emitDispInsName(
                     printf("fmv.%c.x        %s, %s\n", type, fd, xs1);
                     return;
                 default:
-                    printf("%#04x func\n", opcode2);
                     NYI_RISCV64("illegal ins within emitDisInsName!");
                     return;
             }


### PR DESCRIPTION
Remove duplicated code, single- and double-precision instructions differ only in one bit.

Also add missing checks for opcode bits in some instructions.

Part #84834, cc @dotnet/samsung