### PR TITLE
Fix RoundTrip_Export_Import_SPKI and fix typos for SPKI

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLDsa/CompositeMLDsaFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLDsa/CompositeMLDsaFactoryTests.cs
@@ -437,7 +437,7 @@ namespace System.Security.Cryptography.Tests
 
             static void AssertThrows(byte[] encodedBytes)
             {
-                CompositeMLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+                CompositeMLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                     import => Assert.Throws<CryptographicException>(() => import(encodedBytes)),
                     import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(encodedBytes))));
 
@@ -457,7 +457,7 @@ namespace System.Security.Cryptography.Tests
             byte[] spki = CompositeMLDsaTestData.GetIetfTestVector(CompositeMLDsaAlgorithm.MLDsa65WithECDsaP384).Spki;
             byte[] berSpki = AsnUtils.ConvertDerToNonDerBer(spki);
 
-            CompositeMLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(import =>
+            CompositeMLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import =>
                 AssertThrowIfNotSupported(() =>
                     Assert.Throws<CryptographicException>(() => import(berSpki))));
         }
@@ -474,7 +474,7 @@ namespace System.Security.Cryptography.Tests
             algorithmIdentifier.Encode(writer);
             byte[] wrongAsnType = writer.Encode();
 
-            CompositeMLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+            CompositeMLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                 import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(wrongAsnType))));
 
             CompositeMLDsaTestHelpers.AssertImportPkcs8PrivateKey(
@@ -485,7 +485,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
-        public static void ImportSubjectKeyPublicInfo_AlgorithmErrorsInAsn()
+        public static void ImportSubjectPublicKeyInfo_AlgorithmErrorsInAsn()
         {
 #if !NETFRAMEWORK // Does not support exporting RSA SPKI
             if (!OperatingSystem.IsBrowser())
@@ -493,7 +493,7 @@ namespace System.Security.Cryptography.Tests
                 // RSA key
                 using RSA rsa = RSA.Create();
                 byte[] rsaSpkiBytes = rsa.ExportSubjectPublicKeyInfo();
-                CompositeMLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+                CompositeMLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                     import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(rsaSpkiBytes))));
             }
 #endif
@@ -509,17 +509,17 @@ namespace System.Security.Cryptography.Tests
                 SubjectPublicKey = CompositeMLDsaTestData.GetIetfTestVector(CompositeMLDsaAlgorithm.MLDsa65WithECDsaP384).PublicKey,
             };
 
-            CompositeMLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+            CompositeMLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                 import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(spki.Encode()))));
 
             spki.Algorithm.Parameters = AsnUtils.DerNull;
 
-            CompositeMLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+            CompositeMLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                 import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(spki.Encode()))));
 
             // Sanity check
             spki.Algorithm.Parameters = null;
-            CompositeMLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(import => AssertThrowIfNotSupported(() => import(spki.Encode())));
+            CompositeMLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import => AssertThrowIfNotSupported(() => import(spki.Encode())));
         }
 
         [Fact]

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLDsa/CompositeMLDsaImplementationTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLDsa/CompositeMLDsaImplementationTests.cs
@@ -143,10 +143,9 @@ namespace System.Security.Cryptography.Tests
             // Generate new key
             using CompositeMLDsa dsa = GenerateKey(algorithm);
             byte[] publicKey = dsa.ExportCompositeMLDsaPublicKey();
-            byte[] privateKey = dsa.ExportCompositeMLDsaPrivateKey();
 
