### PR TITLE
Optimise Random.Shuffle

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -363,24 +363,17 @@ namespace System
         /// </remarks>
         public void Shuffle<T>(Span<T> values)
         {
-            // This loop is unrolled 2x to improve performance for small spans.
-            for (int i = 0; i < values.Length - 2; i += 2)
+            for (int i = 0; i < values.Length - 1; i++)
             {
-                // Get the j for the i position and the position after.
-                // If i + 1 is the last position of the list, we will just get i + 1 back.
-                int j0 = Next(i, values.Length);
-                int j1 = Next(i + 1, values.Length);
+                int j = Next(i, n);
 
                 // Benchmarks show that the cost of the branch exceeds the
                 // cost of the read and write when the write size is small.
                 // We are not too worried about massive  types, so we
                 // exclude the j != i checks unconditionally.
-                T temp0 = values[i];
-                T temp1 = values[i + 1];
-                values[i] = values[j0];
-                values[i + 1] = values[j1];
-                values[j0] = temp0;
-                values[j1] = temp1;
+                T temp = values[i];
+                values[i] = values[j];
+                values[j] = temp;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -371,7 +371,7 @@ namespace System
                 // cost of the read and write when the write size is small.
                 // So, for all reference types and for all small structs,
                 // do the write regardless.
-                if (sizeof(T) <= 16 || j != i)
+                if (sizeof(T) <= 2 * sizeof(nint) || j != i)
                 {
                     T temp = values[i];
                     values[i] = values[j];

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -361,7 +361,7 @@ namespace System
         ///   This method uses <see cref="Next(int, int)" /> to choose values for shuffling.
         ///   This method is an O(n) operation.
         /// </remarks>
-        public unsafe void Shuffle<T>(Span<T> values)
+        public void Shuffle<T>(Span<T> values)
         {
             // This loop is unrolled 2x to improve performance for small spans.
             for (int i = 0; i < values.Length - 2; i += 2)

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -363,11 +363,9 @@ namespace System
         /// </remarks>
         public unsafe void Shuffle<T>(Span<T> values)
         {
-            int n = values.Length;
-
-            for (int i = 0; i < n - 1; i++)
+            for (int i = 0; i < values.Length - 1; i++)
             {
-                int j = Next(i, n);
+                int j = Next(i, values.Length);
 
                 // Benchmarks show that the cost of the branch exceeds the
                 // cost of the read and write when the write size is small.

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -361,7 +361,7 @@ namespace System
         ///   This method uses <see cref="Next(int, int)" /> to choose values for shuffling.
         ///   This method is an O(n) operation.
         /// </remarks>
-        public void Shuffle<T>(Span<T> values)
+        public unsafe void Shuffle<T>(Span<T> values)
         {
             int n = values.Length;
 
@@ -369,7 +369,11 @@ namespace System
             {
                 int j = Next(i, n);
 
-                if (Unsafe.SizeOf<T>() <= 16 || j != i)
+                // Benchmarks show that the cost of the branch exceeds the cost of the read
+                // and write when the write size is small.
+                // So, for all reference types and for all small structs,
+                // do the write regardless.
+                if (sizeof(T) <= 16 || j != i)
                 {
                     T temp = values[i];
                     values[i] = values[j];

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -369,7 +369,7 @@ namespace System
             {
                 int j = Next(i, n);
 
-                if (j != i)
+                if (Unsafe.SizeOf<T>() <= 16 || j != i)
                 {
                     T temp = values[i];
                     values[i] = values[j];

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -367,10 +367,9 @@ namespace System
             {
                 int j = Next(i, values.Length);
 
-                // Benchmarks show that the cost of the branch exceeds the
-                // cost of the read and write when the write size is small.
-                // We are not too worried about massive  types, so we
-                // exclude the j != i checks unconditionally.
+                // The i != j check is excluded intentionally.
+                // Microbenchmarks show that the extra branch costs more than the redundant read/write for small value types.
+                // Since large value types are uncommon in shuffle scenarios, the trade-off favors removing the branch.
                 T temp = values[i];
                 values[i] = values[j];
                 values[j] = temp;

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -369,8 +369,8 @@ namespace System
             {
                 int j = Next(i, n);
 
-                // Benchmarks show that the cost of the branch exceeds the cost of the read
-                // and write when the write size is small.
+                // Benchmarks show that the cost of the branch exceeds the
+                // cost of the read and write when the write size is small.
                 // So, for all reference types and for all small structs,
                 // do the write regardless.
                 if (sizeof(T) <= 16 || j != i)

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -368,7 +368,7 @@ namespace System
                 int j = Next(i, values.Length);
 
                 // The i != j check is excluded intentionally.
-                // Microbenchmarks show that the extra branch costs more than the redundant read/write for small value types.
+                // Microbenchmarks show that the mispredicted branches cost more than the redundant read/write for small value types.
                 // Since large value types are uncommon in shuffle scenarios, the trade-off favors removing the branch.
                 T temp = values[i];
                 values[i] = values[j];

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -365,7 +365,7 @@ namespace System
         {
             for (int i = 0; i < values.Length - 1; i++)
             {
-                int j = Next(i, n);
+                int j = Next(i, values.Length);
 
                 // Benchmarks show that the cost of the branch exceeds the
                 // cost of the read and write when the write size is small.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/119860

This change does the following:
- Remove the `i != j` check
- Remove unnecessary local `n` (which caused extra assembly)

Benchmarks on AMD CPU (thanks EgorBot):
<img width="573" height="519" alt="image" src="https://github.com/user-attachments/assets/604e587d-64e8-4478-b9e0-26957e8e33df" />
