### PR TITLE
Avoid passing null pointer from empty span to `CreateSymmetricKey`

### DIFF
--- a/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace System.Security.Cryptography
 {
@@ -44,7 +45,7 @@ namespace System.Security.Cryptography
 
             try
             {
-                fixed (byte* pSymmetricKeyMaterial = symmetricKeyMaterial)
+                fixed (byte* pSymmetricKeyMaterial = &MemoryMarshal.GetReference(symmetricKeyMaterial))
                 {
                     _keyHandle = CreateSymmetricKey(pSymmetricKeyMaterial, symmetricKeyMaterialLength);
                 }
@@ -88,7 +89,7 @@ namespace System.Security.Cryptography
 
             try
             {
-                fixed (byte* pSymmetricKeyMaterial = symmetricKeyMaterial)
+                fixed (byte* pSymmetricKeyMaterial = &MemoryMarshal.GetReference(symmetricKeyMaterial))
                 {
                     _keyHandle = CreateSymmetricKey(pSymmetricKeyMaterial, symmetricKeyMaterialLength);
                 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace System.Security.Cryptography
 {
@@ -37,7 +38,7 @@ namespace System.Security.Cryptography
 
             try
             {
-                fixed (byte* pSymmetricKeyMaterial = symmetricKeyMaterial)
+                fixed (byte* pSymmetricKeyMaterial = &MemoryMarshal.GetReference(symmetricKeyMaterial))
                 {
                     _keyHandle = CreateSymmetricKey(pSymmetricKeyMaterial, symmetricKeyMaterialLength);
                 }


### PR DESCRIPTION
The existing code has an implicit call to `symmetricKeyMaterial.GetPinnableReference()`, which returns a null reference for `_length == 0`.