### PR TITLE
properly enumerate uninstrumented bounds

### DIFF
--- a/src/coreclr/vm/debuginfostore.cpp
+++ b/src/coreclr/vm/debuginfostore.cpp
@@ -1420,6 +1420,10 @@ void CompressDebugInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE
 
     pDebugInfo += r.GetNextByteIndex() + cbBounds + cbUninstrumentedBounds + cbVars;
 
+    // NibbleReader reads in units of sizeof(NibbleChunkType)
+    // So we need to account for any partial chunk at the end.
+    pDebugInfo += sizeof(NibbleReader::NibbleChunkType) - 1;
+
     DacEnumMemoryRegion(dac_cast<TADDR>(pStart), pDebugInfo - pStart);
 }
 #endif // DACCESS_COMPILE

--- a/src/coreclr/vm/debuginfostore.cpp
+++ b/src/coreclr/vm/debuginfostore.cpp
@@ -1406,12 +1406,19 @@ void CompressDebugInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE
         _ASSERTE(flagByte == 0);
     }
 
-    NibbleReader r(pDebugInfo, 12 /* maximum size of compressed 2 UINT32s */);
-
+    NibbleReader r(pDebugInfo, 24 /* maximum size of compressed 4 UINT32s */);
+    
     ULONG cbBounds = r.ReadEncodedU32();
+    ULONG cbUninstrumentedBounds = 0;
+    if (cbBounds == DebugInfoBoundsHasInstrumentedBounds)
+    {
+        // This means we have instrumented bounds.
+        cbBounds = r.ReadEncodedU32();
+        cbUninstrumentedBounds = r.ReadEncodedU32();
+    }
     ULONG cbVars   = r.ReadEncodedU32();
 
-    pDebugInfo += r.GetNextByteIndex() + cbBounds + cbVars;
+    pDebugInfo += r.GetNextByteIndex() + cbBounds + cbUninstrumentedBounds + cbVars;
 
     DacEnumMemoryRegion(dac_cast<TADDR>(pStart), pDebugInfo - pStart);
 }

--- a/src/coreclr/vm/debuginfostore.cpp
+++ b/src/coreclr/vm/debuginfostore.cpp
@@ -1407,7 +1407,7 @@ void CompressDebugInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE
     }
 
     NibbleReader r(pDebugInfo, 24 /* maximum size of compressed 4 UINT32s */);
-    
+
     ULONG cbBounds = r.ReadEncodedU32();
     ULONG cbUninstrumentedBounds = 0;
     if (cbBounds == DebugInfoBoundsHasInstrumentedBounds)

--- a/src/coreclr/vm/debuginfostore.cpp
+++ b/src/coreclr/vm/debuginfostore.cpp
@@ -1422,7 +1422,7 @@ void CompressDebugInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE
 
     // NibbleReader reads in units of sizeof(NibbleChunkType)
     // So we need to account for any partial chunk at the end.
-    pDebugInfo += sizeof(NibbleReader::NibbleChunkType) - 1;
+    pDebugInfo = AlignUp(dac_cast<TADDR>(pDebugInfo), sizeof(NibbleReader::NibbleChunkType));
 
     DacEnumMemoryRegion(dac_cast<TADDR>(pStart), pDebugInfo - pStart);
 }


### PR DESCRIPTION
partial fix for https://github.com/dotnet/runtime/issues/119921.

* Updates EnumMemoryRegions to account for uninstrumented bounds added by https://github.com/dotnet/runtime/pull/116031
* Adds padding to end of enumerated DebugInfo stream. This accounts for the nibblereader reading in data in platform pointer sized increments. Previously, if the debuginfo was not aligned the last read would end up partially failing.