### PR TITLE
Fix potential overflow

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -333,7 +333,7 @@ namespace System.Net
 
             private static unsafe void SetField(ref MessageField field, int length, int offset)
             {
-                if (length > short.MaxValue || length < short.MaxValue)
+                if (length > short.MaxValue || length < short.MinValue)
                 {
                     throw new Win32Exception(NTE_FAIL);
                 }

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -333,7 +333,7 @@ namespace System.Net
 
             private static unsafe void SetField(ref MessageField field, int length, int offset)
             {
-                if (length > short.MaxValue || length < short.MinValue)
+                if (length > short.MaxValue || length < 0)
                 {
                     throw new Win32Exception(NTE_FAIL);
                 }

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -333,7 +333,7 @@ namespace System.Net
 
             private static unsafe void SetField(ref MessageField field, int length, int offset)
             {
-                if (length > short.MaxValue)
+                if (length > short.MaxValue || length < short.MaxValue)
                 {
                     throw new Win32Exception(NTE_FAIL);
                 }

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -333,7 +333,7 @@ namespace System.Net
 
             private static unsafe void SetField(ref MessageField field, int length, int offset)
             {
-                if (length > short.MaxValue || length < 0)
+                if (length is < 0 or > short.MaxValue)
                 {
                     throw new Win32Exception(NTE_FAIL);
                 }


### PR DESCRIPTION
As I understand, the length argument cannot be negative in practice, it is a cosmetic check.

Found by Linux Verification Center (linuxtesting.org) with SVACE.