### PR TITLE
[clr-interp] Fix interpreter safepoint to just do a GC transition and not call the managed JIT_GCPoll helper

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1223,7 +1223,10 @@ MAIN_LOOP:
 
                 case INTOP_SAFEPOINT:
                     if (g_TrapReturningThreads)
-                        JIT_PollGC();
+                    {
+                        // Transition into preemptive mode to allow the GC to suspend us
+                        GCX_PREEMP();
+                    }
                     ip++;
                     break;
 


### PR DESCRIPTION
The managed helper includes the GC poll within it, since JIT_GCPoll is itself managed, when we are in a pure interpreted environment, we will go into infinite recursion triggering the INTOP_SAFEPOINT code