### PR TITLE
[release/10.0] Migrate to WiX 5 (#117010)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -168,5 +168,12 @@
     <NodePackageVersion>$(runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion)</NodePackageVersion>
     <!-- The package path for python in src/mono/mono.proj needs to be updated if this changes-->
     <EmsdkVersion>3.1.56</EmsdkVersion>
+    <!-- WiX 5+ dependencies for MSI generation -->
+    <MicrosoftWixVersion>5.0.2-dotnet.2737382</MicrosoftWixVersion>
+    <MicrosoftWixToolsetUIWixextVersion>5.0.2-dotnet.2737382</MicrosoftWixToolsetUIWixextVersion>
+    <MicrosoftWixToolsetDependencyWixextVersion>5.0.2-dotnet.2737382</MicrosoftWixToolsetDependencyWixextVersion>
+    <MicrosoftWixToolsetUtilWixextVersion>5.0.2-dotnet.2737382</MicrosoftWixToolsetUtilWixextVersion>
+    <MicrosoftWixToolsetBalWixextVersion>5.0.2-dotnet.2737382</MicrosoftWixToolsetBalWixextVersion>
+    <MicrosoftWixToolsetHeatVersion>5.0.2-dotnet.2737382</MicrosoftWixToolsetHeatVersion>
   </PropertyGroup>
 </Project>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <SharedFrameworkName>$(MicrosoftNetCoreAppFrameworkName)</SharedFrameworkName>
     <SharedFrameworkFriendlyName>.NET Runtime</SharedFrameworkFriendlyName>
+    <UseWix5>true</UseWix5>
   </PropertyGroup>
 
   <!--

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.targets
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.targets
@@ -4,6 +4,15 @@
 
   <ItemGroup Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)' and '$(TargetsMobile)' != 'true'">
     <PackageReference Condition="'$(SkipInstallersPackageReference)' != 'true'" Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersVersion)" />
+
+    <!-- Microsoft.Wix is a dotnet tool package, so exclude its assets. -->
+    <PackageReference Include="Microsoft.Wix" Version="$(MicrosoftWixVersion)" ExcludeAssets="all" />
+    <!-- Installers needs the $(PkgMicrosoftWixToolsetUIwixext) property to locate the extension. -->
+    <PackageReference Include="Microsoft.WixToolset.UI.wixext" Version="$(MicrosoftWixToolsetUIWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Dependency.wixext" Version="$(MicrosoftWixToolsetDependencyWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Util.wixext" Version="$(MicrosoftWixToolsetUtilWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Bal.wixext" Version="$(MicrosoftWixToolsetBalWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Heat" Version="$(MicrosoftWixToolsetHeatVersion)" />
   </ItemGroup>
 
   <Target Name="AddLongNameDacToPlatformManifest" DependsOnTargets="GetAssemblyVersion" BeforeTargets="GetFilesToPackage">

--- a/src/installer/pkg/sfx/bundle/Microsoft.NETCore.App.Bundle.bundleproj
+++ b/src/installer/pkg/sfx/bundle/Microsoft.NETCore.App.Bundle.bundleproj
@@ -15,9 +15,18 @@
     <MacOSBundleTemplate>$(MSBuildProjectDirectory)/shared-framework-distribution-template-$(TargetArchitecture).xml</MacOSBundleTemplate>
     <MacOSBundleIdentifierName>com.microsoft.dotnet.Microsoft.NETCore.App.$(ProductVersion).osx.$(TargetArchitecture)</MacOSBundleIdentifierName>
     <MacOSBundleResourcesPath>osx_resources</MacOSBundleResourcesPath>
+    <UseWix5>true</UseWix5>
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Microsoft.Wix is a dotnet tool package, so exclude its assets. -->
+    <PackageReference Include="Microsoft.Wix" Version="$(MicrosoftWixVersion)" ExcludeAssets="all" />
+    <!-- Installers needs the $(PkgMicrosoftWixToolsetUIwixext) property to locate the extension. -->
+    <PackageReference Include="Microsoft.WixToolset.UI.wixext" Version="$(MicrosoftWixToolsetUIWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Dependency.wixext" Version="$(MicrosoftWixToolsetDependencyWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Util.wixext" Version="$(MicrosoftWixToolsetUtilWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Bal.wixext" Version="$(MicrosoftWixToolsetBalWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Heat" Version="$(MicrosoftWixToolsetHeatVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
   </ItemGroup>

--- a/src/installer/pkg/sfx/bundle/bundle.thm
+++ b/src/installer/pkg/sfx/bundle/bundle.thm
@@ -1,114 +1,144 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Theme xmlns="http://wixtoolset.org/schemas/thmutil/2010">
-  <Window Width="660" Height="468" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
-    <Font Id="0" Height="-12" Weight="500" Foreground="000000" Background="FFFFFF">Segoe UI</Font>
-    <Font Id="1" Height="-24" Weight="900" Foreground="FFFFFF" Background="D42B51">Segoe UI</Font>
-    <Font Id="2" Height="-22" Weight="500" Foreground="666666">Segoe UI</Font>
-    <Font Id="3" Height="-12" Weight="500" Foreground="000000" Background="FFFFFF">Segoe UI</Font>
-    <Font Id="4" Height="-12" Weight="500" Foreground="ff0000" Background="FFFFFF" Underline="yes">Segoe UI</Font>
-    <Font Id="5" Height="-14" Weight="500" Foreground="444444">Segoe UI</Font>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
+<Theme xmlns="http://wixtoolset.org/schemas/v4/thmutil">
+  <!-- Use system colors where possible as they change based on themes and are automatically adjusted for high contrast.
+       For custom colors, ensure the contrast ratio is at least 4.5:1 (3:1 for large text and other UI components).
+       The WinUI 3 Gallery app can be used to calculate contrast settings. Take note that custom colors for <Font>
+       elements use BGR instead of RGB ordering.
 
-    <Text Name="Title" X="11" Y="11" Width="-11" Height="64" FontId="1" Visible="yes" Center="yes" DisablePrefix="yes">#(loc.Title)</Text>
+       Line spacing for fonts should be rounded to the nearest multiple of 4. For example, Segoe UI with a height of 24 has
+       a line spacing of 31.9, so 32 should be used when calculating the height of a control that contains a single line of text,
+       like a label. For a height of 12, the line spacing to use is 16. -->
+  <Font Id="DefaultFont" Height="-12" Weight="500" Foreground="windowtext" Background="window">Segoe UI</Font>
+  <Font Id="WindowBannerFont" Height="-24" Weight="900" Foreground="FFFFFF" Background="D42B51">Segoe UI</Font>
+  <Font Id="PageHeaderFont" Height="-20" Weight="500" Foreground="graytext" Background="window">Segoe UI</Font>
+  <!-- Do not change the foreground color to "red". While 0127E6 yields acceptable ratios for light/dark backgrounds, some
+       contrast themes like Dusk drops the ratio below 4.5. -->
+  <Font Id="ErrorFont" Height="-12" Weight="900" Foreground="windowtext" Background="window">Segoe UI</Font>
+
+  <!-- In v5, Window@Width and Window@Height refers to the client area, not the window area. wixstdba calls 
+       AdjustWindowRectEx or AdjustWindowRectExForDpi (if supported) to produce a window with the desired client area. -->
+  <Window Width="644" Height="460" HexStyle="100a0000" FontId="DefaultFont" Caption="#(loc.Caption)" IconFile="dotnet.ico">
+    <ImageControl Name="DotNetLogo" X="12" Y="-48" Width="124" Height="124" ImageFile="DotNetLogo_256x.png" Visible="yes" />
+
+    <!-- A width of 0 extends the control to the right of the window. The first label will render an opaque rectangle using
+         the background color of the specified font. The second label overlays the title text. This is necessary since
+         the vertical offset of the text cannot be specified. -->
+    <Label Name="TitleBackground" X="0" Y="0" Width="0" Height="72" FontId="WindowBannerFont" Visible="yes" DisablePrefix="yes" />
+    <Label Name="Title" X="0" Y="12" Width="0" Height="32" FontId="WindowBannerFont" Visible="yes" Center="yes" DisablePrefix="yes">#(loc.Title)</Label>
 
     <Page Name="Help">
-        <Text X="0" Y="0" Width="620" Height="75" FontId="1" />
+      <Label Name="HelpHeader" X="148" Y="80" Width="-12" Height="32" FontId="PageHeaderFont" HexStyle="00000000" DisablePrefix="yes">#(loc.HelpHeader)</Label>
+      <Label Name="HelpText" X="148" Y="124" Width="-12" Height="-48" FontId="DefaultFont" HexStyle="00000000" DisablePrefix="yes">#(loc.HelpText)</Label>
 
-        <Text Name="HelpHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Text>
-        <Text Name="HelpText" X="20" Y="115" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Text>
-        <Button Name="HelpCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.HelpCloseButton)</Button>
-        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+      <Button Name="HelpCancelButton"  X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">
+        <Text>#(loc.HelpCloseButton)</Text>
+        <CloseWindowAction/>
+      </Button>
     </Page>
     <Page Name="Install">
-        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
-        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+      <Label Name="WelcomeHeaderMessage" X="148" Y="80" Width="-12" Height="32" FontId="PageHeaderFont" HexStyle="000000">#(loc.WelcomeHeaderMessage)</Label>
 
-        <Text Name="WelcomeText" X="155" Y="80" Width="-11" Height="-70" FontId="2" HexStyle="0x800000" DisablePrefix="yes" />
-        <Text Name="WelcomeHeaderMessage" X="160" Y="81" Width="300" Height="30" FontId="2">#(loc.WelcomeHeaderMessage)</Text>
-        <Text Name="WelcomeDescription" X="160" Y="125" Width="460" Height="65" FontId="3">#(loc.WelcomeDescription)</Text>
-        <Text Name="LicenseAssent" X="160" Y="244" Width="460" Height="30" FontId="3">#(loc.LicenseAssent)</Text>
-        <Hypertext Name="PrivacyStatementLink" X="185" Y="281" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.PrivacyStatementLink)</Hypertext>
-        <Hypertext Name="EulaLink" X="185" Y="303" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.EulaLink)</Hypertext>
-        <Button Name="InstallButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
-        <Button Name="WelcomeCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
-    </Page>
-    <Page Name="Options">
-        <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
-        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+      <Label Name="WelcomeDescription" X="148" Y="124" Width="-12" Height="144" FontId="DefaultFont" HexStyle="000000">#(loc.WelcomeDescription)</Label>
 
-        <Text X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.OptionsHeader)</Text>
-        <Text X="11" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OptionsLocationLabel)</Text>
-        <Editbox Name="FolderEditbox" X="11" Y="143" Width="-91" Height="21" TabStop="yes" FontId="3" FileSystemAutoComplete="yes" />
-        <Button Name="BrowseButton" X="-11" Y="142" Width="75" Height="23" TabStop="yes" FontId="3">#(loc.OptionsBrowseButton)</Button>
-        <Button Name="OptionsOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.OptionsOkButton)</Button>
-        <Button Name="OptionsCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.OptionsCancelButton)</Button>
-    </Page>
-    <Page Name="FilesInUse">
-        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+      <!-- Align the label with the top of the logo on the left. -->
+      <Label Name="LicenseAssent" X="148" Y="288" Width="-12" Height="32" FontId="DefaultFont" HexStyle="000000">#(loc.LicenseAssent)</Label>
 
-        <Text Name="FilesInUseHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.FilesInUseHeader)</Text>
-        <Text Name="FilesInUseLabel" X="11" Y="121" Width="-11" Height="34" FontId="3" DisablePrefix="yes">#(loc.FilesInUseLabel)</Text>
-        <Text Name="FilesInUseText" X="11" Y="150" Width="-11" Height="-86" FontId="3" DisablePrefix="yes" HexStyle="0x0000000C"></Text>
+      <!-- These controls have larger vertical spacing to improve readability (20 instead of 16). -->
+      <Hypertext Name="PrivacyStatementLink" X="172" Y="320" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</Hypertext>
+      <Hypertext Name="EulaLink" X="172" Y="340" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Licensing Information for .NET&lt;/A&gt;</Hypertext>
 
-        <Button Name="FilesInUseCloseRadioButton" X="300" Y="-65" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseCloseRadioButton)</Button>
-        <Button Name="FilesInUseDontCloseRadioButton" X="300" Y="-45" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseDontCloseRadioButton)</Button>
-
-        <Button Name="FilesInUseOkButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
-        <Button Name="FilesInUseCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.FilesInUseCancelButton)</Button>
-        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+      <Button Name="InstallButton" X="-124" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">#(loc.InstallInstallButton)</Button>
+      <Button Name="InstallCancelButton" X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">
+        <Text>#(loc.InstallCloseButton)</Text>
+        <CloseWindowAction/>
+      </Button>
     </Page>
     <Page Name="Progress">
-        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
-        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+      <Label HexStyle="000000" Name="ProgressHeader" X="12" Y="80" Width="-12" Height="32" FontId="PageHeaderFont" DisablePrefix="yes">#(loc.ProgressHeader)</Label>
+      <Label HexStyle="000000" Name="ProgressLabel" X="12" Y="124" Width="96" Height="16" FontId="DefaultFont" DisablePrefix="yes">#(loc.ProgressLabel)</Label>
+      <Label HexStyle="000000" Name="OverallProgressPackageText" X="108" Y="124" Width="-12" Height="16" FontId="DefaultFont" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Label>
 
-        <Text Name="ProgressHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Text>
-        <Text Name="ProgressLabel" X="11" Y="121" Width="70" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
-        <Text Name="OverallProgressPackageText" X="85" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Text>
-        <Progressbar Name="OverallCalculatedProgressbar" X="11" Y="143" Width="-11" Height="15" />
-        <Button Name="ProgressCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
+      <Progressbar Name="OverallCalculatedProgressbar" X="12" Y="152" Width="-12" Height="20" />
+
+      <Button Name="ProgressCancelButton" X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">
+        #(loc.ProgressCancelButton)
+        <CloseWindowAction/>
+      </Button>
     </Page>
     <Page Name="Modify">
-        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
-        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+      <Label Name="ModifyHeader" X="148" Y="80" Width="-12" Height="32" FontId="PageHeaderFont" DisablePrefix="yes">#(loc.ModifyHeader)</Label>
 
-        <Text Name="ModifyHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Text>
-        <Button Name="RepairButton" X="-231" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
-        <Button Name="UninstallButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
-        <Button Name="ModifyCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
+      <Label Name="ModifyText" X="148" Y="124" Width="-12" Height="-48" FontId="DefaultFont" HexStyle="00000000" DisablePrefix="yes">#(loc.ModifyText)</Label>
+
+      <Button Name="RepairButton" X="-236" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
+      <Button Name="UninstallButton" X="-124" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">#(loc.ModifyUninstallButton)</Button>
+      <Button Name="ModifyCancelButton" X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">
+        <Text>#(loc.ModifyCloseButton)</Text>
+        <CloseWindowAction/>
+      </Button>
     </Page>
     <Page Name="Success">
-        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
-        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+      <Label Name="SuccessHeader" X="148" Y="80" Width="-12" Height="32" HexStyle="00000000" FontId="PageHeaderFont">
+        <!-- Default text to display if none of the conditions are true. -->
+        <Text>#(loc.SuccessHeader)</Text>
+        <Text Condition="WixBundleAction = 2">#(loc.SuccessLayoutHeader)</Text>
+        <Text Condition="WixBundleAction = 3">#(loc.SuccessUnsafeUninstallHeader)</Text>
+        <Text Condition="WixBundleAction = 4">#(loc.SuccessUninstallHeader)</Text>
+        <Text Condition="WixBundleAction = 5">#(loc.SuccessCacheHeader)</Text>
+        <Text Condition="WixBundleAction = 6">#(loc.SuccessInstallHeader)</Text>
+        <Text Condition="WixBundleAction = 7">#(loc.SuccessModifyHeader)</Text>
+        <Text Condition="WixBundleAction = 8">#(loc.SuccessRepairHeader)</Text>
+      </Label>
 
-        <Text Name="SuccessHeader" X="11" Y="80"  Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>
-        <Text Name="SuccessInstallHeader" X="160" Y="80" Width="400" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
-        <Text Name="SuccessRepairHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
-        <Text Name="SuccessUninstallHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
-        <Button Name="LaunchButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
-        <Text Name="SuccessRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
+      <!-- Only display the welcome message when an installation was performed. Message is broken up to
+           ensure tab order is correct. -->
+      <Label HexStyle="00000000" EnableCondition="WixBundleAction = 6" Name="SuccessInstallLocation" X="148" Y="124" Width="-12" Height="16" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.SuccessInstallLocation)</Label>
+      <Label HexStyle="00000000" EnableCondition="WixBundleAction = 6" Name="SuccessInstallProductName" X="172" Y="156" Width="-12" Height="16" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.SuccessInstallProductName)</Label>
+      <Label HexStyle="00000000" EnableCondition="WixBundleAction = 6" Name="ResourcesHeader" X="148" Y="200" Width="-12" Height="32" FontId="PageHeaderFont" HideWhenDisabled="yes">#(loc.ResourcesHeader)</Label>
+      <Hypertext HexStyle="00000000" EnableCondition="WixBundleAction = 6" Name="DocumentationLink" X="172" Y="244" Width="-12" Height="16" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.DocumentationLink)</Hypertext>
+      <Hypertext HexStyle="00000000" EnableCondition="WixBundleAction = 6" Name="ReleaseNotesLink" X="172" Y="264" Width="-12" Height="16" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.ReleaseNotesLink)</Hypertext>
+      <Hypertext HexStyle="00000000" EnableCondition="WixBundleAction = 6" Name="TutorialLink" X="172" Y="284" Width="-12" Height="16" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.TutorialLink)</Hypertext>
+      <Hypertext HexStyle="00000000" EnableCondition="WixBundleAction = 6" Name="TelemetryLink" X="172" Y="304" Width="-12" Height="16" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.TelemetryLink)</Hypertext>
 
-         <Text Name="SuccessInstallLocation" X="160" Y="130" Width="400" Height="20" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallLocation)</Text>
-         <Text Name="SuccessInstallProductName" X="185" Y="155" Width="400" Height="30" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallProductName)</Text>
-         <Text Name="SuccessInstallResourcesHeader" X="160" Y="195" Width="400" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.ResourcesHeader)</Text>
-         <Hypertext Name="DocumentationLink" X="185" Y="238" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.DocumentationLink)</Hypertext>
-         <Hypertext Name="ReleaseNotesLink" X="185" Y="259" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.ReleaseNotesLink)</Hypertext>
-         <Hypertext Name="TutorialLink" X="185" Y="280" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TutorialLink)</Hypertext>
-         <Hypertext Name="TelemetryLink" X="185" Y="301" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TelemetryLink)</Hypertext>
+      <Label X="148" Y="-48" Width="-12" Height="34" FontId="DefaultFont" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">
+        <Text>#(loc.SuccessRestartText)</Text>
+        <Text Condition="WixBundleAction = 3">#(loc.SuccessUninstallRestartText)</Text>
+      </Label>
 
-        <Button Name="SuccessRestartButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
-        <Button Name="SuccessCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>
+      <!-- Calculate the relative offset as follows, assuming there are two buttons, right aligned:
+           First button, X="-12" Width="100"
+           Second button, X="-124" (-12 - 100 (width of first button) - 12 (gap between buttons)) -->
+      <Button Name="SuccessRestartButton" X="-124" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
+      <Button Name="SuccessCloseButton" X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">
+        <Text>#(loc.SuccessCloseButton)</Text>
+        <CloseWindowAction />
+      </Button>
     </Page>
     <Page Name="Failure">
-        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
-        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+      <Label Name="FailureHeader" X="148" Y="80" Width="-12" Height="32" HexStyle="00000000" FontId="PageHeaderFont">
+        <Text>#(loc.FailureHeader)</Text>
+        <Text Condition="WixBundleAction = 2">#(loc.FailureLayoutHeader)</Text>
+        <Text Condition="WixBundleAction = 3">#(loc.FailureUnsafeUninstallHeader)</Text>
+        <Text Condition="WixBundleAction = 4">#(loc.FailureUninstallHeader)</Text>
+        <Text Condition="WixBundleAction = 5">#(loc.FailureCacheHeader)</Text>
+        <Text Condition="WixBundleAction = 6">#(loc.FailureInstallHeader)</Text>
+        <Text Condition="WixBundleAction = 7">#(loc.FailureModifyHeader)</Text>
+        <Text Condition="WixBundleAction = 8">#(loc.FailureRepairHeader)</Text>
+      </Label>
 
