### PR TITLE
[clr-interp] Make the INTERP_DUMP macro useable throughout the compiler

### DIFF
--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -184,9 +184,26 @@ enum InterpType {
 };
 
 #ifdef DEBUG
+extern thread_local bool t_interpDump;
+
+class InterpDumpScope
+{
+    bool m_prev;
+    public:
+    InterpDumpScope(bool enable)
+    {
+        m_prev = t_interpDump;
+        t_interpDump = enable;
+    }
+    ~InterpDumpScope()
+    {
+        t_interpDump = m_prev;
+    }
+};
+
 #define INTERP_DUMP(...)            \
     {                               \
-        if (m_verbose)              \
+        if (t_interpDump)           \
             printf(__VA_ARGS__);    \
     }
 #else
@@ -448,6 +465,9 @@ class InterpCompiler
     friend class InterpGcSlotAllocator;
 
 private:
+#ifdef DEBUG
+    InterpDumpScope m_dumpScope;
+#endif
     CORINFO_METHOD_HANDLE m_methodHnd;
     CORINFO_MODULE_HANDLE m_compScopeHnd;
     COMP_HANDLE m_compHnd;
@@ -489,12 +509,6 @@ private:
     CORINFO_CLASS_HANDLE m_classHnd;
 #ifdef DEBUG
     TArray<char, MallocAllocator> m_methodName;
-#ifdef TARGET_WASM
-    // enable verbose output on wasm temporarily
-    bool m_verbose = true;
-#else
-    bool m_verbose = false;
-#endif // TARGET_WASM
 
     const char* PointerIsClassHandle = (const char*)0x1;
     const char* PointerIsMethodHandle = (const char*)0x2;

--- a/src/coreclr/interpreter/compileropt.cpp
+++ b/src/coreclr/interpreter/compileropt.cpp
@@ -310,7 +310,7 @@ void InterpCompiler::AllocOffsets()
                 continue;
 
 #ifdef DEBUG
-            if (m_verbose)
+            if (t_interpDump)
             {
                 printf("\tins_index %d\t", insIndex);
                 PrintIns(pIns);
@@ -376,7 +376,7 @@ void InterpCompiler::AllocOffsets()
             }
 
 #ifdef DEBUG
-            if (m_verbose)
+            if (t_interpDump)
             {
                 printf("active vars:");
                 for (int i = 0; i < m_pActiveVars->GetSize(); i++)


### PR DESCRIPTION
When implementing some recent work, I wanted to use INTERP_DUMP in a helper class, but that required that I make some ugly changes to pass around the m_verbose flag. This change reverts those odd changes, and instead uses a thread local static to control dumping behavior.