### PR TITLE
Fix GCFrame allocated by interpreted code handling

### DIFF
--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -1189,6 +1189,21 @@ FCIMPL1(void, GCReporting::Register, GCFrame* frame)
 
     // Construct a GCFrame.
     _ASSERTE(frame != NULL);
+#ifdef FEATURE_INTERPRETER
+    Thread *pThread = GetThread();
+    Frame *pFrame = pThread->GetFrame();
+    frame->SetOSStackLocation(frame);
+
+    if ((pFrame != FRAME_TOP) && (pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame))
+    {
+        InterpreterFrame *pInterpFrame = (InterpreterFrame *)(pFrame);
+        InterpMethodContextFrame *pTopInterpMethodContextFrame = pInterpFrame->GetTopInterpMethodContextFrame();
+        if (pTopInterpMethodContextFrame->pStack <= (int8_t*)frame && (int8_t*)frame < pThread->GetInterpThreadContext()->pStackPointer)
+        {
+            frame->SetOSStackLocation(pTopInterpMethodContextFrame);
+        }
+    }
+#endif // FEATURE_INTERPRETER
     frame->Push(GetThread());
 }
 FCIMPLEND

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -513,7 +513,7 @@ static void PopExplicitFrames(Thread *pThread, void *targetSp, void *targetCalle
     if (popGCFrames)
     {
         GCFrame* pGCFrame = pThread->GetGCFrame();
-        while ((pGCFrame != GCFRAME_TOP) && pGCFrame < targetSp)
+        while ((pGCFrame != GCFRAME_TOP) && pGCFrame->GetOSStackLocation() < targetSp)
         {
             pGCFrame->Pop();
             pGCFrame = pThread->GetGCFrame();

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1125,6 +1125,8 @@ GCFrame::GCFrame(Thread *pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL may
     }
     CONTRACTL_END;
 
+    m_osStackLocation = this;
+
 #ifdef USE_CHECKED_OBJECTREFS
     if (!maybeInterior) {
         UINT i;
@@ -1216,7 +1218,7 @@ void GCFrame::Push(Thread* pThread)
     // So GetOsPageSize() is a guess of the maximum stack frame size of any method
     // with multiple GCFrames in coreclr.dll
     _ASSERTE(((m_Next == GCFRAME_TOP) ||
-              (PBYTE(m_Next) + (2 * GetOsPageSize())) > PBYTE(this)) &&
+              (PBYTE(m_Next->GetOSStackLocation()) + (2 * GetOsPageSize())) > PBYTE(this->GetOSStackLocation())) &&
              "Pushing a GCFrame out of order ?");
 
     pThread->SetGCFrame(this);

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1125,7 +1125,9 @@ GCFrame::GCFrame(Thread *pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL may
     }
     CONTRACTL_END;
 
+#ifdef FEATURE_INTERPRETER
     m_osStackLocation = this;
+#endif
 
 #ifdef USE_CHECKED_OBJECTREFS
     if (!maybeInterior) {

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -1917,12 +1917,33 @@ public:
         return m_Next;
     }
 
+    PTR_VOID GetOSStackLocation()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+#ifdef FEATURE_INTERPRETER
+        return m_osStackLocation;
+#else
+        return this;
+#endif
+    }
+
+#ifdef FEATURE_INTERPRETER
+    void SetOSStackLocation(PTR_VOID osStackLocation)
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        m_osStackLocation = osStackLocation;
+    }
+#endif
+
 private:
     PTR_GCFrame   m_Next;
     PTR_Thread    m_pCurThread;
     PTR_OBJECTREF m_pObjRefs;
     UINT          m_numObjRefs;
     BOOL          m_MaybeInterior;
+#ifdef FEATURE_INTERPRETER
+    PTR_VOID      m_osStackLocation;
+#endif
 };
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -1923,7 +1923,7 @@ public:
 #ifdef FEATURE_INTERPRETER
         return m_osStackLocation;
 #else
