### PR TITLE
[release/10.0] Don't warn if we can't find the backing field in trim tools

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -592,21 +592,18 @@ namespace ILLink.Shared.TrimAnalysis
                         }
                     }
 
-                    bool backingFieldFound = backingFieldFromGetter is not null
-                        || backingFieldFromSetter is not null;
-                    bool mismatchingBackingField = backingFieldFromGetter is not null
-                        && backingFieldFromSetter is not null
-                        && backingFieldFromGetter != backingFieldFromSetter;
-
-                    if (backingFieldFound
-                        && !mismatchingBackingField
-                        && IsAutoProperty(property))
+                    FieldDesc backingField = backingFieldFromSetter ?? backingFieldFromGetter!;
+                    if (backingField is not null)
                     {
-                        // We either have a single auto-property accessor or both accessors point to the same backing field
-                        FieldDesc backingField = backingFieldFromSetter ?? backingFieldFromGetter!;
                         if (annotatedFields.Any(a => a.Field == backingField))
                         {
                             _logger.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
+                        }
+                        else if (backingFieldFromGetter is not null
+                            && backingFieldFromSetter is not null
+                            && backingFieldFromGetter != backingFieldFromSetter)
+                        {
+                            _logger.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersCouldNotFindBackingField, property.GetDisplayName());
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -592,7 +592,7 @@ namespace ILLink.Shared.TrimAnalysis
                         }
                     }
 
-                    FieldDesc backingField = backingFieldFromSetter ?? backingFieldFromGetter!;
+                    FieldDesc? backingField = backingFieldFromSetter ?? backingFieldFromGetter;
                     if (backingField is not null)
                     {
                         if (annotatedFields.Any(a => a.Field == backingField))

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -595,15 +595,20 @@ namespace ILLink.Shared.TrimAnalysis
                     FieldDesc? backingField = backingFieldFromSetter ?? backingFieldFromGetter;
                     if (backingField is not null)
                     {
-                        if (annotatedFields.Any(a => a.Field == backingField))
+                        bool validBackingFieldFound = backingFieldFromGetter is null
+                            || backingFieldFromSetter is null
+                            || backingFieldFromGetter == backingFieldFromSetter;
+                        if (validBackingFieldFound)
                         {
-                            _logger.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
-                        }
-                        else if (!(backingFieldFromGetter is not null
-                            && backingFieldFromSetter is not null
-                            && backingFieldFromGetter != backingFieldFromSetter))
-                        {
-                            annotatedFields.Add(new FieldAnnotation(backingField, annotation));
+                            if (annotatedFields.Any(a => a.Field == backingField && a.Annotation != annotation))
+                            {
+                                _logger.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
+                            }
+                            else
+                            {
+                                // Unique backing field with no conflicts with property or existing field
+                                annotatedFields.Add(new FieldAnnotation(backingField, annotation));
+                            }
                         }
                     }
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -599,13 +599,9 @@ namespace ILLink.Shared.TrimAnalysis
                         {
                             _logger.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
                         }
-                        else if (backingFieldFromGetter is not null
+                        else if (!(backingFieldFromGetter is not null
                             && backingFieldFromSetter is not null
-                            && backingFieldFromGetter != backingFieldFromSetter)
-                        {
-                            _logger.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersCouldNotFindBackingField, property.GetDisplayName());
-                        }
-                        else
+                            && backingFieldFromGetter != backingFieldFromSetter))
                         {
                             annotatedFields.Add(new FieldAnnotation(backingField, annotation));
                         }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/FlowAnnotations.cs
@@ -117,11 +117,11 @@ namespace ILLink.Shared.TrimAnalysis
             if (!field.OriginalDefinition.Type.IsTypeInterestingForDataflow(isByRef: field.RefKind is not RefKind.None))
                 return DynamicallyAccessedMemberTypes.None;
 
-            if (field.AssociatedSymbol is IPropertySymbol property)
+            if (field.AssociatedSymbol is IPropertySymbol property
+                && property.IsAutoProperty())
             {
                 // If this is an auto property, we get the property annotation
-                if (property.IsAutoProperty())
-                    return property.GetDynamicallyAccessedMemberTypes();
+                return property.GetDynamicallyAccessedMemberTypes();
             }
 
             return field.GetDynamicallyAccessedMemberTypes();

