### PR TITLE
Fix metadata column definition memory leak

### DIFF
--- a/src/coreclr/md/inc/liteweightstgdb.h
+++ b/src/coreclr/md/inc/liteweightstgdb.h
@@ -69,6 +69,21 @@ protected:
 template <class MiniMd>
 void CLiteWeightStgdb<MiniMd>::Uninit()
 {
+    // Clean up allocated column definitions (same logic as CMiniMdBase destructor)
+    for (ULONG i = 0; i < m_MiniMd.m_TblCount; i++)
+    {
+        if (m_MiniMd.m_TableDefs[i].m_pColDefs != NULL)
+        {
+            // Check if memory was allocated (same logic as UsesAllocatedMemory)
+            BYTE *pMem = COLDES_TO_BYTEARRAY(m_MiniMd.m_TableDefs[i].m_pColDefs);
+            if (*pMem == ALLOCATED_MEMORY_MARKER)
+            {
+                delete[] pMem;
+                m_MiniMd.m_TableDefs[i].m_pColDefs = NULL;
+            }
+        }
+    }
+    
     m_MiniMd.m_StringHeap.Delete();
     m_MiniMd.m_UserStringHeap.Delete();
     m_MiniMd.m_GuidHeap.Delete();


### PR DESCRIPTION
Supposedly fixes this valgrind issue:
```sh
# dotnet 10.0.100-rtm.25479.115, webapi, release, singlefile
$ DOTNET_GCHeapHardLimit=C800000 valgrind --undef-value-errors=no \
    --error-exitcode=1 --leak-check=full --show-leak-kinds=all --log-file=dump dist/app1

...
==809== 185 bytes in 17 blocks are possibly lost in loss record 2,364 of 2,647
==809==    at 0x5459AC8: operator new[](unsigned long, std::nothrow_t const&) (vg_replace_malloc.c:850)
==809==    by 0x44472F7: SetNewColumnDefinition (src/coreclr/md/runtime/metamodel.cpp:852)
==809==    by 0x44472F7: CMiniMdBase::InitColsForTable(CMiniMdSchema&, int, CMiniTableDef*, int, int) (src/coreclr/md/runtime/metamodel.cpp:822)
==809==    by 0x4446ECB: CMiniMdBase::SchemaPopulate2(unsigned int*, int) (src/coreclr/md/runtime/metamodel.cpp:629)
==809==    by 0x4446D73: CMiniMdBase::SchemaPopulate(void const*, unsigned int, unsigned int*) (src/coreclr/md/runtime/metamodel.cpp:559)
==809==    by 0x446ED53: CMiniMd::InitOnMem(void*, unsigned int) (src/coreclr/md/runtime/metamodelro.cpp:67)
==809==    by 0x4470DDF: CLiteWeightStgdb<CMiniMd>::InitOnMem(unsigned int, void const*) (src/coreclr/md/runtime/liteweightstgdb.cpp:148)
==809==    by 0x45684E7: GetMDInternalInterface (src/coreclr/md/runtime/mdinternaldisp.cpp:184)
==809==    by 0x456D9C3: PEImage::OpenMDImport() (src/coreclr/vm/peimage.cpp:314)
==809==    by 0x456D8DB: PEImage::GetMDImport() (src/coreclr/vm/peimage.cpp:286)
==809==    by 0x45E65EB: BinderAcquireImport (src/coreclr/vm/coreassemblyspec.cpp:133)
==809==    by 0x44225EB: BINDER_SPACE::AssemblyName::Init(PEImage*) (src/coreclr/binder/assemblyname.cpp:62)
==809==    by 0x442494F: BINDER_SPACE::Assembly::Init(PEImage*, int) (src/coreclr/binder/assembly.cpp:44)
...
```