### PR TITLE
Remove unsafe `bool` casts

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BFloat16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BFloat16.cs
@@ -475,7 +475,7 @@ namespace System.Numerics
             // Extract sign bit
             ulong sign = (bitValue & double.SignMask) >> 48;
             // Detecting NaN (~0u if a is not NaN)
-            ulong realMask = (ulong)(Unsafe.BitCast<bool, sbyte>(double.IsNaN(value)) - 1);
+            ulong realMask = double.IsNaN(value) ? 0uL : ~0uL;
             // Clear sign bit
             value = double.Abs(value);
             // Rectify values that are Infinity in BFloat16. (float.Min now emits vminps instruction if one of two arguments is a constant)


### PR DESCRIPTION
Follow-up https://github.com/dotnet/runtime/pull/111024.

Contributes to https://github.com/dotnet/runtime/issues/94941.

There is likely a minor performance improvement on arm64, but this is not the motivation for the change.

cc: @huoyaoyuan