### PR TITLE
Add `string.Contains` shims for .NET Standard 2.0

### DIFF
--- a/src/libraries/Common/src/System/CodeDom/CodeTypeReference.cs
+++ b/src/libraries/Common/src/System/CodeDom/CodeTypeReference.cs
@@ -264,11 +264,7 @@ namespace System.Runtime.Serialization
             }
 
             // Now see if we have some arity.  baseType could be null if this is an array type.
-#if NET
-            if (_baseType != null && _baseType.Contains('`')) // string.Contains(char) is .NetCore2.1+ specific
-#else
-            if (_baseType != null && _baseType.IndexOf('`') != -1) // string.Contains(char) is .NetCore2.1+ specific
-#endif
+            if (_baseType != null && _baseType.Contains('`'))
             {
                 _needsFixup = false;
             }

--- a/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
@@ -403,12 +403,11 @@ namespace System.Data.Common
             return currentPosition;
         }
 
-#pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'. This file is built into libraries that don't have string.Contains(char).
         private static bool IsValueValidInternal(string? keyvalue)
         {
             if (null != keyvalue)
             {
-                return (-1 == keyvalue.IndexOf('\u0000')); // string.Contains(char) is .NetCore2.1+ specific
+                return !keyvalue.Contains('\u0000');
             }
             return true;
         }
