### PR TITLE
[release/10.0] [QUIC] Update Windows MsQuic

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -149,7 +149,7 @@
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>9.0.0-preview-20241010.1</MicrosoftPrivateIntellisenseVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.8</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.15</MicrosoftNativeQuicMsQuicSchannelVersion>
     <SystemNetMsQuicTransportVersion>9.0.0-alpha.1.24167.3</SystemNetMsQuicTransportVersion>
     <!-- emscripten / Node
          Note: when the name is updated, make sure to update dependency name in eng/pipelines/common/xplat-setup.yml


### PR DESCRIPTION
Backport of #119747 to release/10.0

## Customer Impact

- [ ] Customer reported
- [x] Found internally

Updates MsQuic library in released Windows runtime. The MsQuic change introduced the /PROFILE flag which adds extra debug information.

## Regression

- [ ] Yes
- [x] No

## Testing

CI.

## Risk

Low, major and minor are the same.
