### PR TITLE
[interp] Fix compile failures causing silent fallback to JIT

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12912,6 +12912,14 @@ static CorJitResult invokeCompileMethod(EECodeGenManager *jitMgr,
         if (FAILED(ret))
         {
             comp->ResetForJitRetry();
+
+#ifdef FEATURE_INTERPRETER
+            // HACK: Suppress silencing of JIT failure for the interpreter jit manager, so that we don't
+            //  silently fall back to JIT when we wanted to interpret a method
+            if (jitMgr->GetCodeType() == (miManaged | miIL | miOPTIL))
+                ;
+            else
+#endif
             ret = CORJIT_SKIPPED;
         }
     }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12912,15 +12912,6 @@ static CorJitResult invokeCompileMethod(EECodeGenManager *jitMgr,
         if (FAILED(ret))
         {
             comp->ResetForJitRetry();
-
-#ifdef FEATURE_INTERPRETER
-            // HACK: Suppress silencing of JIT failure for the interpreter jit manager, so that we don't
-            //  silently fall back to JIT when we wanted to interpret a method
-            if (jitMgr->GetCodeType() == (miManaged | miIL | miOPTIL))
-                ;
-            else
-#endif
-            ret = CORJIT_SKIPPED;
         }
     }
 


### PR DESCRIPTION
baseservices\invalid_operations\InvalidOperations is currently failing downstream of its actual failure - the actual failure is that the interpreter doesn't support the type of calli the test is doing, but right now when we fail compilation as a result of this we silently retry with the JIT.

It seems like the intended behavior is that if we configure a method to be interpreted and it fails due to BADCODE or NO_WAY, we want to fail-fast instead of falling back to JIT. Not sure this is the right solution though.

@janvorli Is this the kind of fix you had in mind? I didn't find a better way to do it but you might have some ideas.