### PR TITLE
Load Standalone GC correctly in component scenarios.

### DIFF
--- a/src/coreclr/vm/gcheaputilities.cpp
+++ b/src/coreclr/vm/gcheaputilities.cpp
@@ -188,8 +188,12 @@ HMODULE LoadStandaloneGc(LPCWSTR libFileName, LPCWSTR libFilePath)
         return nullptr;
     }
 
+    // The APP_CONTEXT_BASE_DIRECTORY is always set by the host. In cases
+    // where the runtime is activated as a component, the base directory
+    // will be an empty string. If the base directory is an empty string, skip it.
     SString appBase;
-    if (HostInformation::GetProperty("APP_CONTEXT_BASE_DIRECTORY", appBase))
+    if (HostInformation::GetProperty("APP_CONTEXT_BASE_DIRECTORY", appBase)
+        && u16_strlen(appBase.GetUnicode()) != 0)
     {
         PathString libPath = appBase.GetUnicode();
         libPath.Append(libFileName);


### PR DESCRIPTION
In .NET component scenarios (for example, C++/CLI), the `APP_CONTEXT_BASE_DIRECTORY` property is set to an empty string. When the standalone GC scenario is exercised using `System.GC.Name` or `DOTNET_GCName`, the empty directory is used as the path and the name appended to nothing. The result is for the load to use the default search path and could load the GC from anywhere. The solution is to use `System.GC.Path` or `DOTNET_GCPath` to get the desired behavior and we "fix" the component issue by going down the fallback path and use the same directory as the `coreclr` binary.

Fixes #119418