### PR TITLE
JIT: Skip bitcast transformation for promoted locals

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -2020,7 +2020,7 @@ private:
                 }
 
                 if ((genTypeSize(indir) == genTypeSize(varDsc)) && (genTypeSize(indir) <= TARGET_POINTER_SIZE) &&
-                    (varTypeIsFloating(indir) || varTypeIsFloating(varDsc)))
+                    (varTypeIsFloating(indir) || varTypeIsFloating(varDsc)) && !varDsc->lvPromoted)
                 {
                     return IndirTransform::BitCast;
                 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_120414/Runtime_120414.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_120414/Runtime_120414.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_120414
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<float> DuplicateFromVec2(Vector2 s) =>
+        Vector128.Create(Unsafe.As<Vector2, double>(ref s)).AsSingle();
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Vector2 testVec = new Vector2(1.0f, 0.5f);
+        Vector128<float> result = DuplicateFromVec2(testVec);
+        Assert.Equal(1.0f, result[0]);
+        Assert.Equal(0.5f, result[1]);
+        Assert.Equal(1.0f, result[2]);
+        Assert.Equal(0.5f, result[3]);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_120414/Runtime_120414.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_120414/Runtime_120414.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The bitcast transformation produces `BITCAST(LCL_VAR)`, but for SIMDs the local can be promoted and this ends up resulting in invalid IR. We would normally go through the `LCL_FLD` path that DNERs the local, so make sure we still do that.

Fix #120414