-            CompositeMLDsaTestHelpers.AssertExportPkcs8PrivateKey(export =>
-                CompositeMLDsaTestHelpers.AssertImportPkcs8PrivateKey(import =>
+            CompositeMLDsaTestHelpers.AssertExportSubjectPublicKeyInfo(export =>
+                CompositeMLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import =>
                 {
                     // Roundtrip it using SPKI
                     using CompositeMLDsa roundTrippedDsa = import(export(dsa));
@@ -154,7 +153,7 @@ namespace System.Security.Cryptography.Tests
                     // The keys should be the same
                     Assert.Equal(algorithm, roundTrippedDsa.Algorithm);
                     AssertExtensions.SequenceEqual(publicKey, roundTrippedDsa.ExportCompositeMLDsaPublicKey());
-                    AssertExtensions.SequenceEqual(privateKey, roundTrippedDsa.ExportCompositeMLDsaPrivateKey());
+                    Assert.Throws<CryptographicException>(() => roundTrippedDsa.ExportCompositeMLDsaPrivateKey());
                 }));
         }
 
@@ -282,7 +281,7 @@ namespace System.Security.Cryptography.Tests
         [MemberData(nameof(CompositeMLDsaTestData.SupportedAlgorithmIetfVectorsTestData), MemberType = typeof(CompositeMLDsaTestData))]
         public void RoundTrip_Import_Export_SpkiPublicKey(CompositeMLDsaTestData.CompositeMLDsaTestVector info)
         {
-            CompositeMLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(import =>
+            CompositeMLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import =>
                 CompositeMLDsaTestHelpers.AssertExportSubjectPublicKeyInfo(export =>
                     CompositeMLDsaTestHelpers.WithDispose(import(info.Spki), dsa =>
                         AssertExtensions.SequenceEqual(info.Spki, export(dsa)))));

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLDsa/CompositeMLDsaTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLDsa/CompositeMLDsaTestHelpers.cs
@@ -68,16 +68,16 @@ namespace System.Security.Cryptography.Tests
                 SubjectPublicKey = publicKey,
             };
 
-            AssertImportSubjectKeyPublicInfo(import => testEmbeddedCall(() => import(spki.Encode())));
+            AssertImportSubjectPublicKeyInfo(import => testEmbeddedCall(() => import(spki.Encode())));
         }
 
-        internal delegate CompositeMLDsa ImportSubjectKeyPublicInfoCallback(byte[] spki);
-        internal static void AssertImportSubjectKeyPublicInfo(Action<ImportSubjectKeyPublicInfoCallback> test) =>
-            AssertImportSubjectKeyPublicInfo(test, test);
+        internal delegate CompositeMLDsa ImportSubjectPublicKeyInfoCallback(byte[] spki);
+        internal static void AssertImportSubjectPublicKeyInfo(Action<ImportSubjectPublicKeyInfoCallback> test) =>
+            AssertImportSubjectPublicKeyInfo(test, test);
 
-        internal static void AssertImportSubjectKeyPublicInfo(
-            Action<ImportSubjectKeyPublicInfoCallback> testDirectCall,
-            Action<ImportSubjectKeyPublicInfoCallback> testEmbeddedCall)
+        internal static void AssertImportSubjectPublicKeyInfo(
+            Action<ImportSubjectPublicKeyInfoCallback> testDirectCall,
+            Action<ImportSubjectPublicKeyInfoCallback> testEmbeddedCall)
         {
             testDirectCall(spki => CompositeMLDsa.ImportSubjectPublicKeyInfo(spki));
             testDirectCall(spki => CompositeMLDsa.ImportSubjectPublicKeyInfo(spki.AsSpan()));

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaImplementationTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaImplementationTests.cs
@@ -92,7 +92,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
-        public static void ImportSubjectKeyPublicInfo_NullSource()
+        public static void ImportSubjectPublicKeyInfo_NullSource()
         {
             AssertExtensions.Throws<ArgumentNullException>("source", () => MLDsa.ImportSubjectPublicKeyInfo(null));
         }
@@ -153,7 +153,7 @@ namespace System.Security.Cryptography.Tests
 
             static void AssertThrows(byte[] encodedBytes)
             {
-                MLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+                MLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                     import => Assert.Throws<CryptographicException>(() => import(encodedBytes)),
                     import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(encodedBytes))));
 
