### PR TITLE
Fix CopyOSContext on amd64

### DIFF
--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -720,15 +720,8 @@ bool DebugIsEECxxException(EXCEPTION_RECORD* pExceptionRecord);
 
 inline void CopyOSContext(T_CONTEXT* pDest, T_CONTEXT* pSrc)
 {
-    SIZE_T cbReadOnlyPost = 0;
-#ifdef TARGET_AMD64
-    cbReadOnlyPost = sizeof(CONTEXT) - offsetof(CONTEXT, FltSave); // older OSes don't have the vector reg fields
-#endif // TARGET_AMD64
-
-    memcpyNoGCRefs(pDest, pSrc, sizeof(T_CONTEXT) - cbReadOnlyPost);
-#ifdef TARGET_AMD64
-    pDest->ContextFlags = (pDest->ContextFlags & ~(CONTEXT_XSTATE | CONTEXT_FLOATING_POINT)) | CONTEXT_AMD64;
-#endif // TARGET_AMD64
+    memcpyNoGCRefs(pDest, pSrc, sizeof(T_CONTEXT));
+    pDest->ContextFlags &= ~(CONTEXT_XSTATE & CONTEXT_AREA_MASK);
 }
 
 void SaveCurrentExceptionInfo(PEXCEPTION_RECORD pRecord, PT_CONTEXT pContext);

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -721,7 +721,9 @@ bool DebugIsEECxxException(EXCEPTION_RECORD* pExceptionRecord);
 inline void CopyOSContext(T_CONTEXT* pDest, T_CONTEXT* pSrc)
 {
     memcpyNoGCRefs(pDest, pSrc, sizeof(T_CONTEXT));
+#ifdef CONTEXT_XSTATE
     pDest->ContextFlags &= ~(CONTEXT_XSTATE & CONTEXT_AREA_MASK);
+#endif
 }
 
 void SaveCurrentExceptionInfo(PEXCEPTION_RECORD pRecord, PT_CONTEXT pContext);


### PR DESCRIPTION
The CopyOSContext was skipping floating point registers on amd64. There was an obsolete comment that on some older Windows, the vector registers are not present in the context. I've found to be a problem when porting nativeAOT EH to CoreCLR and to make the context flags correct, I've removed the CONTEXT_FLOATING_POINT from the ContextFlags. But it now turned out that it prevents EH from correctly restoring non-volatile floating point registers after a catch. Since he ContextFlags don't contain the CONTEXT_FLOATING_POINT, the floating point registers were not restored during the resume.

This change fixes it by removing the amd64 specific handling and always copying the whole CONTEXT structure. It just masks off the CONTEXT_XSTATE, as the XSTATE is stored out of the basic CONTEXT.

Close #118564