### PR TITLE
[mono] Actually free dynamic methods, even if we have profiler attached

### DIFF
--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1371,10 +1371,6 @@ mono_free_method  (MonoMethod *method)
 
 	MONO_PROFILER_RAISE (method_free, (method));
 
-	/* FIXME: This hack will go away when the profiler will support freeing methods */
-	if (G_UNLIKELY (mono_profiler_installed ()))
-		return;
-
 	if (method->signature) {
 		/*
 		 * FIXME: This causes crashes because the types inside signatures and


### PR DESCRIPTION
Ever since the early days of mono, freeing dynamic methods was disabled if a profiler was attached. The reason for this was probably that the profiler might store `MonoMethod` instances in its own data, leading to problems if we free those instances. Looking at the profilers nowadays it is not clear where patterns like this would happen. Profilers that do store methods (like aot, coverage), don't process wrapper methods, so we should be safe since dynamic methods have the MONO_WRAPPER_DYNAMIC_METHOD wrapper type.

The problem is that, nowadays, we can always have a profiler attached even if no actual profiling happens. macios for example always calls mono_profiler_install. I belive actual callbacks can be added later as necessary.