### PR TITLE
TimeZones improvement

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1338,6 +1338,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZone.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.AdjustmentRule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.Cache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.FullGlobalizationData.cs" Condition="'$(UseMinimalGlobalizationData)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.StringSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.TransitionTime.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1509,17 +1509,8 @@ namespace System
             get
             {
                 DateTime utc = UtcNow;
-                long offset = TimeZoneInfo.GetDateTimeNowUtcOffsetFromUtc(utc, out bool isAmbiguousLocalDst).Ticks;
-                long tick = utc.Ticks + offset;
-                if ((ulong)tick <= MaxTicks)
-                {
-                    if (!isAmbiguousLocalDst)
-                    {
-                        return new DateTime((ulong)tick | KindLocal);
-                    }
-                    return new DateTime((ulong)tick | KindLocalAmbiguousDst);
-                }
-                return new DateTime(tick < 0 ? KindLocal : MaxTicks | KindLocal);
+                long localTicks = TimeZoneInfo.GetLocalDateTimeNowTicks(utc, out bool isAmbiguousLocalDst);
+                return new DateTime((ulong)localTicks | (isAmbiguousLocalDst ? KindLocalAmbiguousDst : KindLocal));
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Cache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Cache.cs
@@ -1,0 +1,1403 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This file implements caching of per-year time zone transitions to improve performance
+// when converting between UTC and local time. It also includes helper methods for using
+// the cached data in time conversions.
+//
+// To cache transitions for a year, we must ensure all transitions for that year are
+// included—covering the full range of UTC and local times from
+// "year/01/01 12:00:00 AM" through "year/12/31 11:59:59 PM".
+//
+// Transitions are derived from adjustment rules, which can be either Linux-based or
+// Windows-based:
+//
+// ------------------
+// Linux-based Rules:
+// ------------------
+//   - Store exact transition times using rule.DateStart and rule.DateEnd.
+//   - Transition times are stored in UTC.
+//   - Start and end are both inclusive:
+//       * start → first tick of the transition
+//       * end   → last tick of the transition
+//   - DaylightTransitionStart/DaylightTransitionEnd are not used.
+//   - Identified by rule.NoDaylightTransitions = true.
+//
+// --------------------
+// Windows-based Rules:
+// --------------------
+//   - Store transition times using DaylightTransitionStart and DaylightTransitionEnd.
+//   - Transition times are stored in local time.
+//   - rule.DateStart/DateEnd define which years the rule applies to, not exact transition times.
+//   - Transition start is inclusive; transition end is exclusive.
+//   - Identified by rule.NoDaylightTransitions = false.
+//   - Can represent fixed or floating transitions (e.g., "First Sunday in March at 2:00 AM").
+//   - Can define one or two transitions:
+//       * One transition if start < end.
+//       * Two transitions if start > end. In this case, the year begins and ends in
+//         daylight saving time, with standard time occurring in the middle.
+//         This pattern is common in southern hemisphere countries and occasionally
+//         seen in places like Morocco.
+//   - Special cases:
+//       * Start = 1/1/1 12:00 AM → year starts with DST enabled.
+//       * End   = 1/1/1 12:00 AM → year ends with DST enabled.
+//
+// -----------------
+// Additional Notes:
+// -----------------
+//   - Rules may define BaseUtcOffsetDelta ≠ 0, meaning the base UTC offset changes and
+//     must be accounted for.
+//   - On Linux, both Linux-based and Windows-based rules may appear. Windows typically
+//     uses only Windows-based rules.
+//   - Year transitions are cached using TimeTransition records, always stored in UTC.
+//   - Caching starts with the rule matching the target year’s transitions.
+//     Transitions from the previous year may also be cached to handle year boundaries.
+//     Subsequent transitions are cached if they occur in the same year
+//     or if local/UTC transition times overlap the next rule.
+//     On Linux, it is common to cache multiple years of transitions to ensure full coverage.
+//   - The code is designed to handle consecutive rules, regardless of type.
+//     It supports any mix of Windows- or Linux-based rules, fixed or floating rules,
+//     northern or southern hemisphere rules, and rules that start or end with daylight saving.
+
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    public sealed partial class TimeZoneInfo
+    {
+        /// <summary>
+        /// Gets the UTC offset for the specified UTC time, along with whether it is ambiguous.
+        /// Used by DateTime.Now to get the local time ticks and whether it is ambiguous.
+        /// </summary>
+        internal static long GetLocalDateTimeNowTicks(DateTime utcNow, out bool isAmbiguous) => s_cachedData.GetLocalDateTimeNowTicks(utcNow, out isAmbiguous);
+
+        /// <summary>
+        /// Gets the next transition for the specified UTC time and cache the result for the subsequent calls.
+        /// </summary>
+        /// <param name="utcNow">The current UTC time.</param>
+        /// <returns>A DateTimeNowCache containing details about the next transition after utcNow.</returns>
+        /// <remarks>
+        /// This method calculates the next time zone transition after the specified UTC time.
+        /// The created DateTimeNowCache object will be used when calling DateTime.Now for better performance.
+        /// </remarks>
+        private DateTimeNowCache GetNextNowTransition(DateTime utcNow)
+        {
+            var dateTimeNowCache = new DateTimeNowCache();
+
+            if (!_supportsDaylightSavingTime || _adjustmentRules is null || _adjustmentRules.Length == 0)
+            {
+                // no daylight transitions for this time zone.
+                dateTimeNowCache._nextUtcNowTransitionTicks = DateTime.MaxTicks;
+                dateTimeNowCache._nowUtcOffsetTicks = _baseUtcOffset.Ticks;
+                dateTimeNowCache._dtsAmbiguousOffsetStart = 0;
+                dateTimeNowCache._dtsAmbiguousOffsetEnd = 0;
+
+                return dateTimeNowCache;
+            }
+
+            if (TryGetTransitionsForYear(utcNow.Year, out (int index, int count) transitionInfo))
+            {
+                TimeTransition[] transitions = _yearsTransitions;
+                int boundary = transitionInfo.index + transitionInfo.count;
+                Debug.Assert(boundary <= _yearsTransitionsCount && transitions is not null);
+                long utcNowTicks = utcNow.Ticks;
+
+                // Find the next transition after utcNow
+                for (int i = transitionInfo.index; i < boundary; i++)
+                {
+                    TimeTransition transition = transitions[i];
+
+                    if (utcNowTicks >= transition.DateStart.Ticks && utcNowTicks <= transition.DateEnd.Ticks)
+                    {
+                        // Found transition
+                        dateTimeNowCache._nextUtcNowTransitionTicks = transition.DateEnd.Ticks + 1;
+                        dateTimeNowCache._nowUtcOffsetTicks = _baseUtcOffset.Ticks + transition.Offset.Ticks;
+
+                        if (transition.DaylightSavingOn)
+                        {
+                            // Ambiguous time in daylight saving time period, find the start and end of the ambiguous period in the current transition if it exists
+
+                            DateTime localTransitionStart = SafeCreateDateTimeFromTicks(transition.DateStart.Ticks + transition.Offset.Ticks);
+                            DateTime localTransitionEnd = SafeCreateDateTimeFromTicks(transition.DateEnd.Ticks + transition.Offset.Ticks);
+
+                            // check Ambiguous Overlap with the next transition
+                            if (i < boundary - 1)
+                            {
+                                // If the next transition is also in daylight saving time, extend the ambiguous period to include it
+                                TimeTransition nextTransition = transitions[i + 1];
+
+                                DateTime nextLocalTransitionStart = SafeCreateDateTimeFromTicks(nextTransition.DateStart.Ticks + nextTransition.Offset.Ticks);
+                                DateTime nextLocalTransitionEnd = SafeCreateDateTimeFromTicks(nextTransition.DateEnd.Ticks + nextTransition.Offset.Ticks);
+
+                                DateTime overlapStart = localTransitionStart > nextLocalTransitionStart ? localTransitionStart : nextLocalTransitionStart;
+                                DateTime overlapEnd = localTransitionEnd < nextLocalTransitionEnd ? localTransitionEnd : nextLocalTransitionEnd;
+
+                                if (overlapStart <= overlapEnd)
+                                {
+                                    dateTimeNowCache._dtsAmbiguousOffsetStart = overlapStart.Ticks;
+                                    dateTimeNowCache._dtsAmbiguousOffsetEnd = overlapEnd.Ticks;
+
+                                    return dateTimeNowCache;
+                                }
+                            }
+
+                            // check transition with previous transition
+                            if (i > 0)
+                            {
+                                // If the previous transition is also in daylight saving time, extend the ambiguous period to include it
+                                TimeTransition prevTransition = transitions[i - 1];
+
+                                DateTime prevLocalTransitionStart = SafeCreateDateTimeFromTicks(prevTransition.DateStart.Ticks + prevTransition.Offset.Ticks);
+                                DateTime prevLocalTransitionEnd = SafeCreateDateTimeFromTicks(prevTransition.DateEnd.Ticks + prevTransition.Offset.Ticks);
+
+                                DateTime overlapStart = localTransitionStart > prevLocalTransitionStart ? localTransitionStart : prevLocalTransitionStart;
+                                DateTime overlapEnd = localTransitionEnd < prevLocalTransitionEnd ? localTransitionEnd : prevLocalTransitionEnd;
+
+                                if (overlapStart <= overlapEnd)
+                                {
+                                    dateTimeNowCache._dtsAmbiguousOffsetStart = overlapStart.Ticks;
+                                    dateTimeNowCache._dtsAmbiguousOffsetEnd = overlapEnd.Ticks;
+
+                                    return dateTimeNowCache;
+                                }
+                            }
+                        }
+
+                        // No ambiguous period found
+                        dateTimeNowCache._dtsAmbiguousOffsetStart = 0;
+                        dateTimeNowCache._dtsAmbiguousOffsetEnd = 0;
+
+                        return dateTimeNowCache;
+                    }
+                }
+            }
+
+            // no transition for this Year
+            dateTimeNowCache._nextUtcNowTransitionTicks = utcNow.Year >= MaxYear ? DateTime.MaxTicks : new DateTime(utcNow.Year + 1, 1, 1).Ticks; // check again next year
+            dateTimeNowCache._nowUtcOffsetTicks = _baseUtcOffset.Ticks;
+            dateTimeNowCache._dtsAmbiguousOffsetStart = 0;
+            dateTimeNowCache._dtsAmbiguousOffsetEnd = 0;
+
+            return dateTimeNowCache;
+        }
+
+        /// <summary>
+        /// Determines whether the specified local date and time is invalid in the current time zone.
+        /// An invalid local time is a time that does not exist due to a daylight saving time transition.
+        /// </summary>
+        /// <param name="localDateTime">The local date and time to check.</param>
+        /// <returns>True if the specified local date and time is invalid; otherwise, false.</returns>
+        private bool IsInvalidLocalTime(DateTime localDateTime) => !TryGetUtcOffset(localDateTime, out _);
+
+        /// <summary>
+        /// Determines whether the specified local date and time is ambiguous in the current time zone.
+        /// An ambiguous local time is a time that occurs twice due to a daylight saving time transition.
+        /// </summary>
+        /// <param name="localDateTime">The local date and time to check.</param>
+        /// <param name="offsets">A span to fill with the possible UTC offsets.</param>
+        /// <returns>True if the specified local date and time is ambiguous; otherwise, false.</returns>
+        private bool IsAmbiguousLocalTime(DateTime localDateTime, Span<TimeSpan> offsets = default)
+        {
+            if (!TryGetTransitionsForYear(localDateTime.Year, out (int index, int count) transitionInfo))
+            {
+                return false;
+            }
+
+            TimeTransition[] transitions = _yearsTransitions;
+            int boundary = transitionInfo.index + transitionInfo.count;
+
+            Debug.Assert(boundary <= _yearsTransitionsCount && transitions is not null);
+
+            int encountered = 0;
+            long ticks = localDateTime.Ticks - _baseUtcOffset.Ticks;
+
+            for (int i = transitionInfo.index; i < boundary; i++)
+            {
+                TimeTransition transition = transitions[i];
+                long t = ticks - transition.Offset.Ticks;
+
+                if (t >= transition.DateStart.Ticks && t <= transition.DateEnd.Ticks)
+                {
+                    if (encountered < offsets.Length)
+                    {
+                        offsets[encountered] = transition.Offset + _baseUtcOffset;
+                    }
+
+                    encountered++;
+                }
+            }
+
+            if (offsets.Length >= 2 && offsets[0] > offsets[1])
+            {
+                // Keep app compatibility returning offsets sorted from least to greatest
+                TimeSpan offset = offsets[0];
+                offsets[0] = offsets[1];
+                offsets[1] = offset;
+            }
+
+            return encountered > 1; // More than one transition means the local time is ambiguous
+        }
+
+        private bool IsDaylightSavingOn(DateTime localDateTime)
+        {
+            if (!TryGetTransitionsForYear(localDateTime.Year, out (int index, int count) transitionInfo))
+            {
+                return false;
+            }
+
+            TimeTransition[] transitions = _yearsTransitions;
+            int boundary = transitionInfo.index + transitionInfo.count;
+
+            Debug.Assert(boundary <= _yearsTransitionsCount && transitions is not null);
+
+            long ticks = localDateTime.Ticks - _baseUtcOffset.Ticks;
+
+            for (int i = transitionInfo.index; i < boundary; i++)
+            {
+                TimeTransition transition = transitions[i];
+                long t = ticks - transition.Offset.Ticks;
+
+                if (t >= transition.DateStart.Ticks && t <= transition.DateEnd.Ticks)
+                {
+                    bool ret = transition.DaylightSavingOn;
+
+                    if (i + 1 < boundary && transition.DaylightSavingOn)
+                    {
+                        transition = transitions[i + 1];
+                        t = ticks - transition.Offset.Ticks;
+
+                        // Ambiguous time in daylight saving time period, prefer reporting the standard time status
+                        if (t >= transition.DateStart.Ticks && t <= transition.DateEnd.Ticks)
+                        {
+                            return false;
+                        }
+                    }
+
+                    return ret;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to convert a local date and time to Coordinated Universal Time (UTC).
+        /// </summary>
+        /// <param name="localDateTime">The local date and time to convert.</param>
+        /// <param name="utcDateTime">When this method returns, contains the UTC date and time if the conversion succeeded.</param>
+        /// <returns>True if the conversion was successful; otherwise, false.</returns>
+        /// <remarks>
+        /// This method attempts to convert a local time to UTC. It returns false if the local time is invalid,
+        /// such as during a daylight saving time transition when the local time does not exist.
+        /// </remarks>
+        private bool TryLocalToUtc(DateTime localDateTime, out DateTime utcDateTime)
+        {
+            if (TryGetUtcOffset(localDateTime, out TimeSpan offset))
+            {
+                long ticks = localDateTime.Ticks - offset.Ticks;
+                utcDateTime = SafeCreateDateTimeFromTicks(ticks, DateTimeKind.Utc);
+                return true;
+            }
+
+            utcDateTime = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the UTC offset for a given UTC date and time, along with whether it is in daylight saving time.
+        /// </summary>
+        /// <param name="utcDateTime">The UTC date and time.</param>
+        /// <param name="isDaylightSavingTime">When this method returns, indicates whether the time is in daylight saving time.</param>
+        /// <returns>The UTC offset for the specified UTC date and time.</returns>
+        private TimeSpan GetOffsetForUtcDate(DateTime utcDateTime, out bool isDaylightSavingTime)
+        {
+            if (TryGetTransitionsForYear(utcDateTime.Year, out (int index, int count) transitionInfo))
+            {
+                TimeTransition[] transitions = _yearsTransitions;
+                int boundary = transitionInfo.index + transitionInfo.count;
+
+                Debug.Assert(boundary <= _yearsTransitionsCount && transitions is not null);
+
+                for (int i = transitionInfo.index; i < boundary; i++)
+                {
+                    TimeTransition transition = transitions[i];
+                    if (utcDateTime >= transition.DateStart && utcDateTime <= transition.DateEnd)
+                    {
+                        isDaylightSavingTime = transition.DaylightSavingOn;
+                        return _baseUtcOffset + transition.Offset;
+                    }
+                }
+            }
+
+            // no transitions found
+            isDaylightSavingTime = false;
+            return _baseUtcOffset;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static DateTime SafeCreateDateTimeFromTicks(long ticks, DateTimeKind kind = DateTimeKind.Unspecified)
+            => (ulong)ticks <= DateTime.MaxTicks ? new DateTime(ticks, kind) : (ticks < 0 ? DateTime.MinValue : DateTime.MaxValue);
+
+        /// <summary>
+        /// Gets the UTC offset for a given UTC date and time, along with whether it is in daylight saving time and if it is ambiguous.
+        /// </summary>
+        /// <param name="utcDateTime">The UTC date and time.</param>
+        /// <param name="isDaylightSavingTime">When this method returns, indicates whether the time is in daylight saving time.</param>
+        /// <param name="isAmbiguous">When this method returns, indicates whether the time is ambiguous.</param>
+        /// <returns>The UTC offset for the specified UTC date and time.</returns>
+        private TimeSpan GetOffsetForUtcDate(DateTime utcDateTime, out bool isDaylightSavingTime, out bool isAmbiguous)
+        {
+            TimeSpan offset = GetOffsetForUtcDate(utcDateTime, out isDaylightSavingTime);
+            DateTime localTime = SafeCreateDateTimeFromTicks(utcDateTime.Ticks + offset.Ticks);
+
+            // If the UTC time is not in daylight saving time, it is not considered ambiguous
+            isAmbiguous = isDaylightSavingTime && IsAmbiguousLocalTime(localTime);
+            return offset;
+        }
+
+        /// <summary>
+        /// Converts a Coordinated Universal Time (UTC) to a local date and time.
+        /// </summary>
+        /// <param name="utcDateTime">The UTC date and time to convert.</param>
+        /// <param name="isDaylightSavingTime">When this method returns, indicates whether the resulting local time is in daylight saving time.</param>
+        /// <returns>The local date and time.</returns>
+        private DateTime UtcToLocal(DateTime utcDateTime, out bool isDaylightSavingTime)
+        {
+            long ticks = utcDateTime.Ticks + GetOffsetForUtcDate(utcDateTime, out isDaylightSavingTime).Ticks;
+            return SafeCreateDateTimeFromTicks(ticks);
+        }
+
+        private DateTime UtcToLocal(DateTime utcDateTime, out bool isDaylightSavingTime, out bool isAmbiguous)
+        {
+            long ticks = utcDateTime.Ticks + GetOffsetForUtcDate(utcDateTime, out isDaylightSavingTime, out isAmbiguous).Ticks;
+            return SafeCreateDateTimeFromTicks(ticks);
+        }
+
+        /// <summary>
+        /// Tries to get the UTC offset for a given local date and time.
+        /// </summary>
+        /// <param name="localDateTime">The local date and time.</param>
+        /// <param name="offset">When this method returns, contains the UTC offset if the operation succeeded.</param>
+        /// <returns>True if the UTC offset was successfully retrieved; otherwise, false.</returns>
+        /// <remarks>
+        /// It is possible to have invalid local times that do not map to a UTC offset.
+        /// This can occur during transitions such as daylight saving time changes.
+        /// </remarks>
+        private bool TryGetUtcOffset(DateTime localDateTime, out TimeSpan offset)
+        {
+            if (!TryGetTransitionsForYear(localDateTime.Year, out (int index, int count) transitionInfo))
+            {
+                offset = _baseUtcOffset;
+                return true;
+            }
+
+            TimeTransition[] transitions = _yearsTransitions;
+            int boundary = transitionInfo.index + transitionInfo.count;
+
+            Debug.Assert(boundary <= _yearsTransitionsCount && transitions is not null);
+
+            for (int i = transitionInfo.index; i < boundary; i++)
+            {
+                TimeTransition transition = transitions[i];
+                offset = _baseUtcOffset + transition.Offset;
+                DateTime localTicks = SafeCreateDateTimeFromTicks(localDateTime.Ticks - offset.Ticks);
+                if (localTicks >= transition.DateStart && localTicks <= transition.DateEnd) // Start and End dates in the transitions are inclusive
+                {
+                    // To keep the app compatibility, we need to prefer the standard offset over the DST offset except if the time has local kind and not created with KindLocalAmbiguousDst
+                    if (i + 1 < boundary && transition.DaylightSavingOn && (localDateTime.Kind != DateTimeKind.Local || !localDateTime.IsAmbiguousDaylightSavingTime()))
+                    {
+                        transition = transitions[i + 1];
+                        TimeSpan nextOffset = _baseUtcOffset + transition.Offset;
+                        localTicks = SafeCreateDateTimeFromTicks(localDateTime.Ticks - nextOffset.Ticks);
+                        if (localTicks >= transition.DateStart && localTicks <= transition.DateEnd)
+                        {
+                            offset = nextOffset;
+                        }
+                    }
+
+                    // Found the transition that applies to this local time
+                    return true;
+                }
+            }
+
+            offset = _baseUtcOffset; // No applicable transition found, use base offset
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to get the cached transitions for a specific year.
+        /// </summary>
+        /// <param name="year">The year to get transitions for.</param>
+        /// <param name="transitionInfo">A tuple containing the index and count of transitions.</param>
+        /// <returns>True if transitions are found; otherwise, false.</returns>
+        private bool TryGetTransitionsForYear(int year, out (int index, int count) transitionInfo)
+        {
+            if (_supportsDaylightSavingTime && _adjustmentRules is AdjustmentRule[] { Length: > 0 })
+            {
+                if (_transitionCache.TryGetValue(year, out int transitionData))
+                {
+                    if (transitionData == 0)
+                    {
+                        transitionInfo = (0, 0);
+                        return false;
+                    }
+
+                    transitionInfo = (transitionData & 0xFFFF, transitionData >> 16);
+                    return true;
+                }
+
+                transitionInfo = CacheTransitionsForYear(year);
+                return true;
+            }
+
+            transitionInfo = (0, 0);
+            return false;
+        }
+
+        /// <summary>
+        /// Finds the index of the adjustment rule that applies to the specified year.
+        /// </summary>
+        /// <param name="year">The year to find the adjustment rule for.</param>
+        /// <returns>The index of the adjustment rule if found; otherwise, -1.</returns>
+        private int FindRuleForYear(int year)
+        {
+            Debug.Assert(_adjustmentRules is not null && _adjustmentRules.Length > 0);
+
+            int ruleIndex = -1;
+
+            int top = 0;
+            int bottom = _adjustmentRules.Length - 1;
+
+            while (top <= bottom)
+            {
+                int mid = (top + bottom) / 2;
+                var rule = _adjustmentRules[mid];
+
+                if (year < rule.DateStart.Year)
+                {
+                    bottom = mid - 1;
+                }
+                else if (year > rule.DateEnd.Year)
+                {
+                    top = mid + 1;
+                }
+                else
+                {
+                    // Ensure both Utc and Local transitions are covered
+                    while (mid > 0 &&
+                            (_adjustmentRules[mid - 1].DateEnd.Year >= year ||
+                            (_adjustmentRules[mid - 1].DateEnd + (_baseUtcOffset + _adjustmentRules[mid - 1].BaseUtcOffsetDelta + _adjustmentRules[mid - 1].DaylightDelta)).Year >= year))
+                    {
+                        mid--;
+                    }
+
+                    return mid;
+                }
+            }
+
+            return ruleIndex;
+        }
+
+        /// <summary>
+        /// Grows the given pool array to accommodate the required capacity.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the array.</typeparam>
+        /// <param name="arrayPoolArray">The array to grow.</param>
+        /// <param name="requiredCapacity">The required capacity.</param>
+        internal static void ArrayPoolGrow<T>(ref T[] arrayPoolArray, int requiredCapacity)
+        {
+            T[] tmp = ArrayPool<T>.Shared.Rent(Math.Max(arrayPoolArray.Length * 2, requiredCapacity));
+            arrayPoolArray.CopyTo(tmp.AsSpan());
+            ArrayPool<T>.Shared.Return(arrayPoolArray);
+            arrayPoolArray = tmp;
+        }
+
+        /// <summary>
+        /// Adds a transition to the transitions array, growing the array if necessary.
+        /// </summary>
+        /// <param name="transitions">The array of transitions.</param>
+        /// <param name="count">The current count of transitions.</param>
+        /// <param name="transition">The transition to add.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void AddTransition(ref TimeTransition[] transitions, ref int count, TimeTransition transition)
+        {
+            if (count > 0 && transitions[count - 1].Offset == transition.Offset && transitions[count - 1].DaylightSavingOn == transition.DaylightSavingOn)
+            {
+                // If the last transition has the same offset and daylight saving status, we can merge them
+                transitions[count - 1] = transitions[count - 1] with { DateEnd = transition.DateEnd };
+                return;
+            }
+
+            if (count >= transitions.Length)
+            {
+                ArrayPoolGrow(ref transitions, count * 2);
+            }
+
+            transitions[count++] = transition;
+        }
+
+        /// <summary>
+        /// Converts the start transition time of the adjustment rule to a DateTime for the specified year.
+        /// </summary>
+        /// <param name="year">The year for which to calculate the transition time.</param>
+        /// <param name="rule">The adjustment rule containing the transition information.</param>
+        /// <returns>A DateTime representing the start transition time.</returns>
+        private static DateTime StartTransitionTimeToDateTime(int year, AdjustmentRule rule)
+            => rule.IsStartDateMarkerForBeginningOfYear() ? // Windows special case when the year transition starts at the beginning of the year
+                new DateTime(year, 1, 1, 0, 0, 0, DateTimeKind.Unspecified) :
+                TransitionTimeToDateTime(year, rule.DaylightTransitionStart);
+
+        /// <summary>
+        /// Converts the end transition time of the adjustment rule to a DateTime for the specified year.
+        /// </summary>
+        /// <param name="year">The year for which to calculate the transition time.</param>
+        /// <param name="rule">The adjustment rule containing the transition information.</param>
+        /// <returns>A DateTime representing the end transition time.</returns>
+        private static DateTime EndTransitionTimeToDateTime(int year, AdjustmentRule rule)
+            => rule.IsEndDateMarkerForEndOfYear() ? // Windows special case when the year transition ends at the end of the year
+                year == MaxYear ? DateTime.MaxValue : new DateTime(year + 1, 1, 1, 0, 0, 0, DateTimeKind.Unspecified) :
+                TransitionTimeToDateTime(year, rule.DaylightTransitionEnd);
+
+        /// <summary>
+        /// Helper function that converts a year and TransitionTime into a DateTime.
+        /// </summary>
+        internal static DateTime TransitionTimeToDateTime(int year, TransitionTime transitionTime)
+        {
+            DateTime value;
+            TimeSpan timeOfDay = transitionTime.TimeOfDay.TimeOfDay;
+
+            if (transitionTime.IsFixedDateRule)
+            {
+                // create a DateTime from the passed in year and the properties on the transitionTime
+
+                int day = transitionTime.Day;
+                // if the day is out of range for the month then use the last day of the month
+                if (day > 28)
+                {
+                    int daysInMonth = DateTime.DaysInMonth(year, transitionTime.Month);
+                    if (day > daysInMonth)
+                    {
+                        day = daysInMonth;
+                    }
+                }
+
+                value = new DateTime(year, transitionTime.Month, day) + timeOfDay;
+            }
+            else
+            {
+                if (transitionTime.Week <= 4)
+                {
+                    //
+                    // Get the (transitionTime.Week)th Sunday.
+                    //
+                    value = new DateTime(year, transitionTime.Month, 1) + timeOfDay;
+
+                    int dayOfWeek = (int)value.DayOfWeek;
+                    int delta = (int)transitionTime.DayOfWeek - dayOfWeek;
+                    if (delta < 0)
+                    {
+                        delta += 7;
+                    }
+                    delta += 7 * (transitionTime.Week - 1);
+
+                    if (delta > 0)
+                    {
+                        value = value.AddDays(delta);
+                    }
+                }
+                else
+                {
+                    //
+                    // If TransitionWeek is greater than 4, we will get the last week.
+                    //
+                    int daysInMonth = DateTime.DaysInMonth(year, transitionTime.Month);
+                    value = new DateTime(year, transitionTime.Month, daysInMonth) + timeOfDay;
+
+                    // This is the day of week for the last day of the month.
+                    int dayOfWeek = (int)value.DayOfWeek;
+                    int delta = dayOfWeek - (int)transitionTime.DayOfWeek;
+                    if (delta < 0)
+                    {
+                        delta += 7;
+                    }
+
+                    if (delta > 0)
+                    {
+                        value = value.AddDays(-delta);
+                    }
+                }
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// Caches the time zone transitions for a specific year.
+        /// </summary>
+        /// <param name="year">The year for which to cache transitions.</param>
+        /// <returns>A tuple containing the index and count of cached transitions.</returns>
+        private (int index, int count) CacheTransitionsForYear(int year)
+        {
+            Debug.Assert(_adjustmentRules is not null && _adjustmentRules.Length > 0);
+
+            int ruleIndex = FindRuleForYear(year);
+            if (ruleIndex < 0)
+            {
+                // No rule found for the specified year
+
+                _transitionCache[year] = 0;
+                return (0, 0);
+            }
+
+            Debug.Assert(ruleIndex < _adjustmentRules.Length);
+
+            const int InitialTransitionsCount = 20; // enough to cover all cases
+            int transitionCount = 0;
+            TimeTransition[] allTransitions = ArrayPool<TimeTransition>.Shared.Rent(InitialTransitionsCount);
+
+            AdjustmentRule rule = _adjustmentRules[ruleIndex];
+            if (rule.NoDaylightTransitions)
+            {
+                //
+                // Linux rule, date start and end are stored in UTC
+                //
+
+                long localTicks = _baseUtcOffset.Ticks + rule.DateStart.Ticks + rule.BaseUtcOffsetDelta.Ticks;
+                DateTime startOfYear = new DateTime(year, 1, 1);
+
+                if (rule.DateStart > startOfYear || localTicks > startOfYear.Ticks) // Ensure local start of the year is covered
+                {
+                    //
+                    // Handle transition from previous rule to current rule
+                    //
+
+                    AdjustmentRule? previousRule = ruleIndex > 0 ? _adjustmentRules[ruleIndex - 1] : null;
+
+                    if (previousRule is not null && previousRule.DateEnd.Year >= year - 1)
+                    {
+                        if (previousRule.NoDaylightTransitions)
+                        {
+                            //
+                            // Previous rule is Linux style with Utc start and end dates
+                            //
+
+                            DateTime previousYearTransitionEnd = SafeCreateDateTimeFromTicks(previousRule.DateEnd.Ticks + 1); // UTC coordinate
+                            if (previousYearTransitionEnd.Ticks < rule.DateStart.Ticks - 1)
+                            {
+                                // Gap between the last year transition end and current year transition start. no daylight
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(previousYearTransitionEnd, SafeCreateDateTimeFromTicks(rule.DateStart.Ticks - 1), previousRule.BaseUtcOffsetDelta, false));
+                            }
+                            else
+                            {
+                                // previous year transition end at the current year transition start, then include last year transition
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(previousRule.DateStart, previousRule.DateEnd, previousRule.BaseUtcOffsetDelta + (previousRule.HasDaylightSaving ? previousRule.DaylightDelta : TimeSpan.Zero), previousRule.HasDaylightSaving));
+                            }
+                        }
+                        else
+                        {
+                            //
+                            // Previous rule is Windows style with local start and end dates
+                            //
+
+                            DateTime previousYearStart = StartTransitionTimeToDateTime(year - 1, previousRule); // Local coordinate
+                            DateTime previousYearEnd = EndTransitionTimeToDateTime(year - 1, previousRule); // Local coordinate
+
+                            if (previousYearStart < previousYearEnd)
+                            {
+                                //
+                                // Previous year has one transition period
+                                //
+
+                                // Get previous rule end in UTC coordinates
+                                DateTime previousYearEndUtc = SafeCreateDateTimeFromTicks(previousYearEnd.Ticks - (_baseUtcOffset.Ticks + previousRule.BaseUtcOffsetDelta.Ticks + previousRule.DaylightDelta.Ticks) - 1);
+
+                                if (previousYearEndUtc.Ticks < rule.DateStart.Ticks - 1)
+                                {
+                                    // Gap between the last year transition end and current year transition start. no daylight
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(previousYearEndUtc, SafeCreateDateTimeFromTicks(rule.DateStart.Ticks - 1), previousRule.BaseUtcOffsetDelta, false));
+                                }
+                                else
+                                {
+                                    // previous year transition end at the current year transition start, then include last year transition
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(
+                                                SafeCreateDateTimeFromTicks(previousYearStart.Ticks - (_baseUtcOffset.Ticks + previousRule.BaseUtcOffsetDelta.Ticks)),
+                                                SafeCreateDateTimeFromTicks(rule.DateStart.Ticks - 1),
+                                                previousRule.BaseUtcOffsetDelta + (previousRule.HasDaylightSaving ? previousRule.DaylightDelta : TimeSpan.Zero),
+                                                previousRule.HasDaylightSaving));
+                                }
+                            }
+                            else // previousYearStart > previousYearEnd
+                            {
+                                //
+                                // Previous year has two transition periods. One start from the year beginning while the second go through the end of the year
+                                //
+
+                                long previousEndOfYearUtcTicks = new DateTime(year, 1, 1).Ticks - (_baseUtcOffset.Ticks + previousRule.BaseUtcOffsetDelta.Ticks + previousRule.DaylightDelta.Ticks) - 2;
+                                DateTime previousEndOfYearUtc = SafeCreateDateTimeFromTicks(previousEndOfYearUtcTicks, DateTimeKind.Utc);
+
+                                if (previousEndOfYearUtc.Ticks < rule.DateStart.Ticks - 1)
+                                {
+                                    // Gap between the end of the last year and current year transition start. no daylight
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(SafeCreateDateTimeFromTicks(previousEndOfYearUtc.Ticks + 1), SafeCreateDateTimeFromTicks(rule.DateStart.Ticks - 1), rule.BaseUtcOffsetDelta, false));
+                                }
+
+                                // The daylight start should be around the end of the year and go through the end
+                                DateTime previousYearStartUtc = SafeCreateDateTimeFromTicks(previousYearStart.Ticks - (_baseUtcOffset.Ticks + previousRule.BaseUtcOffsetDelta.Ticks)); // daylight offset is not counted in this start
+
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(previousYearStartUtc, previousEndOfYearUtc, previousRule.BaseUtcOffsetDelta + (previousRule.HasDaylightSaving ? previousRule.DaylightDelta : TimeSpan.Zero), previousRule.HasDaylightSaving));
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // no rule is found
+                        DateTime transitionStart = new DateTime(year > 1 ? year - 1 : 1, 1, 1);
+
+                        if (rule.DateStart < transitionStart)
+                        {
+                            transitionStart = SafeCreateDateTimeFromTicks(transitionStart.Ticks - _baseUtcOffset.Ticks);
+
+                            AddTransition(ref allTransitions, ref transitionCount,
+                                new TimeTransition(transitionStart, SafeCreateDateTimeFromTicks(rule.DateStart.Ticks - 1), TimeSpan.Zero, false));
+                        }
+                    }
+                }
+
+                //
+                // Add the current rule's transition
+                //
+
+                AddTransition(ref allTransitions, ref transitionCount,
+                    new TimeTransition(rule.DateStart, rule.DateEnd, rule.BaseUtcOffsetDelta + (rule.HasDaylightSaving ? rule.DaylightDelta : TimeSpan.Zero), rule.HasDaylightSaving));
+
+                //
+                // Ensure covering the whole year by adding transitions if necessary
+                //
+
+                DateTime endOfCurrentYear = year < MaxYear ? new DateTime(year + 1, 1, 1).AddTicks(-1) : DateTime.MaxValue;
+
+                while (allTransitions[transitionCount - 1].DateEnd < endOfCurrentYear || // UTC end date still not reached the end of the year
+                        allTransitions[transitionCount - 1].DateEnd.Ticks + allTransitions[transitionCount - 1].Offset.Ticks + _baseUtcOffset.Ticks < endOfCurrentYear.Ticks) // local end date still not reached the end of the year
+                {
+                    ruleIndex++;
+                    if (ruleIndex < _adjustmentRules.Length && _adjustmentRules[ruleIndex].DateStart.Year <= allTransitions[transitionCount - 1].DateEnd.Year) // ensure the year is included in the rule
+                    {
+                        AdjustmentRule? nextYearRule = _adjustmentRules[ruleIndex];
+                        if (nextYearRule.NoDaylightTransitions)
+                        {
+                            //
+                            // Next year Rule is Linux style with Utc start and end dates
+                            //
+
+                            if (allTransitions[transitionCount - 1].DateEnd.Ticks < nextYearRule.DateStart.Ticks - 1)
+                            {
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(allTransitions[transitionCount - 1].DateEnd.AddTicks(1), nextYearRule.DateStart.AddTicks(-1), nextYearRule.BaseUtcOffsetDelta, false));
+                            }
+
+                            AddTransition(ref allTransitions, ref transitionCount,
+                                new TimeTransition(nextYearRule.DateStart, nextYearRule.DateEnd, nextYearRule.BaseUtcOffsetDelta + (nextYearRule.HasDaylightSaving ? nextYearRule.DaylightDelta : TimeSpan.Zero), nextYearRule.HasDaylightSaving));
+                        }
+                        else
+                        {
+                            //
+                            // Next Rule is Windows style with local start and end dates
+                            //
+
+                            int nextYear = Math.Min(year + 1, nextYearRule.DateStart.Year);
+                            DateTime nextYearStart = StartTransitionTimeToDateTime(nextYear, nextYearRule); // in local time
+                            DateTime nextYearEnd = EndTransitionTimeToDateTime(nextYear, nextYearRule);     // in local time
+
+                            if (nextYearStart < nextYearEnd)
+                            {
+                                //
+                                // Next year has one transition
+                                //
+
+                                // Get next rule start in UTC coordinates
+                                DateTime nextYearStartUtc = SafeCreateDateTimeFromTicks(nextYearStart.Ticks - (_baseUtcOffset.Ticks + nextYearRule.BaseUtcOffsetDelta.Ticks));
+                                if (allTransitions[transitionCount - 1].DateEnd.Ticks < nextYearStartUtc.Ticks - 1)
+                                {
+                                    // Fill the transition gap between the previous year transition end and next year transition start
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(allTransitions[transitionCount - 1].DateEnd.AddTicks(1), nextYearStartUtc.AddTicks(-1), nextYearRule.BaseUtcOffsetDelta, false));
+                                }
+
+                                // Add next year transition
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(
+                                            nextYearStartUtc,
+                                            SafeCreateDateTimeFromTicks(nextYearEnd.Ticks - (_baseUtcOffset.Ticks + nextYearRule.BaseUtcOffsetDelta.Ticks + nextYearRule.DaylightDelta.Ticks) - 1),
+                                            nextYearRule.BaseUtcOffsetDelta + (nextYearRule.HasDaylightSaving ? nextYearRule.DaylightDelta : TimeSpan.Zero),
+                                            nextYearRule.HasDaylightSaving));
+                            }
+                            else // nextYearStart > nextYearEnd
+                            {
+                                //
+                                // Next year has two transitions, the first start at the beginning of the year and the second ends at the end of the year
+                                //
+
+                                // The daylight should be starting from the beginning in the year and then go till next year transition end date.
+                                DateTime nextYearEndUtc = SafeCreateDateTimeFromTicks(nextYearEnd.Ticks - (_baseUtcOffset.Ticks + nextYearRule.BaseUtcOffsetDelta.Ticks + nextYearRule.DaylightDelta.Ticks) - 1);
+                                DateTime nextBeginningOfYearUtc = SafeCreateDateTimeFromTicks(new DateTime(year + 1, 1, 1).Ticks - (_baseUtcOffset.Ticks + nextYearRule.BaseUtcOffsetDelta.Ticks + nextYearRule.DaylightDelta.Ticks));
+
+                                if (allTransitions[transitionCount - 1].DateEnd.Ticks < nextBeginningOfYearUtc.Ticks - 1)
+                                {
+                                    // Fill the gap between the previous year transition end and next year transition start
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        // Use previous year rule, daylight included as the year started with the daylight
+                                        new TimeTransition(allTransitions[transitionCount - 1].DateEnd.AddTicks(1), nextBeginningOfYearUtc.AddTicks(-1), rule.BaseUtcOffsetDelta + (rule.HasDaylightSaving ? rule.DaylightDelta : TimeSpan.Zero), rule.HasDaylightSaving));
+                                }
+
+                                if (allTransitions[transitionCount - 1].DateEnd < nextYearEndUtc)
+                                {
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(
+                                                allTransitions[transitionCount - 1].DateEnd.AddTicks(1),
+                                                nextYearEndUtc,
+                                                nextYearRule.BaseUtcOffsetDelta + (nextYearRule.HasDaylightSaving ? nextYearRule.DaylightDelta : TimeSpan.Zero),
+                                                nextYearRule.HasDaylightSaving));
+                                }
+                            }
+
+                            if (allTransitions[transitionCount - 1].DateEnd < endOfCurrentYear)
+                            {
+                                // Ensure covering up to and including the end of the year in local and Utc time
+                                if (nextYearRule.BaseUtcOffsetDelta.Ticks > 0)
+                                {
+                                    endOfCurrentYear = SafeCreateDateTimeFromTicks(endOfCurrentYear.Ticks + nextYearRule.BaseUtcOffsetDelta.Ticks);
+                                }
+
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(allTransitions[transitionCount - 1].DateEnd.AddTicks(1), endOfCurrentYear, nextYearRule.BaseUtcOffsetDelta, false));
+                            }
+
+                            break; // We know Windows Rules cover the whole year
+                        }
+                    }
+                    else
+                    {
+                        //
+                        // There is no rule for next year
+                        //
+
+                        DateTime endOfNextYear = year + 1 < MaxYear ? new DateTime(year + 2, 1, 1).AddTicks(-1) : DateTime.MaxValue;
+
+                        if (allTransitions[transitionCount - 1].DateEnd < endOfNextYear)
+                        {
+                            AddTransition(ref allTransitions, ref transitionCount,
+                                new TimeTransition(allTransitions[transitionCount - 1].DateEnd.AddTicks(1), endOfNextYear, TimeSpan.Zero, false));
+                        }
+
+                        // The whole next year should be covered now
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                //
+                // Windows style rule, dates stored as local time
+                //
+
+                DateTime localStart = StartTransitionTimeToDateTime(year, rule); // Local time
+                DateTime localEnd = EndTransitionTimeToDateTime(year, rule); // Local time
+
+                bool startWithDaylightOn = rule.IsStartDateMarkerForBeginningOfYear();
+
+                DateTime utcStart = SafeCreateDateTimeFromTicks(localStart.Ticks - (_baseUtcOffset.Ticks + rule.BaseUtcOffsetDelta.Ticks + (startWithDaylightOn ? rule.DaylightDelta.Ticks : 0)), DateTimeKind.Utc);
+
+                DateTime utcEnd = SafeCreateDateTimeFromTicks(localEnd.Ticks - (_baseUtcOffset.Ticks + rule.BaseUtcOffsetDelta.Ticks + rule.DaylightDelta.Ticks) - 1, DateTimeKind.Utc);
+
+                long startOfCurrentYearUtcTicks = new DateTime(year, 1, 1).Ticks - (_baseUtcOffset.Ticks + rule.BaseUtcOffsetDelta.Ticks + (startWithDaylightOn || localStart > localEnd ? rule.DaylightDelta.Ticks : 0));
+                DateTime startOfCurrentYearUtc = SafeCreateDateTimeFromTicks(startOfCurrentYearUtcTicks, DateTimeKind.Utc);
+                DateTime currentYearStart = new DateTime(year, 1, 1);
+
+                if (localStart < localEnd)
+                {
+                    //
+                    // This year has one transition
+                    //
+
+                    if (utcStart > currentYearStart || localStart > currentYearStart) // check either the year start in Utc or local are covering the beginning of the year
+                    {
+                        //
+                        // cover the beginning of the current year using the previous year transitions
+                        //
+
+                        AdjustmentRule? previousYearRule =
+                            rule.DateStart.Year < year ?
+                                rule :
+                                ruleIndex > 0 && _adjustmentRules[ruleIndex - 1].DateStart.Year <= year - 1 && _adjustmentRules[ruleIndex - 1].DateEnd.Year >= year - 1 ?
+                                    _adjustmentRules[ruleIndex - 1] :
+                                    null;
+
+                        if (previousYearRule is not null)
+                        {
+                            if (previousYearRule.NoDaylightTransitions)
+                            {
+                                //
+                                // Previous rule is Linux style with Utc start and end dates
+                                //
+
+                                DateTime previousYearTransitionEnd = SafeCreateDateTimeFromTicks(previousYearRule.DateEnd.Ticks + 1); // UTC coordinate
+                                if (previousYearTransitionEnd.Ticks < startOfCurrentYearUtc.Ticks - 1)
+                                {
+                                    // Gap between the last year transition end and current year transition start. no daylight
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(previousYearTransitionEnd, SafeCreateDateTimeFromTicks(startOfCurrentYearUtc.Ticks - 1), previousYearRule.BaseUtcOffsetDelta, false));
+                                }
+                                else
+                                {
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(previousYearRule.DateStart, previousYearRule.DateEnd, previousYearRule.BaseUtcOffsetDelta + (previousYearRule.HasDaylightSaving ? previousYearRule.DaylightDelta : TimeSpan.Zero), previousYearRule.HasDaylightSaving));
+                                }
+                            }
+                            else
+                            {
+                                //
+                                // Previous rule is Windows style with local start and end dates
+                                //
+
+                                DateTime previousYearStart = StartTransitionTimeToDateTime(year - 1, previousYearRule); // Local time
+                                DateTime previousYearEnd = EndTransitionTimeToDateTime(year - 1, previousYearRule); // Local time
+
+                                if (previousYearStart < previousYearEnd)
+                                {
+                                    //
+                                    // Previous year has one transition period
+                                    //
+
+                                    // Get previous rule end in UTC coordinates
+                                    DateTime previousYearEndUtc = SafeCreateDateTimeFromTicks(previousYearEnd.Ticks - (_baseUtcOffset.Ticks + previousYearRule.BaseUtcOffsetDelta.Ticks + previousYearRule.DaylightDelta.Ticks));
+
+                                    // previous year transition end at the current year transition start, then include last year transition
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(
+                                                SafeCreateDateTimeFromTicks(previousYearStart.Ticks - (_baseUtcOffset.Ticks + previousYearRule.BaseUtcOffsetDelta.Ticks)),
+                                                SafeCreateDateTimeFromTicks(previousYearEndUtc.Ticks - 1),
+                                                previousYearRule.BaseUtcOffsetDelta + (previousYearRule.HasDaylightSaving ? previousYearRule.DaylightDelta : TimeSpan.Zero),
+                                                previousYearRule.HasDaylightSaving));
+
+                                    if (previousYearEndUtc.Ticks < startOfCurrentYearUtc.Ticks - 1)
+                                    {
+                                        // Gap between the last year transition end and current year transition start. no daylight
+                                        AddTransition(ref allTransitions, ref transitionCount,
+                                            new TimeTransition(previousYearEndUtc, startOfCurrentYearUtc.AddTicks(-1), previousYearRule.BaseUtcOffsetDelta, false));
+                                    }
+                                }
+                                else // previousYearStart > previousYearEnd
+                                {
+                                    //
+                                    // Previous year has two transition periods. One start from the year beginning while the second go through the end of the year
+                                    //
+
+                                    // The daylight start should be around the end of the year and go through the end
+                                    DateTime previousYearStartUtc = SafeCreateDateTimeFromTicks(previousYearStart.Ticks - (_baseUtcOffset.Ticks + previousYearRule.BaseUtcOffsetDelta.Ticks)); // daylight offset is not counted in this start
+
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(
+                                            previousYearStartUtc,
+                                            SafeCreateDateTimeFromTicks(startOfCurrentYearUtc.Ticks - 1),
+                                            previousYearRule.BaseUtcOffsetDelta + (previousYearRule.HasDaylightSaving ? previousYearRule.DaylightDelta : TimeSpan.Zero),
+                                            previousYearRule.HasDaylightSaving));
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // No rule found for the previous year
+                            DateTime previousYearStart = new DateTime(year > 1 ? year - 1 : 1, 1, 1); // real Utc year start
+
+                            if (previousYearStart < startOfCurrentYearUtc)
+                            {
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(previousYearStart, startOfCurrentYearUtc.AddTicks(-1), TimeSpan.Zero, false));
+                            }
+                        }
+
+                        if (startOfCurrentYearUtc.Ticks < utcStart.Ticks - 1)
+                        {
+                            AddTransition(ref allTransitions, ref transitionCount,
+                                new TimeTransition(startOfCurrentYearUtc, utcStart.AddTicks(-1), rule.BaseUtcOffsetDelta, false));
+                        }
+                    }
+
+                    //
+                    // Now add the current rule
+                    //
+
+                    AddTransition(ref allTransitions, ref transitionCount,
+                        new TimeTransition(utcStart, utcEnd, rule.BaseUtcOffsetDelta + (rule.HasDaylightSaving ? rule.DaylightDelta : TimeSpan.Zero), rule.HasDaylightSaving));
+
+                    //
+                    // Check if we still need to cover the rest of the year
+                    //
+
+                    DateTime endOfCurrentYear = year < MaxYear ? new DateTime(year + 1, 1, 1).AddTicks(-1) : DateTime.MaxValue;
+                    long endOfCurrentYearUtcTicks = endOfCurrentYear.Ticks - (_baseUtcOffset.Ticks + rule.BaseUtcOffsetDelta.Ticks + (rule.IsEndDateMarkerForEndOfYear() ? rule.DaylightDelta.Ticks : 0));
+                    DateTime endOfCurrentYearUtc = SafeCreateDateTimeFromTicks(endOfCurrentYearUtcTicks, DateTimeKind.Utc);
+                    if (utcEnd < endOfCurrentYearUtc)
+                    {
+                        AddTransition(ref allTransitions, ref transitionCount,
+                            new TimeTransition(utcEnd.AddTicks(1), endOfCurrentYearUtc, rule.BaseUtcOffsetDelta, false));
+                    }
+
+                    // Check if end of the current year Utc time cover the whole year, we are sure the whole local year is already covered
+                    if (endOfCurrentYearUtc < endOfCurrentYear)
+                    {
+                        AdjustmentRule? nextYearRule = (rule.DateStart.Year <= year + 1 && rule.DateEnd.Year >= year + 1) ? rule :
+                                                                        ruleIndex < _adjustmentRules.Length - 1 && _adjustmentRules[ruleIndex + 1].DateStart.Year <= year + 1 && _adjustmentRules[ruleIndex + 1].DateEnd.Year >= year + 1 ?
+                                                                            _adjustmentRules[ruleIndex + 1] :
+                                                                            null;
+                        if (nextYearRule is not null)
+                        {
+                            if (nextYearRule.NoDaylightTransitions)
+                            {
+                                //
+                                // Linux style rule, it is unlikely case we get a Linux style rule after Windows style rule but we handle it anyway just in case in the future things can change
+                                //
+
+                                if (endOfCurrentYearUtc.Ticks < nextYearRule.DateStart.Ticks - 1)
+                                {
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(endOfCurrentYearUtc.AddTicks(1), nextYearRule.DateStart.AddTicks(-1), nextYearRule.BaseUtcOffsetDelta, false));
+                                }
+
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(nextYearRule.DateStart, nextYearRule.DateEnd, nextYearRule.BaseUtcOffsetDelta + (nextYearRule.HasDaylightSaving ? nextYearRule.DaylightDelta : TimeSpan.Zero), nextYearRule.HasDaylightSaving));
+                            }
+                            else
+                            {
+                                //
+                                // Next rule is Windows style with local start and end dates
+                                //
+
+                                DateTime nextYearStart = StartTransitionTimeToDateTime(year + 1, nextYearRule); // Local time
+                                DateTime nextYearEnd = EndTransitionTimeToDateTime(year + 1, nextYearRule); // Local time
+
+                                DateTime nextYearStartUtc = SafeCreateDateTimeFromTicks(nextYearStart.Ticks - (_baseUtcOffset.Ticks + nextYearRule.BaseUtcOffsetDelta.Ticks +
+                                                                                                        (nextYearRule.IsStartDateMarkerForBeginningOfYear() ? nextYearRule.DaylightDelta.Ticks : 0)));
+
+                                DateTime nextYearEndUtc = SafeCreateDateTimeFromTicks(nextYearEnd.Ticks - (_baseUtcOffset.Ticks + nextYearRule.BaseUtcOffsetDelta.Ticks + nextYearRule.DaylightDelta.Ticks) - 1);
+
+                                if (nextYearStart < nextYearEnd)
+                                {
+                                    //
+                                    // One transition only in this next year
+                                    //
+
+                                    if (endOfCurrentYearUtc.Ticks < nextYearStartUtc.Ticks - 1)
+                                    {
+                                        AddTransition(ref allTransitions, ref transitionCount,
+                                            new TimeTransition(endOfCurrentYearUtc.AddTicks(1), nextYearStartUtc.AddTicks(-1), nextYearRule.BaseUtcOffsetDelta, false));
+                                    }
+
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(nextYearStartUtc, nextYearEndUtc, nextYearRule.BaseUtcOffsetDelta + (nextYearRule.HasDaylightSaving ? nextYearRule.DaylightDelta : TimeSpan.Zero), nextYearRule.HasDaylightSaving));
+                                }
+                                else // nextYearStart > nextYearEnd
+                                {
+                                    //
+                                    // Next year has two transitions, the first starts at the beginning of the year, and the second ends at the end of the year
+                                    //
+
+                                    if (endOfCurrentYearUtc < nextYearEndUtc)
+                                    {
+                                        AddTransition(ref allTransitions, ref transitionCount,
+                                            new TimeTransition(endOfCurrentYearUtc.AddTicks(1), nextYearEndUtc, nextYearRule.BaseUtcOffsetDelta + (nextYearRule.HasDaylightSaving ? nextYearRule.DaylightDelta : TimeSpan.Zero), nextYearRule.HasDaylightSaving));
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (endOfCurrentYearUtc < endOfCurrentYear)
+                            {
+                                // no rule for next year
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(endOfCurrentYearUtc.AddTicks(1), endOfCurrentYear, TimeSpan.Zero, false));
+                            }
+                        }
+                    }
+                }
+                else // localStart > localEnd
+                {
+                    //
+                    // This rule has two transitions, the first starts at the beginning of the year, and the second ends at the end of the year
+                    //
+
+                    // Check if we need to cover any previous transitions to ensure covering the whole year.
+                    // We know the local time is covered, we need to check only the Utc time
+                    if (startOfCurrentYearUtc > currentYearStart)
+                    {
+                        // need to cover the previous year transitions
+                        AdjustmentRule? previousYearRule = rule.DateStart.Year < year ? rule :
+                                                                            ruleIndex > 0 && _adjustmentRules[ruleIndex - 1].DateStart.Year <= year - 1 && _adjustmentRules[ruleIndex - 1].DateEnd.Year >= year - 1 ?
+                                                                                _adjustmentRules[ruleIndex - 1] :
+                                                                                null;
+                        if (previousYearRule is not null)
+                        {
+                            if (previousYearRule.NoDaylightTransitions)
+                            {
+                                //
+                                // Previous year has Linux style rule
+                                //
+
+                                if (startOfCurrentYearUtc.Ticks > previousYearRule.DateEnd.Ticks - 1)
+                                {
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(previousYearRule.DateEnd.AddTicks(1), startOfCurrentYearUtc.AddTicks(-1), rule.BaseUtcOffsetDelta, false));
+                                }
+
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(previousYearRule.DateStart, previousYearRule.DateEnd, previousYearRule.BaseUtcOffsetDelta + (previousYearRule.HasDaylightSaving ? previousYearRule.DaylightDelta : TimeSpan.Zero), previousYearRule.HasDaylightSaving));
+                            }
+                            else
+                            {
+                                //
+                                // Previous year has Windows style rule
+                                //
+
+                                DateTime previousYearStart = StartTransitionTimeToDateTime(year - 1, previousYearRule); // Local time
+                                DateTime previousYearEnd = EndTransitionTimeToDateTime(year - 1, previousYearRule); // Local time
+
+                                DateTime previousYearStartUtc = SafeCreateDateTimeFromTicks(previousYearStart.Ticks - (_baseUtcOffset.Ticks + previousYearRule.BaseUtcOffsetDelta.Ticks +
+                                                                                                (previousYearRule.IsStartDateMarkerForBeginningOfYear() ? previousYearRule.DaylightDelta.Ticks : 0)));
+
+                                if (previousYearStart < previousYearEnd)
+                                {
+                                    //
+                                    // Previous year has one transition
+                                    //
+
+                                    DateTime previousYearEndUtc = SafeCreateDateTimeFromTicks(previousYearEnd.Ticks - (_baseUtcOffset.Ticks + previousYearRule.BaseUtcOffsetDelta.Ticks + previousYearRule.DaylightDelta.Ticks) - 1);
+
+                                    if (previousYearEndUtc.Ticks < startOfCurrentYearUtc.Ticks - 1)
+                                    {
+                                        AddTransition(ref allTransitions, ref transitionCount,
+                                            new TimeTransition(previousYearEndUtc.AddTicks(1), startOfCurrentYearUtc.AddTicks(-1), previousYearRule.BaseUtcOffsetDelta, false));
+                                    }
+                                    else
+                                    {
+
+                                        AddTransition(ref allTransitions, ref transitionCount,
+                                            new TimeTransition(previousYearStartUtc, previousYearEndUtc, previousYearRule.BaseUtcOffsetDelta + (previousYearRule.HasDaylightSaving ? previousYearRule.DaylightDelta : TimeSpan.Zero), previousYearRule.HasDaylightSaving));
+                                    }
+                                }
+                                else // previousYearStart > previousYearEnd
+                                {
+                                    //
+                                    // Previous year has two transitions
+                                    //
+
+                                    if (previousYearStartUtc < startOfCurrentYearUtc)
+                                    {
+                                        // The previous year ends with the daylight transition start
+                                        AddTransition(ref allTransitions, ref transitionCount,
+                                            new TimeTransition(
+                                                    previousYearStartUtc,
+                                                    startOfCurrentYearUtc.AddTicks(-1),
+                                                    previousYearRule.BaseUtcOffsetDelta + (previousYearRule.HasDaylightSaving ? previousYearRule.DaylightDelta : TimeSpan.Zero),
+                                                    previousYearRule.HasDaylightSaving));
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (currentYearStart < startOfCurrentYearUtc)
+                            {
+                                // No previous year rule found, handle accordingly
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(currentYearStart, startOfCurrentYearUtc.AddTicks(-1), TimeSpan.Zero, false));
+                            }
+                        }
+                    }
+
+                    //
+                    // Now add current year transitions
+                    //
+
+                    DateTime endOfCurrentYear = year < MaxYear ? new DateTime(year + 1, 1, 1).AddTicks(-1) : DateTime.MaxValue;
+                    long endOfCurrentYearUtcTicks = endOfCurrentYear.Ticks - (_baseUtcOffset.Ticks + rule.BaseUtcOffsetDelta.Ticks + rule.DaylightDelta.Ticks);
+                    DateTime endOfCurrentYearUtc = SafeCreateDateTimeFromTicks(endOfCurrentYearUtcTicks, DateTimeKind.Utc);
+
+                    AddTransition(ref allTransitions, ref transitionCount,
+                        new TimeTransition(startOfCurrentYearUtc, utcEnd, rule.BaseUtcOffsetDelta + (rule.HasDaylightSaving ? rule.DaylightDelta : TimeSpan.Zero), rule.HasDaylightSaving));
+
+                    AddTransition(ref allTransitions, ref transitionCount,
+                        new TimeTransition(SafeCreateDateTimeFromTicks(utcEnd.Ticks + 1), SafeCreateDateTimeFromTicks(utcStart.Ticks - 1), rule.BaseUtcOffsetDelta, false));
+
+                    AddTransition(ref allTransitions, ref transitionCount,
+                        new TimeTransition(utcStart, endOfCurrentYearUtc, rule.BaseUtcOffsetDelta + (rule.HasDaylightSaving ? rule.DaylightDelta : TimeSpan.Zero), rule.HasDaylightSaving));
+
+                    //
+                    // Check if we need to add more transitions to cover the the end of the year in Utc time. We already know we are covering the end of the year in local time.
+                    //
+
+                    if (endOfCurrentYearUtc < endOfCurrentYear)
+                    {
+                        //
+                        // Cover the transition in the next year in Utc time.
+                        //
+
+                        AdjustmentRule? nextYearRule = rule.DateEnd.Year > year ? rule :
+                                                        ruleIndex < _adjustmentRules.Length - 1 && _adjustmentRules[ruleIndex + 1].DateStart.Year <= year + 1 && _adjustmentRules[ruleIndex + 1].DateEnd.Year >= year + 1 ?
+                                                            _adjustmentRules[ruleIndex + 1] :
+                                                            null;
+
+                        if (nextYearRule is not null)
+                        {
+                            if (nextYearRule.NoDaylightTransitions)
+                            {
+                                //
+                                // Next year rule is Linux style rule. It is unlikely to get Linux style rules after Windows style rule, but handle gracefully.
+                                //
+
+                                if (endOfCurrentYearUtc.Ticks < nextYearRule.DateStart.Ticks)
+                                {
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(endOfCurrentYearUtc.AddTicks(1), nextYearRule.DateStart.AddTicks(-1), nextYearRule.BaseUtcOffsetDelta, false)); // No daylight transitions
+                                }
+                                else
+                                {
+                                    if (endOfCurrentYearUtc < nextYearRule.DateEnd)
+                                    {
+                                        AddTransition(ref allTransitions, ref transitionCount,
+                                            new TimeTransition(
+                                                    endOfCurrentYearUtc.AddTicks(1),
+                                                    nextYearRule.DateEnd,
+                                                    nextYearRule.BaseUtcOffsetDelta + (nextYearRule.HasDaylightSaving ? nextYearRule.DaylightDelta : TimeSpan.Zero),
+                                                    nextYearRule.HasDaylightSaving));
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                //
+                                // Next year rule is Windows style rule.
+                                //
+
+                                DateTime nextYearStart = StartTransitionTimeToDateTime(year + 1, nextYearRule); // in local time
+                                DateTime nextYearEnd = EndTransitionTimeToDateTime(year + 1, nextYearRule);     // in local time
+
+                                DateTime nextYearStartUtc = SafeCreateDateTimeFromTicks(nextYearStart.Ticks -
+                                                (_baseUtcOffset.Ticks + nextYearRule.BaseUtcOffsetDelta.Ticks + (nextYearRule.IsStartDateMarkerForBeginningOfYear() ? nextYearRule.DaylightDelta.Ticks : 0)));
+
+                                DateTime nextYearEndUtc = SafeCreateDateTimeFromTicks(
+                                    nextYearEnd.Ticks - (_baseUtcOffset.Ticks + nextYearRule.BaseUtcOffsetDelta.Ticks + nextYearRule.DaylightDelta.Ticks) - 1);
+
+                                if (nextYearStart < nextYearEnd)
+                                {
+                                    //
+                                    // Next year rule has one transition
+                                    //
+                                    if (endOfCurrentYearUtc.Ticks < nextYearStartUtc.Ticks - 1)
+                                    {
+                                        AddTransition(ref allTransitions, ref transitionCount,
+                                            new TimeTransition(endOfCurrentYearUtc.AddTicks(1), nextYearStartUtc.AddTicks(-1), nextYearRule.BaseUtcOffsetDelta, false)); // No daylight transitions
+                                    }
+
+                                    AddTransition(ref allTransitions, ref transitionCount,
+                                        new TimeTransition(nextYearStartUtc, nextYearEndUtc, nextYearRule.BaseUtcOffsetDelta + (nextYearRule.HasDaylightSaving ? nextYearRule.DaylightDelta : TimeSpan.Zero), nextYearRule.HasDaylightSaving));
+                                }
+                                else
+                                {
+                                    //
+                                    // Next year rule has two transitions, the first starts at the beginning of the year, while the second ends at the end of the year
+                                    //
+
+                                    if (endOfCurrentYearUtc < nextYearEndUtc)
+                                    {
+                                        AddTransition(ref allTransitions, ref transitionCount,
+                                            new TimeTransition(endOfCurrentYearUtc.AddTicks(1), nextYearEndUtc, nextYearRule.BaseUtcOffsetDelta + (nextYearRule.HasDaylightSaving ? nextYearRule.DaylightDelta : TimeSpan.Zero), nextYearRule.HasDaylightSaving));
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // No rule is found
+
+                            if (endOfCurrentYearUtc < endOfCurrentYear)
+                            {
+                                AddTransition(ref allTransitions, ref transitionCount,
+                                    new TimeTransition(endOfCurrentYearUtc.AddTicks(1), endOfCurrentYear, TimeSpan.Zero, false));
+                            }
+                        }
+                    }
+                }
+            }
+
+            (int index, int count) result = CacheTransitions(allTransitions, transitionCount, year);
+            ArrayPool<TimeTransition>.Shared.Return(allTransitions);
+            return result;
+        }
+
+        /// <summary>
+        /// Caches the given time transitions for a specific year.
+        /// </summary>
+        /// <param name="allTransitions">An array of all time transitions.</param>
+        /// <param name="count">The number of valid transitions in the array.</param>
+        /// <param name="year">The year for which the transitions are cached.</param>
+        /// <returns>A tuple containing the index and count of cached transitions.</returns>
+        private (int index, int count) CacheTransitions(TimeTransition[] allTransitions, int count, int year)
+        {
+            Debug.Assert(count > 0 && allTransitions is not null && count < allTransitions.Length);
+
+            lock (_transitionCache)
+            {
+                // We update _yearsTransitions and _yearsTransitionsCount under lock to ensure thread-safety.
+
+                if (count + _yearsTransitionsCount > _yearsTransitions.Length)
+                {
+                    Array.Resize(ref _yearsTransitions, Math.Max(_yearsTransitions.Length * 2, count + _yearsTransitionsCount));
+                }
+
+                Array.Copy(allTransitions, 0, _yearsTransitions, _yearsTransitionsCount, count);
+                int index = _yearsTransitionsCount;
+                _yearsTransitionsCount += count;
+
+                _transitionCache[year] = index | (count << 16);
+
+                return (index, count);
+            }
+        }
+
+        // _transitionCache maps a year to int value. the low 16 bits store the index of the first transition for that year in _yearsTransitions.
+        // the high 16 bits store the number of transitions for that year. We use concurrent dictionary for thread-safe access.
+        private readonly ConcurrentDictionary<int, int> _transitionCache = new ConcurrentDictionary<int, int>();
+
+        // _yearsTransitions stores all transitions for all cached years.
+        // When accessing _yearsTransitions, store it in a local variable as it may be replaced by another thread.
+        // _yearsTransitions can grow but never shrink. This guarantees indexes returned from _transitionCache are always valid.
+        private TimeTransition[] _yearsTransitions = new TimeTransition[10]; // start with 10 transitions and grow as needed
+        private int _yearsTransitionsCount;
+        private const int MaxYear = 9999;
+
+        private record struct TimeTransition(
+            DateTime DateStart,     // UTC
+            DateTime DateEnd,       // UTC
+            TimeSpan Offset,        // Usually rule.BaseUtcOffsetDelta + rule.DaylightDelta
+            bool DaylightSavingOn   // Indicates if daylight saving is active during this transition
+        );
+
+        private sealed class DateTimeNowCache
+        {
+            public long _nextUtcNowTransitionTicks; // ticks when the next transition starts
+            public long _nowUtcOffsetTicks;         // offset in ticks to add to the UtcNow to get the local time
+            public long _dtsAmbiguousOffsetStart;   // if the current transition is DST, the start of the ambiguous time range
+            public long _dtsAmbiguousOffsetEnd;     // if the current transition is DST, the end of the ambiguous time range
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Cache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Cache.cs
@@ -733,14 +733,14 @@ namespace System
                                 // Previous year has two transition periods. One start from the year beginning while the second go through the end of the year
                                 //
 
-                                long previousEndOfYearUtcTicks = new DateTime(year, 1, 1).Ticks - (_baseUtcOffset.Ticks + previousRule.BaseUtcOffsetDelta.Ticks + previousRule.DaylightDelta.Ticks) - 2;
+                                long previousEndOfYearUtcTicks = new DateTime(year, 1, 1).Ticks - (_baseUtcOffset.Ticks + previousRule.BaseUtcOffsetDelta.Ticks + previousRule.DaylightDelta.Ticks) - 1;
                                 DateTime previousEndOfYearUtc = SafeCreateDateTimeFromTicks(previousEndOfYearUtcTicks, DateTimeKind.Utc);
 
-                                if (previousEndOfYearUtc.Ticks <= rule.DateStart.Ticks - 1)
+                                if (previousEndOfYearUtc.Ticks < rule.DateStart.Ticks - 1)
                                 {
                                     // Gap between the end of the last year and current year transition start. no daylight
                                     AddTransition(ref allTransitions, ref transitionCount,
-                                        new TimeTransition(previousEndOfYearUtc, SafeCreateDateTimeFromTicks(rule.DateStart.Ticks - 1), rule.BaseUtcOffsetDelta, false));
+                                        new TimeTransition(SafeCreateDateTimeFromTicks(previousEndOfYearUtc.Ticks + 1), SafeCreateDateTimeFromTicks(rule.DateStart.Ticks - 1), rule.BaseUtcOffsetDelta, false));
                                 }
 
                                 // The daylight start should be around the end of the year and go through the end

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Cache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Cache.cs
@@ -679,7 +679,7 @@ namespace System
                             //
 
                             DateTime previousYearTransitionEnd = SafeCreateDateTimeFromTicks(previousRule.DateEnd.Ticks + 1); // UTC coordinate
-                            if (previousYearTransitionEnd.Ticks < rule.DateStart.Ticks - 1)
+                            if (previousYearTransitionEnd.Ticks <= rule.DateStart.Ticks - 1)
                             {
                                 // Gap between the last year transition end and current year transition start. no daylight
                                 AddTransition(ref allTransitions, ref transitionCount,
@@ -736,11 +736,11 @@ namespace System
                                 long previousEndOfYearUtcTicks = new DateTime(year, 1, 1).Ticks - (_baseUtcOffset.Ticks + previousRule.BaseUtcOffsetDelta.Ticks + previousRule.DaylightDelta.Ticks) - 2;
                                 DateTime previousEndOfYearUtc = SafeCreateDateTimeFromTicks(previousEndOfYearUtcTicks, DateTimeKind.Utc);
 
-                                if (previousEndOfYearUtc.Ticks < rule.DateStart.Ticks - 1)
+                                if (previousEndOfYearUtc.Ticks <= rule.DateStart.Ticks - 1)
                                 {
                                     // Gap between the end of the last year and current year transition start. no daylight
                                     AddTransition(ref allTransitions, ref transitionCount,
-                                        new TimeTransition(SafeCreateDateTimeFromTicks(previousEndOfYearUtc.Ticks + 1), SafeCreateDateTimeFromTicks(rule.DateStart.Ticks - 1), rule.BaseUtcOffsetDelta, false));
+                                        new TimeTransition(previousEndOfYearUtc, SafeCreateDateTimeFromTicks(rule.DateStart.Ticks - 1), rule.BaseUtcOffsetDelta, false));
                                 }
 
                                 // The daylight start should be around the end of the year and go through the end
@@ -944,7 +944,7 @@ namespace System
                                 //
 
                                 DateTime previousYearTransitionEnd = SafeCreateDateTimeFromTicks(previousYearRule.DateEnd.Ticks + 1); // UTC coordinate
-                                if (previousYearTransitionEnd.Ticks < startOfCurrentYearUtc.Ticks - 1)
+                                if (previousYearTransitionEnd.Ticks <= startOfCurrentYearUtc.Ticks - 1)
                                 {
                                     // Gap between the last year transition end and current year transition start. no daylight
                                     AddTransition(ref allTransitions, ref transitionCount,

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -354,13 +354,6 @@ namespace System
         private static TimeZoneInfoResult TryGetTimeZone(string id, out TimeZoneInfo? timeZone, out Exception? e, CachedData cachedData)
             => TryGetTimeZone(id, false, out timeZone, out e, cachedData, alwaysFallbackToLocalMachine: true);
 
-        // DateTime.Now fast path that avoids allocating an historically accurate TimeZoneInfo.Local and just creates a 1-year (current year) accurate time zone
-        internal static TimeSpan GetDateTimeNowUtcOffsetFromUtc(DateTime time, out bool isAmbiguousLocalDst)
-        {
-            // Use the standard code path for Unix since there isn't a faster way of handling current-year-only time zones
-            return GetUtcOffsetFromUtc(time, Local, out _, out isAmbiguousLocalDst);
-        }
-
         // TZFILE(5)                   BSD File Formats Manual                  TZFILE(5)
         //
         // NAME

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -132,16 +132,30 @@ namespace System
                     DateTimeKind.Unspecified;
             }
 
+            internal long GetLocalDateTimeNowTicks(DateTime utcNow, out bool isAmbiguous)
+            {
+                long utcNowTicks = utcNow.Ticks;
+                DateTimeNowCache? dateTimeNowCache = _dateTimeNowCache;
+
+                if (dateTimeNowCache is null || utcNowTicks >= dateTimeNowCache._nextUtcNowTransitionTicks)
+                {
+                    // GetNextNowTransition always create a new instance
+                    dateTimeNowCache = Local.GetNextNowTransition(utcNow);
+                    _dateTimeNowCache = dateTimeNowCache; // volatile write, safe publication
+                }
+
+                long localTicks = SafeCreateDateTimeFromTicks(dateTimeNowCache._nowUtcOffsetTicks + utcNowTicks).Ticks;
+                isAmbiguous = localTicks >= dateTimeNowCache._dtsAmbiguousOffsetStart && localTicks <= dateTimeNowCache._dtsAmbiguousOffsetEnd;
+                return localTicks;
+            }
+
             public Dictionary<string, TimeZoneInfo>? _systemTimeZones;
             public ReadOnlyCollection<TimeZoneInfo>? _readOnlySystemTimeZones;
             public ReadOnlyCollection<TimeZoneInfo>? _readOnlyUnsortedSystemTimeZones;
             public Dictionary<string, TimeZoneInfo>? _timeZonesUsingAlternativeIds;
             public bool _allSystemTimeZonesRead;
+            public volatile DateTimeNowCache? _dateTimeNowCache;
         }
-
-        // used by GetUtcOffsetFromUtc (DateTime.Now, DateTime.ToLocalTime) for max/min whole-day range checks
-        private static readonly DateTime s_maxDateOnly = new DateTime(9999, 12, 31);
-        private static readonly DateTime s_minDateOnly = new DateTime(1, 1, 2);
 
         public string Id => _id;
 
@@ -193,43 +207,14 @@ namespace System
         /// </summary>
         public TimeSpan[] GetAmbiguousTimeOffsets(DateTimeOffset dateTimeOffset)
         {
-            if (!SupportsDaylightSavingTime)
+            Span<TimeSpan> offsets = stackalloc TimeSpan[2];
+
+            if (!SupportsDaylightSavingTime || !IsAmbiguousLocalTime(ConvertTime(dateTimeOffset, this).DateTime, offsets))
             {
                 throw new ArgumentException(SR.Argument_DateTimeOffsetIsNotAmbiguous, nameof(dateTimeOffset));
             }
 
-            DateTime adjustedTime = ConvertTime(dateTimeOffset, this).DateTime;
-
-            bool isAmbiguous = false;
-            AdjustmentRule? rule = GetAdjustmentRuleForAmbiguousOffsets(adjustedTime, out int? ruleIndex);
-            if (rule != null && rule.HasDaylightSaving)
-            {
-                DaylightTimeStruct daylightTime = GetDaylightTime(adjustedTime.Year, rule, ruleIndex);
-                isAmbiguous = GetIsAmbiguousTime(adjustedTime, rule, daylightTime);
-            }
-
-            if (!isAmbiguous)
-            {
-                throw new ArgumentException(SR.Argument_DateTimeOffsetIsNotAmbiguous, nameof(dateTimeOffset));
-            }
-
-            // the passed in dateTime is ambiguous in this TimeZoneInfo instance
-            TimeSpan[] timeSpans = new TimeSpan[2];
-
-            TimeSpan actualUtcOffset = _baseUtcOffset + rule!.BaseUtcOffsetDelta;
-
-            // the TimeSpan array must be sorted from least to greatest
-            if (rule.DaylightDelta > TimeSpan.Zero)
-            {
-                timeSpans[0] = actualUtcOffset; // FUTURE:  + rule.StandardDelta;
-                timeSpans[1] = actualUtcOffset + rule.DaylightDelta;
-            }
-            else
-            {
-                timeSpans[0] = actualUtcOffset + rule.DaylightDelta;
-                timeSpans[1] = actualUtcOffset; // FUTURE: + rule.StandardDelta;
-            }
-            return timeSpans;
+            return offsets.ToArray();
         }
 
         /// <summary>
@@ -259,88 +244,20 @@ namespace System
                 adjustedTime = dateTime;
             }
 
-            bool isAmbiguous = false;
-            AdjustmentRule? rule = GetAdjustmentRuleForAmbiguousOffsets(adjustedTime, out int? ruleIndex);
-            if (rule != null && rule.HasDaylightSaving)
-            {
-                DaylightTimeStruct daylightTime = GetDaylightTime(adjustedTime.Year, rule, ruleIndex);
-                isAmbiguous = GetIsAmbiguousTime(adjustedTime, rule, daylightTime);
-            }
-
-            if (!isAmbiguous)
+            Span<TimeSpan> offsets = stackalloc TimeSpan[2];
+            if (!IsAmbiguousLocalTime(adjustedTime, offsets))
             {
                 throw new ArgumentException(SR.Argument_DateTimeIsNotAmbiguous, nameof(dateTime));
             }
 
-            // the passed in dateTime is ambiguous in this TimeZoneInfo instance
-            TimeSpan[] timeSpans = new TimeSpan[2];
-            TimeSpan actualUtcOffset = _baseUtcOffset + rule!.BaseUtcOffsetDelta;
-
-            // the TimeSpan array must be sorted from least to greatest
-            if (rule.DaylightDelta > TimeSpan.Zero)
-            {
-                timeSpans[0] = actualUtcOffset; // FUTURE:  + rule.StandardDelta;
-                timeSpans[1] = actualUtcOffset + rule.DaylightDelta;
-            }
-            else
-            {
-                timeSpans[0] = actualUtcOffset + rule.DaylightDelta;
-                timeSpans[1] = actualUtcOffset; // FUTURE: + rule.StandardDelta;
-            }
-            return timeSpans;
-        }
-
-        // note the time is already adjusted
-        private AdjustmentRule? GetAdjustmentRuleForAmbiguousOffsets(DateTime adjustedTime, out int? ruleIndex)
-        {
-            AdjustmentRule? rule = GetAdjustmentRuleForTime(adjustedTime, out ruleIndex);
-            if (rule != null && rule.NoDaylightTransitions && !rule.HasDaylightSaving)
-            {
-                // When using NoDaylightTransitions rules, each rule is only for one offset.
-                // When looking for the Daylight savings rules, and we found the non-DST rule,
-                // then we get the rule right before this rule.
-                return GetPreviousAdjustmentRule(rule, ruleIndex);
-            }
-
-            return rule;
-        }
-
-        /// <summary>
-        /// Gets the AdjustmentRule that is immediately preceding the specified rule.
-        /// If the specified rule is the first AdjustmentRule, or it isn't in _adjustmentRules,
-        /// then the specified rule is returned.
-        /// </summary>
-        private AdjustmentRule GetPreviousAdjustmentRule(AdjustmentRule rule, int? ruleIndex)
-        {
-            Debug.Assert(rule.NoDaylightTransitions, "GetPreviousAdjustmentRule should only be used with NoDaylightTransitions rules.");
-            Debug.Assert(_adjustmentRules != null);
-
-            if (ruleIndex.HasValue && 0 < ruleIndex.GetValueOrDefault() && ruleIndex.GetValueOrDefault() < _adjustmentRules.Length)
-            {
-                return _adjustmentRules[ruleIndex.GetValueOrDefault() - 1];
-            }
-
-            AdjustmentRule result = rule;
-            for (int i = 1; i < _adjustmentRules.Length; i++)
-            {
-                // use ReferenceEquals here instead of AdjustmentRule.Equals because
-                // ReferenceEquals is much faster. This is safe because all the callers
-                // of GetPreviousAdjustmentRule pass in a rule that was retrieved from
-                // _adjustmentRules.  A different approach will be needed if this ever changes.
-                if (ReferenceEquals(rule, _adjustmentRules[i]))
-                {
-                    result = _adjustmentRules[i - 1];
-                    break;
-                }
-            }
-            return result;
+            return offsets.ToArray();
         }
 
         /// <summary>
         /// Returns the Universal Coordinated Time (UTC) Offset for the current TimeZoneInfo instance.
         /// </summary>
         public TimeSpan GetUtcOffset(DateTimeOffset dateTimeOffset) =>
-            GetUtcOffsetFromUtc(dateTimeOffset.UtcDateTime, this);
+            GetOffsetForUtcDate(dateTimeOffset.UtcDateTime, out _);
 
         /// <summary>
         /// Returns the Universal Coordinated Time (UTC) Offset for the current TimeZoneInfo instance.
@@ -348,7 +265,7 @@ namespace System
         public TimeSpan GetUtcOffset(DateTime dateTime) =>
             GetUtcOffset(dateTime, TimeZoneInfoOptions.NoThrowOnInvalidTime, s_cachedData);
 
-        // Shortcut for TimeZoneInfo.Local.GetUtcOffset
+        // Shortcut for TimeZoneInfo.Local.GetUtcOffset, it is called from DateTime and DateTimeOffset types.
         internal static TimeSpan GetLocalUtcOffset(DateTime dateTime, TimeZoneInfoOptions flags)
         {
             CachedData cachedData = s_cachedData;
@@ -405,7 +322,7 @@ namespace System
                 }
             }
 
