### PR TITLE
Fix race condition when createdump tries to read /proc/pid/mem before prctl(PR_SET_PTRACER, childpid) is set

### DIFF
--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2474,7 +2474,8 @@ PROCCreateCrashDump(
 
         // Wait for prctl(PR_SET_PTRACER, childpid) in parent
         char buffer;
-        int bytesRead = read(child_read_pipe, &buffer, 1);
+        int bytesRead;
+        while((bytesRead = read(child_read_pipe, &buffer, 1)) < 0 && errno == EINTR);
         close(child_read_pipe);
         
         if (bytesRead != 1)
@@ -2526,7 +2527,8 @@ PROCCreateCrashDump(
         }
 #endif // HAVE_PRCTL_H && HAVE_PR_SET_PTRACER
         // Signal child that prctl(PR_SET_PTRACER, childpid) is done
-        int bytesWritten = write(parent_write_pipe, "S", 1);
+        int bytesWritten;
+        while((bytesWritten = write(parent_write_pipe, "S", 1)) < 0 && errno == EINTR);
         close(parent_write_pipe);
 
         if (bytesWritten != 1)

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2531,7 +2531,7 @@ PROCCreateCrashDump(
 
         if (bytesWritten != 1)
         {
-            fprintf(stderr, "Problem writing to parent_write_pipe: %s (%d)\n", strerror(errno), errno);
+            fprintf(stderr, "Problem writing to createdump parent_write_pipe: %s (%d)\n", strerror(errno), errno);
             close(parent_read_pipe);
             if (errorMessageBuffer != nullptr)
             {

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2459,7 +2459,7 @@ PROCCreateCrashDump(
         {
             sprintf_s(errorMessageBuffer, cbErrorMessageBuffer, "Problem launching createdump: fork() FAILED %s (%d)\n", strerror(errno), errno);
         }
-        for (size_t i = 0; i < 4; i++)
+        for (int i = 0; i < 4; i++)
         {
             close(pipe_descs[i]);
         }

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2479,7 +2479,7 @@ PROCCreateCrashDump(
         
         if (bytesRead != 1)
         {
-            fprintf(stderr, "Problem reading from child_read_pipe: %s (%d)\n", strerror(errno), errno);
+            fprintf(stderr, "Problem reading from createdump child_read_pipe: %s (%d)\n", strerror(errno), errno);
             close(child_write_pipe);
             exit(-1);
         }


### PR DESCRIPTION
[ProcDump-for-Linux](https://github.com/microsoft/ProcDump-for-Linux) is a tool that supports .NET as one of its targets to take dumps. For .NET, it works pretty much as `dotnet-dump` tool, triggering `createdump` utility.

In ProcDump's integration pipelines, we've been seeing some intermittent errors taking .NET dumps. Sometimes we see:

> [createdump] The process or container does not have permissions or access: open(/proc/10170/mem) FAILED Permission denied (13)
> [createdump] Failure took 0ms

We even saw that for the same process, a first dump succeeded, a second one failed with the message above.

After studying the code from createdump's launcher in the CLR, we can see there is a fork: the child execs and becomes `createdump`, while the parent process uses `prctl` syscall to allow `createdump` to read its `/proc/pid/mem`:
https://github.com/dotnet/runtime/blob/6ef2af13f8f88daea9ef0b6324415a1595d1082f/src/coreclr/pal/src/thread/process.cpp#L2448-L2505

We noticed there can be a potential race condition on the code above when the child/`createdump` tries to read `/proc/pid/mem` *before* the parent grants permissions. I assume it is rare in multi-core systems, but it happens quite frequently in our pipelines that have a limited number of cores.

To force the race condition to happen locally, I added a `sleep` on the parent branch right before it calls `prctl` - it always fails with the error message above!

This PR proposes a fix to allow the parent to signal the child using pipes when `prctl(PR_SET_PTRACER, childpid)` is done so it can proceed.