### PR TITLE
[clr-interp] Fail with a BADCODE if the opcode is unknown

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -59,10 +59,12 @@ bool IsInterpDumpActive()
 
 void AssertOpCodeNotImplemented(const uint8_t *ip, size_t offset)
 {
+#ifdef DEBUG
     fprintf(stderr, "IL_%04x %-10s - opcode not supported yet\n",
                 (int32_t)(offset),
                 CEEOpName(CEEDecodeOpcode(&ip)));
-    assert(!"opcode not implemented");
+#endif // DEBUG
+    BADCODE("opcode not implemented");
 }
 
 // GCInfoEncoder needs an IAllocator implementation. This is a simple one that forwards to the Compiler.
@@ -4464,8 +4466,7 @@ void InterpCompiler::EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORI
             break;
         }
         default:
-            // TODO
-            assert(!"Unsupported (yet) static field accessor");
+            BADCODE("Unsupported static field accessor");
             break;
     }
 

--- a/src/coreclr/interpreter/intops.cpp
+++ b/src/coreclr/interpreter/intops.cpp
@@ -96,6 +96,8 @@ const uint32_t g_CEEOpNameOffsets[] = {
 
 const char* CEEOpName(OPCODE op)
 {
+    if (op >= (sizeof(g_CEEOpNameOffsets) / sizeof(g_CEEOpNameOffsets[0])))
+        return "unused";
     return ((const char*)&g_CEEOpNameCharacters) + g_CEEOpNameOffsets[op];
 }
 


### PR DESCRIPTION
- Fail with BADCODE instead of asserting, which allows us to complete running some of the test suites, and will actually do the desired thing in actual retail builds.
- Also protect against unsafe memory access by bounds checking in CEEOpName