### PR TITLE
[clr-interp] InterpreterJitManager::ResolveEHClause behaved incorrectly

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -3371,7 +3371,7 @@ TypeHandle InterpreterJitManager::ResolveEHClause(EE_ILEXCEPTION_CLAUSE* pEHClau
 
     TypeHandle thResolved = EECodeGenManager::ResolveEHClause(pEHClause, pCf);
 
-    if (thResolved.IsSharedByGenericInstantiations())
+    if (thResolved.IsCanonicalSubtype())
     {
         _ASSERTE(!HasCachedTypeHandle(pEHClause));
 


### PR DESCRIPTION
- We need to use IsCanonicalSubtype, not IsSharedByGenericInstantiations as IsSharedByGenericInstantiations returns false for System.__Canon.
- This caused an issue where shared generic catch did not work correctly for methods which simply attempted to catch T, not a more complex generic type.

Fixes test Regressions\coreclr\GitHub_66005\test66005 under the interpreter