### PR TITLE
Make ArrayBuilder stack allocate the first 16 entries for less heap allocations

### DIFF
--- a/src/libraries/Common/src/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/ArrayBuilder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -12,9 +11,7 @@ namespace System.Collections.Generic
     /// <typeparam name="T">The element type.</typeparam>
     internal struct ArrayBuilder<T>
     {
-        private InlineArray16<T> _stackAllocatedBuffer = default;
-        private const int StackAllocatedCapacity = 16;
-        private const int DefaultHeapCapacity = 4;
+        private const int DefaultCapacity = 4;
 
         private T[]? _array; // Starts out null, initialized on first Add.
         private int _count; // Number of items into _array we're using.
@@ -26,9 +23,9 @@ namespace System.Collections.Generic
         public ArrayBuilder(int capacity) : this()
         {
             Debug.Assert(capacity >= 0);
-            if (capacity > StackAllocatedCapacity)
+            if (capacity > 0)
             {
-                _array = new T[capacity - StackAllocatedCapacity];
+                _array = new T[capacity];
             }
         }
 
@@ -36,7 +33,10 @@ namespace System.Collections.Generic
         /// Gets the number of items this instance can store without re-allocating,
         /// or 0 if the backing array is <c>null</c>.
         /// </summary>
-        public int Capacity => _array?.Length + StackAllocatedCapacity ?? StackAllocatedCapacity;
+        public int Capacity => _array?.Length ?? 0;
+
+        /// <summary>Gets the current underlying array.</summary>
+        public T[]? Buffer => _array;
 
         /// <summary>
         /// Gets the number of items in the array currently in use.
@@ -52,7 +52,7 @@ namespace System.Collections.Generic
             get
             {
                 Debug.Assert(index >= 0 && index < _count);
-                return index < StackAllocatedCapacity ? _stackAllocatedBuffer[index] : _array![index - StackAllocatedCapacity];
+                return _array![index];
             }
         }
 
@@ -76,7 +76,7 @@ namespace System.Collections.Generic
         public T First()
         {
             Debug.Assert(_count > 0);
-            return _stackAllocatedBuffer[0];
+            return _array![0];
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace System.Collections.Generic
         public T Last()
         {
             Debug.Assert(_count > 0);
-            return _count <= StackAllocatedCapacity ? _stackAllocatedBuffer[_count - 1] : _array![_count - StackAllocatedCapacity - 1];
+            return _array![_count - 1];
         }
 
         /// <summary>
@@ -101,18 +101,16 @@ namespace System.Collections.Generic
                 return Array.Empty<T>();
             }
 
-            T[] result = new T[_count];
-            int index = 0;
-            foreach (T stackAllocatedValue in _stackAllocatedBuffer)
-            {
-                result[index++] = stackAllocatedValue;
-                if (index >= _count)
-                {
-                    return result;
-                }
-            }
+            Debug.Assert(_array != null); // Nonzero _count should imply this
 
-            _array.AsSpan(0, _count - StackAllocatedCapacity).CopyTo(result.AsSpan(start: StackAllocatedCapacity));
+            T[] result = _array;
+            if (_count < result.Length)
+            {
+                // Avoid a bit of overhead (method call, some branches, extra codegen)
+                // which would be incurred by using Array.Resize
+                result = new T[_count];
+                Array.Copy(_array, result, _count);
+            }
 
 #if DEBUG
             // Try to prevent callers from using the ArrayBuilder after ToArray, if _count != 0.
