### PR TITLE
[release/9.0-staging] `UnsafeAccessor` - ambiguous name and signature match

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/UnsafeAccessors.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/UnsafeAccessors.cs
@@ -318,6 +318,12 @@ namespace Internal.IL
                 return false;
             }
 
+            // Validate generic parameter.
+            if (declSig.GenericParameterCount != maybeSig.GenericParameterCount)
+            {
+                return false;
+            }
+
             // Validate argument count and return type
             if (context.Kind == UnsafeAccessorKind.Constructor)
             {

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
@@ -181,21 +181,76 @@ public static unsafe class UnsafeAccessorsTestsGenerics
         }
     }
 
-    class Base
+    class AmbiguousMethodName
     {
-        protected virtual string CreateMessageGeneric<T>(T t) => $"{nameof(Base)}:{t}";
+        private void M() { }
+        private void M<T>() { }
+        private void N() { }
+
+        private static void SM() { }
+        private static void SM<U>() { }
+        private static void SN() { }
     }
 
-    class GenericBase<T> : Base
+    static class AccessorsAmbiguousMethodName
     {
-        protected virtual string CreateMessage(T t) => $"{nameof(GenericBase<T>)}:{t}";
-        protected override string CreateMessageGeneric<U>(U u) => $"{nameof(GenericBase<T>)}:{u}";
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "M")]
+        public extern static void CallM(AmbiguousMethodName a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "M")]
+        public extern static void CallM<T>(AmbiguousMethodName a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "N")]
+        public extern static void CallN_MissingMethod<T>(AmbiguousMethodName a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "SM")]
+        public extern static void CallSM(AmbiguousMethodName a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "SM")]
+        public extern static void CallSM<U>(AmbiguousMethodName a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "SN")]
+        public extern static void CallSN_MissingMethod<T>(AmbiguousMethodName a);
+    }
+
+    [Fact]
+    public static void Verify_Generic_AmbiguousMethodName()
+    {
+        Console.WriteLine($"Running {nameof(Verify_Generic_AmbiguousMethodName)}");
+
+        {
+            AmbiguousMethodName a = new();
+            AccessorsAmbiguousMethodName.CallM(a);
+            AccessorsAmbiguousMethodName.CallM<int>(a);
+            AccessorsAmbiguousMethodName.CallM<string>(a);
+            AccessorsAmbiguousMethodName.CallM<Guid>(a);
+            Assert.Throws<MissingMethodException>(() => AccessorsAmbiguousMethodName.CallN_MissingMethod<int>(a));
+        }
+
+        {
+            AccessorsAmbiguousMethodName.CallSM(null);
+            AccessorsAmbiguousMethodName.CallSM<int>(null);
+            AccessorsAmbiguousMethodName.CallSM<string>(null);
+            AccessorsAmbiguousMethodName.CallSM<Guid>(null);
+            Assert.Throws<MissingMethodException>(() => AccessorsAmbiguousMethodName.CallSN_MissingMethod<int>(null));
+        }
+    }
+
+    class Base
+    {
+        protected virtual string CreateMessage<T>(T t) => $"{nameof(Base)}<>:{t}";
+    }
+
+    class GenericBase<U> : Base
+    {
+        protected virtual string CreateMessage(U u) => $"{nameof(GenericBase<U>)}:{u}";
+        protected override string CreateMessage<V>(V v) => $"{nameof(GenericBase<U>)}<>:{v}";
     }
 
     sealed class Derived1 : GenericBase<string>
     {
         protected override string CreateMessage(string u) => $"{nameof(Derived1)}:{u}";
-        protected override string CreateMessageGeneric<U>(U t) => $"{nameof(Derived1)}:{t}";
+        protected override string CreateMessage<W>(W w) => $"{nameof(Derived1)}<>:{w}";
     }
 
     sealed class Derived2 : GenericBase<string>
