### PR TITLE
Enhance documentation on updating reference source for new APIs

### DIFF
--- a/docs/coding-guidelines/adding-api-guidelines.md
+++ b/docs/coding-guidelines/adding-api-guidelines.md
@@ -29,6 +29,12 @@ should be added to `net10.0`. [More Information on TargetFrameworks](https://lea
 
 ## Making the changes in repo
 
+**Implement your API modification**
+  - Implement your API modification in the appropriate library project.
+
+**Update the reference source**
+  - [Update the reference source](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/updating-ref-source.md) for the library.
+
 **Update tests**
   - Add new `TargetFramework` to the ```TargetFrameworks```.
   - Add new test code following [conventions](project-guidelines.md#code-file-naming-conventions) for new files to that are specific to the new target framework.

--- a/docs/coding-guidelines/adding-api-guidelines.md
+++ b/docs/coding-guidelines/adding-api-guidelines.md
@@ -33,7 +33,7 @@ should be added to `net10.0`. [More Information on TargetFrameworks](https://lea
   - Implement your API modification in the appropriate library project.
 
 **Update the reference source**
-  - [Update the reference source](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/updating-ref-source.md) for the library.
+  - [Update the reference source](updating-ref-source.md) for the library.
 
 **Update tests**
   - Add new `TargetFramework` to the ```TargetFrameworks```.

--- a/docs/workflow/building/libraries/README.md
+++ b/docs/workflow/building/libraries/README.md
@@ -263,4 +263,6 @@ If changes to the library include any API incompatibilities, calling `dotnet bui
 
 In rare cases where these are expected (e.g. updating APIs previously shipped only in preview or as experimental), the errors may be suppressed. This can be done by following the directions in the error to invoke `dotnet build` (if the project isn't packable) or `dotnet pack` (if the project is packable) with an additional `/p:ApiCompatGenerateSuppressionFile=true` argument.
 
+**Note:** If you are simply adding new APIs, you should not suppress API compatibility errors. Instead, make sure you have updated [the reference source](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/updating-ref-source.md) for the library.
+
 See https://learn.microsoft.com/dotnet/fundamentals/apicompat/overview for more details.

--- a/docs/workflow/building/libraries/README.md
+++ b/docs/workflow/building/libraries/README.md
@@ -263,6 +263,6 @@ If changes to the library include any API incompatibilities, calling `dotnet bui
 
 In rare cases where these are expected (e.g. updating APIs previously shipped only in preview or as experimental), the errors may be suppressed. This can be done by following the directions in the error to invoke `dotnet build` (if the project isn't packable) or `dotnet pack` (if the project is packable) with an additional `/p:ApiCompatGenerateSuppressionFile=true` argument.
 
-**Note:** If you are simply adding new APIs, you should not suppress API compatibility errors. Instead, make sure you have updated [the reference source](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/updating-ref-source.md) for the library.
+**Note:** If you are simply adding new APIs, you should not suppress API compatibility errors. Instead, make sure you have updated [the reference source](../../../coding-guidelines/updating-ref-source.md) for the library.
 
 See https://learn.microsoft.com/dotnet/fundamentals/apicompat/overview for more details.


### PR DESCRIPTION
Updated documentation to emphasize implementing API modifications and updating the reference source when adding new APIs, in response to [the discussion here](https://github.com/dotnet/runtime/pull/120041#discussion_r2376448928).