### PR TITLE
Remove an STJ deep nested object test causing occasional failures

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.WriteTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.WriteTests.cs
@@ -335,8 +335,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(2, true, false)]
         [InlineData(2, false, false)]
         [InlineData(4, false, false)]
-        [InlineData(8, false, false)]
-        [InlineData(16, false, false)] // This results a reader\writer depth of 324 which currently works on all test platforms.
+        [InlineData(8, false, false)] // Greater depths have caused failures on some test machine configurations due to memory constraints
         public async Task DeepNestedJsonFileTest(int depthFactor, bool ignoreNull, bool writeIndented)
         {
             const int ListLength = 10;


### PR DESCRIPTION
We've seen some occurrences of this particular test causing stack overflows on test machines. The test was pushing the limits of previous test machine configurations, but it wasn't adding any material value beyond the other test scenarios.

Once merged, this change will be backported to all servicing branches to eliminate the test failure noise.