### PR TITLE
Fix DispatchProxy Generator Issues with AssemblyLoadContexts

### DIFF
--- a/src/libraries/System.Reflection.DispatchProxy/tests/System.Reflection.DispatchProxy.Tests.csproj
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/System.Reflection.DispatchProxy.Tests.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  
+
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
@@ -12,5 +12,5 @@
   <ItemGroup>
     <ProjectReference Include="TestDependency\System.Reflection.DispatchProxy.TestDependency.csproj" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
This PR fixes two scenarios where DispatchProxy behaves incorrectly when working with multiple AssemblyLoadContexts (ALCs). 
Fixes:
1. Corrects proxy generation where the second ALC could produce a proxy bound to the wrong interface type, leading to InvalidCastException.
2. Fixes the case of creating a proxy when the base proxyType is in a non-collectable ALC (in this case the default ALC) and the interface is in a collectable ALC.

Added Unit test to prevent regressions.

Fixes: https://github.com/dotnet/runtime/issues/109398 