### PR TITLE
Remove darc-pub-dotnet-runtime-488a8a3 feed from Wasm tests

### DIFF
--- a/src/mono/wasi/Wasi.Build.Tests/data/nuget8.config
+++ b/src/mono/wasi/Wasi.Build.Tests/data/nuget8.config
@@ -9,11 +9,6 @@
     <!-- TEST_RESTORE_SOURCES_INSERTION_LINE -->
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="nuget.org"  value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-
-    <!-- work around illink needing a stable version for now -->
-    <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-488a8a3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-488a8a35/nuget/v3/index.json" />
-    <!--  End: Package sources from dotnet-runtime -->
   </packageSources>
     <disabledPackageSources>
     <clear />

--- a/src/mono/wasm/Wasm.Build.Tests/data/nuget8.config
+++ b/src/mono/wasm/Wasm.Build.Tests/data/nuget8.config
@@ -9,11 +9,6 @@
     <!-- TEST_RESTORE_SOURCES_INSERTION_LINE -->
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="nuget.org"  value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-
-    <!-- work around illink needing a stable version for now -->
-    <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-488a8a3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-488a8a35/nuget/v3/index.json" />
-    <!--  End: Package sources from dotnet-runtime -->
   </packageSources>
     <disabledPackageSources>
     <clear />


### PR DESCRIPTION
The feed is no longer needed and it was recently disabled on AzDO and causes test failures in WasmBuildTests