@@ -134,42 +132,25 @@ namespace System.Collections.Generic
         public void UncheckedAdd(T item)
         {
             Debug.Assert(_count < Capacity);
-            if (_count < StackAllocatedCapacity)
-            {
-                _stackAllocatedBuffer[_count++] = item;
-            }
-            else
-            {
-                _array![_count++ - StackAllocatedCapacity] = item;
-            }
+
+            _array![_count++] = item;
         }
 
         private void EnsureCapacity(int minimum)
         {
             Debug.Assert(minimum > Capacity);
 
-            if (minimum < StackAllocatedCapacity)
+            int capacity = Capacity;
+            int nextCapacity = capacity == 0 ? DefaultCapacity : 2 * capacity;
+
+            if ((uint)nextCapacity > (uint)Array.MaxLength)
             {
-                return;
+                nextCapacity = Math.Max(capacity + 1, Array.MaxLength);
             }
 
-            if (_array == null)
-            {
-                // Initial capacity has not been set correctly, we will use the default size
-                _array = new T[DefaultHeapCapacity];
-                return;
-            }
+            nextCapacity = Math.Max(nextCapacity, minimum);
 
-            int nextHeapCapacity = 2 * _array.Length;
-
-            if ((uint)nextHeapCapacity > (uint)Array.MaxLength)
-            {
-                nextHeapCapacity = Math.Max(_array.Length + 1, Array.MaxLength);
-            }
-
-            nextHeapCapacity = Math.Max(nextHeapCapacity, minimum);
-
-            T[] next = new T[nextHeapCapacity];
+            T[] next = new T[nextCapacity];
             if (_count > 0)
             {
                 Array.Copy(_array!, next, _count);

--- a/src/libraries/Common/src/System/Collections/Generic/StackArrayBuilder.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/StackArrayBuilder.cs
@@ -1,0 +1,140 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace StackArrayBuilder;
+
+/// <summary>
+/// Helper type for avoiding allocations while building arrays.
+/// </summary>
+/// <typeparam name="T">The element type.</typeparam>
+/// <remarks>
+/// Will grow heap allocated size, if you need it.
+/// Only use grow in rare cases, as it needs to grow the array, if over already allocated size.
+/// If you are certain of the max size needed, you can use e.g. <code>StackArrayBuilder8</code>
+/// </remarks>
+internal ref struct StackArrayBuilder<T>
+{
+    private InlineArray16<T> _stackAllocatedBuffer = default;
+    public const int StackAllocatedCapacity = 16;
+    private const int DefaultHeapCapacity = 4;
+
+    private T[]? _heapArrayBuffer; // Starts out null, initialized if capacity is over stack allocated size when constructing or on Add.
+    private int _count; // Number of items added.
+
+    /// <summary>
+    /// Initializes the <see cref="StackArrayBuilder{T}"/> with a specified capacity.
+    /// </summary>
+    /// <param name="capacity">The capacity of the array to allocate.</param>
+    public StackArrayBuilder(int capacity) : this()
+    {
+        Debug.Assert(capacity >= 0);
+        if (capacity > StackAllocatedCapacity)
+        {
+            _heapArrayBuffer = new T[capacity - StackAllocatedCapacity];
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of items this instance can store without re-allocating.
+    /// <c>StackAllocatedCapacity</c> if the backing heap array is not needed, all up to that is already stack allocated
+    /// </summary>
+    /// <remarks>Only for unit testing, checking that overallocation does not happen</remarks>
+    public int Capacity => _heapArrayBuffer?.Length + StackAllocatedCapacity ?? StackAllocatedCapacity;
+
+    /// <summary>
+    /// Adds an item, resizing heap allocated array if necessary.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    public void Add(T item)
+    {
+        if (_count == Capacity)
+        {
+            EnsureCapacity(_count + 1);
+        }
+
+        UncheckedAdd(item);
+    }
+
+    /// <summary>
+    /// Creates an array from the contents of this builder.
+    /// </summary>
+    public T[] ToArray()
+    {
+        if (_count == 0)
+        {
+            return [];
+        }
+
+        T[] result = new T[_count];
+        int index = 0;
+        foreach (T stackAllocatedValue in _stackAllocatedBuffer)
+        {
+            result[index++] = stackAllocatedValue;
+            if (index >= _count)
+            {
+                return result;
+            }
+        }
+
+        _heapArrayBuffer.AsSpan(0, _count - StackAllocatedCapacity).CopyTo(result.AsSpan(start: StackAllocatedCapacity));
+
+        return result;
+    }
+
+    /// <summary>
+    /// Adds an item, without checking if there is room.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    /// <remarks>
+    /// Use this method if you know there is enough space in the <see cref="StackArrayBuilder{T}"/>
+    /// for another item, and you are writing performance-sensitive code.
+    /// </remarks>
+    public void UncheckedAdd(T item)
+    {
+        Debug.Assert(_count < Capacity);
+        if (_count < StackAllocatedCapacity)
+        {
+            _stackAllocatedBuffer[_count++] = item;
+        }
+        else
+        {
+            _heapArrayBuffer![_count++ - StackAllocatedCapacity] = item;
+        }
+    }
+
+    private void EnsureCapacity(int minimum)
+    {
+        Debug.Assert(minimum > Capacity);
+
+        if (minimum < StackAllocatedCapacity)
+        {
+            return; // There is still room on the stack
+        }
+
+        if (_heapArrayBuffer == null)
+        {
+            // Initial capacity has not been not set or too low, we will allocate the default heap array size
+            _heapArrayBuffer = new T[DefaultHeapCapacity];
+            return;
+        }
+
+        // Check if allocated heap capacity was enough
+        int defaultCapacityWithHeap = _heapArrayBuffer.Length + StackAllocatedCapacity;
+        if (defaultCapacityWithHeap >= minimum)
+        {
+            return; // current allocated stack+heap is large enough
+        }
+
+        // We need to allocate more heap capacity, by increasing the size of the array
+        int nextHeapCapacity = 2 * _heapArrayBuffer.Length;
+
+        if ((uint)nextHeapCapacity > (uint)Array.MaxLength)
+        {
+            nextHeapCapacity = Math.Max(_heapArrayBuffer.Length + 1, Array.MaxLength);
+        }
+
+        nextHeapCapacity = Math.Max(nextHeapCapacity, minimum);
+
+        Array.Resize(ref _heapArrayBuffer, nextHeapCapacity);
+    }
+}

--- a/src/libraries/Common/src/System/Collections/Generic/StackArrayBuilder8.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/StackArrayBuilder8.cs
@@ -1,0 +1,55 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace StackArrayBuilder;
+
+/// <summary>
+/// Helper type for avoiding allocations while building arrays.
+/// </summary>
+/// <typeparam name="T">The element type.</typeparam>
+/// <remarks>
+/// Throws <code>InvalidOperationException</code>, if the right size is not selected.
+/// Be sure to select the right size to not over- or under-allocate expected size on stack.
+/// </remarks>
+internal ref struct StackArrayBuilder8<T>
+{
+    private InlineArray8<T> _stackAllocatedBuffer = default;
+    public const int StackAllocatedCapacity = 8;
+
+    private int _count = 0; // Number of items added.
+
+    public StackArrayBuilder8()
+    {
+    }
+
+    /// <summary>Adds an item</summary>
+    /// <param name="item">The item to add.</param>
+    public void Add(T item)
+    {
+        if (_count == StackAllocatedCapacity)
+        {
+            throw new InvalidOperationException("Stack allocated capacity exceeded");
+        }
+        _stackAllocatedBuffer[_count++] = item;
+    }
+
+    /// <summary>Creates an array from the contents of this builder.</summary>
+    public T[] ToArray()
+    {
+        if (_count == 0)
+        {
+            return [];
+        }
+
+        T[] result = new T[_count];
+        int index = 0;
+        foreach (T stackAllocatedValue in _stackAllocatedBuffer)
+        {
+            result[index++] = stackAllocatedValue;
+            if (index >= _count)
+            {
+                return result;
+            }
+        }
+        return result;
+    }
+}

--- a/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -47,6 +47,10 @@
              Link="Common\System\Text\ValueStringBuilder.cs" />
     <Compile Include="$(CommonPath)System\Collections\Generic\ArrayBuilder.cs"
              Link="Common\System\Collections\Generic\ArrayBuilder.cs" />
+    <Compile Include="..\..\Common\src\System\Collections\Generic\StackArrayBuilder.cs" 
+             Link="Common\System\Collections\Generic\StackArrayBuilder.cs" />
+    <Compile Include="..\..\Common\src\System\Collections\Generic\StackArrayBuilder8.cs"
+             Link="Common\System\Collections\Generic\StackArrayBuilder8.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">


### PR DESCRIPTION
In [#120336 ](https://github.com/dotnet/runtime/pull/120336#discussion_r2404267777) I was suggested to add the improvements to the already existing `ArrayBuilder<T>` and use that in that PR.

The heap allocated buffer will only be allocated if capacity is above the 16 stack allocated capacity.

In cases where there is no conditional adds and capacity is known, it will not make a difference, as the previous internal buffer will just be returned.  
But in these cases, an array with correct capacity and an index could just be used instead of the `ArrayBuilder<T>`.

I have removed the unused `Buffer` getter.