### PR TITLE
[browser][mono] WasmOptConfigurationFlags cleanup

### DIFF
--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -228,8 +228,24 @@
       <_EmccLinkFlags Include="-Wno-limited-postlink-optimizations"/>
     </ItemGroup>
 
+    <ItemGroup>
+      <WasmOptConfigurationFlags Include="--all-features" />
+      <WasmOptConfigurationFlags Include="--enable-bulk-memory" />
+      <WasmOptConfigurationFlags Include="--enable-sign-ext" />
+      <WasmOptConfigurationFlags Include="--translate-to-new-eh" />
+      <!-- emscripten defaults -->
+      <WasmOptConfigurationFlags Include="--low-memory-unused" />
+      <WasmOptConfigurationFlags Include="--zero-filled-memory" />
+      <WasmOptConfigurationFlags Include="--enable-reference-types" />
+      <WasmOptConfigurationFlags Include="--enable-mutable-globals" />
+      <WasmOptConfigurationFlags Include="--enable-multivalue" />
+      <WasmOptConfigurationFlags Include="--mvp-features" />
+      <WasmOptConfigurationFlags Include="--pass-arg=directize-initial-contents-immutable" />
+      <WasmOptConfigurationFlags Include="--post-emscripten" />
+      <WasmOptConfigurationFlags Include="--strip-target-features" />
+    </ItemGroup>
     <ItemGroup Condition="'$(WasmEnableThreads)' == 'true'">
-      <WasmOptConfigurationFlags Include="--enable-threads;--enable-bulk-memory;--enable-sign-ext" />
+      <WasmOptConfigurationFlags Include="--enable-threads" />
 
       <!-- workaround for https://github.com/emscripten-core/emscripten/issues/18034 -->
       <_EmccLinkFlags Include="-s TEXTDECODER=0"/>
@@ -307,13 +323,13 @@
 
       <CMakeConfigurationEmccFlags Condition="'$(Configuration)' == 'Debug'">-g -Os -DDEBUG=1</CMakeConfigurationEmccFlags>
       <CMakeConfigurationEmccFlags Condition="'$(Configuration)' == 'Release'">-Oz</CMakeConfigurationEmccFlags>
+      <CMakeConfigurationEmccFlags Condition="'$(WasmEnableSIMD)' == 'true'">$(CMakeConfigurationEmccFlags) -msimd128 -mbulk-memory</CMakeConfigurationEmccFlags>
 
-      <CMakeConfigurationLinkFlags Condition="'$(Configuration)' == 'Debug'"  >$(CMakeConfigurationEmccFlags) -s ASSERTIONS=1 </CMakeConfigurationLinkFlags>
-      <CMakeConfigurationLinkFlags Condition="'$(Configuration)' == 'Release'">-O2</CMakeConfigurationLinkFlags>
+      <CMakeConfigurationLinkFlags Condition="'$(Configuration)' == 'Debug'"  >$(CMakeConfigurationEmccFlags) --all-features -s ASSERTIONS=1 </CMakeConfigurationLinkFlags>
+      <CMakeConfigurationLinkFlags Condition="'$(Configuration)' == 'Release'">-O2 --all-features </CMakeConfigurationLinkFlags>
 
       <!-- -lexports.js has the magical property of disabling minification of export names -->
       <CMakeConfigurationLinkFlags>$(CMakeConfigurationLinkFlags) -s EXPORT_ES6=1 -lexports.js</CMakeConfigurationLinkFlags>
-      <CMakeConfigurationLinkFlags Condition="'$(WasmEnableSIMD)' == 'true'">$(CMakeConfigurationLinkFlags) -msimd128</CMakeConfigurationLinkFlags>
       <CMakeConfigurationLinkFlags Condition="'$(WasmEnableThreads)' == 'true'">$(CMakeConfigurationLinkFlags) -Wno-pthreads-mem-growth</CMakeConfigurationLinkFlags>
       <CMakeConfigurationLinkFlags                                            >$(CMakeConfigurationLinkFlags) --emit-symbol-map</CMakeConfigurationLinkFlags>
 