-        <Text Name="FailureHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureHeader)</Text>
-        <Text Name="FailureInstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureInstallHeader)</Text>
-        <Text Name="FailureUninstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureUninstallHeader)</Text>
-        <Text Name="FailureRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRepairHeader)</Text>
-        <Hypertext Name="FailureLogFileLink" X="11" Y="121" Width="-11" Height="42" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
-        <Hypertext Name="FailureMessageText" X="22" Y="163" Width="-11" Height="51" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
-        <Text Name="FailureRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRestartText)</Text>
-        <Button Name="FailureRestartButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
-        <Button Name="FailureCloseButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.FailureCloseButton)</Button>
+      <!-- Reserve three lines of space (2 for the message plus a 3rd for a line break. -->
+      <Hypertext HexStyle="000000" Name="FailureLogFileLink" X="148" Y="124" Width="-12" Height="48" FontId="DefaultFont" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
+
+      <!-- This element is updated by the bootstrapper application. Reserve 3 lines of space. -->
+      <Hypertext HexStyle="000000" Name="FailureMessageText" X="148" Y="172" Width="-12" Height="48" FontId="ErrorFont" TabStop="yes" HideWhenDisabled="yes" />
+
+      <!-- Reserve two lines of space to accommodate localized content. -->
+      <Label X="148" Y="-48" Width="-12" Height="32" FontId="DefaultFont" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">#(loc.FailureRestartText)</Label>
+      <Button Name="FailureRestartButton" X="-124" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
+      <Button Name="FailureCloseButton" X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">
+        <Text>#(loc.FailureCloseButton)</Text>
+        <CloseWindowAction/>
+      </Button>
     </Page>
+  </Window>
 </Theme>

--- a/src/installer/pkg/sfx/bundle/theme/1028/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1028/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] 安裝程式</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">您只需要殼層、文字編輯器和 10 分鐘的時間。
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="[WixBundleName] 安裝程式" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="您只需要殼層、文字編輯器和 10 分鐘的時間。
 
-準備好了嗎? 讓我們開始吧!</String>
-  <String Id="ConfirmCancelMessage">確定要取消嗎?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">前一版</String>
-  <String Id="HelpHeader">安裝說明</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - 在目錄中安裝、修復、解除安裝或
+準備好了嗎? 讓我們開始吧!" />
+  <String Id="ConfirmCancelMessage" Value="確定要取消嗎?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="前一版" />
+  <String Id="HelpHeader" Value="安裝說明" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [directory] - 在目錄中安裝、修復、解除安裝或
    建立搭售方案的完整本機複本。預設為安裝。
 
 /passive | /quiet -  顯示最少 UI 且不含提示，或者不顯示 UI，也
    不顯示提示。預設會顯示 UI 和所有提示。
 
 /norestart   - 隱藏任何重新啟動嘗試。根據預設，UI 會在重新啟動之前提示。
-/log log.txt - 記錄至特定檔案。預設會在 %TEMP% 建立記錄檔。</String>
-  <String Id="HelpCloseButton">關閉(&amp;C)</String>
-  <String Id="InstallAcceptCheckbox">我同意授權條款及條件(&amp;A)</String>
-  <String Id="InstallOptionsButton">選項(&amp;O)</String>
-  <String Id="InstallInstallButton">安裝(&amp;I)</String>
-  <String Id="InstallCloseButton">關閉(&amp;C)</String>
-  <String Id="OptionsHeader">安裝選項</String>
-  <String Id="OptionsLocationLabel">安裝位置: </String>
-  <String Id="OptionsBrowseButton">瀏覽(&amp;B)</String>
-  <String Id="OptionsOkButton">確定(&amp;O)</String>
-  <String Id="OptionsCancelButton">取消(&amp;C)</String>
-  <String Id="ProgressHeader">安裝進度</String>
-  <String Id="ProgressLabel">處理中: </String>
-  <String Id="OverallProgressPackageText">正在初始化...</String>
-  <String Id="ProgressCancelButton">取消(&amp;C)</String>
-  <String Id="ModifyHeader">修改安裝</String>
-  <String Id="ModifyRepairButton">修復(&amp;R)</String>
-  <String Id="ModifyUninstallButton">解除安裝(&amp;U)</String>
-  <String Id="ModifyCloseButton">關閉(&amp;C)</String>
-  <String Id="SuccessRepairHeader">修復已成功完成</String>
-  <String Id="SuccessUninstallHeader">解除安裝已成功完成</String>
-  <String Id="SuccessInstallHeader">安裝成功</String>
-  <String Id="SuccessHeader">設定成功</String>
-  <String Id="SuccessLaunchButton">啟動(&amp;L)</String>
-  <String Id="SuccessRestartText">必須重新啟動電腦，才能使用此軟體。</String>
-  <String Id="SuccessRestartButton">重新啟動(&amp;R)</String>
-  <String Id="SuccessCloseButton">關閉(&amp;C)</String>
-  <String Id="FailureHeader">設定失敗</String>
-  <String Id="FailureInstallHeader">設定失敗</String>
-  <String Id="FailureUninstallHeader">解除安裝失敗</String>
-  <String Id="FailureRepairHeader">修復失敗</String>
-  <String Id="FailureHyperlinkLogText">有一個或多個問題導致安裝程式失敗。請解決問題，然後重試一次安裝。如需詳細資訊，請參閱&lt;a href="#"&gt;記錄檔&lt;/a&gt;。</String>
-  <String Id="FailureRestartText">必須重新啟動電腦，才能完成軟體的復原。</String>
-  <String Id="FailureRestartButton">重新啟動(&amp;R)</String>
-  <String Id="FailureCloseButton">關閉(&amp;C)</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">此作業系統不支援 [PRODUCT_NAME]。如需詳細資訊，請參閱 [LINK_PREREQ_PAGE]。</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">x86 作業系統不支援 [PRODUCT_NAME]。請使用對應的 x86 安裝程式來安裝。</String>
-  <String Id="FilesInUseHeader">使用中的檔案</String>
-  <String Id="FilesInUseLabel">以下應用程式正在使用需要進行更新的檔案:</String>
-  <String Id="FilesInUseCloseRadioButton">關閉應用程式並嘗試重新啟動(&amp;A)</String>
-  <String Id="FilesInUseDontCloseRadioButton">不關閉應用程式，需要重新啟動(&amp;D)</String>
-  <String Id="FilesInUseOkButton">確定(&amp;O)</String>
-  <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
-  <String Id="WelcomeHeaderMessage">.NET 執行階段</String>
-  <String Id="WelcomeDescription">.NET Runtime 可用於在您的 Windows 電腦上執行 .NET 應用程式。.NET 為開放原始碼形式，且可跨平台運作，同時受到 Microsoft 支援。希望您會喜歡!</String>
-  <String Id="LearnMoreTitle">深入了解 .NET</String>
-  <String Id="SuccessInstallLocation">下列項目已安裝在 [DOTNETHOME]</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER]</String>
-  <String Id="ResourcesHeader">資源</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;文件&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;版本資訊&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;教學課程&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET 遙測&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;隱私權聲明&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;.NET 的授權資訊&lt;/A&gt;</String>
-  <String Id="LicenseAssent">按一下 [\[]安裝[\[] 即表示您同意下列條款。</String>
+/log log.txt - 記錄至特定檔案。預設會在 %TEMP% 建立記錄檔。" />
+  <String Id="HelpCloseButton" Value="關閉(&amp;C)" />
+  <String Id="InstallAcceptCheckbox" Value="我同意授權條款及條件(&amp;A)" />
+  <String Id="InstallOptionsButton" Value="選項(&amp;O)" />
+  <String Id="InstallInstallButton" Value="安裝(&amp;I)" />
+  <String Id="InstallCloseButton" Value="關閉(&amp;C)" />
+  <String Id="OptionsHeader" Value="安裝選項" />
+  <String Id="OptionsLocationLabel" Value="安裝位置: " />
+  <String Id="OptionsBrowseButton" Value="瀏覽(&amp;B)" />
+  <String Id="OptionsOkButton" Value="確定(&amp;O)" />
+  <String Id="OptionsCancelButton" Value="取消(&amp;C)" />
+  <String Id="ProgressHeader" Value="安裝進度" />
+  <String Id="ProgressLabel" Value="處理中: " />
+  <String Id="OverallProgressPackageText" Value="正在初始化..." />
+  <String Id="ProgressCancelButton" Value="取消(&amp;C)" />
+  <String Id="ModifyHeader" Value="修改安裝" />
+  <String Id="ModifyRepairButton" Value="修復(&amp;R)" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="解除安裝(&amp;U)" />
+  <String Id="ModifyCloseButton" Value="關閉(&amp;C)" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="修復已成功完成" />
+  <String Id="SuccessUninstallHeader" Value="解除安裝已成功完成" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="安裝成功" />
+  <String Id="SuccessHeader" Value="設定成功" />
+  <String Id="SuccessLaunchButton" Value="啟動(&amp;L)" />
+  <String Id="SuccessRestartText" Value="必須重新啟動電腦，才能使用此軟體。" />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="重新啟動(&amp;R)" />
+  <String Id="SuccessCloseButton" Value="關閉(&amp;C)" />
+  <String Id="FailureHeader" Value="設定失敗" />
+  <String Id="FailureInstallHeader" Value="設定失敗" />
+  <String Id="FailureUninstallHeader" Value="解除安裝失敗" />
+  <String Id="FailureRepairHeader" Value="修復失敗" />
+  <String Id="FailureHyperlinkLogText" Value="有一個或多個問題導致安裝程式失敗。請解決問題，然後重試一次安裝。如需詳細資訊，請參閱&lt;a href=&quot;#&quot;&gt;記錄檔&lt;/a&gt;。" />
+  <String Id="FailureRestartText" Value="必須重新啟動電腦，才能完成軟體的復原。" />
+  <String Id="FailureRestartButton" Value="重新啟動(&amp;R)" />
+  <String Id="FailureCloseButton" Value="關閉(&amp;C)" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="此作業系統不支援 [PRODUCT_NAME]。如需詳細資訊，請參閱 [LINK_PREREQ_PAGE]。" />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="x86 作業系統不支援 [PRODUCT_NAME]。請使用對應的 x86 安裝程式來安裝。" />
+  <String Id="FilesInUseHeader" Value="使用中的檔案" />
+  <String Id="FilesInUseLabel" Value="以下應用程式正在使用需要進行更新的檔案:" />
+  <String Id="FilesInUseCloseRadioButton" Value="關閉應用程式並嘗試重新啟動(&amp;A)" />
+  <String Id="FilesInUseDontCloseRadioButton" Value="不關閉應用程式，需要重新啟動(&amp;D)" />
+  <String Id="FilesInUseOkButton" Value="確定(&amp;O)" />
+  <String Id="FilesInUseCancelButton" Value="取消(&amp;C)" />
+  <String Id="WelcomeHeaderMessage" Value=".NET 執行階段" />
+  <String Id="WelcomeDescription" Value=".NET Runtime 可用於在您的 Windows 電腦上執行 .NET 應用程式。.NET 為開放原始碼形式，且可跨平台運作，同時受到 Microsoft 支援。希望您會喜歡!" />
+  <String Id="LearnMoreTitle" Value="深入了解 .NET" />
+  <String Id="SuccessInstallLocation" Value="下列項目已安裝在 [DOTNETHOME]" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER]" />
+  <String Id="ResourcesHeader" Value="資源" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;文件&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;版本資訊&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;教學課程&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET 遙測&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;隱私權聲明&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;.NET 的授權資訊&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="按一下 [\[]安裝[\[] 即表示您同意下列條款。" />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1029/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1029/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Instalační program pro [WixBundleName]</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">Potřebujete jenom prostředí, textový editor a 10 minut času.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="Instalační program pro [WixBundleName]" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="Potřebujete jenom prostředí, textový editor a 10 minut času.
 
-Jste připraveni? Dejme se tedy do toho!</String>
-  <String Id="ConfirmCancelMessage">Opravdu chcete akci zrušit?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Předchozí verze</String>
-  <String Id="HelpHeader">Nápověda nastavení</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [adresář] – Nainstaluje, opraví, odinstaluje nebo
+Jste připraveni? Dejme se tedy do toho!" />
+  <String Id="ConfirmCancelMessage" Value="Opravdu chcete akci zrušit?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Předchozí verze" />
+  <String Id="HelpHeader" Value="Nápověda nastavení" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [adresář] – Nainstaluje, opraví, odinstaluje nebo
    vytvoří úplnou místní kopii svazku v adresáři. Výchozí možností je instalace.
 
 /passive | /quiet –  Zobrazí minimální uživatelské rozhraní bez výzev nebo nezobrazí žádné uživatelské rozhraní a
    žádné výzvy. Výchozí možností je zobrazení uživatelského rozhraní a všech výzev.
 
 /norestart   – potlačí všechny pokusy o restartování. Ve výchozím nastavení uživatelské rozhraní před restartováním zobrazí výzvu.
-/log log.txt – Uloží protokol do konkrétního souboru. Ve výchozím nastavení bude soubor protokolu vytvořen v adresáři %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Zavřít</String>
-  <String Id="InstallAcceptCheckbox">Souhl&amp;asím s licenčními podmínkami</String>
-  <String Id="InstallOptionsButton">M&amp;ožnosti</String>
-  <String Id="InstallInstallButton">&amp;Instalovat</String>
-  <String Id="InstallCloseButton">&amp;Zavřít</String>
-  <String Id="OptionsHeader">Možnosti instalace</String>
-  <String Id="OptionsLocationLabel">Umístění instalace:</String>
-  <String Id="OptionsBrowseButton">&amp;Procházet</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Storno</String>
-  <String Id="ProgressHeader">Průběh instalace</String>
-  <String Id="ProgressLabel">Probíhá zpracování:</String>
-  <String Id="OverallProgressPackageText">Inicializace...</String>
-  <String Id="ProgressCancelButton">&amp;Storno</String>
-  <String Id="ModifyHeader">Změnit instalaci</String>
-  <String Id="ModifyRepairButton">Op&amp;ravit</String>
-  <String Id="ModifyUninstallButton">O&amp;dinstalovat</String>
-  <String Id="ModifyCloseButton">&amp;Zavřít</String>
-  <String Id="SuccessRepairHeader">Oprava byla úspěšně dokončena</String>
-  <String Id="SuccessUninstallHeader">Odinstalace se úspěšně dokončila</String>
-  <String Id="SuccessInstallHeader">Instalace proběhla úspěšně</String>
-  <String Id="SuccessHeader">Instalace byla úspěšná.</String>
-  <String Id="SuccessLaunchButton">&amp;Spustit</String>
-  <String Id="SuccessRestartText">Před použitím tohoto softwaru musíte restartovat počítač.</String>
-  <String Id="SuccessRestartButton">&amp;Restartovat</String>
-  <String Id="SuccessCloseButton">&amp;Zavřít</String>
-  <String Id="FailureHeader">Instalace se nepovedla</String>
-  <String Id="FailureInstallHeader">Instalace se nepovedla</String>
-  <String Id="FailureUninstallHeader">Odinstalace se nepovedla</String>
-  <String Id="FailureRepairHeader">Oprava se nepovedla</String>
-  <String Id="FailureHyperlinkLogText">Jeden nebo více problémů způsobilo selhání instalace. Opravte tyto problémy a znovu spusťte instalaci. Pro více informací se podívejte do &lt;a href="#"&gt;souboru protokolu&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Pro dokončení vrácení změn tohoto softwaru je potřeba restartovat počítač.</String>
-  <String Id="FailureRestartButton">&amp;Restartovat</String>
-  <String Id="FailureCloseButton">&amp;Zavřít</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] se tomto operačním systému nepodporuje. Další informace: [LINK_PREREQ_PAGE]</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] se v operačních systémech pro platformu x86 nepodporuje. Použijte prosím k instalaci odpovídající instalační program pro platformu x86.</String>
-  <String Id="FilesInUseHeader">Soubory jsou používány</String>
-  <String Id="FilesInUseLabel">Následující aplikace používají soubory, které je potřeba aktualizovat:</String>
-  <String Id="FilesInUseCloseRadioButton">Zavřete &amp;aplikace a zkuste je restartovat.</String>
-  <String Id="FilesInUseDontCloseRadioButton">A&amp;plikace nezavírejte. Bude potřeba provést restart.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Zrušit</String>
-  <String Id="WelcomeHeaderMessage">Modul runtime platformy .NET</String>
-  <String Id="WelcomeDescription">Modul .NET Runtime se používá ke spouštění aplikací .NET na počítači s Windows. .NET je open source, k dispozici pro více platforem a podporovaný Microsoftem. Doufáme, že se vám bude líbit!</String>
-  <String Id="LearnMoreTitle">Další informace o .NET</String>
-  <String Id="SuccessInstallLocation">Do [DOTNETHOME] se nainstalovaly následující položky.</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Prostředky</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Dokumentace&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Zpráva k vydání verze&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Kurzy&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetrie pro platformu .NET&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Prohlášení o zásadách ochrany osobních údajů&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;Informace o licencování pro .NET&lt;/A&gt;</String>
-  <String Id="LicenseAssent">Kliknutím na Nainstalovat vyjadřujete souhlas s následujícími podmínkami.</String>
+/log log.txt – Uloží protokol do konkrétního souboru. Ve výchozím nastavení bude soubor protokolu vytvořen v adresáři %TEMP%." />
+  <String Id="HelpCloseButton" Value="&amp;Zavřít" />
+  <String Id="InstallAcceptCheckbox" Value="Souhl&amp;asím s licenčními podmínkami" />
+  <String Id="InstallOptionsButton" Value="M&amp;ožnosti" />
+  <String Id="InstallInstallButton" Value="&amp;Instalovat" />
+  <String Id="InstallCloseButton" Value="&amp;Zavřít" />
+  <String Id="OptionsHeader" Value="Možnosti instalace" />
+  <String Id="OptionsLocationLabel" Value="Umístění instalace:" />
+  <String Id="OptionsBrowseButton" Value="&amp;Procházet" />
+  <String Id="OptionsOkButton" Value="&amp;OK" />
+  <String Id="OptionsCancelButton" Value="&amp;Storno" />
+  <String Id="ProgressHeader" Value="Průběh instalace" />
+  <String Id="ProgressLabel" Value="Probíhá zpracování:" />
+  <String Id="OverallProgressPackageText" Value="Inicializace..." />
+  <String Id="ProgressCancelButton" Value="&amp;Storno" />
+  <String Id="ModifyHeader" Value="Změnit instalaci" />
+  <String Id="ModifyRepairButton" Value="Op&amp;ravit" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="O&amp;dinstalovat" />
+  <String Id="ModifyCloseButton" Value="&amp;Zavřít" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="Oprava byla úspěšně dokončena" />
+  <String Id="SuccessUninstallHeader" Value="Odinstalace se úspěšně dokončila" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="Instalace proběhla úspěšně" />
+  <String Id="SuccessHeader" Value="Instalace byla úspěšná." />
+  <String Id="SuccessLaunchButton" Value="&amp;Spustit" />
+  <String Id="SuccessRestartText" Value="Před použitím tohoto softwaru musíte restartovat počítač." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Restartovat" />
+  <String Id="SuccessCloseButton" Value="&amp;Zavřít" />
+  <String Id="FailureHeader" Value="Instalace se nepovedla" />
+  <String Id="FailureInstallHeader" Value="Instalace se nepovedla" />
+  <String Id="FailureUninstallHeader" Value="Odinstalace se nepovedla" />
+  <String Id="FailureRepairHeader" Value="Oprava se nepovedla" />
+  <String Id="FailureHyperlinkLogText" Value="Jeden nebo více problémů způsobilo selhání instalace. Opravte tyto problémy a znovu spusťte instalaci. Pro více informací se podívejte do &lt;a href=&quot;#&quot;&gt;souboru protokolu&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="Pro dokončení vrácení změn tohoto softwaru je potřeba restartovat počítač." />
+  <String Id="FailureRestartButton" Value="&amp;Restartovat" />
+  <String Id="FailureCloseButton" Value="&amp;Zavřít" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="[PRODUCT_NAME] se tomto operačním systému nepodporuje. Další informace: [LINK_PREREQ_PAGE]" />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="[PRODUCT_NAME] se v operačních systémech pro platformu x86 nepodporuje. Použijte prosím k instalaci odpovídající instalační program pro platformu x86." />
+  <String Id="FilesInUseHeader" Value="Soubory jsou používány" />
+  <String Id="FilesInUseLabel" Value="Následující aplikace používají soubory, které je potřeba aktualizovat:" />
+  <String Id="FilesInUseCloseRadioButton" Value="Zavřete &amp;aplikace a zkuste je restartovat." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="A&amp;plikace nezavírejte. Bude potřeba provést restart." />
+  <String Id="FilesInUseOkButton" Value="&amp;OK" />
+  <String Id="FilesInUseCancelButton" Value="&amp;Zrušit" />
+  <String Id="WelcomeHeaderMessage" Value="Modul runtime platformy .NET" />
+  <String Id="WelcomeDescription" Value="Modul .NET Runtime se používá ke spouštění aplikací .NET na počítači s Windows. .NET je open source, k dispozici pro více platforem a podporovaný Microsoftem. Doufáme, že se vám bude líbit!" />
+  <String Id="LearnMoreTitle" Value="Další informace o .NET" />
+  <String Id="SuccessInstallLocation" Value="Do [DOTNETHOME] se nainstalovaly následující položky." />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Prostředky" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Dokumentace&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Zpráva k vydání verze&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Kurzy&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;Telemetrie pro platformu .NET&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Prohlášení o zásadách ochrany osobních údajů&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Informace o licencování pro .NET&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="Kliknutím na Nainstalovat vyjadřujete souhlas s následujícími podmínkami." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1031/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1031/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName]-Installationsprogramm</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">Sie benötigen nur eine Shell, einen Text-Editor und 10 Minuten Zeit.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="[WixBundleName]-Installationsprogramm" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="Sie benötigen nur eine Shell, einen Text-Editor und 10 Minuten Zeit.
 