-            return GetUtcOffset(dateTime, this);
+            return TryGetUtcOffset(dateTime, out TimeSpan offset) ? offset : _baseUtcOffset;
         }
 
         /// <summary>
@@ -447,13 +364,7 @@ namespace System
                 dateTime.Kind == DateTimeKind.Utc ? ConvertTime(dateTime, s_utcTimeZone, this, flags, cachedData) :
                 dateTime;
 
-            AdjustmentRule? rule = GetAdjustmentRuleForTime(adjustedTime, out int? ruleIndex);
-            if (rule != null && rule.HasDaylightSaving)
-            {
-                DaylightTimeStruct daylightTime = GetDaylightTime(adjustedTime.Year, rule, ruleIndex);
-                return GetIsAmbiguousTime(adjustedTime, rule, daylightTime);
-            }
-            return false;
+            return IsAmbiguousLocalTime(adjustedTime);
         }
 
         /// <summary>
@@ -527,47 +438,15 @@ namespace System
                 adjustedTime = dateTime;
             }
 
-            //
-            // handle the normal cases...
-            //
-            AdjustmentRule? rule = GetAdjustmentRuleForTime(adjustedTime, out int? ruleIndex);
-            if (rule != null && rule.HasDaylightSaving)
-            {
-                DaylightTimeStruct daylightTime = GetDaylightTime(adjustedTime.Year, rule, ruleIndex);
-                return GetIsDaylightSavings(adjustedTime, rule, daylightTime);
-            }
-            else
-            {
-                return false;
-            }
+            return IsDaylightSavingOn(adjustedTime);
         }
 
         /// <summary>
         /// Returns true when dateTime falls into a "hole in time".
         /// </summary>
         public bool IsInvalidTime(DateTime dateTime)
