### PR TITLE
Normalize `Array.IndexOf` result checks to use `>= 0`

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.InvokeMember.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.InvokeMember.cs
@@ -66,7 +66,7 @@ namespace System.Reflection.Runtime.TypeInfos
             #endregion
 
             #region Check that any named parameters are not null
-            if (namedParams != null && Array.IndexOf(namedParams, null) != -1)
+            if (namedParams != null && Array.IndexOf(namedParams, null) >= 0)
                 // "Named parameter value must not be null."
                 throw new ArgumentException(SR.Arg_NamedParamNull, nameof(namedParams));
             #endregion

--- a/src/coreclr/tools/Common/TypeSystem/Common/ConstructedTypeRewritingHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ConstructedTypeRewritingHelpers.cs
@@ -22,7 +22,7 @@ namespace Internal.TypeSystem
         {
             int directDiscoveryIndex = Array.IndexOf(typesToFind, type);
 
-            if (directDiscoveryIndex != -1)
+            if (directDiscoveryIndex >= 0)
                 return true;
 
             if (type.HasInstantiation)
@@ -72,7 +72,7 @@ namespace Internal.TypeSystem
         {
             int directReplacementIndex = Array.IndexOf(typesToReplace, type);
 
-            if (directReplacementIndex != -1)
+            if (directReplacementIndex >= 0)
                 return replacementTypes[directReplacementIndex];
 
             if (type.HasInstantiation)

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -896,7 +896,7 @@ namespace Internal.TypeSystem
                                     impl = implRecord.Body;
                                     diamondCase = false;
                                 }
-                                else if (Array.IndexOf(mostSpecificInterface.RuntimeInterfaces, runtimeInterface) == -1)
+                                else if (Array.IndexOf(mostSpecificInterface.RuntimeInterfaces, runtimeInterface) < 0)
                                 {
                                     diamondCase = true;
                                 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -878,7 +878,7 @@ namespace Internal.TypeSystem
                         impl = interfaceMethodDefinition;
                     }
                 }
