### PR TITLE
Fix several issues with interpreter and EH

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1280,6 +1280,11 @@ void InterpCompiler::BuildGCInfo(InterpMethod *pInterpMethod)
     gcInfoEncoder->SetStackBaseRegister(0);
     gcInfoEncoder->DefineInterruptibleRange(0, ConvertOffset(m_methodCodeSize));
 
+    if (pInterpMethod->unmanagedCallersOnly)
+    {
+        gcInfoEncoder->SetReversePInvokeFrameSlot(0);
+    }
+
     GENERIC_CONTEXTPARAM_TYPE paramType;
 
     switch (m_methodInfo->options & CORINFO_GENERICS_CTXT_MASK)


### PR DESCRIPTION
This change fixes few issues I have found while investigating coreclr tests failures when running interpreted
* The GC info for reverse pinvoke stubs didn't have the `revPInvokeOffset` set
* When `SfiNext` reached native marker state, it was doing one more unwind to get to the frame function state. That is benign for non-interpreter scenarios, as it doesn't change the regdisplay, but it is useless due to that. But for interpreter, it can actually incorrectly move to interpreted code. The fix is to not to do that unwind and just return.
* The `StackFrameIterator::SkipTo` that is called when `SfiNext` collides with the previous EH was missing copying of the first argument register that can hold the `InterpreterFrame` pointer.
* When `SfiNext` moved out of the last interpreted code frame and the caller of the interpreted code was not managed code (e.g. the `CallDescrWorker`), the `StackFrameIterator`'s regdisplay was not updated to that context.