### PR TITLE
Fix time retrieval for Apple mobile in LogAssert

### DIFF
--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -12,7 +12,7 @@
 #include "ex.h"
 #include "corexcep.h"
 #include <time.h>
-#if defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
+#if defined(HOST_IOS) || defined(HOST_TVOS) || defined(HOST_MACCATALYST)
 #include <sys/time.h>
 #endif
 

--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -163,7 +163,7 @@ VOID LogAssert(
     STRESS_LOG2(LF_ASSERT, LL_ALWAYS, "ASSERT:%s:%d\n", szFile, iLine);
 
     struct timespec ts;
-#if defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
+#if defined(HOST_IOS) || defined(HOST_TVOS) || defined(HOST_MACCATALYST)
     // timespec_get is only available on iOS 13.0+, use gettimeofday instead
     struct timeval tv;
     gettimeofday(&tv, nullptr);

--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -12,6 +12,9 @@
 #include "ex.h"
 #include "corexcep.h"
 #include <time.h>
+#if defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
+#include <sys/time.h>
+#endif
 
 #include <minipal/debugger.h>
 
@@ -160,7 +163,15 @@ VOID LogAssert(
     STRESS_LOG2(LF_ASSERT, LL_ALWAYS, "ASSERT:%s:%d\n", szFile, iLine);
 
     struct timespec ts;
+#if defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
+    // timespec_get is only available on iOS 13.0+, use gettimeofday instead
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+    ts.tv_sec = tv.tv_sec;
+    ts.tv_nsec = tv.tv_usec * 1000;
+#else
     int ret = timespec_get(&ts, TIME_UTC);
+#endif
 
     struct tm local;
 #ifdef HOST_WINDOWS


### PR DESCRIPTION
## Description

The `timespec_get` function introduced in https://github.com/dotnet/runtime/pull/119543 is available only on iOS 13 and later, while the minimum SDK target is iOS 12.2. This change fixes CoreCLR Apple mobile build.

## Changes

Use `gettimeofday` to initialize `timespec` struct.