### PR TITLE
Fix ResourceUpdater.Dispose()

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
@@ -331,7 +331,7 @@ namespace Microsoft.NET.HostModel
             GC.SuppressFinalize(this);
         }
 
-        public void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
@@ -325,13 +325,13 @@ namespace Microsoft.NET.HostModel
                 "Update handle is invalid. This instance may not be used for further updates");
         }
 
-        void IDisposable.Dispose()
+        public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        private void Dispose(bool disposing)
+        public void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.HostModel
     /// <summary>
     /// Provides methods for modifying the embedded native resources in a PE image.
     /// </summary>
-    public class ResourceUpdater : IDisposable
+    public sealed class ResourceUpdater : IDisposable
     {
         private readonly FileStream stream;
         private readonly PEReader _reader;
@@ -325,19 +325,21 @@ namespace Microsoft.NET.HostModel
                 "Update handle is invalid. This instance may not be used for further updates");
         }
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        public void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (disposing)
             {
                 _reader.Dispose();
                 if (!leaveOpen)
+                {
                     stream.Dispose();
+                }
             }
         }
     }

--- a/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ResourceUpdater.cs
@@ -333,10 +333,11 @@ namespace Microsoft.NET.HostModel
 
         public void Dispose(bool disposing)
         {
-            if (disposing && !leaveOpen)
+            if (disposing)
             {
                 _reader.Dispose();
-                stream.Dispose();
+                if (!leaveOpen)
+                    stream.Dispose();
             }
         }
     }


### PR DESCRIPTION
The apphost ResourceUpdater doesn't dispose of the PEReader when `leaveOpen` is true, but the `leaveOpen` should only apply to the FileStream passed to the constructor. The PEReader is not accessible from the creator and cannot be disposed of elsewhere. This causes some race conditions, especially in cases where the PEReader ends up mapping the file into memory.

Fixes https://github.com/dotnet/sdk/issues/50784