### PR TITLE
[ios-clr] Enable building CoreCLR runtime packs for Apple mobile

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -32,6 +32,7 @@
     <!-- Android 32-bit builds blocked by https://github.com/dotnet/runtime/issues/111665 -->
     <_CoreCLRSupportedOS Condition="'$(TargetsAndroid)' == 'true' and '$(TargetArchitecture)' != 'arm' and '$(TargetArchitecture)' != 'x86'">true</_CoreCLRSupportedOS>
     <_CoreCLRSupportedOS Condition="'$(TargetsBrowser)' == 'true'">true</_CoreCLRSupportedOS>
+    <_CoreCLRSupportedOS Condition="'$(TargetsAppleMobile)' == 'true'">true</_CoreCLRSupportedOS>
 
     <_CoreCLRSupportedArch Condition="'$(TargetArchitecture)' != 'ppc64le' and '$(TargetArchitecture)' != 's390x'">true</_CoreCLRSupportedArch>
     <CoreCLRSupported Condition="'$(_CoreCLRSupportedOS)' == 'true' and '$(_CoreCLRSupportedArch)' == 'true'">true</CoreCLRSupported>


### PR DESCRIPTION
## Description

This PR enables building runtime packs for Apple mobile platforms. It includes `libcoreclr` which already includes the clrinterpreter object files.

The following libraries are included:
```
libcoreclr (includes clrinterpreter)
libbrotli (compression libraries)
System.Security.Cryptography.Native.Apple
System.Net.Security.Native
System.IO.Compression.Native
System.Globalization.Native
System.Native
```

Contributes to https://github.com/dotnet/runtime/issues/120050