### PR TITLE
[clr-interp] Fix Open Virtual Delegates

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2461,7 +2461,7 @@ MAIN_LOOP:
                     ip += 4;
 
                     DELEGATEREF* delegateObj = LOCAL_VAR_ADDR(callArgsOffset, DELEGATEREF);
-                    NULL_CHECK(delegateObj);
+                    NULL_CHECK(*delegateObj);
                     PCODE targetAddress = (*delegateObj)->GetMethodPtr();
                     DelegateEEClass *pDelClass = (DelegateEEClass*)(*delegateObj)->GetMethodTable()->GetClass();
                     if ((pDelClass->m_pInstRetBuffCallStub != NULL && pDelClass->m_pInstRetBuffCallStub->GetEntryPoint() == targetAddress) ||

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2489,7 +2489,6 @@ MAIN_LOOP:
                         {
                             targetMethod = COMDelegate::GetMethodDescForOpenVirtualDelegate(*delegateObj);
                             targetMethod = targetMethod->GetMethodDescOfVirtualizedCode(LOCAL_VAR_ADDR(callArgsOffset + INTERP_STACK_SLOT_SIZE, OBJECTREF), targetMethod->GetMethodTable());
-                            // GetMethodDescOfVirtualizedCode will invalidate delegateObj as it is a method which may trigger a GC
                         }
                         else
                         {


### PR DESCRIPTION
- Open virtual delegates have an entrypoint which cannot be processed by NonVirtualEntry2MethodDesc. Handle them specially.