### PR TITLE
Fix EH transition on native to interpreted boundary

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3899,6 +3899,8 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
     bool doingFuncletUnwind = pThis->m_crawl.IsFunclet();
     PCODE preUnwindControlPC = pThis->m_crawl.GetRegisterSet()->ControlPC;
 
+    bool isNativeTransition;
+
     retVal = pThis->Next();
     if (retVal == SWA_FAILED)
     {
@@ -3906,7 +3908,7 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
         goto Exit;
     }
 
-    bool isNativeTransition = (pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME);
+    isNativeTransition = (pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME);
 
 #ifdef FEATURE_INTERPRETER
     if (isNativeTransition &&

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3906,8 +3906,10 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
         goto Exit;
     }
 
+    bool isNativeTransition = (pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME);
+
 #ifdef FEATURE_INTERPRETER
-    if ((pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME) &&
+    if (isNativeTransition &&
         (GetIP(pThis->m_crawl.GetRegisterSet()->pCurrentContext) == InterpreterFrame::DummyCallerIP))
     {
         // The callerIP is InterpreterFrame::DummyCallerIP when we are going to unwind from the first interpreted frame belonging to an InterpreterFrame.
@@ -3931,15 +3933,16 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
                 pInterpreterFrame->UpdateRegDisplay(pThis->m_crawl.GetRegisterSet(), /* updateFloats */ true);
             }
         }
+        else
+        {
+            // The caller of the interpreted code is managed.
+            isNativeTransition = false;
+        }
     }
 #endif // FEATURE_INTERPRETER
 
     // Check for reverse pinvoke or CallDescrWorkerInternal.
-    if ((pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME)
-#ifdef FEATURE_INTERPRETER
-         || (pThis->GetFrameState() == StackFrameIterator::SFITER_DONE)
-#endif // FEATURE_INTERPRETER
-        )
+    if (isNativeTransition)
     {
         EECodeInfo codeInfo(preUnwindControlPC);
 #ifdef USE_GC_INFO_DECODER


### PR DESCRIPTION
There is a case where an interpreted code is called by CallDescrWorker and the code that called the CallDescrWorker was invoked via pinvoke. In that case, the SfiNextWorker was not detecting that the exception propagates to CallDescrWorker due to the fact that the final StackFrameIterator::GetFrameState() was returning SFITER_FRAME_FUNCTION for the next pinvoke and not reporting any intermediate SFITER_NATIVE_MARKER_FRAME.