### PR TITLE
[mono][hotreload] Ignore if we receive an empty update.

### DIFF
--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2381,9 +2381,11 @@ hot_reload_apply_changes (int origin, MonoImage *image_base, gconstpointer dmeta
 	if (!assembly_update_supported (image_base, error)) {
 		return;
 	}
-
+	if (dmeta_bytes == 0 && dil_bytes_orig == 0) //we may receive empty updates
+	{
+		return;
+	}
         static int first_origin = -1;
-
         if (first_origin < 0) {
                 first_origin = origin;
         }

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2381,7 +2381,7 @@ hot_reload_apply_changes (int origin, MonoImage *image_base, gconstpointer dmeta
 	if (!assembly_update_supported (image_base, error)) {
 		return;
 	}
-	if (dmeta_bytes == 0 && dil_bytes_orig == 0) //we may receive empty updates
+	if (dmeta_bytes == 0 && dil_bytes_orig == 0) // we may receive empty updates
 	{
 		return;
 	}


### PR DESCRIPTION
This PR adds a check to ignore empty hot reload updates in the Mono runtime. This prevents unnecessary processing when ASP.NET Core sends empty updates in WebAssembly debugger scenarios where the debugger itself applies the real updates.
And also avoids assertion for receiving updates from System.Reflection.Metadata.MetadataUpdater.ApplyUpdate and from debugger even if one of them was empty.

