### PR TITLE
[clr-interp] Fix interop calls when PInvokePrecodeImport thunks are involved

### DIFF
--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -42,14 +42,14 @@ struct CallStubHeader
         LIMITED_METHOD_CONTRACT;
 
         _ASSERTE(target != 0);
-        Routines[NumRoutines - 1] = target;
+        VolatileStore(&Routines[NumRoutines - 1], target);
     }
 
     PCODE GetTarget()
     {
         LIMITED_METHOD_CONTRACT;
 
-        return Routines[NumRoutines - 1];
+        return VolatileLoadWithoutBarrier(&Routines[NumRoutines - 1]);
     }
 
     size_t GetSize()

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -160,7 +160,7 @@ void InvokeManagedMethod(MethodDesc *pMD, int8_t *pArgs, int8_t *pRet, PCODE tar
             MethodDesc *pMDTarget = GetTargetPInvokeMethodDesc(target);
             MethodDesc *pMDHeaderTarget = GetTargetPInvokeMethodDesc(pHeader->GetTarget());
 
-            _ASSERTE(pMDTarget == NULL || pMDHeaderTarget == NULL);
+            _ASSERTE(pMDTarget == NULL || pMDHeaderTarget == NULL || pMDTarget == pMDHeaderTarget);
             _ASSERTE(pMDTarget == NULL || pMDTarget == pMD);
             _ASSERTE(pMDHeaderTarget == NULL || pMDHeaderTarget == pMD);
 #endif // DEBUG

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -151,16 +151,17 @@ void InvokeManagedMethod(MethodDesc *pMD, int8_t *pArgs, int8_t *pRet, PCODE tar
 
     if (target != (PCODE)NULL)
     {
-        if (target != pHeader->GetTarget())
+        PCODE headerTarget = pHeader->GetTarget();
+        if (target != headerTarget)
         {
 #ifdef DEBUG
             // For pinvokes we may have a PInvokeImportPrecode as a pointer, and need to use passed in target preferentially
             // Since on multiple threads we may be racing to use this method, it is possible that the current target could be
             // the PInvokeImportPrecode or the actual target method, so we should allow either of them to match.
             MethodDesc *pMDTarget = GetTargetPInvokeMethodDesc(target);
-            MethodDesc *pMDHeaderTarget = GetTargetPInvokeMethodDesc(pHeader->GetTarget());
+            MethodDesc *pMDHeaderTarget = GetTargetPInvokeMethodDesc(headerTarget);
 
-            _ASSERTE(pMDTarget == NULL || pMDHeaderTarget == NULL || pMDTarget == pMDHeaderTarget);
+            _ASSERTE(pMDTarget == NULL || pMDHeaderTarget == NULL);
             _ASSERTE(pMDTarget == NULL || pMDTarget == pMD);
             _ASSERTE(pMDHeaderTarget == NULL || pMDHeaderTarget == pMD);
 #endif // DEBUG

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -104,6 +104,33 @@ static CallStubHeader *UpdateCallStubForMethod(MethodDesc *pMD, PCODE target)
     return header;
 }
 
+MethodDesc* GetTargetPInvokeMethodDesc(PCODE target)
+{
+    CONTRACTL
+    {
+        THROWS;
+        MODE_ANY;
+        PRECONDITION(CheckPointer((void*)target));
+    }
+    CONTRACTL_END
+
+    GCX_PREEMP();
+
+    RangeSection * pRS = ExecutionManager::FindCodeRange(target, ExecutionManager::GetScanFlags());
+    if (pRS != NULL && pRS->_flags & RangeSection::RANGE_SECTION_RANGELIST)
+    {
+        if (pRS->_pRangeList->GetCodeBlockKind() == STUB_CODE_BLOCK_STUBPRECODE)
+        {
+            if (((StubPrecode*)target)->GetType() == PRECODE_PINVOKE_IMPORT)
+            {
+                return dac_cast<PTR_MethodDesc>(((PInvokeImportPrecode*)target)->GetMethodDesc());
+            }
+        }
+    }
+
+    return NULL;
+}
+
 void InvokeManagedMethod(MethodDesc *pMD, int8_t *pArgs, int8_t *pRet, PCODE target)
 {
     CONTRACTL
@@ -124,7 +151,21 @@ void InvokeManagedMethod(MethodDesc *pMD, int8_t *pArgs, int8_t *pRet, PCODE tar
 
     if (target != (PCODE)NULL)
     {
-        _ASSERTE(pHeader->GetTarget() == target);
+        if (target != pHeader->GetTarget())
+        {
+#ifdef DEBUG
+            // For pinvokes we may have a PInvokeImportPrecode as a pointer, and need to use passed in target preferentially
+            // Since on multiple threads we may be racing to use this method, it is possible that the current target could be
+            // the PInvokeImportPrecode or the actual target method, so we should allow either of them to match.
+            MethodDesc *pMDTarget = GetTargetPInvokeMethodDesc(target);
+            MethodDesc *pMDHeaderTarget = GetTargetPInvokeMethodDesc(pHeader->GetTarget());
+
+            _ASSERTE(pMDTarget == NULL || pMDHeaderTarget == NULL);
+            _ASSERTE(pMDTarget == NULL || pMDTarget == pMD);
+            _ASSERTE(pMDHeaderTarget == NULL || pMDHeaderTarget == pMD);
+#endif // DEBUG
+            pHeader->SetTarget(target);
+        }
     }
 
     pHeader->Invoke(pHeader->Routines, pArgs, pRet, pHeader->TotalStackSize);


### PR DESCRIPTION
- Handle the case where the dispatch may get upgraded from a PInvokeImportThunk to a direct function pointer