### PR TITLE
[EventPipe][UserEvents] Allow empty tracepoint sets

### DIFF
--- a/src/native/eventpipe/ds-eventpipe-protocol.c
+++ b/src/native/eventpipe/ds-eventpipe-protocol.c
@@ -409,7 +409,7 @@ eventpipe_collect_tracing_command_try_parse_tracepoint_sets (
 	*tracepoint_sets = NULL;
 
 	if (tracepoint_sets_len == 0)
-		return false;
+		return true;
 
 	*tracepoint_sets = ep_rt_object_array_alloc (EventPipeProviderTracepointSet, tracepoint_sets_len);
 	ep_raise_error_if_nok (*tracepoint_sets != NULL);


### PR DESCRIPTION
When enabling a user_events-based eventpipe session, its valid for the tracepoint_sets to be empty if there is a default_tracepoint_name.