@@ -172,7 +172,7 @@ namespace System.Security.Cryptography.Tests
         {
             // Valid BER but invalid DER - uses indefinite length encoding
             byte[] indefiniteLengthOctet = [0x04, 0x80, 0x01, 0x02, 0x03, 0x04, 0x00, 0x00];
-            MLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(import =>
+            MLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import =>
                 AssertThrowIfNotSupported(() =>
                     Assert.Throws<CryptographicException>(() => import(indefiniteLengthOctet))));
         }
@@ -206,7 +206,7 @@ namespace System.Security.Cryptography.Tests
             algorithmIdentifier.Encode(writer);
             byte[] wrongAsnType = writer.Encode();
 
-            MLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+            MLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                 import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(wrongAsnType))));
 
             MLDsaTestHelpers.AssertImportPkcs8PrivateKey(
@@ -217,7 +217,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
-        public static void ImportSubjectKeyPublicInfo_AlgorithmErrorsInAsn()
+        public static void ImportSubjectPublicKeyInfo_AlgorithmErrorsInAsn()
         {
 #if !NETFRAMEWORK // Does not support exporting RSA SPKI
             if (!OperatingSystem.IsBrowser())
@@ -225,7 +225,7 @@ namespace System.Security.Cryptography.Tests
                 // RSA key
                 using RSA rsa = RSA.Create();
                 byte[] rsaSpkiBytes = rsa.ExportSubjectPublicKeyInfo();
-                MLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+                MLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                     import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(rsaSpkiBytes))));
             }
 #endif
@@ -241,17 +241,17 @@ namespace System.Security.Cryptography.Tests
                 SubjectPublicKey = new byte[MLDsaAlgorithm.MLDsa44.PublicKeySizeInBytes]
             };
 
-            MLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+            MLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                 import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(spki.Encode()))));
 
             spki.Algorithm.Parameters = AsnUtils.DerNull;
 
-            MLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+            MLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                 import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(spki.Encode()))));
 
             // Sanity check
             spki.Algorithm.Parameters = null;
-            MLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(import => AssertThrowIfNotSupported(() => import(spki.Encode())));
+            MLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import => AssertThrowIfNotSupported(() => import(spki.Encode())));
         }
 
         [Fact]
@@ -486,7 +486,7 @@ namespace System.Security.Cryptography.Tests
         [MemberData(nameof(MLDsaTestsData.IetfMLDsaAlgorithms), MemberType = typeof(MLDsaTestsData))]
         public void RoundTrip_Import_Export_SPKI(MLDsaKeyInfo info)
         {
-            MLDsaTestHelpers.AssertImportSubjectKeyPublicInfo(import =>
+            MLDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import =>
                 MLDsaTestHelpers.AssertExportSubjectPublicKeyInfo(export =>
                     WithDispose(import(info.Pkcs8PublicKey), mldsa =>
                         AssertExtensions.SequenceEqual(info.Pkcs8PublicKey, export(mldsa)))));

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTestHelpers.cs
@@ -100,16 +100,16 @@ namespace System.Security.Cryptography.Tests
                 SubjectPublicKey = publicKey,
             };
 
-            AssertImportSubjectKeyPublicInfo(import => testEmbeddedCall(() => import(spki.Encode())));
+            AssertImportSubjectPublicKeyInfo(import => testEmbeddedCall(() => import(spki.Encode())));
         }
 
-        internal delegate MLDsa ImportSubjectKeyPublicInfoCallback(byte[] spki);
-        internal static void AssertImportSubjectKeyPublicInfo(Action<ImportSubjectKeyPublicInfoCallback> test) =>
-            AssertImportSubjectKeyPublicInfo(test, test);
+        internal delegate MLDsa ImportSubjectPublicKeyInfoCallback(byte[] spki);
+        internal static void AssertImportSubjectPublicKeyInfo(Action<ImportSubjectPublicKeyInfoCallback> test) =>
+            AssertImportSubjectPublicKeyInfo(test, test);
 
