### PR TITLE
Remove redundant CS8500 suppression

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
@@ -6,8 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#pragma warning disable CS8500 // takes the address of, gets the size of, or declares a pointer to a managed type ('T')
-
 namespace System.Threading
 {
     /// <summary>Provides atomic operations for variables that are shared by multiple threads.</summary>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -133,7 +133,8 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <!-- Disable some C# warnings for the tests. -->
-    <NoWarn>78,162,164,168,169,219,251,252,414,429,618,642,649,652,659,675,1691,1717,1718,3001,3002,3003,3005,3008,8981</NoWarn>
+    <NoWarn>78,162,164,168,169,219,251,252,414,429,618,642,649,652,659,675,1691,1717,1718,3001,3002,3003,3005,3008,8500,8981</NoWarn>
+
     <!--
       Disable xunit warnings that aren't relevant with our custom runner.
       xUnit1028: Use supported test return types. We support test methods that return int where 100 is passing and everything else is failure.

--- a/src/tests/Interop/Swift/SwiftCallbackAbiStress/SwiftCallbackAbiStress.cs
+++ b/src/tests/Interop/Swift/SwiftCallbackAbiStress/SwiftCallbackAbiStress.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable CS8500
-
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;

--- a/src/tests/JIT/Directed/debugging/poisoning/poison.cs
+++ b/src/tests/JIT/Directed/debugging/poisoning/poison.cs
@@ -10,7 +10,6 @@ public class Program
     [ActiveIssue("https://github.com/dotnet/runtime/issues/91923", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile))]
     public static unsafe int TestEntryPoint()
     {
-#pragma warning disable CS8500 // takes address of managed type
         bool result = true;
 
         int poisoned;
@@ -42,7 +41,6 @@ public class Program
         result &= VerifyZero(&zeroed2, sizeof(GCRef));
 
         return result ? 100 : 101;
-#pragma warning restore CS8500
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/JIT/Regression/JitBlue/Runtime_102577/Runtime_102577.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_102577/Runtime_102577.cs
@@ -5,9 +5,6 @@ using System;
 using System.Runtime.CompilerServices;
 using Xunit;
 
-// This takes the address of, gets the size of, or declares a pointer to a managed type
-#pragma warning disable CS8500
-
 public unsafe class Runtime_102577
 {
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/JIT/opt/Misc/Runtime_80086/Runtime_80086.cs
+++ b/src/tests/JIT/opt/Misc/Runtime_80086/Runtime_80086.cs
@@ -6,8 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
 
-#pragma warning disable CS8500
-
 namespace Runtime_80086
 {
     public static unsafe class Test

--- a/src/tests/Loader/classloader/InlineArray/InlineArrayValid.cs
+++ b/src/tests/Loader/classloader/InlineArray/InlineArrayValid.cs
@@ -11,8 +11,6 @@ using System.Runtime.InteropServices;
 
 using Xunit;
 
-// we will be doing "sizeof" with arrays containing managed references.
-#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
 #pragma warning disable CS9184 // 'Inline arrays' language feature is not supported for an inline array type that is not valid as a type argument, or has element type that is not valid as a type argument
 
 [InlineArray(LengthConst)]

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Types.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Types.cs
@@ -66,9 +66,7 @@ class TargetClass
     private Type M_S1Array(S1[][][] c) => typeof(S1[][][]);
     private Type M_S1Array(S1[][,] c) => typeof(S1[][,]);
 
-#pragma warning disable CS8500
     private unsafe void M_C1Pointer(C1* c) { }
-#pragma warning restore CS8500
 
     private class InnerClass
     {

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/universal_generics.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/universal_generics.cs
@@ -461,9 +461,7 @@ namespace UniversalGen
         [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void TestAsPointer(T x)
         {
-#pragma warning disable CS8500 // takes address of managed type
             IntPtr unsafeValuePtr = (IntPtr)&x;
-#pragma warning restore CS8500
             GC.Collect();
             GC.Collect();
             GC.Collect();

--- a/src/tests/reflection/regression/github_25697/25697.cs
+++ b/src/tests/reflection/regression/github_25697/25697.cs
@@ -5,8 +5,6 @@ using System;
 using System.Reflection;
 using Xunit;
 
-#pragma warning disable CS8500
-
 unsafe public class Program
 {
 
@@ -32,5 +30,3 @@ unsafe public class Program
         return 100;
     }
 }
-
-#pragma warning restore CS8500


### PR DESCRIPTION
Remove specific suppressions of `CS8500: takes address of managed type` as it is suppressed for the entire repo.
