### PR TITLE
[mono][aot] Increase the max symbol size

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -638,7 +638,7 @@ is_direct_pinvoke_enabled (const MonoAotCompile *acfg)
 
 /* Wrappers around the image writer functions */
 
-#define MAX_SYMBOL_SIZE 256
+#define MAX_SYMBOL_SIZE 1024
 
 #if defined(TARGET_WIN32) && defined(TARGET_X86)
 static const char *


### PR DESCRIPTION
Long symbol names were truncated, leading to duplicate names in the generated assembly file. This was making the compiler fail due to duplicate symbol names.