-        {
-            bool isInvalid = false;
-
-            if ((dateTime.Kind == DateTimeKind.Unspecified) ||
-                (dateTime.Kind == DateTimeKind.Local && s_cachedData.GetCorrespondingKind(this) == DateTimeKind.Local))
-            {
-                // only check Unspecified and (Local when this TimeZoneInfo instance is Local)
-                AdjustmentRule? rule = GetAdjustmentRuleForTime(dateTime, out int? ruleIndex);
-
-                if (rule != null && rule.HasDaylightSaving)
-                {
-                    DaylightTimeStruct daylightTime = GetDaylightTime(dateTime.Year, rule, ruleIndex);
-                    isInvalid = GetIsInvalidTime(dateTime, rule, daylightTime);
-                }
-                else
-                {
-                    isInvalid = false;
-                }
-            }
-
-            return isInvalid;
-        }
+            => (dateTime.Kind == DateTimeKind.Unspecified) || (dateTime.Kind == DateTimeKind.Local && s_cachedData.GetCorrespondingKind(this) == DateTimeKind.Local) ?
+                IsInvalidLocalTime(dateTime) : false;
 
         /// <summary>
         /// Clears data from static members.
@@ -708,7 +587,7 @@ namespace System
 
             // calculate the destination time zone offset
             DateTime utcDateTime = dateTimeOffset.UtcDateTime;
