### PR TITLE
[interp] Null-check calli function pointers + interp diagnostics

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -46,6 +46,11 @@ static const char *g_stackTypeString[] = { "I4", "I8", "R4", "R8", "O ", "VT", "
 const char* CorInfoHelperToName(CorInfoHelpFunc helper);
 
 /*****************************************************************************/
+bool IsInterpDumpActive()
+{
+    return t_interpDump;
+}
+
 void AssertOpCodeNotImplemented(const uint8_t *ip, size_t offset)
 {
     fprintf(stderr, "IL_%04x %-10s - opcode not supported yet\n",

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -156,13 +156,19 @@ void CILInterp::setTargetOS(CORINFO_OS os)
 {
 }
 
+bool IsInterpDumpActive();
+
 INTERPRETER_NORETURN void NO_WAY(const char* message)
 {
+    if (IsInterpDumpActive())
+        printf("Error during interpreter method compilation: %s\n", message ? message : "unknown error");
     throw InterpException(message, CORJIT_INTERNALERROR);
 }
 
 INTERPRETER_NORETURN void BADCODE(const char* message)
 {
+    if (IsInterpDumpActive())
+        printf("Error during interpreter method compilation: %s\n", message ? message : "unknown error");
     throw InterpException(message, CORJIT_BADCODE);
 }
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -740,9 +740,13 @@ MAIN_LOOP:
                     ip++;
                     break;
                 case INTOP_STORESTUBCONTEXT:
-                    LOCAL_VAR(ip[1], void*) = GetMostRecentUMEntryThunkData();
+                {
+                    void *thunkData = GetMostRecentUMEntryThunkData();
+                    assert(thunkData);
+                    LOCAL_VAR(ip[1], void*) = thunkData;
                     ip += 2;
                     break;
+                }
                 case INTOP_LDC_I4:
                     LOCAL_VAR(ip[1], int32_t) = ip[2];
                     ip += 3;
@@ -2284,21 +2288,23 @@ MAIN_LOOP:
                     // Save current execution state for when we return from called method
                     pFrame->ip = ip;
 
+                    PCODE calliFunctionPointer = LOCAL_VAR(calliFunctionPointerVar, PCODE);
+                    assert(calliFunctionPointer);
+
                     // Interpreter-FIXME: isTailcall
                     if (flags & (int32_t)CalliFlags::PInvoke)
                     {
                         if (flags & (int32_t)CalliFlags::SuppressGCTransition)
                         {
-                            InvokeUnmanagedCalli(LOCAL_VAR(calliFunctionPointerVar, PCODE), cookie, callArgsAddress, returnValueAddress);
+                            InvokeUnmanagedCalli(calliFunctionPointer, cookie, callArgsAddress, returnValueAddress);
                         }
                         else
                         {
-                            InvokeUnmanagedCalliWithTransition(LOCAL_VAR(calliFunctionPointerVar, PCODE), cookie, stack, pFrame, callArgsAddress, returnValueAddress);
+                            InvokeUnmanagedCalliWithTransition(calliFunctionPointer, cookie, stack, pFrame, callArgsAddress, returnValueAddress);
                         }
                     }
                     else
                     {
-                        PCODE calliFunctionPointer = LOCAL_VAR(calliFunctionPointerVar, PCODE);
 #ifdef FEATURE_PORTABLE_ENTRYPOINTS
                         // WASM-TODO: We may end up here with native JIT helper entrypoint without MethodDesc
                         // that CALL_INTERP_METHOD is not able to handle. This is a potential problem for

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7688,6 +7688,17 @@ InterpThreadContext* Thread::GetInterpThreadContext()
 {
     WRAPPER_NO_CONTRACT;
 
+    // HACK: FIXME: InterpreterStub can be called on a native thread with no managed Thread,
+    //  and when this happens it calls us with a null thisptr in order to populate everything
+    if (this == nullptr)
+    {
+        _ASSERTE(GetThreadNULLOk() == NULL);
+        Thread *actualThread = SetupThreadNoThrow();
+        if (actualThread == NULL)
+            COMPlusThrow(kOutOfMemoryException);
+        return actualThread->GetInterpThreadContext();
+    }
+
     if (m_pInterpThreadContext == nullptr)
     {
         m_pInterpThreadContext = new (nothrow) InterpThreadContext();

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7688,17 +7688,6 @@ InterpThreadContext* Thread::GetInterpThreadContext()
 {
     WRAPPER_NO_CONTRACT;
 
-    // HACK: FIXME: InterpreterStub can be called on a native thread with no managed Thread,
-    //  and when this happens it calls us with a null thisptr in order to populate everything
-    if (this == nullptr)
-    {
-        _ASSERTE(GetThreadNULLOk() == NULL);
-        Thread *actualThread = SetupThreadNoThrow();
-        if (actualThread == NULL)
-            COMPlusThrow(kOutOfMemoryException);
-        return actualThread->GetInterpThreadContext();
-    }
-
     if (m_pInterpThreadContext == nullptr)
     {
         m_pInterpThreadContext = new (nothrow) InterpThreadContext();


### PR DESCRIPTION
A check failure in baseservices\invalid_operations\InvalidOperations revealed that we need to do this, I think. This doesn't fix the test though, something else is wrong with it.

The reason the calli ptr is null is that the stubcontext value is null, so I also updated the interpreter to fail-fast when this happens - it should never be null.

Also adds some interp diagnostics so that if BADCODE() aborts compilation on a method we're dumping, we print the failure reason to the console.