### PR TITLE
Add in ISOFormatString & ISOShortDateFormat methods

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1748,6 +1748,18 @@ namespace System
         public string ToShortTimeString()
         {
             return DateTimeFormat.Format(this, "t", null);
+
+        }
+
+        public string ToISOFormatString()
+        {
+            return DateTimeFormat.Format(this, "u", null);
+
+        }
+        public string ToISOShortDateString()
+        {
+            return DateTimeFormat.Format(this, "u", null).Substring(0, 10);
+
         }
 
         public override string ToString()


### PR DESCRIPTION
WIP Attempt at adding 2 methods for returning the ISO8601 formats so that I can get these free downstream in the PowerShell 7.6.x release cycle

- ISOShortDate `yyyy-MM-dd` 
- ISOFormatString `yyyy-MM-dd HH:mm:ss:ms`

(not currently tested as I only did a [git partial clone](https://mslinn.com/git/600-partial-clone.html) locally)
This is first PR attempt into dotnet
Based off of [The Universal sortable u format specifier](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-universal-sortable-u-format-specifier)