-Bereit? Los geht's!</String>
-  <String Id="ConfirmCancelMessage">Möchten Sie den Vorgang wirklich abbrechen?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Vorherige Version</String>
-  <String Id="HelpHeader">Setup-Hilfe</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [Verzeichnis] - installiert, repariert, deinstalliert oder
+Bereit? Los geht's!" />
+  <String Id="ConfirmCancelMessage" Value="Möchten Sie den Vorgang wirklich abbrechen?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Vorherige Version" />
+  <String Id="HelpHeader" Value="Setup-Hilfe" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [Verzeichnis] - installiert, repariert, deinstalliert oder
    erstellt eine vollständige lokale Kopie des Bundles im Verzeichnis. Installieren ist die Standardeinstellung.
 
 /passive | /quiet -  zeigt eine minimale Benutzeroberfläche ohne Eingabeaufforderungen oder keine
    Benutzeroberfläche und keine Eingabeaufforderungen an. Standardmäßig werden die Benutzeroberfläche und alle Eingabeaufforderungen angezeigt.
 
 /norestart   - Unterdrückt alle Neustartversuche. Standardmäßig fordert die Benutzeroberfläche zum Bestätigen eines Neustarts auf.
-/log log.txt - Erstellt das Protokoll in einer bestimmten Datei. Standardmäßig wird die Protokolldatei in %TEMP% erstellt.</String>
-  <String Id="HelpCloseButton">S&amp;chließen</String>
-  <String Id="InstallAcceptCheckbox">Ich &amp;stimme den Bedingungen des Lizenzvertrags zu</String>
-  <String Id="InstallOptionsButton">&amp;Optionen</String>
-  <String Id="InstallInstallButton">&amp;Installieren</String>
-  <String Id="InstallCloseButton">S&amp;chließen</String>
-  <String Id="OptionsHeader">Setupoptionen</String>
-  <String Id="OptionsLocationLabel">Installationspfad:</String>
-  <String Id="OptionsBrowseButton">&amp;Durchsuchen</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Abbrechen</String>
-  <String Id="ProgressHeader">Setupstatus</String>
-  <String Id="ProgressLabel">Wird verarbeitet:</String>
-  <String Id="OverallProgressPackageText">Wird initialisiert...</String>
-  <String Id="ProgressCancelButton">&amp;Abbrechen</String>
-  <String Id="ModifyHeader">Setup ändern</String>
-  <String Id="ModifyRepairButton">&amp;Reparieren</String>
-  <String Id="ModifyUninstallButton">&amp;Deinstallieren</String>
-  <String Id="ModifyCloseButton">S&amp;chließen</String>
-  <String Id="SuccessRepairHeader">Reparatur erfolgreich abgeschlossen</String>
-  <String Id="SuccessUninstallHeader">Deinstallation erfolgreich abgeschlossen</String>
-  <String Id="SuccessInstallHeader">Die Installation war erfolgreich.</String>
-  <String Id="SuccessHeader">Setup wurde erfolgreich abgeschlossen</String>
-  <String Id="SuccessLaunchButton">&amp;Starten</String>
-  <String Id="SuccessRestartText">Sie müssen den Computer neu starten, bevor Sie die Software verwenden können.</String>
-  <String Id="SuccessRestartButton">&amp;Neustart</String>
-  <String Id="SuccessCloseButton">S&amp;chließen</String>
-  <String Id="FailureHeader">Setupfehler</String>
-  <String Id="FailureInstallHeader">Fehler beim Setup</String>
-  <String Id="FailureUninstallHeader">Fehler bei der Deinstallation</String>
-  <String Id="FailureRepairHeader">Fehler bei der Reparatur</String>
-  <String Id="FailureHyperlinkLogText">Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href="#"&gt;Protokolldatei&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Sie müssen den Computer neu starten, um das Zurücksetzen der Software abzuschließen.</String>
-  <String Id="FailureRestartButton">&amp;Neustart</String>
-  <String Id="FailureCloseButton">S&amp;chließen</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] wird auf diesem Betriebssystem nicht unterstützt. Weitere Informationen finden Sie unter [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] wird auf x86-Betriebssystemen nicht unterstützt. Installieren Sie das entsprechende x86-Installationsprogramm.</String>
-  <String Id="FilesInUseHeader">Dateien in Verwendung</String>
-  <String Id="FilesInUseLabel">Die folgenden Anwendungen verwenden Dateien, die aktualisiert werden müssen:</String>
-  <String Id="FilesInUseCloseRadioButton">Schließen Sie die &amp;Anwendungen, und versuchen Sie sie erneut zu starten.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Anwendungen nicht schließen. Ein Neustart ist erforderlich.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Abbrechen</String>
-  <String Id="WelcomeHeaderMessage">.NET-Runtime</String>
-  <String Id="WelcomeDescription">Die .NET-Runtime wird zum Ausführen von .NET-Anwendungen auf Ihrem Windows-Computer verwendet. .NET ist ein plattformübergreifendes Open-Source-Framework, das von Microsoft unterstützt wird. Wir wünschen Ihnen viel Spaß damit!</String>
-  <String Id="LearnMoreTitle">Weitere Informationen zu .NET</String>
-  <String Id="SuccessInstallLocation">Folgendes wurde unter [DOTNETHOME] installiert.</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Ressourcen</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Dokumentation&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Versionshinweise&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET-Telemetrie&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Datenschutzerklärung&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;Lizenzierungsinformationen für .NET&lt;/A&gt;</String>
-  <String Id="LicenseAssent">Durch Klicken auf "Installieren" stimmen Sie den nachstehenden Bedingungen zu.</String>
+/log log.txt - Erstellt das Protokoll in einer bestimmten Datei. Standardmäßig wird die Protokolldatei in %TEMP% erstellt." />
+  <String Id="HelpCloseButton" Value="S&amp;chließen" />
+  <String Id="InstallAcceptCheckbox" Value="Ich &amp;stimme den Bedingungen des Lizenzvertrags zu" />
+  <String Id="InstallOptionsButton" Value="&amp;Optionen" />
+  <String Id="InstallInstallButton" Value="&amp;Installieren" />
+  <String Id="InstallCloseButton" Value="S&amp;chließen" />
+  <String Id="OptionsHeader" Value="Setupoptionen" />
+  <String Id="OptionsLocationLabel" Value="Installationspfad:" />
+  <String Id="OptionsBrowseButton" Value="&amp;Durchsuchen" />
+  <String Id="OptionsOkButton" Value="&amp;OK" />
+  <String Id="OptionsCancelButton" Value="&amp;Abbrechen" />
+  <String Id="ProgressHeader" Value="Setupstatus" />
+  <String Id="ProgressLabel" Value="Wird verarbeitet:" />
+  <String Id="OverallProgressPackageText" Value="Wird initialisiert..." />
+  <String Id="ProgressCancelButton" Value="&amp;Abbrechen" />
+  <String Id="ModifyHeader" Value="Setup ändern" />
+  <String Id="ModifyRepairButton" Value="&amp;Reparieren" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="&amp;Deinstallieren" />
+  <String Id="ModifyCloseButton" Value="S&amp;chließen" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="Reparatur erfolgreich abgeschlossen" />
+  <String Id="SuccessUninstallHeader" Value="Deinstallation erfolgreich abgeschlossen" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="Die Installation war erfolgreich." />
+  <String Id="SuccessHeader" Value="Setup wurde erfolgreich abgeschlossen" />
+  <String Id="SuccessLaunchButton" Value="&amp;Starten" />
+  <String Id="SuccessRestartText" Value="Sie müssen den Computer neu starten, bevor Sie die Software verwenden können." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Neustart" />
+  <String Id="SuccessCloseButton" Value="S&amp;chließen" />
+  <String Id="FailureHeader" Value="Setupfehler" />
+  <String Id="FailureInstallHeader" Value="Fehler beim Setup" />
+  <String Id="FailureUninstallHeader" Value="Fehler bei der Deinstallation" />
+  <String Id="FailureRepairHeader" Value="Fehler bei der Reparatur" />
+  <String Id="FailureHyperlinkLogText" Value="Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href=&quot;#&quot;&gt;Protokolldatei&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="Sie müssen den Computer neu starten, um das Zurücksetzen der Software abzuschließen." />
+  <String Id="FailureRestartButton" Value="&amp;Neustart" />
+  <String Id="FailureCloseButton" Value="S&amp;chließen" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="[PRODUCT_NAME] wird auf diesem Betriebssystem nicht unterstützt. Weitere Informationen finden Sie unter [LINK_PREREQ_PAGE]." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="[PRODUCT_NAME] wird auf x86-Betriebssystemen nicht unterstützt. Installieren Sie das entsprechende x86-Installationsprogramm." />
+  <String Id="FilesInUseHeader" Value="Dateien in Verwendung" />
+  <String Id="FilesInUseLabel" Value="Die folgenden Anwendungen verwenden Dateien, die aktualisiert werden müssen:" />
+  <String Id="FilesInUseCloseRadioButton" Value="Schließen Sie die &amp;Anwendungen, und versuchen Sie sie erneut zu starten." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;Anwendungen nicht schließen. Ein Neustart ist erforderlich." />
+  <String Id="FilesInUseOkButton" Value="&amp;OK" />
+  <String Id="FilesInUseCancelButton" Value="&amp;Abbrechen" />
+  <String Id="WelcomeHeaderMessage" Value=".NET-Runtime" />
+  <String Id="WelcomeDescription" Value="Die .NET-Runtime wird zum Ausführen von .NET-Anwendungen auf Ihrem Windows-Computer verwendet. .NET ist ein plattformübergreifendes Open-Source-Framework, das von Microsoft unterstützt wird. Wir wünschen Ihnen viel Spaß damit!" />
+  <String Id="LearnMoreTitle" Value="Weitere Informationen zu .NET" />
+  <String Id="SuccessInstallLocation" Value="Folgendes wurde unter [DOTNETHOME] installiert." />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Ressourcen" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Dokumentation&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Versionshinweise&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET-Telemetrie&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Datenschutzerklärung&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Lizenzierungsinformationen für .NET&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="Durch Klicken auf „Installieren“ stimmen Sie den nachstehenden Bedingungen zu." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1033/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1033/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="[WixBundleName] Installer" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="You just need a shell, a text editor and 10 minutes of your time.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
+Ready? Set? Let's go!" />
+  <String Id="ConfirmCancelMessage" Value="Are you sure you want to cancel?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Previous version" />
+  <String Id="HelpHeader" Value="Setup Help" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
    creates a complete local copy of the bundle in directory. Install is the default.
 
 /passive | /quiet -  displays minimal UI with no prompts or displays no UI and
    no prompts. By default UI and all prompts are displayed.
 
 /norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">.NET Runtime</String>
-  <String Id="WelcomeDescription">The .NET Runtime is used to run .NET applications, on your Windows computer. .NET is open source, cross platform, and supported by Microsoft. We hope you enjoy it!</String>
-  <String Id="LearnMoreTitle">Learn more about .NET</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Licensing Information for .NET&lt;/A&gt;</String>
-  <String Id="LicenseAssent">By clicking Install, you agree to the following terms.</String>
+/log log.txt - logs to a specific file. By default a log file is created in %TEMP%." />
+  <String Id="HelpCloseButton" Value="&amp;Close" />
+  <String Id="InstallAcceptCheckbox" Value="I &amp;agree to the license terms and conditions" />
+  <String Id="InstallOptionsButton" Value="&amp;Options" />
+  <String Id="InstallInstallButton" Value="&amp;Install" />
+  <String Id="InstallCloseButton" Value="&amp;Close" />
+  <String Id="OptionsHeader" Value="Setup Options" />
+  <String Id="OptionsLocationLabel" Value="Install location:" />
+  <String Id="OptionsBrowseButton" Value="&amp;Browse" />
+  <String Id="OptionsOkButton" Value="&amp;OK" />
+  <String Id="OptionsCancelButton" Value="&amp;Cancel" />
+  <String Id="ProgressHeader" Value="Setup Progress" />
+  <String Id="ProgressLabel" Value="Processing:" />
+  <String Id="OverallProgressPackageText" Value="Initializing..." />
+  <String Id="ProgressCancelButton" Value="&amp;Cancel" />
+  <String Id="ModifyHeader" Value="Modify Setup" />
+  <String Id="ModifyRepairButton" Value="&amp;Repair" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="&amp;Uninstall" />
+  <String Id="ModifyCloseButton" Value="&amp;Close" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="Repair Successfully Completed" />
+  <String Id="SuccessUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="Installation was successful" />
+  <String Id="SuccessHeader" Value="Setup Successful" />
+  <String Id="SuccessLaunchButton" Value="&amp;Launch" />
+  <String Id="SuccessRestartText" Value="You must restart your computer before you can use the software." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Restart" />
+  <String Id="SuccessCloseButton" Value="&amp;Close" />
+  <String Id="FailureHeader" Value="Setup Failed" />
+  <String Id="FailureInstallHeader" Value="Setup Failed" />
+  <String Id="FailureUninstallHeader" Value="Uninstall Failed" />
+  <String Id="FailureRepairHeader" Value="Repair Failed" />
+  <String Id="FailureHyperlinkLogText" Value="One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information, see the &lt;a href=&quot;#&quot;&gt;log file&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="You must restart your computer to complete the rollback of the software." />
+  <String Id="FailureRestartButton" Value="&amp;Restart" />
+  <String Id="FailureCloseButton" Value="&amp;Close" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE]." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer." />
+  <String Id="FilesInUseHeader" Value="Files In Use" />
+  <String Id="FilesInUseLabel" Value="The following applications are using files that need to be updated:" />
+  <String Id="FilesInUseCloseRadioButton" Value="Close the &amp;applications and attempt to restart them." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;Do not close applications. A reboot will be required." />
+  <String Id="FilesInUseOkButton" Value="&amp;OK" />
+  <String Id="FilesInUseCancelButton" Value="&amp;Cancel" />
+  <String Id="WelcomeHeaderMessage" Value=".NET Runtime" />
+  <String Id="WelcomeDescription" Value="The .NET Runtime is used to run .NET applications, on your Windows computer. .NET is open source, cross platform, and supported by Microsoft. We hope you enjoy it!" />
+  <String Id="LearnMoreTitle" Value="Learn more about .NET" />
+  <String Id="SuccessInstallLocation" Value="The following was installed at [DOTNETHOME]" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Resources" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Telemetry&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Licensing Information for .NET&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="By clicking Install, you agree to the following terms." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1036/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1036/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Programme d’installation de [WixBundleName]</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">Vous avez juste besoin d'un interpréteur de commandes, d'un éditeur de texte et de 10 minutes.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="Programme d’installation de [WixBundleName]" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="Vous avez juste besoin d'un interpréteur de commandes, d'un éditeur de texte et de 10 minutes.
 
-À vos marques ? Prêt ? Partez !</String>
-  <String Id="ConfirmCancelMessage">Voulez-vous vraiment annuler ?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Version précédente</String>
-  <String Id="HelpHeader">Aide du programme d'installation</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [répertoire] - installe, répare, désinstalle ou
+À vos marques ? Prêt ? Partez !" />
+  <String Id="ConfirmCancelMessage" Value="Voulez-vous vraiment annuler ?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Version précédente" />
+  <String Id="HelpHeader" Value="Aide du programme d'installation" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [répertoire] - installe, répare, désinstalle ou
    crée une copie locale complète du bundle dans le répertoire. Install est l'option par défaut.
 
 /passive | /quiet -  affiche une interface utilisateur minimale, sans invite, ou n'affiche 
    ni interface utilisateur, ni invite. Par défaut, l'interface utilisateur et toutes les invites sont affichées.
 
 /norestart   - supprime toutes les tentatives de redémarrage. Par défaut, l'interface utilisateur affiche une invite avant le redémarrage.
-/log log.txt - enregistre les informations dans un fichier spécifique. Par défaut, un fichier journal est créé dans %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Fermer</String>
-  <String Id="InstallAcceptCheckbox">J'&amp;accepte les conditions générales de la licence</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Installer</String>
-  <String Id="InstallCloseButton">&amp;Fermer</String>
-  <String Id="OptionsHeader">Options d'installation</String>
-  <String Id="OptionsLocationLabel">Emplacement de l'installation :</String>
-  <String Id="OptionsBrowseButton">&amp;Parcourir</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Annuler</String>
-  <String Id="ProgressHeader">Avancement de l'installation</String>
-  <String Id="ProgressLabel">En cours :</String>
-  <String Id="OverallProgressPackageText">Initialisation...</String>
-  <String Id="ProgressCancelButton">&amp;Annuler</String>
-  <String Id="ModifyHeader">Modifier l'installation</String>
-  <String Id="ModifyRepairButton">&amp;Réparer</String>
-  <String Id="ModifyUninstallButton">&amp;Désinstaller</String>
-  <String Id="ModifyCloseButton">&amp;Fermer</String>
-  <String Id="SuccessRepairHeader">Réparation terminée avec succès</String>
-  <String Id="SuccessUninstallHeader">Désinstallation terminée avec succès</String>
-  <String Id="SuccessInstallHeader">Installation réussie</String>
-  <String Id="SuccessHeader">Opération réussie</String>
-  <String Id="SuccessLaunchButton">&amp;Démarrer</String>
-  <String Id="SuccessRestartText">Vous devez redémarrer votre ordinateur avant de pouvoir utiliser le logiciel.</String>
-  <String Id="SuccessRestartButton">&amp;Redémarrer</String>
-  <String Id="SuccessCloseButton">&amp;Fermer</String>
-  <String Id="FailureHeader">Échec de l'installation</String>
-  <String Id="FailureInstallHeader">Échec de l'installation</String>
-  <String Id="FailureUninstallHeader">Échec de la désinstallation</String>
-  <String Id="FailureRepairHeader">Échec de la réparation</String>
-  <String Id="FailureHyperlinkLogText">Le programme d’installation a échoué en raison d’un ou de plusieurs problèmes. Veuillez corriger ces problèmes, puis relancez le programme d’installation. Pour plus d’informations, consultez le &lt;a href="#"&gt;fichier journal&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Vous devez redémarrer votre ordinateur pour terminer l'opération de restauration du logiciel.</String>
-  <String Id="FailureRestartButton">&amp;Redémarrer</String>
-  <String Id="FailureCloseButton">&amp;Fermer</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] n'est pas pris en charge sur ce système d'exploitation. Pour plus d'informations, consultez [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] n'est pas pris en charge sur les systèmes d'exploitation x86. Effectuez l'installation à l'aide du programme d'installation x86 correspondant.</String>
-  <String Id="FilesInUseHeader">Fichiers en cours d'utilisation</String>
-  <String Id="FilesInUseLabel">Les applications suivantes utilisent des fichiers nécessitant une mise à jour :</String>
-  <String Id="FilesInUseCloseRadioButton">&amp;Fermer les applications essayer de les ouvrir de nouveau.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Ne pas fermer les applications. Un redémarrage sera nécessaire.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Annuler</String>
-  <String Id="WelcomeHeaderMessage">Runtime .NET</String>
-  <String Id="WelcomeDescription">Le runtime .NET vous permet d'exécuter les applications .NET sur votre ordinateur Windows. .NET est open source, multiplateforme et pris en charge par Microsoft. Nous espérons que vous l'apprécierez !</String>
-  <String Id="LearnMoreTitle">En savoir plus sur .NET</String>
-  <String Id="SuccessInstallLocation">L'élément suivant a été installé sur [DOTNETHOME]</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Ressources</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Documentation&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Notes de publication&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Tutoriels&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Télémétrie .NET&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Déclaration de confidentialité&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;Informations de licence pour .NET&lt;/A&gt;</String>
-  <String Id="LicenseAssent">En cliquant sur Installer, vous acceptez les conditions suivantes.</String>
+/log log.txt - enregistre les informations dans un fichier spécifique. Par défaut, un fichier journal est créé dans %TEMP%." />
+  <String Id="HelpCloseButton" Value="&amp;Fermer" />
+  <String Id="InstallAcceptCheckbox" Value="J'&amp;accepte les conditions générales de la licence" />
+  <String Id="InstallOptionsButton" Value="&amp;Options" />
+  <String Id="InstallInstallButton" Value="&amp;Installer" />
+  <String Id="InstallCloseButton" Value="&amp;Fermer" />
+  <String Id="OptionsHeader" Value="Options d'installation" />
+  <String Id="OptionsLocationLabel" Value="Emplacement de l'installation :" />
+  <String Id="OptionsBrowseButton" Value="&amp;Parcourir" />
+  <String Id="OptionsOkButton" Value="&amp;OK" />
+  <String Id="OptionsCancelButton" Value="&amp;Annuler" />
+  <String Id="ProgressHeader" Value="Avancement de l'installation" />
+  <String Id="ProgressLabel" Value="En cours :" />
+  <String Id="OverallProgressPackageText" Value="Initialisation..." />
+  <String Id="ProgressCancelButton" Value="&amp;Annuler" />
+  <String Id="ModifyHeader" Value="Modifier l'installation" />
+  <String Id="ModifyRepairButton" Value="&amp;Réparer" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="&amp;Désinstaller" />
+  <String Id="ModifyCloseButton" Value="&amp;Fermer" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="Réparation terminée avec succès" />
+  <String Id="SuccessUninstallHeader" Value="Désinstallation terminée avec succès" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="Installation réussie" />
+  <String Id="SuccessHeader" Value="Opération réussie" />
+  <String Id="SuccessLaunchButton" Value="&amp;Démarrer" />
+  <String Id="SuccessRestartText" Value="Vous devez redémarrer votre ordinateur avant de pouvoir utiliser le logiciel." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Redémarrer" />
+  <String Id="SuccessCloseButton" Value="&amp;Fermer" />
+  <String Id="FailureHeader" Value="Échec de l'installation" />
+  <String Id="FailureInstallHeader" Value="Échec de l'installation" />
+  <String Id="FailureUninstallHeader" Value="Échec de la désinstallation" />
+  <String Id="FailureRepairHeader" Value="Échec de la réparation" />
+  <String Id="FailureHyperlinkLogText" Value="Le programme d’installation a échoué en raison d’un ou de plusieurs problèmes. Veuillez corriger ces problèmes, puis relancez le programme d’installation. Pour plus d’informations, consultez le &lt;a href=&quot;#&quot;&gt;fichier journal&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="Vous devez redémarrer votre ordinateur pour terminer l'opération de restauration du logiciel." />
+  <String Id="FailureRestartButton" Value="&amp;Redémarrer" />
+  <String Id="FailureCloseButton" Value="&amp;Fermer" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="[PRODUCT_NAME] n'est pas pris en charge sur ce système d'exploitation. Pour plus d'informations, consultez [LINK_PREREQ_PAGE]." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="[PRODUCT_NAME] n'est pas pris en charge sur les systèmes d'exploitation x86. Effectuez l'installation à l'aide du programme d'installation x86 correspondant." />
+  <String Id="FilesInUseHeader" Value="Fichiers en cours d'utilisation" />
+  <String Id="FilesInUseLabel" Value="Les applications suivantes utilisent des fichiers nécessitant une mise à jour :" />
+  <String Id="FilesInUseCloseRadioButton" Value="&amp;Fermer les applications essayer de les ouvrir de nouveau." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;Ne pas fermer les applications. Un redémarrage sera nécessaire." />
+  <String Id="FilesInUseOkButton" Value="&amp;OK" />
+  <String Id="FilesInUseCancelButton" Value="&amp;Annuler" />
+  <String Id="WelcomeHeaderMessage" Value="Runtime .NET" />
+  <String Id="WelcomeDescription" Value="Le runtime .NET vous permet d'exécuter les applications .NET sur votre ordinateur Windows. .NET est open source, multiplateforme et pris en charge par Microsoft. Nous espérons que vous l'apprécierez !" />
+  <String Id="LearnMoreTitle" Value="En savoir plus sur .NET" />
+  <String Id="SuccessInstallLocation" Value="L'élément suivant a été installé sur [DOTNETHOME]" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Ressources" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Notes de publication&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutoriels&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;Télémétrie .NET&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Déclaration de confidentialité&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Informations de licence pour .NET&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="En cliquant sur Installer, vous acceptez les conditions suivantes." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1040/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1040/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Programma di installazione di [WixBundleName]</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">Bastano solo una shell, un editor di testo e 10 minuti di tempo.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="Programma di installazione di [WixBundleName]" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="Bastano solo una shell, un editor di testo e 10 minuti di tempo.
 