@@ -419,14 +418,13 @@ namespace System.Data.Common
             {
 #if DEBUG
                 bool compValue = s_connectionStringValidKeyRegex.IsMatch(keyname);
-                Debug.Assert(((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000'))) == compValue, "IsValueValid mismatch with regex");
+                Debug.Assert((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && !keyname.Contains('\u0000') == compValue, "IsValueValid mismatch with regex");
 #endif
                 // string.Contains(char) is .NetCore2.1+ specific
-                return ((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000')));
+                return (0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && !keyname.Contains('\u0000');
             }
             return false;
         }
-#pragma warning restore CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'
 
 #if DEBUG
         private static Dictionary<string, string> SplitConnectionString(string connectionString, Dictionary<string, string>? synonyms, bool firstKey)

--- a/src/libraries/Common/src/System/NetStandardShims.String.cs
+++ b/src/libraries/Common/src/System/NetStandardShims.String.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System
+{
+    internal static partial class NetStandardShims
+    {
+        extension(string @this)
+        {
+            public bool Contains(char value)
+            {
+#pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'
+                return @this.IndexOf(value) >= 0;
+#pragma warning restore CA2249
+            }
+
+            public bool Contains(string value, StringComparison comparisonType)
+            {
+#pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'
+                return @this.IndexOf(value, comparisonType) >= 0;
+#pragma warning restore CA2249
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);REGISTRY_ASSEMBLY</DefineConstants>
-    <NoWarn>$(NoWarn);CA2249</NoWarn>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 

--- a/src/libraries/System.CodeDom/src/Microsoft/CSharp/CSharpCodeGenerator.cs
+++ b/src/libraries/System.CodeDom/src/Microsoft/CSharp/CSharpCodeGenerator.cs
@@ -192,10 +192,8 @@ namespace Microsoft.CSharp
             // If the string is short, use C style quoting (e.g "\r\n")
             // Also do it if it is too long to fit in one line
             // If the string contains '\0', verbatim style won't work.
-#pragma warning disable CA2249 // Consider using 'string.Contains' instead of 'string.IndexOf'
-            if (value.Length < 256 || value.Length > 1500 || (value.IndexOf('\0') != -1)) // string.Contains(char) is .NetCore2.1+ specific
+            if (value.Length < 256 || value.Length > 1500 || value.Contains('\0'))
                 return QuoteSnippetStringCStyle(value);
-#pragma warning restore CA2249
 
             // Otherwise, use 'verbatim' style quoting (e.g. @"foo")
             return QuoteSnippetStringVerbatimStyle(value);

--- a/src/libraries/System.CodeDom/src/Microsoft/VisualBasic/VBCodeGenerator.cs
+++ b/src/libraries/System.CodeDom/src/Microsoft/VisualBasic/VBCodeGenerator.cs
@@ -862,11 +862,7 @@ namespace Microsoft.VisualBasic
                 string typeName = GetTypeOutput(e.CreateType);
                 Output.Write(typeName);
 
-#if NET
                 if (!typeName.Contains('('))
-#else
-                if (typeName.IndexOf('(') == -1)
-#endif
                 {
                     Output.Write("()");
                 }

--- a/src/libraries/System.CodeDom/src/System.CodeDom.csproj
+++ b/src/libraries/System.CodeDom/src/System.CodeDom.csproj
@@ -138,4 +138,8 @@
     <Compile Include="$(CommonPath)System\CSharpHelpers.cs" />
     <Compile Include="StringExtensions.cs" />
   </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
+    <Compile Include="$(CommonPath)System\NetStandardShims.String.cs" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
-    <NoWarn>$(NoWarn);CA2249</NoWarn>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>
@@ -273,6 +272,10 @@
     <Compile Include="System\Diagnostics\TraceSection.cs" />
     <Compile Include="System\Diagnostics\TypedElement.cs" />
     <Compile Include="System\Diagnostics\TraceUtils.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
+    <Compile Include="$(CommonPath)System\NetStandardShims.String.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/BaseConfigurationRecord.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/BaseConfigurationRecord.cs
@@ -3082,7 +3082,7 @@ namespace System.Configuration
                 throw new ConfigurationErrorsException(SR.Config_location_path_invalid_first_character, errorInfo);
 
             // do not allow problematic starting characters
-            if (InvalidFirstSubPathCharacters.IndexOf(subPath[0]) != -1)
+            if (InvalidFirstSubPathCharacters.Contains(subPath[0]))
                 throw new ConfigurationErrorsException(SR.Config_location_path_invalid_first_character, errorInfo);
 
             // do not allow whitespace at end of subPath, as the OS
@@ -3092,7 +3092,7 @@ namespace System.Configuration
                 throw new ConfigurationErrorsException(SR.Config_location_path_invalid_last_character, errorInfo);
 
             // the file system ignores trailing '.', '\', or '/', so do not allow it in a location subpath specification
-            if (InvalidLastSubPathCharacters.IndexOf(subPath[subPath.Length - 1]) != -1)
+            if (InvalidLastSubPathCharacters.Contains(subPath[subPath.Length - 1]))
                 throw new ConfigurationErrorsException(SR.Config_location_path_invalid_last_character, errorInfo);
 
             // combination of URI reserved characters and OS invalid filename characters, minus / (allowed reserved character)
@@ -3205,7 +3205,7 @@ namespace System.Configuration
             if (string.IsNullOrEmpty(configSource) || Path.IsPathRooted(configSource))
                 throw new ConfigurationErrorsException(SR.Config_source_invalid_format, errorInfo);
 
-            if (configSource.IndexOf('\\') != -1 || configSource.IndexOf('/') != -1) // string.Contains(char) is .NetCore2.1+ specific
+            if (configSource.Contains('\\') || configSource.Contains('/'))
             {
                 string newConfigSource = configSource.Replace('\\', '/');
                 if (!ConfigPathUtility.IsValid(newConfigSource))

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationLockCollection.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationLockCollection.cs
@@ -219,12 +219,7 @@ namespace System.Configuration
             }
 
             string parentListEnclosed = "," + _seedList + ",";
-            if (name.Equals(_ignoreName) ||
-#if NET
-                parentListEnclosed.Contains("," + name + ",", StringComparison.Ordinal))
-#else
-                parentListEnclosed.IndexOf("," + name + ",", StringComparison.Ordinal) >= 0)
-#endif
+            if (name.Equals(_ignoreName) || parentListEnclosed.Contains("," + name + ",", StringComparison.Ordinal))
                 return true;
             return _internalDictionary.Contains(name) &&
                 (((ConfigurationValueFlags)_internalDictionary[name] & ConfigurationValueFlags.Inherited) != 0);

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationProperty.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationProperty.cs
@@ -133,11 +133,7 @@ namespace System.Configuration
 
                 if (collectionAttribute != null)
                 {
-#if NET
                     if (!collectionAttribute.AddItemName.Contains(','))
-#else
-                    if (collectionAttribute.AddItemName.IndexOf(',') == -1)
-#endif
                     {
                         AddElementName = collectionAttribute.AddItemName;
                     }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationSectionCollection.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationSectionCollection.cs
@@ -85,11 +85,7 @@ namespace System.Configuration
                 throw ExceptionUtil.ParameterNullOrEmpty(nameof(name));
 
             // prevent GetConfig from returning config not in this collection
-#if NET
             if (name.Contains('/'))
-#else
-            if (name.IndexOf('/') >= 0)
-#endif
                 return null;
 
             // get the section from the config record

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationSectionGroupCollection.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationSectionGroupCollection.cs
@@ -89,11 +89,7 @@ namespace System.Configuration
                 throw ExceptionUtil.ParameterNullOrEmpty(nameof(name));
 
             // prevent GetConfig from returning config not in this collection
-#if NET
             if (name.Contains('/'))
-#else
-            if (name.IndexOf('/') >= 0)
-#endif
                 return null;
 
             // get the section group

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/TypeUtil.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/TypeUtil.cs
@@ -49,7 +49,7 @@ namespace System.Configuration
 
             // Don't bother to look around if we've already got something that
             // is clearly not a simple type name.
-            if (string.IsNullOrEmpty(typeString) || typeString.IndexOf(',') != -1) // string.Contains(char) is .NetCore2.1+ specific
+            if (string.IsNullOrEmpty(typeString) || typeString.Contains(','))
                 return null;
 
             // Ignore all exceptions, otherwise callers will get unexpected

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -97,6 +97,9 @@
     <Compile Include="System\Diagnostics\TraceSourceConfigurationTests.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
     <Compile Include="System\Drawing\Configuration\SystemDrawingSectionTests.cs" />
   </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
+    <Compile Include="$(CommonPath)System\NetStandardShims.String.cs" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Configuration.ConfigurationManager.csproj" />
     <!-- Apple mobile trimming descriptor for Mono runtime -->

--- a/src/libraries/System.Data.Odbc/src/Common/System/Data/Common/AdapterUtil.Odbc.cs
+++ b/src/libraries/System.Data.Odbc/src/Common/System/Data/Common/AdapterUtil.Odbc.cs
@@ -637,7 +637,7 @@ namespace System.Data.Common
 
             foreach (char currentChar in unescapedString)
             {
-                if (specialCharacters.IndexOf(currentChar) >= 0)
+                if (specialCharacters.Contains(currentChar))
                 {
                     escapedString.Append('\\');
                 }

--- a/src/libraries/System.Data.Odbc/src/Common/System/Data/Common/DbConnectionOptions.cs
+++ b/src/libraries/System.Data.Odbc/src/Common/System/Data/Common/DbConnectionOptions.cs
@@ -167,7 +167,7 @@ namespace System.Data.Common
                     builder.Append(keyValue);
                 }
                 // string.Contains(char) is .NetCore2.1+ specific
-                else if ((-1 != keyValue.IndexOf('\"')) && (-1 == keyValue.IndexOf('\'')))
+                else if (keyValue.Contains('\"') && !keyValue.Contains('\''))
                 {
                     // <val"ue> -> <'val"ue'>
                     builder.Append('\'');
@@ -450,7 +450,7 @@ namespace System.Data.Common
             {
                 throw ADP.InvalidKeyname(keyword);
             }
-            if ((null != value) && value.IndexOf('\0') >= 0)
+            if ((null != value) && value.Contains('\0'))
             {
                 throw ADP.InvalidValue(keyword);
             }

--- a/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
+++ b/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum)-unix;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <TargetFrameworks Condition="'$(NetCoreAppPrevious)' != ''">$(TargetFrameworks);$(NetCoreAppPrevious)-windows;$(NetCoreAppPrevious)-unix;$(NetCoreAppPrevious)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>$(NoWarn);CA2249;CA1838</NoWarn>
+    <NoWarn>$(NoWarn);CA1838</NoWarn>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides a collection of classes used to access an ODBC data source in the managed space

--- a/src/libraries/System.Data.OleDb/src/DbConnectionOptions.cs
+++ b/src/libraries/System.Data.OleDb/src/DbConnectionOptions.cs
@@ -237,7 +237,7 @@ namespace System.Data.Common
                     // <value> -> <value>
                     builder.Append(keyValue);
                 }
-                else if ((-1 != keyValue.IndexOf('\"')) && (-1 == keyValue.IndexOf('\'')))
+                else if (keyValue.Contains('\"') && keyValue.Contains('\''))
                 {
                     // <val"ue> -> <'val"ue'>
                     builder.Append('\'');
@@ -760,7 +760,7 @@ namespace System.Data.Common
         {
             if (null != keyvalue)
             {
-                return (-1 == keyvalue.IndexOf('\u0000'));
+                return !keyvalue.Contains('\u0000');
             }
             return true;
         }
@@ -771,9 +771,9 @@ namespace System.Data.Common
             {
 #if DEBUG
                 bool compValue = ConnectionStringValidKeyRegex.IsMatch(keyname);
-                Debug.Assert(((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000'))) == compValue, "IsValueValid mismatch with regex");
+                Debug.Assert(((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && !keyname.Contains('\u0000')) == compValue, "IsValueValid mismatch with regex");
 #endif
-                return ((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000')));
+                return (0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && !keyname.Contains('\u0000');
             }
             return false;
         }

--- a/src/libraries/System.Data.OleDb/src/OleDbConnectionStringBuilder.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbConnectionStringBuilder.cs
@@ -631,7 +631,7 @@ namespace System.Data.OleDb
                     }
                     else
                     {
-                        if (svalue.IndexOf(',') != -1)
+                        if (svalue.Contains(','))
                         {
                             int convertedValue = 0;
                             string[] values = svalue.Split(OleDbConnectionInternal.s_comma);

--- a/src/libraries/System.Data.OleDb/src/System.Data.OleDb.csproj
+++ b/src/libraries/System.Data.OleDb/src/System.Data.OleDb.csproj
@@ -4,8 +4,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <TargetFrameworks Condition="'$(NetCoreAppPrevious)' != ''">$(TargetFrameworks);$(NetCoreAppPrevious)-windows;$(NetCoreAppPrevious)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Suppress CA2249: Consider using String.Contains instead of String.IndexOf to avoid ifdefs. -->
-    <NoWarn>$(NoWarn);CA2249</NoWarn>
     <!-- Suppress SYSLIB0004: 'RuntimeHelpers.PrepareConstrainedRegions()' is obsolete to avoid ifdefs. -->
     <NoWarn>$(NoWarn);SYSLIB0004</NoWarn>
     <!-- Suppress CS3016: Arrays as attribute arguments is not CLS-compliant to work around https://github.com/dotnet/roslyn/issues/68526 in generated code -->

--- a/src/libraries/System.Data.OleDb/src/System/Data/Common/AdapterUtil.cs
+++ b/src/libraries/System.Data.OleDb/src/System/Data/Common/AdapterUtil.cs
@@ -1014,7 +1014,7 @@ namespace System.Data.Common
 
             foreach (char currentChar in unescapedString)
             {
-                if (specialCharacters.IndexOf(currentChar) >= 0)
+                if (specialCharacters.Contains(currentChar))
                 {
                     escapedString.Append('\\');
                 }

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks Condition="'$(NetCoreAppPrevious)' != ''">$(TargetFrameworks);$(NetCoreAppPrevious)-windows;$(NetCoreAppPrevious)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <NoWarn>$(NoWarn);CA2249</NoWarn>
     <NoWarn>$(NoWarn);IDE0059;IDE0060;CA1822;CA1859</NoWarn>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Context.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Context.cs
@@ -100,8 +100,7 @@ namespace System.DirectoryServices.AccountManagement
                 // if they just passed user then append the machine name here.
                 if (null != userName)
                 {
-                    int index = userName.IndexOf('\\');
-                    if (index == -1)
+                    if (!userName.Contains('\\'))
                     {
                         userName = _serverName + "\\" + userName;
                     }

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
@@ -151,6 +151,10 @@
     <Compile Include="System\ThrowHelper.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
+    <Compile Include="$(CommonPath)System\NetStandardShims.String.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Helpers.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Helpers.cs
@@ -134,11 +134,7 @@ namespace System.Reflection.TypeLoading
 
         public static string UnescapeTypeNameIdentifier(this string identifier)
         {
-#if NET
             if (identifier.Contains('\\'))
-#else
-            if (identifier.IndexOf('\\') != -1)
-#endif
             {
                 StringBuilder sbUnescapedName = new StringBuilder(identifier.Length);
                 for (int i = 0; i < identifier.Length; i++)

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <TargetFrameworks Condition="'$(NetCoreAppPrevious)' != ''">$(TargetFrameworks);$(NetCoreAppPrevious)-windows;$(NetCoreAppPrevious)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>$(NoWarn);CA2249;CA1865</NoWarn>
+    <NoWarn>$(NoWarn);CA1865</NoWarn>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides the System.ServiceProcess.ServiceController class, which allows you to connect to a Windows service, manipulate it, or get information about it.

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
@@ -456,7 +456,7 @@ namespace System.ServiceProcess
         private static bool CheckMachineName(string value)
         {
             // string.Contains(char) is .NetCore2.1+ specific
-            return !string.IsNullOrWhiteSpace(value) && value.IndexOf('\\') == -1;
+            return !string.IsNullOrWhiteSpace(value) && !value.Contains('\\');
         }
 
         /// <summary>


### PR DESCRIPTION
* Add C# 14 extension members to polyfill the following APIs:
  * [String.Contains(Char)](https://apisof.net/catalog/0c6d87988019eff50b8ec5bf57a97e5c)
  * [String.Contains(String, StringComparison)](https://apisof.net/catalog/0a3a7c3c3d721b7e06bd47f16d97edd3)

* Remove suppression of CA2249: Consider using 'string.Contains' instead of 'string.IndexOf'
