### PR TITLE
Handle Implicit arguments consistently between interpreter and JIT

### DIFF
--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -25,6 +25,7 @@ This is a list of additions and edits to be made in ECMA-335 specifications. It 
 - [API documentation](#api-documentation)
 - [Debug Interchange Format](#debug-interchange-format)
 - [Extended layout](#extended-layout)
+- [Implict argument conversion rules](#implicit-arg-coercion)
 
 ## Signatures
 
@@ -1191,3 +1192,6 @@ In section II.23.1.15, the following row is added to the table:
 |-----|------|------|
 | `ExtendedLayout` | 0x00000018 | Layout is supplied by a `System.Runtime.InteropServices.ExtendedLayoutAttribute` custom attribute |
 
+## Implicit Arg Coercion
+
+Implicit argument coercion as defined in section III.1.6 does not match with existing practice in CLR runtimes. Notably, implicit argument coercion of an `int32` on the IL evaluation stack to a `native unsigned int` is a sign extending operation, not a zero-extending operation.

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -25,7 +25,7 @@ This is a list of additions and edits to be made in ECMA-335 specifications. It 
 - [API documentation](#api-documentation)
 - [Debug Interchange Format](#debug-interchange-format)
 - [Extended layout](#extended-layout)
-- [Implict argument conversion rules](#implicit-arg-coercion)
+- [Implicit argument conversion rules](#implicit-arg-coercion)
 
 ## Signatures
 

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -25,7 +25,7 @@ This is a list of additions and edits to be made in ECMA-335 specifications. It 
 - [API documentation](#api-documentation)
 - [Debug Interchange Format](#debug-interchange-format)
 - [Extended layout](#extended-layout)
-- [Implict argument conversion rules](#implicit-arg-coercion)
+- [Implicit argument coercion rules](#implicit-argument-coercion-rules)
 
 ## Signatures
 
@@ -1192,6 +1192,6 @@ In section II.23.1.15, the following row is added to the table:
 |-----|------|------|
 | `ExtendedLayout` | 0x00000018 | Layout is supplied by a `System.Runtime.InteropServices.ExtendedLayoutAttribute` custom attribute |
 
-## Implicit Arg Coercion
+## Implict argument coercion rules
 
 Implicit argument coercion as defined in section III.1.6 does not match with existing practice in CLR runtimes. Notably, implicit argument coercion of an `int32` on the IL evaluation stack to a `native unsigned int` is a sign extending operation, not a zero-extending operation.

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3849,7 +3849,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
 #ifdef TARGET_64BIT
                     case CORINFO_TYPE_NATIVEINT:
                     case CORINFO_TYPE_NATIVEUINT:
-                        EmitConv(m_pStackPointer + iCurrentStackArg, StackTypeI8, INTOP_CONV_I8_I4);
+                        EmitConv(m_pStackPointer + iCurrentStackArg, StackTypeI8, INTOP_CONV_I8_I4); // This subtly differs from the published ECMA spec, and is what is defined in the Ecma-335-Augments.md document
                         break;
 #endif // TARGET_64BIT
                     case CORINFO_TYPE_BYTE:
@@ -4327,7 +4327,7 @@ void InterpCompiler::EmitStind(InterpType interpType, CORINFO_CLASS_HANDLE clsHn
     {
         EmitConv(m_pStackPointer + stackIndexValue, StackTypeR8, INTOP_CONV_R8_R4);
     }
-    else if (enableImplicitArgConversionRules && interpType == InterpTypeI8 && m_pStackPointer[stackIndexValue].type == StackTypeI4)
+    else if (enableImplicitArgConversionRules && interpType == InterpTypeI8 && m_pStackPointer[stackIndexValue].type == StackTypeI4) // This subtly differs from the published ECMA spec for section III.1.6, and is what is defined in the Ecma-335-Augments.md document
     {
         EmitConv(m_pStackPointer + stackIndexValue, StackTypeI8, INTOP_CONV_I8_I4);
     }

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -737,7 +737,7 @@ private:
     void    EmitCalli(bool isTailCall, void* calliCookie, int callIFunctionPointerVar, CORINFO_SIG_INFO* callSiteSig);
     bool    EmitNamedIntrinsicCall(NamedIntrinsic ni, bool nonVirtualCall, CORINFO_CLASS_HANDLE clsHnd, CORINFO_METHOD_HANDLE method, CORINFO_SIG_INFO sig);
     void    EmitLdind(InterpType type, CORINFO_CLASS_HANDLE clsHnd, int32_t offset);
-    void    EmitStind(InterpType type, CORINFO_CLASS_HANDLE clsHnd, int32_t offset, bool reverseSVarOrder);
+    void    EmitStind(InterpType type, CORINFO_CLASS_HANDLE clsHnd, int32_t offset, bool reverseSVarOrder, bool enableImplicitArgConversionRules);
     void    EmitLdelem(int32_t opcode, InterpType type);
     void    EmitStelem(InterpType type);
     void    EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORINFO_RESOLVED_TOKEN *pResolvedToken);

--- a/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion.il
+++ b/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion.il
@@ -49,6 +49,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnMonoAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.TestPlatforms) = {
+          string('Handling of implicit arg coercion rules III.1.6 differs between Mono and CoreCLR, and this tests the CoreCLR behavior, and what we've put in the augments')
+          int32(0xFFFFFFFF) // Any
+      }
+
       .entrypoint
       // Code size       36 (0x24)
       .maxstack  2

--- a/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion.il
+++ b/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion.il
@@ -11,6 +11,7 @@
 {
 }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .namespace JitTest_implicit_arg_coercion
 {
   .class public auto ansi beforefieldinit TestClass
@@ -50,7 +51,7 @@
           01 00 00 00
       )
       .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnMonoAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.TestPlatforms) = {
-          string('Handling of implicit arg coercion rules III.1.6 differs between Mono and CoreCLR, and this tests the CoreCLR behavior, and what we've put in the augments')
+          string('Handling of implicit arg coercion rules III.1.6 differs between Mono and CoreCLR, and this tests the CoreCLR behavior, and what we have put in the augments')
           int32(0xFFFFFFFF) // Any
       }
 

--- a/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion.il
+++ b/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion.il
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern mscorlib { }
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+.assembly ASSEMBLY_NAME
+{
+}
+.assembly extern xunit.core {}
+.namespace JitTest_implicit_arg_coercion
+{
+  .class public auto ansi beforefieldinit TestClass
+         extends [mscorlib]System.Object
+  {
+    .field private static native int s_data
+    .field private static native uint s_udata
+
+    .method public hidebysig static native int TakeNativeIntArg(native int) cil managed
+    {
+        ldarg.0
+        ret
+    }
+
+    .method public hidebysig static native uint TakeNativeUIntArg(native uint) cil managed
+    {
+        ldarg.0
+        ret
+    }
+
+    .method public hidebysig static int32 TakeU2Arg(uint16) cil managed
+    {
+        ldarg.0
+        ret
+    }
+
+    .method public hidebysig static int32 TakeU1Arg(uint8) cil managed
+    {
+        ldarg.0
+        ret
+    }
+
+    .method public hidebysig static int32
+            Main() cil managed
+    {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
+      // Code size       36 (0x24)
+      .maxstack  2
+      ldc.i4.m1
+      stsfld native int JitTest_implicit_arg_coercion.TestClass::s_data
+      ldc.i4.m1
+      stsfld native uint JitTest_implicit_arg_coercion.TestClass::s_udata
+
+      ldsfld native int JitTest_implicit_arg_coercion.TestClass::s_data
+      conv.u8
+      box        [mscorlib]System.UInt64
+      call       void [System.Console]System.Console::WriteLine(object)
+
+      ldsfld native uint JitTest_implicit_arg_coercion.TestClass::s_udata
+      conv.u8
+      box        [mscorlib]System.UInt64
+      call       void [System.Console]System.Console::WriteLine(object)
+
+      ldc.i4.m1
+      conv.i
+      box        [mscorlib]System.UInt64
+      call       void [System.Console]System.Console::WriteLine(object)
+
+      ldc.i4.m1
+      conv.u
+      box        [mscorlib]System.UInt64
+      call       void [System.Console]System.Console::WriteLine(object)
+
+      ldc.i4.m1
+      conv.i
+      ldsfld native int JitTest_implicit_arg_coercion.TestClass::s_data
+      beq IL_PassNativeInt
+      ldstr      "Failed conversion of i4 into i for stsfld"
+      call       void [System.Console]System.Console::WriteLine(string)
+      ldc.i4.s 101
+      ret
+
+      IL_PassNativeInt:
+      ldc.i4.m1
+      conv.i // The published ECMA 335 spec specifies that we should use the implicit argument coercion rules in section III.
+      ldsfld native uint JitTest_implicit_arg_coercion.TestClass::s_udata
+      beq IL_PassNativeUInt
+      ldstr      "Failed conversion of i4 into u for stsfld"
+      call       void [System.Console]System.Console::WriteLine(string)
+      ldc.i4.s 102
+      ret
+      IL_PassNativeUInt:
+
+      ldc.i4.m1
+      call native int [ASSEMBLY_NAME]JitTest_implicit_arg_coercion.TestClass::TakeNativeIntArg(native int)
+      ldc.i4.m1
+      conv.i
+      beq IL_PassNativeIntCall
+      ldstr      "Failed conversion of i4 into i for argument call"
+      call       void [System.Console]System.Console::WriteLine(string)
+      ldc.i4.s 103
+      ret
+      IL_PassNativeIntCall:
+
+      ldc.i4.m1
+      call native uint [ASSEMBLY_NAME]JitTest_implicit_arg_coercion.TestClass::TakeNativeUIntArg(native uint)
+      ldc.i4.m1
+      conv.i
+      beq IL_PassNativeUIntCall
+      ldstr      "Failed conversion of i4 into u for argument call"
+      call       void [System.Console]System.Console::WriteLine(string)
+      ldc.i4.s 104
+      ret
+      IL_PassNativeUIntCall:
+
+      ldc.i4.m1
+      call int32 [ASSEMBLY_NAME]JitTest_implicit_arg_coercion.TestClass::TakeU2Arg(uint16)
+      ldc.i4 0xFFFF
+      beq IL_PassU2Call
+      ldstr      "Failed conversion of i4 into u2 for argument call"
+      call       void [System.Console]System.Console::WriteLine(string)
+      ldc.i4.s 105
+      ret
+      IL_PassU2Call:
+
+      ldc.i4.m1
+      call int32 [ASSEMBLY_NAME]JitTest_implicit_arg_coercion.TestClass::TakeU1Arg(uint8)
+      ldc.i4 0xFF
+      beq IL_PassU1Call
+      ldstr      "Failed conversion of i4 into u1 for argument call"
+      call       void [System.Console]System.Console::WriteLine(string)
+      ldc.i4.s 105
+      ret
+      IL_PassU1Call:
+
+      ldstr      "Passed => 100"
+      IL_001c:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_0021:  ldc.i4.s   100
+      IL_0023:  ret
+    } // end of method TestClass::Main
+
+    .method public hidebysig specialname rtspecialname
+            instance void .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method TestClass::.ctor
+
+  } // end of class TestClass
+
+} // end of namespace JitTest_implicit_arg_coercion
+
+//*********** DISASSEMBLY COMPLETE ***********************
+// WARNING: Created Win32 resource file ldnull.res

--- a/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_d.il
+++ b/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_d.il
@@ -1,0 +1,1 @@
+#define ASSEMBLY_NAME "implicit_arg_coercion_d"

--- a/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_d.ilproj
+++ b/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_d.ilproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_d.ilproj
+++ b/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_d.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="implicit_arg_coercion_d.il" />
+    <Compile Include="implicit_arg_coercion.il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_r.il
+++ b/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_r.il
@@ -1,0 +1,1 @@
+#define ASSEMBLY_NAME "implicit_arg_coercion_r"

--- a/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_r.ilproj
+++ b/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_r.ilproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_r.ilproj
+++ b/src/tests/JIT/Methodical/casts/coverage/implicit_arg_coercion_r.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="implicit_arg_coercion_r.il" />
+    <Compile Include="implicit_arg_coercion.il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- The JIT did not match the behavior specified in the ECMA 335 standard. However, since its behavior is long-standing, instead of fixing the JIT, I'm proposing a new section in the ECMA augments document.
- I've written tests for the scenarios where the conversion happens
- And I've fixed the interpreter compiler to match the behavior the JIT has for these scenarios