### PR TITLE
JIT: Fix heap allocations

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -620,6 +620,8 @@ function(add_jit jitName)
         link_natvis_sources_for_target(${jitName} PRIVATE clrjit.natvis)
     endif()
 
+    add_compile_definitions(JIT_STANDALONE_BUILD)
+
     # add the install targets
     install_clr(TARGETS ${jitName} DESTINATIONS . COMPONENT alljits)
 endfunction()

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -620,7 +620,7 @@ function(add_jit jitName)
         link_natvis_sources_for_target(${jitName} PRIVATE clrjit.natvis)
     endif()
 
-    add_compile_definitions(JIT_STANDALONE_BUILD)
+    target_compile_definitions(${jitName} PRIVATE JIT_STANDALONE_BUILD)
 
     # add the install targets
     install_clr(TARGETS ${jitName} DESTINATIONS . COMPONENT alljits)

--- a/src/coreclr/jit/alloc.cpp
+++ b/src/coreclr/jit/alloc.cpp
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#include <new>
 #include "jitpch.h"
 
 #if defined(_MSC_VER)
@@ -328,7 +329,7 @@ void ArenaAllocator::dumpMaxMemStats(FILE* file)
 }
 #endif // MEASURE_MEM_ALLOC
 
-void* operator new(std::size_t size)
+void* __cdecl operator new(std::size_t size)
 {
     assert(!"heap new called; use malloc directly if heap allocation was intended");
     if (size == 0)
@@ -345,7 +346,7 @@ void* operator new(std::size_t size)
     return result;
 }
 
-void* operator new[](std::size_t size)
+void* __cdecl operator new[](std::size_t size)
 {
     assert(!"heap new called; use malloc directly if heap allocation was intended");
     if (size == 0)
@@ -362,12 +363,12 @@ void* operator new[](std::size_t size)
     return result;
 }
 
-void operator delete(void* ptr) noexcept
+void __cdecl operator delete(void* ptr) noexcept
 {
     free(ptr);
 }
 
-void operator delete[](void* ptr) noexcept
+void __cdecl operator delete[](void* ptr) noexcept
 {
     free(ptr);
 }

--- a/src/coreclr/jit/alloc.cpp
+++ b/src/coreclr/jit/alloc.cpp
@@ -327,3 +327,43 @@ void ArenaAllocator::dumpMaxMemStats(FILE* file)
     s_maxStats.Print(file);
 }
 #endif // MEASURE_MEM_ALLOC
+
+void* operator new(std::size_t size)
+{
+    assert(!"heap new called; use malloc directly if heap allocation was intended");
+    if (size == 0)
+    {
+        size++;
+    }
+
+    void* result = malloc(size);
+    if (result == nullptr)
+        throw std::bad_alloc{};
+
+    return result;
+}
+
+void* operator new[](std::size_t size)
+{
+    assert(!"heap new called; use malloc directly if heap allocation was intended");
+    if (size == 0)
+    {
+        size++;
+    }
+
+    void* result = malloc(size);
+    if (result == nullptr)
+        throw std::bad_alloc{};
+
+    return result;
+}
+
+void operator delete(void* ptr) noexcept
+{
+    free(ptr);
+}
+
+void operator delete[](void* ptr) noexcept
+{
+    free(ptr);
+}

--- a/src/coreclr/jit/alloc.cpp
+++ b/src/coreclr/jit/alloc.cpp
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#include <new>
 #include "jitpch.h"
 
 #if defined(_MSC_VER)

--- a/src/coreclr/jit/alloc.cpp
+++ b/src/coreclr/jit/alloc.cpp
@@ -328,9 +328,12 @@ void ArenaAllocator::dumpMaxMemStats(FILE* file)
 }
 #endif // MEASURE_MEM_ALLOC
 
