### PR TITLE
Revert SA1129 suppression in `System.Speech`

### DIFF
--- a/src/libraries/System.Speech/src/AudioFormat/SpeechAudioFormatInfo.cs
+++ b/src/libraries/System.Speech/src/AudioFormat/SpeechAudioFormatInfo.cs
@@ -141,7 +141,7 @@ namespace System.Speech.AudioFormat
         {
             get
             {
-                WAVEFORMATEX wfx = new();
+                WAVEFORMATEX wfx = default;
                 wfx.wFormatTag = (short)EncodingFormat;
                 wfx.nChannels = (short)ChannelCount;
                 wfx.nSamplesPerSec = SamplesPerSecond;

--- a/src/libraries/System.Speech/src/Internal/SapiInterop/SpAudioStreamWrapper.cs
+++ b/src/libraries/System.Speech/src/Internal/SapiInterop/SpAudioStreamWrapper.cs
@@ -19,7 +19,7 @@ namespace System.Speech.Internal.SapiInterop
 
             if (audioFormat != null)
             {
-                WAVEFORMATEX wfx = new();
+                WAVEFORMATEX wfx = default;
                 wfx.wFormatTag = (short)audioFormat.EncodingFormat;
                 wfx.nChannels = (short)audioFormat.ChannelCount;
                 wfx.nSamplesPerSec = audioFormat.SamplesPerSecond;
@@ -78,7 +78,7 @@ namespace System.Speech.Internal.SapiInterop
         {
             BinaryReader br = new(stream);
             // Read the riff Header
-            RIFFHDR riff = new();
+            RIFFHDR riff = default;
 
             riff._id = br.ReadUInt32();
             riff._len = br.ReadInt32();
@@ -89,7 +89,7 @@ namespace System.Speech.Internal.SapiInterop
                 throw new FormatException();
             }
 
-            BLOCKHDR block = new();
+            BLOCKHDR block = default;
             block._id = br.ReadUInt32();
             block._len = br.ReadInt32();
 
@@ -112,7 +112,7 @@ namespace System.Speech.Internal.SapiInterop
 
             while (true)
             {
-                DATAHDR dataHdr = new();
+                DATAHDR dataHdr = default;
 
                 // check for the end of file (+8 for the 2 DWORD)
                 if (stream.Position + 8 >= stream.Length)

--- a/src/libraries/System.Speech/src/Internal/SrgsCompiler/Arc.cs
+++ b/src/libraries/System.Speech/src/Internal/SrgsCompiler/Arc.cs
@@ -183,7 +183,7 @@ namespace System.Speech.Internal.SrgsCompiler
 
         internal float Serialize(StreamMarshaler streamBuffer, bool isLast, uint arcIndex)
         {
-            CfgArc A = new();
+            CfgArc A = default;
 
             A.LastArc = isLast;
             A.HasSemanticTag = SemanticTagCount > 0;
@@ -223,7 +223,7 @@ namespace System.Speech.Internal.SrgsCompiler
 
         internal static float SerializeExtraEpsilonWithTag(StreamMarshaler streamBuffer, Arc arc, bool isLast, uint arcIndex)
         {
-            CfgArc A = new();
+            CfgArc A = default;
 
             A.LastArc = isLast;
             A.HasSemanticTag = true;

--- a/src/libraries/System.Speech/src/Internal/SrgsCompiler/BackEnd.cs
+++ b/src/libraries/System.Speech/src/Internal/SrgsCompiler/BackEnd.cs
@@ -127,7 +127,7 @@ namespace System.Speech.Internal.SrgsCompiler
             //
             //  Write a dummy 0 index state entry
             //
-            CfgArc dummyArc = new();
+            CfgArc dummyArc = default;
 
             System.Diagnostics.Debug.Assert(streamBuffer.Stream.Position - startStreamPosition == header.pArcs);
             streamBuffer.WriteStream(dummyArc);
@@ -817,7 +817,7 @@ namespace System.Speech.Internal.SrgsCompiler
             //
             Arc[] apArcTable = new Arc[header.arcs.Length];
             bool fLastArcNull = true;
-            CfgArc pLastArc = new();
+            CfgArc pLastArc = default;
             State currentState = null;
             SortedDictionary<int, Rule>.Enumerator ieFirstArcs = ruleFirstArcs.GetEnumerator();
 

--- a/src/libraries/System.Speech/src/Internal/SrgsCompiler/CFGGrammar.cs
+++ b/src/libraries/System.Speech/src/Internal/SrgsCompiler/CFGGrammar.cs
@@ -248,7 +248,7 @@ namespace System.Speech.Internal.SrgsCompiler
             //  Because in 64-bit code, pointers != sizeof(ULONG) we copy each member explicitly.
             //
 
-            CfgHeader header = new();
+            CfgHeader header = default;
             header.FormatId = cfgSerializedHeader.FormatId;
             header.GrammarGUID = cfgSerializedHeader.GrammarGUID;
             header.langId = cfgSerializedHeader.LangID;

--- a/src/libraries/System.Speech/src/Internal/SrgsCompiler/ScriptRef.cs
+++ b/src/libraries/System.Speech/src/Internal/SrgsCompiler/ScriptRef.cs
@@ -25,7 +25,7 @@ namespace System.Speech.Internal.SrgsCompiler
 
         internal void Serialize(StringBlob symbols, StreamMarshaler streamBuffer)
         {
-            CfgScriptRef script = new();
+            CfgScriptRef script = default;
 
             // Get the symbol id for the rule
             script._idRule = symbols.Find(_rule);

--- a/src/libraries/System.Speech/src/Internal/Synthesis/AudioBase.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/AudioBase.cs
@@ -94,7 +94,7 @@ namespace System.Speech.Internal.Synthesis
                 // Fake a header for ALaw and ULaw
                 if (!string.IsNullOrEmpty(audio._mimeType))
                 {
-                    WAVEFORMATEX wfx = new();
+                    WAVEFORMATEX wfx = default;
 
                     wfx.nChannels = 1;
                     wfx.nSamplesPerSec = 8000;
@@ -164,7 +164,7 @@ namespace System.Speech.Internal.Synthesis
                         {
                             while (true)
                             {
-                                DATAHDR dataHdr = new();
+                                DATAHDR dataHdr = default;
 
                                 // check for the end of file (+8 for the 2 DWORD)
                                 if (audio._stream.Position + 8 >= audio._stream.Length)
@@ -208,7 +208,7 @@ namespace System.Speech.Internal.Synthesis
         internal static byte[] GetWaveFormat(BinaryReader br)
         {
             // Read the riff Header
-            RIFFHDR riff = new();
+            RIFFHDR riff = default;
 
             riff._id = br.ReadUInt32();
             riff._len = br.ReadInt32();
@@ -219,7 +219,7 @@ namespace System.Speech.Internal.Synthesis
                 return null;
             }
 
-            BLOCKHDR block = new();
+            BLOCKHDR block = default;
             block._id = br.ReadUInt32();
             block._len = br.ReadInt32();
 
@@ -392,7 +392,7 @@ namespace System.Speech.Internal.Synthesis
         {
             GCHandle gc = GCHandle.Alloc(waveHeader, GCHandleType.Pinned);
             IntPtr ptr = gc.AddrOfPinnedObject();
-            WAVEFORMATEX wfx = new();
+            WAVEFORMATEX wfx = default;
             wfx.wFormatTag = Marshal.ReadInt16(ptr);
             wfx.nChannels = Marshal.ReadInt16(ptr, 2);
             wfx.nSamplesPerSec = Marshal.ReadInt32(ptr, 4);
@@ -444,7 +444,7 @@ namespace System.Speech.Internal.Synthesis
         {
             get
             {
-                WAVEFORMATEX wfx = new();
+                WAVEFORMATEX wfx = default;
                 wfx.wFormatTag = 1;
                 wfx.nChannels = 1;
                 wfx.nSamplesPerSec = 22050;

--- a/src/libraries/System.Speech/src/Internal/Synthesis/AudioDeviceOut.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/AudioDeviceOut.cs
@@ -309,7 +309,7 @@ namespace System.Speech.Internal.Synthesis
         internal static Interop.WinMM.MMSYSERR GetDeviceName(int deviceId, [MarshalAs(UnmanagedType.LPWStr)] out string prodName)
         {
             prodName = string.Empty;
-            Interop.WinMM.WAVEOUTCAPS caps = new();
+            Interop.WinMM.WAVEOUTCAPS caps = default;
 
             Interop.WinMM.MMSYSERR result = Interop.WinMM.waveOutGetDevCaps((IntPtr)deviceId, ref caps, Marshal.SizeOf<Interop.WinMM.WAVEOUTCAPS>());
             if (result != Interop.WinMM.MMSYSERR.NOERROR)

--- a/src/libraries/System.Speech/src/Internal/Synthesis/AudioFileOut.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/AudioFileOut.cs
@@ -25,7 +25,7 @@ namespace System.Speech.Internal.Synthesis
             _startStreamPosition = _stream.Position;
             _hasHeader = headerInfo;
 
-            _wfxOut = new WAVEFORMATEX();
+            _wfxOut = default;
             // if we have a formatInfo object, format conversion may be necessary
             if (formatInfo != null)
             {

--- a/src/libraries/System.Speech/src/Internal/Synthesis/ConvertTextFrag.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/ConvertTextFrag.cs
@@ -28,7 +28,7 @@ namespace System.Speech.Internal.Synthesis
                 SPVTEXTFRAG sapiFrag = new();
 
                 // start with the text fragment
-                sapiFrag.gcNext = fFirst ? new GCHandle() : sapiFragLast;
+                sapiFrag.gcNext = fFirst ? default : sapiFragLast;
                 sapiFrag.pNext = fFirst ? IntPtr.Zero : sapiFragLast.AddrOfPinnedObject();
                 sapiFrag.gcText = GCHandle.Alloc(textFragment.TextToSpeak, GCHandleType.Pinned);
                 sapiFrag.pTextStart = sapiFrag.gcText.AddrOfPinnedObject();
@@ -36,7 +36,7 @@ namespace System.Speech.Internal.Synthesis
                 sapiFrag.ulTextLen = textFragment.TextLength;
 
                 // State
-                SPVSTATE sapiState = new();
+                SPVSTATE sapiState = default;
                 FragmentState ssmlState = textFragment.State;
                 sapiState.eAction = (SPVACTIONS)ssmlState.Action;
                 sapiState.LangID = (short)ssmlState.LangId;
@@ -72,7 +72,7 @@ namespace System.Speech.Internal.Synthesis
                 }
                 else
                 {
-                    sapiFrag.gcPhoneme = new GCHandle();
+                    sapiFrag.gcPhoneme = default;
                     sapiState.pPhoneIds = IntPtr.Zero;
                 }
 

--- a/src/libraries/System.Speech/src/Internal/Synthesis/SSmlParser.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/SSmlParser.cs
@@ -78,7 +78,7 @@ namespace System.Speech.Internal.Synthesis
         /// </summary>
         private static void ProcessSpeakElement(XmlReader reader, ISsmlParser engine, object voice)
         {
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             ssmlAttributes._voice = voice;
             ssmlAttributes._age = VoiceAge.NotSet;
             ssmlAttributes._gender = VoiceGender.NotSet;
@@ -217,7 +217,7 @@ namespace System.Speech.Internal.Synthesis
         private static void ProcessElement(XmlReader reader, ISsmlParser engine, string sElement, SsmlElement possibleElements, SsmlAttributes ssmAttributesParent, bool fIgnore, List<SsmlXmlAttribute> extraAttributes)
         {
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
 
             // This is equivalent to a memcpy
             ssmlAttributes = ssmAttributesParent;
@@ -296,7 +296,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.Audio, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -357,7 +357,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.Break, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -432,7 +432,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.Desc, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -488,7 +488,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.Emphasis, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -548,7 +548,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.Mark, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -645,7 +645,7 @@ namespace System.Speech.Internal.Synthesis
         private static void ParseTextBlock(XmlReader reader, ISsmlParser engine, bool isParagraph, string sElement, SsmlAttributes ssmAttributesParent, bool fIgnore)
         {
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -713,7 +713,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.Phoneme, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -835,7 +835,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.Prosody, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -918,7 +918,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.SayAs, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -987,7 +987,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.Sub, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -1050,7 +1050,7 @@ namespace System.Speech.Internal.Synthesis
             }
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
 
             // This is equivalent to a memcpy
             ssmlAttributes = ssmAttributesParent;
@@ -1219,7 +1219,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.Lexicon, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
             List<SsmlXmlAttribute> extraAttributes = null;
 
             // This is equivalent to a memcpy
@@ -1288,7 +1288,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(elementAllowed, element, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
 
             // This is equivalent to a memcpy
             ssmlAttributes = ssmAttributesParent;
@@ -1322,7 +1322,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(elementAllowed, element, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
 
             // This is equivalent to a memcpy
             ssmlAttributes = ssmAttributesParent;
@@ -1381,7 +1381,7 @@ namespace System.Speech.Internal.Synthesis
             string sElement = ValidateElement(element, SsmlElement.PromptEngineDatabase, reader.Name);
 
             // Make a local copy of the ssmlAttribute
-            SsmlAttributes ssmlAttributes = new();
+            SsmlAttributes ssmlAttributes = default;
 
             // This is equivalent to a memcpy
             ssmlAttributes = ssmAttributesParent;
@@ -1539,8 +1539,8 @@ namespace System.Speech.Internal.Synthesis
                     int comma = NextChar(achContour, start, ',', true, out percent);
                     int parenthesis = NextChar(achContour, comma, ')', true, out ignored);
 
-                    ProsodyNumber timePosition = new();
-                    ProsodyNumber target = new();
+                    ProsodyNumber timePosition = default;
+                    ProsodyNumber target = default;
 
                     // Parse the 2 numbers
                     if (!percent || !TryParseNumber(contour.Substring(start, comma - (start + 1)), ref timePosition) || timePosition.SsmlAttributeId == ProsodyNumber.AbsoluteNumber)

--- a/src/libraries/System.Speech/src/Internal/Synthesis/TTSEngineProxy.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/TTSEngineProxy.cs
@@ -126,7 +126,7 @@ namespace System.Speech.Internal.Synthesis
         {
             // Initialize TTS Engine
             Guid formatId = SAPIGuids.SPDFID_WaveFormatEx;
-            Guid guidNull = new();
+            Guid guidNull = default;
             IntPtr coMem = IntPtr.Zero;
 
             _sapiEngine.GetOutputFormat(ref formatId, preferredFormat, out guidNull, out coMem);
@@ -149,7 +149,7 @@ namespace System.Speech.Internal.Synthesis
             try
             {
                 IntPtr waveFormat = gc.AddrOfPinnedObject();
-                GCHandle spvTextFragment = new();
+                GCHandle spvTextFragment = default;
 
                 if (ConvertTextFrag.ToSapi(frags, ref spvTextFragment))
                 {

--- a/src/libraries/System.Speech/src/Internal/Synthesis/TTSVoice.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/TTSVoice.cs
@@ -91,7 +91,7 @@ namespace System.Speech.Internal.Synthesis
             if (_waveFormat == null || !Array.Equals(targetWaveFormat, _waveFormat))
             {
                 IntPtr waveFormat = IntPtr.Zero;
-                GCHandle targetFormat = new();
+                GCHandle targetFormat = default;
 
                 if (targetWaveFormat != null)
                 {

--- a/src/libraries/System.Speech/src/Internal/Synthesis/VoiceSynthesis.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/VoiceSynthesis.cs
@@ -759,7 +759,7 @@ namespace System.Speech.Internal.Synthesis
                                             //--- Make sure we have a voice defined by now
                                             if (!paramSpeak._isXml)
                                             {
-                                                FragmentState fragmentState = new();
+                                                FragmentState fragmentState = default;
                                                 fragmentState.Action = TtsEngineAction.Speak;
                                                 fragmentState.Prosody = new Prosody();
                                                 TextFragment textFragment = new(fragmentState, paramSpeak._textToSpeak);

--- a/src/libraries/System.Speech/src/System.Speech.csproj
+++ b/src/libraries/System.Speech/src/System.Speech.csproj
@@ -6,8 +6,7 @@
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- CS0649: uninitialized interop type fields -->
-    <!-- SA1129: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3277 -->
-    <NoWarn>$(NoWarn);CS0649;SA1129;IDE0059;IDE0060;CA1822;CA1852</NoWarn>
+    <NoWarn>$(NoWarn);CS0649;IDE0059;IDE0060;CA1822;CA1852</NoWarn>
 
     <!-- TODO: Document public visible types and members. https://github.com/dotnet/runtime/issues/87711
          Set SuppressPlatformNotSupportedAssemblyDocXmlError as this library uses the PNSE infrastructure


### PR DESCRIPTION
Remove unnecessary suppression of SA1129: Do not use default value type constructor
