### PR TITLE
[clr-interp] StackMark handling for interpreter

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1296,10 +1296,30 @@ bool SystemDomain::IsReflectionInvocationMethod(MethodDesc* pMeth)
 
 struct CallersDataWithStackMark
 {
-    StackCrawlMark* stackMark;
-    BOOL foundMe;
-    MethodDesc* pFoundMethod;
-    MethodDesc* pPrevMethod;
+    CallersDataWithStackMark(StackCrawlMark* mark, PTR_Thread thread) :
+        stackMark(mark)
+#ifdef FEATURE_INTERPRETER
+        // Since the interpreter has its own stack, we need to get a pointer which can be compared on the real
+        // stack so that IsInCalleesFrames can work correctly.
+        , stackMarkOnOSStack(ConvertStackMarkToPointerOnOSStack(thread, mark))
+#endif
+    {
+    }
+    StackCrawlMark* const stackMark;
+#ifdef FEATURE_INTERPRETER
+    PTR_VOID stackMarkOnOSStack;
+#endif
+    PTR_VOID GetStackMarkPointerToCheckAgainstStack()
+    {
+#ifdef FEATURE_INTERPRETER
+        return stackMarkOnOSStack;
+#else
+        return (PTR_VOID)stackMark;
+#endif
+    }
+    BOOL foundMe = FALSE;
+    MethodDesc* pFoundMethod = NULL;
+    MethodDesc* pPrevMethod = NULL;
 };
 
 /*static*/
@@ -1320,11 +1340,10 @@ Module* SystemDomain::GetCallersModule(StackCrawlMark* stackMark)
 
     GCX_COOP();
 
-    CallersDataWithStackMark cdata;
-    ZeroMemory(&cdata, sizeof(CallersDataWithStackMark));
-    cdata.stackMark = stackMark;
+    PTR_Thread pThread = GetThread();
+    CallersDataWithStackMark cdata(stackMark, pThread);
 
