### PR TITLE
[PERF] Remove HybridGlobalization from perf-ios-scenarios-build-jobs.yml

### DIFF
--- a/eng/pipelines/performance/templates/perf-ios-scenarios-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-ios-scenarios-build-jobs.yml
@@ -1,11 +1,10 @@
 parameters:
-  hybridGlobalization: true
   mono: false
   nativeAot: false
 
 jobs:
   - ${{ if eq(parameters.mono, true) }}:
-    # build mono iOS scenarios HybridGlobalization
+    # build mono iOS scenarios
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
         jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -19,11 +18,9 @@ jobs:
           isOfficialBuild: false
           postBuildSteps:
             - template: /eng/pipelines/performance/templates/build-perf-sample-apps.yml
-              parameters:
-                hybridGlobalization: ${{ parameters.hybridGlobalization }}
 
   - ${{ if eq(parameters.nativeAot, true) }}:
-    # build NativeAOT iOS scenarios HybridGlobalization
+    # build NativeAOT iOS scenarios
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
         jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -37,5 +34,3 @@ jobs:
           isOfficialBuild: false
           postBuildSteps:
             - template: /eng/pipelines/performance/templates/build-perf-sample-apps.yml
-              parameters:
-                hybridGlobalization: ${{ parameters.hybridGlobalization }}


### PR DESCRIPTION
Remove HybridGlobalization from perf-ios-scenarios-build-jobs.yml, the last place in the performance repo testing flow that references it from the cleanup. 

Follow-up from https://github.com/dotnet/runtime/pull/119399.