### PR TITLE
Fix buffer overflow in source array access by limiting source_count to MAX_SUPPORTED_CPUS

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -10865,11 +10865,13 @@ void gc_heap::merge_mark_lists (size_t total_mark_list_size)
         gc_heap* heap = g_heaps[i];
         if (heap->mark_list_piece_start[source_number] < heap->mark_list_piece_end[source_number])
         {
-            source[source_count] = heap->mark_list_piece_start[source_number];
-            source_end[source_count] = heap->mark_list_piece_end[source_number];
-            source_heap[source_count] = i;
             if (source_count < MAX_SUPPORTED_CPUS)
+            {
+                source[source_count] = heap->mark_list_piece_start[source_number];
+                source_end[source_count] = heap->mark_list_piece_end[source_number];
+                source_heap[source_count] = i;
                 source_count++;
+            }
         }
     }
 


### PR DESCRIPTION
Accessing the element in the array 'source' may cause a buffer overflow because the index 'source_count' value might be out of range (values in [64, +inf]) as indicated in the conditional expression.