### PR TITLE
Fix check for recursion in calls to AppContext.OnUnhandledException

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -113,7 +113,7 @@ namespace System
             }
             else
             {
-                if (s_crashingThreadId == previousCrashingThreadId)
+                if (s_crashingThreadId == currentThreadId)
                 {
                     Environment.FailFast("OnUnhandledException called recursively");
                 }


### PR DESCRIPTION
The check is not correct and results in FailFast when a second thread tries to call this method. The `previousCrashingThreadId` is always the `s_crashingThreadId` for the second and following threads hitting this method. The correct check is to compare the `currentThreadId` with the `s_crashingThreadId`.

Close #119731