### PR TITLE
Avoid `Unsafe.AsPointer` in `MethodTable.GetField` methods

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -1277,13 +1277,13 @@ namespace Internal.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref T GetField<T>(EETypeField eField)
         {
-            return ref Unsafe.As<byte, T>(ref Unsafe.AddByteOffset(ref Unsafe.As<MethodTable, byte>(ref Unsafe.AsRef(in this)), GetFieldOffset(eField)));
+            return ref Unsafe.As<byte, T>(ref Unsafe.AddByteOffset(ref Unsafe.As<MethodTable, byte>(ref Unsafe.AsRef(in this)), (nint)GetFieldOffset(eField)));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref T GetField<T>(uint offset)
         {
-            return ref Unsafe.As<byte, T>(ref Unsafe.AddByteOffset(ref Unsafe.As<MethodTable, byte>(ref Unsafe.AsRef(in this)), offset));
+            return ref Unsafe.As<byte, T>(ref Unsafe.AddByteOffset(ref Unsafe.As<MethodTable, byte>(ref Unsafe.AsRef(in this)), (nint)offset));
         }
 
 #if TYPE_LOADER_IMPLEMENTATION

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -1277,13 +1277,17 @@ namespace Internal.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref T GetField<T>(EETypeField eField)
         {
+#pragma warning disable CS9084 // Struct member returns 'this' or other instance members by reference
             return ref Unsafe.As<byte, T>(ref Unsafe.AddByteOffset(ref Unsafe.As<MethodTable, byte>(ref Unsafe.AsRef(in this)), (nint)GetFieldOffset(eField)));
+#pragma warning restore CS9084
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref T GetField<T>(uint offset)
         {
+#pragma warning disable CS9084 // Struct member returns 'this' or other instance members by reference
             return ref Unsafe.As<byte, T>(ref Unsafe.AddByteOffset(ref Unsafe.As<MethodTable, byte>(ref Unsafe.AsRef(in this)), (nint)offset));
+#pragma warning restore CS9084
         }
 
 #if TYPE_LOADER_IMPLEMENTATION

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -1277,13 +1277,13 @@ namespace Internal.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref T GetField<T>(EETypeField eField)
         {
-            return ref Unsafe.As<byte, T>(ref *((byte*)Unsafe.AsPointer(ref this) + GetFieldOffset(eField)));
+            return ref Unsafe.As<byte, T>(ref Unsafe.AddByteOffset(ref Unsafe.As<MethodTable, byte>(ref Unsafe.AsRef(in this)), GetFieldOffset(eField)));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref T GetField<T>(uint offset)
         {
-            return ref Unsafe.As<byte, T>(ref *((byte*)Unsafe.AsPointer(ref this) + offset));
+            return ref Unsafe.As<byte, T>(ref Unsafe.AddByteOffset(ref Unsafe.As<MethodTable, byte>(ref Unsafe.AsRef(in this)), offset));
         }
 
 #if TYPE_LOADER_IMPLEMENTATION


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/99144