### PR TITLE
Consider all MemberInfo references for IsCollectible

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.CoreCLR.cs
@@ -173,7 +173,7 @@ namespace System.Reflection
         internal RuntimeType GetRuntimeType() { return m_declaringType; }
         internal RuntimeModule GetRuntimeModule() { return RuntimeTypeHandle.GetModule(m_declaringType); }
         internal RuntimeAssembly GetRuntimeAssembly() { return GetRuntimeModule().GetRuntimeAssembly(); }
-        public override bool IsCollectible => m_declaringType.IsCollectible;
+        public override bool IsCollectible => ReflectedTypeInternal.IsCollectible;
         #endregion
 
         #region MethodBase Overrides

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
@@ -129,7 +129,7 @@ namespace System.Reflection
         public override int MetadataToken => m_token;
         public override Module Module => GetRuntimeModule();
         internal RuntimeModule GetRuntimeModule() { return m_declaringType.GetRuntimeModule(); }
-        public override bool IsCollectible => m_declaringType.IsCollectible;
+        public override bool IsCollectible => ReflectedTypeInternal.IsCollectible;
         #endregion
 
         #region EventInfo Overrides

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -45,7 +45,7 @@ namespace System.Reflection
         public sealed override bool HasSameMetadataDefinitionAs(MemberInfo other) => HasSameMetadataDefinitionAsCore<RuntimeFieldInfo>(other);
 
         public override Module Module => GetRuntimeModule();
