### PR TITLE
Remove suppression of PreSharp 56503

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -101,10 +101,7 @@ namespace System.Runtime.Serialization.Json
         // The encoding conversion and buffering breaks seeking.
         public override long Position
         {
-            get
-            {
-                throw new NotSupportedException();
-            }
+            get { throw new NotSupportedException(); }
             set { throw new NotSupportedException(); }
         }
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -103,7 +103,6 @@ namespace System.Runtime.Serialization.Json
         {
             get
             {
-#pragma warning suppress 56503 // The contract for non seekable stream is to throw exception
                 throw new NotSupportedException();
             }
             set { throw new NotSupportedException(); }


### PR DESCRIPTION
Remove suppression of PreSharp 56503: Property get methods should not throw exceptions.