-Pronti per iniziare?</String>
-  <String Id="ConfirmCancelMessage">Annullare?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Versione precedente</String>
-  <String Id="HelpHeader">Guida all'installazione</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installa, ripara, disinstalla o
+Pronti per iniziare?" />
+  <String Id="ConfirmCancelMessage" Value="Annullare?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Versione precedente" />
+  <String Id="HelpHeader" Value="Guida all'installazione" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [directory] - installa, ripara, disinstalla o
    crea una copia locale completa del bundle nella directory. L'opzione predefinita è install.
 
 /passive | /quiet -  visualizza un'interfaccia utente minima senza prompt oppure non visualizza alcuna interfaccia utente
    né prompt. Per impostazione predefinita, viene visualizzata l'intera interfaccia utente e tutti i prompt.
 
 /norestart   - annulla qualsiasi tentativo di riavvio. Per impostazione predefinita, l'interfaccia utente visualizza una richiesta prima del riavvio.
-/log log.txt - registra il log in un file specifico. Per impostazione predefinita, viene creato un file di log in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Chiudi</String>
-  <String Id="InstallAcceptCheckbox">&amp;Accetto i termini e le condizioni di licenza</String>
-  <String Id="InstallOptionsButton">&amp;Opzioni</String>
-  <String Id="InstallInstallButton">&amp;Installa</String>
-  <String Id="InstallCloseButton">&amp;Chiudi</String>
-  <String Id="OptionsHeader">Opzioni di installazione</String>
-  <String Id="OptionsLocationLabel">Percorso di installazione:</String>
-  <String Id="OptionsBrowseButton">&amp;Sfoglia</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">Ann&amp;ulla</String>
-  <String Id="ProgressHeader">Stato installazione</String>
-  <String Id="ProgressLabel">Elaborazione di:</String>
-  <String Id="OverallProgressPackageText">Inizializzazione in corso...</String>
-  <String Id="ProgressCancelButton">Ann&amp;ulla</String>
-  <String Id="ModifyHeader">Modifica installazione</String>
-  <String Id="ModifyRepairButton">&amp;Ripristina</String>
-  <String Id="ModifyUninstallButton">&amp;Disinstalla</String>
-  <String Id="ModifyCloseButton">&amp;Chiudi</String>
-  <String Id="SuccessRepairHeader">La riparazione è stata completata</String>
-  <String Id="SuccessUninstallHeader">La disinstallazione è stata completata</String>
-  <String Id="SuccessInstallHeader">L'installazione è riuscita</String>
-  <String Id="SuccessHeader">Installazione completata</String>
-  <String Id="SuccessLaunchButton">&amp;Avvia</String>
-  <String Id="SuccessRestartText">È necessario riavviare il computer prima di utilizzare il software.</String>
-  <String Id="SuccessRestartButton">&amp;Riavvia</String>
-  <String Id="SuccessCloseButton">&amp;Chiudi</String>
-  <String Id="FailureHeader">Installazione non riuscita</String>
-  <String Id="FailureInstallHeader">L'installazione non è riuscita</String>
-  <String Id="FailureUninstallHeader">Disinstallazione non riuscita</String>
-  <String Id="FailureRepairHeader">La riparazione non è riuscita</String>
-  <String Id="FailureHyperlinkLogText">Installazione non riuscita a causa di uno o più problemi. Risolvere i problemi e ritentare l'installazione. Per ulteriori informazioni, vedere il &lt;a href="#"&gt;file di log&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">È necessario riavviare il computer per completare il rollback del software.</String>
-  <String Id="FailureRestartButton">&amp;Riavvia</String>
-  <String Id="FailureCloseButton">&amp;Chiudi</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] non è supportato in questo sistema operativo. Per altre informazioni, vedere [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] non è supportato in sistemi operativi x86. Eseguire l'installazione usando il programma di installazione x86 corrispondente.</String>
-  <String Id="FilesInUseHeader">File in uso</String>
-  <String Id="FilesInUseLabel">Le applicazioni seguenti usano file che necessitano di aggiornamento:</String>
-  <String Id="FilesInUseCloseRadioButton">Chiudere le &amp;applicazioni e provare a riavviarle.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Non chiudere le applicazioni; sarà necessario riavviare il sistema</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Annulla</String>
-  <String Id="WelcomeHeaderMessage">Runtime .NET</String>
-  <String Id="WelcomeDescription">Runtime di .NET consente di eseguire applicazioni .NET nel computer Windows. .NET è open source, multipiattaforma e supportato da Microsoft.</String>
-  <String Id="LearnMoreTitle">Altre informazioni su .NET</String>
-  <String Id="SuccessInstallLocation">I componenti seguenti sono stati installati in [DOTNETHOME]</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Risorse</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Documentazione&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Note sulla versione&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Esercitazioni&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetria di .NET&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Informativa sulla privacy&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;Informazioni sulla licenza per .NET&lt;/A&gt;</String>
-  <String Id="LicenseAssent">Facendo clic su Installa, si accettano le condizioni seguenti.</String>
+/log log.txt - registra il log in un file specifico. Per impostazione predefinita, viene creato un file di log in %TEMP%." />
+  <String Id="HelpCloseButton" Value="&amp;Chiudi" />
+  <String Id="InstallAcceptCheckbox" Value="&amp;Accetto i termini e le condizioni di licenza" />
+  <String Id="InstallOptionsButton" Value="&amp;Opzioni" />
+  <String Id="InstallInstallButton" Value="&amp;Installa" />
+  <String Id="InstallCloseButton" Value="&amp;Chiudi" />
+  <String Id="OptionsHeader" Value="Opzioni di installazione" />
+  <String Id="OptionsLocationLabel" Value="Percorso di installazione:" />
+  <String Id="OptionsBrowseButton" Value="&amp;Sfoglia" />
+  <String Id="OptionsOkButton" Value="&amp;OK" />
+  <String Id="OptionsCancelButton" Value="Ann&amp;ulla" />
+  <String Id="ProgressHeader" Value="Stato installazione" />
+  <String Id="ProgressLabel" Value="Elaborazione di:" />
+  <String Id="OverallProgressPackageText" Value="Inizializzazione in corso..." />
+  <String Id="ProgressCancelButton" Value="Ann&amp;ulla" />
+  <String Id="ModifyHeader" Value="Modifica installazione" />
+  <String Id="ModifyRepairButton" Value="&amp;Ripristina" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="&amp;Disinstalla" />
+  <String Id="ModifyCloseButton" Value="&amp;Chiudi" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="La riparazione è stata completata" />
+  <String Id="SuccessUninstallHeader" Value="La disinstallazione è stata completata" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="L'installazione è riuscita" />
+  <String Id="SuccessHeader" Value="Installazione completata" />
+  <String Id="SuccessLaunchButton" Value="&amp;Avvia" />
+  <String Id="SuccessRestartText" Value="È necessario riavviare il computer prima di utilizzare il software." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Riavvia" />
+  <String Id="SuccessCloseButton" Value="&amp;Chiudi" />
+  <String Id="FailureHeader" Value="Installazione non riuscita" />
+  <String Id="FailureInstallHeader" Value="L'installazione non è riuscita" />
+  <String Id="FailureUninstallHeader" Value="Disinstallazione non riuscita" />
+  <String Id="FailureRepairHeader" Value="La riparazione non è riuscita" />
+  <String Id="FailureHyperlinkLogText" Value="Installazione non riuscita a causa di uno o più problemi. Risolvere i problemi e ritentare l'installazione. Per ulteriori informazioni, vedere il &lt;a href=&quot;#&quot;&gt;file di log&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="È necessario riavviare il computer per completare il rollback del software." />
+  <String Id="FailureRestartButton" Value="&amp;Riavvia" />
+  <String Id="FailureCloseButton" Value="&amp;Chiudi" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="[PRODUCT_NAME] non è supportato in questo sistema operativo. Per altre informazioni, vedere [LINK_PREREQ_PAGE]." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="[PRODUCT_NAME] non è supportato in sistemi operativi x86. Eseguire l'installazione usando il programma di installazione x86 corrispondente." />
+  <String Id="FilesInUseHeader" Value="File in uso" />
+  <String Id="FilesInUseLabel" Value="Le applicazioni seguenti usano file che necessitano di aggiornamento:" />
+  <String Id="FilesInUseCloseRadioButton" Value="Chiudere le &amp;applicazioni e provare a riavviarle." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;Non chiudere le applicazioni; sarà necessario riavviare il sistema" />
+  <String Id="FilesInUseOkButton" Value="&amp;OK" />
+  <String Id="FilesInUseCancelButton" Value="&amp;Annulla" />
+  <String Id="WelcomeHeaderMessage" Value="Runtime .NET" />
+  <String Id="WelcomeDescription" Value="Runtime di .NET consente di eseguire applicazioni .NET nel computer Windows. .NET è open source, multipiattaforma e supportato da Microsoft." />
+  <String Id="LearnMoreTitle" Value="Altre informazioni su .NET" />
+  <String Id="SuccessInstallLocation" Value="I componenti seguenti sono stati installati in [DOTNETHOME]" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Risorse" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentazione&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Note sulla versione&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Esercitazioni&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;Telemetria di .NET&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Informativa sulla privacy&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Informazioni sulla licenza per .NET&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="Facendo clic su Installa, si accettano le condizioni seguenti." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1041/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1041/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] インストーラー</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">必要なのは、シェル、テキスト エディター、それに時間が 10 分のみです。
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="[WixBundleName] インストーラー" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="必要なのは、シェル、テキスト エディター、それに時間が 10 分のみです。
 
-では、始めましょう。</String>
-  <String Id="ConfirmCancelMessage">取り消しますか?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">以前のバージョン</String>
-  <String Id="HelpHeader">セットアップのヘルプ</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - バンドルの完全なローカル コピーに対する
+では、始めましょう。" />
+  <String Id="ConfirmCancelMessage" Value="取り消しますか?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="以前のバージョン" />
+  <String Id="HelpHeader" Value="セットアップのヘルプ" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [directory] - バンドルの完全なローカル コピーに対する
   ディレクトリへのインストール、修復、ディレクトリからのアンインストール、またはディレクトリ内への作成を行います。既定の設定はインストールです。
 
 /passive | /quiet -  最小限の UI だけを表示しプロンプトは表示しない、または UI もプロンプトも
    表示しません。既定では UI とすべてのプロンプトが表示されます。
 
 /norestart   - 再起動を抑制します。既定では再起動前に確認メッセージが表示されます。
-/log log.txt - 特定のファイルに記録します。ログ ファイルは既定では %TEMP% に作成されます。</String>
-  <String Id="HelpCloseButton">閉じる(&amp;C)</String>
-  <String Id="InstallAcceptCheckbox">ライセンス条項および使用条件に同意する(&amp;A)</String>
-  <String Id="InstallOptionsButton">オプション(&amp;O)</String>
-  <String Id="InstallInstallButton">インストール(&amp;I)</String>
-  <String Id="InstallCloseButton">閉じる(&amp;C)</String>
-  <String Id="OptionsHeader">セットアップ オプション</String>
-  <String Id="OptionsLocationLabel">インストール場所:</String>
-  <String Id="OptionsBrowseButton">参照(&amp;B)</String>
-  <String Id="OptionsOkButton">OK(&amp;O)</String>
-  <String Id="OptionsCancelButton">キャンセル(&amp;C)</String>
-  <String Id="ProgressHeader">セットアップの進行状況</String>
-  <String Id="ProgressLabel">処理中:</String>
-  <String Id="OverallProgressPackageText">初期化しています...</String>
-  <String Id="ProgressCancelButton">キャンセル(&amp;C)</String>
-  <String Id="ModifyHeader">セットアップの変更</String>
-  <String Id="ModifyRepairButton">修復(&amp;R)</String>
-  <String Id="ModifyUninstallButton">アンインストール(&amp;U)</String>
-  <String Id="ModifyCloseButton">閉じる(&amp;C)</String>
-  <String Id="SuccessRepairHeader">修復が正常に完了しました</String>
-  <String Id="SuccessUninstallHeader">アンインストールが正常に完了しました</String>
-  <String Id="SuccessInstallHeader">インストールが正常に終了しました</String>
-  <String Id="SuccessHeader">セットアップ完了</String>
-  <String Id="SuccessLaunchButton">起動(&amp;L)</String>
-  <String Id="SuccessRestartText">ソフトウェアを使用する前にコンピューターを再起動する必要があります。</String>
-  <String Id="SuccessRestartButton">再起動(&amp;R)</String>
-  <String Id="SuccessCloseButton">閉じる(&amp;C)</String>
-  <String Id="FailureHeader">セットアップに失敗しました</String>
-  <String Id="FailureInstallHeader">セットアップに失敗しました</String>
-  <String Id="FailureUninstallHeader">アンインストールに失敗しました</String>
-  <String Id="FailureRepairHeader">修復に失敗しました</String>
-  <String Id="FailureHyperlinkLogText">1 つまたは複数の問題により、セットアップが失敗しました。問題を解決してからセットアップを再試行してください。詳細については、&lt;a href="#"&gt;ログ ファイル&lt;/a&gt;を参照してください。</String>
-  <String Id="FailureRestartText">ソフトウェアのロールバックを完了するには、コンピューターを再起動する必要があります。</String>
-  <String Id="FailureRestartButton">再起動(&amp;R)</String>
-  <String Id="FailureCloseButton">閉じる(&amp;C)</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] は、このオペレーティング システムではサポートされていません。詳細については、[LINK_PREREQ_PAGE] を参照してください。</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">x86 オペレーティング システムでは、[PRODUCT_NAME] はサポートされていません。対応する x86 インストーラーを使用してインストールしてください。</String>
-  <String Id="FilesInUseHeader">ファイルが使用中</String>
-  <String Id="FilesInUseLabel">次のアプリケーションは、更新の必要があるファイルを使用しています:</String>
-  <String Id="FilesInUseCloseRadioButton">アプリケーションを閉じて再起動を試みる。(&amp;A)</String>
-  <String Id="FilesInUseDontCloseRadioButton">アプリケーションを終了させない (コンピューターの再起動が必要になります)(&amp;D)</String>
-  <String Id="FilesInUseOkButton">OK(&amp;O)</String>
-  <String Id="FilesInUseCancelButton">キャンセル(&amp;C)</String>
-  <String Id="WelcomeHeaderMessage">.NET Runtime</String>
-  <String Id="WelcomeDescription">.NET Runtime は、Windows コンピューターで .NET アプリケーションを実行するために使用されます。.NET はオープン ソースのクロス プラットフォームで、Microsoft によってサポートされています。ぜひご利用ください。</String>
-  <String Id="LearnMoreTitle">.Net の詳細情報</String>
-  <String Id="SuccessInstallLocation">[DOTNETHOME] に以下がインストールされました</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">リソース</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;ドキュメント&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;リリース ノート&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;チュートリアル&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET テレメトリ&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;プライバシーに関する声明&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;.NET のライセンス情報&lt;/A&gt;</String>
-  <String Id="LicenseAssent">インストール をクリックすると、次の条項に同意したものと見なされます。</String>
+/log log.txt - 特定のファイルに記録します。ログ ファイルは既定では %TEMP% に作成されます。" />
+  <String Id="HelpCloseButton" Value="閉じる(&amp;C)" />
+  <String Id="InstallAcceptCheckbox" Value="ライセンス条項および使用条件に同意する(&amp;A)" />
+  <String Id="InstallOptionsButton" Value="オプション(&amp;O)" />
+  <String Id="InstallInstallButton" Value="インストール(&amp;I)" />
+  <String Id="InstallCloseButton" Value="閉じる(&amp;C)" />
+  <String Id="OptionsHeader" Value="セットアップ オプション" />
+  <String Id="OptionsLocationLabel" Value="インストール場所:" />
+  <String Id="OptionsBrowseButton" Value="参照(&amp;B)" />
+  <String Id="OptionsOkButton" Value="OK(&amp;O)" />
+  <String Id="OptionsCancelButton" Value="キャンセル(&amp;C)" />
+  <String Id="ProgressHeader" Value="セットアップの進行状況" />
+  <String Id="ProgressLabel" Value="処理中:" />
+  <String Id="OverallProgressPackageText" Value="初期化しています..." />
+  <String Id="ProgressCancelButton" Value="キャンセル(&amp;C)" />
+  <String Id="ModifyHeader" Value="セットアップの変更" />
+  <String Id="ModifyRepairButton" Value="修復(&amp;R)" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="アンインストール(&amp;U)" />
+  <String Id="ModifyCloseButton" Value="閉じる(&amp;C)" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="修復が正常に完了しました" />
+  <String Id="SuccessUninstallHeader" Value="アンインストールが正常に完了しました" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="インストールが正常に終了しました" />
+  <String Id="SuccessHeader" Value="セットアップ完了" />
+  <String Id="SuccessLaunchButton" Value="起動(&amp;L)" />
+  <String Id="SuccessRestartText" Value="ソフトウェアを使用する前にコンピューターを再起動する必要があります。" />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="再起動(&amp;R)" />
+  <String Id="SuccessCloseButton" Value="閉じる(&amp;C)" />
+  <String Id="FailureHeader" Value="セットアップに失敗しました" />
+  <String Id="FailureInstallHeader" Value="セットアップに失敗しました" />
+  <String Id="FailureUninstallHeader" Value="アンインストールに失敗しました" />
+  <String Id="FailureRepairHeader" Value="修復に失敗しました" />
+  <String Id="FailureHyperlinkLogText" Value="1 つまたは複数の問題により、セットアップが失敗しました。問題を解決してからセットアップを再試行してください。詳細については、&lt;a href=&quot;#&quot;&gt;ログ ファイル&lt;/a&gt;を参照してください。" />
+  <String Id="FailureRestartText" Value="ソフトウェアのロールバックを完了するには、コンピューターを再起動する必要があります。" />
+  <String Id="FailureRestartButton" Value="再起動(&amp;R)" />
+  <String Id="FailureCloseButton" Value="閉じる(&amp;C)" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="[PRODUCT_NAME] は、このオペレーティング システムではサポートされていません。詳細については、[LINK_PREREQ_PAGE] を参照してください。" />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="x86 オペレーティング システムでは、[PRODUCT_NAME] はサポートされていません。対応する x86 インストーラーを使用してインストールしてください。" />
+  <String Id="FilesInUseHeader" Value="ファイルが使用中" />
+  <String Id="FilesInUseLabel" Value="次のアプリケーションは、更新の必要があるファイルを使用しています:" />
+  <String Id="FilesInUseCloseRadioButton" Value="アプリケーションを閉じて再起動を試みる。(&amp;A)" />
+  <String Id="FilesInUseDontCloseRadioButton" Value="アプリケーションを終了させない (コンピューターの再起動が必要になります)(&amp;D)" />
+  <String Id="FilesInUseOkButton" Value="OK(&amp;O)" />
+  <String Id="FilesInUseCancelButton" Value="キャンセル(&amp;C)" />
+  <String Id="WelcomeHeaderMessage" Value=".NET Runtime" />
+  <String Id="WelcomeDescription" Value=".NET Runtime は、Windows コンピューターで .NET アプリケーションを実行するために使用されます。.NET はオープン ソースのクロス プラットフォームで、Microsoft によってサポートされています。ぜひご利用ください。" />
+  <String Id="LearnMoreTitle" Value=".Net の詳細情報" />
+  <String Id="SuccessInstallLocation" Value="[DOTNETHOME] に以下がインストールされました" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="リソース" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;ドキュメント&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;リリース ノート&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;チュートリアル&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET テレメトリ&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;プライバシーに関する声明&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;.NET のライセンス情報&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="インストール をクリックすると、次の条項に同意したものと見なされます。" />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1042/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1042/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] 설치 관리자</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">셸, 텍스트 편집기, 10분의 시간만 있으면 됩니다.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="[WixBundleName] 설치 관리자" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="셸, 텍스트 편집기, 10분의 시간만 있으면 됩니다.
 