-            TimeSpan destinationOffset = GetUtcOffsetFromUtc(utcDateTime, destinationTimeZone);
+            TimeSpan destinationOffset = destinationTimeZone.GetOffsetForUtcDate(utcDateTime, out _);
 
             // check for overflow
             long ticks = utcDateTime.Ticks + destinationOffset.Ticks;
@@ -759,35 +638,18 @@ namespace System
                 throw new ArgumentException(SR.Argument_ConvertMismatch, nameof(sourceTimeZone));
             }
 
-            //
-            // check to see if the DateTime is in an invalid time range.  This check
-            // requires the current AdjustmentRule and DaylightTime - which are also
-            // needed to calculate 'sourceOffset' in the normal conversion case.
-            // By calculating the 'sourceOffset' here we improve the
-            // performance for the normal case at the expense of the 'ArgumentException'
-            // case and Loss-less Local special cases.
-            //
-            AdjustmentRule? sourceRule = sourceTimeZone.GetAdjustmentRuleForTime(dateTime, out int? sourceRuleIndex);
-            TimeSpan sourceOffset = sourceTimeZone.BaseUtcOffset;
+            bool isInvalidTime = !sourceTimeZone.TryLocalToUtc(dateTime, out DateTime utcDateTime);
 
-            if (sourceRule != null)
+            if (((flags & TimeZoneInfoOptions.NoThrowOnInvalidTime) == 0) && isInvalidTime)
             {
-                sourceOffset += sourceRule.BaseUtcOffsetDelta;
-                if (sourceRule.HasDaylightSaving)
-                {
-                    DaylightTimeStruct sourceDaylightTime = sourceTimeZone.GetDaylightTime(dateTime.Year, sourceRule, sourceRuleIndex);
+                throw new ArgumentException(SR.Argument_DateTimeIsInvalid, nameof(dateTime));
+            }
 
-                    // 'dateTime' might be in an invalid time range since it is in an AdjustmentRule
-                    // period that supports DST
-                    if (((flags & TimeZoneInfoOptions.NoThrowOnInvalidTime) == 0) && GetIsInvalidTime(dateTime, sourceRule, sourceDaylightTime))
-                    {
-                        throw new ArgumentException(SR.Argument_DateTimeIsInvalid, nameof(dateTime));
-                    }
-                    bool sourceIsDaylightSavings = GetIsDaylightSavings(dateTime, sourceRule, sourceDaylightTime);
-
-                    // adjust the sourceOffset according to the Adjustment Rule / Daylight Saving Rule
-                    sourceOffset += (sourceIsDaylightSavings ? sourceRule.DaylightDelta : TimeSpan.Zero /*FUTURE: sourceRule.StandardDelta*/);
-                }
+            if (isInvalidTime)
+            {
+                // This is not logical to do but we are keeping it for app compatibility reason.
+                // We get here if the dateTime is invalid in the source time zone.
+                utcDateTime = new DateTime(dateTime.Ticks + sourceTimeZone.BaseUtcOffset.Ticks, DateTimeKind.Utc);
             }
 
             DateTimeKind targetKind = cachedData.GetCorrespondingKind(destinationTimeZone);
