### PR TITLE
Add missing nullability annotation to `Unsafe.As(Object)`

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
@@ -27,7 +27,7 @@ namespace Internal.Runtime
         public T? TryAllocateObject<T>() where T : class
         {
             MethodTable* pMT = MethodTable.Of<T>();
-            return Unsafe.As<T?>(TryAllocateObject(pMT, pMT->BaseSize));
+            return Unsafe.As<T>(TryAllocateObject(pMT, pMT->BaseSize));
         }
 
         private object? TryAllocateObject(MethodTable* type, nuint objectSize)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -156,7 +156,7 @@ namespace System.Runtime.InteropServices
 
             foreach (GCHandle weakNativeObjectWrapperHandle in s_referenceTrackerNativeObjectWrapperCache)
             {
-                ReferenceTrackerNativeObjectWrapper? nativeObjectWrapper = Unsafe.As<ReferenceTrackerNativeObjectWrapper?>(weakNativeObjectWrapperHandle.Target);
+                ReferenceTrackerNativeObjectWrapper? nativeObjectWrapper = Unsafe.As<ReferenceTrackerNativeObjectWrapper>(weakNativeObjectWrapperHandle.Target);
                 if (nativeObjectWrapper != null &&
                     nativeObjectWrapper.TrackerObject != IntPtr.Zero)
                 {
@@ -183,7 +183,7 @@ namespace System.Runtime.InteropServices
         {
             foreach (GCHandle weakNativeObjectWrapperHandle in s_referenceTrackerNativeObjectWrapperCache)
             {
-                ReferenceTrackerNativeObjectWrapper? nativeObjectWrapper = Unsafe.As<ReferenceTrackerNativeObjectWrapper?>(weakNativeObjectWrapperHandle.Target);
+                ReferenceTrackerNativeObjectWrapper? nativeObjectWrapper = Unsafe.As<ReferenceTrackerNativeObjectWrapper>(weakNativeObjectWrapperHandle.Target);
                 if (nativeObjectWrapper != null &&
                     nativeObjectWrapper.TrackerObject != IntPtr.Zero &&
                     !RuntimeImports.RhIsPromoted(nativeObjectWrapper.ProxyHandle.Target))

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/SharedArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/SharedArrayPool.cs
@@ -60,7 +60,7 @@ namespace System.Buffers
             SharedArrayPoolThreadLocalArray[]? tlsBuckets = t_tlsBuckets;
             if (tlsBuckets is not null && (uint)bucketIndex < (uint)tlsBuckets.Length)
             {
-                buffer = Unsafe.As<T[]?>(tlsBuckets[bucketIndex].Array);
+                buffer = Unsafe.As<T[]>(tlsBuckets[bucketIndex].Array);
                 if (buffer is not null)
                 {
                     tlsBuckets[bucketIndex].Array = null;
@@ -79,7 +79,7 @@ namespace System.Buffers
                 SharedArrayPoolPartitions? b = perCoreBuckets[bucketIndex];
                 if (b is not null)
                 {
-                    buffer = Unsafe.As<T[]?>(b.TryPop());
+                    buffer = Unsafe.As<T[]>(b.TryPop());
                     if (buffer is not null)
                     {
                         if (log.IsEnabled())

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -737,7 +737,7 @@ namespace System.Collections.Generic
             internal static IAlternateEqualityComparer<TAlternateKey, TKey> GetAlternateComparer(Dictionary<TKey, TValue> dictionary)
             {
                 Debug.Assert(IsCompatibleKey(dictionary));
-                return Unsafe.As<IAlternateEqualityComparer<TAlternateKey, TKey>>(dictionary._comparer);
+                return Unsafe.As<IAlternateEqualityComparer<TAlternateKey, TKey>>(dictionary._comparer)!;
             }
 
             /// <summary>Gets the value associated with the specified alternate key.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -444,7 +444,7 @@ namespace System.Collections.Generic
             internal static IAlternateEqualityComparer<TAlternate, T> GetAlternateComparer(HashSet<T> set)
             {
                 Debug.Assert(IsCompatibleItem(set));
-                return Unsafe.As<IAlternateEqualityComparer<TAlternate, T>>(set._comparer);
+                return Unsafe.As<IAlternateEqualityComparer<TAlternate, T>>(set._comparer)!;
             }
 
             /// <summary>Adds the specified element to a set.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/ComAwareWeakReference.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ComAwareWeakReference.cs
@@ -112,7 +112,7 @@ namespace System
                 if (_comInfo != null)
                 {
                     // Check if the target is still null
-                    target = Unsafe.As<T?>(GCHandle.InternalGet(_weakHandle));
+                    target = Unsafe.As<T>(GCHandle.InternalGet(_weakHandle));
                     if (target == null)
                     {
                         // Resolve and reset. Perform runtime cast to catch bugs

--- a/src/libraries/System.Private.CoreLib/src/System/ComAwareWeakReference.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ComAwareWeakReference.cs
@@ -146,14 +146,14 @@ namespace System
                 GC.SuppressFinalize(newRef);
             }
 
-            return Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits));
+            return Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits)!);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ComAwareWeakReference GetFromTaggedReference(nint taggedHandle)
         {
             Debug.Assert((taggedHandle & ComAwareBit) != 0);
-            return Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits));
+            return Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits)!);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -161,7 +161,7 @@ namespace System
         {
             ComAwareWeakReference comAwareRef = comInfo != null ?
                 EnsureComAwareReference(ref taggedHandle) :
-                Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits));
+                Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits)!);
 
             comAwareRef.SetTarget(target, comInfo);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -683,7 +683,7 @@ namespace System.Runtime.CompilerServices
                     if (oKey != null)
                     {
                         key = Unsafe.As<TKey>(oKey);
-                        value = Unsafe.As<TValue>(oValue);
+                        value = Unsafe.As<TValue>(oValue!);
                         return true;
                     }
                 }
