### PR TITLE
Draft: RFC 6761 handling for invalid and *.localhost

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -426,6 +426,19 @@ namespace System.Net
                 return resultOnFailure;
             }
 
+            if (hostName.Equals("invalid", StringComparison.OrdinalIgnoreCase) ||
+                hostName.EndsWith(".invalid", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new SocketException((int)SocketError.HostNotFound);
+            }
+
+            if (hostName.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+                hostName.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                IPAddress[] loopbacks = new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback };
+                return justAddresses ? (object)loopbacks : new IPHostEntry { AddressList = loopbacks, HostName = hostName, Aliases = Array.Empty<string>() };
+            }
+
             // NameResolutionActivity may have already been set if we're being called from RunAsync.
             NameResolutionActivity activity = activityOrDefault ?? NameResolutionTelemetry.Log.BeforeResolution(hostName);
 


### PR DESCRIPTION
This is a draft PR for [issue #118569](https://github.com/dotnet/runtime/issues/118569).

### Motivation
RFC 6761 defines special-use domain names:
- `invalid` and `*.invalid` must always return NXDOMAIN
- `localhost` and `*.localhost` must always resolve to the loopback address

Currently, .NET relies fully on the OS resolver, which may allow `invalid` to resolve if defined in `/etc/hosts` or DNS, and may not handle `*.localhost` consistently across platforms.

### Proposed approach
- Intercept `invalid` and `*.invalid` before OS resolution → throw `SocketException` with `HostNotFound` (simulate NXDOMAIN).
- Intercept `localhost` and `*.localhost` before OS resolution → return `IPAddress.Loopback` and `IPAddress.IPv6Loopback`.
- Otherwise, fallback to the platform resolver as today.

### Status
- Draft PR to validate the idea/approach with maintainers.
- No tests included yet.
- Once approach is confirmed, I’ll proceed with the real implementation, unit tests and CI validation.
