### PR TITLE
Avoid double Dictionary lookups (incl. hashkey generation) by using new Dictionary methods

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1177,10 +1177,8 @@ namespace System
                         {
                             string name = eventInfo.Name;
 
-                            if (csEventInfos.ContainsKey(name))
+                            if (!csEventInfos.TryAdd(name, eventInfo))
                                 continue;
-
-                            csEventInfos[name] = eventInfo;
                         }
                         else
                         {

--- a/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
@@ -481,9 +481,9 @@ namespace System.Data.Common
                     {
                         throw ADP.KeywordNotSupported(keyname);
                     }
-                    if (!firstKey)
+                    if (!firstKey || !parsetable.ContainsKey(realkeyname))
                     {
-                        parsetable.TryAdd(realkeyname, keyvalue!);
+                        parsetable[realkeyname] = keyvalue!; // last key-value pair wins (or first)
                     }
                 }
             }
@@ -578,9 +578,9 @@ namespace System.Data.Common
                     {
                         throw ADP.KeywordNotSupported(keyname);
                     }
-                    if (!firstKey)
+                    if (!firstKey || !parsetable.ContainsKey(realkeyname))
                     {
-                        parsetable.TryAdd(realkeyname, keyvalue);
+                        parsetable[realkeyname] = keyvalue; // last key-value pair wins (or first)
                     }
 
                     if (null != localKeychain)

--- a/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
@@ -481,9 +481,9 @@ namespace System.Data.Common
                     {
                         throw ADP.KeywordNotSupported(keyname);
                     }
-                    if (!firstKey || !parsetable.ContainsKey(realkeyname))
+                    if (!firstKey)
                     {
-                        parsetable[realkeyname] = keyvalue!; // last key-value pair wins (or first)
+                        parsetable.TryAdd(realkeyname, keyvalue!); // last key-value pair wins (or first)
                     }
                 }
             }
@@ -578,9 +578,9 @@ namespace System.Data.Common
                     {
                         throw ADP.KeywordNotSupported(keyname);
                     }
-                    if (!firstKey || !parsetable.ContainsKey(realkeyname))
+                    if (!firstKey)
                     {
-                        parsetable[realkeyname] = keyvalue; // last key-value pair wins (or first)
+                        parsetable.TryAdd(realkeyname, keyvalue); // last key-value pair wins (or first)
                     }
 
                     if (null != localKeychain)

--- a/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
@@ -483,7 +483,7 @@ namespace System.Data.Common
                     }
                     if (!firstKey)
                     {
-                        parsetable.TryAdd(realkeyname, keyvalue!); // last key-value pair wins (or first)
+                        parsetable.TryAdd(realkeyname, keyvalue!);
                     }
                 }
             }
@@ -580,7 +580,7 @@ namespace System.Data.Common
                     }
                     if (!firstKey)
                     {
-                        parsetable.TryAdd(realkeyname, keyvalue); // last key-value pair wins (or first)
+                        parsetable.TryAdd(realkeyname, keyvalue);
                     }
 
                     if (null != localKeychain)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Compiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/Compiler.cs
@@ -96,10 +96,7 @@ namespace System.Xml.Xsl.Xslt
 
         public void AddModule(string baseUri)
         {
-            if (!_moduleOrder.ContainsKey(baseUri))
-            {
-                _moduleOrder[baseUri] = _moduleOrder.Count;
-            }
+            _moduleOrder.TryAdd(baseUri, _moduleOrder.Count);
         }
 
         public void ApplyNsAliases(ref string? prefix, ref string nsUri)


### PR DESCRIPTION
Not sure if this is in very hot code paths, it is mostly correctness.