@@ -711,7 +711,7 @@ namespace System.Runtime.CompilerServices
                 if (entryIndex != -1)
                 {
                     RemoveIndex(entryIndex);
-                    value = Unsafe.As<TValue>(valueObject);
+                    value = Unsafe.As<TValue>(valueObject!);
                     return true;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -61,7 +61,7 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [return: NotNullIfNotNull(nameof(o))]
-        public static T As<T>(object? o) where T : class?
+        public static T? As<T>(object? o) where T : class?
         {
             throw new PlatformNotSupportedException();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.T.cs
@@ -49,7 +49,7 @@ namespace System.Runtime.InteropServices
                 IntPtr handle = _handle;
                 GCHandle.CheckUninitialized(handle);
                 // Skip the type check to provide lowest overhead.
-                return Unsafe.As<T>(GCHandle.InternalGet(handle));
+                return Unsafe.As<T>(GCHandle.InternalGet(handle)!);
             }
             set
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PinnedGCHandle.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PinnedGCHandle.T.cs
@@ -51,7 +51,7 @@ namespace System.Runtime.InteropServices
                 IntPtr handle = _handle;
                 GCHandle.CheckUninitialized(handle);
                 // Skip the type check to provide lowest overhead.
-                return Unsafe.As<T>(GCHandle.InternalGet(handle));
+                return Unsafe.As<T>(GCHandle.InternalGet(handle)!);
             }
             set
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
@@ -72,7 +72,7 @@ namespace System.Runtime.InteropServices
             {
                 foreach (GCHandle weakNativeObjectWrapperHandle in s_referenceTrackerNativeObjectWrapperCache)
                 {
-                    ReferenceTrackerNativeObjectWrapper? nativeObjectWrapper = Unsafe.As<ReferenceTrackerNativeObjectWrapper?>(weakNativeObjectWrapperHandle.Target);
+                    ReferenceTrackerNativeObjectWrapper? nativeObjectWrapper = Unsafe.As<ReferenceTrackerNativeObjectWrapper>(weakNativeObjectWrapperHandle.Target);
                     if (nativeObjectWrapper != null &&
                         nativeObjectWrapper._contextToken == contextToken)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/WeakGCHandle.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/WeakGCHandle.T.cs
@@ -53,7 +53,7 @@ namespace System.Runtime.InteropServices
             IntPtr handle = _handle;
             GCHandle.CheckUninitialized(handle);
             // Skip the type check to provide lowest overhead.
-            T? obj = Unsafe.As<T?>(GCHandle.InternalGet(handle));
+            T? obj = Unsafe.As<T>(GCHandle.InternalGet(handle));
             target = obj;
             return obj != null;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
@@ -219,7 +219,7 @@ namespace System.Threading
         [NonVersionable]
         [return: NotNullIfNotNull(nameof(location))]
         public static T Read<T>([NotNullIfNotNull(nameof(location))] ref readonly T location) where T : class? =>
-            Unsafe.As<T>(Unsafe.As<T, VolatileObject>(ref Unsafe.AsRef(in location)).Value);
+            Unsafe.As<T>(Unsafe.As<T, VolatileObject>(ref Unsafe.AsRef(in location)).Value)!;
 
         [Intrinsic]
         [NonVersionable]

--- a/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
@@ -143,7 +143,7 @@ namespace System
                 {
                     ComAwareWeakReference cwr = ComAwareWeakReference.GetFromTaggedReference(th);
 
-                    target = Unsafe.As<T?>(cwr.Target) ?? cwr.RehydrateTarget<T>();
+                    target = Unsafe.As<T>(cwr.Target) ?? cwr.RehydrateTarget<T>();
 
                     // must keep the instance alive as long as we use the handle.
                     GC.KeepAlive(this);
@@ -154,9 +154,9 @@ namespace System
 
                 // unsafe cast is ok as the handle cannot be destroyed and recycled while we keep the instance alive
 #if FEATURE_JAVAMARSHAL
-                target = Unsafe.As<T?>(GCHandle.InternalGetBridgeWait(th));
+                target = Unsafe.As<T>(GCHandle.InternalGetBridgeWait(th));
 #else
-                target = Unsafe.As<T?>(GCHandle.InternalGet(th));
+                target = Unsafe.As<T>(GCHandle.InternalGet(th));
 #endif
 
                 // must keep the instance alive as long as we use the handle.


### PR DESCRIPTION
The annotation was present in the reference assembly but not the implementation.