### PR TITLE
Suppress IDE0060 breaking local builds

### DIFF
--- a/src/libraries/Common/src/Internal/VersionResilientHashCode.cs
+++ b/src/libraries/Common/src/Internal/VersionResilientHashCode.cs
@@ -20,14 +20,13 @@ namespace Internal
             private int _hash2;
             private int _numCharactersHashed;
 
-#pragma warning disable IDE0060
             public HashCodeBuilder(ReadOnlySpan<byte> seed)
             {
                 _hash1 = 0x6DA3B944;
                 _hash2 = 0;
                 _numCharactersHashed = 0;
+                Append(seed);
             }
-#pragma warning restore IDE0060
 
             public void Append(ReadOnlySpan<byte> src)
             {

--- a/src/libraries/Common/src/Internal/VersionResilientHashCode.cs
+++ b/src/libraries/Common/src/Internal/VersionResilientHashCode.cs
@@ -20,12 +20,14 @@ namespace Internal
             private int _hash2;
             private int _numCharactersHashed;
 
+#pragma warning disable IDE0060
             public HashCodeBuilder(ReadOnlySpan<byte> seed)
             {
                 _hash1 = 0x6DA3B944;
                 _hash2 = 0;
                 _numCharactersHashed = 0;
             }
+#pragma warning restore IDE0060
 
             public void Append(ReadOnlySpan<byte> src)
             {


### PR DESCRIPTION
Not sure why this unused parameter is here, though. Looks like a bug that it's not used?