### PR TITLE
[interp] Suppress tailcall flag if target is a non-marshaled pinvoke

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3551,6 +3551,10 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             }
             else
             {
+                // Tail call target needs to be IL
+                if (tailcall && isPInvoke && !isMarshaledPInvoke)
+                    tailcall = false;
+
                 // Normal call
                 InterpOpcode opcode;
                 if (isDelegateInvoke)
@@ -3560,7 +3564,6 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                 }
                 else if (tailcall)
                 {
-                    assert(!isPInvoke && !isMarshaledPInvoke);
                     opcode = INTOP_CALL_TAIL;
                 }
                 else


### PR DESCRIPTION
Fixes JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28901