### PR TITLE
[clr-interp] Fix EH clause var construction

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1346,7 +1346,7 @@ void InterpCompiler::BuildGCInfo(InterpMethod *pInterpMethod)
     {
         InterpVar *pVar = &m_pVars[i];
 
-        if (pVar->offset == 0xFFFFFFFF)
+        if (pVar->offset == UNALLOCATED_VAR_OFFSET)
         {
             // This variable is not actually allocated, so skip it
             // This can happen for EH clause variables that are never used
@@ -1862,8 +1862,8 @@ void InterpCompiler::CreateILVars()
     {
         // These aren't actually global vars, but we alloc them here so that they are located in predictable spots on the
         // list of vars so we can refer to them easily
-        int32_t align;
-        new (&m_pVars[index]) InterpVar(InterpTypeO, NULL, GetInterpTypeStackSize(NULL, InterpTypeO, &align));
+        int32_t dummyAlign;
+        new (&m_pVars[index]) InterpVar(InterpTypeO, NULL, GetInterpTypeStackSize(NULL, InterpTypeO, &dummyAlign));
         INTERP_DUMP("alloc EH clause var %d\n", index);
         index++;
         m_varsSize++; // When we computed m_varsSize above, we didn't account for the clause vars

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1774,7 +1774,7 @@ void InterpCompiler::CreateILVars()
     // add some starting extra space for new vars
     m_varsCapacity = m_numILVars + m_methodInfo->EHcount + 64;
     m_pVars = (InterpVar*)AllocTemporary0(m_varsCapacity * sizeof (InterpVar));
-    m_varsSize = m_numILVars + hasParamArg + (hasThisPointerShadowCopyAsParamIndex ? 1 : 0);
+    m_varsSize = m_numILVars + hasParamArg + (hasThisPointerShadowCopyAsParamIndex ? 1 : 0) + m_methodInfo->EHcount;
 
     offset = 0;
 
@@ -1799,7 +1799,7 @@ void InterpCompiler::CreateILVars()
         {
             assert(interpType == InterpTypeO);
             assert(!hasParamArg); // We don't support both a param arg and a this pointer shadow copy
-            m_paramArgIndex = m_varsSize - 1; // The param arg is stored after the IL locals in the m_pVars array
+            m_paramArgIndex = m_numILVars; // The param arg is stored after the IL locals in the m_pVars array
         }
         CreateNextLocalVar(hasThisPointerShadowCopyAsParamIndex ? m_paramArgIndex : 0, argClass, interpType, &offset);
         argIndexOffset++;
@@ -1807,7 +1807,7 @@ void InterpCompiler::CreateILVars()
 
     if (hasParamArg)
     {
-        m_paramArgIndex = m_varsSize - 1; // The param arg is stored after the IL locals in the m_pVars array
+        m_paramArgIndex = m_numILVars; // The param arg is stored after the IL locals in the m_pVars array
         CreateNextLocalVar(m_paramArgIndex, NULL, InterpTypeI, &offset);
     }
 
@@ -1866,8 +1866,8 @@ void InterpCompiler::CreateILVars()
         new (&m_pVars[index]) InterpVar(InterpTypeO, NULL, GetInterpTypeStackSize(NULL, InterpTypeO, &dummyAlign));
         INTERP_DUMP("alloc EH clause var %d\n", index);
         index++;
-        m_varsSize++; // When we computed m_varsSize above, we didn't account for the clause vars
     }
+    assert(index == m_varsSize);
 
     m_totalVarsStackSize = offset;
 }

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -364,6 +364,8 @@ struct InterpBasicBlock
     }
 };
 
+#define UNALLOCATED_VAR_OFFSET -1
+
 struct InterpVar
 {
     CORINFO_CLASS_HANDLE clsHnd;
@@ -391,7 +393,7 @@ struct InterpVar
         this->interpType = interpType;
         this->clsHnd = clsHnd;
         this->size = size;
-        offset = -1;
+        offset = UNALLOCATED_VAR_OFFSET;
         liveStart = NULL;
         bbIndex = -1;
 


### PR DESCRIPTION
- These vars were not be accounted for in m_varsSize, which caused overlaps in the assigned vars
- I also noticed that we were allocating these as global vars, and they don't need to be, so I've tweaked that as well

This was causing generalized memory corruption around several tests with EH.