### PR TITLE
Don't try and instrument methods that are not tiering eligible

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12453,8 +12453,17 @@ HRESULT CEEJitInfo::allocPgoInstrumentationBySchema(
     JIT_TO_EE_TRANSITION();
 
 #ifdef FEATURE_PGO
+
+    // Only try instrumenting tiering-eligible methods
     MethodDesc* pMD = (MethodDesc*)ftnHnd;
-    hr = PgoManager::allocPgoInstrumentationBySchema(pMD, pSchema, countSchemaItems, pInstrumentationData);
+    if (pMD->IsEligibleForTieredCompilation())
+    {
+        hr = PgoManager::allocPgoInstrumentationBySchema(pMD, pSchema, countSchemaItems, pInstrumentationData);
+    }
+    else
+    {
+        hr = E_NOTIMPL;
+    }
 #else
     _ASSERTE(!"allocMethodBlockCounts not implemented on CEEJitInfo!");
     hr = E_NOTIMPL;


### PR DESCRIPTION
Under certain stress modes the JIT may enable PGO instrumentation even if the VM has not asked for it. On the VM side, block these attempts for methods that are not tiering eligible by ensuring that schema allocation requests immediately fail.

Fixes #120237