@@ -798,16 +660,13 @@ namespace System
                 return dateTime;
             }
 
-            long utcTicks = dateTime.Ticks - sourceOffset.Ticks;
-
-            // handle the normal case by converting from 'source' to UTC and then to 'target'
-            DateTime targetConverted = ConvertUtcToTimeZone(utcTicks, destinationTimeZone, out bool isAmbiguousLocalDst);
+            DateTime targetConverted = destinationTimeZone.UtcToLocal(utcDateTime, out _);
 
             if (targetKind == DateTimeKind.Local)
             {
                 // Because the ticks conversion between UTC and local is lossy, we need to capture whether the
                 // time is in a repeated hour so that it can be passed to the DateTime constructor.
-                return new DateTime(targetConverted.Ticks, DateTimeKind.Local, isAmbiguousLocalDst);
+                return new DateTime(targetConverted.Ticks, DateTimeKind.Local, destinationTimeZone.IsAmbiguousLocalTime(targetConverted));
             }
             else
             {
@@ -1167,60 +1026,6 @@ namespace System
             _supportsDaylightSavingTime = (bool)info.GetValue("SupportsDaylightSavingTime", typeof(bool))!; // Do not rename (binary serialization)
         }
 
-        private AdjustmentRule? GetAdjustmentRuleForTime(DateTime dateTime, out int? ruleIndex)
-        {
-            AdjustmentRule? result = GetAdjustmentRuleForTime(dateTime, dateTimeisUtc: false, ruleIndex: out ruleIndex);
-            Debug.Assert(result == null || ruleIndex.HasValue, "If an AdjustmentRule was found, ruleIndex should also be set.");
-
-            return result;
-        }
-
-        private AdjustmentRule? GetAdjustmentRuleForTime(DateTime dateTime, bool dateTimeisUtc, out int? ruleIndex)
-        {
-            if (_adjustmentRules == null || _adjustmentRules.Length == 0)
-            {
-                ruleIndex = null;
-                return null;
-            }
-
-            // Only check the whole-date portion of the dateTime for DateTimeKind.Unspecified rules -
-            // This is because the AdjustmentRule DateStart & DateEnd are stored as
-            // Date-only values {4/2/2006 - 10/28/2006} but actually represent the
-            // time span {4/2/2006@00:00:00.00000 - 10/28/2006@23:59:59.99999}
-            DateTime date = dateTimeisUtc ?
-                (dateTime + BaseUtcOffset).Date :
-                dateTime.Date;
-
-            int low = 0;
-            int high = _adjustmentRules.Length - 1;
-
-            while (low <= high)
-            {
-                int median = low + ((high - low) >> 1);
-
-                AdjustmentRule rule = _adjustmentRules[median];
-                AdjustmentRule previousRule = median > 0 ? _adjustmentRules[median - 1] : rule;
-
-                int compareResult = CompareAdjustmentRuleToDateTime(rule, previousRule, dateTime, date, dateTimeisUtc);
-                if (compareResult == 0)
-                {
-                    ruleIndex = median;
-                    return rule;
-                }
-                else if (compareResult < 0)
-                {
-                    low = median + 1;
-                }
-                else
-                {
-                    high = median - 1;
-                }
-            }
-
-            ruleIndex = null;
-            return null;
-        }
-
         /// <summary>
         /// Determines if 'rule' is the correct AdjustmentRule for the given dateTime.
         /// </summary>
