### PR TITLE
Make case insensitive matches respect case insensitivity on the root.

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
@@ -17,23 +17,37 @@ namespace Microsoft.Extensions.FileSystemGlobbing
     {
         private static readonly char[] DirectorySeparators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
         private readonly IEnumerable<string> _files;
+        private readonly StringComparison _comparisonType;
+
+        /// <summary>
+        /// Creates a new case-sensitive InMemoryDirectoryInfo with the root directory and files given.
+        /// </summary>
+        /// <param name="rootDir">The root directory that this FileSystem will use.</param>
+        /// <param name="files">Collection of file names. If relative paths <paramref name="rootDir"/> will be prepended to the paths.</param>
+        public InMemoryDirectoryInfo(string rootDir, IEnumerable<string>? files)
+            : this(rootDir, files, false, StringComparison.Ordinal)
+        {
+        }
 
         /// <summary>
         /// Creates a new InMemoryDirectoryInfo with the root directory and files given.
         /// </summary>
         /// <param name="rootDir">The root directory that this FileSystem will use.</param>
         /// <param name="files">Collection of file names. If relative paths <paramref name="rootDir"/> will be prepended to the paths.</param>
-        public InMemoryDirectoryInfo(string rootDir, IEnumerable<string>? files)
-            : this(rootDir, files, false)
+        /// <param name="comparisonType">The comparison type for the root directory. When files are enumerated they will be compared with the root directory using this comparison type.</param>
+        public InMemoryDirectoryInfo(string rootDir, IEnumerable<string>? files, StringComparison comparisonType)
+            : this(rootDir, files, false, comparisonType)
         {
         }
 
-        private InMemoryDirectoryInfo(string rootDir, IEnumerable<string>? files, bool normalized)
+        private InMemoryDirectoryInfo(string rootDir, IEnumerable<string>? files, bool normalized, StringComparison comparisonType)
         {
             if (string.IsNullOrEmpty(rootDir))
             {
                 throw new ArgumentNullException(nameof(rootDir));
             }
+
+            _comparisonType = comparisonType;
 
             files ??= new List<string>();
 
@@ -76,7 +90,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
 
         /// <inheritdoc />
         public override DirectoryInfoBase? ParentDirectory =>
-            new InMemoryDirectoryInfo(Path.GetDirectoryName(FullName)!, _files, true);
+            new InMemoryDirectoryInfo(Path.GetDirectoryName(FullName)!, _files, true, _comparisonType);
 
         /// <inheritdoc />
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
@@ -113,15 +127,15 @@ namespace Microsoft.Extensions.FileSystemGlobbing
 
             foreach (KeyValuePair<string, List<string>> item in dict)
             {
-                yield return new InMemoryDirectoryInfo(item.Key, item.Value, true);
+                yield return new InMemoryDirectoryInfo(item.Key, item.Value, true, _comparisonType);
             }
         }
 
-        private static bool IsRootDirectory(string rootDir, string filePath)
+        private bool IsRootDirectory(string rootDir, string filePath)
         {
             int rootDirLength = rootDir.Length;
 
-            return filePath.StartsWith(rootDir, StringComparison.Ordinal) &&
+            return filePath.StartsWith(rootDir, _comparisonType) &&
                 (rootDir[rootDirLength - 1] == Path.DirectorySeparatorChar ||
                 filePath.IndexOf(Path.DirectorySeparatorChar, rootDirLength) == rootDirLength);
         }
@@ -131,12 +145,12 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         {
             if (string.Equals(path, "..", StringComparison.Ordinal))
             {
-                return new InMemoryDirectoryInfo(Path.Combine(FullName, path), _files, true);
+                return new InMemoryDirectoryInfo(Path.Combine(FullName, path), _files, true, _comparisonType);
             }
             else
             {
                 string normPath = Path.GetFullPath(path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
-                return new InMemoryDirectoryInfo(normPath, _files, true);
+                return new InMemoryDirectoryInfo(normPath, _files, true, _comparisonType);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         /// <param name="rootDir">The root directory that this FileSystem will use.</param>
         /// <param name="files">Collection of file names. If relative paths <paramref name="rootDir"/> will be prepended to the paths.</param>
         /// <param name="comparisonType">The comparison type for the root directory. When files are enumerated they will be compared with the root directory using this comparison type.</param>
-        public InMemoryDirectoryInfo(string rootDir, IEnumerable<string>? files, StringComparison comparisonType)
+        internal InMemoryDirectoryInfo(string rootDir, IEnumerable<string>? files, StringComparison comparisonType)
             : this(rootDir, files, false, comparisonType)
         {
         }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Matcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Matcher.cs
@@ -100,8 +100,9 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         private readonly List<IPattern>? _excludePatterns;
         private readonly List<IncludeOrExcludeValue<IPattern>>? _includeOrExcludePatterns;
         private readonly PatternBuilder _builder;
-        internal readonly StringComparison _comparison;
         private readonly bool _preserveFilterOrder;
+
+        internal StringComparison ComparisonType { get; }
 
         /// <summary>
         /// Initializes an instance of <see cref="Matcher" /> using case-insensitive matching
@@ -130,7 +131,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         /// </param>
         public Matcher(StringComparison comparisonType = StringComparison.OrdinalIgnoreCase, bool preserveFilterOrder = false)
         {
-            _comparison = comparisonType;
+            ComparisonType = comparisonType;
             _builder = new PatternBuilder(comparisonType);
             _preserveFilterOrder = preserveFilterOrder;
 
@@ -199,8 +200,8 @@ namespace Microsoft.Extensions.FileSystemGlobbing
             ArgumentNullException.ThrowIfNull(directoryInfo);
 
             return _preserveFilterOrder ?
-                new MatcherContext(_includeOrExcludePatterns!, directoryInfo, _comparison).Execute() :
-                new MatcherContext(_includePatterns!, _excludePatterns!, directoryInfo, _comparison).Execute();
+                new MatcherContext(_includeOrExcludePatterns!, directoryInfo, ComparisonType).Execute() :
+                new MatcherContext(_includePatterns!, _excludePatterns!, directoryInfo, ComparisonType).Execute();
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Matcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Matcher.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         private readonly List<IPattern>? _excludePatterns;
         private readonly List<IncludeOrExcludeValue<IPattern>>? _includeOrExcludePatterns;
         private readonly PatternBuilder _builder;
-        private readonly StringComparison _comparison;
+        internal readonly StringComparison _comparison;
         private readonly bool _preserveFilterOrder;
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/MatcherExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/MatcherExtensions.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         {
             ArgumentNullException.ThrowIfNull(matcher);
 
-            return matcher.Execute(new InMemoryDirectoryInfo(rootDir, files, matcher._comparison));
+            return matcher.Execute(new InMemoryDirectoryInfo(rootDir, files, matcher.ComparisonType));
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/MatcherExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/MatcherExtensions.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         {
             ArgumentNullException.ThrowIfNull(matcher);
 
-            return matcher.Execute(new InMemoryDirectoryInfo(rootDir, files));
+            return matcher.Execute(new InMemoryDirectoryInfo(rootDir, files, matcher._comparison));
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -932,7 +932,6 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             Assert.Equal(expectedSubPaths.Length, patternMatchingResult.Files.Count());
         }
 
-
         [Theory]
         [InlineData(@"C:\this\example\root", @"C:\this\EXAMPLE\root", "**/*", new[] { "some/test/file.txt" })]
         [InlineData(@"C:\this\EXAMPLE\root", @"C:\this\example\root", "**/*", new[] { "some/test/file.txt" })]

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -901,5 +901,51 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
                 Assert.True(matcher.Match([$"../{cwdFolderName}/{file}"]).HasMatches);
             }
         }
+
+        [Theory]
+        [InlineData(@"C:\this\example\root", @"C:\this\EXAMPLE\root", "**/*", new[] { "some/test/file.txt" })]
+        [InlineData(@"C:\this\example\root", @"C:\this\example\root", "**/*", new[] { "some/test/file.txt" })]
+        [InlineData(@"C:\this\EXAMPLE\root", @"C:\this\example\root", "**/*", new[] { "some/test/file.txt" })]
+        public void VerifyFiles_InMemory_HasCaseInsensitiveRootMatches(string matchRoot, string filesRoot, string pattern, string[] expectedSubPaths)
+        {
+            Matcher matcher = new(StringComparison.OrdinalIgnoreCase);
+            matcher.AddInclude(pattern);
+
+            PatternMatchingResult patternMatchingResult = matcher.Match(matchRoot,
+                expectedSubPaths.Select(expectedSubPath => Path.Combine(filesRoot, expectedSubPath)));
+
+            Assert.True(patternMatchingResult.HasMatches);
+            Assert.Equal(expectedSubPaths.Length, patternMatchingResult.Files.Count());
+        }
+
+        [Theory]
+        [InlineData(@"C:\this\example\root", @"C:\this\example\root", "**/*", new[] { "some/test/file.txt" })]
+        public void VerifyFiles_InMemory_HasCaseSensitiveRootMatches(string matchRoot, string filesRoot, string pattern, string[] expectedSubPaths)
+        {
+            Matcher matcher = new(StringComparison.Ordinal);
+            matcher.AddInclude(pattern);
+
+            PatternMatchingResult patternMatchingResult = matcher.Match(matchRoot,
+                expectedSubPaths.Select(expectedSubPath => Path.Combine(filesRoot, expectedSubPath)));
+
+            Assert.True(patternMatchingResult.HasMatches);
+            Assert.Equal(expectedSubPaths.Length, patternMatchingResult.Files.Count());
+        }
+
+
+        [Theory]
+        [InlineData(@"C:\this\example\root", @"C:\this\EXAMPLE\root", "**/*", new[] { "some/test/file.txt" })]
+        [InlineData(@"C:\this\EXAMPLE\root", @"C:\this\example\root", "**/*", new[] { "some/test/file.txt" })]
+        public void VerifyFiles_InMemory_HasCaseSensitiveRootMisses(string matchRoot, string filesRoot, string pattern, string[] expectedSubPaths)
+        {
+            Matcher matcher = new(StringComparison.Ordinal);
+            matcher.AddInclude(pattern);
+
+            PatternMatchingResult patternMatchingResult = matcher.Match(matchRoot,
+                expectedSubPaths.Select(expectedSubPath => Path.Combine(filesRoot, expectedSubPath)));
+
+            Assert.False(patternMatchingResult.HasMatches);
+            Assert.Equal(0, patternMatchingResult.Files.Count());
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -903,9 +903,9 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         }
 
         [Theory]
-        [InlineData(@"C:\this\example\root", @"C:\this\EXAMPLE\root", "**/*", new[] { "some/test/file.txt" })]
-        [InlineData(@"C:\this\example\root", @"C:\this\example\root", "**/*", new[] { "some/test/file.txt" })]
-        [InlineData(@"C:\this\EXAMPLE\root", @"C:\this\example\root", "**/*", new[] { "some/test/file.txt" })]
+        [InlineData(@"/this/example/root", @"/this/EXAMPLE/root", "**/*", new[] { "some/test/file.txt" })]
+        [InlineData(@"/this/example/root", @"/this/example/root", "**/*", new[] { "some/test/file.txt" })]
+        [InlineData(@"/this/EXAMPLE/root", @"/this/example/root", "**/*", new[] { "some/test/file.txt" })]
         public void VerifyFiles_InMemory_HasCaseInsensitiveRootMatches(string matchRoot, string filesRoot, string pattern, string[] expectedSubPaths)
         {
             Matcher matcher = new(StringComparison.OrdinalIgnoreCase);
@@ -919,7 +919,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         }
 
         [Theory]
-        [InlineData(@"C:\this\example\root", @"C:\this\example\root", "**/*", new[] { "some/test/file.txt" })]
+        [InlineData(@"/this/example/root", @"/this/example/root", "**/*", new[] { "some/test/file.txt" })]
         public void VerifyFiles_InMemory_HasCaseSensitiveRootMatches(string matchRoot, string filesRoot, string pattern, string[] expectedSubPaths)
         {
             Matcher matcher = new(StringComparison.Ordinal);
@@ -933,8 +933,8 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         }
 
         [Theory]
-        [InlineData(@"C:\this\example\root", @"C:\this\EXAMPLE\root", "**/*", new[] { "some/test/file.txt" })]
-        [InlineData(@"C:\this\EXAMPLE\root", @"C:\this\example\root", "**/*", new[] { "some/test/file.txt" })]
+        [InlineData(@"/this/example/root", @"/this/EXAMPLE/root", "**/*", new[] { "some/test/file.txt" })]
+        [InlineData(@"/this/EXAMPLE/root", @"/this/example/root", "**/*", new[] { "some/test/file.txt" })]
         public void VerifyFiles_InMemory_HasCaseSensitiveRootMisses(string matchRoot, string filesRoot, string pattern, string[] expectedSubPaths)
         {
             Matcher matcher = new(StringComparison.Ordinal);


### PR DESCRIPTION
This change addresses #119117 by making the `Matcher` match root directories case-insensitively when the Matcher is configured to be case-insensitive.

I'm not exactly sure this is the right way to go about this so I'm very open to feedback. The tack I took was to try to limit breaking changes while also fixing the bug.

One problem I hit was that the offending method on the `Matcher` is actually an extension method. That means it does not have access to the private `StringComparison` type on the matcher it is extending. I chose to make it a get-only internal property instead of moving the extension method into the matcher type in order to avoid changing the interface.

Another potential issue is that the `InMemoryDirectoryInfo` is still case-sensitive by default where the typical pattern in this repository has been to make things case-insensitive. Again this was just to avoid any breaking changes.