### PR TITLE
Fix error SC2068 in shell scripts

### DIFF
--- a/src/mono/mono/arch/riscv/riscv-codegen-test.sh
+++ b/src/mono/mono/arch/riscv/riscv-codegen-test.sh
@@ -8,7 +8,7 @@ else
 	bits=32
 fi
 
-gcc -I../../.. -I../../eglib riscv-codegen-test.c -o riscv-codegen-test $@ || exit 1
+gcc -I../../.. -I../../eglib riscv-codegen-test.c -o riscv-codegen-test "$@" || exit 1
 ./riscv-codegen-test > riscv-codegen.s || exit 1
 riscv64-unknown-linux-gnu-as riscv-codegen.s -o riscv-codegen.elf || exit 1
 riscv64-unknown-linux-gnu-objdump -D -M numeric,no-aliases riscv-codegen.elf > riscv-codegen.res || exit 1

--- a/src/native/libs/verify-entrypoints.sh
+++ b/src/native/libs/verify-entrypoints.sh
@@ -35,7 +35,7 @@ for line in $(<$2); do
   fi
 done
 
-diffList=$(echo -n ${entriesList[@]} ${dllList[@]} | tr " " "\n" | sort | uniq -u)
+diffList=$(echo -n "${entriesList[@]}" "${dllList[@]}" | tr " " "\n" | sort | uniq -u)
 
 if [ -n "$diffList" ]; then
   echo "ERROR: $2 file did not match entries exported from $1" >&2

--- a/src/tests/Common/scripts/bringup_runtest.sh
+++ b/src/tests/Common/scripts/bringup_runtest.sh
@@ -527,7 +527,7 @@ function read_array {
             theArray[${#theArray[@]}]=$line
         fi
     done < "$1"
-    echo ${theArray[@]}
+    echo "${theArray[@]}"
 }
 
 function load_unsupported_tests {


### PR DESCRIPTION
Fix SC2068 (error): Double quote array expansions to avoid re-splitting elements.

https://www.shellcheck.net/wiki/SC2068
