### PR TITLE
Remove suppression of PreSharp 56500

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaImporter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaImporter.cs
@@ -60,7 +60,6 @@ namespace System.Runtime.Serialization
             {
                 CompileSchemaSet(_schemaSet);
             }
-#pragma warning suppress 56500 // covered by FxCOP
             catch (Exception ex) when (!ExceptionUtility.IsFatal(ex))
             {
                 throw new ArgumentException(SR.Format(SR.CannotImportInvalidSchemas), ex);

--- a/src/libraries/System.Speech/src/Internal/SapiInterop/SapiProxy.cs
+++ b/src/libraries/System.Speech/src/Internal/SapiInterop/SapiProxy.cs
@@ -106,8 +106,6 @@ namespace System.Speech.Internal.SapiInterop
             #endregion
         }
 
-#pragma warning disable 56500 // Remove all the catch all statements warnings used by the interop layer
-
         internal class MTAThread : SapiProxy, IDisposable
         {
             #region Constructors

--- a/src/libraries/System.Speech/src/Internal/SrgsCompiler/AppDomainGrammarProxy.cs
+++ b/src/libraries/System.Speech/src/Internal/SrgsCompiler/AppDomainGrammarProxy.cs
@@ -10,8 +10,6 @@ using System.Text;
 
 #endregion
 
-#pragma warning disable 56500 // Remove all the catch all statements warnings used by the interop layer
-
 namespace System.Speech.Internal.SrgsCompiler
 {
     internal class AppDomainGrammarProxy : MarshalByRefObject

--- a/src/libraries/System.Speech/src/Internal/Synthesis/EngineSiteSapi.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/EngineSiteSapi.cs
@@ -7,8 +7,6 @@ using System.Runtime.InteropServices.ComTypes;
 using System.Speech.Internal.SapiInterop;
 using System.Speech.Synthesis.TtsEngine;
 
-#pragma warning disable 56500 // Remove all the catch all statements warnings used by the interop layer
-
 namespace System.Speech.Internal.Synthesis
 {
     [ComVisible(true)]

--- a/src/libraries/System.Speech/src/Recognition/Grammar.cs
+++ b/src/libraries/System.Speech/src/Recognition/Grammar.cs
@@ -13,8 +13,6 @@ using System.Speech.Internal.SrgsCompiler;
 using System.Speech.Recognition.SrgsGrammar;
 using System.Text;
 
-#pragma warning disable 56500 // Remove all the catch all statements warnings used by the interop layer
-
 namespace System.Speech.Recognition
 {
     // Class for grammars which are to be loaded from SRGS or CFG.

--- a/src/libraries/System.Speech/src/Recognition/RecognizerBase.cs
+++ b/src/libraries/System.Speech/src/Recognition/RecognizerBase.cs
@@ -1687,8 +1687,6 @@ ISpGrammarResourceLoader
             ActivateRule(sapiGrammar, uri, ruleName);
         }
 
-        // Method called on background thread to do actual grammar loading.
-#pragma warning disable 56500 // Transferring exceptions to another thread
         private void LoadGrammarAsyncCallback(object grammarObject)
         {
             Debug.WriteLine("Loading grammar asynchronously.");
@@ -1750,8 +1748,6 @@ ISpGrammarResourceLoader
                 _asyncWorkerUI.PostOperation(new WaitCallback(LoadGrammarAsyncCompletedCallback), grammarObject);
             }
         }
-
-#pragma warning restore 56500
 
         // Method called by AsyncOperationManager on appropriate thread when async grammar loading completes.
         private void LoadGrammarAsyncCompletedCallback(object grammarObject)
@@ -1995,9 +1991,6 @@ ISpGrammarResourceLoader
             }
         }
 
-        // Method called on background thread {from RecognizeAsync} to start recognition process.
-#pragma warning disable 56500 // Transferring exceptions to another thread
-
         private void RecognizeAsyncWaitForGrammarsToLoad(object unused)
         {
             Debug.WriteLine("Waiting for any pending grammar loads to complete.");
@@ -2066,7 +2059,6 @@ ISpGrammarResourceLoader
                 _asyncWorkerUI.PostOperation(new WaitCallback(RecognizeAsyncWaitForGrammarsToLoadFailed), eventArgs);
             }
         }
-#pragma warning restore 56500
 
         // Method called on app thread model used to fire the RecognizeCompelted event args if recognition stopped prematurely
         private void RecognizeAsyncWaitForGrammarsToLoadFailed(object eventArgs)

--- a/src/libraries/System.Speech/src/Recognition/RecognizerBase.cs
+++ b/src/libraries/System.Speech/src/Recognition/RecognizerBase.cs
@@ -1687,6 +1687,7 @@ ISpGrammarResourceLoader
             ActivateRule(sapiGrammar, uri, ruleName);
         }
 
+        // Method called on background thread to do actual grammar loading.
         private void LoadGrammarAsyncCallback(object grammarObject)
         {
             Debug.WriteLine("Loading grammar asynchronously.");
@@ -1991,6 +1992,7 @@ ISpGrammarResourceLoader
             }
         }
 
+        // Method called on background thread {from RecognizeAsync} to start recognition process.
         private void RecognizeAsyncWaitForGrammarsToLoad(object unused)
         {
             Debug.WriteLine("Waiting for any pending grammar loads to complete.");

--- a/src/libraries/System.Speech/src/Recognition/SrgsGrammar/SrgsGrammar.cs
+++ b/src/libraries/System.Speech/src/Recognition/SrgsGrammar/SrgsGrammar.cs
@@ -8,8 +8,6 @@ using System.Speech.Internal;
 using System.Speech.Internal.SrgsParser;
 using System.Xml;
 
-#pragma warning disable 56500 // Remove all the catch all statements warnings used by the interop layer
-
 namespace System.Speech.Recognition.SrgsGrammar
 {
     [Serializable]

--- a/src/libraries/System.Speech/src/Result/RecognizedPhrase.cs
+++ b/src/libraries/System.Speech/src/Result/RecognizedPhrase.cs
@@ -15,8 +15,6 @@ using System.Text;
 using System.Xml;
 using System.Xml.XPath;
 
-#pragma warning disable 56500 // Remove all the catch all statements warnings used by the interop layer
-
 namespace System.Speech.Recognition
 {
     [Serializable]


### PR DESCRIPTION
Remove suppression of obsolete PreSharp error 56500: Avoid swallowing errors by catching non-specific exceptions