--- a/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
@@ -101,7 +101,7 @@ namespace ILLink.Shared
         XmlInvalidValueForAttributeActionForResource = 2039,
         XmlCouldNotFindResourceToRemoveInAssembly = 2040,
         DynamicallyAccessedMembersIsNotAllowedOnMethods = 2041,
-        DynamicallyAccessedMembersCouldNotFindBackingField = 2042,
+        unused_DynamicallyAccessedMembersCouldNotFindBackingField = 2042,
         DynamicallyAccessedMembersConflictsBetweenPropertyAndAccessor = 2043,
         XmlCouldNotFindAnyTypeInNamespace = 2044,
         AttributeIsReferencedButTrimmerRemoveAllInstances = 2045,

--- a/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -425,13 +425,9 @@ namespace ILLink.Shared.TrimAnalysis
                         {
                             _context.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
                         }
-                        else if (backingFieldFromGetter is not null
+                        if (!(backingFieldFromGetter is not null
                             && backingFieldFromSetter is not null
-                            && backingFieldFromGetter != backingFieldFromSetter)
-                        {
-                            _context.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersCouldNotFindBackingField, property.GetDisplayName());
-                        }
-                        else
+                            && backingFieldFromGetter != backingFieldFromSetter))
                         {
                             annotatedFields.Add(new FieldAnnotation(backingField, annotation));
                         }

--- a/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -418,7 +418,7 @@ namespace ILLink.Shared.TrimAnalysis
                     }
 
 
-                    FieldDefinition backingField = backingFieldFromSetter ?? backingFieldFromGetter!;
+                    FieldDefinition? backingField = backingFieldFromSetter ?? backingFieldFromGetter;
                     if (backingField is not null)
                     {
                         if (annotatedFields.Any(a => a.Field == backingField))

--- a/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -421,15 +421,20 @@ namespace ILLink.Shared.TrimAnalysis
                     FieldDefinition? backingField = backingFieldFromSetter ?? backingFieldFromGetter;
                     if (backingField is not null)
                     {
-                        if (annotatedFields.Any(a => a.Field == backingField))
+                        bool validBackingFieldFound = backingFieldFromGetter is null
+                            || backingFieldFromSetter is null
+                            || backingFieldFromGetter == backingFieldFromSetter;
+                        if (validBackingFieldFound)
                         {
-                            _context.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
-                        }
-                        if (!(backingFieldFromGetter is not null
-                            && backingFieldFromSetter is not null
-                            && backingFieldFromGetter != backingFieldFromSetter))
-                        {
-                            annotatedFields.Add(new FieldAnnotation(backingField, annotation));
+                            if (annotatedFields.Any(a => a.Field == backingField && a.Annotation != annotation))
+                            {
+                                _context.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
+                            }
+                            else
+                            {
+                                // Unique backing field with no conflicts with property or existing field
+                                annotatedFields.Add(new FieldAnnotation(backingField, annotation));
+                            }
                         }
                     }
                 }

--- a/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -417,20 +417,19 @@ namespace ILLink.Shared.TrimAnalysis
                         }
                     }
 
-                    bool backingFieldFound = backingFieldFromGetter is not null
-                        || backingFieldFromSetter is not null;
-                    bool mismatchingBackingField = backingFieldFromGetter is not null
-                        && backingFieldFromSetter is not null
-                        && backingFieldFromGetter != backingFieldFromSetter;
 