-        internal static void AssertImportSubjectKeyPublicInfo(
-            Action<ImportSubjectKeyPublicInfoCallback> testDirectCall,
-            Action<ImportSubjectKeyPublicInfoCallback> testEmbeddedCall)
+        internal static void AssertImportSubjectPublicKeyInfo(
+            Action<ImportSubjectPublicKeyInfoCallback> testDirectCall,
+            Action<ImportSubjectPublicKeyInfoCallback> testEmbeddedCall)
         {
             testDirectCall(spki => MLDsa.ImportSubjectPublicKeyInfo(spki));
             testDirectCall(spki => MLDsa.ImportSubjectPublicKeyInfo(spki.AsSpan()));

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaFactoryTests.cs
@@ -73,7 +73,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
 
             static void AssertThrows(byte[] encodedBytes)
             {
-                SlhDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+                SlhDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                     import => Assert.Throws<CryptographicException>(() => import(encodedBytes)),
                     import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(encodedBytes))));
 
@@ -92,7 +92,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         {
             // Valid BER but invalid DER - uses indefinite length encoding
             byte[] indefiniteLengthOctet = [0x04, 0x80, 0x01, 0x02, 0x03, 0x04, 0x00, 0x00];
-            SlhDsaTestHelpers.AssertImportSubjectKeyPublicInfo(import =>
+            SlhDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import =>
                 AssertThrowIfNotSupported(() =>
                     Assert.Throws<CryptographicException>(() => import(indefiniteLengthOctet))));
         }
@@ -109,7 +109,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             algorithmIdentifier.Encode(writer);
             byte[] wrongAsnType = writer.Encode();
 
-            SlhDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+            SlhDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                 import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(wrongAsnType))));
 
             SlhDsaTestHelpers.AssertImportPkcs8PrivateKey(
@@ -120,7 +120,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         }
 
         [Fact]
-        public static void ImportSubjectKeyPublicInfo_AlgorithmErrorsInAsn()
+        public static void ImportSubjectPublicKeyInfo_AlgorithmErrorsInAsn()
         {
 #if !NETFRAMEWORK // Does not support exporting RSA SPKI
             if (!OperatingSystem.IsBrowser())
@@ -128,7 +128,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 // RSA key
                 using RSA rsa = RSA.Create();
                 byte[] rsaSpkiBytes = rsa.ExportSubjectPublicKeyInfo();
-                SlhDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+                SlhDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                     import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(rsaSpkiBytes))));
             }
 #endif
@@ -144,17 +144,17 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 SubjectPublicKey = new byte[SlhDsaAlgorithm.SlhDsaSha2_128s.PublicKeySizeInBytes]
             };
 
-            SlhDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+            SlhDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                 import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(spki.Encode()))));
 
             spki.Algorithm.Parameters = AsnUtils.DerNull;
 
-            SlhDsaTestHelpers.AssertImportSubjectKeyPublicInfo(
+            SlhDsaTestHelpers.AssertImportSubjectPublicKeyInfo(
                 import => AssertThrowIfNotSupported(() => Assert.Throws<CryptographicException>(() => import(spki.Encode()))));
 
             // Sanity check
             spki.Algorithm.Parameters = null;
-            SlhDsaTestHelpers.AssertImportSubjectKeyPublicInfo(import => AssertThrowIfNotSupported(() => import(spki.Encode())));
+            SlhDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import => AssertThrowIfNotSupported(() => import(spki.Encode())));
         }
 
         [Fact]

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaImplementationTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaImplementationTests.cs
@@ -129,10 +129,9 @@ namespace System.Security.Cryptography.SLHDsa.Tests
             // Generate new key
             using SlhDsa slhDsa = GenerateKey(algorithm);
             byte[] publicKey = slhDsa.ExportSlhDsaPublicKey();
