### PR TITLE
Fix incorrect cast_class initialization for primitive types due to init order

### DIFF
--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -605,15 +605,15 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		switch (m_class_get_byval_arg (klass)->type) {
 			case MONO_TYPE_I1:
 				if (mono_defaults.byte_class)
-					klass->cast_class = mono_defaults.byte_class;
+					mono_defaults.byte_class->cast_class = klass;
 				break;
 			case MONO_TYPE_U1:
 				if (mono_defaults.sbyte_class)
-					mono_defaults.sbyte_class = klass;
+					klass->cast_class = mono_defaults.sbyte_class;
 				break;
 			case MONO_TYPE_I2:
 				if (mono_defaults.uint16_class)
-					mono_defaults.uint16_class = klass;
+					mono_defaults.uint16_class->cast_class = klass;
 				break;
 			case MONO_TYPE_U2:
 				if (mono_defaults.int16_class)
@@ -621,7 +621,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 				break;
 			case MONO_TYPE_I4:
 				if (mono_defaults.uint32_class)
-					mono_defaults.uint32_class = klass;
+					mono_defaults.uint32_class->cast_class = klass;
 				break;
 			case MONO_TYPE_U4:
 				if (mono_defaults.int32_class)
@@ -629,7 +629,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 				break;
 			case MONO_TYPE_I8:
 				if (mono_defaults.uint64_class)
-					mono_defaults.uint64_class = klass;
+					mono_defaults.uint64_class->cast_class = klass;
 				break;
 			case MONO_TYPE_U8:
 				if (mono_defaults.int64_class)


### PR DESCRIPTION
Ensure correct cast_class assignment for primitive types (e.g., byte/sbyte, uint16/int16) regardless of initialization order.
This change guarantees that byte->cast_class points to sbyte, sbyte->cast_class points to itself, and similarly for other types.
Prevents global default type pointers and cast_class pointers from becoming inconsistent due to type initialization order.
