### PR TITLE
Revert "Add a flag to hostfxr_resolve_sdk2_flags_t to silence error messages"

### DIFF
--- a/docs/design/features/hosting-layer-apis.md
+++ b/docs/design/features/hosting-layer-apis.md
@@ -61,7 +61,6 @@ If the application is successfully executed, this value will return the exit cod
 enum hostfxr_resolve_sdk2_flags_t
 {
     disallow_prerelease = 0x1,
-    do_not_print_errors = 0x2,
 };
 
 enum hostfxr_resolve_sdk2_result_key_t

--- a/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostFXR.cs
+++ b/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostFXR.cs
@@ -16,7 +16,6 @@ namespace HostApiInvokerApp
             internal enum hostfxr_resolve_sdk2_flags_t : int
             {
                 disallow_prerelease = 0x1,
-                do_not_print_errors = 0x2,
             }
 
             internal enum hostfxr_resolve_sdk2_result_key_t : int

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -159,30 +159,6 @@ namespace HostActivation.Tests
                 .And.HaveStdOutContaining($"{api} data:[{expectedData}]");
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Hostfxr_resolve_sdk2_NoGlobalJson_NoWriteToStdResolvesTheSame(bool do_not_print_errors)
-        {
-            // With no global.json and disallowing previews, pick latest non-preview
-
-            var f = sharedTestState.SdkAndFrameworkFixture;
-            string expectedData = string.Join(';', new[]
-            {
-                ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "1.2.300")),
-                ("global_json_state", "not_found"),
-            });
-
-            string api = ApiNames.hostfxr_resolve_sdk2;
-            string flags = do_not_print_errors ? "disallow_prerelease,do_not_print_errors" : "disallow_prerelease";
-            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, NoGlobalJson, flags)
-                .EnableTracingAndCaptureOutputs()
-                .Execute()
-                .Should().Pass()
-                .And.ReturnStatusCode(api, Constants.ErrorCode.Success)
-                .And.HaveStdOutContaining($"{api} data:[{expectedData}]");
-        }
-
         [Fact]
         public void Hostfxr_resolve_sdk2_GlobalJson_DisallowPrerelease()
         {
@@ -323,32 +299,6 @@ namespace HostActivation.Tests
                     .And.ReturnStatusCode(api, Constants.ErrorCode.SdkResolveFailure)
                     .And.HaveStdOutContaining($"{api} data:[{expectedData}]");
             }
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Hostfxr_resolve_sdk2_FailsToResolve_NoWriteToStd(bool do_not_print_errors)
-        {
-            var f = sharedTestState.SdkAndFrameworkFixture;
-            string api = ApiNames.hostfxr_resolve_sdk2;
-            using TestArtifact workingDir = TestArtifact.Create(nameof(Hostfxr_resolve_sdk2_FailsToResolve_NoWriteToStd));
-
-            string invalidVersion = "1.2.0"; // feature band < 1 triggers __invalid_data_no_fallback
-            GlobalJson.CreateWithVersion(workingDir.Location, invalidVersion);
-
-            var result = TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, do_not_print_errors ? "do_not_print_errors" : "0")
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute();
-
-            result.Should().Pass()
-                .And.ReturnStatusCode(api, Constants.ErrorCode.SdkResolveFailure);
-
-            if (do_not_print_errors)
-                result.StdErr.Should().BeEmpty();
-            else
-                result.StdErr.Should().Contain("A compatible .NET SDK was not found.");
         }
 
         [Fact]

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -166,7 +166,6 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk(
 enum hostfxr_resolve_sdk2_flags_t : int32_t
 {
     disallow_prerelease = 0x1,
-    do_not_print_errors = 0x2,
 };
 
 enum class hostfxr_resolve_sdk2_result_key_t : int32_t
@@ -219,8 +218,6 @@ namespace
 //         disallow_prerelease (0x1)
 //           do not allow resolution to return a prerelease SDK version
 //           unless  prerelease version was specified via global.json.
-//         do_not_print_errors (0x2)
-//           do not write any error messages to stderr.
 //
 //   result
 //      Callback invoked to return values. It can be invoked more
@@ -285,9 +282,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk2(
         working_dir,
         (flags & hostfxr_resolve_sdk2_flags_t::disallow_prerelease) == 0);
 
-    auto resolved_sdk_dir = resolver.resolve(
-        exe_dir,
-        (flags & hostfxr_resolve_sdk2_flags_t::do_not_print_errors) == 0);
+    auto resolved_sdk_dir = resolver.resolve(exe_dir);
     if (!resolved_sdk_dir.empty())
     {
         result(


### PR DESCRIPTION
This reverts commit fc5252eed30e95e218cfe16f6f5d0c750a8f8cb6 (https://github.com/dotnet/runtime/pull/119729). It isn't necessary after sdk reverted the telemetry change, and it adds unnecessarily to the API. The best workaround for similar functionality would be to use `hostfxr_set_error_writer` to swallow the messages before the call to `hostfxr_resolve_sdk2`.