### PR TITLE
[mono][interp] Avoid leaving around pages without access

### DIFF
--- a/src/mono/mono/utils/mono-threads-posix.c
+++ b/src/mono/mono/utils/mono-threads-posix.c
@@ -296,14 +296,15 @@ mono_memory_barrier_process_wide (void)
 	// Changing a helper memory page protection from read / write to no access
 	// causes the OS to issue IPI to flush TLBs on all processors. This also
 	// results in flushing the processor buffers.
-	status = mono_mprotect (memory_barrier_process_wide_helper_page, mono_pagesize (), MONO_MMAP_READ | MONO_MMAP_WRITE);
-	g_assert (status == 0);
 
 	// Ensure that the page is dirty before we change the protection so that
 	// we prevent the OS from skipping the global TLB flush.
 	__sync_add_and_fetch ((size_t*)memory_barrier_process_wide_helper_page, 1);
 
 	status = mono_mprotect (memory_barrier_process_wide_helper_page, mono_pagesize (), MONO_MMAP_NONE);
+	g_assert (status == 0);
+
+	status = mono_mprotect (memory_barrier_process_wide_helper_page, mono_pagesize (), MONO_MMAP_READ | MONO_MMAP_WRITE);
 	g_assert (status == 0);
 
 	status = pthread_mutex_unlock (&memory_barrier_process_wide_mutex);

--- a/src/mono/mono/utils/mono-threads-posix.c
+++ b/src/mono/mono/utils/mono-threads-posix.c
@@ -304,6 +304,9 @@ mono_memory_barrier_process_wide (void)
 	status = mono_mprotect (memory_barrier_process_wide_helper_page, mono_pagesize (), MONO_MMAP_NONE);
 	g_assert (status == 0);
 
+	// We expected the protection change above to have triggered the memory barrier.
+	// We now undo the protection change so that memory allocation profilers don't
+	// get confused by this memory lacking access permissions (ex with Instruments).
 	status = mono_mprotect (memory_barrier_process_wide_helper_page, mono_pagesize (), MONO_MMAP_READ | MONO_MMAP_WRITE);
 	g_assert (status == 0);
 


### PR DESCRIPTION
Otherwise it would crash instruments when trying to access it. This impacts mostly interpreter because we have the memory barrier call in `sgen_client_scan_thread_data` when interpreter is enabled.

Fixes https://github.com/dotnet/runtime/issues/90394