### PR TITLE
Fix CodeQL detecting EVP_chacha20_poly1305 during cmake configure

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/configure.cmake
+++ b/src/native/libs/System.Security.Cryptography.Native/configure.cmake
@@ -15,11 +15,6 @@ check_function_exists(
 	HAVE_OPENSSL_ALPN)
 
 check_function_exists(
-    EVP_chacha20_poly1305
-    HAVE_OPENSSL_CHACHA20POLY1305
-)
-
-check_function_exists(
     EVP_sha3_256
     HAVE_OPENSSL_SHA3
 )
@@ -33,6 +28,12 @@ check_function_exists(
     EVP_PKEY_sign_message_init
     HAVE_OPENSSL_EVP_PKEY_SIGN_MESSAGE_INIT
 )
+
+check_source_compiles(C "
+#include <openssl/evp.h>
+// CodeQL [SM01923] This is a CMake function detection script for the OpenSSL API used to implement the .NET API System.Security.Cryptography.ChaCha20Poly1305, it is not actually using the algorithm here
+int main(void) { const EVP_CIPHER* cipher = EVP_chacha20_poly1305(); return 1; }"
+HAVE_OPENSSL_CHACHA20POLY1305)
 
 check_source_compiles(C "
 #include <openssl/engine.h>


### PR DESCRIPTION
Some internal CodeQL rules are picking up this instance but since CMake generates a random directory path for the function detection it results in a lot of duplicate bugs.

Use the CodeQL comment syntax to suppress it. We need to use check_source_compiles() instead of check_function_exists() so that we can inject the suppression comment.
