### PR TITLE
Replace Marshal.SizeOf with sizeof operator

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.Windows.cs
@@ -26,7 +26,7 @@ namespace System.Security.Cryptography
                     throw new CryptographicException();
                 }
 
-                int blobHeaderSize = Marshal.SizeOf<BCRYPT_MLKEM_KEY_BLOB>();
+                int blobHeaderSize = sizeof(BCRYPT_MLKEM_KEY_BLOB);
                 int keySize = checked((int)blob->cbKey);
 
                 if (keySize != destination.Length)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Windows.BuildChain.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Windows.BuildChain.cs
@@ -36,7 +36,7 @@ namespace System.Security.Cryptography.X509Certificates
                 using (SafeCertStoreHandle extraStoreHandle = ConvertStoreToSafeHandle(extraStore))
                 {
                     Interop.Crypt32.CERT_CHAIN_PARA chainPara = default;
-                    chainPara.cbSize = Marshal.SizeOf<Interop.Crypt32.CERT_CHAIN_PARA>();
+                    chainPara.cbSize = sizeof(Interop.Crypt32.CERT_CHAIN_PARA);
 
                     int applicationPolicyCount;
                     using (SafeHandle applicationPolicyOids = applicationPolicy!.ToLpstrArray(out applicationPolicyCount))
@@ -88,12 +88,15 @@ namespace System.Security.Cryptography.X509Certificates
             if (trustMode == X509ChainTrustMode.CustomRootTrust)
             {
                 // Need to get a valid SafeCertStoreHandle otherwise the default stores will be trusted
-                using (SafeCertStoreHandle customTrustStoreHandle = ConvertStoreToSafeHandle(customTrustStore, true))
+                unsafe
                 {
-                    Interop.Crypt32.CERT_CHAIN_ENGINE_CONFIG customChainEngine = default;
-                    customChainEngine.cbSize = Marshal.SizeOf<Interop.Crypt32.CERT_CHAIN_ENGINE_CONFIG>();
-                    customChainEngine.hExclusiveRoot = customTrustStoreHandle.DangerousGetHandle();
-                    chainEngineHandle = Interop.crypt32.CertCreateCertificateChainEngine(ref customChainEngine);
+                    using (SafeCertStoreHandle customTrustStoreHandle = ConvertStoreToSafeHandle(customTrustStore, true))
+                    {
+                        Interop.Crypt32.CERT_CHAIN_ENGINE_CONFIG customChainEngine = default;
+                        customChainEngine.cbSize = sizeof(Interop.Crypt32.CERT_CHAIN_ENGINE_CONFIG);
+                        customChainEngine.hExclusiveRoot = customTrustStoreHandle.DangerousGetHandle();
+                        chainEngineHandle = Interop.crypt32.CertCreateCertificateChainEngine(ref customChainEngine);
+                    }
                 }
             }
             else


### PR DESCRIPTION
This implements the suggestion from @jkotas to use `sizeof` instead of `Marshal.SizeOf` for blittable structs, or to stop using the native heap entirely for some others.

https://github.com/dotnet/runtime/pull/120342#discussion_r2400473657

This does not do the one in `StorePal.Windows.Export.cs‎` since I assumed that one will be taken in the linked PR.