-준비되셨나요? 시작합니다!</String>
-  <String Id="ConfirmCancelMessage">취소하시겠습니까?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">이전 버전</String>
-  <String Id="HelpHeader">설치 도움말</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - 디렉터리에 번들의 전체 로컬 복사본을 설치, 복구, 제거 또는
+준비되셨나요? 시작합니다!" />
+  <String Id="ConfirmCancelMessage" Value="취소하시겠습니까?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="이전 버전" />
+  <String Id="HelpHeader" Value="설치 도움말" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [directory] - 디렉터리에 번들의 전체 로컬 복사본을 설치, 복구, 제거 또는
    작성합니다. 설치가 기본값입니다.
 
 /passive | /quiet -  프롬프트 없이 최소 UI를 표시하거나 UI 및
    프롬프트를 표시하지 않습니다. 기본적으로 UI와 모든 프롬프트가 표시됩니다.
 
 /norestart   - 다시 시작하지 않게 합니다. 기본적으로 UI에서는 다시 시작하기 전에 묻는 메시지를 표시합니다.
-/log log.txt - 특정 파일에 기록합니다. 기본적으로 로그 파일은 %TEMP%에 만들어집니다.</String>
-  <String Id="HelpCloseButton">닫기(&amp;C)</String>
-  <String Id="InstallAcceptCheckbox">동의함(&amp;A)</String>
-  <String Id="InstallOptionsButton">옵션(&amp;O)</String>
-  <String Id="InstallInstallButton">설치(&amp;I)</String>
-  <String Id="InstallCloseButton">닫기(&amp;C)</String>
-  <String Id="OptionsHeader">설치 옵션</String>
-  <String Id="OptionsLocationLabel">설치 위치:</String>
-  <String Id="OptionsBrowseButton">찾아보기(&amp;B)</String>
-  <String Id="OptionsOkButton">확인(&amp;O)</String>
-  <String Id="OptionsCancelButton">취소(&amp;C)</String>
-  <String Id="ProgressHeader">설치 진행률</String>
-  <String Id="ProgressLabel">처리 중:</String>
-  <String Id="OverallProgressPackageText">초기화하는 중...</String>
-  <String Id="ProgressCancelButton">취소(&amp;C)</String>
-  <String Id="ModifyHeader">설치 수정</String>
-  <String Id="ModifyRepairButton">복구(&amp;R)</String>
-  <String Id="ModifyUninstallButton">제거(&amp;U)</String>
-  <String Id="ModifyCloseButton">닫기(&amp;C)</String>
-  <String Id="SuccessRepairHeader">복구 완료됨</String>
-  <String Id="SuccessUninstallHeader">제거 완료됨</String>
-  <String Id="SuccessInstallHeader">설치가 완료되었습니다.</String>
-  <String Id="SuccessHeader">설치 완료</String>
-  <String Id="SuccessLaunchButton">시작(&amp;L)</String>
-  <String Id="SuccessRestartText">소프트웨어를 사용하려면 먼저 컴퓨터를 다시 시작해야 합니다.</String>
-  <String Id="SuccessRestartButton">다시 시작(&amp;R)</String>
-  <String Id="SuccessCloseButton">닫기(&amp;C)</String>
-  <String Id="FailureHeader">설치 실패</String>
-  <String Id="FailureInstallHeader">설치 실패</String>
-  <String Id="FailureUninstallHeader">제거 실패</String>
-  <String Id="FailureRepairHeader">복구 실패</String>
-  <String Id="FailureHyperlinkLogText">하나 이상의 문제가 발생하여 설치하지 못했습니다. 문제를 해결한 다음 설치를 다시 시도하십시오. 자세한 내용은 &lt;a href="#"&gt;로그 파일&lt;/a&gt;을 참조하십시오.</String>
-  <String Id="FailureRestartText">소프트웨어 롤백을 완료하려면 컴퓨터를 다시 시작해야 합니다.</String>
-  <String Id="FailureRestartButton">다시 시작(&amp;R)</String>
-  <String Id="FailureCloseButton">닫기(&amp;C)</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">이 운영 체제에서는 [PRODUCT_NAME]이(가) 지원되지 않습니다. 자세한 내용은 [LINK_PREREQ_PAGE]을(를) 참조하세요.</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">x86 운영 체제에서는 [PRODUCT_NAME]이(가) 지원되지 않습니다. 해당 x86 설치 관리자를 사용하여 설치하세요.</String>
-  <String Id="FilesInUseHeader">사용 중인 파일</String>
-  <String Id="FilesInUseLabel">다음의 응용 프로그램이 업데이트해야 할 파일을 사용 중입니다.</String>
-  <String Id="FilesInUseCloseRadioButton">응용 프로그램을 닫고 다시 시작합니다(&amp;A).</String>
-  <String Id="FilesInUseDontCloseRadioButton">응용 프로그램을 닫지 않습니다(&amp;D). 다시 부팅해야 합니다.</String>
-  <String Id="FilesInUseOkButton">확인(&amp;O)</String>
-  <String Id="FilesInUseCancelButton">취소(&amp;C)</String>
-  <String Id="WelcomeHeaderMessage">.NET 런타임</String>
-  <String Id="WelcomeDescription">.NET 런타임은 Windows 컴퓨터에서 .NET 애플리케이션을 실행하는 데 사용됩니다. .NET은 오픈 소스 및 플랫폼 간이며 Microsoft에서 지원합니다. .NET을 유용하게 사용하시길 바랍니다.</String>
-  <String Id="LearnMoreTitle">.NET에 대한 자세한 정보</String>
-  <String Id="SuccessInstallLocation">다음이 [DOTNETHOME]에 설치되었습니다.</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">리소스</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;설명서&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;릴리스 정보&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;자습서&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET 원격 분석&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;개인정보처리방침&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;.NET에 대한 라이선스 정보&lt;/A&gt;</String>
-  <String Id="LicenseAssent">설치를 클릭하면 다음 사용 약관에 동의하는 것입니다.</String>
+/log log.txt - 특정 파일에 기록합니다. 기본적으로 로그 파일은 %TEMP%에 만들어집니다." />
+  <String Id="HelpCloseButton" Value="닫기(&amp;C)" />
+  <String Id="InstallAcceptCheckbox" Value="동의함(&amp;A)" />
+  <String Id="InstallOptionsButton" Value="옵션(&amp;O)" />
+  <String Id="InstallInstallButton" Value="설치(&amp;I)" />
+  <String Id="InstallCloseButton" Value="닫기(&amp;C)" />
+  <String Id="OptionsHeader" Value="설치 옵션" />
+  <String Id="OptionsLocationLabel" Value="설치 위치:" />
+  <String Id="OptionsBrowseButton" Value="찾아보기(&amp;B)" />
+  <String Id="OptionsOkButton" Value="확인(&amp;O)" />
+  <String Id="OptionsCancelButton" Value="취소(&amp;C)" />
+  <String Id="ProgressHeader" Value="설치 진행률" />
+  <String Id="ProgressLabel" Value="처리 중:" />
+  <String Id="OverallProgressPackageText" Value="초기화하는 중..." />
+  <String Id="ProgressCancelButton" Value="취소(&amp;C)" />
+  <String Id="ModifyHeader" Value="설치 수정" />
+  <String Id="ModifyRepairButton" Value="복구(&amp;R)" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="제거(&amp;U)" />
+  <String Id="ModifyCloseButton" Value="닫기(&amp;C)" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="복구 완료됨" />
+  <String Id="SuccessUninstallHeader" Value="제거 완료됨" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="설치가 완료되었습니다." />
+  <String Id="SuccessHeader" Value="설치 완료" />
+  <String Id="SuccessLaunchButton" Value="시작(&amp;L)" />
+  <String Id="SuccessRestartText" Value="소프트웨어를 사용하려면 먼저 컴퓨터를 다시 시작해야 합니다." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="다시 시작(&amp;R)" />
+  <String Id="SuccessCloseButton" Value="닫기(&amp;C)" />
+  <String Id="FailureHeader" Value="설치 실패" />
+  <String Id="FailureInstallHeader" Value="설치 실패" />
+  <String Id="FailureUninstallHeader" Value="제거 실패" />
+  <String Id="FailureRepairHeader" Value="복구 실패" />
+  <String Id="FailureHyperlinkLogText" Value="하나 이상의 문제가 발생하여 설치하지 못했습니다. 문제를 해결한 다음 설치를 다시 시도하십시오. 자세한 내용은 &lt;a href=&quot;#&quot;&gt;로그 파일&lt;/a&gt;을 참조하십시오." />
+  <String Id="FailureRestartText" Value="소프트웨어 롤백을 완료하려면 컴퓨터를 다시 시작해야 합니다." />
+  <String Id="FailureRestartButton" Value="다시 시작(&amp;R)" />
+  <String Id="FailureCloseButton" Value="닫기(&amp;C)" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="이 운영 체제에서는 [PRODUCT_NAME]이(가) 지원되지 않습니다. 자세한 내용은 [LINK_PREREQ_PAGE]을(를) 참조하세요." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="x86 운영 체제에서는 [PRODUCT_NAME]이(가) 지원되지 않습니다. 해당 x86 설치 관리자를 사용하여 설치하세요." />
+  <String Id="FilesInUseHeader" Value="사용 중인 파일" />
+  <String Id="FilesInUseLabel" Value="다음의 응용 프로그램이 업데이트해야 할 파일을 사용 중입니다." />
+  <String Id="FilesInUseCloseRadioButton" Value="응용 프로그램을 닫고 다시 시작합니다(&amp;A)." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="응용 프로그램을 닫지 않습니다(&amp;D). 다시 부팅해야 합니다." />
+  <String Id="FilesInUseOkButton" Value="확인(&amp;O)" />
+  <String Id="FilesInUseCancelButton" Value="취소(&amp;C)" />
+  <String Id="WelcomeHeaderMessage" Value=".NET 런타임" />
+  <String Id="WelcomeDescription" Value=".NET 런타임은 Windows 컴퓨터에서 .NET 애플리케이션을 실행하는 데 사용됩니다. .NET은 오픈 소스 및 플랫폼 간이며 Microsoft에서 지원합니다. .NET을 유용하게 사용하시길 바랍니다." />
+  <String Id="LearnMoreTitle" Value=".NET에 대한 자세한 정보" />
+  <String Id="SuccessInstallLocation" Value="다음이 [DOTNETHOME]에 설치되었습니다." />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="리소스" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;설명서&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;릴리스 정보&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;자습서&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET 원격 분석&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;개인정보처리방침&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;.NET에 대한 라이선스 정보&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="설치를 클릭하면 다음 사용 약관에 동의하는 것입니다." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1045/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1045/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Instalator pakietu [WixBundleName]</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">Potrzebujemy tylko powłoki, edytora tekstu i 10 minut czasu.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="Instalator pakietu [WixBundleName]" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="Potrzebujemy tylko powłoki, edytora tekstu i 10 minut czasu.
 
-Wszystko gotowe? Zaczynamy!</String>
-  <String Id="ConfirmCancelMessage">Czy na pewno chcesz anulować?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Poprzednia wersja</String>
-  <String Id="HelpHeader">Instalator — Pomoc</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [katalog] - Instaluje, naprawia, odinstalowuje
+Wszystko gotowe? Zaczynamy!" />
+  <String Id="ConfirmCancelMessage" Value="Czy na pewno chcesz anulować?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Poprzednia wersja" />
+  <String Id="HelpHeader" Value="Instalator — Pomoc" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [katalog] - Instaluje, naprawia, odinstalowuje
    lub tworzy pełną lokalną kopię pakietu w katalogu. Domyślnie jest używany przełącznik install.
 
 /passive | /quiet -  Wyświetla ograniczony interfejs użytkownika bez monitów albo nie wyświetla ani interfejsu użytkownika,
    ani monitów. Domyślnie jest wyświetlany interfejs użytkownika oraz wszystkie monity.
 
 /norestart   - Pomija próby ponownego uruchomienia. Domyślnie interfejs użytkownika wyświetla monit przed ponownym uruchomieniem.
-/log log.txt - Tworzy dziennik w określonym pliku. Domyślnie plik dziennika jest tworzony w katalogu %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Zamknij</String>
-  <String Id="InstallAcceptCheckbox">Zg&amp;adzam się na warunki licencji</String>
-  <String Id="InstallOptionsButton">&amp;Opcje</String>
-  <String Id="InstallInstallButton">Za&amp;instaluj</String>
-  <String Id="InstallCloseButton">&amp;Zamknij</String>
-  <String Id="OptionsHeader">Opcje instalatora</String>
-  <String Id="OptionsLocationLabel">Lokalizacja instalacji:</String>
-  <String Id="OptionsBrowseButton">&amp;Przeglądaj</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Anuluj</String>
-  <String Id="ProgressHeader">Postęp instalacji</String>
-  <String Id="ProgressLabel">Przetwarzanie:</String>
-  <String Id="OverallProgressPackageText">Trwa inicjowanie...</String>
-  <String Id="ProgressCancelButton">&amp;Anuluj</String>
-  <String Id="ModifyHeader">Zmodyfikuj instalatora</String>
-  <String Id="ModifyRepairButton">Nap&amp;raw</String>
-  <String Id="ModifyUninstallButton">O&amp;dinstaluj</String>
-  <String Id="ModifyCloseButton">&amp;Zamknij</String>
-  <String Id="SuccessRepairHeader">Pomyślnie ukończono naprawę</String>
-  <String Id="SuccessUninstallHeader">Pomyślnie ukończono operację odinstalowania</String>
-  <String Id="SuccessInstallHeader">Instalacja przebiegła pomyślnie</String>
-  <String Id="SuccessHeader">Instalacja przebiegła pomyślnie</String>
-  <String Id="SuccessLaunchButton">&amp;Uruchom</String>
-  <String Id="SuccessRestartText">Aby korzystać z oprogramowania, należy ponownie uruchomić komputer.</String>
-  <String Id="SuccessRestartButton">&amp;Uruchom ponownie</String>
-  <String Id="SuccessCloseButton">&amp;Zamknij</String>
-  <String Id="FailureHeader">Instalacja nie powiodła się</String>
-  <String Id="FailureInstallHeader">Konfiguracja nie powiodła się</String>
-  <String Id="FailureUninstallHeader">Operacja odinstalowania nie powiodła się</String>
-  <String Id="FailureRepairHeader">Naprawa nie powiodła się</String>
-  <String Id="FailureHyperlinkLogText">Jeden lub więcej problemów spowodował niepowodzenie instalacji. Napraw błędy, a następnie uruchom ponownie instalację. Aby uzyskać więcej informacji zobacz &lt;a href="#"&gt;plik dziennika&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Należy ponownie uruchomić komputer, aby dokończyć wycofywanie oprogramowania.</String>
-  <String Id="FailureRestartButton">&amp;Uruchom ponownie</String>
-  <String Id="FailureCloseButton">&amp;Zamknij</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">Produkt [PRODUCT_NAME] nie jest obsługiwany w tym systemie operacyjnym. Aby uzyskać więcej informacji, zobacz [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">Produkt [PRODUCT_NAME] nie jest obsługiwany w systemach operacyjnych x86. Przeprowadź instalację przy użyciu odpowiedniego instalatora x86.</String>
-  <String Id="FilesInUseHeader">Pliki w użyciu</String>
-  <String Id="FilesInUseLabel">Następujące aplikacje korzystają z plików, które muszą zostać zaktualizowane:</String>
-  <String Id="FilesInUseCloseRadioButton">Zamknij &amp;aplikacje i spróbuj je ponownie uruchomić.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Nie zamykaj aplikacji. Będzie konieczne ponowne uruchomienie.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Anuluj</String>
-  <String Id="WelcomeHeaderMessage">Środowisko uruchomieniowe platformy .NET</String>
-  <String Id="WelcomeDescription">Środowisko uruchomieniowe platformy .NET służy do uruchamiania aplikacji platformy .NET na komputerze z systemem Windows. Platforma .NET jest oprogramowaniem typu open source, działa na różnych platformach i jest obsługiwana przez firmę Microsoft. Mamy nadzieję, że Ci się podoba!</String>
-  <String Id="LearnMoreTitle">Dowiedz się więcej o platformie .NET</String>
-  <String Id="SuccessInstallLocation">Następujące elementy zainstalowano w [DOTNETHOME]</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Zasoby</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Dokumentacja&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Informacje o wersji&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Samouczki&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetria platformy .NET&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Zasady zachowania poufności informacji&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;Informacje o licencjonowaniu dla platformy .NET&lt;/A&gt;</String>
-  <String Id="LicenseAssent">Klikając pozycję Zainstaluj, wyrażasz zgodę na następujące warunki.</String>
+/log log.txt - Tworzy dziennik w określonym pliku. Domyślnie plik dziennika jest tworzony w katalogu %TEMP%." />
+  <String Id="HelpCloseButton" Value="&amp;Zamknij" />
+  <String Id="InstallAcceptCheckbox" Value="Zg&amp;adzam się na warunki licencji" />
+  <String Id="InstallOptionsButton" Value="&amp;Opcje" />
+  <String Id="InstallInstallButton" Value="Za&amp;instaluj" />
+  <String Id="InstallCloseButton" Value="&amp;Zamknij" />
+  <String Id="OptionsHeader" Value="Opcje instalatora" />
+  <String Id="OptionsLocationLabel" Value="Lokalizacja instalacji:" />
+  <String Id="OptionsBrowseButton" Value="&amp;Przeglądaj" />
+  <String Id="OptionsOkButton" Value="&amp;OK" />
+  <String Id="OptionsCancelButton" Value="&amp;Anuluj" />
+  <String Id="ProgressHeader" Value="Postęp instalacji" />
+  <String Id="ProgressLabel" Value="Przetwarzanie:" />
+  <String Id="OverallProgressPackageText" Value="Trwa inicjowanie..." />
+  <String Id="ProgressCancelButton" Value="&amp;Anuluj" />
+  <String Id="ModifyHeader" Value="Zmodyfikuj instalatora" />
+  <String Id="ModifyRepairButton" Value="Nap&amp;raw" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="O&amp;dinstaluj" />
+  <String Id="ModifyCloseButton" Value="&amp;Zamknij" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="Pomyślnie ukończono naprawę" />
+  <String Id="SuccessUninstallHeader" Value="Pomyślnie ukończono operację odinstalowania" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="Instalacja przebiegła pomyślnie" />
+  <String Id="SuccessHeader" Value="Instalacja przebiegła pomyślnie" />
+  <String Id="SuccessLaunchButton" Value="&amp;Uruchom" />
+  <String Id="SuccessRestartText" Value="Aby korzystać z oprogramowania, należy ponownie uruchomić komputer." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Uruchom ponownie" />
+  <String Id="SuccessCloseButton" Value="&amp;Zamknij" />
+  <String Id="FailureHeader" Value="Instalacja nie powiodła się" />
+  <String Id="FailureInstallHeader" Value="Konfiguracja nie powiodła się" />
+  <String Id="FailureUninstallHeader" Value="Operacja odinstalowania nie powiodła się" />
+  <String Id="FailureRepairHeader" Value="Naprawa nie powiodła się" />
+  <String Id="FailureHyperlinkLogText" Value="Jeden lub więcej problemów spowodował niepowodzenie instalacji. Napraw błędy, a następnie uruchom ponownie instalację. Aby uzyskać więcej informacji zobacz &lt;a href=&quot;#&quot;&gt;plik dziennika&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="Należy ponownie uruchomić komputer, aby dokończyć wycofywanie oprogramowania." />
+  <String Id="FailureRestartButton" Value="&amp;Uruchom ponownie" />
+  <String Id="FailureCloseButton" Value="&amp;Zamknij" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="Produkt [PRODUCT_NAME] nie jest obsługiwany w tym systemie operacyjnym. Aby uzyskać więcej informacji, zobacz [LINK_PREREQ_PAGE]." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="Produkt [PRODUCT_NAME] nie jest obsługiwany w systemach operacyjnych x86. Przeprowadź instalację przy użyciu odpowiedniego instalatora x86." />
+  <String Id="FilesInUseHeader" Value="Pliki w użyciu" />
+  <String Id="FilesInUseLabel" Value="Następujące aplikacje korzystają z plików, które muszą zostać zaktualizowane:" />
+  <String Id="FilesInUseCloseRadioButton" Value="Zamknij &amp;aplikacje i spróbuj je ponownie uruchomić." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;Nie zamykaj aplikacji. Będzie konieczne ponowne uruchomienie." />
+  <String Id="FilesInUseOkButton" Value="&amp;OK" />
+  <String Id="FilesInUseCancelButton" Value="&amp;Anuluj" />
+  <String Id="WelcomeHeaderMessage" Value="Środowisko uruchomieniowe platformy .NET" />
+  <String Id="WelcomeDescription" Value="Środowisko uruchomieniowe platformy .NET służy do uruchamiania aplikacji platformy .NET na komputerze z systemem Windows. Platforma .NET jest oprogramowaniem typu open source, działa na różnych platformach i jest obsługiwana przez firmę Microsoft. Mamy nadzieję, że Ci się podoba!" />
+  <String Id="LearnMoreTitle" Value="Dowiedz się więcej o platformie .NET" />
+  <String Id="SuccessInstallLocation" Value="Następujące elementy zainstalowano w [DOTNETHOME]" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Zasoby" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Dokumentacja&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Informacje o wersji&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Samouczki&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;Telemetria platformy .NET&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Zasady zachowania poufności informacji&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Informacje o licencjonowaniu dla platformy .NET&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="Klikając pozycję Zainstaluj, wyrażasz zgodę na następujące warunki." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1046/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1046/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Instalador do [WixBundleName]</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">Você só precisa de um shell, um editor de texto e 10 minutos de seu tempo.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="Instalador do [WixBundleName]" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="Você só precisa de um shell, um editor de texto e 10 minutos de seu tempo.
 