@@ -1230,12 +1035,12 @@ namespace System
         /// A value greater than zero if rule is for times after dateTime.
         /// </returns>
         private int CompareAdjustmentRuleToDateTime(AdjustmentRule rule, AdjustmentRule previousRule,
-            DateTime dateTime, DateTime dateOnly, bool dateTimeisUtc)
+            DateTime dateTime, DateTime dateOnly, bool dateTimeIsUtc)
         {
             bool isAfterStart;
             if (rule.DateStart.Kind == DateTimeKind.Utc)
             {
-                DateTime dateTimeToCompare = dateTimeisUtc ?
+                DateTime dateTimeToCompare = dateTimeIsUtc ?
                     dateTime :
                     // use the previous rule to compute the dateTimeToCompare, since the time daylight savings "switches"
                     // is based on the previous rule's offset
@@ -1257,7 +1062,7 @@ namespace System
             bool isBeforeEnd;
             if (rule.DateEnd.Kind == DateTimeKind.Utc)
             {
-                DateTime dateTimeToCompare = dateTimeisUtc ?
+                DateTime dateTimeToCompare = dateTimeIsUtc ?
                     dateTime :
                     ConvertToUtc(dateTime, rule.DaylightDelta, rule.BaseUtcOffsetDelta);
 
@@ -1304,555 +1109,6 @@ namespace System
         }
 
         /// <summary>
-        /// Helper function that converts a dateTime from UTC into the destinationTimeZone
-        /// - Returns DateTime.MaxValue when the converted value is too large.
-        /// - Returns DateTime.MinValue when the converted value is too small.
-        /// </summary>
-        private static DateTime ConvertUtcToTimeZone(long ticks, TimeZoneInfo destinationTimeZone, out bool isAmbiguousLocalDst)
-        {
-            // used to calculate the UTC offset in the destinationTimeZone
-            DateTime utcConverted =
-                ticks > DateTime.MaxTicks ? DateTime.MaxValue :
-                ticks < DateTime.MinTicks ? DateTime.MinValue :
-                new DateTime(ticks);
-
-            // verify the time is between MinValue and MaxValue in the new time zone
-            TimeSpan offset = GetUtcOffsetFromUtc(utcConverted, destinationTimeZone, out isAmbiguousLocalDst);
-            ticks += offset.Ticks;
-
-            return
-                ticks > DateTime.MaxTicks ? DateTime.MaxValue :
-                ticks < DateTime.MinTicks ? DateTime.MinValue :
-                new DateTime(ticks);
-        }
-
-        /// <summary>
-        /// Helper function that returns a DaylightTime from a year and AdjustmentRule.
-        /// </summary>
-        private DaylightTimeStruct GetDaylightTime(int year, AdjustmentRule rule, int? ruleIndex)
-        {
-            TimeSpan delta = rule.DaylightDelta;
-            DateTime startTime;
-            DateTime endTime;
-            if (rule.NoDaylightTransitions)
-            {
-                // NoDaylightTransitions rules don't use DaylightTransition Start and End, instead
-                // the DateStart and DateEnd are UTC times that represent when daylight savings time changes.
-                // Convert the UTC times into adjusted time zone times.
-
-                // use the previous rule to calculate the startTime, since the DST change happens w.r.t. the previous rule
-                AdjustmentRule previousRule = GetPreviousAdjustmentRule(rule, ruleIndex);
-                startTime = ConvertFromUtc(rule.DateStart, previousRule.DaylightDelta, previousRule.BaseUtcOffsetDelta);
-
-                endTime = ConvertFromUtc(rule.DateEnd, rule.DaylightDelta, rule.BaseUtcOffsetDelta);
-            }
-            else
-            {
-                startTime = TransitionTimeToDateTime(year, rule.DaylightTransitionStart);
-                endTime = TransitionTimeToDateTime(year, rule.DaylightTransitionEnd);
-            }
-            return new DaylightTimeStruct(startTime, endTime, delta);
-        }
-
-        /// <summary>
-        /// Helper function that checks if a given dateTime is in Daylight Saving Time (DST).
-        /// This function assumes the dateTime and AdjustmentRule are both in the same time zone.
-        /// </summary>
-        private static bool GetIsDaylightSavings(DateTime time, AdjustmentRule rule, DaylightTimeStruct daylightTime)
-        {
-            if (rule == null)
-            {
-                return false;
-            }
-
-            DateTime startTime;
-            DateTime endTime;
-
-            if (time.Kind == DateTimeKind.Local)
-            {
-                // startTime and endTime represent the period from either the start of
-                // DST to the end and ***includes*** the potentially overlapped times
-                startTime = rule.IsStartDateMarkerForBeginningOfYear() ?
-                    new DateTime(daylightTime.Start.Year, 1, 1) :
-                    daylightTime.Start + daylightTime.Delta;
-
-                endTime = rule.IsEndDateMarkerForEndOfYear() ?
-                    new DateTime(daylightTime.End.Year + 1, 1, 1).AddTicks(-1) :
-                    daylightTime.End;
-            }
-            else
-            {
-                // startTime and endTime represent the period from either the start of DST to the end and
-                // ***does not include*** the potentially overlapped times
-                //
-                //         -=-=-=-=-=- Pacific Standard Time -=-=-=-=-=-=-
-                //    April 2, 2006                            October 29, 2006
-                // 2AM            3AM                        1AM              2AM
-                // |      +1 hr     |                        |       -1 hr      |
-                // | <invalid time> |                        | <ambiguous time> |
-                //                  [========== DST ========>)
-                //
-                //        -=-=-=-=-=- Some Weird Time Zone -=-=-=-=-=-=-
-                //    April 2, 2006                          October 29, 2006
-                // 1AM              2AM                    2AM              3AM
-                // |      -1 hr       |                      |       +1 hr      |
-                // | <ambiguous time> |                      |  <invalid time>  |
-                //                    [======== DST ========>)
-                //
-                bool invalidAtStart = rule.DaylightDelta > TimeSpan.Zero;
-
-                startTime = rule.IsStartDateMarkerForBeginningOfYear() ?
-                    new DateTime(daylightTime.Start.Year, 1, 1) :
-                    daylightTime.Start + (invalidAtStart ? rule.DaylightDelta : TimeSpan.Zero); /* FUTURE: - rule.StandardDelta; */
-
-                endTime = rule.IsEndDateMarkerForEndOfYear() ?
-                    new DateTime(daylightTime.End.Year + 1, 1, 1).AddTicks(-1) :
-                    daylightTime.End + (invalidAtStart ? -rule.DaylightDelta : TimeSpan.Zero);
-            }
-
-            bool isDst = CheckIsDst(startTime, time, endTime, false, rule);
-
-            // If this date was previously converted from a UTC date and we were able to detect that the local
-            // DateTime would be ambiguous, this data is stored in the DateTime to resolve this ambiguity.
-            if (isDst && time.Kind == DateTimeKind.Local)
-            {
-                // For normal time zones, the ambiguous hour is the last hour of daylight saving when you wind the
-                // clock back. It is theoretically possible to have a positive delta, (which would really be daylight
-                // reduction time), where you would have to wind the clock back in the begnning.
-                if (GetIsAmbiguousTime(time, rule, daylightTime))
-                {
-                    isDst = time.IsAmbiguousDaylightSavingTime();
-                }
-            }
-
-            return isDst;
-        }
-
-        /// <summary>
-        /// Gets the offset that should be used to calculate DST start times from a UTC time.
-        /// </summary>
-        private TimeSpan GetDaylightSavingsStartOffsetFromUtc(TimeSpan baseUtcOffset, AdjustmentRule rule, int? ruleIndex)
-        {
-            if (rule.NoDaylightTransitions)
-            {
-                // use the previous rule to calculate the startTime, since the DST change happens w.r.t. the previous rule
-                AdjustmentRule previousRule = GetPreviousAdjustmentRule(rule, ruleIndex);
-                return baseUtcOffset + previousRule.BaseUtcOffsetDelta + previousRule.DaylightDelta;
-            }
-            else
-            {
-                return baseUtcOffset + rule.BaseUtcOffsetDelta; /* FUTURE: + rule.StandardDelta; */
-            }
-        }
-
-        /// <summary>
-        /// Gets the offset that should be used to calculate DST end times from a UTC time.
-        /// </summary>
-        private static TimeSpan GetDaylightSavingsEndOffsetFromUtc(TimeSpan baseUtcOffset, AdjustmentRule rule)
-        {
-            // NOTE: even NoDaylightTransitions rules use this logic since DST ends w.r.t. the current rule
-            return baseUtcOffset + rule.BaseUtcOffsetDelta + rule.DaylightDelta; /* FUTURE: + rule.StandardDelta; */
-        }
-
-        /// <summary>
-        /// Helper function that checks if a given dateTime is in Daylight Saving Time (DST).
-        /// This function assumes the dateTime is in UTC and AdjustmentRule is in a different time zone.
-        /// </summary>
-        private static bool GetIsDaylightSavingsFromUtc(DateTime time, int year, TimeSpan utc, AdjustmentRule rule, int? ruleIndex, out bool isAmbiguousLocalDst, TimeZoneInfo zone)
-        {
-            isAmbiguousLocalDst = false;
-
-            if (rule == null)
-            {
-                return false;
-            }
-
-            // Get the daylight changes for the year of the specified time.
-            DaylightTimeStruct daylightTime = zone.GetDaylightTime(year, rule, ruleIndex);
-
-            // The start and end times represent the range of universal times that are in DST for that year.
-            // Within that there is an ambiguous hour, usually right at the end, but at the beginning in
-            // the unusual case of a negative daylight savings delta.
-            // We need to handle the case if the current rule has daylight saving end by the end of year. If so, we need to check if next year starts with daylight saving on
-            // and get the actual daylight saving end time. Here is example for such case:
-            //      Converting the UTC datetime "12/31/2011 8:00:00 PM" to "(UTC+03:00) Moscow, St. Petersburg, Volgograd (RTZ 2)" zone.
-            //      In 2011 the daylight saving will go through the end of the year. If we use the end of 2011 as the daylight saving end,
-            //      that will fail the conversion because the UTC time +4 hours (3 hours for the zone UTC offset and 1 hour for daylight saving) will move us to the next year "1/1/2012 12:00 AM",
-            //      checking against the end of 2011 will tell we are not in daylight saving which is wrong and the conversion will be off by one hour.
-            // Note we handle the similar case when rule year start with daylight saving and previous year end with daylight saving.
-
-            bool ignoreYearAdjustment = false;
-            TimeSpan dstStartOffset = zone.GetDaylightSavingsStartOffsetFromUtc(utc, rule, ruleIndex);
-            DateTime startTime;
-            if (rule.IsStartDateMarkerForBeginningOfYear() && daylightTime.Start.Year is > 1 and int startYear)
-            {
-                if (TryGetStartOfDstIfYearEndWithDst(startYear - 1, utc, zone, out startTime))
-                {
-                    ignoreYearAdjustment = true;
-                }
-                else
-                {
-                    startTime = new DateTime(startYear, 1, 1) - dstStartOffset;
-                }
-            }
-            else
-            {
-                startTime = daylightTime.Start - dstStartOffset;
-            }
-
-            TimeSpan dstEndOffset = GetDaylightSavingsEndOffsetFromUtc(utc, rule);
-            DateTime endTime;
-            if (rule.IsEndDateMarkerForEndOfYear() && daylightTime.End.Year is < 9999 and int endYear)
-            {
-                if (TryGetEndOfDstIfYearStartWithDst(endYear + 1, utc, zone, out endTime))
-                {
-                    ignoreYearAdjustment = true;
-                }
-                else
-                {
-                    endTime = new DateTime(endYear + 1, 1, 1).AddTicks(-1) - dstEndOffset;
-                }
-            }
-            else
-            {
-                endTime = daylightTime.End - dstEndOffset;
-            }
-
-            DateTime ambiguousStart;
-            DateTime ambiguousEnd;
-            if (daylightTime.Delta.Ticks > 0)
-            {
-                ambiguousStart = endTime - daylightTime.Delta;
-                ambiguousEnd = endTime;
-            }
-            else
-            {
-                ambiguousStart = startTime;
-                ambiguousEnd = startTime - daylightTime.Delta;
-            }
-
-            bool isDst = CheckIsDst(startTime, time, endTime, ignoreYearAdjustment, rule);
-
-            // See if the resulting local time becomes ambiguous. This must be captured here or the
-            // DateTime will not be able to round-trip back to UTC accurately.
-            if (isDst)
-            {
-                isAmbiguousLocalDst = (time >= ambiguousStart && time < ambiguousEnd);
-
-                if (!isAmbiguousLocalDst && ambiguousStart.Year != ambiguousEnd.Year)
-                {
-                    // there exists an extreme corner case where the start or end period is on a year boundary and
-                    // because of this the comparison above might have been performed for a year-early or a year-later
-                    // than it should have been.
-                    DateTime ambiguousStartModified;
-                    DateTime ambiguousEndModified;
-                    try
-                    {
-                        ambiguousStartModified = ambiguousStart.AddYears(1);
-                        ambiguousEndModified = ambiguousEnd.AddYears(1);
-                        isAmbiguousLocalDst = (time >= ambiguousStartModified && time < ambiguousEndModified);
-                    }
-                    catch (ArgumentOutOfRangeException) { }
-
-                    if (!isAmbiguousLocalDst)
-                    {
-                        try
-                        {
-                            ambiguousStartModified = ambiguousStart.AddYears(-1);
-                            ambiguousEndModified = ambiguousEnd.AddYears(-1);
-                            isAmbiguousLocalDst = (time >= ambiguousStartModified && time < ambiguousEndModified);
-                        }
-                        catch (ArgumentOutOfRangeException) { }
-                    }
-                }
-            }
-
-            return isDst;
-        }
-
-        // This method checks if a specific year start with DST, if so, will get when the DST ends that year and return true.
-        // Otherwise will return false.
-        private static bool TryGetEndOfDstIfYearStartWithDst(int nextYear, TimeSpan utc, TimeZoneInfo zone, out DateTime dstEnd)
-        {
-            AdjustmentRule? nextYearRule = zone.GetAdjustmentRuleForTime(new DateTime(nextYear, 1, 1), out int? nextYearRuleIndex);
-
-            // DST is not supported if the year doesn't have a rule.
-            if (nextYearRule is null)
-            {
-                dstEnd = default;
-                return false;
-            }
-
-            DaylightTimeStruct nextdaylightTime;
-
-            // If the year starts with DST on, calculate where it ends.
-            if (nextYearRule.IsStartDateMarkerForBeginningOfYear())
-            {
-                // Check if DST ends specified as Jan 1st, 12:00 AM which means the year will end with DST on.
-                if (nextYearRule.IsEndDateMarkerForEndOfYear())
-                {
-                    dstEnd = new DateTime(nextYear, 12, 31) - utc - nextYearRule.BaseUtcOffsetDelta - nextYearRule.DaylightDelta;
-                }
-                else
-                {
-                    // The year doesn't end with DST. Calculate the DST end date regularly as specified in the rule.
-                    nextdaylightTime = zone.GetDaylightTime(nextYear, nextYearRule, nextYearRuleIndex);
-                    dstEnd = nextdaylightTime.End - utc - nextYearRule.BaseUtcOffsetDelta - nextYearRule.DaylightDelta;
-                }
-
-                return true;
-            }
-
-            nextdaylightTime = zone.GetDaylightTime(nextYear, nextYearRule, nextYearRuleIndex);
-
-            // Check if we are dealing with a southern sphere time zone.
-            // If the rule specifies the DST end as of Jan 1st, 12:00 AM that means the year will end with DST on
-            // but also means the year not started with DST as we already checked that before.
-            if (nextdaylightTime.End < nextdaylightTime.Start && !nextYearRule.IsEndDateMarkerForEndOfYear())
-            {
-                // It is the Southern sphere time zone. The year is started with DST on. Use the DST end to get the when DST ends that year.
-                dstEnd = nextdaylightTime.End - utc - nextYearRule.BaseUtcOffsetDelta - nextYearRule.DaylightDelta;
-                return true;
-            }
-
-            // The year is not starting with DST.
-            dstEnd = default;
-            return false;
-        }
-
-        // This method checks if a specific year end with DST, if so, will get when the DST starts that year and return true.
-        // Otherwise will return false.
-        private static bool TryGetStartOfDstIfYearEndWithDst(int previousYear, TimeSpan utc, TimeZoneInfo zone, out DateTime dstStart)
-        {
-            AdjustmentRule? previousYearRule = zone.GetAdjustmentRuleForTime(new DateTime(previousYear, 12, 31), out int? previousYearRuleIndex);
-
-            // DST is not supported if the year doesn't have a rule.
-            if (previousYearRule is null)
-            {
-                dstStart = default;
-                return false;
-            }
-
-            DaylightTimeStruct previousDaylightTime = zone.GetDaylightTime(previousYear, previousYearRule, previousYearRuleIndex);
-
-            // If the rule is specifying that the year ends with DST on or DST starts after it ends for the year (i.e. it is in the Southern hemisphere), calculate the time DST started
-            if (previousYearRule.IsEndDateMarkerForEndOfYear() || previousDaylightTime.Start > previousDaylightTime.End)
-            {
-                dstStart = previousDaylightTime.Start - utc - previousYearRule.BaseUtcOffsetDelta;
-                return true;
-            }
-
-            dstStart = default;
-            return false;
-        }
-
-        private static bool CheckIsDst(DateTime startTime, DateTime time, DateTime endTime, bool ignoreYearAdjustment, AdjustmentRule rule)
-        {
-            // NoDaylightTransitions AdjustmentRules should never get their year adjusted since they adjust the offset for the
-            // entire time period - which may be for multiple years
-            if (!ignoreYearAdjustment && !rule.NoDaylightTransitions)
-            {
-                int startTimeYear = startTime.Year;
-                int endTimeYear = endTime.Year;
-
-                if (startTimeYear != endTimeYear)
-                {
-                    endTime = endTime.AddYears(startTimeYear - endTimeYear);
-                }
-
-                int timeYear = time.Year;
-
-                if (startTimeYear != timeYear)
-                {
-                    time = time.AddYears(startTimeYear - timeYear);
-                }
-            }
-
-            if (startTime > endTime)
-            {
-                // In southern hemisphere, the daylight saving time starts later in the year, and ends in the beginning of next year.
-                // Note, the summer in the southern hemisphere begins late in the year.
-                return time < endTime || time >= startTime;
-            }
-            else if (rule.NoDaylightTransitions)
-            {
-                // In NoDaylightTransitions AdjustmentRules, the startTime is always before the endTime,
-                // and both the start and end times are inclusive
-                return time >= startTime && time <= endTime;
-            }
-            else
-            {
-                // In northern hemisphere, the daylight saving time starts in the middle of the year.
-                return time >= startTime && time < endTime;
-            }
-        }
-
-        /// <summary>
-        /// Returns true when the dateTime falls into an ambiguous time range.
-        ///
-        /// For example, in Pacific Standard Time on Sunday, October 29, 2006 time jumps from
-        /// 2AM to 1AM.  This means the timeline on Sunday proceeds as follows:
-        /// 12AM ... [1AM ... 1:59:59AM -> 1AM ... 1:59:59AM] 2AM ... 3AM ...
-        ///
-        /// In this example, any DateTime values that fall into the [1AM - 1:59:59AM] range
-        /// are ambiguous; as it is unclear if these times are in Daylight Saving Time.
-        /// </summary>
-        private static bool GetIsAmbiguousTime(DateTime time, AdjustmentRule rule, DaylightTimeStruct daylightTime)
-        {
-            bool isAmbiguous = false;
-            if (rule == null || rule.DaylightDelta == TimeSpan.Zero)
-            {
-                return isAmbiguous;
-            }
-
-            DateTime startAmbiguousTime;
-            DateTime endAmbiguousTime;
-
-            // if at DST start we transition forward in time then there is an ambiguous time range at the DST end
-            if (rule.DaylightDelta > TimeSpan.Zero)
-            {
-                if (rule.IsEndDateMarkerForEndOfYear())
-                { // year end with daylight on so there is no ambiguous time
-                    return false;
-                }
-                startAmbiguousTime = daylightTime.End;
-                endAmbiguousTime = daylightTime.End - rule.DaylightDelta; /* FUTURE: + rule.StandardDelta; */
-            }
-            else
-            {
-                if (rule.IsStartDateMarkerForBeginningOfYear())
-                { // year start with daylight on so there is no ambiguous time
-                    return false;
-                }
-                startAmbiguousTime = daylightTime.Start;
-                endAmbiguousTime = daylightTime.Start + rule.DaylightDelta; /* FUTURE: - rule.StandardDelta; */
-            }
-
-            isAmbiguous = (time >= endAmbiguousTime && time < startAmbiguousTime);
-
-            if (!isAmbiguous && startAmbiguousTime.Year != endAmbiguousTime.Year)
-            {
-                // there exists an extreme corner case where the start or end period is on a year boundary and
-                // because of this the comparison above might have been performed for a year-early or a year-later
-                // than it should have been.
-                DateTime startModifiedAmbiguousTime;
-                DateTime endModifiedAmbiguousTime;
-                try
-                {
-                    startModifiedAmbiguousTime = startAmbiguousTime.AddYears(1);
-                    endModifiedAmbiguousTime = endAmbiguousTime.AddYears(1);
-                    isAmbiguous = (time >= endModifiedAmbiguousTime && time < startModifiedAmbiguousTime);
-                }
-                catch (ArgumentOutOfRangeException) { }
-
-                if (!isAmbiguous)
-                {
-                    try
-                    {
-                        startModifiedAmbiguousTime = startAmbiguousTime.AddYears(-1);
-                        endModifiedAmbiguousTime = endAmbiguousTime.AddYears(-1);
-                        isAmbiguous = (time >= endModifiedAmbiguousTime && time < startModifiedAmbiguousTime);
-                    }
-                    catch (ArgumentOutOfRangeException) { }
-                }
-            }
-            return isAmbiguous;
-        }
-
-        /// <summary>
-        /// Helper function that checks if a given DateTime is in an invalid time ("time hole")
-        /// A "time hole" occurs at a DST transition point when time jumps forward;
-        /// For example, in Pacific Standard Time on Sunday, April 2, 2006 time jumps from
-        /// 1:59:59.9999999 to 3AM.  The time range 2AM to 2:59:59.9999999AM is the "time hole".
-        /// A "time hole" is not limited to only occurring at the start of DST, and may occur at
-        /// the end of DST as well.
-        /// </summary>
-        private static bool GetIsInvalidTime(DateTime time, AdjustmentRule rule, DaylightTimeStruct daylightTime)
-        {
-            bool isInvalid = false;
-            if (rule == null || rule.DaylightDelta == TimeSpan.Zero)
-            {
-                return isInvalid;
-            }
-
-            DateTime startInvalidTime;
-            DateTime endInvalidTime;
-
-            // if at DST start we transition forward in time then there is an ambiguous time range at the DST end
-            if (rule.DaylightDelta < TimeSpan.Zero)
-            {
-                // if the year ends with daylight saving on then there cannot be any time-hole's in that year.
-                if (rule.IsEndDateMarkerForEndOfYear())
-                    return false;
-
-                startInvalidTime = daylightTime.End;
-                endInvalidTime = daylightTime.End - rule.DaylightDelta; /* FUTURE: + rule.StandardDelta; */
-            }
-            else
-            {
-                // if the year starts with daylight saving on then there cannot be any time-hole's in that year.
-                if (rule.IsStartDateMarkerForBeginningOfYear())
-                    return false;
-
-                startInvalidTime = daylightTime.Start;
-                endInvalidTime = daylightTime.Start + rule.DaylightDelta; /* FUTURE: - rule.StandardDelta; */
-            }
-
-            isInvalid = (time >= startInvalidTime && time < endInvalidTime);
-
-            if (!isInvalid && startInvalidTime.Year != endInvalidTime.Year)
-            {
-                // there exists an extreme corner case where the start or end period is on a year boundary and
-                // because of this the comparison above might have been performed for a year-early or a year-later
-                // than it should have been.
-                DateTime startModifiedInvalidTime;
-                DateTime endModifiedInvalidTime;
-                try
-                {
-                    startModifiedInvalidTime = startInvalidTime.AddYears(1);
-                    endModifiedInvalidTime = endInvalidTime.AddYears(1);
-                    isInvalid = (time >= startModifiedInvalidTime && time < endModifiedInvalidTime);
-                }
-                catch (ArgumentOutOfRangeException) { }
-
-                if (!isInvalid)
-                {
-                    try
-                    {
-                        startModifiedInvalidTime = startInvalidTime.AddYears(-1);
-                        endModifiedInvalidTime = endInvalidTime.AddYears(-1);
-                        isInvalid = (time >= startModifiedInvalidTime && time < endModifiedInvalidTime);
-                    }
-                    catch (ArgumentOutOfRangeException) { }
-                }
-            }
-            return isInvalid;
-        }
-
-        /// <summary>
-        /// Helper function that calculates the UTC offset for a dateTime in a timeZone.
-        /// This function assumes that the dateTime is already converted into the timeZone.
-        /// </summary>
-        private static TimeSpan GetUtcOffset(DateTime time, TimeZoneInfo zone)
-        {
-            TimeSpan baseOffset = zone.BaseUtcOffset;
-            AdjustmentRule? rule = zone.GetAdjustmentRuleForTime(time, out int? ruleIndex);
-
-            if (rule != null)
-            {
-                baseOffset += rule.BaseUtcOffsetDelta;
-                if (rule.HasDaylightSaving)
-                {
-                    DaylightTimeStruct daylightTime = zone.GetDaylightTime(time.Year, rule, ruleIndex);
-                    bool isDaylightSavings = GetIsDaylightSavings(time, rule, daylightTime);
-                    baseOffset += (isDaylightSavings ? rule.DaylightDelta : TimeSpan.Zero /* FUTURE: rule.StandardDelta */);
-                }
-            }
-
-            return baseOffset;
-        }
-
-        /// <summary>
         /// Helper function that calculates the UTC offset for a UTC-dateTime in a timeZone.
         /// This function assumes that the dateTime is represented in UTC and has *not* already been converted into the timeZone.
         /// </summary>
@@ -1871,122 +1127,7 @@ namespace System
         /// This function assumes that the dateTime is represented in UTC and has *not* already been converted into the timeZone.
         /// </summary>
         internal static TimeSpan GetUtcOffsetFromUtc(DateTime time, TimeZoneInfo zone, out bool isDaylightSavings, out bool isAmbiguousLocalDst)
-        {
-            isDaylightSavings = false;
-            isAmbiguousLocalDst = false;
-            TimeSpan baseOffset = zone.BaseUtcOffset;
-            int year;
-            int? ruleIndex;
-            AdjustmentRule? rule;
-
-            if (time > s_maxDateOnly)
-            {
-                rule = zone.GetAdjustmentRuleForTime(DateTime.MaxValue, out ruleIndex);
-                year = 9999;
-            }
-            else if (time < s_minDateOnly)
-            {
-                rule = zone.GetAdjustmentRuleForTime(DateTime.MinValue, out ruleIndex);
-                year = 1;
-            }
-            else
-            {
-                rule = zone.GetAdjustmentRuleForTime(time, dateTimeisUtc: true, ruleIndex: out ruleIndex);
-                Debug.Assert(rule == null || ruleIndex.HasValue,
-                    "If GetAdjustmentRuleForTime returned an AdjustmentRule, ruleIndex should also be set.");
-
-                // As we get the associated rule using the adjusted targetTime, we should use the adjusted year (targetTime.Year) too as after adding the baseOffset,
-                // sometimes the year value can change if the input datetime was very close to the beginning or the end of the year. Examples of such cases:
-                //      Libya Standard Time when used with the date 2011-12-31T23:59:59.9999999Z
-                //      "W. Australia Standard Time" used with date 2005-12-31T23:59:00.0000000Z
-                DateTime targetTime = time + baseOffset;
-                year = targetTime.Year;
-            }
-
-            if (rule != null)
-            {
-                baseOffset += rule.BaseUtcOffsetDelta;
-                if (rule.HasDaylightSaving)
-                {
-                    isDaylightSavings = GetIsDaylightSavingsFromUtc(time, year, zone._baseUtcOffset, rule, ruleIndex, out isAmbiguousLocalDst, zone);
-                    baseOffset += (isDaylightSavings ? rule.DaylightDelta : TimeSpan.Zero /* FUTURE: rule.StandardDelta */);
-                }
-            }
-
-            return baseOffset;
-        }
-
-        /// <summary>
-        /// Helper function that converts a year and TransitionTime into a DateTime.
-        /// </summary>
-        internal static DateTime TransitionTimeToDateTime(int year, TransitionTime transitionTime)
-        {
-            DateTime value;
-            TimeSpan timeOfDay = transitionTime.TimeOfDay.TimeOfDay;
-
-            if (transitionTime.IsFixedDateRule)
-            {
-                // create a DateTime from the passed in year and the properties on the transitionTime
-
-                int day = transitionTime.Day;
-                // if the day is out of range for the month then use the last day of the month
-                if (day > 28)
-                {
-                    int daysInMonth = DateTime.DaysInMonth(year, transitionTime.Month);
-                    if (day > daysInMonth)
-                    {
-                        day = daysInMonth;
-                    }
-                }
-
-                value = new DateTime(year, transitionTime.Month, day) + timeOfDay;
-            }
-            else
-            {
-                if (transitionTime.Week <= 4)
-                {
-                    //
-                    // Get the (transitionTime.Week)th Sunday.
-                    //
-                    value = new DateTime(year, transitionTime.Month, 1) + timeOfDay;
-
-                    int dayOfWeek = (int)value.DayOfWeek;
-                    int delta = (int)transitionTime.DayOfWeek - dayOfWeek;
-                    if (delta < 0)
-                    {
-                        delta += 7;
-                    }
-                    delta += 7 * (transitionTime.Week - 1);
-
-                    if (delta > 0)
-                    {
-                        value = value.AddDays(delta);
-                    }
-                }
-                else
-                {
-                    //
-                    // If TransitionWeek is greater than 4, we will get the last week.
-                    //
-                    int daysInMonth = DateTime.DaysInMonth(year, transitionTime.Month);
-                    value = new DateTime(year, transitionTime.Month, daysInMonth) + timeOfDay;
-
-                    // This is the day of week for the last day of the month.
-                    int dayOfWeek = (int)value.DayOfWeek;
-                    int delta = dayOfWeek - (int)transitionTime.DayOfWeek;
-                    if (delta < 0)
-                    {
-                        delta += 7;
-                    }
-
-                    if (delta > 0)
-                    {
-                        value = value.AddDays(-delta);
-                    }
-                }
-            }
-            return value;
-        }
+            => zone.GetOffsetForUtcDate(time, out isDaylightSavings, out isAmbiguousLocalDst);
 
         /// <summary>
         /// Helper function for retrieving a TimeZoneInfo object by time_zone_name.

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -660,13 +660,13 @@ namespace System
                 return dateTime;
             }
 
-            DateTime targetConverted = destinationTimeZone.UtcToLocal(utcDateTime, out _);
+            DateTime targetConverted = destinationTimeZone.UtcToLocal(utcDateTime, out bool isDaylightSaving);
 
             if (targetKind == DateTimeKind.Local)
             {
                 // Because the ticks conversion between UTC and local is lossy, we need to capture whether the
                 // time is in a repeated hour so that it can be passed to the DateTime constructor.
-                return new DateTime(targetConverted.Ticks, DateTimeKind.Local, destinationTimeZone.IsAmbiguousLocalTime(targetConverted));
+                return new DateTime(targetConverted.Ticks, DateTimeKind.Local, isDaylightSaving && destinationTimeZone.IsAmbiguousLocalTime(targetConverted));
             }
             else
             {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -13,6 +13,7 @@ using System.Text.RegularExpressions;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
+using System.Reflection;
 
 namespace System.Tests
 {
@@ -185,6 +186,20 @@ namespace System.Tests
                 Assert.False(TimeZoneInfo.TryFindSystemTimeZoneById("Yukon Standard Time", out _));
                 return;
             }
+        }
+
+        [Theory]
+        [InlineData("2019-12-31T20:00:00", "2020-01-01T01:00:00")]
+        [InlineData("2019-12-31T20:30:00", "2020-01-01T01:30:00")]
+        [InlineData("2020-12-31T20:00:00", "2020-12-31T23:00:00")]
+        [InlineData("2020-12-31T20:30:00", "2020-12-31T23:30:00")]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void TestVolgogradTZ(string utcTime, string expectedVolgogradTime)
+        {
+            TimeZoneInfo volgogradTZ = TimeZoneInfo.FindSystemTimeZoneById("Volgograd Standard Time");
+            DateTime dt = DateTime.ParseExact(utcTime, "s", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            DateTime convertedDt = TimeZoneInfo.ConvertTimeFromUtc(dt, volgogradTZ);
+            Assert.Equal(DateTime.ParseExact(expectedVolgogradTime, "s", CultureInfo.InvariantCulture), convertedDt);
         }
 
         [Fact]
@@ -2154,7 +2169,28 @@ namespace System.Tests
             {
                 foreach (TimeZoneInfo.AdjustmentRule ar in tzi.GetAdjustmentRules())
                 {
-                    Assert.True(Math.Abs((tzi.GetUtcOffset(ar.DateStart)).TotalHours) <= 14.0);
+                    try
+                    {
+                        Assert.True(Math.Abs((tzi.GetUtcOffset(ar.DateStart)).TotalHours) <= 14.0);
+                    }
+                    catch (Exception ex)
+                    {
+                        string message = $"`tzi.GetUtcOffset({ar.DateStart})` throws ArgumentOutOfRangeException" +
+                            Environment.NewLine +
+                            $" for TimeZoneInfo '{tzi.Id}' with BaseUtcOffset '{tzi.BaseUtcOffset}'" +
+                            Environment.NewLine +
+                            $" and AdjustmentRule DateStart '{ar.DateStart}', DateEnd '{ar.DateEnd}', DaylightDelta '{ar.DaylightDelta}'" +
+                            Environment.NewLine +
+                            $"BaseUtcOffsetDelta         : {ar.BaseUtcOffsetDelta}" +
+                            Environment.NewLine +
+                            $"DaylightTransitionStart    : M:{ar.DaylightTransitionStart.Month}, D:{ar.DaylightTransitionStart.Day}, W:{ar.DaylightTransitionStart.Week}, DoW:{ar.DaylightTransitionStart.DayOfWeek}, Time:{ar.DaylightTransitionStart.TimeOfDay}, FixedDate:{ar.DaylightTransitionStart.IsFixedDateRule}" +
+                            Environment.NewLine +
+                            $"DaylightTransitionEnd      : M:{ar.DaylightTransitionEnd.Month}, D:{ar.DaylightTransitionEnd.Day}, W:{ar.DaylightTransitionEnd.Week}, DoW:{ar.DaylightTransitionEnd.DayOfWeek}, Time:{ar.DaylightTransitionEnd.TimeOfDay}, FixedDate:{ar.DaylightTransitionEnd.IsFixedDateRule}" +
+                            Environment.NewLine +
+                            $"NoDaylightTransitions      : {ar.GetType().GetProperty("NoDaylightTransitions", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(ar)}";
+
+                        throw new Exception(message, ex);
+                    }
                 }
             }
         }
@@ -2799,6 +2835,68 @@ namespace System.Tests
                 Assert.Equal(info1.DaylightName, info2.DaylightName);
                 Assert.Equal(info1.DisplayName, info2.DisplayName);
             }, windowsId, ianaId).Dispose();
