### PR TITLE
[release/8.0-staging] Disable Multicast SocketOption test

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -66,6 +66,7 @@ namespace System.Net.Sockets.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))] // Skip on Nano: https://github.com/dotnet/runtime/issues/26286
         [ActiveIssue("https://github.com/dotnet/runtime/issues/113827", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile))]
+        [SkipOnPlatform(TestPlatforms.OSX, "Multicast interface selection fails on macOS 14+ due to changes in how the system handles network interface parameters")]
         public async Task MulticastInterface_Set_AnyInterface_Succeeds()
         {
             // On all platforms, index 0 means "any interface"


### PR DESCRIPTION
Backport of #119888 to release/9.0-staging

/cc @liveans

## Customer Impact

- [ ] Customer reported
- [X] Found internally

[Select one or both of the boxes. Describe how this issue impacts customers, citing the expected and actual behaviors and scope of the issue. If customer-reported, provide the issue number.]

## Regression

- [X] Yes - in OS Kernel
- [ ] No

[If yes, specify when the regression was introduced. Provide the PR or commit if known.]

## Testing

CI

## Risk

None, test-only.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.