### PR TITLE
Use -warnings-as-errors in Swift compilation

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 
 add_custom_command(
     OUTPUT pal_swiftbindings.o
-    COMMAND xcrun swiftc -emit-object -static -parse-as-library -enable-library-evolution -g ${SWIFT_OPTIMIZATION_FLAG} -runtime-compatibility-version none ${SWIFT_SDK_FLAG} -target ${SWIFT_COMPILER_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift -o pal_swiftbindings.o
+    COMMAND xcrun swiftc -emit-object -static -parse-as-library -enable-library-evolution -warnings-as-errors -g ${SWIFT_OPTIMIZATION_FLAG} -runtime-compatibility-version none ${SWIFT_SDK_FLAG} -target ${SWIFT_COMPILER_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift -o pal_swiftbindings.o
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift
     COMMENT "Compiling Swift file pal_swiftbindings.swift"
 )


### PR DESCRIPTION
Right now our Swift CryptoKit bindings will compile with warnings.

The good news is we don't actually have any warnings, but we should guard this at build-time.

Before:

```
  317 |     #warning("potato!")
      |              `- warning: potato!
  318 |     let ikm = Data(bytesNoCopy: ikmPtr, count: Int(ikmLength), deallocator: Data.Deallocator.none)
  319 |     let salt = Data(bytesNoCopy: saltPtr, count: Int(saltLength), deallocator: Data.Deallocator.none)
  [ 85%] Linking C static library libSystem.Security.Cryptography.Native.Apple.a
  [ 85%] Linking C shared library libSystem.Security.Cryptography.Native.Apple.dylib
  [ 92%] Built target System.Security.Cryptography.Native.Apple-Static
  Verifying System.Security.Cryptography.Native.Apple points against entrypoints.c 
  Stripping symbols from libSystem.Security.Cryptography.Native.Apple.dylib into libSystem.Security.Cryptography.Native.Apple.dylib.dwarf
  [100%] Built target System.Security.Cryptography.Native.Appl
```

After:

```
 /Users/vcsjones/Projects/runtime/src/native/libs/System.Security.Cryptography.Native.Apple/pal_swiftbindings.swift:317:14: error: potato!
  315 |     destinationLength: Int32) -> Int32 {
  316 | 
  317 |     #warning("potato!")
      |              `- error: potato!
```