-        public override bool IsCollectible => m_declaringType.IsCollectible;
+        public override bool IsCollectible => ReflectedTypeInternal.IsCollectible;
 
         #endregion
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
@@ -322,6 +322,9 @@ namespace System.Reflection
         {
             get
             {
+                if (ReflectedTypeInternal.IsCollectible)
+                    return true;
+
                 bool isCollectible = RuntimeMethodHandle.IsCollectible(new RuntimeMethodHandleInternal(m_handle));
                 GC.KeepAlive(this); // We directly pass the native handle above - make sure this object stays alive for the call
                 return isCollectible;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -180,7 +180,7 @@ namespace System.Reflection
 
         public override Module Module => GetRuntimeModule();
         internal RuntimeModule GetRuntimeModule() { return m_declaringType.GetRuntimeModule(); }
-        public override bool IsCollectible => m_declaringType.IsCollectible;
+        public override bool IsCollectible => ReflectedTypeInternal.IsCollectible;
 
         public override bool Equals(object? obj) =>
             ReferenceEquals(this, obj) ||

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/IsCollectibleTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/IsCollectibleTests.cs
@@ -132,17 +132,10 @@ namespace System.Reflection.Tests
             }).Dispose();
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [InlineData("MyField")]
-        [InlineData("MyProperty")]
-        [InlineData("MyMethod")]
-        [InlineData("MyGenericMethod")]
-        [InlineData("MyStaticMethod")]
-        [InlineData("MyStaticField")]
-        [InlineData("MyStaticGenericMethod")]
-        public void MemberInfo_IsCollectibleFalse_WhenUsingAssemblyLoad(string memberName)
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void MemberInfo_IsCollectibleFalse_WhenUsingAssemblyLoad()
         {
-            RemoteExecutor.Invoke((marshalledName) =>
+            RemoteExecutor.Invoke(() =>
             {
                 Type t1 = Type.GetType(
                     "TestCollectibleAssembly.MyTestClass, TestCollectibleAssembly, Version=1.0.0.0",
@@ -153,25 +146,18 @@ namespace System.Reflection.Tests
 
                 Assert.NotNull(t1);
 
-                var member = t1.GetMember(marshalledName).FirstOrDefault();
+                foreach (var member in t1.GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    Assert.False(member.IsCollectible, member.ToString());
+                }
 
-                Assert.NotNull(member);
-
-                Assert.False(member.IsCollectible);
-            }, memberName).Dispose();
+            }).Dispose();
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [InlineData("MyStaticGenericField")]
-        [InlineData("MyStaticField")]
-        [InlineData("MyStaticGenericMethod")]
-        [InlineData("MyStaticMethod")]
-        [InlineData("MyGenericField")]
-        [InlineData("MyGenericProperty")]
-        [InlineData("MyGenericMethod")]
-        public void MemberInfoGeneric_IsCollectibleFalse_WhenUsingAssemblyLoad(string memberName)
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void MemberInfoGeneric_IsCollectibleFalse_WhenUsingAssemblyLoad()
         {
-            RemoteExecutor.Invoke((marshalledName) =>
+            RemoteExecutor.Invoke(() =>
             {
                 Type t1 = Type.GetType(
                     "TestCollectibleAssembly.MyGenericTestClass`1[System.Int32], TestCollectibleAssembly, Version=1.0.0.0",
@@ -182,25 +168,18 @@ namespace System.Reflection.Tests
 
                 Assert.NotNull(t1);
 
-                var member = t1.GetMember(marshalledName).FirstOrDefault();
+                foreach (var member in t1.GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    Assert.False(member.IsCollectible, member.ToString());
+                }
 
-                Assert.NotNull(member);
-
-                Assert.False(member.IsCollectible);
-            }, memberName).Dispose();
+            }).Dispose();
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [InlineData("MyField")]
-        [InlineData("MyProperty")]
-        [InlineData("MyMethod")]
-        [InlineData("MyGenericMethod")]
-        [InlineData("MyStaticMethod")]
-        [InlineData("MyStaticField")]
-        [InlineData("MyStaticGenericMethod")]
-        public void MemberInfo_IsCollectibleTrue_WhenUsingAssemblyLoadContext(string memberName)
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void MemberInfo_IsCollectibleTrue_WhenUsingAssemblyLoadContext()
         {
-            RemoteExecutor.Invoke((marshalledName) =>
+            RemoteExecutor.Invoke(() =>
             {
                 AssemblyLoadContext alc = new TestAssemblyLoadContext();
 
@@ -213,25 +192,18 @@ namespace System.Reflection.Tests
 
                 Assert.NotNull(t1);
 
-                var member = t1.GetMember(marshalledName).FirstOrDefault();
+                foreach (var member in t1.GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    Assert.True(member.IsCollectible, member.ToString());
+                }
 
-                Assert.NotNull(member);
-
-                Assert.True(member.IsCollectible);
-            }, memberName).Dispose();
+            }).Dispose();
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [InlineData("MyStaticGenericField")]
-        [InlineData("MyStaticField")]
-        [InlineData("MyStaticGenericMethod")]
-        [InlineData("MyStaticMethod")]
-        [InlineData("MyGenericField")]
-        [InlineData("MyGenericProperty")]
-        [InlineData("MyGenericMethod")]
-        public void MemberInfoGeneric_IsCollectibleTrue_WhenUsingAssemblyLoadContext(string memberName)
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void MemberInfoGeneric_IsCollectibleTrue_WhenUsingAssemblyLoadContext()
         {
-            RemoteExecutor.Invoke((marshalledName) =>
+            RemoteExecutor.Invoke(() =>
             {
                 AssemblyLoadContext alc = new TestAssemblyLoadContext();
 
@@ -244,12 +216,12 @@ namespace System.Reflection.Tests
 
                 Assert.NotNull(t1);
 
-                var member = t1.GetMember(marshalledName).FirstOrDefault();
+                foreach (var member in t1.GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    Assert.True(member.IsCollectible, member.ToString());
+                }
 
-                Assert.NotNull(member);
-
-                Assert.True(member.IsCollectible);
-            }, memberName).Dispose();
+            }).Dispose();
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
@@ -268,7 +240,16 @@ namespace System.Reflection.Tests
 
                 Assert.NotNull(t1);
 
-                Assert.True(t1.IsCollectible);
+                foreach (var member in t1.GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    if (member is Type)
+                    {
+                        continue;
+                    }
+
+                    Assert.True(member.IsCollectible, member.ToString());
+                }
+
             }).Dispose();
         }
     }


### PR DESCRIPTION
Use ReflectedType instead DeclaringType since ReflectedType can be colletible even when DeclaringType is not.

These fixes support typical IsCollectible use case where the property is used to determine whether or how the reflection objects can be cached.

Fix #119697