@@ -209,33 +264,33 @@ public static unsafe class UnsafeAccessorsTestsGenerics
         Console.WriteLine($"Running {nameof(Verify_Generic_InheritanceMethodResolution)}");
         {
             Base a = new();
-            Assert.Equal($"{nameof(Base)}:1", CreateMessage<int>(a, 1));
-            Assert.Equal($"{nameof(Base)}:{expect}", CreateMessage<string>(a, expect));
-            Assert.Equal($"{nameof(Base)}:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
+            Assert.Equal($"{nameof(Base)}<>:1", CreateMessage<int>(a, 1));
+            Assert.Equal($"{nameof(Base)}<>:{expect}", CreateMessage<string>(a, expect));
+            Assert.Equal($"{nameof(Base)}<>:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
         }
         {
             GenericBase<int> a = new();
-            Assert.Equal($"{nameof(GenericBase<int>)}:1", CreateMessage<int>(a, 1));
-            Assert.Equal($"{nameof(GenericBase<int>)}:{expect}", CreateMessage<string>(a, expect));
-            Assert.Equal($"{nameof(GenericBase<int>)}:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
+            Assert.Equal($"{nameof(GenericBase<int>)}<>:1", CreateMessage<int>(a, 1));
+            Assert.Equal($"{nameof(GenericBase<int>)}<>:{expect}", CreateMessage<string>(a, expect));
+            Assert.Equal($"{nameof(GenericBase<int>)}<>:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
         }
         {
             GenericBase<string> a = new();
-            Assert.Equal($"{nameof(GenericBase<string>)}:1", CreateMessage<int>(a, 1));
-            Assert.Equal($"{nameof(GenericBase<string>)}:{expect}", CreateMessage<string>(a, expect));
-            Assert.Equal($"{nameof(GenericBase<string>)}:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
+            Assert.Equal($"{nameof(GenericBase<string>)}<>:1", CreateMessage<int>(a, 1));
+            Assert.Equal($"{nameof(GenericBase<string>)}<>:{expect}", CreateMessage<string>(a, expect));
+            Assert.Equal($"{nameof(GenericBase<string>)}<>:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
         }
         {
             GenericBase<Struct> a = new();
-            Assert.Equal($"{nameof(GenericBase<Struct>)}:1", CreateMessage<int>(a, 1));
-            Assert.Equal($"{nameof(GenericBase<Struct>)}:{expect}", CreateMessage<string>(a, expect));
-            Assert.Equal($"{nameof(GenericBase<Struct>)}:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
+            Assert.Equal($"{nameof(GenericBase<Struct>)}<>:1", CreateMessage<int>(a, 1));
+            Assert.Equal($"{nameof(GenericBase<Struct>)}<>:{expect}", CreateMessage<string>(a, expect));
+            Assert.Equal($"{nameof(GenericBase<Struct>)}<>:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
         }
         {
             Derived1 a = new();
-            Assert.Equal($"{nameof(Derived1)}:1", CreateMessage<int>(a, 1));
-            Assert.Equal($"{nameof(Derived1)}:{expect}", CreateMessage<string>(a, expect));
-            Assert.Equal($"{nameof(Derived1)}:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
+            Assert.Equal($"{nameof(Derived1)}<>:1", CreateMessage<int>(a, 1));
+            Assert.Equal($"{nameof(Derived1)}<>:{expect}", CreateMessage<string>(a, expect));
+            Assert.Equal($"{nameof(Derived1)}<>:{nameof(Struct)}", CreateMessage<Struct>(a, new Struct()));
         }
         {
             // Verify resolution of generic override logic.
@@ -245,7 +300,7 @@ public static unsafe class UnsafeAccessorsTestsGenerics
             Assert.Equal($"{nameof(GenericBase<string>)}:{expect}", Accessors<string>.CreateMessage(a2, expect));
         }
 
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "CreateMessageGeneric")]
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "CreateMessage")]
         extern static string CreateMessage<W>(Base b, W w);
     }
 


### PR DESCRIPTION
Backport of #119972 to release/9.0-staging

/cc @AaronRobinsonMSFT

## Customer Impact

- [x] Customer reported
- [ ] Found internally

The `UnsafeAccessorAttribute` doesn't properly differentiate ambiguity for between the two signatures below. Both are `void(*)(void)` and in that case the generic calling convention isn't used to indicate distinct signatures.

```csharp
class C
{
    private static void M() { }
    private static void M<T>() { }
}
```

Customer reported in https://github.com/dotnet/runtime/issues/119875.

## Regression

- [x] Yes
- [ ] No

This is regression from .NET 8 because we didn't support generics method with `UnsafeAccessorAttribute`. When it was added in .NET 9, a test case was missed. A new test was added to validate this scenario.

## Testing

A test was added.

## Risk

Low.