+        }
+
+        public static TheoryData<DateTime, string, bool> InvalidTimeTestData => new()
+        {
+            // Paraguay DST start (invalid time)
+            { new DateTime(2024, 10, 6, 0, 0, 0), "America/Asuncion", true },
+            // Berlin DST start (invalid time)
+            { new DateTime(2025, 3, 30, 2, 30, 0), "Europe/Berlin", true },
+            // Lisbon DST start (invalid time)
+            { new DateTime(2025, 3, 30, 1, 30, 0), "Europe/Lisbon", true },
+            // London DST start (invalid time)
+            { new DateTime(2025, 3, 30, 1, 30, 0), "Europe/London", true },
+            // Valid time after DST transition in Paraguay
+            { new DateTime(2024, 10, 6, 1, 0, 0), "America/Asuncion", false },
+            // Valid time in Berlin
+            { new DateTime(2025, 4, 19, 15, 0, 0), "Europe/Berlin", false },
+            // should not be invalid, but BCL DateTimeZone detects it to be invalid
+            { new DateTime(1995, 3, 26, 3, 0, 0), "Europe/Lisbon", false },
+            // Kiritimati skipped the whole day of Dec 31st in 1994 due to an offset change
+            { new DateTime(1994, 12, 31, 0, 0, 0), "Pacific/Kiritimati", true },
+            { new DateTime(1994, 12, 31, 12, 0, 0), "Pacific/Kiritimati", true },
+            { new DateTime(1994, 12, 31, 12, 23, 59), "Pacific/Kiritimati", true },
+            // Moscow switched to UTC+4 in 2011
+            { new DateTime(2011, 3, 27, 2, 0, 0), "Europe/Moscow", true },
+        };
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [MemberData(nameof(InvalidTimeTestData))]
+        public static void IsInvalidTimeTestOnLinux(DateTime testTime, string timeZoneId, bool expectedIsInvalid)
+        {
+            TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            Assert.Equal(expectedIsInvalid, timeZone.IsInvalidTime(testTime));
+        }
+
+        public static TheoryData<DateTime, string, bool> AmbiguousTimeTestData => new()
+        {
+            // DST end in Berlin (ambiguous)
+            { new DateTime(2023, 10, 29, 2, 30, 0), "Europe/Berlin", true },
+            // DST end in London (ambiguous)
+            { new DateTime(2023, 10, 29, 1, 30, 0), "Europe/London", true },
+            // DST end in Lisbon (ambiguous)
+            { new DateTime(2023, 10, 29, 1, 30, 0), "Europe/Lisbon", true },
+            // DST end in Lisbon (not ambiguous due to time zone switch at the same time)
+            { new DateTime(1992, 9, 27, 1, 30, 0), "Europe/Lisbon", false },
+            // After DST transition in Berlin (not ambiguous)
+            { new DateTime(2023, 10, 29, 3, 0, 0), "Europe/Berlin", false },
+            // DST end in New York (ambiguous)
+            { new DateTime(2023, 11, 5, 1, 30, 0), "America/New_York", true },
+            // Normal DST time in Berlin (not ambiguous)
+            { new DateTime(2023, 7, 15, 12, 0, 0), "Europe/Berlin", false },
+            // Moscow switched to UTC+3 in 2014
+            { new DateTime(2014, 10, 26, 1, 0, 0), "Europe/Moscow", true },
+        };
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [MemberData(nameof(AmbiguousTimeTestData))]
+        public static void IsAmbiguousTimeTestOnLinux(DateTime testTime, string timeZoneId, bool expectedIsAmbiguous)
+        {
+            TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            Assert.Equal(expectedIsAmbiguous, timeZone.IsAmbiguousTime(testTime));
         }
 
         private static bool IsEnglishUILanguage => CultureInfo.CurrentUICulture.Name.Length == 0 || CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "en";


