### PR TITLE
Protect throwable around interpreted funclet call

### DIFF
--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -2186,7 +2186,9 @@ DWORD_PTR InterpreterCodeManager::CallFunclet(OBJECTREF throwable, void* pHandle
     exceptionClauseArgs.isFilter = isFilter;
     exceptionClauseArgs.throwable = throwable;
 
+    GCPROTECT_BEGIN(exceptionClauseArgs.throwable);
     InterpExecMethod(&frames.interpreterFrame, &frames.interpMethodContextFrame, threadContext, &exceptionClauseArgs);
+    GCPROTECT_END();
 
     frames.interpreterFrame.Pop();
 


### PR DESCRIPTION
The InterpreterCodeManager::CallFunclet was not protecting the exceptionClauseArgs.throwable across the call to the interpreter. That lead to assert in some cases.

This change fixes it.