### PR TITLE
include memory required to do MethodDefLookup in minidumps

### DIFF
--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3759,6 +3759,7 @@ MethodDesc::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
         {
             EX_TRY
             {
+                ilVersion.GetModule()->LookupMethodDef(ilVersion.GetMethodDef());
                 ilVersion.GetActiveNativeCodeVersion(dac_cast<PTR_MethodDesc>(this));
                 ilVersion.GetVersionId();
                 ilVersion.GetRejitState();


### PR DESCRIPTION
resolves #119921

While working on https://github.com/dotnet/runtime/pull/119965, I ran into another issue where we expect to be able to map MethodDef -> MethodDesc using the LookupMap on the module for methods on the stack in minidump scenarios. https://github.com/dotnet/runtime/pull/119111 inadvertently removed the call to `Module::LookupMethodDef` from `GetIL` where it was enumerated. As a fix, I modified `MethodDesc::EnumMemoryRegions` to explicitly enumerate it.

Sample call stack from before #119111 was merged:
```
MSCORDACCORE! DacInstantiateTypeByAddressHelper + 0x70 (0x00007ffb`5edfc870)
MSCORDACCORE! Module::LookupMethodDef + 0xA4 (0x00007ffb`5ede6244)
MSCORDACCORE! ILCodeVersion::GetIL + 0xA9 (0x00007ffb`5ee83d29)
MSCORDACCORE! MethodDesc::EnumMemoryRegions + 0x670 (0x00007ffb`5ee7b540)
MSCORDACCORE! Thread::EnumMemoryRegionsWorker + 0x8E6 (0x00007ffb`5ee745a6)
MSCORDACCORE! Thread::EnumMemoryRegions + 0x364 (0x00007ffb`5ee73c94)
MSCORDACCORE! ThreadStore::EnumMemoryRegions + 0x323 (0x00007ffb`5ee74943)
MSCORDACCORE! ClrDataAccess::EnumMemDumpAllThreadsStack + 0x580 (0x00007ffb`5ee2b040)
MSCORDACCORE! ClrDataAccess::EnumMemoryRegionsWorkerSkinny + 0x52 (0x00007ffb`5ee2c8f2)
MSCORDACCORE! ClrDataAccess::EnumMemoryRegionsWrapper + 0x25 (0x00007ffb`5ee2cdb5)
MSCORDACCORE! ClrDataAccess::EnumMemoryRegions + 0x134 (0x00007ffb`5ee2cf24)
```