### PR DESCRIPTION

This change aims to improve time zone handling in .NET.

## Current Issues

* **Performance problems**: Multiple reports highlight performance concerns when converting times across different time zones—especially between local and UTC. The performance degradation is even more noticeable on Linux. More details are included below. Examples of reported issues: [#24839](https://github.com/dotnet/runtime/issues/24839), [#24277](https://github.com/dotnet/runtime/issues/24277), [#25075](https://github.com/dotnet/runtime/issues/25075).

* **Correctness and reliability**: Users occasionally report incorrect results when working with time zones. A major contributing factor is that the time zone handling code was originally written long ago and has since been patched many times. These incremental fixes have made the implementation difficult to maintain, and it’s often unclear whether a new fix might cause regressions elsewhere. While we have fair to good test coverage, it cannot guarantee correctness across all possible time conversion scenarios and supported time zones. Examples of reported issues: [#118915](https://github.com/dotnet/runtime/issues/118915), [#114476](https://github.com/dotnet/runtime/issues/114476).

## How Time Zones Work Today

When converting time between time zones, .NET primarily relies on the [base UTC offset](https://learn.microsoft.com/en-us/dotnet/api/system.timezoneinfo.baseutcoffset?view=net-9.0) (e.g., -8:00 hours for Pacific Standard Time) along with historical and future transition data for each zone. These transitions are expressed through **AdjustmentRules**, where each rule covers one or more years.

An **AdjustmentRule** specifies:

* The start and end of the years it applies to.
* When daylight saving time (DST) begins and ends.
* Any difference in the base UTC offset for a particular year, represented by [BaseUtcOffsetDelta](https://learn.microsoft.com/en-us/dotnet/api/system.timezoneinfo.adjustmentrule.baseutcoffsetdelta?view=net-9.0).

### Data sources

* **Windows**: Rules are read from the Registry at `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Time Zones`.
* **Linux**: Rules come from the `tzdata` package, which contains the [IANA](https://www.iana.org/time-zones) database. IANA data is much more comprehensive, including detailed historical records for every time zone. This means Linux typically has far more rules per time zone than Windows.

### Rule types

1. **Fixed rules** – explicitly define the absolute start and end dates/times of DST transitions.
2. **Floating rules** – define transitions in relative terms (e.g., “DST starts on the first Sunday in March at 2:00 AM, and ends on the last Sunday in November at 2:00 AM”).

* On **Windows**, most rules are stored as floating rules, so a single rule can cover many years.
* On **Linux**, most rules are fixed, which leads to a much larger number of entries. Linux also includes some floating rules, typically for future years.

Another difference: Windows stores transition times in **local time**, while Linux stores them in **UTC**. Since the sources differ, .NET does not normalize this when reading the data.

### Conversion process

When converting time between zones, .NET:

1. Checks whether the zone supports daylight saving time.
2. Locates the appropriate rule for the target year.

   * For floating rules, the exact transition dates are calculated (e.g., Pacific Standard Time in 2025 transitions on March 9 at 2:00 AM and November 2 at 2:00 AM).
3. Applies the rule to perform the conversion.

   * If the conversion crosses year boundaries, rules from adjacent years may also need to be consulted.
   * Special cases exist for southern hemisphere zones, where DST may be active at the start and end of the year, with standard time only in the middle. In these cases, a single year can include multiple transitions.

### Summary

The conversion process involves significant computation, especially on Linux, where the number of rules per time zone is much higher.

## The Change

We are introducing a **per-year cache** to store time zone transitions. This cache is created on-demand—only when a given year is accessed—and contains all possible transitions for that year.

Each cache entry includes:

* A list of all transitions within the year.
* The corresponding time offsets for each transition.
* A flag indicating whether the period is daylight saving or standard time.
* All date/times stored in **UTC**, ensuring consistency during conversions.

With this approach, time conversion requires only a **single cache lookup**, without repeatedly consulting the underlying rules. The cache mapping is stored in a **concurrent dictionary**, allowing efficient thread-safe access.

### Benefits

* **Performance**: Eliminates repeated rule lookups by reusing cached transitions.
* **Simplicity**: Conversion logic now uses helper methods backed by the cache, replacing the more complex rule-based path.
* **Compatibility**: Care was taken to maintain application compatibility, particularly for cases where conversion behavior depends on `DateTime.Kind`.

In other words, rules are used only when building a new cache entry; once cached, all conversions run through the simplified lookup path.

**Note:** In typical scenarios, users work with only a small range of years for time conversions, so the cache should not pose any issues. For extreme cases, developers can clear the cache using `TimeZoneInfo.ClearCachedData`.

## Testing

* Performed extensive **manual testing** on both Windows and Linux, validating nearly every second across all supported years and time zones.
* Verified that all **regression tests** pass successfully on Windows and Linux, ensuring compatibility.
* Added **new test cases** to cover previously reported issues that are now resolved with this change.
* Conducted **performance measurements** for various time zone operations, including `DateTime.Now`.

## Performance results

### Windows 

```
BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.6584/24H2/2024Update/HudsonValley)
11th Gen Intel Core i7-11700 2.50GHz, 1 CPU, 16 logical and 8 physical cores
```


| Faster                                               | base/diff | Base Median (ns) | Diff Median (ns) |
| ---------------------------------------------------- | ---------:| ----------------:| ----------------:|
| Baseline.Program.ConvertTimeFromUtc                  |      3.93 |            47.97 |            12.21 |
| Baseline.Program.ConvertTimeUsingLocalDateKind       |      3.47 |            66.70 |            19.21 |
| Baseline.Program.ConvertTimeUsingUnspecifiedDateKind |      3.34 |            63.77 |            19.07 |
| Baseline.Program.ConvertTimeToUtc                    |      2.98 |            48.33 |            16.23 |
| Baseline.Program.DateTimeNow                         |      2.81 |            54.57 |            19.42 |
| Baseline.Program.GetUtcOffset                        |      2.48 |            98.64 |            39.83 |
| Baseline.Program.ConvertTimeUsingUtcDateKind         |      2.39 |            19.66 |             8.23 |


### Linux (WSL)

```
BenchmarkDotNet v0.15.2, Linux Ubuntu 25.04 (Plucky Puffin)
11th Gen Intel Core i7-11700 2.50GHz, 1 CPU, 16 logical and 8 physical cores
```

| Faster                                               | base/diff | Base Median (ns) | Diff Median (ns) |
| ---------------------------------------------------- | ---------:| ----------------:| ----------------:|
| Baseline.Program.ConvertTimeToUtc                    |      4.70 |            63.80 |            13.57 |
| Baseline.Program.ConvertTimeUsingLocalDateKind       |      4.25 |            80.09 |            18.84 |
| Baseline.Program.ConvertTimeUsingUnspecifiedDateKind |      4.01 |            79.23 |            19.78 |
| Baseline.Program.ConvertTimeFromUtc                  |      3.54 |            39.34 |            11.12 |
| Baseline.Program.DateTimeNow                         |      3.51 |            50.99 |            14.54 |
| Baseline.Program.GetUtcOffset                        |      2.87 |           100.40 |            34.94 |
| Baseline.Program.ConvertTimeUsingUtcDateKind         |      1.64 |            17.60 |            10.73 |

## Opportunities

This change opens the door to several improvements:

* **API simplification**: We could refine our APIs to offer a more streamlined experience. While we already recommend using `DateTimeOffset` instead of `DateTime` for time zone scenarios, many developers still rely on `DateTime` and often run into issues related to `DateTime.Kind`. A cleaner API surface could help mitigate these problems.
* **Additional data sources**: With the new caching approach, we could more easily support alternative time zone data sources, such as ICU, to improve coverage on Windows. The main challenge would be exposing rules through existing APIs, though these rules would no longer be required for computation.

Fixes #24839, #24277, #25075, #118915, #114476

