### PR TITLE
[mono][sgen] Enable configuration of nursery allowance ratio

### DIFF
--- a/src/mono/mono/sgen/sgen-conf.h
+++ b/src/mono/mono/sgen/sgen-conf.h
@@ -201,21 +201,6 @@ typedef target_mword SgenDescriptor;
 #define SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO 0.33
 
 /*
- * Default ratio of memory we want to release in a major collection in relation to the current heap size.
- *
- * A major collection target is to free a given amount of memory. This amount is a ratio of the major heap size.
- *
- * Values above 0.5 cause the heap to agressively grow when it's small and waste memory when it's big.
- * Lower values will produce more reasonable sized heaps when it's small, but will be suboptimal at large
- * sizes as they will use a small fraction only.
- *
- */
-#define SGEN_DEFAULT_SAVE_TARGET_RATIO 0.5
-
-#define SGEN_MIN_SAVE_TARGET_RATIO 0.1
-#define SGEN_MAX_SAVE_TARGET_RATIO 2.0
-
-/*
  * Configurable cementing parameters.
  *
  * If there are too many pinned nursery objects with many references

--- a/src/mono/mono/sgen/sgen-gc.c
+++ b/src/mono/mono/sgen/sgen-gc.c
@@ -3446,7 +3446,7 @@ sgen_gc_init (void)
 	size_t soft_limit = 0;
 	int result;
 	gboolean debug_print_allowance = FALSE;
-	double allowance_ratio = 0, save_target = 0;
+	double allowance_ratio = 0;
 	gboolean cement_enabled = TRUE;
 
 	do {
@@ -3603,15 +3603,6 @@ sgen_gc_init (void)
 				}
 				continue;
 			}
-			if (g_str_has_prefix (opt, "save-target-ratio=")) {
-				double val;
-				opt = strchr (opt, '=') + 1;
-				if (parse_double_in_interval (MONO_GC_PARAMS_NAME, "save-target-ratio", opt,
-						SGEN_MIN_SAVE_TARGET_RATIO, SGEN_MAX_SAVE_TARGET_RATIO, &val)) {
-					save_target = val;
-				}
-				continue;
-			}
 			if (g_str_has_prefix (opt, "default-allowance-ratio=")) {
 				double val;
 				opt = strchr (opt, '=') + 1;
@@ -3687,14 +3678,12 @@ sgen_gc_init (void)
 			fprintf (stderr, "  [no-]cementing\n");
 			fprintf (stderr, "  [no-]dynamic-nursery\n");
 			fprintf (stderr, "  remset-copy-clear-par\n");
+			fprintf (stderr, "  default-allowance-ratio=R (where R must be between %.2f - %.2f).\n", SGEN_MIN_ALLOWANCE_NURSERY_SIZE_RATIO, SGEN_MAX_ALLOWANCE_NURSERY_SIZE_RATIO);
 			if (sgen_major_collector.print_gc_param_usage)
 				sgen_major_collector.print_gc_param_usage ();
 			if (sgen_minor_collector.print_gc_param_usage)
 				sgen_minor_collector.print_gc_param_usage ();
 			sgen_client_print_gc_params_usage ();
-			fprintf (stderr, " Experimental options:\n");
-			fprintf (stderr, "  save-target-ratio=R (where R must be between %.2f - %.2f).\n", SGEN_MIN_SAVE_TARGET_RATIO, SGEN_MAX_SAVE_TARGET_RATIO);
-			fprintf (stderr, "  default-allowance-ratio=R (where R must be between %.2f - %.2f).\n", SGEN_MIN_ALLOWANCE_NURSERY_SIZE_RATIO, SGEN_MAX_ALLOWANCE_NURSERY_SIZE_RATIO);
 			fprintf (stderr, "\n");
 
 			usage_printed = TRUE;
@@ -3882,7 +3871,7 @@ sgen_gc_init (void)
 
 	sgen_thread_pool_start ();
 
-	sgen_memgov_init (max_heap, soft_limit, debug_print_allowance, allowance_ratio, save_target);
+	sgen_memgov_init (max_heap, soft_limit, debug_print_allowance, allowance_ratio);
 
 	memset (&remset, 0, sizeof (remset));
 

--- a/src/mono/mono/sgen/sgen-memory-governor.c
+++ b/src/mono/mono/sgen/sgen-memory-governor.c
@@ -545,6 +545,9 @@ sgen_memgov_init (size_t max_heap, size_t soft_limit, gboolean debug_allowance, 
 
 	sgen_gc_info.total_nursery_size_bytes = sgen_get_nursery_end () - sgen_get_nursery_start ();
 
+	if (allowance_ratio)
+		default_allowance_nursery_size_ratio = allowance_ratio;
+
 	if (max_heap == 0) {
 		sgen_gc_info.total_available_memory_bytes = mono_determine_physical_ram_size ();
 
@@ -572,9 +575,6 @@ sgen_memgov_init (size_t max_heap, size_t soft_limit, gboolean debug_allowance, 
 
 	sgen_gc_info.total_available_memory_bytes = max_heap;
 	sgen_gc_info.high_memory_load_threshold_bytes = GDOUBLE_TO_UINT64 (.9 * sgen_gc_info.total_available_memory_bytes);
-
-	if (allowance_ratio)
-		default_allowance_nursery_size_ratio = allowance_ratio;
 
 	if (save_target)
 		save_target_ratio = save_target;

--- a/src/mono/mono/sgen/sgen-memory-governor.c
+++ b/src/mono/mono/sgen/sgen-memory-governor.c
@@ -45,7 +45,6 @@ static mword max_heap_size = ((mword)0)- ((mword)1);
 static mword soft_heap_limit = ((mword)0) - ((mword)1);
 
 static double default_allowance_nursery_size_ratio = SGEN_DEFAULT_ALLOWANCE_NURSERY_SIZE_RATIO;
-static double save_target_ratio = SGEN_DEFAULT_SAVE_TARGET_RATIO;
 
 /**/
 static mword allocated_heap;