@@ -328,7 +344,7 @@
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DMONO_OBJ_INCLUDES=&quot;$(MonoObjDir.TrimEnd('\/').Replace('\','/'))&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DMONO_ARTIFACTS_DIR=&quot;$(MonoArtifactsPath.TrimEnd('\/').Replace('\','/'))&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DNATIVE_BIN_DIR=&quot;$(NativeBinDir.TrimEnd('\/').Replace('\','/'))&quot;</CMakeBuildRuntimeConfigureCmd>
-      <CMakeBuildRuntimeConfigureCmd Condition="'$(WasmEnableSIMD)' == 'true'">$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_COMPILE_OPTIONS=&quot;-msimd128&quot; -DCONFIGURATION_INTERPSIMDTABLES_LIB=&quot;simd&quot;</CMakeBuildRuntimeConfigureCmd>
+      <CMakeBuildRuntimeConfigureCmd Condition="'$(WasmEnableSIMD)' == 'true'">$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_COMPILE_OPTION1=&quot;-msimd128&quot; -DCONFIGURATION_COMPILE_OPTION2=&quot;-mbulk-memory&quot; -DCONFIGURATION_INTERPSIMDTABLES_LIB=&quot;simd&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd Condition="'$(WasmEnableSIMD)' != 'true'">$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_INTERPSIMDTABLES_LIB=&quot;nosimd&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd Condition="'$(WasmEnableThreads)' == 'true'">$(CMakeBuildRuntimeConfigureCmd) -DDISABLE_THREADS=0</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd Condition="'$(WasmEnableJsInteropByValue)' == 'true'">$(CMakeBuildRuntimeConfigureCmd) -DENABLE_JS_INTEROP_BY_VALUE=1</CMakeBuildRuntimeConfigureCmd>

--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -218,6 +218,7 @@
       <_EmccExportedLibraryFunction>"[@(EmccExportedLibraryFunction -> '%27%(Identity)%27', ',')]"</_EmccExportedLibraryFunction>
       <_EmccExportedRuntimeMethods>"[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]"</_EmccExportedRuntimeMethods>
       <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
+      <_WasmOptConfigurationFlags>"[@(WasmOptConfigurationFlags -> '%27%(Identity)%27', ',')]"</_WasmOptConfigurationFlags>
       <!-- reserve at least enough space to complete initializing sgen without growing the heap -->
       <EmccInitialHeapSize>33554432</EmccInitialHeapSize>
       <EmccStackSize>5MB</EmccStackSize>
@@ -230,7 +231,7 @@
       <_EmccLinkFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-Wno-pthreads-mem-growth" />
       <_EmccLinkFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-s PTHREAD_POOL_SIZE=0" />
       <_EmccLinkFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-s PTHREAD_POOL_SIZE_STRICT=0" />
-      <_EmccLinkFlags Condition="'$(WasmEnableSIMD)' == 'true'" Include="-s BINARYEN_EXTRA_PASSES=@(WasmOptConfigurationFlags, ',')" />
+      <_EmccLinkFlags Condition="'$(WasmEnableSIMD)' == 'true'" Include="-s BINARYEN_EXTRA_PASSES=$(_WasmOptConfigurationFlags)" />
       <_EmccLinkFlags Include="-s ALLOW_MEMORY_GROWTH=1" />
       <!-- for jiterpreter -->
       <_EmccLinkFlags Include="-s ALLOW_TABLE_GROWTH=1" />

--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -193,41 +193,6 @@
     <ItemGroup Condition="'$(WasmEnableThreads)' == 'true'">
       <EmccExportedFunction Include="_emscripten_main_runtime_thread_id"  />
     </ItemGroup>
-    <PropertyGroup>
-      <_EmccExportedLibraryFunction>"[@(EmccExportedLibraryFunction -> '%27%(Identity)%27', ',')]"</_EmccExportedLibraryFunction>
-      <_EmccExportedRuntimeMethods>"[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]"</_EmccExportedRuntimeMethods>
-      <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
-      <!-- reserve at least enough space to complete initializing sgen without growing the heap -->
-      <EmccInitialHeapSize>33554432</EmccInitialHeapSize>
-      <EmccStackSize>5MB</EmccStackSize>
-    </PropertyGroup>
-    <ItemGroup>
-      <_EmccLinkFlags Include="-Wno-unused-command-line-argument" />
-      <_EmccLinkFlags Include="-s INITIAL_MEMORY=$(EmccInitialHeapSize)" />
-      <_EmccLinkFlags Include="-s STACK_SIZE=$(EmccStackSize)" />
-      <_EmccCommonFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-s USE_PTHREADS=1" />
-      <_EmccLinkFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-Wno-pthreads-mem-growth" />
-      <_EmccLinkFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-s PTHREAD_POOL_SIZE=0" />
-      <_EmccLinkFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-s PTHREAD_POOL_SIZE_STRICT=0" />
-      <_EmccLinkFlags Include="-s ALLOW_MEMORY_GROWTH=1" />
-      <!-- for jiterpreter -->
-      <_EmccLinkFlags Include="-s ALLOW_TABLE_GROWTH=1" />
-      <_EmccLinkFlags Include="-s NO_EXIT_RUNTIME=0" />
-      <_EmccLinkFlags Include="-s FORCE_FILESYSTEM=1" />
-      <_EmccLinkFlags Condition="'$(_EmccExportedLibraryFunction)' != ''" Include="-s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$(_EmccExportedLibraryFunction)" />
-      <_EmccLinkFlags Include="-s EXPORTED_RUNTIME_METHODS=$(_EmccExportedRuntimeMethods)" />
-      <_EmccLinkFlags Include="-s EXPORTED_FUNCTIONS=$(_EmccExportedFunctions)" />
-      <_EmccLinkFlags Include="--source-map-base http://example.com" />
-      <_EmccLinkFlags Include="-s WASM_BIGINT=1" />
-      <_EmccLinkFlags Include="-s EXPORT_NAME=&quot;'createDotnetRuntime'&quot;" />
-      <_EmccLinkFlags Include="-s MODULARIZE=1" />
-
-      <_EmccLinkFlags Include="-s ENVIRONMENT=&quot;web,webview,worker,node,shell&quot;" />
-      <!-- remove -Wno-limited-postlink-optimizations once below issue is fixed
-           active issue: https://github.com/emscripten-core/emscripten/pull/16727 -->
-      <_EmccLinkFlags Include="-Wno-limited-postlink-optimizations"/>
-    </ItemGroup>
-
     <ItemGroup>
       <WasmOptConfigurationFlags Include="--all-features" />
       <WasmOptConfigurationFlags Include="--enable-bulk-memory" />
@@ -246,9 +211,43 @@
     </ItemGroup>
     <ItemGroup Condition="'$(WasmEnableThreads)' == 'true'">
       <WasmOptConfigurationFlags Include="--enable-threads" />
-
       <!-- workaround for https://github.com/emscripten-core/emscripten/issues/18034 -->
       <_EmccLinkFlags Include="-s TEXTDECODER=0"/>
+    </ItemGroup>
+    <PropertyGroup>
+      <_EmccExportedLibraryFunction>"[@(EmccExportedLibraryFunction -> '%27%(Identity)%27', ',')]"</_EmccExportedLibraryFunction>
+      <_EmccExportedRuntimeMethods>"[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]"</_EmccExportedRuntimeMethods>
+      <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
+      <!-- reserve at least enough space to complete initializing sgen without growing the heap -->
+      <EmccInitialHeapSize>33554432</EmccInitialHeapSize>
+      <EmccStackSize>5MB</EmccStackSize>
+    </PropertyGroup>
+    <ItemGroup>
+      <_EmccLinkFlags Include="-Wno-unused-command-line-argument" />
+      <_EmccLinkFlags Include="-s INITIAL_MEMORY=$(EmccInitialHeapSize)" />
+      <_EmccLinkFlags Include="-s STACK_SIZE=$(EmccStackSize)" />
+      <_EmccCommonFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-s USE_PTHREADS=1" />
+      <_EmccLinkFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-Wno-pthreads-mem-growth" />
+      <_EmccLinkFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-s PTHREAD_POOL_SIZE=0" />
+      <_EmccLinkFlags Condition="'$(WasmEnableThreads)' == 'true'" Include="-s PTHREAD_POOL_SIZE_STRICT=0" />
+      <_EmccLinkFlags Condition="'$(WasmEnableSIMD)' == 'true'" Include="-s BINARYEN_EXTRA_PASSES=@(WasmOptConfigurationFlags, ',')" />
+      <_EmccLinkFlags Include="-s ALLOW_MEMORY_GROWTH=1" />
+      <!-- for jiterpreter -->
+      <_EmccLinkFlags Include="-s ALLOW_TABLE_GROWTH=1" />
+      <_EmccLinkFlags Include="-s NO_EXIT_RUNTIME=0" />
+      <_EmccLinkFlags Include="-s FORCE_FILESYSTEM=1" />
+      <_EmccLinkFlags Condition="'$(_EmccExportedLibraryFunction)' != ''" Include="-s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$(_EmccExportedLibraryFunction)" />
+      <_EmccLinkFlags Include="-s EXPORTED_RUNTIME_METHODS=$(_EmccExportedRuntimeMethods)" />
+      <_EmccLinkFlags Include="-s EXPORTED_FUNCTIONS=$(_EmccExportedFunctions)" />
+      <_EmccLinkFlags Include="--source-map-base http://example.com" />
+      <_EmccLinkFlags Include="-s WASM_BIGINT=1" />
+      <_EmccLinkFlags Include="-s EXPORT_NAME=&quot;'createDotnetRuntime'&quot;" />
+      <_EmccLinkFlags Include="-s MODULARIZE=1" />
+
+      <_EmccLinkFlags Include="-s ENVIRONMENT=&quot;web,webview,worker,node,shell&quot;" />
+      <!-- remove -Wno-limited-postlink-optimizations once below issue is fixed
+           active issue: https://github.com/emscripten-core/emscripten/pull/16727 -->
+      <_EmccLinkFlags Include="-Wno-limited-postlink-optimizations"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(OS)' != 'Windows_NT'">

--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -218,7 +218,7 @@
       <_EmccExportedLibraryFunction>"[@(EmccExportedLibraryFunction -> '%27%(Identity)%27', ',')]"</_EmccExportedLibraryFunction>
       <_EmccExportedRuntimeMethods>"[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]"</_EmccExportedRuntimeMethods>
       <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
-      <_WasmOptConfigurationFlags>"[@(WasmOptConfigurationFlags -> '%27%(Identity)%27', ',')]"</_WasmOptConfigurationFlags>
+      <_WasmOptConfigurationFlags>"@(WasmOptConfigurationFlags -> '%27%(Identity)%27', ',')"</_WasmOptConfigurationFlags>
       <!-- reserve at least enough space to complete initializing sgen without growing the heap -->
       <EmccInitialHeapSize>33554432</EmccInitialHeapSize>
       <EmccStackSize>5MB</EmccStackSize>

--- a/src/mono/browser/build/BrowserWasmApp.targets
+++ b/src/mono/browser/build/BrowserWasmApp.targets
@@ -56,7 +56,7 @@
 
     <_WasmDefaultFlags Condition="'$(WasmEnableExceptionHandling)' == 'false'">-fexceptions</_WasmDefaultFlags>
     <_WasmDefaultFlags Condition="'$(WasmEnableExceptionHandling)' != 'false'">-fwasm-exceptions</_WasmDefaultFlags>
-    <_WasmDefaultFlags Condition="'$(WasmEnableSIMD)' == 'true'">-msimd128</_WasmDefaultFlags>
+    <_WasmDefaultFlags Condition="'$(WasmEnableSIMD)' == 'true'">-msimd128 -mbulk-memory</_WasmDefaultFlags>
 
     <_WasmOutputFileName Condition="'$(WasmSingleFileBundle)' != 'true'">dotnet.native.wasm</_WasmOutputFileName>
 

--- a/src/mono/browser/runtime/CMakeLists.txt
+++ b/src/mono/browser/runtime/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_EXECUTABLE_SUFFIX ".js")
 add_executable(dotnet.native runtime.c corebindings.c driver.c pinvoke.c)
 
 target_include_directories(dotnet.native PUBLIC ${MONO_INCLUDES} ${MONO_OBJ_INCLUDES} ${CMAKE_CURRENT_BINARY_DIR}/include/wasm)
-target_compile_options(dotnet.native PUBLIC @${NATIVE_BIN_DIR}/src/emcc-default.rsp @${NATIVE_BIN_DIR}/src/emcc-compile.rsp -DGEN_PINVOKE=1 ${CONFIGURATION_COMPILE_OPTIONS})
+target_compile_options(dotnet.native PUBLIC @${NATIVE_BIN_DIR}/src/emcc-default.rsp @${NATIVE_BIN_DIR}/src/emcc-compile.rsp -DGEN_PINVOKE=1 ${CONFIGURATION_COMPILE_OPTION1} ${CONFIGURATION_COMPILE_OPTION2})
 
 set_target_properties(dotnet.native PROPERTIES COMPILE_FLAGS ${CONFIGURATION_EMCC_FLAGS})
 
@@ -39,12 +39,12 @@ set_target_properties(dotnet.native PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${NATIVE_BIN_DIR}")
 
 set(ignoreMeWasmOptFlags "${CONFIGURATION_WASM_OPT_FLAGS}")
-set(ignoreMeWasmOptAdditionalFlags "${CONFIGURATION_COMPILE_OPTIONS}")
+set(ignoreMeWasmOptAdditionalFlags "${CONFIGURATION_COMPILE_OPTION1}" "${CONFIGURATION_COMPILE_OPTION2}")
 set(ignoreMeEmsdkPath "${EMSDK_PATH}")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_custom_command(TARGET dotnet.native
-                        POST_BUILD COMMAND ${EMSDK_PATH}/bin/wasm-opt --enable-exception-handling --enable-simd --enable-bulk-memory ${CONFIGURATION_WASM_OPT_FLAGS} --strip-dwarf ${NATIVE_BIN_DIR}/dotnet.native.wasm -o ${NATIVE_BIN_DIR}/dotnet.native.wasm
+                        POST_BUILD COMMAND ${EMSDK_PATH}/bin/wasm-opt ${CONFIGURATION_WASM_OPT_FLAGS} --strip-dwarf ${NATIVE_BIN_DIR}/dotnet.native.wasm -o ${NATIVE_BIN_DIR}/dotnet.native.wasm
                         COMMENT "Stripping debug symbols from dotnet.native.wasm using wasm-opt")
 endif()
 

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -484,7 +484,7 @@ endif()
 if(HOST_BROWSER OR HOST_WASI)
   add_library(mono-wasm-simd STATIC interp/interp-simd.c)
   target_link_libraries (mono-wasm-simd PRIVATE monoapi eglib_api)
-  set_target_properties(mono-wasm-simd PROPERTIES COMPILE_FLAGS "-msimd128")
+  set_target_properties(mono-wasm-simd PROPERTIES COMPILE_FLAGS "-msimd128 -mbulk-memory")
   install(TARGETS mono-wasm-simd LIBRARY)
 endif()
 

--- a/src/mono/wasi/wasi.proj
+++ b/src/mono/wasi/wasi.proj
@@ -59,8 +59,14 @@
   <Target Name="GenerateWasiPropsAndRspFiles">
 
     <!-- Generate wasm-props.json -->
+    <ItemGroup>
+      <WasmOptConfigurationFlags Include="--all-features" />
+      <WasmOptConfigurationFlags Include="--enable-bulk-memory" />
+      <WasmOptConfigurationFlags Include="--enable-sign-ext" />
+      <WasmOptConfigurationFlags Include="--low-memory-unused" />
+    </ItemGroup>
     <ItemGroup Condition="'$(WasmEnableThreads)' == 'true'">
-      <WasmOptConfigurationFlags Include="--enable-threads;--enable-bulk-memory;--enable-sign-ext" />
+      <WasmOptConfigurationFlags Include="--enable-threads" />
     </ItemGroup>
 
     <ItemGroup>
@@ -156,7 +162,7 @@
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DMONO_OBJ_INCLUDES=&quot;$(MonoObjDir.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DMONO_ARTIFACTS_DIR=&quot;$(MonoArtifactsPath.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd>$(CMakeBuildRuntimeConfigureCmd) -DNATIVE_BIN_DIR=&quot;$(NativeBinDir.TrimEnd('\/'))&quot;</CMakeBuildRuntimeConfigureCmd>
-      <CMakeBuildRuntimeConfigureCmd Condition="'$(WasmEnableSIMD)' == 'true'">$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_COMPILE_OPTIONS=&quot;-msimd128&quot; -DCONFIGURATION_INTERPSIMDTABLES_LIB=&quot;simd&quot;</CMakeBuildRuntimeConfigureCmd>
+      <CMakeBuildRuntimeConfigureCmd Condition="'$(WasmEnableSIMD)' == 'true'">$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_COMPILE_OPTIONS=&quot;-msimd128 -mbulk-memory&quot; -DCONFIGURATION_INTERPSIMDTABLES_LIB=&quot;simd&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd Condition="'$(WasmEnableSIMD)' != 'true'">$(CMakeBuildRuntimeConfigureCmd) -DCONFIGURATION_INTERPSIMDTABLES_LIB=&quot;nosimd&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd Condition="'$(WasmEnableThreads)' == 'true'">$(CMakeBuildRuntimeConfigureCmd) -DDISABLE_THREADS=0</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd Condition="'$(OS)' == 'Windows_NT'">call &quot;$(RepositoryEngineeringDir)native\init-vs-env.cmd&quot; wasm &amp;&amp; $(CMakeBuildRuntimeConfigureCmd)</CMakeBuildRuntimeConfigureCmd>

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -462,12 +462,12 @@
 
   <Target Name="_WasmCommonPrepareForWasmBuildNative" Condition="'$(WasmBuildNative)' == 'true'">
     <ItemGroup>
+      <!-- WasmOptConfigurationFlags property is set by reading from wasm-props.json -->
+      <WasmOptConfigurationFlags Include="@(_DefaulWasmOptConfigurationFlags)" />
+
       <WasmOptConfigurationFlags Include="--enable-simd" Condition="'$(WasmEnableSIMD)' == 'true'" />
       <WasmOptConfigurationFlags Include="--enable-exception-handling" Condition="'$(WasmExceptionHandling)' == 'true'" />
       <WasmOptConfigurationFlags Include="--strip-dwarf" Condition="'$(WasmNativeStrip)' == 'true'" />
-
-      <!-- WasmOptConfigurationFlags property is set by reading from wasm-props.json -->
-      <WasmOptConfigurationFlags Include="@(_DefaulWasmOptConfigurationFlags)" />
     </ItemGroup>
   </Target>
 
@@ -911,8 +911,8 @@
   <Target Name="_RunWasmOptPostLink" Condition="'$(WasmRunWasmOpt)' == 'true'">
     <Error Condition="'$(_WasmOutputFileName)' == ''" Text="Could not determine %24(_WasmOutputFileName)" />
 
-    <Message Text="Running wasm-opt with --strip-target-features --post-emscripten -O2 --low-memory-unused --zero-filled-memory --pass-arg=directize-initial-contents-immutable --mvp-features --enable-multivalue --enable-mutable-globals --enable-reference-types --enable-sign-ext --enable-simd --enable-exception-handling --enable-bulk-memory @(WasmOptConfigurationFlags, ' ')" Importance="High" />
-    <Exec Command="wasm-opt$(_ExeExt) --strip-target-features --post-emscripten -O2 --low-memory-unused --zero-filled-memory --pass-arg=directize-initial-contents-immutable --mvp-features --enable-multivalue --enable-mutable-globals --enable-reference-types --enable-sign-ext --enable-simd --enable-exception-handling --enable-bulk-memory @(WasmOptConfigurationFlags, ' ') &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot; -o &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot;"
+    <Message Text="Running wasm-opt with @(WasmOptConfigurationFlags, ' ')" Importance="High" />
+    <Exec Command="wasm-opt$(_ExeExt) @(WasmOptConfigurationFlags, ' ') &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot; -o &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot;"
           IgnoreStandardErrorWarningFormat="true"
           EnvironmentVariables="@(WasmToolchainEnvVars)" />
   </Target>


### PR DESCRIPTION
new default for runtime pack
`--enable-bulk-memory`
`--enable-sign-ext`
`--translate-to-new-eh`

existing defaults from emscripten that should be passed when we call `wasm-opt` ourselves.
`--low-memory-unused`
`--zero-filled-memory`
`--enable-reference-types`
`--enable-mutable-globals`
`--enable-multivalue`
`--mvp-features`
`--pass-arg=directize-initial-contents-immutable`
`--post-emscripten`
`--strip-target-features`

`-msimd128` and  `-mbulk-memory` are compiler flags not only linker flags, right ?

Contributes to https://github.com/dotnet/perf-autofiling-issues/issues/62390