### PR TITLE
[release/9.0-staging] Prevent format injection in hosting Windows PAL printf functions when redirected to file

### DIFF
--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -22,6 +22,14 @@ void pal::file_vprintf(FILE* f, const pal::char_t* format, va_list vl)
 }
 
 namespace {
+    void file_printf(FILE* fallbackFileHandle, const pal::char_t* format, ...)
+    {
+        va_list args;
+        va_start(args, format);
+        pal::file_vprintf(fallbackFileHandle, format, args);
+        va_end(args);
+    }
+
     void print_line_to_handle(const pal::char_t* message, HANDLE handle, FILE* fallbackFileHandle) {
         // String functions like vfwprintf convert wide to multi-byte characters as if wcrtomb were called - that is, using the current C locale (LC_TYPE).
         // In order to properly print UTF-8 and GB18030 characters to the console without requiring the user to use chcp to a compatible locale, we use WriteConsoleW.
@@ -33,7 +41,7 @@ namespace {
         {
             // We use file_vprintf to handle UTF-8 formatting. The WriteFile api will output the bytes directly with Unicode bytes,
             // while pal::file_vprintf will convert the characters to UTF-8.
-            pal::file_vprintf(fallbackFileHandle, message, va_list());
+            file_printf(fallbackFileHandle, _X("%s"), message);
         }
         else {
             ::WriteConsoleW(handle, message, (int)pal::strlen(message), NULL, NULL);


### PR DESCRIPTION
Fixes Issue #119566

main PR #119568
# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

# Customer Impact

Prevents crashes when a path in deps.json or a framework name in runtimeconfig.json contains a '%' character.

# Regression

Yes, introduced by #102295

# Testing

<!-- What kind of testing has been done with the fix. -->

Manual validation with testing

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

Low risk. This is a standard fix for this scenario, and it's only reachable on .NET 9 with an opt-in `COREHOST_TRACE=1` environment variable.

# Package authoring no longer needed in .NET 9

IMPORTANT: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.