### PR TITLE
Refactor HashData on hash classes to use a single implementation

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -592,6 +592,7 @@
     <Compile Include="System\Security\Cryptography\HashAlgorithmName.cs" />
     <Compile Include="System\Security\Cryptography\HashAlgorithmNames.cs" />
     <Compile Include="System\Security\Cryptography\HashProvider.cs" />
+    <Compile Include="System\Security\Cryptography\HashStatic.cs" />
     <Compile Include="System\Security\Cryptography\Helpers.cs" />
     <Compile Include="System\Security\Cryptography\HKDF.cs" />
     <Compile Include="System\Security\Cryptography\HKDFManagedImplementation.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashStatic.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashStatic.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography
+{
+    internal interface IHashStatic
+    {
+        internal static abstract int HashSizeInBytes { get; }
+        internal static abstract string HashAlgorithmName { get; }
+        internal static abstract bool IsSupported { get; }
+    }
+
+    // This class acts as a single implementation of the hash classes that the public APIs defer to.
+    // The public APIs call these methods directly, so they need to behave as if they were public,
+    // including parameter validation and async behavior.
+    internal static class HashStatic<THash> where THash : IHashStatic
+    {
+        internal static byte[] HashData(byte[] source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return HashData(new ReadOnlySpan<byte>(source));
+        }
+
+        internal static byte[] HashData(ReadOnlySpan<byte> source)
+        {
+            byte[] buffer = GC.AllocateUninitializedArray<byte>(THash.HashSizeInBytes);
+
+            int written = HashData(source, buffer.AsSpan());
+            Debug.Assert(written == buffer.Length);
+
+            return buffer;
+        }
+
+        internal static int HashData(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            if (!TryHashData(source, destination, out int bytesWritten))
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+
+            return bytesWritten;
+        }
+
+        internal static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+        {
+            CheckPlatformSupport();
+
+            if (destination.Length < THash.HashSizeInBytes)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = HashProviderDispenser.OneShotHashProvider.HashData(THash.HashAlgorithmName, source, destination);
+            Debug.Assert(bytesWritten == THash.HashSizeInBytes);
+
+            return true;
+        }
+
+        internal static int HashData(Stream source, Span<byte> destination)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            if (destination.Length < THash.HashSizeInBytes)
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+
+            if (!source.CanRead)
+                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
+
+            CheckPlatformSupport();
+            return LiteHashProvider.HashStream(THash.HashAlgorithmName, source, destination);
+        }
+
+        public static byte[] HashData(Stream source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            if (!source.CanRead)
+                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
+
+            CheckPlatformSupport();
+            return LiteHashProvider.HashStream(THash.HashAlgorithmName, THash.HashSizeInBytes, source);
+        }
+
+        internal static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            if (!source.CanRead)
+                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
+
+            CheckPlatformSupport();
+            return LiteHashProvider.HashStreamAsync(THash.HashAlgorithmName, source, cancellationToken);
+        }
+
+        internal static ValueTask<int> HashDataAsync(
+            Stream source,
+            Memory<byte> destination,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            if (destination.Length < THash.HashSizeInBytes)
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+
+            if (!source.CanRead)
+                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
+
+            CheckPlatformSupport();
+            return LiteHashProvider.HashStreamAsync(
+                THash.HashAlgorithmName,
+                source,
+                destination,
+                cancellationToken);
+        }
+
+        internal static void CheckPlatformSupport()
+        {
+            if (!THash.IsSupported)
+                throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA1.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA1.cs
@@ -18,6 +18,13 @@ namespace System.Security.Cryptography
 
     public abstract class SHA1 : HashAlgorithm
     {
+        private sealed class HashTrait : IHashStatic
+        {
+            static int IHashStatic.HashSizeInBytes => HashSizeInBytes;
+            static string IHashStatic.HashAlgorithmName => HashAlgorithmNames.SHA1;
+            static bool IHashStatic.IsSupported => true;
+        }
+
         /// <summary>
         /// The hash size produced by the SHA1 algorithm, in bits.
         /// </summary>
@@ -48,27 +55,14 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentNullException">
         /// <paramref name="source" /> is <see langword="null" />.
         /// </exception>
-        public static byte[] HashData(byte[] source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(source));
-        }
+        public static byte[] HashData(byte[] source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA1 algorithm.
         /// </summary>
         /// <param name="source">The data to hash.</param>
         /// <returns>The hash of the data.</returns>
-        public static byte[] HashData(ReadOnlySpan<byte> source)
-        {
-            byte[] buffer = GC.AllocateUninitializedArray<byte>(HashSizeInBytes);
-
-            int written = HashData(source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
-        }
+        public static byte[] HashData(ReadOnlySpan<byte> source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA1 algorithm.
@@ -82,10 +76,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(source, destination, out int bytesWritten))
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            return bytesWritten;
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
         /// <summary>
@@ -102,16 +93,7 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.HashData(HashAlgorithmNames.SHA1, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HashStatic<HashTrait>.TryHashData(source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -135,15 +117,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA1, source, destination);
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
         /// <summary>
@@ -157,15 +131,7 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static byte[] HashData(Stream source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA1, HashSizeInBytes, source);
-        }
+        public static byte[] HashData(Stream source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Asynchronously computes the hash of a stream using the SHA1 algorithm.
@@ -184,12 +150,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStreamAsync(HashAlgorithmNames.SHA1, source, cancellationToken);
+            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
         }
 
         /// <summary>
@@ -220,19 +181,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStreamAsync(
-                HashAlgorithmNames.SHA1,
-                source,
-                destination,
-                cancellationToken);
+            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
         }
 
         private sealed class Implementation : SHA1

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA256.cs
@@ -18,6 +18,13 @@ namespace System.Security.Cryptography
 
     public abstract class SHA256 : HashAlgorithm
     {
+        private sealed class HashTrait : IHashStatic
+        {
+            static int IHashStatic.HashSizeInBytes => HashSizeInBytes;
+            static string IHashStatic.HashAlgorithmName => HashAlgorithmNames.SHA256;
+            static bool IHashStatic.IsSupported => true;
+        }
+
         /// <summary>
         /// The hash size produced by the SHA256 algorithm, in bits.
         /// </summary>
@@ -47,27 +54,14 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentNullException">
         /// <paramref name="source" /> is <see langword="null" />.
         /// </exception>
-        public static byte[] HashData(byte[] source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(source));
-        }
+        public static byte[] HashData(byte[] source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA256 algorithm.
         /// </summary>
         /// <param name="source">The data to hash.</param>
         /// <returns>The hash of the data.</returns>
-        public static byte[] HashData(ReadOnlySpan<byte> source)
-        {
-            byte[] buffer = GC.AllocateUninitializedArray<byte>(HashSizeInBytes);
-
-            int written = HashData(source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
-        }
+        public static byte[] HashData(ReadOnlySpan<byte> source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA256 algorithm.
@@ -81,10 +75,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(source, destination, out int bytesWritten))
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            return bytesWritten;
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
 
@@ -102,16 +93,7 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.HashData(HashAlgorithmNames.SHA256, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HashStatic<HashTrait>.TryHashData(source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -135,15 +117,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA256, source, destination);
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
         /// <summary>
@@ -157,15 +131,7 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static byte[] HashData(Stream source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA256, HashSizeInBytes, source);
-        }
+        public static byte[] HashData(Stream source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Asynchronously computes the hash of a stream using the SHA256 algorithm.
@@ -184,12 +150,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStreamAsync(HashAlgorithmNames.SHA256, source, cancellationToken);
+            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
         }
 
         /// <summary>
@@ -220,19 +181,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStreamAsync(
-                HashAlgorithmNames.SHA256,
-                source,
-                destination,
-                cancellationToken);
+            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
         }
 
         private sealed class Implementation : SHA256

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA384.cs
@@ -18,6 +18,13 @@ namespace System.Security.Cryptography
 
     public abstract class SHA384 : HashAlgorithm
     {
+        private sealed class HashTrait : IHashStatic
+        {
+            static int IHashStatic.HashSizeInBytes => HashSizeInBytes;
+            static string IHashStatic.HashAlgorithmName => HashAlgorithmNames.SHA384;
+            static bool IHashStatic.IsSupported => true;
+        }
+
         /// <summary>
         /// The hash size produced by the SHA384 algorithm, in bits.
         /// </summary>
@@ -47,27 +54,14 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentNullException">
         /// <paramref name="source" /> is <see langword="null" />.
         /// </exception>
-        public static byte[] HashData(byte[] source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(source));
-        }
+        public static byte[] HashData(byte[] source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA384 algorithm.
         /// </summary>
         /// <param name="source">The data to hash.</param>
         /// <returns>The hash of the data.</returns>
-        public static byte[] HashData(ReadOnlySpan<byte> source)
-        {
-            byte[] buffer = GC.AllocateUninitializedArray<byte>(HashSizeInBytes);
-
-            int written = HashData(source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
-        }
+        public static byte[] HashData(ReadOnlySpan<byte> source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA384 algorithm.
@@ -81,10 +75,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(source, destination, out int bytesWritten))
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            return bytesWritten;
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
         /// <summary>
@@ -101,16 +92,7 @@ namespace System.Security.Cryptography
         /// </returns>
         public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.HashData(HashAlgorithmNames.SHA384, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HashStatic<HashTrait>.TryHashData(source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -134,15 +116,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA384, source, destination);
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
         /// <summary>
@@ -156,15 +130,7 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static byte[] HashData(Stream source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA384, HashSizeInBytes, source);
-        }
+        public static byte[] HashData(Stream source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Asynchronously computes the hash of a stream using the SHA384 algorithm.
@@ -183,12 +149,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStreamAsync(HashAlgorithmNames.SHA384, source, cancellationToken);
+            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
         }
 
         /// <summary>
@@ -219,19 +180,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            return LiteHashProvider.HashStreamAsync(
-                HashAlgorithmNames.SHA384,
-                source,
-                destination,
-                cancellationToken);
+            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
         }
 
         private sealed class Implementation : SHA384

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_384.cs
@@ -18,6 +18,13 @@ namespace System.Security.Cryptography
     /// </remarks>
     public abstract class SHA3_384 : HashAlgorithm
     {
+        private sealed class HashTrait : IHashStatic
+        {
+            static int IHashStatic.HashSizeInBytes => HashSizeInBytes;
+            static string IHashStatic.HashAlgorithmName => HashAlgorithmNames.SHA3_384;
+            static bool IHashStatic.IsSupported => IsSupported;
+        }
+
         /// <summary>
         /// The hash size produced by the SHA3-384 algorithm, in bits.
         /// </summary>
@@ -55,7 +62,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static new SHA3_384 Create()
         {
-            CheckSha3Support();
+            HashStatic<HashTrait>.CheckPlatformSupport();
             return new Implementation();
         }
 
@@ -70,12 +77,7 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-384.
         /// </exception>
-        public static byte[] HashData(byte[] source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(source));
-        }
+        public static byte[] HashData(byte[] source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA3-384 algorithm.
@@ -85,15 +87,7 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-384.
         /// </exception>
-        public static byte[] HashData(ReadOnlySpan<byte> source)
-        {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
-        }
+        public static byte[] HashData(ReadOnlySpan<byte> source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA3-384 algorithm.
@@ -110,10 +104,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(source, destination, out int bytesWritten))
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            return bytesWritten;
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
 
@@ -134,18 +125,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            CheckSha3Support();
-
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.HashData(HashAlgorithmNames.SHA3_384, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HashStatic<HashTrait>.TryHashData(source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -172,16 +152,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            CheckSha3Support();
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA3_384, source, destination);
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
         /// <summary>
@@ -198,16 +169,7 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-384.
         /// </exception>
-        public static byte[] HashData(Stream source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            CheckSha3Support();
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA3_384, HashSizeInBytes, source);
-        }
+        public static byte[] HashData(Stream source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Asynchronously computes the hash of a stream using the SHA3-384 algorithm.
@@ -229,13 +191,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            CheckSha3Support();
-            return LiteHashProvider.HashStreamAsync(HashAlgorithmNames.SHA3_384, source, cancellationToken);
+            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
         }
 
         /// <summary>
@@ -269,26 +225,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            CheckSha3Support();
-            return LiteHashProvider.HashStreamAsync(
-                HashAlgorithmNames.SHA3_384,
-                source,
-                destination,
-                cancellationToken);
-        }
-
-        private static void CheckSha3Support()
-        {
-            if (!IsSupported)
-                throw new PlatformNotSupportedException();
+            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
         }
 
         private sealed class Implementation : SHA3_384

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_512.cs
@@ -18,6 +18,13 @@ namespace System.Security.Cryptography
     /// </remarks>
     public abstract class SHA3_512 : HashAlgorithm
     {
+        private sealed class HashTrait : IHashStatic
+        {
+            static int IHashStatic.HashSizeInBytes => HashSizeInBytes;
+            static string IHashStatic.HashAlgorithmName => HashAlgorithmNames.SHA3_512;
+            static bool IHashStatic.IsSupported => IsSupported;
+        }
+
         /// <summary>
         /// The hash size produced by the SHA3-512 algorithm, in bits.
         /// </summary>
@@ -55,7 +62,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static new SHA3_512 Create()
         {
-            CheckSha3Support();
+            HashStatic<HashTrait>.CheckPlatformSupport();
             return new Implementation();
         }
 
@@ -70,12 +77,7 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-512.
         /// </exception>
-        public static byte[] HashData(byte[] source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            return HashData(new ReadOnlySpan<byte>(source));
-        }
+        public static byte[] HashData(byte[] source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA3-512 algorithm.
@@ -85,15 +87,7 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-512.
         /// </exception>
-        public static byte[] HashData(ReadOnlySpan<byte> source)
-        {
-            byte[] buffer = new byte[HashSizeInBytes];
-
-            int written = HashData(source, buffer.AsSpan());
-            Debug.Assert(written == buffer.Length);
-
-            return buffer;
-        }
+        public static byte[] HashData(ReadOnlySpan<byte> source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Computes the hash of data using the SHA3-512 algorithm.
@@ -110,10 +104,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            if (!TryHashData(source, destination, out int bytesWritten))
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            return bytesWritten;
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
         /// <summary>
@@ -133,18 +124,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
         {
-            CheckSha3Support();
-
-            if (destination.Length < HashSizeInBytes)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = HashProviderDispenser.OneShotHashProvider.HashData(HashAlgorithmNames.SHA3_512, source, destination);
-            Debug.Assert(bytesWritten == HashSizeInBytes);
-
-            return true;
+            return HashStatic<HashTrait>.TryHashData(source, destination, out bytesWritten);
         }
 
         /// <summary>
@@ -171,16 +151,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static int HashData(Stream source, Span<byte> destination)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            CheckSha3Support();
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA3_512, source, destination);
+            return HashStatic<HashTrait>.HashData(source, destination);
         }
 
         /// <summary>
@@ -197,16 +168,7 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-512.
         /// </exception>
-        public static byte[] HashData(Stream source)
-        {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            CheckSha3Support();
-            return LiteHashProvider.HashStream(HashAlgorithmNames.SHA3_512, HashSizeInBytes, source);
-        }
+        public static byte[] HashData(Stream source) => HashStatic<HashTrait>.HashData(source);
 
         /// <summary>
         /// Asynchronously computes the hash of a stream using the SHA3-512 algorithm.
@@ -228,13 +190,7 @@ namespace System.Security.Cryptography
         /// </exception>
         public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            CheckSha3Support();
-            return LiteHashProvider.HashStreamAsync(HashAlgorithmNames.SHA3_512, source, cancellationToken);
+            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
         }
 
         /// <summary>
@@ -268,26 +224,7 @@ namespace System.Security.Cryptography
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(source);
-
-            if (destination.Length < HashSizeInBytes)
-                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-
-            if (!source.CanRead)
-                throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
-
-            CheckSha3Support();
-            return LiteHashProvider.HashStreamAsync(
-                HashAlgorithmNames.SHA3_512,
-                source,
-                destination,
-                cancellationToken);
-        }
-
-        private static void CheckSha3Support()
-        {
-            if (!IsSupported)
-                throw new PlatformNotSupportedException();
+            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
         }
 
         private sealed class Implementation : SHA3_512


### PR DESCRIPTION
This is the same refactoring as #119823 except for hashes instead of HMAC. 