### PR TITLE
Extract HMAC.HashData{Async} into HMACStatic

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACMD5.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACMD5.cs
@@ -21,6 +21,10 @@ namespace System.Security.Cryptography
         {
             static int IHMACStatic.HashSizeInBytes => HashSizeInBytes;
             static string IHMACStatic.HashAlgorithmName => HashAlgorithmNames.MD5;
+
+            // Even though MD5 is not supported on browser, we return true and let it act as an unknown algorithm
+            // instead of an unsupported algorithm.
+            static bool IHMACStatic.IsSupported => true;
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACMD5.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACMD5.cs
@@ -94,10 +94,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(key), new ReadOnlySpan<byte>(source));
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -109,12 +106,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(key, source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -131,12 +123,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(key, source, destination, out int bytesWritten))
-            {
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-            }
-
-            return bytesWritten;
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -155,16 +142,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.MacData(HashAlgorithmNames.MD5, key, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -190,15 +168,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.MD5, key, source, destination);
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -216,12 +186,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.MD5, HashSizeInBytes, key, source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -239,9 +204,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static byte[] HashData(byte[] key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashData(new ReadOnlySpan<byte>(key), source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -263,12 +226,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(HashAlgorithmNames.MD5, key.Span, source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -290,9 +248,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -326,20 +282,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(
-                HashAlgorithmNames.MD5,
-                key.Span,
-                source,
-                destination,
-                cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA1.cs
@@ -99,10 +99,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(key), new ReadOnlySpan<byte>(source));
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -113,12 +110,7 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(key, source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -134,12 +126,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(key, source, destination, out int bytesWritten))
-            {
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-            }
-
-            return bytesWritten;
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -157,16 +144,7 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.MacData(HashAlgorithmNames.SHA1, key, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -191,15 +169,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA1, key, source, destination);
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -216,12 +186,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA1, HashSizeInBytes, key, source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -238,9 +203,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashData(new ReadOnlySpan<byte>(key), source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -261,12 +224,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(HashAlgorithmNames.SHA1, key.Span, source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -287,9 +245,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -322,20 +278,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(
-                HashAlgorithmNames.SHA1,
-                key.Span,
-                source,
-                destination,
-                cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA1.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography
         {
             static int IHMACStatic.HashSizeInBytes => HashSizeInBytes;
             static string IHMACStatic.HashAlgorithmName => HashAlgorithmNames.SHA1;
+            static bool IHMACStatic.IsSupported => true;
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA256.cs
@@ -21,6 +21,7 @@ namespace System.Security.Cryptography
         {
             static int IHMACStatic.HashSizeInBytes => HashSizeInBytes;
             static string IHMACStatic.HashAlgorithmName => HashAlgorithmNames.SHA256;
+            static bool IHMACStatic.IsSupported => true;
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA256.cs
@@ -91,10 +91,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(key), new ReadOnlySpan<byte>(source));
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -105,12 +102,7 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(key, source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -126,12 +118,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(key, source, destination, out int bytesWritten))
-            {
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-            }
-
-            return bytesWritten;
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -149,16 +136,7 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.MacData(HashAlgorithmNames.SHA256, key, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -183,15 +161,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA256, key, source, destination);
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -208,12 +178,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA256, HashSizeInBytes, key, source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -230,9 +195,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashData(new ReadOnlySpan<byte>(key), source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -253,12 +216,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(HashAlgorithmNames.SHA256, key.Span, source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -279,9 +237,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -314,20 +270,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(
-                HashAlgorithmNames.SHA256,
-                key.Span,
-                source,
-                destination,
-                cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA384.cs
@@ -21,6 +21,7 @@ namespace System.Security.Cryptography
         {
             static int IHMACStatic.HashSizeInBytes => HashSizeInBytes;
             static string IHMACStatic.HashAlgorithmName => HashAlgorithmNames.SHA384;
+            static bool IHMACStatic.IsSupported => true;
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA384.cs
@@ -108,10 +108,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(key), new ReadOnlySpan<byte>(source));
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -122,12 +119,7 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(key, source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -143,12 +135,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(key, source, destination, out int bytesWritten))
-            {
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-            }
-
-            return bytesWritten;
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -166,16 +153,7 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.MacData(HashAlgorithmNames.SHA384, key, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -200,15 +178,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA384, key, source, destination);
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -225,12 +195,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA384, HashSizeInBytes, key, source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -247,9 +212,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashData(new ReadOnlySpan<byte>(key), source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -270,12 +233,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(HashAlgorithmNames.SHA384, key.Span, source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -296,9 +254,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -331,20 +287,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(
-                HashAlgorithmNames.SHA384,
-                key.Span,
-                source,
-                destination,
-                cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_256.cs
@@ -127,10 +127,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(key), new ReadOnlySpan<byte>(source));
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -141,12 +139,8 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(key, source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -162,12 +156,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(key, source, destination, out int bytesWritten))
-            {
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-            }
-
-            return bytesWritten;
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -186,17 +176,7 @@ namespace System.Security.Cryptography
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
             CheckSha3Support();
-
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.MacData(HashAlgorithmNames.SHA3_256, key, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -221,16 +201,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA3_256, key, source, destination);
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -247,13 +219,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA3_256, HashSizeInBytes, key, source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -270,9 +237,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashData(new ReadOnlySpan<byte>(key), source);
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -293,13 +259,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStreamAsync(HashAlgorithmNames.SHA3_256, key.Span, source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -355,21 +316,8 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStreamAsync(
-                HashAlgorithmNames.SHA3_256,
-                key.Span,
-                source,
-                destination,
-                cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_256.cs
@@ -18,6 +18,7 @@ namespace System.Security.Cryptography
         {
             static int IHMACStatic.HashSizeInBytes => HashSizeInBytes;
             static string IHMACStatic.HashAlgorithmName => HashAlgorithmNames.SHA3_256;
+            static bool IHMACStatic.IsSupported => IsSupported;
         }
 
         private HMACCommon _hMacCommon;
@@ -64,7 +65,7 @@ namespace System.Security.Cryptography
         public HMACSHA3_256(byte[] key)
         {
             ArgumentNullException.ThrowIfNull(key);
-            CheckSha3Support();
+            HMACStatic<HMACTrait>.CheckPlatformSupport();
 
             this.HashName = HashAlgorithmNames.SHA3_256;
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA3_256, key, BlockSize);
@@ -127,7 +128,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -139,7 +139,6 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -156,7 +155,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
@@ -175,7 +173,6 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
@@ -201,7 +198,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
@@ -219,7 +215,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -237,7 +232,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, Stream source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -259,7 +253,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
@@ -281,9 +274,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -316,7 +307,6 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
@@ -342,7 +332,6 @@ namespace System.Security.Cryptography
         /// </remarks>
         public static bool Verify(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, ReadOnlySpan<byte> hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -352,7 +341,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static bool Verify(byte[] key, byte[] source, byte[] hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -383,7 +371,6 @@ namespace System.Security.Cryptography
         /// </remarks>
         public static bool Verify(ReadOnlySpan<byte> key, Stream source, ReadOnlySpan<byte> hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -393,7 +380,6 @@ namespace System.Security.Cryptography
         /// <inheritdoc cref="Verify(ReadOnlySpan{byte}, Stream, ReadOnlySpan{byte})" />
         public static bool Verify(byte[] key, Stream source, byte[] hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -432,7 +418,6 @@ namespace System.Security.Cryptography
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
         }
 
@@ -446,7 +431,6 @@ namespace System.Security.Cryptography
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
         }
 
@@ -463,12 +447,6 @@ namespace System.Security.Cryptography
                 }
             }
             base.Dispose(disposing);
-        }
-
-        private static void CheckSha3Support()
-        {
-            if (!IsSupported)
-                throw new PlatformNotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_384.cs
@@ -18,6 +18,7 @@ namespace System.Security.Cryptography
         {
             static int IHMACStatic.HashSizeInBytes => HashSizeInBytes;
             static string IHMACStatic.HashAlgorithmName => HashAlgorithmNames.SHA3_384;
+            static bool IHMACStatic.IsSupported => IsSupported;
         }
 
         private HMACCommon _hMacCommon;
@@ -64,7 +65,7 @@ namespace System.Security.Cryptography
         public HMACSHA3_384(byte[] key)
         {
             ArgumentNullException.ThrowIfNull(key);
-            CheckSha3Support();
+            HMACStatic<HMACTrait>.CheckPlatformSupport();
 
             this.HashName = HashAlgorithmNames.SHA3_384;
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA3_384, key, BlockSize);
@@ -127,7 +128,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -139,7 +139,6 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -156,7 +155,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
@@ -175,7 +173,6 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
@@ -201,7 +198,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
@@ -219,7 +215,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -237,9 +232,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashData(new ReadOnlySpan<byte>(key), source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -260,7 +253,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
@@ -282,9 +274,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -317,7 +307,6 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
@@ -343,7 +332,6 @@ namespace System.Security.Cryptography
         /// </remarks>
         public static bool Verify(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, ReadOnlySpan<byte> hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -353,7 +341,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static bool Verify(byte[] key, byte[] source, byte[] hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -384,7 +371,6 @@ namespace System.Security.Cryptography
         /// </remarks>
         public static bool Verify(ReadOnlySpan<byte> key, Stream source, ReadOnlySpan<byte> hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -394,7 +380,6 @@ namespace System.Security.Cryptography
         /// <inheritdoc cref="Verify(ReadOnlySpan{byte}, Stream, ReadOnlySpan{byte})" />
         public static bool Verify(byte[] key, Stream source, byte[] hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -433,7 +418,6 @@ namespace System.Security.Cryptography
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
         }
 
@@ -447,7 +431,6 @@ namespace System.Security.Cryptography
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
         }
 
@@ -464,12 +447,6 @@ namespace System.Security.Cryptography
                 }
             }
             base.Dispose(disposing);
-        }
-
-        private static void CheckSha3Support()
-        {
-            if (!IsSupported)
-                throw new PlatformNotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_384.cs
@@ -127,10 +127,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(key), new ReadOnlySpan<byte>(source));
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -141,12 +139,8 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(key, source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -162,12 +156,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(key, source, destination, out int bytesWritten))
-            {
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-            }
-
-            return bytesWritten;
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -186,17 +176,7 @@ namespace System.Security.Cryptography
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
             CheckSha3Support();
-
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.MacData(HashAlgorithmNames.SHA3_384, key, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -221,16 +201,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA3_384, key, source, destination);
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -247,13 +219,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA3_384, HashSizeInBytes, key, source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -293,13 +260,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStreamAsync(HashAlgorithmNames.SHA3_384, key.Span, source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -355,21 +317,8 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStreamAsync(
-                HashAlgorithmNames.SHA3_384,
-                key.Span,
-                source,
-                destination,
-                cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_512.cs
@@ -127,10 +127,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(key), new ReadOnlySpan<byte>(source));
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -141,12 +139,8 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(key, source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -162,12 +156,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(key, source, destination, out int bytesWritten))
-            {
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-            }
-
-            return bytesWritten;
+            CheckSha3Support();
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -186,17 +176,7 @@ namespace System.Security.Cryptography
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
             CheckSha3Support();
-
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.MacData(HashAlgorithmNames.SHA3_512, key, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -221,16 +201,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA3_512, key, source, destination);
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -247,13 +219,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA3_512, HashSizeInBytes, key, source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -293,13 +260,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStreamAsync(HashAlgorithmNames.SHA3_512, key.Span, source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -355,21 +317,8 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
             CheckSha3Support();
-            return LiteHashProvider.HmacStreamAsync(
-                HashAlgorithmNames.SHA3_512,
-                key.Span,
-                source,
-                destination,
-                cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_512.cs
@@ -18,6 +18,7 @@ namespace System.Security.Cryptography
         {
             static int IHMACStatic.HashSizeInBytes => HashSizeInBytes;
             static string IHMACStatic.HashAlgorithmName => HashAlgorithmNames.SHA3_512;
+            static bool IHMACStatic.IsSupported => IsSupported;
         }
 
         private HMACCommon _hMacCommon;
@@ -64,7 +65,7 @@ namespace System.Security.Cryptography
         public HMACSHA3_512(byte[] key)
         {
             ArgumentNullException.ThrowIfNull(key);
-            CheckSha3Support();
+            HMACStatic<HMACTrait>.CheckPlatformSupport();
 
             this.HashName = HashAlgorithmNames.SHA3_512;
             _hMacCommon = new HMACCommon(HashAlgorithmNames.SHA3_512, key, BlockSize);
@@ -127,7 +128,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -139,7 +139,6 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -156,7 +155,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
@@ -175,7 +173,6 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
@@ -201,7 +198,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
@@ -219,7 +215,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
@@ -237,9 +232,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashData(new ReadOnlySpan<byte>(key), source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -260,7 +253,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
@@ -282,9 +274,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -317,7 +307,6 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
@@ -343,7 +332,6 @@ namespace System.Security.Cryptography
         /// </remarks>
         public static bool Verify(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, ReadOnlySpan<byte> hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -353,7 +341,6 @@ namespace System.Security.Cryptography
         /// </exception>
         public static bool Verify(byte[] key, byte[] source, byte[] hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -384,7 +371,6 @@ namespace System.Security.Cryptography
         /// </remarks>
         public static bool Verify(ReadOnlySpan<byte> key, Stream source, ReadOnlySpan<byte> hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -394,7 +380,6 @@ namespace System.Security.Cryptography
         /// <inheritdoc cref="Verify(ReadOnlySpan{byte}, Stream, ReadOnlySpan{byte})" />
         public static bool Verify(byte[] key, Stream source, byte[] hash)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.Verify(key, source, hash);
         }
 
@@ -433,7 +418,6 @@ namespace System.Security.Cryptography
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
         }
 
@@ -447,7 +431,6 @@ namespace System.Security.Cryptography
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            CheckSha3Support();
             return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
         }
 
@@ -464,12 +447,6 @@ namespace System.Security.Cryptography
                 }
             }
             base.Dispose(disposing);
-        }
-
-        private static void CheckSha3Support()
-        {
-            if (!IsSupported)
-                throw new PlatformNotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA512.cs
@@ -21,6 +21,7 @@ namespace System.Security.Cryptography
         {
             static int IHMACStatic.HashSizeInBytes => HashSizeInBytes;
             static string IHMACStatic.HashAlgorithmName => HashAlgorithmNames.SHA512;
+            static bool IHMACStatic.IsSupported => true;
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA512.cs
@@ -105,10 +105,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, byte[] source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(key), new ReadOnlySpan<byte>(source));
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -119,12 +116,7 @@ namespace System.Security.Cryptography
         /// <returns>The HMAC of the data.</returns>
         public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source)
         {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(key, source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -140,12 +132,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(key, source, destination, out int bytesWritten))
-            {
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-            }
-
-            return bytesWritten;
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -163,16 +150,7 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.MacData(HashAlgorithmNames.SHA512, key, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HMACStatic<HMACTrait>.TryHashData(key, source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -197,15 +175,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA512, key, source, destination);
+            return HMACStatic<HMACTrait>.HashData(key, source, destination);
         }
 
         /// <summary>
@@ -222,12 +192,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(ReadOnlySpan<byte> key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStream(HashAlgorithmNames.SHA512, HashSizeInBytes, key, source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -244,9 +209,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static byte[] HashData(byte[] key, Stream source)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashData(new ReadOnlySpan<byte>(key), source);
+            return HMACStatic<HMACTrait>.HashData(key, source);
         }
 
         /// <summary>
@@ -267,12 +230,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(HashAlgorithmNames.SHA512, key.Span, source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -293,9 +251,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(key);
-
-            return HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
         }
 
         /// <summary>
@@ -328,20 +284,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HmacStreamAsync(
-                HashAlgorithmNames.SHA512,
-                key.Span,
-                source,
-                destination,
-                cancellationToken);
+            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/tests/HmacTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HmacTests.cs
@@ -1472,17 +1472,17 @@ namespace System.Security.Cryptography.Tests
                 Verify(new ReadOnlySpan<byte>(key), ReadOnlySpan<byte>.Empty, new byte[THmacTrait.HashSizeInBytes]));
 
             Assert.Throws<PlatformNotSupportedException>(() =>
-                Verify(key, UntouchableStream.Instance, new byte[THmacTrait.HashSizeInBytes]));
+                Verify(key, Stream.Null, new byte[THmacTrait.HashSizeInBytes]));
             Assert.Throws<PlatformNotSupportedException>(() =>
-                Verify(new ReadOnlySpan<byte>(key), UntouchableStream.Instance, new byte[THmacTrait.HashSizeInBytes]));
+                Verify(new ReadOnlySpan<byte>(key), Stream.Null, new byte[THmacTrait.HashSizeInBytes]));
 
             Assert.Throws<PlatformNotSupportedException>(() =>
-                VerifyAsync(key, UntouchableStream.Instance, new byte[THmacTrait.HashSizeInBytes], default(CancellationToken)));
+                VerifyAsync(key, Stream.Null, new byte[THmacTrait.HashSizeInBytes], default(CancellationToken)));
 
             Assert.Throws<PlatformNotSupportedException>(() =>
                 VerifyAsync(
                     new ReadOnlyMemory<byte>(key),
-                    UntouchableStream.Instance,
+                    Stream.Null,
                     new byte[THmacTrait.HashSizeInBytes],
                     default(CancellationToken)));
         }


### PR DESCRIPTION
This PR:

1. Move the HashData and HashDataAsync implementations to HMACStatic so we can deduplicate all of the parameter checking and implementation.
2. Move the platform checks in to HMACStatic for SHA-3. This revealed an issue with `Verify` - we were doing the platform check before the parameter checks. The throw order between HashData and Verify is now consistent.