### PR TITLE
Remove redundant nullability attributes

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
@@ -217,13 +217,12 @@ namespace System.Threading
 
         [Intrinsic]
         [NonVersionable]
-        [return: NotNullIfNotNull(nameof(location))]
-        public static T Read<T>([NotNullIfNotNull(nameof(location))] ref readonly T location) where T : class? =>
+        public static T Read<T>(ref readonly T location) where T : class? =>
             Unsafe.As<T>(Unsafe.As<T, VolatileObject>(ref Unsafe.AsRef(in location)).Value)!;
 
         [Intrinsic]
         [NonVersionable]
-        public static void Write<T>([NotNullIfNotNull(nameof(value))] ref T location, T value) where T : class? =>
+        public static void Write<T>(ref T location, T value) where T : class? =>
             Unsafe.As<T, VolatileObject>(ref location).Value = value;
         #endregion
 

--- a/src/libraries/System.Threading/ref/System.Threading.cs
+++ b/src/libraries/System.Threading/ref/System.Threading.cs
@@ -613,8 +613,7 @@ namespace System.Threading
         public static ulong Read(ref readonly ulong location) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static System.UIntPtr Read(ref readonly System.UIntPtr location) { throw null; }
-        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("location")]
-        public static T Read<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("location")] ref readonly T location) where T : class? { throw null; }
+        public static T Read<T>(ref readonly T location) where T : class? { throw null; }
 
         public static void Write(ref bool location, bool value) { }
         public static void Write(ref byte location, byte value) { }
@@ -634,7 +633,7 @@ namespace System.Threading
         public static void Write(ref ulong location, ulong value) { }
         [System.CLSCompliantAttribute(false)]
         public static void Write(ref System.UIntPtr location, System.UIntPtr value) { }
-        public static void Write<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("value")] ref T location, T value) where T : class? { }
+        public static void Write<T>(ref T location, T value) where T : class? { }
         public static void ReadBarrier() { }
         public static void WriteBarrier() { }
     }


### PR DESCRIPTION
Remove redundant nullability attributes from `Volatile.Read<T>` and `Volatile.Write<T>` as they have no effect on the generic type.