-Tudo pronto? Então, vamos nessa!</String>
-  <String Id="ConfirmCancelMessage">Tem certeza de que deseja cancelar?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Versão anterior</String>
-  <String Id="HelpHeader">Ajuda da Instalação</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [diretório] - instala, repara, desinstala ou
+Tudo pronto? Então, vamos nessa!" />
+  <String Id="ConfirmCancelMessage" Value="Tem certeza de que deseja cancelar?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Versão anterior" />
+  <String Id="HelpHeader" Value="Ajuda da Instalação" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [diretório] - instala, repara, desinstala ou
    cria uma cópia local completa do pacote no diretório. Install é o padrão
 
 /passive | /quiet -  exibe a interface do usuário mínima sem nenhum prompt ou não exibe nenhuma interface do usuário e
    nenhum prompt. Por padrão, a interface do usuário e todos os prompts são exibidos.
 
 /norestart   - suprime qualquer tentativa de reiniciar. Por padrão, a interface do usuário perguntará antes de reiniciar.
-/log log.txt - registra em um arquivo específico. Por padrão, um arquivo de log é criado em %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Fechar</String>
-  <String Id="InstallAcceptCheckbox">Eu &amp;concordo com os termos e condições da licença</String>
-  <String Id="InstallOptionsButton">&amp;Opções</String>
-  <String Id="InstallInstallButton">&amp;Instalar</String>
-  <String Id="InstallCloseButton">&amp;Fechar</String>
-  <String Id="OptionsHeader">Opções de Instalação</String>
-  <String Id="OptionsLocationLabel">Local de instalação:</String>
-  <String Id="OptionsBrowseButton">&amp;Procurar</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancelar</String>
-  <String Id="ProgressHeader">Progresso da Instalação</String>
-  <String Id="ProgressLabel">Processando:</String>
-  <String Id="OverallProgressPackageText">Inicializando...</String>
-  <String Id="ProgressCancelButton">&amp;Cancelar</String>
-  <String Id="ModifyHeader">Modificar Instalação</String>
-  <String Id="ModifyRepairButton">&amp;Reparar</String>
-  <String Id="ModifyUninstallButton">&amp;Desinstalar</String>
-  <String Id="ModifyCloseButton">&amp;Fechar</String>
-  <String Id="SuccessRepairHeader">Reparação Concluída com Êxito</String>
-  <String Id="SuccessUninstallHeader">Desinstalação Concluída com Êxito</String>
-  <String Id="SuccessInstallHeader">A instalação foi bem-sucedida</String>
-  <String Id="SuccessHeader">Instalação com Êxito</String>
-  <String Id="SuccessLaunchButton">&amp;Iniciar</String>
-  <String Id="SuccessRestartText">Reinicie o computador para poder usar o software.</String>
-  <String Id="SuccessRestartButton">&amp;Reiniciar</String>
-  <String Id="SuccessCloseButton">&amp;Fechar</String>
-  <String Id="FailureHeader">Falha na Instalação</String>
-  <String Id="FailureInstallHeader">Falha na Instalação</String>
-  <String Id="FailureUninstallHeader">Falha na Desinstalação</String>
-  <String Id="FailureRepairHeader">Falha ao Reparar</String>
-  <String Id="FailureHyperlinkLogText">Um ou mais problemas causaram falha na instalação. Corrija-os e tente instalar novamente. Para obter mais informações, consulte o &lt;a href="#"&gt;arquivo de log&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Reinicie o computador para concluir a reversão do software.</String>
-  <String Id="FailureRestartButton">&amp;Reiniciar</String>
-  <String Id="FailureCloseButton">&amp;Fechar</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">Não há suporte para o [PRODUCT_NAME] neste sistema operacional. Para obter mais informações, confira [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">O [PRODUCT_NAME] não tem suporte em sistemas operacionais x86. Instale usando o instalador x86 correspondente.</String>
-  <String Id="FilesInUseHeader">Arquivos em Uso</String>
-  <String Id="FilesInUseLabel">Os aplicativos a seguir estão usando arquivos que precisam ser atualizados:</String>
-  <String Id="FilesInUseCloseRadioButton">Feche os &amp;aplicativos e tente reiniciá-los.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Não feche os aplicativos. Uma reinicialização será necessária.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
-  <String Id="WelcomeHeaderMessage">Runtime do .NET</String>
-  <String Id="WelcomeDescription">O Runtime do .NET é usado para executar aplicativos .NET no seu computador com Windows. O .NET é um software de código aberto, com plataforma cruzada e possui o suporte da Microsoft. Esperamos que você goste!</String>
-  <String Id="LearnMoreTitle">Saiba mais sobre o .NET</String>
-  <String Id="SuccessInstallLocation">O seguinte foi instalado em [DOTNETHOME]</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Recursos</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Documentação&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Notas sobre a Versão&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Tutoriais&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetria do .NET&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Política de Privacidade&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;Informações de licenciamento para .NET&lt;/A&gt;</String>
-  <String Id="LicenseAssent">Ao clicar em instalar, você concorda com os termos a seguir.</String>
+/log log.txt - registra em um arquivo específico. Por padrão, um arquivo de log é criado em %TEMP%." />
+  <String Id="HelpCloseButton" Value="&amp;Fechar" />
+  <String Id="InstallAcceptCheckbox" Value="Eu &amp;concordo com os termos e condições da licença" />
+  <String Id="InstallOptionsButton" Value="&amp;Opções" />
+  <String Id="InstallInstallButton" Value="&amp;Instalar" />
+  <String Id="InstallCloseButton" Value="&amp;Fechar" />
+  <String Id="OptionsHeader" Value="Opções de Instalação" />
+  <String Id="OptionsLocationLabel" Value="Local de instalação:" />
+  <String Id="OptionsBrowseButton" Value="&amp;Procurar" />
+  <String Id="OptionsOkButton" Value="&amp;OK" />
+  <String Id="OptionsCancelButton" Value="&amp;Cancelar" />
+  <String Id="ProgressHeader" Value="Progresso da Instalação" />
+  <String Id="ProgressLabel" Value="Processando:" />
+  <String Id="OverallProgressPackageText" Value="Inicializando..." />
+  <String Id="ProgressCancelButton" Value="&amp;Cancelar" />
+  <String Id="ModifyHeader" Value="Modificar Instalação" />
+  <String Id="ModifyRepairButton" Value="&amp;Reparar" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="&amp;Desinstalar" />
+  <String Id="ModifyCloseButton" Value="&amp;Fechar" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="Reparação Concluída com Êxito" />
+  <String Id="SuccessUninstallHeader" Value="Desinstalação Concluída com Êxito" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="A instalação foi bem-sucedida" />
+  <String Id="SuccessHeader" Value="Instalação com Êxito" />
+  <String Id="SuccessLaunchButton" Value="&amp;Iniciar" />
+  <String Id="SuccessRestartText" Value="Reinicie o computador para poder usar o software." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Reiniciar" />
+  <String Id="SuccessCloseButton" Value="&amp;Fechar" />
+  <String Id="FailureHeader" Value="Falha na Instalação" />
+  <String Id="FailureInstallHeader" Value="Falha na Instalação" />
+  <String Id="FailureUninstallHeader" Value="Falha na Desinstalação" />
+  <String Id="FailureRepairHeader" Value="Falha ao Reparar" />
+  <String Id="FailureHyperlinkLogText" Value="Um ou mais problemas causaram falha na instalação. Corrija-os e tente instalar novamente. Para obter mais informações, consulte o &lt;a href=&quot;#&quot;&gt;arquivo de log&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="Reinicie o computador para concluir a reversão do software." />
+  <String Id="FailureRestartButton" Value="&amp;Reiniciar" />
+  <String Id="FailureCloseButton" Value="&amp;Fechar" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="Não há suporte para o [PRODUCT_NAME] neste sistema operacional. Para obter mais informações, confira [LINK_PREREQ_PAGE]." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="O [PRODUCT_NAME] não tem suporte em sistemas operacionais x86. Instale usando o instalador x86 correspondente." />
+  <String Id="FilesInUseHeader" Value="Arquivos em Uso" />
+  <String Id="FilesInUseLabel" Value="Os aplicativos a seguir estão usando arquivos que precisam ser atualizados:" />
+  <String Id="FilesInUseCloseRadioButton" Value="Feche os &amp;aplicativos e tente reiniciá-los." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;Não feche os aplicativos. Uma reinicialização será necessária." />
+  <String Id="FilesInUseOkButton" Value="&amp;OK" />
+  <String Id="FilesInUseCancelButton" Value="&amp;Cancelar" />
+  <String Id="WelcomeHeaderMessage" Value="Runtime do .NET" />
+  <String Id="WelcomeDescription" Value="O Runtime do .NET é usado para executar aplicativos .NET no seu computador com Windows. O .NET é um software de código aberto, com plataforma cruzada e possui o suporte da Microsoft. Esperamos que você goste!" />
+  <String Id="LearnMoreTitle" Value="Saiba mais sobre o .NET" />
+  <String Id="SuccessInstallLocation" Value="O seguinte foi instalado em [DOTNETHOME]" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Recursos" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentação&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Notas sobre a Versão&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutoriais&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;Telemetria do .NET&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Política de Privacidade&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Informações de licenciamento para .NET&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="Ao clicar em instalar, você concorda com os termos a seguir." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1049/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1049/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Установщик [WixBundleName]</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">Вам требуется только оболочка, текстовый редактор и 10 минут времени.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="Установщик [WixBundleName]" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="Вам требуется только оболочка, текстовый редактор и 10 минут времени.
 
-Готовы? Тогда приступим!</String>
-  <String Id="ConfirmCancelMessage">Отменить?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Предыдущая версия</String>
-  <String Id="HelpHeader">Справка по установке</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [каталог] — установка, восстановление, удаление или
+Готовы? Тогда приступим!" />
+  <String Id="ConfirmCancelMessage" Value="Отменить?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Предыдущая версия" />
+  <String Id="HelpHeader" Value="Справка по установке" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [каталог] — установка, восстановление, удаление или
  создание полной локальной копии пакета в каталоге. По умолчанию — установка.
 
 /passive | /quiet — отображение минимального пользовательского интерфейса без запросов или работа без пользовательского интерфейса и
  без запросов. По умолчанию отображаются пользовательский интерфейс и все запросы.
 
 /norestart — отключение всех попыток перезагрузки. По умолчанию в пользовательском интерфейсе перед перезагрузкой отображается запрос.
-/log log.txt — запись журнала в указанный файл. По умолчанию файл журнала создается в папке %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Закрыть</String>
-  <String Id="InstallAcceptCheckbox">Я &amp;принимаю условия лицензии</String>
-  <String Id="InstallOptionsButton">&amp;Параметры</String>
-  <String Id="InstallInstallButton">&amp;Установить</String>
-  <String Id="InstallCloseButton">&amp;Закрыть</String>
-  <String Id="OptionsHeader">Параметры установки</String>
-  <String Id="OptionsLocationLabel">Расположение установки:</String>
-  <String Id="OptionsBrowseButton">&amp;Обзор</String>
-  <String Id="OptionsOkButton">&amp;ОК</String>
-  <String Id="OptionsCancelButton">Отм&amp;ена</String>
-  <String Id="ProgressHeader">Ход установки</String>
-  <String Id="ProgressLabel">Обработка:</String>
-  <String Id="OverallProgressPackageText">Инициализация...</String>
-  <String Id="ProgressCancelButton">Отм&amp;ена</String>
-  <String Id="ModifyHeader">Изменение установки</String>
-  <String Id="ModifyRepairButton">&amp;Исправить</String>
-  <String Id="ModifyUninstallButton">&amp;Удалить</String>
-  <String Id="ModifyCloseButton">&amp;Закрыть</String>
-  <String Id="SuccessRepairHeader">Исправление успешно завершено</String>
-  <String Id="SuccessUninstallHeader">Удаление успешно завершено</String>
-  <String Id="SuccessInstallHeader">Установка успешно завершена</String>
-  <String Id="SuccessHeader">Установка успешно завершена</String>
-  <String Id="SuccessLaunchButton">&amp;Запустить</String>
-  <String Id="SuccessRestartText">Перед использованием программного обеспечения необходимо перезапустить компьютер.</String>
-  <String Id="SuccessRestartButton">&amp;Перезапустить</String>
-  <String Id="SuccessCloseButton">&amp;Закрыть</String>
-  <String Id="FailureHeader">Сбой установки</String>
-  <String Id="FailureInstallHeader">Сбой установки</String>
-  <String Id="FailureUninstallHeader">Сбой удаления</String>
-  <String Id="FailureRepairHeader">Сбой восстановления</String>
-  <String Id="FailureHyperlinkLogText">Одна или несколько проблем вызывали сбой программы установки. Исправьте эти проблемы и попробуйте повторить установку. Дополнительные сведения см. в &lt;a href="#"&gt;файле журнала&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Необходимо перезагрузить компьютер, чтобы завершить откат программного обеспечения.</String>
-  <String Id="FailureRestartButton">&amp;Перезапустить</String>
-  <String Id="FailureCloseButton">&amp;Закрыть</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">Продукт [PRODUCT_NAME] не поддерживается в этой операционной системе. Дополнительные сведения: [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">Продукт [PRODUCT_NAME] не поддерживается в операционных системах x86. Установите с помощью соответствующего установщика x86.</String>
-  <String Id="FilesInUseHeader">Используемые файлы</String>
-  <String Id="FilesInUseLabel">Следующие приложения используют файлы, которые следует обновить:</String>
-  <String Id="FilesInUseCloseRadioButton">Закройте &amp;приложения и попробуйте перезапустить их.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывайте приложения. Потребуется перезагрузка компьютера.</String>
-  <String Id="FilesInUseOkButton">&amp;ОК</String>
-  <String Id="FilesInUseCancelButton">&amp;Отменить</String>
-  <String Id="WelcomeHeaderMessage">Среда выполнения .NET</String>
-  <String Id="WelcomeDescription">Среда выполнения .NET используется для запуска приложений .NET на компьютерах с Windows. Среда .NET является открытой, кроссплатформенной и поддерживается Майкрософт. Надеемся, вам понравится!</String>
-  <String Id="LearnMoreTitle">Дополнительные сведения о .NET</String>
-  <String Id="SuccessInstallLocation">Следующее было установлено в [DOTNETHOME]</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Ресурсы</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Документация&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Заметки о выпуске&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Руководства&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Телеметрия .NET&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Заявление о конфиденциальности&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;Сведения о лицензировании .NET&lt;/A&gt;</String>
-  <String Id="LicenseAssent">Нажимая кнопку "Установить", вы принимаете следующие условия.</String>
+/log log.txt — запись журнала в указанный файл. По умолчанию файл журнала создается в папке %TEMP%." />
+  <String Id="HelpCloseButton" Value="&amp;Закрыть" />
+  <String Id="InstallAcceptCheckbox" Value="Я &amp;принимаю условия лицензии" />
+  <String Id="InstallOptionsButton" Value="&amp;Параметры" />
+  <String Id="InstallInstallButton" Value="&amp;Установить" />
+  <String Id="InstallCloseButton" Value="&amp;Закрыть" />
+  <String Id="OptionsHeader" Value="Параметры установки" />
+  <String Id="OptionsLocationLabel" Value="Расположение установки:" />
+  <String Id="OptionsBrowseButton" Value="&amp;Обзор" />
+  <String Id="OptionsOkButton" Value="&amp;ОК" />
+  <String Id="OptionsCancelButton" Value="Отм&amp;ена" />
+  <String Id="ProgressHeader" Value="Ход установки" />
+  <String Id="ProgressLabel" Value="Обработка:" />
+  <String Id="OverallProgressPackageText" Value="Инициализация..." />
+  <String Id="ProgressCancelButton" Value="Отм&amp;ена" />
+  <String Id="ModifyHeader" Value="Изменение установки" />
+  <String Id="ModifyRepairButton" Value="&amp;Исправить" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="&amp;Удалить" />
+  <String Id="ModifyCloseButton" Value="&amp;Закрыть" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="Исправление успешно завершено" />
+  <String Id="SuccessUninstallHeader" Value="Удаление успешно завершено" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="Установка успешно завершена" />
+  <String Id="SuccessHeader" Value="Установка успешно завершена" />
+  <String Id="SuccessLaunchButton" Value="&amp;Запустить" />
+  <String Id="SuccessRestartText" Value="Перед использованием программного обеспечения необходимо перезапустить компьютер." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Перезапустить" />
+  <String Id="SuccessCloseButton" Value="&amp;Закрыть" />
+  <String Id="FailureHeader" Value="Сбой установки" />
+  <String Id="FailureInstallHeader" Value="Сбой установки" />
+  <String Id="FailureUninstallHeader" Value="Сбой удаления" />
+  <String Id="FailureRepairHeader" Value="Сбой восстановления" />
+  <String Id="FailureHyperlinkLogText" Value="Одна или несколько проблем вызывали сбой программы установки. Исправьте эти проблемы и попробуйте повторить установку. Дополнительные сведения см. в &lt;a href=&quot;#&quot;&gt;файле журнала&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="Необходимо перезагрузить компьютер, чтобы завершить откат программного обеспечения." />
+  <String Id="FailureRestartButton" Value="&amp;Перезапустить" />
+  <String Id="FailureCloseButton" Value="&amp;Закрыть" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="Продукт [PRODUCT_NAME] не поддерживается в этой операционной системе. Дополнительные сведения: [LINK_PREREQ_PAGE]." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="Продукт [PRODUCT_NAME] не поддерживается в операционных системах x86. Установите с помощью соответствующего установщика x86." />
+  <String Id="FilesInUseHeader" Value="Используемые файлы" />
+  <String Id="FilesInUseLabel" Value="Следующие приложения используют файлы, которые следует обновить:" />
+  <String Id="FilesInUseCloseRadioButton" Value="Закройте &amp;приложения и попробуйте перезапустить их." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;Не закрывайте приложения. Потребуется перезагрузка компьютера." />
+  <String Id="FilesInUseOkButton" Value="&amp;ОК" />
+  <String Id="FilesInUseCancelButton" Value="&amp;Отменить" />
+  <String Id="WelcomeHeaderMessage" Value="Среда выполнения .NET" />
+  <String Id="WelcomeDescription" Value="Среда выполнения .NET используется для запуска приложений .NET на компьютерах с Windows. Среда .NET является открытой, кроссплатформенной и поддерживается Майкрософт. Надеемся, вам понравится!" />
+  <String Id="LearnMoreTitle" Value="Дополнительные сведения о .NET" />
+  <String Id="SuccessInstallLocation" Value="Следующее было установлено в [DOTNETHOME]" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Ресурсы" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Документация&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Заметки о выпуске&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Руководства&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;Телеметрия .NET&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Заявление о конфиденциальности&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Сведения о лицензировании .NET&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="Нажимая кнопку &quot;Установить&quot;, вы принимаете следующие условия." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/1055/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1055/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Yükleyicisi</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">Yalnızca bir kabuğa, bir metin düzenleyicisine ve 10 dakikalık bir zamana ihtiyacınız var.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="[WixBundleName] Yükleyicisi" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="Yalnızca bir kabuğa, bir metin düzenleyicisine ve 10 dakikalık bir zamana ihtiyacınız var.
 
