### PR TITLE
[interp] Make InterpreterStub handle being called on threads without a Thread object

### DIFF
--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -564,11 +564,14 @@ NESTED_ENTRY InterpreterStub, _TEXT
         mov             rbx, METHODDESC_REGISTER
 
         INLINE_GETTHREAD r10; thrashes rax and r11
+        test            r10, r10
+        jz              NoManagedThread
 
         mov             rax, qword ptr [r10 + OFFSETOF__Thread__m_pInterpThreadContext]
         test            rax, rax
         jnz             HaveInterpThreadContext
 
+NoManagedThread:
         mov             rcx, r10
         call            Thread_GetInterpThreadContext
         RESTORE_ARGUMENT_REGISTERS __PWTB_ArgumentRegisters

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -4,8 +4,6 @@
 include AsmMacros.inc
 include asmconstants.inc
 
-Thread_GetInterpThreadContext  TEXTEQU <?GetInterpThreadContext@Thread@@QEAAPEAUInterpThreadContext@@XZ>
-
 extern PInvokeImportWorker:proc
 extern ThePreStub:proc
 extern  ProfileEnter:proc
@@ -15,7 +13,7 @@ extern OnHijackWorker:proc
 extern JIT_RareDisableHelperWorker:proc
 ifdef FEATURE_INTERPRETER
 extern ExecuteInterpretedMethod:proc
-extern Thread_GetInterpThreadContext:proc
+extern GetInterpThreadContextWithPossiblyMissingThread:proc
 endif
 
 extern g_pPollGC:QWORD
@@ -573,7 +571,7 @@ NESTED_ENTRY InterpreterStub, _TEXT
 
 NoManagedThread:
         mov             rcx, r10
-        call            Thread_GetInterpThreadContext
+        call            GetInterpThreadContextWithPossiblyMissingThread
         RESTORE_ARGUMENT_REGISTERS __PWTB_ArgumentRegisters
         RESTORE_FLOAT_ARGUMENT_REGISTERS __PWTB_FloatArgumentRegisters
 

--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -443,13 +443,16 @@ NESTED_ENTRY InterpreterStub, _TEXT, NoHandler
 
         INLINE_GETTHREAD // result in rax, it can thrash all argument registers as it can call a helper
         mov             r10, rax
+        test            rax, rax
+        jz              LOCAL_LABEL(NoManagedThread)
 
         mov             rax, qword ptr [r10 + OFFSETOF__Thread__m_pInterpThreadContext]
         test            rax, rax
         jnz             LOCAL_LABEL(HaveInterpThreadContext)
 
+LOCAL_LABEL(NoManagedThread):
         mov             rcx, r10
-        call            C_FUNC(_ZN6Thread22GetInterpThreadContextEv) // Thread::GetInterpThreadContext
+        call            C_FUNC(GetInterpThreadContextWithPossiblyMissingThread)
 
 LOCAL_LABEL(HaveInterpThreadContext):
         mov             r10, qword ptr [rax + OFFSETOF__InterpThreadContext__pStackPointer]
@@ -1708,7 +1711,7 @@ NESTED_ENTRY CallJittedMethodRetVoid, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
         alloc_stack 0x10
-        save_reg_postrsp r10, 0 
+        save_reg_postrsp r10, 0
 END_PROLOGUE
         sub rsp, rcx // total stack space
         mov r11, rdi // The routines list

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -694,12 +694,14 @@ NESTED_ENTRY InterpreterStub, _TEXT, NoHandler
     mov x21, x0
 #endif
     INLINE_GETTHREAD x20 // thrashes x0 on Apple OSes (and possibly other arg registers on other Unixes)