-            byte[] privateKey = slhDsa.ExportSlhDsaPrivateKey();
 
-            SlhDsaTestHelpers.AssertExportPkcs8PrivateKey(export =>
-                SlhDsaTestHelpers.AssertImportPkcs8PrivateKey(import =>
+            SlhDsaTestHelpers.AssertExportSubjectPublicKeyInfo(export =>
+                SlhDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import =>
                 {
                     // Roundtrip it using SPKI
                     using SlhDsa roundTrippedSlhDsa = import(export(slhDsa));
@@ -140,7 +139,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                     // The keys should be the same
                     Assert.Equal(algorithm, roundTrippedSlhDsa.Algorithm);
                     AssertExtensions.SequenceEqual(publicKey, roundTrippedSlhDsa.ExportSlhDsaPublicKey());
-                    AssertExtensions.SequenceEqual(privateKey, roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
+                    Assert.Throws<CryptographicException>(() => roundTrippedSlhDsa.ExportSlhDsaPrivateKey());
                 }));
         }
 
@@ -268,7 +267,7 @@ namespace System.Security.Cryptography.SLHDsa.Tests
         [MemberData(nameof(SlhDsaTestData.GeneratedKeyInfosData), MemberType = typeof(SlhDsaTestData))]
         public void RoundTrip_Import_Export_SPKI(SlhDsaTestData.SlhDsaGeneratedKeyInfo info)
         {
-            SlhDsaTestHelpers.AssertImportSubjectKeyPublicInfo(import =>
+            SlhDsaTestHelpers.AssertImportSubjectPublicKeyInfo(import =>
                 SlhDsaTestHelpers.AssertExportSubjectPublicKeyInfo(export =>
                     SlhDsaTestHelpers.WithDispose(import(info.Pkcs8PublicKey), slhDsa =>
                         AssertExtensions.SequenceEqual(info.Pkcs8PublicKey, export(slhDsa)))));

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/SlhDsa/SlhDsaTestHelpers.cs
@@ -76,16 +76,16 @@ namespace System.Security.Cryptography.SLHDsa.Tests
                 SubjectPublicKey = publicKey,
             };
 
-            AssertImportSubjectKeyPublicInfo(import => testEmbeddedCall(() => import(spki.Encode())));
+            AssertImportSubjectPublicKeyInfo(import => testEmbeddedCall(() => import(spki.Encode())));
         }
 
-        internal delegate SlhDsa ImportSubjectKeyPublicInfoCallback(byte[] spki);
-        internal static void AssertImportSubjectKeyPublicInfo(Action<ImportSubjectKeyPublicInfoCallback> test) =>
-            AssertImportSubjectKeyPublicInfo(test, test);
+        internal delegate SlhDsa ImportSubjectPublicKeyInfoCallback(byte[] spki);
+        internal static void AssertImportSubjectPublicKeyInfo(Action<ImportSubjectPublicKeyInfoCallback> test) =>
+            AssertImportSubjectPublicKeyInfo(test, test);
 
-        internal static void AssertImportSubjectKeyPublicInfo(
-            Action<ImportSubjectKeyPublicInfoCallback> testDirectCall,
-            Action<ImportSubjectKeyPublicInfoCallback> testEmbeddedCall)
+        internal static void AssertImportSubjectPublicKeyInfo(
+            Action<ImportSubjectPublicKeyInfoCallback> testDirectCall,
+            Action<ImportSubjectPublicKeyInfoCallback> testEmbeddedCall)
         {
             testDirectCall(spki => SlhDsa.ImportSubjectPublicKeyInfo(spki));
             testDirectCall(spki => SlhDsa.ImportSubjectPublicKeyInfo(spki.AsSpan()));


### PR DESCRIPTION
- Change RoundTrip_Export_Import_SPKI to actually test SPKI instead of PKCS\#8
- Change SubjectKeyPublicInfo to SubjectPublicKeyInfo