### PR TITLE
[cDAC] fix ICF function logic

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameIterator.cs
@@ -254,9 +254,9 @@ internal sealed class FrameIterator
 
     private static bool InlinedCallFrameHasFunction(Data.InlinedCallFrame frame, Target target)
     {
-        if (target.PointerSize == 4)
+        if (target.PointerSize == sizeof(ulong))
         {
-            return frame.Datum != TargetPointer.Null && (frame.Datum.Value & 0x1) != 0;
+            return frame.Datum != TargetPointer.Null && (frame.Datum.Value & 0x1) == 0;
         }
         else
         {


### PR DESCRIPTION
This logic was previously reversed from the runtime. See:
https://github.com/dotnet/runtime/blob/ce6fab18bb5c7392b1d084839af6ea0308f66217/src/coreclr/vm/frames.h#L2171-L2181

Todo: Add more SOS testing, CI should have caught this.