### PR TITLE
Backport macOS 26 Tahoe test fixes to release/9.0-staging

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -44,6 +44,7 @@ namespace System
         public static bool IsNotMacOsAppleSilicon => !IsMacOsAppleSilicon;
         public static bool IsAppSandbox => Environment.GetEnvironmentVariable("APP_SANDBOX_CONTAINER_ID") != null;
         public static bool IsNotAppSandbox => !IsAppSandbox;
+        public static bool IsApplePlatform26OrLater => IsApplePlatform && Environment.OSVersion.Version.Major >= 26;
 
         public static Version OpenSslVersion => !IsApplePlatform && !IsWindows && !IsAndroid ?
             GetOpenSslVersion() :

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -288,13 +288,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                     // Check some known conditions.
 
-                    if (PlatformDetection.UsesAppleCrypto)
-                    {
-                        Assert.Equal(3, chain.ChainElements.Count);
-                    }
-                    else if (OperatingSystem.IsLinux())
+                    if (OperatingSystem.IsLinux() || PlatformDetection.IsApplePlatform26OrLater)
                     {
                         Assert.Equal(2, chain.ChainElements.Count);
+                    }
+                    else if (PlatformDetection.IsApplePlatform)
+                    {
+                        Assert.Equal(3, chain.ChainElements.Count);
                     }
                 }
             }
@@ -1179,12 +1179,12 @@ yY1kePIfwE+GFWvagZ2ehANB/6LgBTT8jFhR95Tw2oE3N0I=");
                 chain.ChainPolicy.ExtraStore.Add(intermediateCert);
                 Assert.False(chain.Build(cert));
 
-                if (PlatformDetection.IsAndroid)
+                if (PlatformDetection.IsAndroid || PlatformDetection.IsApplePlatform26OrLater)
                 {
                     // Android always validates trust as part of building a path,
                     // so violations comes back as PartialChain with no elements
+                    // Apple 26 no longer block these SKIs since the roots are no longer trusted at all and are expired.
                     Assert.Equal(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
-                    Assert.Equal(0, chain.ChainElements.Count);
                 }
                 else
                 {


### PR DESCRIPTION
Backport dotnet/runtime#118652
Backport dotnet/runtime#118777

## Customer Impact

None, test only change. 

## Regression

- [ ] Yes
- [X] No

## Testing

These tests were failing against macOS 26 RC. They now pass against macOS 26 RC.

## Risk

None, test only change.