### PR TITLE
[clr-interp] Fix dynamic methods

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -13409,8 +13409,28 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
             ret = portableEntryPoint;
 
 #else // !FEATURE_PORTABLE_ENTRYPOINTS
+            InterpreterPrecode* pPrecode = NULL;
             AllocMemTracker amt;
-            InterpreterPrecode* pPrecode = Precode::AllocateInterpreterPrecode(ret, ftn->GetLoaderAllocator(), &amt);
+            if (ftn->IsDynamicMethod())
+            {
+                // For LCG methods, the precode is stashed in the DynamicMethodDesc, and is shared across all future uses of the DynamicMethodDesc
+                DynamicMethodDesc* pDMD = ftn->AsDynamicMethodDesc();
+                if (pDMD->m_interpreterPrecode != NULL)
+                {
+                    pPrecode = pDMD->m_interpreterPrecode;
+                    pPrecode->GetData()->ByteCodeAddr = ret;
+                    FlushCacheForDynamicMappedStub(pPrecode, sizeof(InterpreterPrecode));
+                }
+                else
+                {
+                    pPrecode = Precode::AllocateInterpreterPrecode(ret, ftn->GetLoaderAllocator(), &amt);
+                    pDMD->m_interpreterPrecode = pPrecode;
+                }
+            }
+            else
+            {
+                pPrecode = Precode::AllocateInterpreterPrecode(ret, ftn->GetLoaderAllocator(), &amt);
+            }
             amt.SuppressRelease();
             ret = PINSTRToPCODE(pPrecode->GetEntryPoint());
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2426,6 +2426,11 @@ void MethodDesc::Reset()
     {
         *GetAddrOfNativeCodeSlot() = (PCODE)NULL;
     }
+
+#ifdef FEATURE_INTERPRETER
+    ClearInterpreterCodePointer();
+#endif
+
     _ASSERTE(!HasNativeCode());
 }
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2713,7 +2713,7 @@ protected:
 
 public:
 
-#ifdef FEATURE_INTERPRETER
+#if defined(FEATURE_INTERPRETER) && !defined(FEATURE_PORTABLE_ENTRYPOINTS)
     // Cached InterpreterPrecode instance for dynamic methods to avoid repeated allocations.
     DPTR(struct InterpreterPrecode) m_interpreterPrecode;
 #endif

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2714,6 +2714,7 @@ protected:
 public:
 
 #ifdef FEATURE_INTERPRETER
+    // Cached InterpreterPrecode instance for dynamic methods to avoid repeated allocations.
     DPTR(struct InterpreterPrecode) m_interpreterPrecode;
 #endif
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1817,6 +1817,11 @@ public:
         LIMITED_METHOD_CONTRACT;
         VolatileStore(&m_interpreterCode, interpreterCode);
     }
+    void ClearInterpreterCodePointer()
+    {
+        LIMITED_METHOD_CONTRACT;
+        VolatileStore(&m_interpreterCode, dac_cast<PTR_InterpByteCodeStart>((TADDR)NULL));
+    }
 #endif // FEATURE_INTERPRETER
 
 #ifdef _DEBUG
@@ -2707,6 +2712,11 @@ protected:
     PTR_DynamicResolver m_pResolver;
 
 public:
+
+#ifdef FEATURE_INTERPRETER
+    DPTR(struct InterpreterPrecode) m_interpreterPrecode;
+#endif
+
     enum ILStubType : DWORD
     {
         StubNotSet = 0,


### PR DESCRIPTION
- We needed to clear the interpreter code pointer
- We needed to re-use any InterpreterPrecode that are associated with a dynamic method