-Hazır mısınız? Haydi başlayalım!</String>
-  <String Id="ConfirmCancelMessage">İptal etmek istediğinizden emin misiniz?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Önceki sürüm</String>
-  <String Id="HelpHeader">Kurulum Yardımı</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [dizin] - yükler, onarır, kaldırır ya da
+Hazır mısınız? Haydi başlayalım!" />
+  <String Id="ConfirmCancelMessage" Value="İptal etmek istediğinizden emin misiniz?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Önceki sürüm" />
+  <String Id="HelpHeader" Value="Kurulum Yardımı" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [dizin] - yükler, onarır, kaldırır ya da
    dizindeki paketin tam bir yerel kopyasını oluşturur. Varsayılan install değeridir.
 
 /passive | /quiet -  en az düzeyde istemsiz UI gösterir ya da hiç UI göstermez ve
    istem yoktur. Varsayılan olarak UI ve tüm istemler görüntülenir.
 
 /norestart   - yeniden başlama denemelerini engeller. Varsayılan olarak UI yeniden başlatılmadan önce sorar.
-/log log.txt - belirli bir günlük dosyası tutar. Varsayılan olarak %TEMP% içinde bir günlük dosyası oluşturulur.</String>
-  <String Id="HelpCloseButton">&amp;Kapat</String>
-  <String Id="InstallAcceptCheckbox">Lisans hüküm ve koşullarını &amp;kabul ediyorum</String>
-  <String Id="InstallOptionsButton">&amp;Seçenekler</String>
-  <String Id="InstallInstallButton">Yü&amp;kle</String>
-  <String Id="InstallCloseButton">&amp;Kapat</String>
-  <String Id="OptionsHeader">Kurulum Seçenekleri</String>
-  <String Id="OptionsLocationLabel">Yükleme konumu:</String>
-  <String Id="OptionsBrowseButton">&amp;Gözat</String>
-  <String Id="OptionsOkButton">&amp;Tamam</String>
-  <String Id="OptionsCancelButton">İ&amp;ptal</String>
-  <String Id="ProgressHeader">Kurulum İlerleme Durumu</String>
-  <String Id="ProgressLabel">İşleniyor:</String>
-  <String Id="OverallProgressPackageText">Başlatılıyor...</String>
-  <String Id="ProgressCancelButton">İ&amp;ptal</String>
-  <String Id="ModifyHeader">Kurulumu değiştir</String>
-  <String Id="ModifyRepairButton">&amp;Onar</String>
-  <String Id="ModifyUninstallButton">&amp;Kaldır</String>
-  <String Id="ModifyCloseButton">&amp;Kapat</String>
-  <String Id="SuccessRepairHeader">Onarım Başarıyla Tamamlandı</String>
-  <String Id="SuccessUninstallHeader">Kaldırma Başarıyla Tamamlandı</String>
-  <String Id="SuccessInstallHeader">Yükleme başarılı oldu</String>
-  <String Id="SuccessHeader">Kurulum Başarılı</String>
-  <String Id="SuccessLaunchButton">&amp;Başlat</String>
-  <String Id="SuccessRestartText">Yazılımı kullanabilmeniz için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="SuccessRestartButton">&amp;Yeniden Başlat</String>
-  <String Id="SuccessCloseButton">&amp;Kapat</String>
-  <String Id="FailureHeader">Kurulum Başarısız</String>
-  <String Id="FailureInstallHeader">Kurulum Başarısız</String>
-  <String Id="FailureUninstallHeader">Kaldırma Başarısız</String>
-  <String Id="FailureRepairHeader">Onarım Başarısız</String>
-  <String Id="FailureHyperlinkLogText">Bir ya da daha fazla sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href="#"&gt;günlük dosyasına&lt;/a&gt; bakın.</String>
-  <String Id="FailureRestartText">Yazılımın geri alınmasını tamamlamak için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="FailureRestartButton">&amp;Yeniden Başlat</String>
-  <String Id="FailureCloseButton">&amp;Kapat</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] bu işletim sisteminde desteklenmiyor. Daha fazla bilgi için bkz. [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME], x86 işletim sistemlerinde desteklenmiyor. Lütfen karşılık gelen x86 yükleyicisini kullanarak yükleyin.</String>
-  <String Id="FilesInUseHeader">Kullanımda Olan Dosyalar</String>
-  <String Id="FilesInUseLabel">Şu uygulamalar güncelleştirilmesi gereken dosyaları kullanıyor:</String>
-  <String Id="FilesInUseCloseRadioButton">&amp;Uygulamaları kapatın ve yeniden başlatmayı deneyin.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Uygulamaları kapatmayın. Sistemi yeniden başlatmanız gerekir.</String>
-  <String Id="FilesInUseOkButton">&amp;Tamam</String>
-  <String Id="FilesInUseCancelButton">İ&amp;ptal</String>
-  <String Id="WelcomeHeaderMessage">.NET Çalışma Zamanı</String>
-  <String Id="WelcomeDescription">.NET Çalışma Zamanı, Windows bilgisayarınızda .NET uygulamalarını çalıştırmak için kullanılır. .NET açık kaynaktır, platformlar arasında kullanılabilir ve Microsoft tarafından desteklenmektedir. Beğeneceğinizi umuyoruz!</String>
-  <String Id="LearnMoreTitle">.NET hakkında daha fazla bilgi edinin</String>
-  <String Id="SuccessInstallLocation">Aşağıdakiler [DOTNETHOME] konumunda yüklendi</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Kaynaklar</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Belgeler&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Sürüm Notları&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Öğreticiler&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET Telemetrisi&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Gizlilik Bildirimi&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;.NET için Lisans Bilgileri&lt;/A&gt;</String>
-  <String Id="LicenseAssent">Yükle'ye tıklayarak aşağıdaki koşulları kabul etmiş olursunuz.</String>
+/log log.txt - belirli bir günlük dosyası tutar. Varsayılan olarak %TEMP% içinde bir günlük dosyası oluşturulur." />
+  <String Id="HelpCloseButton" Value="&amp;Kapat" />
+  <String Id="InstallAcceptCheckbox" Value="Lisans hüküm ve koşullarını &amp;kabul ediyorum" />
+  <String Id="InstallOptionsButton" Value="&amp;Seçenekler" />
+  <String Id="InstallInstallButton" Value="Yü&amp;kle" />
+  <String Id="InstallCloseButton" Value="&amp;Kapat" />
+  <String Id="OptionsHeader" Value="Kurulum Seçenekleri" />
+  <String Id="OptionsLocationLabel" Value="Yükleme konumu:" />
+  <String Id="OptionsBrowseButton" Value="&amp;Gözat" />
+  <String Id="OptionsOkButton" Value="&amp;Tamam" />
+  <String Id="OptionsCancelButton" Value="İ&amp;ptal" />
+  <String Id="ProgressHeader" Value="Kurulum İlerleme Durumu" />
+  <String Id="ProgressLabel" Value="İşleniyor:" />
+  <String Id="OverallProgressPackageText" Value="Başlatılıyor..." />
+  <String Id="ProgressCancelButton" Value="İ&amp;ptal" />
+  <String Id="ModifyHeader" Value="Kurulumu değiştir" />
+  <String Id="ModifyRepairButton" Value="&amp;Onar" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="&amp;Kaldır" />
+  <String Id="ModifyCloseButton" Value="&amp;Kapat" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="Onarım Başarıyla Tamamlandı" />
+  <String Id="SuccessUninstallHeader" Value="Kaldırma Başarıyla Tamamlandı" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="Yükleme başarılı oldu" />
+  <String Id="SuccessHeader" Value="Kurulum Başarılı" />
+  <String Id="SuccessLaunchButton" Value="&amp;Başlat" />
+  <String Id="SuccessRestartText" Value="Yazılımı kullanabilmeniz için bilgisayarınızı yeniden başlatmanız gerekiyor." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Yeniden Başlat" />
+  <String Id="SuccessCloseButton" Value="&amp;Kapat" />
+  <String Id="FailureHeader" Value="Kurulum Başarısız" />
+  <String Id="FailureInstallHeader" Value="Kurulum Başarısız" />
+  <String Id="FailureUninstallHeader" Value="Kaldırma Başarısız" />
+  <String Id="FailureRepairHeader" Value="Onarım Başarısız" />
+  <String Id="FailureHyperlinkLogText" Value="Bir ya da daha fazla sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href=&quot;#&quot;&gt;günlük dosyasına&lt;/a&gt; bakın." />
+  <String Id="FailureRestartText" Value="Yazılımın geri alınmasını tamamlamak için bilgisayarınızı yeniden başlatmanız gerekiyor." />
+  <String Id="FailureRestartButton" Value="&amp;Yeniden Başlat" />
+  <String Id="FailureCloseButton" Value="&amp;Kapat" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="[PRODUCT_NAME] bu işletim sisteminde desteklenmiyor. Daha fazla bilgi için bkz. [LINK_PREREQ_PAGE]." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="[PRODUCT_NAME], x86 işletim sistemlerinde desteklenmiyor. Lütfen karşılık gelen x86 yükleyicisini kullanarak yükleyin." />
+  <String Id="FilesInUseHeader" Value="Kullanımda Olan Dosyalar" />
+  <String Id="FilesInUseLabel" Value="Şu uygulamalar güncelleştirilmesi gereken dosyaları kullanıyor:" />
+  <String Id="FilesInUseCloseRadioButton" Value="&amp;Uygulamaları kapatın ve yeniden başlatmayı deneyin." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;Uygulamaları kapatmayın. Sistemi yeniden başlatmanız gerekir." />
+  <String Id="FilesInUseOkButton" Value="&amp;Tamam" />
+  <String Id="FilesInUseCancelButton" Value="İ&amp;ptal" />
+  <String Id="WelcomeHeaderMessage" Value=".NET Çalışma Zamanı" />
+  <String Id="WelcomeDescription" Value=".NET Çalışma Zamanı, Windows bilgisayarınızda .NET uygulamalarını çalıştırmak için kullanılır. .NET açık kaynaktır, platformlar arasında kullanılabilir ve Microsoft tarafından desteklenmektedir. Beğeneceğinizi umuyoruz!" />
+  <String Id="LearnMoreTitle" Value=".NET hakkında daha fazla bilgi edinin" />
+  <String Id="SuccessInstallLocation" Value="Aşağıdakiler [DOTNETHOME] konumunda yüklendi" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Kaynaklar" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Belgeler&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Sürüm Notları&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Öğreticiler&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Telemetrisi&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Gizlilik Bildirimi&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;.NET için Lisans Bilgileri&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="Yükle'ye tıklayarak aşağıdaki koşulları kabul etmiş olursunuz." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/2052/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/2052/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] 安装程序</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">你只需要一个 shell、一个文本编辑器，还需花 10 分钟即可。
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="[WixBundleName] 安装程序" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="你只需要一个 shell、一个文本编辑器，还需花 10 分钟即可。
 
-准备好了吗? 要设置? 让我们开始吧!</String>
-  <String Id="ConfirmCancelMessage">是否确实要取消?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">上一版本</String>
-  <String Id="HelpHeader">安装程序帮助</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [目录] - 安装、修复、卸载
+准备好了吗? 要设置? 让我们开始吧!" />
+  <String Id="ConfirmCancelMessage" Value="是否确实要取消?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="上一版本" />
+  <String Id="HelpHeader" Value="安装程序帮助" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [目录] - 安装、修复、卸载
    目录中的安装包或创建其完整本地副本。Install 为默认选择。
 
 /passive | /quiet -  显示最少的 UI 且无提示，或不显示 UI 且
    无提示。默认显示 UI 及全部提示。
 
 /norestart   - 禁止任何重新启动。默认在重新启动前显示提示 UI。
-/log log.txt - 向特定文件写入日志。默认在 %TEMP% 中创建日志文件。</String>
-  <String Id="HelpCloseButton">关闭(&amp;C)</String>
-  <String Id="InstallAcceptCheckbox">我同意许可条款和条件(&amp;A)</String>
-  <String Id="InstallOptionsButton">选项(&amp;O)</String>
-  <String Id="InstallInstallButton">安装(&amp;I)</String>
-  <String Id="InstallCloseButton">关闭(&amp;C)</String>
-  <String Id="OptionsHeader">安装选项</String>
-  <String Id="OptionsLocationLabel">安装位置:</String>
-  <String Id="OptionsBrowseButton">浏览(&amp;B)</String>
-  <String Id="OptionsOkButton">确定(&amp;O)</String>
-  <String Id="OptionsCancelButton">取消(&amp;C)</String>
-  <String Id="ProgressHeader">安装进度</String>
-  <String Id="ProgressLabel">正在处理:</String>
-  <String Id="OverallProgressPackageText">正在初始化...</String>
-  <String Id="ProgressCancelButton">取消(&amp;C)</String>
-  <String Id="ModifyHeader">修改安装程序</String>
-  <String Id="ModifyRepairButton">修复(&amp;R)</String>
-  <String Id="ModifyUninstallButton">卸载(&amp;U)</String>
-  <String Id="ModifyCloseButton">关闭(&amp;C)</String>
-  <String Id="SuccessRepairHeader">成功完成了修复</String>
-  <String Id="SuccessUninstallHeader">成功完成了卸载</String>
-  <String Id="SuccessInstallHeader">安装成功</String>
-  <String Id="SuccessHeader">设置成功</String>
-  <String Id="SuccessLaunchButton">启动(&amp;L)</String>
-  <String Id="SuccessRestartText">您必须先重新启动计算机，然后才能使用该软件。</String>
-  <String Id="SuccessRestartButton">重新启动(&amp;R)</String>
-  <String Id="SuccessCloseButton">关闭(&amp;C)</String>
-  <String Id="FailureHeader">安装失败</String>
-  <String Id="FailureInstallHeader">安装失败</String>
-  <String Id="FailureUninstallHeader">卸载失败</String>
-  <String Id="FailureRepairHeader">修复失败</String>
-  <String Id="FailureHyperlinkLogText">一个或多个问题导致了安装失败。请修复这些问题，然后重试安装。有关详细信息，请参阅&lt;a href="#"&gt;日志文件&lt;/a&gt;。</String>
-  <String Id="FailureRestartText">必须重新启动计算机才能完成软件回退。</String>
-  <String Id="FailureRestartButton">重新启动(&amp;R)</String>
-  <String Id="FailureCloseButton">关闭(&amp;C)</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">此操作系统不支持 [PRODUCT_NAME]。有关详细信息，请参阅[LINK_PREREQ_PAGE]。</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">x86 操作系统不支持该 [PRODUCT_NAME]。请使用相应的 x86 安装程序进行安装。</String>
-  <String Id="FilesInUseHeader">文件正在使用</String>
-  <String Id="FilesInUseLabel">以下应用程序正在使用的文件需要更新:</String>
-  <String Id="FilesInUseCloseRadioButton">关闭应用程序并尝试重启(&amp;A)。</String>
-  <String Id="FilesInUseDontCloseRadioButton">不关闭应用程序(&amp;D)。需要重启。</String>
-  <String Id="FilesInUseOkButton">确定(&amp;O)</String>
-  <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
-  <String Id="WelcomeHeaderMessage">.NET 运行时</String>
-  <String Id="WelcomeDescription">.NET 运行时用于在 Windows 计算机上运行 .NET 应用程序。.NET 是开源、跨平台的，且由 Microsoft 提供支持。希望你喜欢它!</String>
-  <String Id="LearnMoreTitle">了解有关 .NET 的详细信息</String>
-  <String Id="SuccessInstallLocation">以下项已安装到 [DOTNETHOME]</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">资源</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;文档&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;发行说明&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;教程&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET 遥测&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;隐私声明&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;.NET 的许可信息&lt;/A&gt;</String>
-  <String Id="LicenseAssent">单击“安装”即表示你同意以下条款。</String>
+/log log.txt - 向特定文件写入日志。默认在 %TEMP% 中创建日志文件。" />
+  <String Id="HelpCloseButton" Value="关闭(&amp;C)" />
+  <String Id="InstallAcceptCheckbox" Value="我同意许可条款和条件(&amp;A)" />
+  <String Id="InstallOptionsButton" Value="选项(&amp;O)" />
+  <String Id="InstallInstallButton" Value="安装(&amp;I)" />
+  <String Id="InstallCloseButton" Value="关闭(&amp;C)" />
+  <String Id="OptionsHeader" Value="安装选项" />
+  <String Id="OptionsLocationLabel" Value="安装位置:" />
+  <String Id="OptionsBrowseButton" Value="浏览(&amp;B)" />
+  <String Id="OptionsOkButton" Value="确定(&amp;O)" />
+  <String Id="OptionsCancelButton" Value="取消(&amp;C)" />
+  <String Id="ProgressHeader" Value="安装进度" />
+  <String Id="ProgressLabel" Value="正在处理:" />
+  <String Id="OverallProgressPackageText" Value="正在初始化..." />
+  <String Id="ProgressCancelButton" Value="取消(&amp;C)" />
+  <String Id="ModifyHeader" Value="修改安装程序" />
+  <String Id="ModifyRepairButton" Value="修复(&amp;R)" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="卸载(&amp;U)" />
+  <String Id="ModifyCloseButton" Value="关闭(&amp;C)" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="成功完成了修复" />
+  <String Id="SuccessUninstallHeader" Value="成功完成了卸载" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="安装成功" />
+  <String Id="SuccessHeader" Value="设置成功" />
+  <String Id="SuccessLaunchButton" Value="启动(&amp;L)" />
+  <String Id="SuccessRestartText" Value="您必须先重新启动计算机，然后才能使用该软件。" />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="重新启动(&amp;R)" />
+  <String Id="SuccessCloseButton" Value="关闭(&amp;C)" />
+  <String Id="FailureHeader" Value="安装失败" />
+  <String Id="FailureInstallHeader" Value="安装失败" />
+  <String Id="FailureUninstallHeader" Value="卸载失败" />
+  <String Id="FailureRepairHeader" Value="修复失败" />
+  <String Id="FailureHyperlinkLogText" Value="一个或多个问题导致了安装失败。请修复这些问题，然后重试安装。有关详细信息，请参阅&lt;a href=&quot;#&quot;&gt;日志文件&lt;/a&gt;。" />
+  <String Id="FailureRestartText" Value="必须重新启动计算机才能完成软件回退。" />
+  <String Id="FailureRestartButton" Value="重新启动(&amp;R)" />
+  <String Id="FailureCloseButton" Value="关闭(&amp;C)" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="此操作系统不支持 [PRODUCT_NAME]。有关详细信息，请参阅[LINK_PREREQ_PAGE]。" />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="x86 操作系统不支持该 [PRODUCT_NAME]。请使用相应的 x86 安装程序进行安装。" />
+  <String Id="FilesInUseHeader" Value="文件正在使用" />
+  <String Id="FilesInUseLabel" Value="以下应用程序正在使用的文件需要更新:" />
+  <String Id="FilesInUseCloseRadioButton" Value="关闭应用程序并尝试重启(&amp;A)。" />
+  <String Id="FilesInUseDontCloseRadioButton" Value="不关闭应用程序(&amp;D)。需要重启。" />
+  <String Id="FilesInUseOkButton" Value="确定(&amp;O)" />
+  <String Id="FilesInUseCancelButton" Value="取消(&amp;C)" />
+  <String Id="WelcomeHeaderMessage" Value=".NET 运行时" />
+  <String Id="WelcomeDescription" Value=".NET 运行时用于在 Windows 计算机上运行 .NET 应用程序。.NET 是开源、跨平台的，且由 Microsoft 提供支持。希望你喜欢它!" />
+  <String Id="LearnMoreTitle" Value="了解有关 .NET 的详细信息" />
+  <String Id="SuccessInstallLocation" Value="以下项已安装到 [DOTNETHOME]" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="资源" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;文档&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;发行说明&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;教程&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET 遥测&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;隐私声明&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;.NET 的许可信息&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="单击“安装”即表示你同意以下条款。" />
 </WixLocalization>

--- a/src/installer/pkg/sfx/bundle/theme/3082/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/3082/bundle.wxl
@@ -1,74 +1,79 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Instalador de [WixBundleName]</String>
-  <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">Solo necesita un shell, un editor de texto y 10 minutos.
+﻿<WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
+  <String Id="Caption" Value="Instalador de [WixBundleName]" />
+  <String Id="Title" Value="[BUNDLEMONIKER]" />
+  <String Id="Motto" Value="Solo necesita un shell, un editor de texto y 10 minutos.
 
-¿Preparados? ¿Listos? ¡Ya!</String>
-  <String Id="ConfirmCancelMessage">¿Está seguro de que desea cancelar la operación?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Versión anterior</String>
-  <String Id="HelpHeader">Ayuda del programa de instalación</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - instala, repara, desinstala o
+¿Preparados? ¿Listos? ¡Ya!" />
+  <String Id="ConfirmCancelMessage" Value="¿Está seguro de que desea cancelar la operación?" />
+  <String Id="ExecuteUpgradeRelatedBundleMessage" Value="Versión anterior" />
+  <String Id="HelpHeader" Value="Ayuda del programa de instalación" />
+  <String Id="HelpText" Value="/install | /repair | /uninstall | /layout [directory] - instala, repara, desinstala o
    crea una copia local completa del paquete en el directorio. Install es la opción predeterminada.
 
 /passive | /quiet -  muestra una IU mínima sin peticiones, o bien no muestra la IU 
   ni las peticiones. De forma predeterminada, se muestran la IU y todas las peticiones.
 
 /norestart   - suprime los intentos de reiniciar. De forma predeterminada, la IU preguntará antes de reiniciar.
