### PR TITLE
[release/10.0] Set IDE0031 to suggestion in eng/CodeAnalysis.src.globalconfig

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1667,7 +1667,7 @@ dotnet_diagnostic.IDE0029.severity = warning
 dotnet_diagnostic.IDE0030.severity = warning
 
 # IDE0031: Use null propagation
-dotnet_diagnostic.IDE0031.severity = warning
+dotnet_diagnostic.IDE0031.severity = suggestion
 
 # IDE0032: Use auto property
 dotnet_diagnostic.IDE0032.severity = silent


### PR DESCRIPTION
Alternative solution for the backport of https://github.com/dotnet/runtime/pull/119722

Instead of backporting fixing the IDE0031 which is a quite large change we just turn the severity into `suggestion`.

## Customer Impact

- [X] Customer reported
- [X] Found internally

There's a Roslyn bug where the `suggestion` severity for `dotnet_style_null_propagation` in .editorconfig incorrectly overrides the IDE0031 `warning` severity set in eng/CodeAnalysis.src.globalconfig on some machines only (root cause is currently being investigated in https://github.com/dotnet/roslyn/issues/80301).

This causes build breaks on machines where this doesn't happen and the IDE0031 warning severity is active.

## Regression

- [ ] Yes
- [X] No

## Testing

The CI build verifies this works.

## Risk

Low. This just turns an analyzer code style finding from warning to suggestion.