-                else if (Array.IndexOf(runtimeInterface.RuntimeInterfaces, interfaceMethodOwningType) != -1)
+                else if (Array.IndexOf(runtimeInterface.RuntimeInterfaces, interfaceMethodOwningType) >= 0)
                 {
                     // This interface might provide a default implementation
                     MethodImplRecord[] possibleImpls = runtimeInterface.FindMethodsImplWithMatchingDeclName(interfaceMethod.Name);
@@ -890,7 +890,7 @@ namespace Internal.TypeSystem
                             {
                                 // This interface provides a default implementation.
                                 // Is it also most specific?
-                                if (mostSpecificInterface == null || Array.IndexOf(runtimeInterface.RuntimeInterfaces, mostSpecificInterface) != -1)
+                                if (mostSpecificInterface == null || Array.IndexOf(runtimeInterface.RuntimeInterfaces, mostSpecificInterface) >= 0)
                                 {
                                     mostSpecificInterface = runtimeInterface;
                                     impl = implRecord.Body;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -123,7 +123,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool IsSlotUsed(MethodDesc slot)
         {
-            Debug.Assert(Array.IndexOf(_slots, slot) != -1);
+            Debug.Assert(Array.IndexOf(_slots, slot) >= 0);
             return true;
         }
 
@@ -176,7 +176,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool IsSlotUsed(MethodDesc slot)
         {
-            Debug.Assert(Array.IndexOf(_slots, slot) != -1);
+            Debug.Assert(Array.IndexOf(_slots, slot) >= 0);
 #if DEBUG
             _isLocked = true;
 #endif
@@ -198,7 +198,7 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(!virtualMethod.HasInstantiation);
             Debug.Assert(virtualMethod.IsVirtual);
             Debug.Assert(virtualMethod.OwningType == _type);
-            Debug.Assert(Array.IndexOf(_slots, virtualMethod) != -1);
+            Debug.Assert(Array.IndexOf(_slots, virtualMethod) >= 0);
 #if DEBUG
             Debug.Assert(!_isLocked);
 #endif

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetUnixVersion.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetUnixVersion.cs
@@ -37,7 +37,7 @@ internal static partial class Interop
                 return string.Empty;
             }
 
-            Debug.Assert(Array.IndexOf<byte>(version, 0) != -1);
+            Debug.Assert(Array.IndexOf<byte>(version, 0) >= 0);
             unsafe
             {
                 fixed (byte* ptr = version)

--- a/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -90,7 +90,7 @@ namespace System.Collections.Generic
             // via EqualityComparer<T>.Default.Equals, we
             // only make one virtual call to EqualityComparer.LastIndexOf.
 
-            return _size != 0 && Array.LastIndexOf(_array, item, _size - 1) != -1;
+            return _size != 0 && Array.LastIndexOf(_array, item, _size - 1) >= 0;
         }
 
         // Copies the stack into an array.

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -179,7 +179,7 @@ namespace System.ComponentModel
                 int invariantIndex = Array.IndexOf(installedCultures, CultureInfo.InvariantCulture);
 
                 CultureInfo[] array;
-                if (invariantIndex != -1)
+                if (invariantIndex >= 0)
                 {
                     Debug.Assert(invariantIndex >= 0 && invariantIndex < installedCultures.Length);
                     installedCultures[invariantIndex] = null;

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
@@ -733,7 +733,7 @@ namespace System.IO
 
                 public void Clear() => Items = Array.Empty<string>();
 
-                public bool Contains(string item) => Array.IndexOf(Items, item) != -1;
+                public bool Contains(string item) => Array.IndexOf(Items, item) >= 0;
 
                 public void CopyTo(string[] array, int arrayIndex) => Items.CopyTo(array, arrayIndex);
 

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ContentType.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ContentType.cs
@@ -497,7 +497,7 @@ namespace System.IO.Packaging
         /// <param name="ch">input character</param>
         /// <returns></returns>
         private static bool IsLinearWhiteSpaceChar(char ch) =>
-            ch <= ' ' && Array.IndexOf(s_linearWhiteSpaceChars, ch) != -1;
+            ch <= ' ' && Array.IndexOf(s_linearWhiteSpaceChars, ch) >= 0;
 
         #endregion Private Methods
 

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PartBasedPackageProperties.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PartBasedPackageProperties.cs
@@ -539,7 +539,7 @@ namespace System.IO.Packaging
                     PackageXmlEnum xmlStringIndex = PackageXmlStringTable.GetEnumOf(localName);
                     string? valueType = PackageXmlStringTable.GetValueType(xmlStringIndex);
 
-                    if (Array.IndexOf(s_validProperties, xmlStringIndex) == -1)  // An unexpected element is an error.
+                    if (Array.IndexOf(s_validProperties, xmlStringIndex) < 0)  // An unexpected element is an error.
                     {
                         throw new XmlException(
                             SR.Format(SR.InvalidPropertyNameInCorePropertiesPart, reader.LocalName),

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseHeaderReader.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseHeaderReader.cs
@@ -42,7 +42,7 @@ namespace System.Net.Http
                 int colonIndex = Array.IndexOf(_buffer, ':', startIndex, length);
 
                 // Skip malformed header lines that are missing the colon character.
-                if (colonIndex == -1)
+                if (colonIndex < 0)
                 {
                     continue;
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ObjectCollection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ObjectCollection.cs
@@ -90,7 +90,7 @@ namespace System.Net.Http.Headers
         public bool Contains(T item) =>
             _size <= 0 ? false :
             _items is T o ? o.Equals(item) :
-            _items is T[] items && Array.IndexOf(items, item, 0, _size) != -1;
+            _items is T[] items && Array.IndexOf(items, item, 0, _size) >= 0;
 
         public void CopyTo(T[] array, int arrayIndex)
         {
@@ -127,7 +127,7 @@ namespace System.Net.Http.Headers
             else if (_items is T[] items)
             {
                 int index = Array.IndexOf(items, item, 0, _size);
-                if (index != -1)
+                if (index >= 0)
                 {
                     _size--;
                     if (index < _size)

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
@@ -86,7 +86,7 @@ namespace System.Net
                     for (int i = 0; i < hostEntry.IPAddressCount; i++)
                     {
                         Interop.Sys.IPAddress nativeAddr = addressHandle[i];
-                        if (Array.IndexOf(nativeAddresses, nativeAddr, 0, nativeAddressCount) == -1 &&
+                        if (Array.IndexOf(nativeAddresses, nativeAddr, 0, nativeAddressCount) < 0 &&
                             (!nativeAddr.IsIPv6 || SocketProtocolSupportPal.OSSupportsIPv6)) // Do not include IPv6 addresses if IPV6 support is force-disabled
                         {
                             nativeAddresses[nativeAddressCount++] = nativeAddr;

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Android.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Android.cs
@@ -185,7 +185,7 @@ namespace System.Net.NetworkInformation
 
             for (int i = 0; i < newAddresses.Length; i++)
             {
-                if (Array.IndexOf(oldAddresses, newAddresses[i]) == -1)
+                if (Array.IndexOf(oldAddresses, newAddresses[i]) < 0)
                 {
                     return true;
                 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -444,7 +444,7 @@ namespace System.Net.Security
                                 for (int ii = 0; ii < elementsCount; ++ii)
                                 {
                                     string issuer = chain.ChainElements[ii].Certificate!.Issuer;
-                                    found = Array.IndexOf(issuers, issuer) != -1;
+                                    found = Array.IndexOf(issuers, issuer) >= 0;
                                     if (found)
                                     {
                                         if (NetEventSource.Log.IsEnabled())

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.NonWasm.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.NonWasm.cs
@@ -26,7 +26,7 @@ namespace System.Net
             {
                 EnsureNetworkChangeRegistration();
                 IPAddress[] localAddresses = s_localAddresses ??= Dns.GetHostEntry(Dns.GetHostName()).AddressList;
-                return Array.IndexOf(localAddresses, hostAddress) != -1;
+                return Array.IndexOf(localAddresses, hostAddress) >= 0;
             }
 
             // No dot?  Local.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
@@ -428,7 +428,7 @@ namespace System.Runtime.InteropServices.Marshalling
 
         private readonly void ThrowIfNotVarType(params VarEnum[] requiredType)
         {
-            if (Array.IndexOf(requiredType, VarType) == -1)
+            if (Array.IndexOf(requiredType, VarType) < 0)
             {
                 throw new InvalidOperationException(SR.Format(SR.ComVariant_TypeIsNotSupportedType, VarType, string.Join(", ", requiredType)));
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
@@ -562,7 +562,7 @@ namespace Microsoft.Interop.Analyzers
                         // Named arguments in specified order, followed by any named arguments with no preferred order
                         string name = arg.NameEquals.Name.Identifier.Text;
                         int index = System.Array.IndexOf(s_preferredAttributeArgumentOrder, name);
-                        return index == -1 ? int.MaxValue : index;
+                        return index < 0 ? int.MaxValue : index;
                     })));
             return generator.ReplaceNode(attribute, attribute.ArgumentList, updatedArgList);
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -219,13 +219,13 @@ namespace Microsoft.Interop
                 set => _edgeMap[to * NodeCount + from] = value;
             }
 
-            public bool AnyEdges => Array.IndexOf(_edgeMap, true) != -1;
+            public bool AnyEdges => Array.IndexOf(_edgeMap, true) >= 0;
 
             public int NodeCount { get; }
 
             public bool AnyIncomingEdge(int to)
             {
-                return Array.IndexOf(_edgeMap, true, to * NodeCount, NodeCount) != -1;
+                return Array.IndexOf(_edgeMap, true, to * NodeCount, NodeCount) >= 0;
             }
         }
 

--- a/src/mono/System.Private.CoreLib/src/System/MulticastDelegate.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/MulticastDelegate.Mono.cs
@@ -222,7 +222,7 @@ namespace System
             else if (other.delegates == null)
             {
                 int idx = Array.LastIndexOf(delegates, other);
-                if (idx == -1)
+                if (idx < 0)
                     return this;
 
                 if (delegates.Length <= 1)

--- a/src/mono/wasm/host/WebServerStartup.cs
+++ b/src/mono/wasm/host/WebServerStartup.cs
@@ -64,7 +64,7 @@ internal sealed class WebServerStartup
             do
             {
                 current = Random.Shared.Next(range.Start.Value, range.End.Value);
-            } while (Array.IndexOf(except, current) > -1);
+            } while (Array.IndexOf(except, current) >= 0);
 
             return current;
         }


### PR DESCRIPTION
Update checks against the result of `Array.IndexOf` to consistently use `>= 0` instead of comparing directly to `-1`.

### Summary

Typical patterns seen in the codebase:

```cs
Array.IndexOf(items, item, 0, _size) != -1;
Array.IndexOf(items, item, 0, _size) > -1;
Array.IndexOf(items, item, 0, _size) == -1;
```

Normalized forms:

```
// item exists
Array.IndexOf(items, item, 0, _size) >= 0;

// item does not exist
Array.IndexOf(items, item, 0, _size) < 0;
```

### Rationale

This is a purely mechanical, semantic-preserving change that has some minor codegen benefits.

Diffs: https://github.com/MihuBot/runtime-utils/issues/1526