-        return this;
+        return dac_cast<PTR_VOID>(this);
 #endif
     }
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7758,6 +7758,23 @@ BOOL Thread::IsAddressInStack (PTR_VOID addr) const
     return m_CacheStackLimit < addr && addr <= m_CacheStackBase;
 }
 
+PTR_GCFrame Thread::GetGCFrame()
+{
+    SUPPORTS_DAC;
+
+#ifdef _DEBUG_IMPL
+    WRAPPER_NO_CONTRACT;
+    if (this == GetThreadNULLOk())
+    {
+        void* curSP;
+        curSP = (void *)GetCurrentSP();
+        _ASSERTE((m_pGCFrame == (GCFrame*)-1) || (curSP <= m_pGCFrame->GetOSStackLocation() && m_pGCFrame->GetOSStackLocation() < m_CacheStackBase));
+    }
+#endif
+
+    return m_pGCFrame;
+}
+
 #ifdef DACCESS_COMPILE
 
 void

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1166,22 +1166,7 @@ public:
     //--------------------------------------------------------------
     // Returns innermost active GCFrame.
     //--------------------------------------------------------------
-    PTR_GCFrame GetGCFrame()
-    {
-        SUPPORTS_DAC;
-
-#ifdef _DEBUG_IMPL
-        WRAPPER_NO_CONTRACT;
-        if (this == GetThreadNULLOk())
-        {
-            void* curSP;
-            curSP = (void *)GetCurrentSP();
-            _ASSERTE((m_pGCFrame == (GCFrame*)-1) || (curSP <= m_pGCFrame && m_pGCFrame < m_CacheStackBase));
-        }
-#endif
-
-        return m_pGCFrame;
-    }
+    PTR_GCFrame GetGCFrame();
 
     //--------------------------------------------------------------
     // Replaces innermost active Frames.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
@@ -14,6 +14,7 @@ namespace System.Runtime
         private void** _pObjRefs;
         private uint _numObjRefs;
         private int _maybeInterior;
+        private nuint _reserved3;
 
         public GCFrameRegistration(void** allocation, uint elemCount, bool areByRefs = true)
         {
@@ -22,6 +23,7 @@ namespace System.Runtime
             _pObjRefs = allocation;
             _numObjRefs = elemCount;
             _maybeInterior = areByRefs ? 1 : 0;
+            _reserved3 = 0;
         }
 
 #if CORECLR

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
@@ -14,8 +14,9 @@ namespace System.Runtime
         private void** _pObjRefs;
         private uint _numObjRefs;
         private int _maybeInterior;
-        private nuint _reserved3;
-
+#if FEATURE_INTERPRETER
+        private nuint _osStackLocation;
+#endif
         public GCFrameRegistration(void** allocation, uint elemCount, bool areByRefs = true)
         {
             _reserved1 = 0;
@@ -23,7 +24,9 @@ namespace System.Runtime
             _pObjRefs = allocation;
             _numObjRefs = elemCount;
             _maybeInterior = areByRefs ? 1 : 0;
-            _reserved3 = 0;
+#if FEATURE_INTERPRETER
+            _osStackLocation = 0;
+#endif
         }
 
 #if CORECLR

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
@@ -17,6 +17,7 @@ namespace System.Runtime
 #if FEATURE_INTERPRETER
         private nuint _osStackLocation;
 #endif
+
         public GCFrameRegistration(void** allocation, uint elemCount, bool areByRefs = true)
         {
             _reserved1 = 0;


### PR DESCRIPTION
There are few cases where GCFrame is created by managed code as a managed local. When that code is interpreted, this local is on the interpreter stack which is NOT the processor stack. So various debug checks and also removing these GCFrames from the per-thread chain doesn't work.

This change adds an "os stack location" member to the GCFrame that is set to "this" for GCFrames allocated in native code. For the ones allocated by the interpreted managed code, it is set to the InterpMethodContextFrame of the frame that created it. That value is then used instead of the raw GCFrame pointer to compare locations of these frames.