+#ifdef JIT_STANDALONE_BUILD
+
 void* __cdecl operator new(std::size_t size)
 {
-    assert(!"heap new called; use malloc directly if heap allocation was intended");
+    assert(!"Global new called; use HostAllocator if long-lived allocation was intended");
+
     if (size == 0)
     {
         size++;
@@ -347,7 +350,8 @@ void* __cdecl operator new(std::size_t size)
 
 void* __cdecl operator new[](std::size_t size)
 {
-    assert(!"heap new called; use malloc directly if heap allocation was intended");
+    assert(!"Global new called; use HostAllocator if long-lived allocation was intended");
+
     if (size == 0)
     {
         size++;
@@ -371,3 +375,5 @@ void __cdecl operator delete[](void* ptr) noexcept
 {
     free(ptr);
 }
+
+#endif

--- a/src/coreclr/jit/alloc.cpp
+++ b/src/coreclr/jit/alloc.cpp
@@ -338,7 +338,9 @@ void* operator new(std::size_t size)
 
     void* result = malloc(size);
     if (result == nullptr)
+    {
         throw std::bad_alloc{};
+    }
 
     return result;
 }
@@ -353,7 +355,9 @@ void* operator new[](std::size_t size)
 
     void* result = malloc(size);
     if (result == nullptr)
+    {
         throw std::bad_alloc{};
+    }
 
     return result;
 }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -874,15 +874,15 @@ LinearScan::LinearScan(Compiler* theCompiler)
     }
     else
     {
-        regIndices =
-            new regNumber[]{REG_RAX,   REG_RCX,   REG_RDX,   REG_RBX,   REG_RSP,   REG_RBP,   REG_RSI,   REG_RDI,
-                            REG_R8,    REG_R9,    REG_R10,   REG_R11,   REG_R12,   REG_R13,   REG_R14,   REG_R15,
-                            REG_XMM0,  REG_XMM1,  REG_XMM2,  REG_XMM3,  REG_XMM4,  REG_XMM5,  REG_XMM6,  REG_XMM7,
-                            REG_XMM8,  REG_XMM9,  REG_XMM10, REG_XMM11, REG_XMM12, REG_XMM13, REG_XMM14, REG_XMM15,
-                            REG_XMM16, REG_XMM17, REG_XMM18, REG_XMM19, REG_XMM20, REG_XMM21, REG_XMM22, REG_XMM23,
-                            REG_XMM24, REG_XMM25, REG_XMM26, REG_XMM27, REG_XMM28, REG_XMM29, REG_XMM30, REG_XMM31,
-                            REG_K0,    REG_K1,    REG_K2,    REG_K3,    REG_K4,    REG_K5,    REG_K6,    REG_K7,
-                            REG_COUNT};
+        regIndices = new (theCompiler, CMK_LSRA)
+            regNumber[]{REG_RAX,   REG_RCX,   REG_RDX,   REG_RBX,   REG_RSP,   REG_RBP,   REG_RSI,   REG_RDI,
+                        REG_R8,    REG_R9,    REG_R10,   REG_R11,   REG_R12,   REG_R13,   REG_R14,   REG_R15,
+                        REG_XMM0,  REG_XMM1,  REG_XMM2,  REG_XMM3,  REG_XMM4,  REG_XMM5,  REG_XMM6,  REG_XMM7,
+                        REG_XMM8,  REG_XMM9,  REG_XMM10, REG_XMM11, REG_XMM12, REG_XMM13, REG_XMM14, REG_XMM15,
+                        REG_XMM16, REG_XMM17, REG_XMM18, REG_XMM19, REG_XMM20, REG_XMM21, REG_XMM22, REG_XMM23,
+                        REG_XMM24, REG_XMM25, REG_XMM26, REG_XMM27, REG_XMM28, REG_XMM29, REG_XMM30, REG_XMM31,
+                        REG_K0,    REG_K1,    REG_K2,    REG_K3,    REG_K4,    REG_K5,    REG_K6,    REG_K7,
+                        REG_COUNT};
     }
 #endif // TARGET_AMD64
 
@@ -12575,7 +12575,7 @@ LinearScan::RegisterSelection::RegisterSelection(LinearScan* linearScan)
     this->linearScan = linearScan;
 
 #ifdef DEBUG
-    mappingTable = new ScoreMappingTable(linearScan->compiler->getAllocator(CMK_LSRA));
+    mappingTable = new (linearScan->compiler, CMK_LSRA) ScoreMappingTable(linearScan->compiler->getAllocator(CMK_LSRA));
 
 #define REG_SEL_DEF(stat, value, shortname, orderSeqId)                                                                \
     mappingTable->Set(stat, &LinearScan::RegisterSelection::try_##stat);


### PR DESCRIPTION
Also override the global new operators to assert unconditionally, to catch this common pitfall proactively.
Ideally that would be a compile time diagnostic, but I could not figure out how to make that happen.

Fix #120285