### PR TITLE
[clr-interp] Disable more tests that assume inlining will happen

### DIFF
--- a/src/tests/JIT/Directed/forceinlining/AttributeConflict.ilproj
+++ b/src/tests/JIT/Directed/forceinlining/AttributeConflict.ilproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Interpreter does not support Inlining -->
+    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AttributeConflict.il" />

--- a/src/tests/JIT/Directed/forceinlining/PositiveCases.ilproj
+++ b/src/tests/JIT/Directed/forceinlining/PositiveCases.ilproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Interpreter does not support Inlining -->
+    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PositiveCases.il" />

--- a/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
@@ -5,6 +5,8 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Interpreter does not support object stack allocation -->
+    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
- These tests assume that inilining happens in specific ways. Given that the interpreter does not have an interpreter, it doesn't work well.