-/log log.txt - se registra en un archivo específico. De forma predeterminada, se crea un archivo de registro en %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Cerrar</String>
-  <String Id="InstallAcceptCheckbox">&amp;Acepto los términos y condiciones de licencia</String>
-  <String Id="InstallOptionsButton">&amp;Opciones</String>
-  <String Id="InstallInstallButton">&amp;Instalar</String>
-  <String Id="InstallCloseButton">&amp;Cerrar</String>
-  <String Id="OptionsHeader">Opciones de instalación</String>
-  <String Id="OptionsLocationLabel">Ubicación de instalación:</String>
-  <String Id="OptionsBrowseButton">E&amp;xaminar</String>
-  <String Id="OptionsOkButton">&amp;Aceptar</String>
-  <String Id="OptionsCancelButton">&amp;Cancelar</String>
-  <String Id="ProgressHeader">Progreso de la instalación</String>
-  <String Id="ProgressLabel">Procesando:</String>
-  <String Id="OverallProgressPackageText">Inicializando...</String>
-  <String Id="ProgressCancelButton">&amp;Cancelar</String>
-  <String Id="ModifyHeader">Modificar instalación</String>
-  <String Id="ModifyRepairButton">&amp;Reparar</String>
-  <String Id="ModifyUninstallButton">&amp;Desinstalar</String>
-  <String Id="ModifyCloseButton">&amp;Cerrar</String>
-  <String Id="SuccessRepairHeader">La reparación se completó correctamente</String>
-  <String Id="SuccessUninstallHeader">La desinstalación se completó correctamente</String>
-  <String Id="SuccessInstallHeader">La instalación se realizó correctamente</String>
-  <String Id="SuccessHeader">La instalación o desinstalación se realizó correctamente</String>
-  <String Id="SuccessLaunchButton">&amp;Iniciar</String>
-  <String Id="SuccessRestartText">Debe reiniciar el equipo para poder usar el software.</String>
-  <String Id="SuccessRestartButton">&amp;Reiniciar</String>
-  <String Id="SuccessCloseButton">&amp;Cerrar</String>
-  <String Id="FailureHeader">Error de instalación</String>
-  <String Id="FailureInstallHeader">Error de instalación</String>
-  <String Id="FailureUninstallHeader">No se pudo desinstalar</String>
-  <String Id="FailureRepairHeader">No se pudo reparar</String>
-  <String Id="FailureHyperlinkLogText">Error de instalación debido a uno o varios problemas. Corrija los problemas e intente de nuevo la instalación. Para obtener más información, consulte el &lt;a href="#"&gt;archivo de registro&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Debe reiniciar el equipo para completar la reversión del software.</String>
-  <String Id="FailureRestartButton">&amp;Reiniciar</String>
-  <String Id="FailureCloseButton">&amp;Cerrar</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] no se admite en este sistema operativo. Para obtener más información, consulte [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] no es compatible con los sistemas operativos x86. Instálelo con el instalador x86 correspondiente.</String>
-  <String Id="FilesInUseHeader">Archivos en uso</String>
-  <String Id="FilesInUseLabel">Las siguientes aplicaciones usan archivos que se deben actualizar:</String>
-  <String Id="FilesInUseCloseRadioButton">Cerrar las &amp;aplicaciones e intentar reiniciarlas.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;No cerrar las aplicaciones. Será necesario un reinicio.</String>
-  <String Id="FilesInUseOkButton">&amp;Aceptar</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
-  <String Id="WelcomeHeaderMessage">Entorno de ejecución .NET</String>
-  <String Id="WelcomeDescription">.NET Runtime se usa para ejecutar aplicaciones .NET en un equipo con Windows. Microsoft admite .NET, un código abierto multiplataforma. Esperamos que lo disfrute.</String>
-  <String Id="LearnMoreTitle">Más información sobre .NET</String>
-  <String Id="SuccessInstallLocation">Lo siguiente se instaló en [DOTNETHOME]</String>
-  <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Recursos</String>
-  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Documentación&lt;/A&gt;</String>
-  <String Id="ReleaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Notas de la versión&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Tutoriales&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetría de .NET&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Declaración de privacidad&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF="https://aka.ms/dotnet-license-windows"&gt;Información de licencias de .NET&lt;/A&gt;</String>
-  <String Id="LicenseAssent">Al hacer clic en Instalar, acepta los términos siguientes.</String>
+/log log.txt - se registra en un archivo específico. De forma predeterminada, se crea un archivo de registro en %TEMP%." />
+  <String Id="HelpCloseButton" Value="&amp;Cerrar" />
+  <String Id="InstallAcceptCheckbox" Value="&amp;Acepto los términos y condiciones de licencia" />
+  <String Id="InstallOptionsButton" Value="&amp;Opciones" />
+  <String Id="InstallInstallButton" Value="&amp;Instalar" />
+  <String Id="InstallCloseButton" Value="&amp;Cerrar" />
+  <String Id="OptionsHeader" Value="Opciones de instalación" />
+  <String Id="OptionsLocationLabel" Value="Ubicación de instalación:" />
+  <String Id="OptionsBrowseButton" Value="E&amp;xaminar" />
+  <String Id="OptionsOkButton" Value="&amp;Aceptar" />
+  <String Id="OptionsCancelButton" Value="&amp;Cancelar" />
+  <String Id="ProgressHeader" Value="Progreso de la instalación" />
+  <String Id="ProgressLabel" Value="Procesando:" />
+  <String Id="OverallProgressPackageText" Value="Inicializando..." />
+  <String Id="ProgressCancelButton" Value="&amp;Cancelar" />
+  <String Id="ModifyHeader" Value="Modificar instalación" />
+  <String Id="ModifyRepairButton" Value="&amp;Reparar" />
+  <String Id="ModifyText" Value="Select repair to reinstall the product or uninstall to remove it." />
+  <String Id="ModifyUninstallButton" Value="&amp;Desinstalar" />
+  <String Id="ModifyCloseButton" Value="&amp;Cerrar" />
+  <String Id="SuccessCacheHeader" Value="Cache Successfully Completed" />
+  <String Id="SuccessRepairHeader" Value="La reparación se completó correctamente" />
+  <String Id="SuccessUninstallHeader" Value="La desinstalación se completó correctamente" />
+  <String Id="SuccessLayoutHeader" Value="Layout Successfully Completed" />
+  <String Id="SuccessModifyHeader" Value="Modify Successfully Completed" />
+  <String Id="SuccessUnsafeUninstallHeader" Value="Uninstall Successfully Completed" />
+  <String Id="SuccessInstallHeader" Value="La instalación se realizó correctamente" />
+  <String Id="SuccessHeader" Value="La instalación o desinstalación se realizó correctamente" />
+  <String Id="SuccessLaunchButton" Value="&amp;Iniciar" />
+  <String Id="SuccessRestartText" Value="Debe reiniciar el equipo para poder usar el software." />
+  <String Id="SuccessUninstallRestartText" Value="You must restart your computer to complete the removal of the software." />
+  <String Id="SuccessRestartButton" Value="&amp;Reiniciar" />
+  <String Id="SuccessCloseButton" Value="&amp;Cerrar" />
+  <String Id="FailureHeader" Value="Error de instalación" />
+  <String Id="FailureInstallHeader" Value="Error de instalación" />
+  <String Id="FailureUninstallHeader" Value="No se pudo desinstalar" />
+  <String Id="FailureRepairHeader" Value="No se pudo reparar" />
+  <String Id="FailureHyperlinkLogText" Value="Error de instalación debido a uno o varios problemas. Corrija los problemas e intente de nuevo la instalación. Para obtener más información, consulte el &lt;a href=&quot;#&quot;&gt;archivo de registro&lt;/a&gt;." />
+  <String Id="FailureRestartText" Value="Debe reiniciar el equipo para completar la reversión del software." />
+  <String Id="FailureRestartButton" Value="&amp;Reiniciar" />
+  <String Id="FailureCloseButton" Value="&amp;Cerrar" />
+  <String Id="FailureNotSupportedCurrentOperatingSystem" Value="[PRODUCT_NAME] no se admite en este sistema operativo. Para obtener más información, consulte [LINK_PREREQ_PAGE]." />
+  <String Id="FailureNotSupportedX86OperatingSystem" Value="[PRODUCT_NAME] no es compatible con los sistemas operativos x86. Instálelo con el instalador x86 correspondiente." />
+  <String Id="FilesInUseHeader" Value="Archivos en uso" />
+  <String Id="FilesInUseLabel" Value="Las siguientes aplicaciones usan archivos que se deben actualizar:" />
+  <String Id="FilesInUseCloseRadioButton" Value="Cerrar las &amp;aplicaciones e intentar reiniciarlas." />
+  <String Id="FilesInUseDontCloseRadioButton" Value="&amp;No cerrar las aplicaciones. Será necesario un reinicio." />
+  <String Id="FilesInUseOkButton" Value="&amp;Aceptar" />
+  <String Id="FilesInUseCancelButton" Value="&amp;Cancelar" />
+  <String Id="WelcomeHeaderMessage" Value="Entorno de ejecución .NET" />
+  <String Id="WelcomeDescription" Value=".NET Runtime se usa para ejecutar aplicaciones .NET en un equipo con Windows. Microsoft admite .NET, un código abierto multiplataforma. Esperamos que lo disfrute." />
+  <String Id="LearnMoreTitle" Value="Más información sobre .NET" />
+  <String Id="SuccessInstallLocation" Value="Lo siguiente se instaló en [DOTNETHOME]" />
+  <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
+  <String Id="ResourcesHeader" Value="Recursos" />
+  <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentación&lt;/A&gt;" />
+  <String Id="ReleaseNotesLink" Value="&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Notas de la versión&lt;/A&gt;" />
+  <String Id="TutorialLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutoriales&lt;/A&gt;" />
+  <String Id="TelemetryLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;Telemetría de .NET&lt;/A&gt;" />
+  <String Id="PrivacyStatementLink" Value="&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Declaración de privacidad&lt;/A&gt;" />
+  <String Id="EulaLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Información de licencias de .NET&lt;/A&gt;" />
+  <String Id="LicenseAssent" Value="Al hacer clic en Instalar, acepta los términos siguientes." />
 </WixLocalization>

--- a/src/installer/pkg/sfx/installers/Directory.Build.props
+++ b/src/installer/pkg/sfx/installers/Directory.Build.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <BuildDebPackage Condition="'$(TargetsLinuxGlibc)' == 'true'">true</BuildDebPackage>
     <BuildRpmPackage Condition="'$(TargetsLinuxGlibc)' == 'true'">true</BuildRpmPackage>
+    <UseWix5>true</UseWix5>
   </PropertyGroup>
 </Project>

--- a/src/installer/pkg/sfx/installers/Directory.Build.targets
+++ b/src/installer/pkg/sfx/installers/Directory.Build.targets
@@ -2,6 +2,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersVersion)" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(UseWix5)' == 'true'">
+    <!-- Microsoft.Wix is a dotnet tool package, so exclude its assets. -->
+    <PackageReference Include="Microsoft.Wix" Version="$(MicrosoftWixVersion)" ExcludeAssets="all" />
+    <!-- Installers needs the $(PkgMicrosoftWixToolsetUIwixext) property to locate the extension. -->
+    <PackageReference Include="Microsoft.WixToolset.UI.wixext" Version="$(MicrosoftWixToolsetUIWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Dependency.wixext" Version="$(MicrosoftWixToolsetDependencyWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Util.wixext" Version="$(MicrosoftWixToolsetUtilWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Bal.wixext" Version="$(MicrosoftWixToolsetBalWixextVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WixToolset.Heat" Version="$(MicrosoftWixToolsetHeatVersion)" />
+  </ItemGroup>
   
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 </Project>

--- a/src/installer/pkg/sfx/installers/host.wxs
+++ b/src/installer/pkg/sfx/installers/host.wxs
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
   <?include "$(var.SharedWixDir)\variables.wxi" ?>
 
@@ -20,38 +20,48 @@
         1. the legacy SDK can be subsequently installed
         2. the user runs 'dotnet' commands directly against 'ProgramFiles'\dotnet\dotnet.exe -->
 
-      <Component Id="cmpCoreHost" Directory="DOTNETHOME" Guid="{45399BBB-DDA5-4386-A2E9-618FB3C54A18}" >
+      <Component Id="cmpCoreHost" Directory="DOTNETHOME" Guid="{45399BBB-DDA5-4386-A2E9-618FB3C54A18}">
         <File Id="fileCoreHostExe" KeyPath="yes" Source="$(var.HostSrc)\dotnet.exe">
           <CopyFile Id="copyFileCoreHostExe" DestinationDirectory="PROGRAMFILES_DOTNET" />
         </File>
       </Component>
         
-      <Component Id="cmpSharedHostVersionRegistry" Directory="DOTNETHOME" Guid="*">
+      <Component Id="cmpSharedHostVersionRegistry" Directory="DOTNETHOME">
         <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedhost">
           <RegistryValue KeyPath="yes" Action="write" Name="Version" Type="string" Value="$(var.NugetVersion)"/>
         </RegistryKey>
       </Component>
 
-      <Component Id="cmpInstallLocation" Directory="TARGETDIR" Guid="*" Win64="no">
+      <Component Id="cmpInstallLocation" Directory="TARGETDIR" Bitness="always32">
         <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)">
           <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME]" KeyPath="yes"/>
         </RegistryKey>
       </Component>
 
-      <Component Id="cmpPath" Directory="DOTNETHOME" Guid="*">
-        <?if $(var.Platform)~=x64 ?>
+      <?if $(var.Platform)~=x64 ?>
         <!-- For x64 installer, only add the sharedhost key when actually on native architecture. -->
-        <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
-        <?elseif $(var.Platform)~=x86 ?>
+        <Component Id="cmpPath" Directory="DOTNETHOME" Condition="NOT NON_NATIVE_ARCHITECTURE">
+          <!-- A stable keypath with the right SxS characteristics for our PATH entry-->
+          <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedhost">
+            <RegistryValue KeyPath="yes" Action="write" Name="Path" Type="string" Value="[DOTNETHOME]"/>
+          </RegistryKey>
+        </Component>
+      <?elseif $(var.Platform)~=x86 ?>
         <!-- For x86 installer, only add the key when not on 64-bit platform. -->
-        <Condition>NOT VersionNT64</Condition>
-        <?endif?>
-
-        <!-- A stable keypath with the right SxS characteristics for our PATH entry-->
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedhost">
-          <RegistryValue KeyPath="yes" Action="write" Name="Path" Type="string" Value="[DOTNETHOME]"/>
-        </RegistryKey>
-      </Component>
+        <Component Id="cmpPath" Directory="DOTNETHOME" Condition="NOT VersionNT64">
+          <!-- A stable keypath with the right SxS characteristics for our PATH entry-->
+          <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedhost">
+            <RegistryValue KeyPath="yes" Action="write" Name="Path" Type="string" Value="[DOTNETHOME]"/>
+          </RegistryKey>
+        </Component>
+      <?else?>
+        <Component Id="cmpPath" Directory="DOTNETHOME">
+          <!-- A stable keypath with the right SxS characteristics for our PATH entry-->
+          <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedhost">
+            <RegistryValue KeyPath="yes" Action="write" Name="Path" Type="string" Value="[DOTNETHOME]"/>
+          </RegistryKey>
+        </Component>
+      <?endif?>
 
       <Component Id="cmpLicenseFiles" Directory="DOTNETHOME" Guid="{A61CBE5B-1282-4F29-90AD-63597AA2372E}">
         <File Id="fileLicenseTxt" KeyPath="yes" Source="$(var.HostSrc)\LICENSE.txt">
@@ -68,9 +78,9 @@
     <Property Id="ProductCPU" Value="$(var.Platform)" />
     <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />
 
-    <DirectoryRef Id="$(var.Program_Files)">
+    <StandardDirectory Id="ProgramFiles6432Folder">
       <Directory Id="PROGRAMFILES_DOTNET" Name="dotnet" />
-    </DirectoryRef>
+    </StandardDirectory>
     
     <?if $(var.Platform)~=x64 ?>
     <CustomActionRef Id="Set_PROGRAMFILES_DOTNET_NON_NATIVE_ARCHITECTURE" />
@@ -79,34 +89,43 @@
 
   <Fragment>
     <Property Id="DISABLE_SETTING_HOST_PATH" Secure="yes">
-      <RegistrySearch Id="DisableSettingHostPathSearch" Root="HKLM" Key="SOFTWARE\Microsoft\.NET" Type="raw" Name="DisableSettingHostPath"/>
+      <RegistrySearch Id="DisableSettingHostPathSearch" Root="HKLM" Key="SOFTWARE\Microsoft\.NET" Type="raw" Name="DisableSettingHostPath" />
     </Property>
 
-    <Component Id="cmpSetPath" Guid="{0B910ED8-0877-473D-8658-647382324433}" Directory="DOTNETHOME">
-      <CreateFolder />
-      <!-- Always set the SYSTEM PATH, unless DisableSettingHostPath is 1. -->
-      <?if $(var.Platform)~=x64 ?>
-      <!-- For x64 installer, only add to PATH when actually on native architecture. -->
-      <Condition><![CDATA[DISABLE_SETTING_HOST_PATH <> "#1" AND NOT NON_NATIVE_ARCHITECTURE]]></Condition>
-      <?elseif $(var.Platform)~=x86 ?>
-      <!-- For x86 installer, only add to PATH when not on 64-bit platform. -->
-      <Condition><![CDATA[DISABLE_SETTING_HOST_PATH <> "#1" AND NOT VersionNT64]]></Condition>
-      <?endif?>
-      <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]" Part="last" Action="set" System="yes" />
-    </Component>
+    <?if $(var.Platform)~=x64 ?>
+      <Component Id="cmpSetPath" Guid="{0B910ED8-0877-473D-8658-647382324433}" Directory="DOTNETHOME" Condition="DISABLE_SETTING_HOST_PATH &lt;&gt; &quot;#1&quot; AND NOT NON_NATIVE_ARCHITECTURE">
+        <CreateFolder />
+        <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]" Part="last" Action="set" System="yes" />
+      </Component>
+    <?elseif $(var.Platform)~=x86 ?>
+      <Component Id="cmpSetPath" Guid="{0B910ED8-0877-473D-8658-647382324433}" Directory="DOTNETHOME" Condition="DISABLE_SETTING_HOST_PATH &lt;&gt; &quot;#1&quot; AND NOT VersionNT64">
+        <CreateFolder />
+        <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]" Part="last" Action="set" System="yes" />
+      </Component>
+    <?else?>
+      <Component Id="cmpSetPath" Guid="{0B910ED8-0877-473D-8658-647382324433}" Directory="DOTNETHOME">
+        <CreateFolder />
+        <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]" Part="last" Action="set" System="yes" />
+      </Component>
+    <?endif?>
+
+    <util:BroadcastEnvironmentChange Action="set" Sequence="afterInstallFinalize" />
 
     <InstallExecuteSequence>
-      <!-- Only broadcast the change if the component is enabled. -->
-      <Custom Action="WixBroadcastEnvironmentChange" After="InstallFinalize">
-        <![CDATA[DISABLE_SETTING_HOST_PATH <> "#1"]]>
-      </Custom>
+      <?if $(var.Platform)~=x64 ?>
+        <Custom Action="override Wix4BroadcastEnvironmentChange_X64" After="InstallFinalize" Condition="DISABLE_SETTING_HOST_PATH &lt;&gt; &quot;#1&quot;"/>
+      <?elseif $(var.Platform)~=x86 ?>
+        <Custom Action="override Wix4BroadcastEnvironmentChange_X86" After="InstallFinalize" Condition="DISABLE_SETTING_HOST_PATH &lt;&gt; &quot;#1&quot;"/>
+      <?elseif $(var.Platform)~=arm64 ?>
+        <Custom Action="override Wix4BroadcastEnvironmentChange_A64" After="InstallFinalize" Condition="DISABLE_SETTING_HOST_PATH &lt;&gt; &quot;#1&quot;"/>
+      <?else?>
+        <?error Unknown platform, $(var.Platform) ?>
+      <?endif?>
     </InstallExecuteSequence>
   </Fragment>
   
   <Fragment>
     <!-- Unlike DOTNETHOME which gives precedence to a user specified value over an x64 suffix, here we always want the suffixed path -->
-    <SetProperty Action="Set_PROGRAMFILES_DOTNET_NON_NATIVE_ARCHITECTURE" Id="PROGRAMFILES_DOTNET" Value="[$(var.Program_Files)]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE">
-      NON_NATIVE_ARCHITECTURE
-    </SetProperty>
+    <SetProperty Action="Set_PROGRAMFILES_DOTNET_NON_NATIVE_ARCHITECTURE" Id="PROGRAMFILES_DOTNET" Value="[ProgramFiles6432Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE" Condition="NON_NATIVE_ARCHITECTURE" />
   </Fragment>
 </Wix>


### PR DESCRIPTION
Backport of #117010. These are the runtime changes to migrate to WiX 5. This includes updating the WiX 3 source files to WiX 5 in addition to UI and localization updates. It also sets the flag telling arcade dependencies to use WiX 5 instead of WiX 3.

WiX 3 is out of support so we need to move to WiX 5 to ensure we get the latest security updates going forward.

## Customer Impact

No expected impact.

## Regression

- [ ] Yes
- [x] No

## Testing

Manually validated by CTI team.

## Risk

Medium. This could introduce new issues, but we need to move to WiX 5 so it's better to find and fix bugs in RC2 rather than in GA.