### PR TITLE
CmsSigner: dispose X509Chain

### DIFF
--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
@@ -503,11 +503,6 @@ namespace System.Security.Cryptography.Pkcs
                     }
                     finally
                     {
-                        for (int i = 0; i < chain.ChainElements.Count; i++)
-                        {
-                            chain.ChainElements[i].Certificate.Dispose();
-                        }
-
                         chain.Dispose();
                     }
                 }


### PR DESCRIPTION
Call Dispose for X509Chain class instance

Found by Linux Verification Center (linuxtesting.org) with SVACE.