### PR TITLE
Add missing TlsAlertMessage members

### DIFF
--- a/src/libraries/Common/src/System/Net/Security/TlsAlertMessage.cs
+++ b/src/libraries/Common/src/System/Net/Security/TlsAlertMessage.cs
@@ -12,6 +12,7 @@ namespace System.Net.Security
         RecordOverflow = 22, // error
         DecompressionFail = 30, // error
         HandshakeFailure = 40, // error
+        NoCertificate = 41, // reserved - Used in SSLv3 but not in TLS
         BadCertificate = 42, // warning or error
         UnsupportedCert = 43, // warning or error
         CertificateRevoked = 44, // warning or error
@@ -22,12 +23,24 @@ namespace System.Net.Security
         AccessDenied = 49, // error
         DecodeError = 50, // error
         DecryptError = 51, // error
+        TooManyCidsRequested = 52, // error
         ExportRestriction = 60, // reserved
         ProtocolVersion = 70, // error
-        InsuffientSecurity = 71, // error
+        InsufficientSecurity = 71, // error
         InternalError = 80, // error
+        InappropriateFallback = 86, // error
         UserCanceled = 90, // warning or error
         NoRenegotiation = 100, // warning
-        UnsupportedExt = 110, // error
+        MissingExtension = 109, // error
+        UnsupportedExtension = 110, // error
+        CertificateUnobtainable = 111, // reserved - Used in TLS versions prior to 1.3
+        UnrecognizedName = 112, // error
+        BadCertificateStatusResponse = 113, // error
+        BadCertificateHashValue = 114, // reserved - Used in TLS versions prior to 1.3
+        UnknownPskIdentity = 115, // error
+        CertificateRequired = 116, // error
+        GeneralError = 117, // error
+        NoApplicationProtocol = 120, // error
+        EchRequired = 121, // error
     }
 }

--- a/src/libraries/System.Net.Security/tests/UnitTests/TlsAlertsMatchWindowsInterop.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/TlsAlertsMatchWindowsInterop.cs
@@ -32,11 +32,11 @@ namespace System.Net.Security.Tests
             Assert.Equal((int)TlsAlertMessage.DecryptError, Interop.SChannel.TLS1_ALERT_DECRYPT_ERROR);
             Assert.Equal((int)TlsAlertMessage.ExportRestriction, Interop.SChannel.TLS1_ALERT_EXPORT_RESTRICTION);
             Assert.Equal((int)TlsAlertMessage.ProtocolVersion, Interop.SChannel.TLS1_ALERT_PROTOCOL_VERSION);
-            Assert.Equal((int)TlsAlertMessage.InsuffientSecurity, Interop.SChannel.TLS1_ALERT_INSUFFIENT_SECURITY);
+            Assert.Equal((int)TlsAlertMessage.InsufficientSecurity, Interop.SChannel.TLS1_ALERT_INSUFFIENT_SECURITY);
             Assert.Equal((int)TlsAlertMessage.InternalError, Interop.SChannel.TLS1_ALERT_INTERNAL_ERROR);
             Assert.Equal((int)TlsAlertMessage.UserCanceled, Interop.SChannel.TLS1_ALERT_USER_CANCELED);
             Assert.Equal((int)TlsAlertMessage.NoRenegotiation, Interop.SChannel.TLS1_ALERT_NO_RENEGOTIATION);
-            Assert.Equal((int)TlsAlertMessage.UnsupportedExt, Interop.SChannel.TLS1_ALERT_UNSUPPORTED_EXT);
+            Assert.Equal((int)TlsAlertMessage.UnsupportedExtension, Interop.SChannel.TLS1_ALERT_UNSUPPORTED_EXT);
         }
     }
 }


### PR DESCRIPTION
This would improve error messages in cases like https://github.com/dotnet/runtime/issues/120257

```

    System.Net.Http.Functional.Tests.HttpClientHandlerTest_Http3.Public_Interop_ExactVersion_BufferContent_Success(uri: "https://quic.nginx.org/") [FAIL]
      System.Net.Http.HttpRequestException : Authentication failed because the remote party sent a TLS alert: '112'. (quic.nginx.org:443)
      ---- System.Security.Authentication.AuthenticationException : Authentication failed because the remote party sent a TLS alert: '112'.
```

After this PR, it would read TLS alert 'UnrecognizedName'.