### PR TITLE
Clarify that all byref-like structs are zeroed in runtime async spec

### DIFF
--- a/docs/design/specs/runtime-async.md
+++ b/docs/design/specs/runtime-async.md
@@ -40,7 +40,7 @@ Async methods support suspension using one of the following methods:
           public static void AwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion;
           [MethodImpl(MethodImplOptions.Async)]
           public static void UnsafeAwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion;
-          
+
           [MethodImpl(MethodImplOptions.Async)]
           public static void Await(Task task);
           [MethodImpl(MethodImplOptions.Async)]
@@ -64,7 +64,7 @@ Async methods support suspension using one of the following methods:
 
 These methods are only legal to call inside async methods. The `...AwaitAwaiter` methods will have semantics analogous to the current `AsyncTaskMethodBuilder.AwaitOnCompleted/AwaitUnsafeOnCompleted` methods. After calling either method, it can be presumed that the task or awaiter has completed. The `Await` methods perform suspension like the `...AwaitAwaiter` methods, but are optimized for calling on the return value of a call to an async method. To achieve maximum performance, the IL sequence of two `call` instructions -- one to the async method and immediately one to the `Await` method -- should be preferred.
 
-Local variables used across suspension points are considered "hoisted." That is, only "hoisted" local variables will have their state preserved after returning from a suspension. By-ref variables may not be hoisted across suspension points, and any read of a by-ref variable after a suspension point will produce null. Structs containing by-ref variables will also not be hoisted across suspension points and will have their default value after a suspension point.
+Local variables used across suspension points are considered "hoisted." That is, only "hoisted" local variables will have their state preserved after returning from a suspension. By-ref variables may not be hoisted across suspension points, and any read of a by-ref variable after a suspension point will produce null. Byref-like structs will also not be hoisted across suspension points and will have their default value after a suspension point.
 In the same way, pinning locals may not be "hoisted" across suspension points and will have `null` value after a suspension point.
 
 Async methods have some temporary restrictions with may be lifted later:


### PR DESCRIPTION
We agreed on zeroing all byref-like structs [here](https://github.com/dotnet/runtime/pull/112918#discussion_r2002130073), so clarify that in the spec.