### PR TITLE
[browser] Expect fingerprint in dotnet.native.wasm asset identity

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -162,7 +162,7 @@
     <MicrosoftExtensionsLoggingVersion>3.1.7</MicrosoftExtensionsLoggingVersion>
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- sdk version, for testing workloads -->
-    <SdkVersionForWorkloadTesting>10.0.100-rc.2.25476.107</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>10.0.0-rtm.25479.115</SdkVersionForWorkloadTesting>
     <EmsdkPackageVersion>10.0.0-preview.7.25359.101</EmsdkPackageVersion>
     <NodePackageVersion>$(runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion)</NodePackageVersion>
     <!-- The package path for python in src/mono/mono.proj needs to be updated if this changes-->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -162,7 +162,7 @@
     <MicrosoftExtensionsLoggingVersion>3.1.7</MicrosoftExtensionsLoggingVersion>
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- sdk version, for testing workloads -->
-    <SdkVersionForWorkloadTesting>10.0.100-rtm.25479.115</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>$(MicrosoftDotNetApiCompatTaskVersion)</SdkVersionForWorkloadTesting>
     <EmsdkPackageVersion>10.0.0-preview.7.25359.101</EmsdkPackageVersion>
     <NodePackageVersion>$(runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion)</NodePackageVersion>
     <!-- The package path for python in src/mono/mono.proj needs to be updated if this changes-->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -162,7 +162,7 @@
     <MicrosoftExtensionsLoggingVersion>3.1.7</MicrosoftExtensionsLoggingVersion>
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- sdk version, for testing workloads -->
-    <SdkVersionForWorkloadTesting>$(MicrosoftDotNetApiCompatTaskVersion)</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>10.0.100-rc.2.25476.107</SdkVersionForWorkloadTesting>
     <EmsdkPackageVersion>10.0.0-preview.7.25359.101</EmsdkPackageVersion>
     <NodePackageVersion>$(runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion)</NodePackageVersion>
     <!-- The package path for python in src/mono/mono.proj needs to be updated if this changes-->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -162,7 +162,7 @@
     <MicrosoftExtensionsLoggingVersion>3.1.7</MicrosoftExtensionsLoggingVersion>
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- sdk version, for testing workloads -->
-    <SdkVersionForWorkloadTesting>10.0.0-rtm.25479.115</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>10.0.100-rtm.25479.115</SdkVersionForWorkloadTesting>
     <EmsdkPackageVersion>10.0.0-preview.7.25359.101</EmsdkPackageVersion>
     <NodePackageVersion>$(runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion)</NodePackageVersion>
     <!-- The package path for python in src/mono/mono.proj needs to be updated if this changes-->

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
@@ -324,9 +324,9 @@ public class ComputeWasmPublishAssets : Task
 
         static bool IsDotNetWasm(string key)
         {
-            var name = Path.GetFileName(key);
-            return string.Equals("dotnet.native.wasm", name, StringComparison.Ordinal)
-                || string.Equals("dotnet.wasm", name, StringComparison.Ordinal);
+            var fileName = Path.GetFileName(key);
+            return (fileName.StartsWith("dotnet.native", StringComparison.Ordinal) && fileName.EndsWith(".wasm", StringComparison.Ordinal))
+                || string.Equals("dotnet.wasm", fileName, StringComparison.Ordinal);
         }
     }
 


### PR DESCRIPTION
In https://github.com/dotnet/sdk/pull/50949 we changed the identity of StaticWebAsset to contain fingerprint (`dotnet.native.wasm` -> `dotnet.native.FP.wasm`). This PR accommodates this when checking for `dotnet.native.wasm` asset from build.

The SDK change didn't flown to the runtime yet, and so Wasm.Build.Tests won't test it yet.

Contributes to https://github.com/dotnet/sdk/issues/51045