+    cbz x20, LOCAL_LABEL(NoManagedThread)
 
     ldr x11, [x20, #OFFSETOF__Thread__m_pInterpThreadContext]
     cbnz x11, LOCAL_LABEL(HaveInterpThreadContext)
 
+LOCAL_LABEL(NoManagedThread):
 #ifdef TARGET_APPLE
-    // There Thread::GetInterpThreadContext can destroy all argument registers, so we
+    // GetInterpThreadContextWithPossiblyMissingThread can destroy all argument registers, so we
     // need to save them. For non-Apple, they have been already saved in the PROLOG_WITH_TRANSITION_BLOCK
     // Restore x0 thrashed by the INLINE_GETTHREAD
     mov x0, x21
@@ -708,7 +710,7 @@ NESTED_ENTRY InterpreterStub, _TEXT, NoHandler
 #endif
 
     mov x0, x20
-    bl C_FUNC(_ZN6Thread22GetInterpThreadContextEv) // Thread::GetInterpThreadContext
+    bl C_FUNC(GetInterpThreadContextWithPossiblyMissingThread)
     mov x11, x0
 
 #ifndef TARGET_APPLE

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -24,8 +24,7 @@
     IMPORT HijackHandler
     IMPORT ThrowControlForThread
 #ifdef FEATURE_INTERPRETER
-    SETALIAS Thread_GetInterpThreadContext, ?GetInterpThreadContext@Thread@@QEAAPEAUInterpThreadContext@@XZ
-    IMPORT $Thread_GetInterpThreadContext
+    IMPORT GetInterpThreadContextWithPossiblyMissingThread
     IMPORT ExecuteInterpretedMethod
 #endif
 
@@ -1065,12 +1064,14 @@ JIT_PollGCRarePath
         PROLOG_WITH_TRANSITION_BLOCK
 
         INLINE_GETTHREAD x20, x19
+        cbz x20, NoManagedThread
 
         ldr x11, [x20, #OFFSETOF__Thread__m_pInterpThreadContext]
         cbnz x11, HaveInterpThreadContext
 
+NoManagedThread
         mov x0, x20
-        bl $Thread_GetInterpThreadContext
+        bl GetInterpThreadContextWithPossiblyMissingThread
         mov x11, x0
         RESTORE_ARGUMENT_REGISTERS sp, __PWTB_ArgumentRegisters
         RESTORE_FLOAT_ARGUMENT_REGISTERS sp, __PWTB_FloatArgumentRegisters

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7705,7 +7705,12 @@ InterpThreadContext* Thread::GetInterpThreadContext()
 
 extern "C" InterpThreadContext* STDCALL GetInterpThreadContextWithPossiblyMissingThread(Thread *pThread)
 {
-    LIMITED_METHOD_CONTRACT;
+    CONTRACTL
+    {
+        THROWS;
+        if (GetThreadNULLOk()) {GC_TRIGGERS;} else {DISABLED(GC_NOTRIGGER);}
+    }
+    CONTRACTL_END;
 
     if (pThread == nullptr)
     {

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7705,13 +7705,11 @@ InterpThreadContext* Thread::GetInterpThreadContext()
 
 extern "C" InterpThreadContext* STDCALL GetInterpThreadContextWithPossiblyMissingThread(Thread *pThread)
 {
+    LIMITED_METHOD_CONTRACT;
+
     if (pThread == nullptr)
     {
-        pThread = SetupThreadNoThrow();
-        if (pThread == nullptr)
-        {
-            COMPlusThrow(kOutOfMemoryException);
-        }
+        pThread = SetupThread();
     }
 
     return pThread->GetInterpThreadContext();

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7695,23 +7695,24 @@ InterpThreadContext* Thread::GetInterpThreadContext()
 {
     WRAPPER_NO_CONTRACT;
 
-    // HACK: FIXME: InterpreterStub can be called on a native thread with no managed Thread,
-    //  and when this happens it calls us with a null thisptr in order to populate everything
-    if (this == nullptr)
-    {
-        _ASSERTE(GetThreadNULLOk() == NULL);
-        Thread *actualThread = SetupThreadNoThrow();
-        if (actualThread == NULL)
-            COMPlusThrow(kOutOfMemoryException);
-        return actualThread->GetInterpThreadContext();
-    }
-
     if (m_pInterpThreadContext == nullptr)
     {
         m_pInterpThreadContext = new (nothrow) InterpThreadContext();
     }
 
     return m_pInterpThreadContext;
+}
+
+extern "C" InterpThreadContext* STDCALL GetInterpThreadContextWithPossiblyMissingThread(Thread *pThread)
+{
+    if (pThread == nullptr)
+    {
+        pThread = SetupThreadNoThrow();
+        if (pThread == NULL)
+            COMPlusThrow(kOutOfMemoryException);
+    }
+
+    return pThread->GetInterpThreadContext();
 }
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7708,7 +7708,6 @@ extern "C" InterpThreadContext* STDCALL GetInterpThreadContextWithPossiblyMissin
     CONTRACTL
     {
         THROWS;
-        if (GetThreadNULLOk()) {GC_TRIGGERS;} else {DISABLED(GC_NOTRIGGER);}
     }
     CONTRACTL_END;
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7695,6 +7695,17 @@ InterpThreadContext* Thread::GetInterpThreadContext()
 {
     WRAPPER_NO_CONTRACT;
 
+    // HACK: FIXME: InterpreterStub can be called on a native thread with no managed Thread,
+    //  and when this happens it calls us with a null thisptr in order to populate everything
+    if (this == nullptr)
+    {
+        _ASSERTE(GetThreadNULLOk() == NULL);
+        Thread *actualThread = SetupThreadNoThrow();
+        if (actualThread == NULL)
+            COMPlusThrow(kOutOfMemoryException);
+        return actualThread->GetInterpThreadContext();
+    }
+
     if (m_pInterpThreadContext == nullptr)
     {
         m_pInterpThreadContext = new (nothrow) InterpThreadContext();

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7708,8 +7708,10 @@ extern "C" InterpThreadContext* STDCALL GetInterpThreadContextWithPossiblyMissin
     if (pThread == nullptr)
     {
         pThread = SetupThreadNoThrow();
-        if (pThread == NULL)
+        if (pThread == nullptr)
+        {
             COMPlusThrow(kOutOfMemoryException);
+        }
     }
 
     return pThread->GetInterpThreadContext();


### PR DESCRIPTION
Fixes Interop\GCBridge\BridgeTest, sort of (it also has an intermittent gc hole I think is fixed by https://github.com/dotnet/runtime/pull/119867)