### PR TITLE
Add ninja .NET dependencies on macOS

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -48,6 +48,7 @@ case "$os" in
         brew bundle --no-upgrade --file=- <<EOF
 brew "cmake"
 brew "icu4c"
+brew "ninja"
 brew "openssl@3"
 brew "pkgconf"
 brew "python3"


### PR DESCRIPTION
Add ninja to macOS .NET dependencies - it is required to build the mono subset when running something like `./build.sh -subset mono.runtime` (I got a really nondescript error when trying to build without it). Not sure if this is the way we want to solve it, as it seems like ninja is *meant to be* optional - if we want to solve this a different way, or just don't care, just lmk.