@@ -528,7 +527,7 @@ sgen_memgov_try_alloc_space (mword size, int space)
 }
 
 void
-sgen_memgov_init (size_t max_heap, size_t soft_limit, gboolean debug_allowance, double allowance_ratio, double save_target)
+sgen_memgov_init (size_t max_heap, size_t soft_limit, gboolean debug_allowance, double allowance_ratio)
 {
 	if (soft_limit)
 		soft_heap_limit = soft_limit;
@@ -575,9 +574,6 @@ sgen_memgov_init (size_t max_heap, size_t soft_limit, gboolean debug_allowance, 
 
 	sgen_gc_info.total_available_memory_bytes = max_heap;
 	sgen_gc_info.high_memory_load_threshold_bytes = GDOUBLE_TO_UINT64 (.9 * sgen_gc_info.total_available_memory_bytes);
-
-	if (save_target)
-		save_target_ratio = save_target;
 }
 
 #endif

--- a/src/mono/mono/sgen/sgen-memory-governor.h
+++ b/src/mono/mono/sgen/sgen-memory-governor.h
@@ -9,7 +9,7 @@
 #define __MONO_SGEN_MEMORY_GOVERNOR_H__
 
 /* Heap limits */
-void sgen_memgov_init (size_t max_heap, size_t soft_limit, gboolean debug_allowance, double min_allowance_ratio, double save_target);
+void sgen_memgov_init (size_t max_heap, size_t soft_limit, gboolean debug_allowance, double min_allowance_ratio);
 void sgen_memgov_release_space (mword size, int space);
 gboolean sgen_memgov_try_alloc_space (mword size, int space);
 


### PR DESCRIPTION
The option was ignored if max-heap-size wasn't set. Also remove unused gc params option.