### PR TITLE
Avoid some allocations in `BitVector256`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/BitVector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/BitVector256.cs
@@ -50,28 +50,32 @@ namespace System.Buffers
 
         public readonly char[] GetCharValues()
         {
-            var chars = new List<char>();
+            Span<char> chars = stackalloc char[256];
+            int size = 0;
             for (int i = 0; i < 256; i++)
             {
                 if (ContainsUnchecked(i))
                 {
-                    chars.Add((char)i);
+                    chars[size] = (char)i;
+                    size++;
                 }
             }
-            return chars.ToArray();
+            return chars.Slice(0, size).ToArray();
         }
 
         public readonly byte[] GetByteValues()
         {
-            var bytes = new List<byte>();
+            Span<byte> bytes = stackalloc byte[256];
+            int size = 0;
             for (int i = 0; i < 256; i++)
             {
                 if (ContainsUnchecked(i))
                 {
-                    bytes.Add((byte)i);
+                    bytes[size] = (byte)i;
+                    size++;
                 }
             }
-            return bytes.ToArray();
+            return bytes.Slice(0, size).ToArray();
         }
     }
 }


### PR DESCRIPTION
Avoid eight unnecessary allocations (the list, plus seven internal arrays due to resizing).