-                    if (backingFieldFound
-                        && !mismatchingBackingField
-                        && IsAutoProperty(property))
+                    FieldDefinition backingField = backingFieldFromSetter ?? backingFieldFromGetter!;
+                    if (backingField is not null)
                     {
-                        FieldDefinition backingField = backingFieldFromSetter ?? backingFieldFromGetter!;
                         if (annotatedFields.Any(a => a.Field == backingField))
                         {
                             _context.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
+                        }
+                        else if (backingFieldFromGetter is not null
+                            && backingFieldFromSetter is not null
+                            && backingFieldFromGetter != backingFieldFromSetter)
+                        {
+                            _context.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersCouldNotFindBackingField, property.GetDisplayName());
                         }
                         else
                         {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -351,14 +351,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             {
                 // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
                 [ExpectedWarning("IL2043", "PropertyWithExistingMismatchedAttributes", "PropertyWithExistingMismatchedAttributes.get", Tool.Trimmer | Tool.NativeAot, "")]
-                [ExpectedWarning("IL2078", "return value", "PropertyWithExistingMismatchedAttributes_Field", Tool.Trimmer | Tool.NativeAot, "")]
+                [ExpectedWarning("IL2078", "return value", "PropertyWithExistingMismatchedAttributes_Field")]
                 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
                 [CompilerGenerated]
                 get { return PropertyWithExistingMismatchedAttributes_Field; }
 
                 // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
                 [ExpectedWarning("IL2043", "PropertyWithExistingMismatchedAttributes", "PropertyWithExistingMismatchedAttributes.set", Tool.Trimmer | Tool.NativeAot, "")]
-                [ExpectedWarning("IL2069", "PropertyWithExistingMismatchedAttributes_Field", "parameter 'value'", Tool.Trimmer | Tool.NativeAot, "")]
+                [ExpectedWarning("IL2069", "PropertyWithExistingMismatchedAttributes_Field", "parameter 'value'")]
                 [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
                 [CompilerGenerated]
                 set { PropertyWithExistingMismatchedAttributes_Field = value; }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -311,32 +311,57 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
             public void TestPropertyWithExistingAttributes()
             {
-                _ = PropertyWithExistingAttributes;
-                PropertyWithExistingAttributes = null;
+                _ = PropertyWithExistingMatchingAttributes;
+                PropertyWithExistingMatchingAttributes = null;
+                _ = PropertyWithExistingMismatchedAttributes;
+                PropertyWithExistingMismatchedAttributes = null;
             }
 
             // Analyzer doesn't try to detect backing fields of properties: https://github.com/dotnet/linker/issues/2273
-            [ExpectedWarning("IL2056", "PropertyWithExistingAttributes", "PropertyWithExistingAttributes_Field", Tool.Trimmer | Tool.NativeAot, "")]
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
             [CompilerGenerated]
-            Type PropertyWithExistingAttributes_Field;
+            Type PropertyWithExistingMatchingAttributes_Field;
 
-            [ExpectedWarning("IL2043", ["PropertyWithExistingAttributes", "PropertyWithExistingAttributes.get"], Tool.Analyzer, "")]
-            [ExpectedWarning("IL2043", ["PropertyWithExistingAttributes", "PropertyWithExistingAttributes.set"], Tool.Analyzer, "")]
+            [ExpectedWarning("IL2043", ["PropertyWithExistingMatchingAttributes", "PropertyWithExistingMatchingAttributes.get"], Tool.Analyzer, "")]
+            [ExpectedWarning("IL2043", ["PropertyWithExistingMatchingAttributes", "PropertyWithExistingMatchingAttributes.set"], Tool.Analyzer, "")]
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-            Type PropertyWithExistingAttributes
+            Type PropertyWithExistingMatchingAttributes
             {
-                // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
-                [ExpectedWarning("IL2043", "PropertyWithExistingAttributes", "PropertyWithExistingAttributes.get", Tool.Trimmer | Tool.NativeAot, "")]
+                [ExpectedWarning("IL2043", ["PropertyWithExistingMatchingAttributes", "PropertyWithExistingMatchingAttributes.get"], Tool.Trimmer | Tool.NativeAot, "")]
                 [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
                 [CompilerGenerated]
-                get { return PropertyWithExistingAttributes_Field; }
+                get { return PropertyWithExistingMatchingAttributes_Field; }
 
-                // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
-                [ExpectedWarning("IL2043", "PropertyWithExistingAttributes", "PropertyWithExistingAttributes.set", Tool.Trimmer | Tool.NativeAot, "")]
+                [ExpectedWarning("IL2043", ["PropertyWithExistingMatchingAttributes", "PropertyWithExistingMatchingAttributes.set"], Tool.Trimmer | Tool.NativeAot, "")]
                 [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
                 [CompilerGenerated]
-                set { PropertyWithExistingAttributes_Field = value; }
+                set { PropertyWithExistingMatchingAttributes_Field = value; }
+            }
+
+            // Analyzer doesn't try to detect backing fields of properties: https://github.com/dotnet/linker/issues/2273
+            [ExpectedWarning("IL2056", "PropertyWithExistingMismatchedAttributes", "PropertyWithExistingMismatchedAttributes_Field", Tool.Trimmer | Tool.NativeAot, "")]
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+            [CompilerGenerated]
+            Type PropertyWithExistingMismatchedAttributes_Field;
+
+            [ExpectedWarning("IL2043", ["PropertyWithExistingMismatchedAttributes", "PropertyWithExistingMismatchedAttributes.get"], Tool.Analyzer, "")]
+            [ExpectedWarning("IL2043", ["PropertyWithExistingMismatchedAttributes", "PropertyWithExistingMismatchedAttributes.set"], Tool.Analyzer, "")]
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+            Type PropertyWithExistingMismatchedAttributes
+            {
+                // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
+                [ExpectedWarning("IL2043", "PropertyWithExistingMismatchedAttributes", "PropertyWithExistingMismatchedAttributes.get", Tool.Trimmer | Tool.NativeAot, "")]
+                [ExpectedWarning("IL2078", "return value", "PropertyWithExistingMismatchedAttributes_Field", Tool.Trimmer | Tool.NativeAot, "")]
+                [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+                [CompilerGenerated]
+                get { return PropertyWithExistingMismatchedAttributes_Field; }
+
+                // On property/accessor mismatch, ILLink warns on accessor and analyzer warns on property https://github.com/dotnet/linker/issues/2654
+                [ExpectedWarning("IL2043", "PropertyWithExistingMismatchedAttributes", "PropertyWithExistingMismatchedAttributes.set", Tool.Trimmer | Tool.NativeAot, "")]
+                [ExpectedWarning("IL2069", "PropertyWithExistingMismatchedAttributes_Field", "parameter 'value'", Tool.Trimmer | Tool.NativeAot, "")]
+                [param: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+                [CompilerGenerated]
+                set { PropertyWithExistingMismatchedAttributes_Field = value; }
             }
 
             // When the property annotation conflicts with the getter/setter annotation,

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -288,8 +288,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             private Type PropertyWithDifferentBackingFields_SetterField;
 
             // Analyzer doesn't try to detect backing fields of properties: https://github.com/dotnet/linker/issues/2273
-            [ExpectedWarning("IL2042",
-                "Mono.Linker.Tests.Cases.DataFlow.PropertyDataFlow.TestAutomaticPropagationType.PropertyWithDifferentBackingFields", Tool.Trimmer | Tool.NativeAot, "Requires IL")]
             [ExpectedWarning("IL2078",
                 nameof(TestAutomaticPropagationType) + "." + nameof(PropertyWithDifferentBackingFields) + ".get",
                 "Type", Tool.Analyzer, "")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -959,7 +959,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             private Type Property_BackingField;
 
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
             public Type Property
             {
                 [CompilerGenerated]
@@ -980,7 +979,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
             public Type PropertyAutoSet
             {
                 [CompilerGenerated]
@@ -995,10 +993,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
             public Type PropertyAutoGet
             {
-                [ExpectedWarning("IL2078", ["return value", nameof(PropertyAutoGet), "BackingField"], producedBy: Tool.NativeAot | Tool.Trimmer, "Requires IL")]
                 get;
                 [CompilerGenerated]
                 set
@@ -1010,7 +1006,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
             public Type PropertyManualSet
             {
                 [CompilerGenerated]
@@ -1025,7 +1020,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
             public Type PropertyManualGet
             {
                 [ExpectedWarning("IL2078", "return value", nameof(Property_BackingField))]
@@ -1040,7 +1034,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-            [ExpectedWarning("IL2042", Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
             public Type PropertyOnlyGet
             {
                 [CompilerGenerated]
@@ -1054,7 +1047,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-            [ExpectedWarning("IL2042", nameof(PropertyOnlySet), Tool.NativeAot | Tool.Trimmer, "Requires IL")] // Can't find backing field
             public Type PropertyOnlySet
             {
                 [CompilerGenerated]


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/119820

We added a warning when we cannot find the backing field of an auto property in https://github.com/dotnet/runtime/pull/119329 which caused some issues in illink->ilc scenarios when an auto property was stubbed out. Instead, we should just not propagate the DAM annotation. If failing to find the backing field doesn't affect the trim safety, no warnings should be surfaced.

## Customer Impact

- [ ] Customer reported
- [X] Found internally


## Regression

- [x] Yes
- [ ] No

The previous change introduced new warnings in situations that didn't arise before.

## Testing

New unit tests were added, and existing tests were updated to expect the new behavior.

## Risk

Low. This only removes warnings that occur when the tools can't find a backing field for an auto-property. No trim-safety warnings or trim behavior should be changed.