### PR TITLE
[clr-interp] Fix conservative reporting data in gc enumeration

### DIFF
--- a/src/coreclr/nativeaot/Runtime/GcEnum.cpp
+++ b/src/coreclr/nativeaot/Runtime/GcEnum.cpp
@@ -72,13 +72,22 @@ static void GcEnumObject(PTR_PTR_Object ppObj, uint32_t flags, ScanFunc* fnGcEnu
     //
     assert((flags & ~(GC_CALL_INTERIOR | GC_CALL_PINNED)) == 0);
 
-    // for interior pointers, we optimize the case in which
-    //  it points into the current threads stack area
-    //
-    if (flags & GC_CALL_INTERIOR)
+    if ((flags & GC_CALL_PINNED) && !pSc->promotion)
+    {
+        // Do nothing. This is the relocate phase, for something that was pinned. It does not need
+        // to be relocated.
+    }
+    else if (flags & GC_CALL_INTERIOR)
+    {
+        // for interior pointers, we optimize the case in which
+        //  it points into the current threads stack area
+        //
         PromoteCarefully(ppObj, flags, fnGcEnumRef, pSc);
+    }
     else
+    {
         fnGcEnumRef(ppObj, pSc, flags);
+    }
 }
 
 void EnumGcRef(PTR_OBJECTREF pRef, GCRefKind kind, ScanFunc* fnGcEnumRef, ScanContext* pSc)

--- a/src/coreclr/vm/gcenv.ee.common.cpp
+++ b/src/coreclr/vm/gcenv.ee.common.cpp
@@ -215,7 +215,9 @@ void GcEnumObject(LPVOID pData, OBJECTREF *pObj, uint32_t flags)
         PromoteCarefully(pCtx->f, ppObj, pCtx->sc, flags);
     }
     else
+    {
         (pCtx->f)(ppObj, pCtx->sc, flags);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/vm/gcenv.ee.common.cpp
+++ b/src/coreclr/vm/gcenv.ee.common.cpp
@@ -200,11 +200,20 @@ void GcEnumObject(LPVOID pData, OBJECTREF *pObj, uint32_t flags)
     //
     assert((flags & ~(GC_CALL_INTERIOR|GC_CALL_PINNED)) == 0);
 
-    // for interior pointers, we optimize the case in which
-    //  it points into the current threads stack area
-    //
-    if (flags & GC_CALL_INTERIOR)
+    if ((flags & GC_CALL_PINNED) && !pCtx->sc->promotion)
+    {
+        // Do nothing. This is the relocate phase, for something that was pinned. It does not need
+        // to be relocated, and on interpreter builds, where we use conservative reporting in some situations,
+        // we MUST NOT attempt to do promotion here, as the GC is not expecting conservative reporting to report
+        // conservative roots during the relocate phase.
+    }
+    else if (flags & GC_CALL_INTERIOR)
+    {
+        // for interior pointers, we optimize the case in which
+        //  it points into the current threads stack area
+        //
         PromoteCarefully(pCtx->f, ppObj, pCtx->sc, flags);
+    }
     else
         (pCtx->f)(ppObj, pCtx->sc, flags);
 }


### PR DESCRIPTION
I found that if the conservative reference pointed into the GC it caused problems in the relocation logic in the GC. For all forms of pinned references, the relocation phase isn't necessary, so add a check for it and avoid the problem.