### PR TITLE
Remove unused hashLength parameter

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.Apple.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.Apple.cs
@@ -13,9 +13,8 @@ namespace System.Security.Cryptography
             OperatingSystem.IsIOSVersionAtLeast(14) ||
             OperatingSystem.IsTvOSVersionAtLeast(14);
 
-        private static void Extract(
+        private static void ExtractCore(
             HashAlgorithmName hashAlgorithmName,
-            int hashLength,
             ReadOnlySpan<byte> ikm,
             ReadOnlySpan<byte> salt,
             Span<byte> prk)
@@ -28,7 +27,7 @@ namespace System.Security.Cryptography
             }
             else
             {
-                HKDFManagedImplementation.Extract(hashAlgorithmName, hashLength, ikm, salt, prk);
+                HKDFManagedImplementation.Extract(hashAlgorithmName, ikm, salt, prk);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.Managed.cs
@@ -5,14 +5,13 @@ namespace System.Security.Cryptography
 {
     public static partial class HKDF
     {
-        private static void Extract(
+        private static void ExtractCore(
             HashAlgorithmName hashAlgorithmName,
-            int hashLength,
             ReadOnlySpan<byte> ikm,
             ReadOnlySpan<byte> salt,
             Span<byte> prk)
         {
-            HKDFManagedImplementation.Extract(hashAlgorithmName, hashLength, ikm, salt, prk);
+            HKDFManagedImplementation.Extract(hashAlgorithmName, ikm, salt, prk);
         }
 
         private static void Expand(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.OpenSsl.cs
@@ -9,9 +9,8 @@ namespace System.Security.Cryptography
     {
         private static readonly bool s_hasOpenSslImplementation = Interop.Crypto.EvpKdfAlgs.Hkdf is not null;
 
-        private static void Extract(
+        private static void ExtractCore(
             HashAlgorithmName hashAlgorithmName,
-            int hashLength,
             ReadOnlySpan<byte> ikm,
             ReadOnlySpan<byte> salt,
             Span<byte> prk)
@@ -25,7 +24,7 @@ namespace System.Security.Cryptography
             }
             else
             {
-                HKDFManagedImplementation.Extract(hashAlgorithmName, hashLength, ikm, salt, prk);
+                HKDFManagedImplementation.Extract(hashAlgorithmName, ikm, salt, prk);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDF.cs
@@ -35,7 +35,7 @@ namespace System.Security.Cryptography
             int hashLength = Helpers.HashLength(hashAlgorithmName);
             byte[] prk = new byte[hashLength];
 
-            Extract(hashAlgorithmName, hashLength, ikm, salt, prk);
+            ExtractCore(hashAlgorithmName, ikm, salt, prk);
             return prk;
         }
 
@@ -62,7 +62,7 @@ namespace System.Security.Cryptography
                 prk = prk.Slice(0, hashLength);
             }
 
-            Extract(hashAlgorithmName, hashLength, ikm, salt, prk);
+            ExtractCore(hashAlgorithmName, ikm, salt, prk);
             return hashLength;
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDFManagedImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HKDFManagedImplementation.cs
@@ -9,9 +9,8 @@ namespace System.Security.Cryptography
 {
     internal static class HKDFManagedImplementation
     {
-        internal static void Extract(HashAlgorithmName hashAlgorithmName, int hashLength, ReadOnlySpan<byte> ikm, ReadOnlySpan<byte> salt, Span<byte> prk)
+        internal static void Extract(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> ikm, ReadOnlySpan<byte> salt, Span<byte> prk)
         {
-            Debug.Assert(Helpers.HashLength(hashAlgorithmName) == hashLength);
             int written = CryptographicOperations.HmacData(hashAlgorithmName, salt, ikm, prk);
             Debug.Assert(written == prk.Length, $"Bytes written is {written} bytes which does not match output length ({prk.Length} bytes)");
         }
@@ -87,7 +86,7 @@ namespace System.Security.Cryptography
         {
             Span<byte> prk = stackalloc byte[hashLength];
 
-            Extract(hashAlgorithmName, hashLength, ikm, salt, prk);
+            Extract(hashAlgorithmName, ikm, salt, prk);
             Expand(hashAlgorithmName, hashLength, prk, output, info);
             CryptographicOperations.ZeroMemory(prk);
         }


### PR DESCRIPTION
Follow up to https://github.com/dotnet/runtime/pull/119998#discussion_r2373242917.

We don't do anything meaningful with the `hashLength` parameter for `Extract`, so let's get rid of it.

This also changes to partial name to have a `Core` suffix since removing the parameter resulted in having the same signature as the public method.