### PR TITLE
[S390X] remove redundant load

### DIFF
--- a/src/mono/mono/mini/mini-s390x.c
+++ b/src/mono/mono/mini/mini-s390x.c
@@ -4845,7 +4845,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			} else {
 				S390_SET (code, s390_r13, ins->inst_p0);
 				s390_le (code, ins->dreg, 0, s390_r13, 0);
-				s390_le (code, ins->dreg, 0, s390_r13, 0);
 			}
 		}
 			break;


### PR DESCRIPTION
Remove extra redudant load.
ins->dreg is always fpr and sreg is always r13 so they can't be aliased as well, so it's a redundant load.