### PR TITLE
[mono][sgen] Fix incorrect condition when checking if we should do a major collection

### DIFF
--- a/src/mono/mono/sgen/sgen-memory-governor.c
+++ b/src/mono/mono/sgen/sgen-memory-governor.c
@@ -141,7 +141,7 @@ sgen_need_major_collection_conservative (void)
 	size_t max_allowance = GDOUBLE_TO_SIZE (max_last_collection_heap_size * SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO);
 	max_allowance = MAX (max_allowance, GDOUBLE_TO_SIZE (MIN_MINOR_COLLECTION_ALLOWANCE));
 
-	return min_heap_size > max_allowance;
+	return min_heap_size > (max_last_collection_heap_size + max_allowance);
 }
 
 static size_t


### PR DESCRIPTION
When we are in this method, major sweep hasn't yet finished so we check with some imprecise conservative values. min_heap_size is a conservative lower limit of the actual heap size. Allowance represents how much more we allow the heap to grow after the previous major collection. We were comparing the min_heap_size with the allowance by mistake, when we should have compared it with the next major trigger size (which is the heap_size after the last collection plus the allowance).

Wrong condition added in https://github.com/dotnet/runtime/pull/98154, causing excessive GCs in some scenarios and regression from .net8 to .net9.

Fixes https://github.com/dotnet/runtime/issues/119580