-    GetThread()->StackWalkFrames(CallersMethodCallbackWithStackMark, &cdata, FUNCTIONSONLY | LIGHTUNWIND);
+    pThread->StackWalkFrames(CallersMethodCallbackWithStackMark, &cdata, FUNCTIONSONLY | LIGHTUNWIND);
 
     if(cdata.pFoundMethod) {
         return cdata.pFoundMethod->GetModule();
@@ -1369,7 +1388,7 @@ StackWalkAction SystemDomain::CallersMethodCallbackWithStackMark(CrawlFrame* pCf
     CallersDataWithStackMark* pCaller = (CallersDataWithStackMark*) data;
     if (pCaller->stackMark)
     {
-        if (!pCf->IsInCalleesFrames(pCaller->stackMark))
+        if (!pCf->IsInCalleesFrames(pCaller->GetStackMarkPointerToCheckAgainstStack()))
         {
             // save the current in case it is the one we want
             pCaller->pPrevMethod = pFunc;
@@ -1425,7 +1444,7 @@ StackWalkAction SystemDomain::CallersMethodCallbackWithStackMark(CrawlFrame* pCf
 
     // If we got here, we must already be in the frame containing the stack mark and we are not looking for "me".
     _ASSERTE(pCaller->stackMark &&
-             pCf->IsInCalleesFrames(pCaller->stackMark) &&
+             pCf->IsInCalleesFrames(pCaller->GetStackMarkPointerToCheckAgainstStack()) &&
              *(pCaller->stackMark) != LookForMe);
 
     // When looking for caller's caller, we delay returning results for another

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1307,7 +1307,7 @@ struct CallersDataWithStackMark
     }
     StackCrawlMark* const stackMark;
 #ifdef FEATURE_INTERPRETER
-    PTR_VOID stackMarkOnOSStack;
+    PTR_VOID const stackMarkOnOSStack;
 #endif
     PTR_VOID GetStackMarkPointerToCheckAgainstStack()
     {

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -693,8 +693,28 @@ Done:
 }
 
 struct SkipStruct {
-    StackCrawlMark* pStackMark;
-    MethodDesc*     pMeth;
+    SkipStruct(StackCrawlMark* mark, PTR_Thread thread) :
+        pStackMark(mark)
+#ifdef FEATURE_INTERPRETER
+        // Since the interpreter has its own stack, we need to get a pointer which can be compared on the real
+        // stack so that IsInCalleesFrames can work correctly.
+        , stackMarkOnOSStack(ConvertStackMarkToPointerOnOSStack(thread, mark))
+#endif
+    {
+    }
+    StackCrawlMark* const pStackMark;
+#ifdef FEATURE_INTERPRETER
+    PTR_VOID const stackMarkOnOSStack;
+#endif
+    PTR_VOID GetStackMarkPointerToCheckAgainstStack()
+    {
+#ifdef FEATURE_INTERPRETER
+        return stackMarkOnOSStack;
+#else
+        return (PTR_VOID)stackMark;
+#endif
+    }
+    MethodDesc*     pMeth = NULL;
 };
 
 // This method is called by the GetMethod function and will crawl backward
@@ -722,7 +742,7 @@ static StackWalkAction SkipMethods(CrawlFrame* frame, VOID* data) {
     // which frame the stack mark was in one frame later. This is
     // fine since we only implement LookForMyCaller.
     _ASSERTE(*pSkip->pStackMark == LookForMyCaller);
-    if (!frame->IsInCalleesFrames(pSkip->pStackMark))
+    if (!frame->IsInCalleesFrames(pSkip->GetStackMarkPointerToCheckAgainstStack()))
         return SWA_CONTINUE;
 
     pSkip->pMeth = pFunc;
@@ -738,10 +758,9 @@ extern "C" MethodDesc* QCALLTYPE MethodBase_GetCurrentMethod(QCall::StackCrawlMa
 
     BEGIN_QCALL;
 
-    SkipStruct skip;
-    skip.pStackMark = stackMark;
-    skip.pMeth = 0;
-    GetThread()->StackWalkFrames(SkipMethods, &skip, FUNCTIONSONLY | LIGHTUNWIND);
+    PTR_Thread pThread = GetThread();
+    SkipStruct skip(stackMark, pThread);
+    pThread->StackWalkFrames(SkipMethods, &skip, FUNCTIONSONLY | LIGHTUNWIND);
 
     // If C<Foo>.m<Bar> was called, the stack walker returns C<__Canon>.m<__Canon>. We cannot
     // get know that the instantiation used Foo or Bar at that point. So the next best thing

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -711,7 +711,7 @@ struct SkipStruct {
 #ifdef FEATURE_INTERPRETER
         return stackMarkOnOSStack;
 #else
-        return (PTR_VOID)stackMark;
+        return (PTR_VOID)pStackMark;
 #endif
     }
     MethodDesc*     pMeth = NULL;

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -56,7 +56,6 @@ PTR_VOID ConvertStackMarkToPointerOnOSStack(PTR_Thread pThread, PTR_VOID stackMa
     if ((stackMark < pThread->GetCachedStackLimit()) || stackMark > pThread->GetCachedStackBase())
     {
         PTR_Frame pFrame = pThread->GetFrame();
-        PTR_InterpMethodContextFrame pLastFoundWhereStackIsLessThanOrEqualToStackMark = NULL;
         while (pFrame != FRAME_TOP)
         {
             if (pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -45,6 +45,54 @@ Assembly* CrawlFrame::GetAssembly()
     return pAssembly;
 }
 
+PTR_VOID ConvertStackMarkToPointerOnOSStack(PTR_Thread pThread, PTR_VOID stackMark)
+{
+#ifdef FEATURE_INTERPRETER
+    LIMITED_METHOD_DAC_CONTRACT;
+
+    if (stackMark == NULL)
+        return NULL;
+
+    if ((stackMark < pThread->GetCachedStackLimit()) || stackMark > pThread->GetCachedStackBase())
+    {
+        PTR_Frame pFrame = pThread->GetFrame();
+        PTR_InterpMethodContextFrame pLastFoundWhereStackIsLessThanOrEqualToStackMark = NULL;
+        while (pFrame != FRAME_TOP)
+        {
+            if (pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+            {
+                PTR_InterpreterFrame pInterpFrame = dac_cast<PTR_InterpreterFrame>(pFrame);
+                PTR_InterpMethodContextFrame pTopInterpMethodContextFrame = pInterpFrame->GetTopInterpMethodContextFrame();
+                while (pTopInterpMethodContextFrame->pNext && pTopInterpMethodContextFrame->pNext->ip != 0)
+                {
+                    pTopInterpMethodContextFrame = pTopInterpMethodContextFrame->pNext;
+                }
+                while (pTopInterpMethodContextFrame->pParent && pTopInterpMethodContextFrame->ip == 0)
+                {
+                    pTopInterpMethodContextFrame = pTopInterpMethodContextFrame->pParent;
+                }
+
+                PTR_InterpMethodContextFrame pCurrent = pTopInterpMethodContextFrame;
+                do
+                {
+                    if (dac_cast<PTR_VOID>(pCurrent->pStack) <= stackMark)
+                    {
+                        return dac_cast<PTR_VOID>(dac_cast<TADDR>(pCurrent) + 1);
+                    }
+                    pCurrent = pCurrent->pParent;
+                } while (pCurrent != NULL);
+                
+            }
+
+            pFrame = pFrame->PtrNextFrame();
+        }
+
+        _ASSERTE(!"Unable to find InterpMethodContextFrame for stackMark that appears to be on the interpreter stack");
+    }
+#endif
+    return stackMark;
+}
+
 BOOL CrawlFrame::IsInCalleesFrames(LPVOID stackPointer)
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -62,15 +62,6 @@ PTR_VOID ConvertStackMarkToPointerOnOSStack(PTR_Thread pThread, PTR_VOID stackMa
             {
                 PTR_InterpreterFrame pInterpFrame = dac_cast<PTR_InterpreterFrame>(pFrame);
                 PTR_InterpMethodContextFrame pTopInterpMethodContextFrame = pInterpFrame->GetTopInterpMethodContextFrame();
-                while (pTopInterpMethodContextFrame->pNext && pTopInterpMethodContextFrame->pNext->ip != 0)
-                {
-                    pTopInterpMethodContextFrame = pTopInterpMethodContextFrame->pNext;
-                }
-                while (pTopInterpMethodContextFrame->pParent && pTopInterpMethodContextFrame->ip == 0)
-                {
-                    pTopInterpMethodContextFrame = pTopInterpMethodContextFrame->pParent;
-                }
-
                 PTR_InterpMethodContextFrame pCurrent = pTopInterpMethodContextFrame;
                 do
                 {

--- a/src/coreclr/vm/stackwalk.h
+++ b/src/coreclr/vm/stackwalk.h
@@ -756,5 +756,6 @@ private:
 };
 
 void SetUpRegdisplayForStackWalk(Thread * pThread, T_CONTEXT * pContext, REGDISPLAY * pRegdisplay);
+PTR_VOID ConvertStackMarkToPointerOnOSStack(PTR_Thread pThread, PTR_VOID stackMark);
 
 #endif


### PR DESCRIPTION
- StackMark handling relies on comparing the stackmark's address to the stack pointer, but the interpreter stack is seperate.
- Fix this by converting the StackMark pointer to a pointer on the OS stack and then do the compares