### PR TITLE
[iOS] Implement IgnoreSymbols for CompreInfo in managed code

### DIFF
--- a/docs/design/features/globalization-hybrid-mode.md
+++ b/docs/design/features/globalization-hybrid-mode.md
@@ -30,7 +30,7 @@ Due to these differences, the exact result of string compariso on Apple platform
 
 The number of `CompareOptions` and `NSStringCompareOptions` combinations are limited. Originally supported combinations can be found [here for CompareOptions](https://learn.microsoft.com/dotnet/api/system.globalization.compareoptions) and [here for NSStringCompareOptions](https://developer.apple.com/documentation/foundation/nsstringcompareoptions).
 
-- `IgnoreSymbols` is not supported because there is no equivalent in native api. Throws `PlatformNotSupportedException`.
+- `IgnoreSymbols` is supported by filtering ignorable symbols on the managed side before invoking the native API.
 
 - `IgnoreKanaType` is implemented using [`kCFStringTransformHiraganaKatakana`](https://developer.apple.com/documentation/corefoundation/kcfstringtransformhiraganakatakana?language=objc) then comparing strings.
 
@@ -71,10 +71,6 @@ The number of `CompareOptions` and `NSStringCompareOptions` combinations are lim
 
    `CompareOptions.IgnoreWidth` is mapped to `NSStringCompareOptions.NSWidthInsensitiveSearch | NSStringCompareOptions.NSLiteralSearch`
 
-- All combinations that contain below `CompareOptions` always throw `PlatformNotSupportedException`:
-
-   `IgnoreSymbols`
-
 ## String starts with / ends with
 
 Affected public APIs:
@@ -91,7 +87,7 @@ Apple Native API does not expose locale-sensitive endsWith/startsWith function. 
 
 - `IgnoreSymbols`
 
-   As there is no IgnoreSymbols equivalent in NSStringCompareOptions all `CompareOptions` combinations that include `IgnoreSymbols` throw `PlatformNotSupportedException`
+   Supported by filtering ignorable symbols on the managed side prior to comparison using native API.
 
 ## String indexing
 
@@ -129,7 +125,7 @@ Not covered case:
 
 - `IgnoreSymbols`
 
-   As there is no IgnoreSymbols equivalent in NSStringCompareOptions all `CompareOptions` combinations that include `IgnoreSymbols` throw `PlatformNotSupportedException`
+   Supported by filtering ignorable symbols on the managed side prior to comparison using native API.
 
 - Some letters consist of more than one grapheme.
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -78,16 +78,15 @@ namespace System.Globalization
             }
             else
             {
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+                if (GlobalizationMode.Hybrid)
+                    return IndexOfCoreNative(target, source, options, fromBeginning, matchLengthPtr);
+#endif
                 // GetReference may return nullptr if the input span is defaulted. The native layer handles
                 // this appropriately; no workaround is needed on the managed side.
-
                 fixed (char* pSource = &MemoryMarshal.GetReference(source))
                 fixed (char* pTarget = &MemoryMarshal.GetReference(target))
                 {
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-                    if (GlobalizationMode.Hybrid)
-                        return IndexOfCoreNative(pTarget, target.Length, pSource, source.Length, options, fromBeginning, matchLengthPtr);
-#endif
                     if (fromBeginning)
                         return Interop.Globalization.IndexOf(_sortHandle, pTarget, target.Length, pSource, source.Length, options, matchLengthPtr);
                     else
@@ -207,7 +206,7 @@ namespace System.Globalization
             InteropCall:
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
                 if (GlobalizationMode.Hybrid)
-                    return IndexOfCoreNative(b, target.Length, a, source.Length, options, fromBeginning, matchLengthPtr);
+                    return IndexOfCoreNative(target, source, options, fromBeginning, matchLengthPtr);
 #endif
                 if (fromBeginning)
                     return Interop.Globalization.IndexOf(_sortHandle, b, target.Length, a, source.Length, options, matchLengthPtr);
@@ -301,7 +300,7 @@ namespace System.Globalization
             InteropCall:
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
                 if (GlobalizationMode.Hybrid)
-                    return IndexOfCoreNative(b, target.Length, a, source.Length, options, fromBeginning, matchLengthPtr);
+                    return IndexOfCoreNative(target, source, options, fromBeginning, matchLengthPtr);
 #endif
                 if (fromBeginning)
                     return Interop.Globalization.IndexOf(_sortHandle, b, target.Length, a, source.Length, options, matchLengthPtr);
@@ -328,13 +327,13 @@ namespace System.Globalization
             }
             else
             {
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+                if (GlobalizationMode.Hybrid)
+                    return NativeStartsWith(prefix, source, options);
+#endif
                 fixed (char* pSource = &MemoryMarshal.GetReference(source)) // could be null (or otherwise unable to be dereferenced)
                 fixed (char* pPrefix = &MemoryMarshal.GetReference(prefix))
                 {
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-                    if (GlobalizationMode.Hybrid)
-                        return NativeStartsWith(pPrefix, prefix.Length, pSource, source.Length, options);
-#endif
                     return Interop.Globalization.StartsWith(_sortHandle, pPrefix, prefix.Length, pSource, source.Length, options, matchLengthPtr);
                 }
             }
@@ -416,7 +415,7 @@ namespace System.Globalization
             InteropCall:
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
                 if (GlobalizationMode.Hybrid)
-                    return NativeStartsWith(bp, prefix.Length, ap, source.Length, options);
+                    return NativeStartsWith(prefix, source, options);
 #endif
                 return Interop.Globalization.StartsWith(_sortHandle, bp, prefix.Length, ap, source.Length, options, matchLengthPtr);
             }
@@ -488,7 +487,7 @@ namespace System.Globalization
             InteropCall:
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
                 if (GlobalizationMode.Hybrid)
-                    return NativeStartsWith(bp, prefix.Length, ap, source.Length, options);
+                    return NativeStartsWith(prefix, source, options);
 #endif
                 return Interop.Globalization.StartsWith(_sortHandle, bp, prefix.Length, ap, source.Length, options, matchLengthPtr);
             }
@@ -512,13 +511,13 @@ namespace System.Globalization
             }
             else
             {
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+                if (GlobalizationMode.Hybrid)
+                    return NativeEndsWith(suffix, source, options);
+#endif
                 fixed (char* pSource = &MemoryMarshal.GetReference(source)) // could be null (or otherwise unable to be dereferenced)
                 fixed (char* pSuffix = &MemoryMarshal.GetReference(suffix))
                 {
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-                    if (GlobalizationMode.Hybrid)
-                        return NativeEndsWith(pSuffix, suffix.Length, pSource, source.Length, options);
-#endif
                     return Interop.Globalization.EndsWith(_sortHandle, pSuffix, suffix.Length, pSource, source.Length, options, matchLengthPtr);
                 }
             }
@@ -601,7 +600,7 @@ namespace System.Globalization
             InteropCall:
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
                 if (GlobalizationMode.Hybrid)
-                    return NativeEndsWith(bp, suffix.Length, ap, source.Length, options);
+                    return NativeEndsWith(suffix, source, options);
 #endif
                 return Interop.Globalization.EndsWith(_sortHandle, bp, suffix.Length, ap, source.Length, options, matchLengthPtr);
             }
@@ -673,7 +672,7 @@ namespace System.Globalization
             InteropCall:
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
                 if (GlobalizationMode.Hybrid)
-                    return NativeEndsWith(bp, suffix.Length, ap, source.Length, options);
+                    return NativeEndsWith(suffix, source, options);
 #endif
                 return Interop.Globalization.EndsWith(_sortHandle, bp, suffix.Length, ap, source.Length, options, matchLengthPtr);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
@@ -249,10 +249,7 @@ namespace System.Globalization
                     for (int j = 0; j < consumed; j++)
                     {
                         destination[writeIndex] = input[i + j];
-                        if (indexMap is not null)
-                        {
-                            indexMap[writeIndex] = i;
-                        }
+                        indexMap?[writeIndex] = i;
                         writeIndex++;
                     }
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
@@ -4,6 +4,8 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -18,6 +20,8 @@ namespace System.Globalization
             ERROR_MIXED_COMPOSITION_NOT_FOUND = -3,
         }
 
+        private const int StackAllocThreshold = 256;
+
         private unsafe int CompareStringNative(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2, CompareOptions options)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -25,27 +29,34 @@ namespace System.Globalization
 
             AssertComparisonSupported(options);
 
-            using SymbolFilterHelper helper1 = new SymbolFilterHelper();
-            using SymbolFilterHelper helper2 = new SymbolFilterHelper();
+            char[]? rentedArray1 = null;
+            char[]? rentedArray2 = null;
 
             // Handle IgnoreSymbols preprocessing
             if ((options & CompareOptions.IgnoreSymbols) != 0)
             {
-                string1 = helper1.GetFilteredString(string1, generateIndexMap: false);
-                string2 = helper2.GetFilteredString(string2, generateIndexMap: false);
+                string1 = GetFilteredString(string1, stackalloc char[StackAllocThreshold], out rentedArray1, out _, generateIndexMap: false);
+                string2 = GetFilteredString(string2, stackalloc char[StackAllocThreshold], out rentedArray2, out _, generateIndexMap: false);
 
                 // Remove the flag before passing to native since we handled it here
                 options &= ~CompareOptions.IgnoreSymbols;
             }
 
-            // GetReference may return nullptr if the input span is defaulted. The native layer handles
-            // this appropriately; no workaround is needed on the managed side.
-            fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
-            fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
+            try
             {
-                int result = Interop.Globalization.CompareStringNative(m_name, m_name.Length, pString1, string1.Length, pString2, string2.Length, options);
-                Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
-                return result;
+                // GetReference may return nullptr if the input span is defaulted. The native layer handles
+                // this appropriately; no workaround is needed on the managed side.
+                fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
+                fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
+                {
+                    int result = Interop.Globalization.CompareStringNative(m_name, m_name.Length, pString1, string1.Length, pString2, string2.Length, options);
+                    Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+                    return result;
+                }
+            }
+            finally
+            {
+                ReturnBuffers(rentedArray1, rentedArray2);
             }
         }
 
@@ -53,94 +64,108 @@ namespace System.Globalization
         {
             AssertComparisonSupported(options);
 
-            using SymbolFilterHelper targetHelper = new SymbolFilterHelper();
-            using SymbolFilterHelper sourceHelper = new SymbolFilterHelper();
+            char[]? rentedTargetArray = null;
+            char[]? rentedSourceArray = null;
+            int[]? rentedIndexMap = null;
             bool ignoreSymbols = (options & CompareOptions.IgnoreSymbols) != 0;
 
             // If we are ignoring symbols, preprocess the strings by removing specified Unicode categories.
             if (ignoreSymbols)
             {
-                target = targetHelper.GetFilteredString(target, generateIndexMap: false);
-                source = sourceHelper.GetFilteredString(source, generateIndexMap: true);
+                target = GetFilteredString(target, stackalloc char[StackAllocThreshold], out rentedTargetArray, out _, generateIndexMap: false);
+                source = GetFilteredString(source, stackalloc char[StackAllocThreshold], out rentedSourceArray, out rentedIndexMap, generateIndexMap: true);
 
                 // Remove the flag before passing to native since we handled it here
                 options &= ~CompareOptions.IgnoreSymbols;
             }
 
-            Interop.Range result;
-            fixed (char* pTarget = &MemoryMarshal.GetReference(target))
-            fixed (char* pSource = &MemoryMarshal.GetReference(source))
+            try
             {
-                result = Interop.Globalization.IndexOfNative(m_name, m_name.Length, pTarget, target.Length, pSource, source.Length, options, fromBeginning);
-                Debug.Assert(result.Location != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
-                if (result.Location == (int)ErrorCodes.ERROR_MIXED_COMPOSITION_NOT_FOUND)
-                    throw new PlatformNotSupportedException(SR.PlatformNotSupported_HybridGlobalizationWithMixedCompositions);
-            }
+                Interop.Range result;
+                fixed (char* pTarget = &MemoryMarshal.GetReference(target))
+                fixed (char* pSource = &MemoryMarshal.GetReference(source))
+                {
+                    result = Interop.Globalization.IndexOfNative(m_name, m_name.Length, pTarget, target.Length, pSource, source.Length, options, fromBeginning);
+                    Debug.Assert(result.Location != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+                    if (result.Location == (int)ErrorCodes.ERROR_MIXED_COMPOSITION_NOT_FOUND)
+                        throw new PlatformNotSupportedException(SR.PlatformNotSupported_HybridGlobalizationWithMixedCompositions);
+                }
 
-            int nativeLocation = result.Location;
-            int nativeLength = result.Length;
+                int nativeLocation = result.Location;
+                int nativeLength = result.Length;
 
+                // If not ignoring symbols / nothing found / an error code / no index map (no symbols found in source), just propagate.
+                if (!ignoreSymbols || nativeLocation < 0 || rentedIndexMap is null)
+                {
+                    if (matchLengthPtr != null)
+                        *matchLengthPtr = nativeLength;
+                    return nativeLocation;
+                }
 
-            // If not ignoring symbols / nothing found / an error code / no index map (no symbols found in source), just propagate.
-            if (!ignoreSymbols || nativeLocation < 0 || sourceHelper.IndexMap is null)
-            {
+                // If ignoring symbols, map filtered indices back to original indices, expanding match length to include removed symbol chars inside the span.
+                int originalStart = rentedIndexMap[nativeLocation];
+                int filteredEnd = nativeLocation + nativeLength - 1;
+
+                Debug.Assert(filteredEnd < source.Length,
+                    $"Filtered end index {filteredEnd} should not exceed the length of the filtered string {source.Length}. nativeLocation={nativeLocation}, nativeLength={nativeLength}");
+
+                // Find the end position of the character at filteredEnd in the original string.
+                int endCharStartPos = rentedIndexMap[filteredEnd];
+
+                // Check if the previous position belongs to the same character (first unit of a surrogate pair)
+                int firstUnit = (filteredEnd > 0 && rentedIndexMap[filteredEnd - 1] == endCharStartPos)
+                    ? filteredEnd - 1
+                    : filteredEnd;
+
+                // Check if the next position belongs to the same character (second unit of a surrogate pair)
+                int lastUnit = (filteredEnd + 1 < source.Length && rentedIndexMap[filteredEnd + 1] == endCharStartPos)
+                    ? filteredEnd + 1
+                    : filteredEnd;
+
+                int endCharWidth = lastUnit - firstUnit + 1;
+                int originalEnd = endCharStartPos + endCharWidth;
+                int originalLength = originalEnd - originalStart;
+
                 if (matchLengthPtr != null)
-                    *matchLengthPtr = nativeLength;
-                return nativeLocation;
+                    *matchLengthPtr = originalLength;
+                return originalStart;
             }
-
-            // If ignoring symbols, map filtered indices back to original indices, expanding match length to include removed symbol chars inside the span.
-            int originalStart = sourceHelper.IndexMap[nativeLocation];
-            int filteredEnd = nativeLocation + nativeLength - 1;
-
-            Debug.Assert(filteredEnd < source.Length,
-                $"Filtered end index {filteredEnd} should not exceed the length of the filtered string {source.Length}. nativeLocation={nativeLocation}, nativeLength={nativeLength}");
-
-            // Find the end position of the character at filteredEnd in the original string.
-            int endCharStartPos = sourceHelper.IndexMap[filteredEnd];
-
-            // Check if the previous position belongs to the same character (first unit of a surrogate pair)
-            int firstUnit = (filteredEnd > 0 && sourceHelper.IndexMap[filteredEnd - 1] == endCharStartPos)
-                ? filteredEnd - 1
-                : filteredEnd;
-
-            // Check if the next position belongs to the same character (second unit of a surrogate pair)
-            int lastUnit = (filteredEnd + 1 < source.Length && sourceHelper.IndexMap[filteredEnd + 1] == endCharStartPos)
-                ? filteredEnd + 1
-                : filteredEnd;
-
-            int endCharWidth = lastUnit - firstUnit + 1;
-            int originalEnd = endCharStartPos + endCharWidth;
-            int originalLength = originalEnd - originalStart;
-
-            if (matchLengthPtr != null)
-                *matchLengthPtr = originalLength;
-            return originalStart;
+            finally
+            {
+                ReturnBuffers(rentedTargetArray, rentedSourceArray, rentedIndexMap);
+            }
         }
 
         private unsafe bool NativeStartsWith(ReadOnlySpan<char> prefix, ReadOnlySpan<char> source, CompareOptions options)
         {
             AssertComparisonSupported(options);
 
-            using SymbolFilterHelper prefixHelper = new SymbolFilterHelper();
-            using SymbolFilterHelper sourceHelper = new SymbolFilterHelper();
+            char[]? rentedPrefixArray = null;
+            char[]? rentedSourceArray = null;
 
             // Handle IgnoreSymbols preprocessing
             if ((options & CompareOptions.IgnoreSymbols) != 0)
             {
-                prefix = prefixHelper.GetFilteredString(prefix, generateIndexMap: false);
-                source = sourceHelper.GetFilteredString(source, generateIndexMap: false);
+                prefix = GetFilteredString(prefix, stackalloc char[StackAllocThreshold], out rentedPrefixArray, out _, generateIndexMap: false);
+                source = GetFilteredString(source, stackalloc char[StackAllocThreshold], out rentedSourceArray, out _, generateIndexMap: false);
 
                 // Remove the flag before passing to native since we handled it here
                 options &= ~CompareOptions.IgnoreSymbols;
             }
 
-            fixed (char* pPrefix = &MemoryMarshal.GetReference(prefix))
-            fixed (char* pSource = &MemoryMarshal.GetReference(source))
+            try
             {
-                int result = Interop.Globalization.StartsWithNative(m_name, m_name.Length, pPrefix, prefix.Length, pSource, source.Length, options);
-                Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
-                return result > 0;
+                fixed (char* pPrefix = &MemoryMarshal.GetReference(prefix))
+                fixed (char* pSource = &MemoryMarshal.GetReference(source))
+                {
+                    int result = Interop.Globalization.StartsWithNative(m_name, m_name.Length, pPrefix, prefix.Length, pSource, source.Length, options);
+                    Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+                    return result > 0;
+                }
+            }
+            finally
+            {
+                ReturnBuffers(rentedPrefixArray, rentedSourceArray);
             }
         }
 
@@ -148,172 +173,164 @@ namespace System.Globalization
         {
             AssertComparisonSupported(options);
 
-            using SymbolFilterHelper suffixHelper = new SymbolFilterHelper();
-            using SymbolFilterHelper sourceHelper = new SymbolFilterHelper();
+            char[]? rentedSuffixArray = null;
+            char[]? rentedSourceArray = null;
 
             // Handle IgnoreSymbols preprocessing
             if ((options & CompareOptions.IgnoreSymbols) != 0)
             {
-                suffix = suffixHelper.GetFilteredString(suffix, generateIndexMap: false);
-                source = sourceHelper.GetFilteredString(source, generateIndexMap: false);
+                suffix = GetFilteredString(suffix, stackalloc char[StackAllocThreshold], out rentedSuffixArray, out _, generateIndexMap: false);
+                source = GetFilteredString(source, stackalloc char[StackAllocThreshold], out rentedSourceArray, out _, generateIndexMap: false);
 
                 // Remove the flag before passing to native since we handled it here
                 options &= ~CompareOptions.IgnoreSymbols;
             }
 
-            fixed (char* pSuffix = &MemoryMarshal.GetReference(suffix))
-            fixed (char* pSource = &MemoryMarshal.GetReference(source))
+            try
             {
-                int result = Interop.Globalization.EndsWithNative(m_name, m_name.Length, pSuffix, suffix.Length, pSource, source.Length, options);
-                Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
-                return result > 0;
+                fixed (char* pSuffix = &MemoryMarshal.GetReference(suffix))
+                fixed (char* pSource = &MemoryMarshal.GetReference(source))
+                {
+                    int result = Interop.Globalization.EndsWithNative(m_name, m_name.Length, pSuffix, suffix.Length, pSource, source.Length, options);
+                    Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+                    return result > 0;
+                }
+            }
+            finally
+            {
+                ReturnBuffers(rentedSuffixArray, rentedSourceArray);
             }
         }
 
         /// <summary>
-        /// Helper struct that manages buffers for filtering symbols from a span.
-        /// Uses ArrayPool for memory allocation.
-        /// Implements IDisposable to return rented arrays.
+        /// Returns multiple rented buffers to their respective pools if they were allocated.
         /// </summary>
-        private ref struct SymbolFilterHelper
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ReturnBuffers(char[]? charBuffer1 = null, char[]? charBuffer2 = null, int[]? indexMapBuffer = null)
         {
-            private char[]? _arrayToReturnToPool;
+            if (charBuffer1 is not null)
+                ArrayPool<char>.Shared.Return(charBuffer1);
+            if (charBuffer2 is not null)
+                ArrayPool<char>.Shared.Return(charBuffer2);
+            if (indexMapBuffer is not null)
+                ArrayPool<int>.Shared.Return(indexMapBuffer);
+        }
 
-            public SymbolFilterHelper() { }
+        /// <summary>
+        /// Filters ignorable symbols from the input span.
+        /// </summary>
+        /// <param name="input">The input span to filter.</param>
+        /// <param name="stackBuffer">A stack-allocated buffer to use for small inputs or if no symbols are found.</param>
+        /// <param name="rentedCharArray">Outputs a rented char array if input is too large for stackBuffer and contains symbols. Null if stackBuffer was sufficient.</param>
+        /// <param name="rentedIndexMap">Outputs a rented int array for the index map if generateIndexMap is true and symbols were found. Null otherwise.</param>
+        /// <param name="generateIndexMap">If true, generates an index map tracking each character's original position.</param>
+        /// <returns>
+        /// A span containing the filtered string with ignorable symbols removed. If no symbols are found,
+        /// returns the original input span without allocating.
+        /// </returns>
+        private static ReadOnlySpan<char> GetFilteredString(
+            ReadOnlySpan<char> input,
+            scoped Span<char> stackBuffer,
+            out char[]? rentedCharArray,
+            out int[]? rentedIndexMap,
+            bool generateIndexMap)
+        {
+            rentedCharArray = null;
+            rentedIndexMap = null;
 
-            /// <summary>
-            /// Gets the index map array, or null if no index map was generated.
-            /// </summary>
-            public int[]? IndexMap { get; private set; }
+            int i = 0;
+            int consumed = 0;
 
-            /// <summary>
-            /// Filters ignorable symbols from the input span and optionally generates an index map.
-            /// </summary>
-            /// <param name="input">The input span to filter.</param>
-            /// <param name="generateIndexMap">
-            /// If <c>true</c>, generates an index map that tracks the position of each character in the filtered
-            /// output back to its original position in the input. The map is accessible via <see cref="IndexMap"/>.
-            /// </param>
-            /// <returns>
-            /// A span containing the filtered string with ignorable symbols removed. If no symbols are found,
-            /// returns the original input span without allocating. Otherwise, returns a span backed by
-            /// pooled memory that will be returned when <see cref="Dispose"/> is called.
-            /// </returns>
-            public ReadOnlySpan<char> GetFilteredString(ReadOnlySpan<char> input, bool generateIndexMap = false)
+            // Fast path: scan through the input until we find the first ignorable symbol
+            for (; i < input.Length;)
             {
-                if (_arrayToReturnToPool is not null || IndexMap is not null)
+                Rune.DecodeFromUtf16(input.Slice(i), out Rune rune, out consumed);
+                if (IsIgnorableSymbol(rune))
                 {
-                    Dispose();
+                    break;
                 }
+                i += consumed;
+            }
 
-                int i = 0;
-                int consumed = 0;
-                // Fast path: scan through the input until we find the first ignorable symbol
-                for (; i < input.Length;)
+            // If we scanned the entire input without finding any ignorable symbols, return original input
+            if (i >= input.Length)
+            {
+                return input;
+            }
+
+            // Found symbols - decide whether to use stack or heap allocation
+            Span<char> outSpan = input.Length <= stackBuffer.Length ? stackBuffer : (rentedCharArray = ArrayPool<char>.Shared.Rent(input.Length));
+            // Copy the initial segment that contains no ignorable symbols (positions 0 to i-1)
+            input.Slice(0, i).CopyTo(outSpan);
+
+            // Initialize the index map for the initial segment with identity mapping
+            if (generateIndexMap)
+            {
+                rentedIndexMap = ArrayPool<int>.Shared.Rent(input.Length);
+                for (int j = 0; j < i; j++)
                 {
-                    Rune.DecodeFromUtf16(input.Slice(i), out Rune rune, out consumed);
-                    if (IsIgnorableSymbol(rune))
+                    rentedIndexMap[j] = j;
+                }
+            }
+
+            int writeIndex = i;
+            i += consumed; // skip the ignorable symbol we just found
+
+            for (; i < input.Length;)
+            {
+                Rune.DecodeFromUtf16(input.Slice(i), out Rune rune, out consumed);
+                if (!IsIgnorableSymbol(rune))
+                {
+                    // Copy the UTF-16 units and map each filtered position to the start of the original character
+                    outSpan[writeIndex] = input[i];
+                    rentedIndexMap?[writeIndex] = i;
+                    writeIndex++;
+
+                    if (consumed > 1)
                     {
-                        break;
-                    }
-                    i += consumed;
-                }
-
-                // If we scanned the entire input without finding any ignorable symbols, return original input
-                if (i >= input.Length)
-                {
-                    return input;
-                }
-
-                // Rent buffers from ArrayPool
-                _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(input.Length);
-                Span<char> outSpan = _arrayToReturnToPool;
-
-                // Copy the initial segment that contains no ignorable symbols (positions 0 to i-1)
-                input.Slice(0, i).CopyTo(outSpan);
-                if (generateIndexMap)
-                {
-                    // Initialize the index map for the initial segment with identity mapping
-                    IndexMap = ArrayPool<int>.Shared.Rent(input.Length);
-                    for (int j = 0; j < i; j++)
-                    {
-                        IndexMap![j] = j;
-                    }
-                }
-
-                int writeIndex = i;
-                i += consumed; // skip the ignorable symbol we just found
-
-                for (; i < input.Length;)
-                {
-                    Rune.DecodeFromUtf16(input.Slice(i), out Rune rune, out consumed);
-                    if (!IsIgnorableSymbol(rune))
-                    {
-                        // Copy the UTF-16 units and map each filtered position to the start of the original character
-                        outSpan[writeIndex] = input[i];
-                        IndexMap?[writeIndex] = i;
+                        outSpan[writeIndex] = input[i + 1];
+                        rentedIndexMap?[writeIndex] = i;
                         writeIndex++;
-
-                        if (consumed > 1)
-                        {
-                            outSpan[writeIndex] = input[i + 1];
-                            IndexMap?[writeIndex] = i + 1;
-                            writeIndex++;
-                        }
                     }
-                    i += consumed;
                 }
-
-                return outSpan.Slice(0, writeIndex);
+                i += consumed;
             }
 
-            public void Dispose()
-            {
-                if (_arrayToReturnToPool is not null)
-                {
-                    ArrayPool<char>.Shared.Return(_arrayToReturnToPool);
-                    _arrayToReturnToPool = null;
-                }
-                if (IndexMap is not null)
-                {
-                    ArrayPool<int>.Shared.Return(IndexMap);
-                    IndexMap = null;
-                }
-            }
+            return outSpan.Slice(0, writeIndex);
+        }
 
-            /// <summary>
-            /// Determines whether the specified rune should be ignored when using CompareOptions.IgnoreSymbols.
-            /// </summary>
-            /// <param name="rune">The rune to check.</param>
-            /// <returns>
-            /// <c>true</c> if the rune should be ignored; otherwise, <c>false</c>.
-            /// </returns>
-            /// <remarks>
-            /// This method returns <c>true</c> for:
-            /// - All separator categories (SpaceSeparator, LineSeparator, ParagraphSeparator)
-            /// - All punctuation categories (ConnectorPunctuation through OtherPunctuation)
-            /// - All symbol categories (MathSymbol through ModifierSymbol)
-            /// - Whitespace control characters (tab, line feed, vertical tab, form feed, carriage return, etc.)
-            /// </remarks>
-            private static bool IsIgnorableSymbol(Rune rune)
-            {
-                UnicodeCategory category = CharUnicodeInfo.GetUnicodeCategory(rune.Value);
+        /// <summary>
+        /// Determines whether the specified rune should be ignored when using CompareOptions.IgnoreSymbols.
+        /// </summary>
+        /// <param name="rune">The rune to check.</param>
+        /// <returns>
+        /// <c>true</c> if the rune should be ignored; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// This method returns <c>true</c> for:
+        /// - All separator categories (SpaceSeparator, LineSeparator, ParagraphSeparator)
+        /// - All punctuation categories (ConnectorPunctuation through OtherPunctuation)
+        /// - All symbol categories (MathSymbol through ModifierSymbol)
+        /// - Whitespace control characters (tab, line feed, vertical tab, form feed, carriage return, etc.)
+        /// </remarks>
+        private static bool IsIgnorableSymbol(Rune rune)
+        {
+            UnicodeCategory category = CharUnicodeInfo.GetUnicodeCategory(rune.Value);
 
-                // Check for separator categories (11-13)
-                if (category >= UnicodeCategory.SpaceSeparator && category <= UnicodeCategory.ParagraphSeparator)
-                    return true;
+            // Check for separator categories (11-13)
+            if (category >= UnicodeCategory.SpaceSeparator && category <= UnicodeCategory.ParagraphSeparator)
+                return true;
 
-                // Check for punctuation/symbol categories (18-27)
-                if (category >= UnicodeCategory.ConnectorPunctuation && category <= UnicodeCategory.ModifierSymbol)
-                    return true;
+            // Check for punctuation/symbol categories (18-27)
+            if (category >= UnicodeCategory.ConnectorPunctuation && category <= UnicodeCategory.ModifierSymbol)
+                return true;
 
-                // For Control (14) and Format (15) categories, only include whitespace characters
-                // This includes: tab (U+0009), LF (U+000A), VT (U+000B), FF (U+000C), CR (U+000D), NEL (U+0085)
-                if (category == UnicodeCategory.Control || category == UnicodeCategory.Format)
-                    return Rune.IsWhiteSpace(rune);
+            // For Control (14) and Format (15) categories, only include whitespace characters
+            // This includes: tab (U+0009), LF (U+000A), VT (U+000B), FF (U+000C), CR (U+000D), NEL (U+0085)
+            if (category == UnicodeCategory.Control || category == UnicodeCategory.Format)
+                return Rune.IsWhiteSpace(rune);
 
-                return false;
-            }
+            return false;
         }
 
         private static void AssertComparisonSupported(CompareOptions options)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
@@ -20,223 +20,255 @@ namespace System.Globalization
             ERROR_MIXED_COMPOSITION_NOT_FOUND = -3,
         }
 
-        private const int StackAllocThreshold = 256;
+        private const int StackAllocThreshold = 150;
 
-        private unsafe int CompareStringNative(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2, CompareOptions options)
+        private unsafe int CompareStringNative(scoped ReadOnlySpan<char> string1, scoped ReadOnlySpan<char> string2, CompareOptions options)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(!GlobalizationMode.UseNls);
 
             AssertComparisonSupported(options);
 
-            char[]? rentedArray1 = null;
-            char[]? rentedArray2 = null;
+            using SymbolFilteringBuffer buffer1 = new SymbolFilteringBuffer();
+            using SymbolFilteringBuffer buffer2 = new SymbolFilteringBuffer();
+
+            Span<char> stackBuffer1 = stackalloc char[StackAllocThreshold];
+            Span<char> stackBuffer2 = stackalloc char[StackAllocThreshold];
 
             // Handle IgnoreSymbols preprocessing
             if ((options & CompareOptions.IgnoreSymbols) != 0)
             {
-                string1 = GetFilteredString(string1, stackalloc char[StackAllocThreshold], out rentedArray1, out _, generateIndexMap: false);
-                string2 = GetFilteredString(string2, stackalloc char[StackAllocThreshold], out rentedArray2, out _, generateIndexMap: false);
+                string1 = !buffer1.TryFilterString(string1, stackBuffer1, Span<int>.Empty) ? string1 :
+                    buffer1.RentedFilteredBuffer is not null ?
+                    buffer1.RentedFilteredBuffer.AsSpan(0, buffer1.FilteredLength) :
+                    stackBuffer1.Slice(0, buffer1.FilteredLength);
+
+                string2 = !buffer2.TryFilterString(string2, stackBuffer2, Span<int>.Empty) ? string2 :
+                    buffer2.RentedFilteredBuffer is not null ?
+                    buffer2.RentedFilteredBuffer.AsSpan(0, buffer2.FilteredLength) :
+                    stackBuffer2.Slice(0, buffer2.FilteredLength);
 
                 // Remove the flag before passing to native since we handled it here
                 options &= ~CompareOptions.IgnoreSymbols;
             }
 
-            try
+            // GetReference may return nullptr if the input span is defaulted. The native layer handles
+            // this appropriately; no workaround is needed on the managed side.
+            fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
+            fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
             {
-                // GetReference may return nullptr if the input span is defaulted. The native layer handles
-                // this appropriately; no workaround is needed on the managed side.
-                fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
-                fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
-                {
-                    int result = Interop.Globalization.CompareStringNative(m_name, m_name.Length, pString1, string1.Length, pString2, string2.Length, options);
-                    Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
-                    return result;
-                }
-            }
-            finally
-            {
-                ReturnBuffers(rentedArray1, rentedArray2);
+                int result = Interop.Globalization.CompareStringNative(m_name, m_name.Length, pString1, string1.Length, pString2, string2.Length, options);
+                Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+                return result;
             }
         }
 
-        private unsafe int IndexOfCoreNative(ReadOnlySpan<char> target, ReadOnlySpan<char> source, CompareOptions options, bool fromBeginning, int* matchLengthPtr)
+        private unsafe int IndexOfCoreNative(scoped ReadOnlySpan<char> target, scoped ReadOnlySpan<char> source, CompareOptions options, bool fromBeginning, int* matchLengthPtr)
         {
             AssertComparisonSupported(options);
 
-            char[]? rentedTargetArray = null;
-            char[]? rentedSourceArray = null;
-            int[]? rentedIndexMap = null;
             bool ignoreSymbols = (options & CompareOptions.IgnoreSymbols) != 0;
+
+            using SymbolFilteringBuffer buffer1 = new SymbolFilteringBuffer();
+            using SymbolFilteringBuffer buffer2 = new SymbolFilteringBuffer();
+
+            Span<char> stackBuffer1 = stackalloc char[StackAllocThreshold];
+            Span<char> stackBuffer2 = stackalloc char[StackAllocThreshold];
+            Span<int> stackIndexMap = stackalloc int[StackAllocThreshold];
 
             // If we are ignoring symbols, preprocess the strings by removing specified Unicode categories.
             if (ignoreSymbols)
             {
-                target = GetFilteredString(target, stackalloc char[StackAllocThreshold], out rentedTargetArray, out _, generateIndexMap: false);
-                source = GetFilteredString(source, stackalloc char[StackAllocThreshold], out rentedSourceArray, out rentedIndexMap, generateIndexMap: true);
+                target = !buffer1.TryFilterString(target, stackBuffer1, Span<int>.Empty) ? target :
+                    buffer1.RentedFilteredBuffer is not null ?
+                    buffer1.RentedFilteredBuffer.AsSpan(0, buffer1.FilteredLength) :
+                    stackBuffer1.Slice(0, buffer1.FilteredLength);
+
+                source = !buffer2.TryFilterString(source, stackBuffer2, stackIndexMap) ? source :
+                    buffer2.RentedFilteredBuffer is not null ?
+                    buffer2.RentedFilteredBuffer.AsSpan(0, buffer2.FilteredLength) :
+                    stackBuffer2.Slice(0, buffer2.FilteredLength);
 
                 // Remove the flag before passing to native since we handled it here
                 options &= ~CompareOptions.IgnoreSymbols;
             }
 
-            try
+            Interop.Range result;
+            fixed (char* pTarget = &MemoryMarshal.GetReference(target))
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
             {
-                Interop.Range result;
-                fixed (char* pTarget = &MemoryMarshal.GetReference(target))
-                fixed (char* pSource = &MemoryMarshal.GetReference(source))
-                {
-                    result = Interop.Globalization.IndexOfNative(m_name, m_name.Length, pTarget, target.Length, pSource, source.Length, options, fromBeginning);
-                    Debug.Assert(result.Location != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
-                    if (result.Location == (int)ErrorCodes.ERROR_MIXED_COMPOSITION_NOT_FOUND)
-                        throw new PlatformNotSupportedException(SR.PlatformNotSupported_HybridGlobalizationWithMixedCompositions);
-                }
+                result = Interop.Globalization.IndexOfNative(m_name, m_name.Length, pTarget, target.Length, pSource, source.Length, options, fromBeginning);
+                Debug.Assert(result.Location != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+                if (result.Location == (int)ErrorCodes.ERROR_MIXED_COMPOSITION_NOT_FOUND)
+                    throw new PlatformNotSupportedException(SR.PlatformNotSupported_HybridGlobalizationWithMixedCompositions);
+            }
 
-                int nativeLocation = result.Location;
-                int nativeLength = result.Length;
+            int nativeLocation = result.Location;
+            int nativeLength = result.Length;
 
-                // If not ignoring symbols / nothing found / an error code / no index map (no symbols found in source), just propagate.
-                if (!ignoreSymbols || nativeLocation < 0 || rentedIndexMap is null)
-                {
-                    if (matchLengthPtr != null)
-                        *matchLengthPtr = nativeLength;
-                    return nativeLocation;
-                }
-
-                // If ignoring symbols, map filtered indices back to original indices, expanding match length to include removed symbol chars inside the span.
-                int originalStart = rentedIndexMap[nativeLocation];
-                int filteredEnd = nativeLocation + nativeLength - 1;
-
-                Debug.Assert(filteredEnd < source.Length,
-                    $"Filtered end index {filteredEnd} should not exceed the length of the filtered string {source.Length}. nativeLocation={nativeLocation}, nativeLength={nativeLength}");
-
-                // Find the end position of the character at filteredEnd in the original string.
-                int endCharStartPos = rentedIndexMap[filteredEnd];
-
-                // Check if the previous position belongs to the same character (first unit of a surrogate pair)
-                int firstUnit = (filteredEnd > 0 && rentedIndexMap[filteredEnd - 1] == endCharStartPos)
-                    ? filteredEnd - 1
-                    : filteredEnd;
-
-                // Check if the next position belongs to the same character (second unit of a surrogate pair)
-                int lastUnit = (filteredEnd + 1 < source.Length && rentedIndexMap[filteredEnd + 1] == endCharStartPos)
-                    ? filteredEnd + 1
-                    : filteredEnd;
-
-                int endCharWidth = lastUnit - firstUnit + 1;
-                int originalEnd = endCharStartPos + endCharWidth;
-                int originalLength = originalEnd - originalStart;
-
+            // If not ignoring symbols / nothing found / an error code / no index map (no symbols found in source), just propagate.
+            // buffer2.FilteredLength == 0 means no symbols were found in source, so no index map was created.
+            if (!ignoreSymbols || buffer2.FilteredLength == 0 || nativeLocation < 0)
+            {
                 if (matchLengthPtr != null)
-                    *matchLengthPtr = originalLength;
-                return originalStart;
+                    *matchLengthPtr = nativeLength;
+                return nativeLocation;
             }
-            finally
-            {
-                ReturnBuffers(rentedTargetArray, rentedSourceArray, rentedIndexMap);
-            }
+
+            Span<int> rentedIndexMap = buffer2.RentedIndexMapBuffer is not null ?
+                                        buffer2.RentedIndexMapBuffer.AsSpan(0, buffer2.FilteredLength) :
+                                        stackIndexMap.Slice(0, buffer2.FilteredLength);
+
+            // If ignoring symbols, map filtered indices back to original indices, expanding match length to include removed symbol chars inside the span.
+            int originalStart = rentedIndexMap[nativeLocation];
+            int filteredEnd = nativeLocation + nativeLength - 1;
+
+            Debug.Assert(filteredEnd < source.Length,
+                $"Filtered end index {filteredEnd} should not exceed the length of the filtered string {source.Length}. nativeLocation={nativeLocation}, nativeLength={nativeLength}");
+
+            // Find the end position of the character at filteredEnd in the original string.
+            int endCharStartPos = rentedIndexMap[filteredEnd];
+
+            // Check if the previous position belongs to the same character (first unit of a surrogate pair)
+            int firstUnit = (filteredEnd > 0 && rentedIndexMap[filteredEnd - 1] == endCharStartPos)
+                ? filteredEnd - 1
+                : filteredEnd;
+
+            // Check if the next position belongs to the same character (second unit of a surrogate pair)
+            int lastUnit = (filteredEnd + 1 < source.Length && rentedIndexMap[filteredEnd + 1] == endCharStartPos)
+                ? filteredEnd + 1
+                : filteredEnd;
+
+            int endCharWidth = lastUnit - firstUnit + 1;
+            int originalEnd = endCharStartPos + endCharWidth;
+            int originalLength = originalEnd - originalStart;
+
+            if (matchLengthPtr != null)
+                *matchLengthPtr = originalLength;
+
+            return originalStart;
         }
 
-        private unsafe bool NativeStartsWith(ReadOnlySpan<char> prefix, ReadOnlySpan<char> source, CompareOptions options)
+        private unsafe bool NativeStartsWith(scoped ReadOnlySpan<char> prefix, scoped ReadOnlySpan<char> source, CompareOptions options)
         {
             AssertComparisonSupported(options);
 
-            char[]? rentedPrefixArray = null;
-            char[]? rentedSourceArray = null;
+            using SymbolFilteringBuffer buffer1 = new SymbolFilteringBuffer();
+            using SymbolFilteringBuffer buffer2 = new SymbolFilteringBuffer();
+
+            Span<char> stackBuffer1 = stackalloc char[StackAllocThreshold];
+            Span<char> stackBuffer2 = stackalloc char[StackAllocThreshold];
 
             // Handle IgnoreSymbols preprocessing
             if ((options & CompareOptions.IgnoreSymbols) != 0)
             {
-                prefix = GetFilteredString(prefix, stackalloc char[StackAllocThreshold], out rentedPrefixArray, out _, generateIndexMap: false);
-                source = GetFilteredString(source, stackalloc char[StackAllocThreshold], out rentedSourceArray, out _, generateIndexMap: false);
+                prefix = !buffer1.TryFilterString(prefix, stackBuffer1, Span<int>.Empty) ? prefix :
+                    buffer1.RentedFilteredBuffer is not null ?
+                    buffer1.RentedFilteredBuffer.AsSpan(0, buffer1.FilteredLength) :
+                    stackBuffer1.Slice(0, buffer1.FilteredLength);
+
+                source = !buffer2.TryFilterString(source, stackBuffer2, Span<int>.Empty) ? source :
+                    buffer2.RentedFilteredBuffer is not null ?
+                    buffer2.RentedFilteredBuffer.AsSpan(0, buffer2.FilteredLength) :
+                    stackBuffer2.Slice(0, buffer2.FilteredLength);
 
                 // Remove the flag before passing to native since we handled it here
                 options &= ~CompareOptions.IgnoreSymbols;
             }
 
-            try
+            fixed (char* pPrefix = &MemoryMarshal.GetReference(prefix))
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
             {
-                fixed (char* pPrefix = &MemoryMarshal.GetReference(prefix))
-                fixed (char* pSource = &MemoryMarshal.GetReference(source))
-                {
-                    int result = Interop.Globalization.StartsWithNative(m_name, m_name.Length, pPrefix, prefix.Length, pSource, source.Length, options);
-                    Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
-                    return result > 0;
-                }
-            }
-            finally
-            {
-                ReturnBuffers(rentedPrefixArray, rentedSourceArray);
+                int result = Interop.Globalization.StartsWithNative(m_name, m_name.Length, pPrefix, prefix.Length, pSource, source.Length, options);
+                Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+                return result > 0;
             }
         }
 
-        private unsafe bool NativeEndsWith(ReadOnlySpan<char> suffix, ReadOnlySpan<char> source, CompareOptions options)
+        private unsafe bool NativeEndsWith(scoped ReadOnlySpan<char> suffix, scoped ReadOnlySpan<char> source, CompareOptions options)
         {
             AssertComparisonSupported(options);
 
-            char[]? rentedSuffixArray = null;
-            char[]? rentedSourceArray = null;
+            using SymbolFilteringBuffer buffer1 = new SymbolFilteringBuffer();
+            using SymbolFilteringBuffer buffer2 = new SymbolFilteringBuffer();
+
+            Span<char> stackBuffer1 = stackalloc char[StackAllocThreshold];
+            Span<char> stackBuffer2 = stackalloc char[StackAllocThreshold];
 
             // Handle IgnoreSymbols preprocessing
             if ((options & CompareOptions.IgnoreSymbols) != 0)
             {
-                suffix = GetFilteredString(suffix, stackalloc char[StackAllocThreshold], out rentedSuffixArray, out _, generateIndexMap: false);
-                source = GetFilteredString(source, stackalloc char[StackAllocThreshold], out rentedSourceArray, out _, generateIndexMap: false);
+                suffix = !buffer1.TryFilterString(suffix, stackBuffer1, Span<int>.Empty) ? suffix :
+                    buffer1.RentedFilteredBuffer is not null ?
+                    buffer1.RentedFilteredBuffer.AsSpan(0, buffer1.FilteredLength) :
+                    stackBuffer1.Slice(0, buffer1.FilteredLength);
+
+                source = !buffer2.TryFilterString(source, stackBuffer2, Span<int>.Empty) ? source :
+                    buffer2.RentedFilteredBuffer is not null ?
+                    buffer2.RentedFilteredBuffer.AsSpan(0, buffer2.FilteredLength) :
+                    stackBuffer2.Slice(0, buffer2.FilteredLength);
 
                 // Remove the flag before passing to native since we handled it here
                 options &= ~CompareOptions.IgnoreSymbols;
             }
 
-            try
+            fixed (char* pSuffix = &MemoryMarshal.GetReference(suffix))
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
             {
-                fixed (char* pSuffix = &MemoryMarshal.GetReference(suffix))
-                fixed (char* pSource = &MemoryMarshal.GetReference(source))
-                {
-                    int result = Interop.Globalization.EndsWithNative(m_name, m_name.Length, pSuffix, suffix.Length, pSource, source.Length, options);
-                    Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
-                    return result > 0;
-                }
-            }
-            finally
-            {
-                ReturnBuffers(rentedSuffixArray, rentedSourceArray);
+                int result = Interop.Globalization.EndsWithNative(m_name, m_name.Length, pSuffix, suffix.Length, pSource, source.Length, options);
+                Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+                return result > 0;
             }
         }
 
-        /// <summary>
-        /// Returns multiple rented buffers to their respective pools if they were allocated.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ReturnBuffers(char[]? charBuffer1 = null, char[]? charBuffer2 = null, int[]? indexMapBuffer = null)
+        private static void AssertComparisonSupported(CompareOptions options)
         {
-            if (charBuffer1 is not null)
-                ArrayPool<char>.Shared.Return(charBuffer1);
-            if (charBuffer2 is not null)
-                ArrayPool<char>.Shared.Return(charBuffer2);
-            if (indexMapBuffer is not null)
-                ArrayPool<int>.Shared.Return(indexMapBuffer);
+            if ((options | SupportedCompareOptions) != SupportedCompareOptions)
+                throw new PlatformNotSupportedException(GetPNSE(options));
         }
 
+        private const CompareOptions SupportedCompareOptions = CompareOptions.None | CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace |
+                                                               CompareOptions.IgnoreWidth | CompareOptions.StringSort | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreSymbols;
+
+        private static string GetPNSE(CompareOptions options) =>
+            SR.Format(SR.PlatformNotSupported_HybridGlobalizationWithCompareOptions, options);
+    }
+
+    internal struct SymbolFilteringBuffer : IDisposable
+    {
+        public SymbolFilteringBuffer()
+        {
+            RentedFilteredBuffer = null;
+            RentedIndexMapBuffer = null;
+            FilteredLength = 0;
+        }
+
+        public char[]? RentedFilteredBuffer { get; set; }
+        public int[]?  RentedIndexMapBuffer { get; set; }
+        public int FilteredLength { get; set; }
+
         /// <summary>
-        /// Filters ignorable symbols from the input span.
+        /// Attempt to filter ignorable symbols from the input string.
         /// </summary>
-        /// <param name="input">The input span to filter.</param>
-        /// <param name="stackBuffer">A stack-allocated buffer to use for small inputs or if no symbols are found.</param>
-        /// <param name="rentedCharArray">Outputs a rented char array if input is too large for stackBuffer and contains symbols. Null if stackBuffer was sufficient.</param>
-        /// <param name="rentedIndexMap">Outputs a rented int array for the index map if generateIndexMap is true and symbols were found. Null otherwise.</param>
-        /// <param name="generateIndexMap">If true, generates an index map tracking each character's original position.</param>
-        /// <returns>
-        /// A span containing the filtered string with ignorable symbols removed. If no symbols are found,
-        /// returns the original input span without allocating.
-        /// </returns>
-        private static ReadOnlySpan<char> GetFilteredString(
+        /// <remarks>If the input contains ignorable symbols and the stack buffers are not large enough to
+        /// hold the filtered result, the method may fall back to heap allocation. The index mapping buffer is only
+        /// populated if index mapping is needed. This method does not modify the original input.</remarks>
+        /// <param name="input">The input string to be filtered, represented as a read-only span of UTF-16 characters.</param>
+        /// <param name="filteredStackBuffer">A stack-allocated buffer to receive the filtered characters. If this buffer is not long enough to hold the filtered result,
+        /// the method may fall to use the ArrayPool.
+        /// </param>
+        /// <param name="indexMapStackBuffer">A stack-allocated buffer to receive the mapping from filtered character positions to their original indices
+        /// in the input. if this span is empty, means ni need to create the index mapping.</param>
+        /// <returns>true if the string is filtered removing symbols from there. false if there is no symbols found in the input.</returns>
+        internal bool TryFilterString(
             ReadOnlySpan<char> input,
-            scoped Span<char> stackBuffer,
-            out char[]? rentedCharArray,
-            out int[]? rentedIndexMap,
-            bool generateIndexMap)
+            Span<char> filteredStackBuffer,
+            Span<int>  indexMapStackBuffer)
         {
-            rentedCharArray = null;
-            rentedIndexMap = null;
+            if (RentedFilteredBuffer is not null || RentedIndexMapBuffer is not null)
+            {
+                Dispose();
+            }
 
             int i = 0;
             int consumed = 0;
@@ -252,28 +284,31 @@ namespace System.Globalization
                 i += consumed;
             }
 
-            // If we scanned the entire input without finding any ignorable symbols, return original input
+            // If we scanned the entire input without finding any ignorable symbols, return false
             if (i >= input.Length)
             {
-                return input;
+                return false;
             }
 
             // Found symbols - decide whether to use stack or heap allocation
-            Span<char> outSpan = input.Length <= stackBuffer.Length ? stackBuffer : (rentedCharArray = ArrayPool<char>.Shared.Rent(input.Length));
+            Span<char> outSpan = input.Length <= filteredStackBuffer.Length ? filteredStackBuffer : (RentedFilteredBuffer = ArrayPool<char>.Shared.Rent(input.Length));
             // Copy the initial segment that contains no ignorable symbols (positions 0 to i-1)
             input.Slice(0, i).CopyTo(outSpan);
 
+            Span<int> indexMap = indexMapStackBuffer.IsEmpty ?
+                                    Span<int>.Empty :
+                                    (indexMapStackBuffer.Length >= input.Length ? indexMapStackBuffer : (RentedIndexMapBuffer = ArrayPool<int>.Shared.Rent(input.Length)));
+
             // Initialize the index map for the initial segment with identity mapping
-            if (generateIndexMap)
+            if (!indexMap.IsEmpty)
             {
-                rentedIndexMap = ArrayPool<int>.Shared.Rent(input.Length);
                 for (int j = 0; j < i; j++)
                 {
-                    rentedIndexMap[j] = j;
+                    indexMap[j] = j;
                 }
             }
 
-            int writeIndex = i;
+            FilteredLength = i;
             i += consumed; // skip the ignorable symbol we just found
 
             for (; i < input.Length;)
@@ -282,21 +317,27 @@ namespace System.Globalization
                 if (!IsIgnorableSymbol(rune))
                 {
                     // Copy the UTF-16 units and map each filtered position to the start of the original character
-                    outSpan[writeIndex] = input[i];
-                    rentedIndexMap?[writeIndex] = i;
-                    writeIndex++;
+                    outSpan[FilteredLength] = input[i];
+                    if (!indexMap.IsEmpty)
+                    {
+                        indexMap[FilteredLength] = i;
+                    }
+                    FilteredLength++;
 
                     if (consumed > 1)
                     {
-                        outSpan[writeIndex] = input[i + 1];
-                        rentedIndexMap?[writeIndex] = i;
-                        writeIndex++;
+                        outSpan[FilteredLength] = input[i + 1];
+                        if (!indexMap.IsEmpty)
+                        {
+                            indexMap[FilteredLength] = i + 1;
+                        }
+                        FilteredLength++;
                     }
                 }
                 i += consumed;
             }
 
-            return outSpan.Slice(0, writeIndex);
+            return true;
         }
 
         /// <summary>
@@ -333,16 +374,20 @@ namespace System.Globalization
             return false;
         }
 
-        private static void AssertComparisonSupported(CompareOptions options)
+        public void Dispose()
         {
-            if ((options | SupportedCompareOptions) != SupportedCompareOptions)
-                throw new PlatformNotSupportedException(GetPNSE(options));
+            if (RentedFilteredBuffer is not null)
+            {
+                ArrayPool<char>.Shared.Return(RentedFilteredBuffer);
+                RentedFilteredBuffer = null;
+            }
+            if (RentedIndexMapBuffer is not null)
+            {
+                ArrayPool<int>.Shared.Return(RentedIndexMapBuffer);
+                RentedIndexMapBuffer = null;
+            }
+
+            FilteredLength = 0;
         }
-
-        private const CompareOptions SupportedCompareOptions = CompareOptions.None | CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace |
-                                                               CompareOptions.IgnoreWidth | CompareOptions.StringSort | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreSymbols;
-
-        private static string GetPNSE(CompareOptions options) =>
-            SR.Format(SR.PlatformNotSupported_HybridGlobalizationWithCompareOptions, options);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
@@ -255,10 +255,10 @@ namespace System.Globalization
         /// populated if index mapping is needed. This method does not modify the original input.</remarks>
         /// <param name="input">The input string to be filtered, represented as a read-only span of UTF-16 characters.</param>
         /// <param name="filteredStackBuffer">A stack-allocated buffer to receive the filtered characters. If this buffer is not long enough to hold the filtered result,
-        /// the method may fall to use the ArrayPool.
+        /// the method may fall back to using the ArrayPool.
         /// </param>
         /// <param name="indexMapStackBuffer">A stack-allocated buffer to receive the mapping from filtered character positions to their original indices
-        /// in the input. if this span is empty, means ni need to create the index mapping.</param>
+        /// in the input. if this span is empty, means no need to create the index mapping.</param>
         /// <returns>true if the string is filtered removing symbols from there. false if there is no symbols found in the input.</returns>
         internal bool TryFilterString(
             ReadOnlySpan<char> input,

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
@@ -198,17 +198,16 @@ namespace System.Globalization
             /// <param name="input">The input span to filter.</param>
             /// <param name="generateIndexMap">
             /// If <c>true</c>, generates an index map that tracks the position of each character in the filtered
-            /// output back to its original position in the input. The map is accessible via <see cref="IndexMap"/>.
+            /// output back to its original position in the input. The map is accessible via <see cref="GetIndexMap"/>.
             /// </param>
             /// <returns>
             /// A span containing the filtered string with ignorable symbols removed. If no symbols are found,
-            /// returns the original input span without allocating. For short strings (up to 256 characters),
-            /// uses stack allocation. For longer strings, uses a rented array from <see cref="ArrayPool{T}"/>
-            /// that will be returned when <see cref="Dispose"/> is called.
+            /// returns the original input span without allocating. Otherwise, returns a span backed by either
+            /// stack-allocated or pooled memory that will be returned when <see cref="Dispose"/> is called.
             /// </returns>
             public ReadOnlySpan<char> GetFilteredString(ReadOnlySpan<char> input, bool generateIndexMap = false)
             {
-                if (_arrayToReturnToPool is not null)
+                if (_arrayToReturnToPool is not null || _indexMapArrayToReturnToPool is not null)
                 {
                     Dispose();
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.iOS.cs
@@ -25,13 +25,27 @@ namespace System.Globalization
 
             AssertComparisonSupported(options);
 
+            // Handle IgnoreSymbols preprocessing
+            bool ignoreSymbols = (options & CompareOptions.IgnoreSymbols) != 0;
+            ReadOnlySpan<char> filteredString1 = string1;
+            ReadOnlySpan<char> filteredString2 = string2;
+
+            if (ignoreSymbols)
+            {
+                filteredString1 = FilterSymbolsFromSpan(string1, out _);
+                filteredString2 = FilterSymbolsFromSpan(string2, out _);
+
+                // Remove the flag before passing to native since we handled it here
+                options &= ~CompareOptions.IgnoreSymbols;
+            }
+
             // GetReference may return nullptr if the input span is defaulted. The native layer handles
             // this appropriately; no workaround is needed on the managed side.
             int result;
-            fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
-            fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
+            fixed (char* pString1 = &MemoryMarshal.GetReference(filteredString1))
+            fixed (char* pString2 = &MemoryMarshal.GetReference(filteredString2))
             {
-                result = Interop.Globalization.CompareStringNative(m_name, m_name.Length, pString1, string1.Length, pString2, string2.Length, options);
+                result = Interop.Globalization.CompareStringNative(m_name, m_name.Length, pString1, filteredString1.Length, pString2, filteredString2.Length, options);
             }
 
             Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
@@ -39,38 +53,214 @@ namespace System.Globalization
             return result;
         }
 
-        private unsafe int IndexOfCoreNative(char* target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options, bool fromBeginning, int* matchLengthPtr)
+        private unsafe int IndexOfCoreNative(ReadOnlySpan<char> target, ReadOnlySpan<char> source, CompareOptions options, bool fromBeginning, int* matchLengthPtr)
         {
             AssertComparisonSupported(options);
+            // We only implement managed preprocessing for IgnoreSymbols.
+            bool ignoreSymbols = (options & CompareOptions.IgnoreSymbols) != 0;
+            ReadOnlySpan<char> filteredTarget = target;
+            ReadOnlySpan<char> filteredSource = source;
+            int[]? sourceIndexMap = null; // maps each char index in filteredSource to original source char index
 
-            Interop.Range result = Interop.Globalization.IndexOfNative(m_name, m_name.Length, target, cwTargetLength, pSource, cwSourceLength, options, fromBeginning);
-            Debug.Assert(result.Location != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
-            if (result.Location == (int)ErrorCodes.ERROR_MIXED_COMPOSITION_NOT_FOUND)
-                throw new PlatformNotSupportedException(SR.PlatformNotSupported_HybridGlobalizationWithMixedCompositions);
+            // If we are ignoring symbols, preprocess the strings by removing specified Unicode categories.
+            if (ignoreSymbols)
+            {
+                filteredTarget = FilterSymbolsFromSpan(target, out _);
+                filteredSource = FilterSymbolsFromSpan(source, out sourceIndexMap);
+
+                // Remove the flag before passing to native since we handled it here.
+                options &= ~CompareOptions.IgnoreSymbols;
+            }
+
+            int nativeLocation;
+            int nativeLength;
+            fixed (char* pTarget = &MemoryMarshal.GetReference(filteredTarget))
+            fixed (char* pSource = &MemoryMarshal.GetReference(filteredSource))
+            {
+                Interop.Range result = Interop.Globalization.IndexOfNative(m_name, m_name.Length, pTarget, filteredTarget.Length, pSource, filteredSource.Length, options, fromBeginning);
+                Debug.Assert(result.Location != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+                if (result.Location == (int)ErrorCodes.ERROR_MIXED_COMPOSITION_NOT_FOUND)
+                    throw new PlatformNotSupportedException(SR.PlatformNotSupported_HybridGlobalizationWithMixedCompositions);
+                nativeLocation = result.Location;
+                nativeLength = result.Length;
+            }
+
+            if (!ignoreSymbols)
+            {
+                if (matchLengthPtr != null)
+                    *matchLengthPtr = nativeLength;
+                return nativeLocation;
+            }
+
+            // If ignoring symbols and nothing found, or an error code, or no source index map, just propagate.
+            if (nativeLocation < 0 || sourceIndexMap == null)
+            {
+                if (matchLengthPtr != null)
+                    *matchLengthPtr = nativeLength;
+                return nativeLocation;
+            }
+
+            // Map filtered indices back to original indices, expanding match length to include removed symbol chars inside the span.
+            // nativeLocation is index into filteredSource; nativeLength is length in filteredSource UTF-16 code units.
+            int originalStart = sourceIndexMap[nativeLocation];
+            int filteredEnd = nativeLocation + nativeLength - 1;
+
+            Debug.Assert(filteredEnd < sourceIndexMap.Length,
+                $"Filtered end index {filteredEnd} should not exceed the length of the filtered string {sourceIndexMap.Length}. nativeLocation={nativeLocation}, nativeLength={nativeLength}");
+
+            int originalEnd = sourceIndexMap[filteredEnd];
+            int originalLength = originalEnd - originalStart + 1;
+
             if (matchLengthPtr != null)
-                *matchLengthPtr = result.Length;
-
-            return result.Location;
+                *matchLengthPtr = originalLength;
+            return originalStart;
         }
 
-        private unsafe bool NativeStartsWith(char* pPrefix, int cwPrefixLength, char* pSource, int cwSourceLength, CompareOptions options)
+        /// <summary>
+        /// Determines whether the specified rune should be ignored when using CompareOptions.IgnoreSymbols.
+        /// </summary>
+        /// <param name="rune">The rune to check.</param>
+        /// <returns>
+        /// <c>true</c> if the rune should be ignored; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// This method returns <c>true</c> for:
+        /// - All separator categories (SpaceSeparator, LineSeparator, ParagraphSeparator)
+        /// - All punctuation categories (ConnectorPunctuation through OtherPunctuation)
+        /// - All symbol categories (MathSymbol through ModifierSymbol)
+        /// - Whitespace control characters (tab, line feed, vertical tab, form feed, carriage return, etc.)
+        /// </remarks>
+        private static bool IsIgnorableSymbol(Rune rune)
+        {
+            UnicodeCategory category = CharUnicodeInfo.GetUnicodeCategory(rune.Value);
+
+            // Check for separator categories (11-13)
+            if (category >= UnicodeCategory.SpaceSeparator && category <= UnicodeCategory.ParagraphSeparator)
+                return true;
+
+            // Check for punctuation/symbol categories (18-27)
+            if (category >= UnicodeCategory.ConnectorPunctuation && category <= UnicodeCategory.ModifierSymbol)
+                return true;
+
+            // For Control (14) and Format (15) categories, only include whitespace characters
+            // This includes: tab (U+0009), LF (U+000A), VT (U+000B), FF (U+000C), CR (U+000D), NEL (U+0085)
+            if (category == UnicodeCategory.Control || category == UnicodeCategory.Format)
+                return Rune.IsWhiteSpace(rune);
+
+            return false;
+        }
+
+        private unsafe bool NativeStartsWith(ReadOnlySpan<char> prefix, ReadOnlySpan<char> source, CompareOptions options)
         {
             AssertComparisonSupported(options);
 
-            int result = Interop.Globalization.StartsWithNative(m_name, m_name.Length, pPrefix, cwPrefixLength, pSource, cwSourceLength, options);
+            // Handle IgnoreSymbols preprocessing
+            bool ignoreSymbols = (options & CompareOptions.IgnoreSymbols) != 0;
+            ReadOnlySpan<char> filteredPrefix = prefix;
+            ReadOnlySpan<char> filteredSource = source;
+
+            if (ignoreSymbols)
+            {
+                filteredPrefix = FilterSymbolsFromSpan(prefix, out _);
+                filteredSource = FilterSymbolsFromSpan(source, out _);
+
+                // Remove the flag before passing to native since we handled it here
+                options &= ~CompareOptions.IgnoreSymbols;
+            }
+
+            int result;
+            fixed (char* pPrefix = &MemoryMarshal.GetReference(filteredPrefix))
+            fixed (char* pSource = &MemoryMarshal.GetReference(filteredSource))
+            {
+                result = Interop.Globalization.StartsWithNative(m_name, m_name.Length, pPrefix, filteredPrefix.Length, pSource, filteredSource.Length, options);
+            }
             Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
 
-            return result > 0 ? true : false;
+            return result > 0;
         }
 
-        private unsafe bool NativeEndsWith(char* pSuffix, int cwSuffixLength, char* pSource, int cwSourceLength, CompareOptions options)
+        private unsafe bool NativeEndsWith(ReadOnlySpan<char> suffix, ReadOnlySpan<char> source, CompareOptions options)
         {
             AssertComparisonSupported(options);
 
-            int result = Interop.Globalization.EndsWithNative(m_name, m_name.Length, pSuffix, cwSuffixLength, pSource, cwSourceLength, options);
+            // Handle IgnoreSymbols preprocessing
+            bool ignoreSymbols = (options & CompareOptions.IgnoreSymbols) != 0;
+            ReadOnlySpan<char> filteredSuffix = suffix;
+            ReadOnlySpan<char> filteredSource = source;
+
+            if (ignoreSymbols)
+            {
+                filteredSuffix = FilterSymbolsFromSpan(suffix, out _);
+                filteredSource = FilterSymbolsFromSpan(source, out _);
+
+                // Remove the flag before passing to native since we handled it here
+                options &= ~CompareOptions.IgnoreSymbols;
+            }
+
+            int result;
+            fixed (char* pSuffix = &MemoryMarshal.GetReference(filteredSuffix))
+            fixed (char* pSource = &MemoryMarshal.GetReference(filteredSource))
+            {
+                result = Interop.Globalization.EndsWithNative(m_name, m_name.Length, pSuffix, filteredSuffix.Length, pSource, filteredSource.Length, options);
+            }
             Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
 
-            return result > 0 ? true : false;
+            return result > 0;
+        }
+
+        /// <summary>
+        /// Filters out ignorable symbol characters from the input span.
+        /// </summary>
+        /// <param name="input">The input span to filter.</param>
+        /// <param name="indexMap">
+        /// When this method returns, contains a mapping array where each index in the filtered output
+        /// maps to the corresponding character index in the original input span. This parameter is
+        /// passed uninitialized and will be null if no symbols were removed.
+        /// </param>
+        /// <returns>
+        /// A read-only span with ignorable symbols removed. If no symbols were found, returns the
+        /// original input span unchanged.
+        /// </returns>
+        private static ReadOnlySpan<char> FilterSymbolsFromSpan(ReadOnlySpan<char> input, out int[]? indexMap)
+        {
+            int length = input.Length;
+            bool hasSymbols = false;
+            List<char> keptChars = new List<char>(length);
+            List<int> mapping = new List<int>(length);
+            // TODO: Use ArrayPool<char> for keptChars and mapping to avoid allocations.
+            for (int i = 0; i < length;)
+            {
+                Rune.DecodeFromUtf16(input.Slice(i), out Rune rune, out int consumed);
+                bool remove = IsIgnorableSymbol(rune);
+
+                if (!remove)
+                {
+                    // Copy the UTF-16 units and map each filtered position to the start of the original character
+                    for (int j = 0; j < consumed; j++)
+                    {
+                        keptChars.Add(input[i + j]);
+                        mapping.Add(i);
+                    }
+                }
+                else
+                {
+                    hasSymbols = true;
+                }
+
+                i += consumed;
+            }
+
+            if (!hasSymbols)
+            {
+                // No symbols removed; return original span and no mapping.
+                indexMap = null;
+                return input;
+            }
+            else
+            {
+                indexMap = mapping.ToArray();
+                return keptChars.ToArray();
+            }
         }
 
         private static void AssertComparisonSupported(CompareOptions options)
@@ -80,7 +270,7 @@ namespace System.Globalization
         }
 
         private const CompareOptions SupportedCompareOptions = CompareOptions.None | CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace |
-                                                               CompareOptions.IgnoreWidth | CompareOptions.StringSort | CompareOptions.IgnoreKanaType;
+                                                               CompareOptions.IgnoreWidth | CompareOptions.StringSort | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreSymbols;
 
         private static string GetPNSE(CompareOptions options) =>
             SR.Format(SR.PlatformNotSupported_HybridGlobalizationWithCompareOptions, options);

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -225,11 +225,7 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "FooBar", "Foo\u0400Bar", CompareOptions.Ordinal, -1 };
             yield return new object[] { s_invariantCompare, "FooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace, 0 };
 
-            // In HybridGlobalization on Apple platforms IgnoreSymbols is not supported
-            if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
-            {
-                yield return new object[] { s_invariantCompare, "Test's", "Tests", CompareOptions.IgnoreSymbols, 0 };
-            }
+            yield return new object[] { s_invariantCompare, "Test's", "Tests", CompareOptions.IgnoreSymbols, 0 };
             yield return new object[] { s_invariantCompare, "Test's", "Tests", CompareOptions.StringSort, -1 };
 
             yield return new object[] { s_invariantCompare, null, "Tests", CompareOptions.None, -1 };
@@ -251,26 +247,15 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "\uFF9E", "\u3099", CompareOptions.IgnoreCase, 0 };
             yield return new object[] { s_invariantCompare, "\u20A9", "\uFFE6", CompareOptions.IgnoreCase, -1 };
             yield return new object[] { s_invariantCompare, "\u20A9", "\uFFE6", CompareOptions.None, -1 };
-
-            // In HybridGlobalization mode on Apple platforms IgnoreSymbols is not supported
-            if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
-            {
-                yield return new object[] { s_invariantCompare, "\u0021", "\uFF01", CompareOptions.IgnoreSymbols, 0 };
-                yield return new object[] { s_invariantCompare, "\uFF65", "\u30FB", CompareOptions.IgnoreSymbols, 0 };
-                yield return new object[] { s_invariantCompare, "\u00A2", "\uFFE0", CompareOptions.IgnoreSymbols, 0 };
-                yield return new object[] { s_invariantCompare, "$", "&", CompareOptions.IgnoreSymbols, 0 };
-            }
+            yield return new object[] { s_invariantCompare, "\u0021", "\uFF01", CompareOptions.IgnoreSymbols, 0 };
+            yield return new object[] { s_invariantCompare, "\uFF65", "\u30FB", CompareOptions.IgnoreSymbols, 0 };
+            yield return new object[] { s_invariantCompare, "\u00A2", "\uFFE0", CompareOptions.IgnoreSymbols, 0 };
+            yield return new object[] { s_invariantCompare, "$", "&", CompareOptions.IgnoreSymbols, 0 };
             yield return new object[] { s_invariantCompare, "\u0021", "\uFF01", CompareOptions.None, -1 };
             yield return new object[] { s_invariantCompare, "\u20A9", "\uFFE6", CompareOptions.IgnoreWidth, 0 };
             yield return new object[] { s_invariantCompare, "\u0021", "\uFF01", CompareOptions.IgnoreWidth, 0 };
             yield return new object[] { s_invariantCompare, "\uFF66", "\u30F2", CompareOptions.IgnoreWidth, 0 };
-
-            // In HybridGlobalization mode on Apple platforms IgnoreSymbols is not supported
-            if(PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
-            {
-                yield return new object[] { s_invariantCompare, "\uFF66", "\u30F2", CompareOptions.IgnoreSymbols, s_expectedHalfToFullFormsComparison };
-            }
-
+            yield return new object[] { s_invariantCompare, "\uFF66", "\u30F2", CompareOptions.IgnoreSymbols, s_expectedHalfToFullFormsComparison };
             yield return new object[] { s_invariantCompare, "\uFF66", "\u30F2", CompareOptions.IgnoreCase, s_expectedHalfToFullFormsComparison };
             yield return new object[] { s_invariantCompare, "\uFF66", "\u30F2", CompareOptions.IgnoreNonSpace, s_expectedHalfToFullFormsComparison };
             yield return new object[] { s_invariantCompare, "\uFF66", "\u30F2", CompareOptions.None, s_expectedHalfToFullFormsComparison };

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -128,6 +128,13 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "Tes ting", "Testing", 0, 8, CompareOptions.None, -1, 0 };
             yield return new object[] { s_invariantCompare, "'Te st  i ng!", "Testing", 0, 11, CompareOptions.IgnoreSymbols, -1, 0 };
 
+            // Ignore symbols - long strings (over 256 chars) to test ArrayPool buffer allocation on iOS
+            if (PlatformDetection.IsHybridGlobalizationOnApplePlatform)
+            {
+                yield return new object[] { s_invariantCompare, new string('a', 100) + new string('b', 50) + "$" + new string('b', 50) + "!" + new string('c', 100), new string('b', 100), 0, 303, CompareOptions.IgnoreSymbols, 100, 102 };
+                yield return new object[] { s_invariantCompare, new string('a', 100) + new string('b', 100) + new string('c', 100), new string('b', 100), 0, 300, CompareOptions.IgnoreSymbols, 100, 100 };
+            }
+
             yield return new object[] { s_invariantCompare, "cbabababdbaba", "ab", 0, 13, CompareOptions.None, 2, 2 };
 
             // Ordinal should be case-sensitive

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -108,30 +108,30 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "Test\ting\n", "Testing", 0, 9, CompareOptions.IgnoreSymbols, 0, 8 }; // Tab and newline
 
             // Ignore symbols - multiple whitespace and punctuation
-            yield return new object[] { s_invariantCompare, "  Testing,  ", "Testing", 0, 11, CompareOptions.IgnoreSymbols, 2, 7 };
+            yield return new object[] { s_invariantCompare, "  Testing,  ", "Testing", 0, 12, CompareOptions.IgnoreSymbols, 2, 7 };
             yield return new object[] { s_invariantCompare, "'Te st  i ng!", "Testing", 0, 13, CompareOptions.IgnoreSymbols, 1, 11 };
 
             // Ignore symbols - mixed categories
             yield return new object[] { s_invariantCompare, "$Te%s t&ing+", "Testing", 0, 12, CompareOptions.IgnoreSymbols, 1, 10 };
-            yield return new object[] { s_invariantCompare, ", Hello World!", "HelloWorld", 0, 13, CompareOptions.IgnoreSymbols, 2, 11 };
+            yield return new object[] { s_invariantCompare, ", Hello World!", "HelloWorld", 0, 14, CompareOptions.IgnoreSymbols, 2, 11 };
 
             // Ignore symbols - source contains surrogates (to match) + symbols (to ignore)
             yield return new object[] { s_invariantCompare, "$\U0001D7D8Testing!", "\U0001D7D8Testing", 0, 11, CompareOptions.IgnoreSymbols, 1, 9 }; 
             yield return new object[] { s_invariantCompare, "Test$\U0001D7D8ing", "Test\U0001D7D8ing", 0, 10, CompareOptions.IgnoreSymbols, 0, 10 }; 
             yield return new object[] { s_invariantCompare, "$Testing\U0001D7DA", "Testing\U0001D7DA", 0, 10, CompareOptions.IgnoreSymbols, 1, 9 }; 
             yield return new object[] { s_invariantCompare, "$\U0001D7D8Test!\U0001D7D9ing", "\U0001D7D8Test\U0001D7D9ing", 0, 13, CompareOptions.IgnoreSymbols, 1, 12 }; 
-            yield return new object[] { s_invariantCompare, "\U0001D7D8 Test$ \U0001D7D9 ing!", "\U0001D7D8 Test \U0001D7D9 ing", 0, 15, CompareOptions.IgnoreSymbols, 0, 15 };
-            yield return new object[] { s_invariantCompare, "!$\U0001D7D8Test\U0001D7D9ing\U0001D7DA!", "\U0001D7D8Test\U0001D7D9ing\U0001D7DA", 0, 15, CompareOptions.IgnoreSymbols, 2, 13 };
+            yield return new object[] { s_invariantCompare, "\U0001D7D8 Test$ \U0001D7D9 ing!", "\U0001D7D8 Test \U0001D7D9 ing", 0, 16, CompareOptions.IgnoreSymbols, 0, 15 };
+            yield return new object[] { s_invariantCompare, "!$\U0001D7D8Test\U0001D7D9ing\U0001D7DA!", "\U0001D7D8Test\U0001D7D9ing\U0001D7DA", 0, 16, CompareOptions.IgnoreSymbols, 2, 13 };
 
             // With symbols - should not match
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 0, 11, CompareOptions.None, -1, 0 };
             yield return new object[] { s_invariantCompare, "Tes ting", "Testing", 0, 8, CompareOptions.None, -1, 0 };
-            yield return new object[] { s_invariantCompare, "'Te st  i ng!", "Testing", 0, 11, CompareOptions.IgnoreSymbols, -1, 0 };
+            yield return new object[] { s_invariantCompare, "'Te st  i ng!", "Testing", 0, 11, CompareOptions.IgnoreSymbols, -1, 0 }; // Not enough characters to match
 
             // Ignore symbols - long strings (over 256 chars) to test ArrayPool buffer allocation on iOS
             if (PlatformDetection.IsHybridGlobalizationOnApplePlatform)
             {
-                yield return new object[] { s_invariantCompare, new string('a', 100) + new string('b', 50) + "$" + new string('b', 50) + "!" + new string('c', 100), new string('b', 100), 0, 303, CompareOptions.IgnoreSymbols, 100, 102 };
+                yield return new object[] { s_invariantCompare, new string('a', 100) + new string('b', 50) + "$" + new string('b', 50) + "!" + new string('c', 100), new string('b', 100), 0, 302, CompareOptions.IgnoreSymbols, 100, 101 };
                 yield return new object[] { s_invariantCompare, new string('a', 100) + new string('b', 100) + new string('c', 100), new string('b', 100), 0, 300, CompareOptions.IgnoreSymbols, 100, 100 };
             }
 

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -82,10 +82,43 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "", "\u200d", 0, 0, CompareOptions.None, 0, 0 };
             yield return new object[] { s_invariantCompare, "hello", "\u200d", 1, 3, CompareOptions.IgnoreCase, 1, 0 };
 
-            // Ignore symbols
-            if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform) // IgnoreSymbols are not supported
-                yield return new object[] { s_invariantCompare, "More Test's", "Tests", 0, 11, CompareOptions.IgnoreSymbols, 5, 6 };
+            // Ignore symbols - punctuation characters
+            yield return new object[] { s_invariantCompare, "More Test's", "Tests", 0, 11, CompareOptions.IgnoreSymbols, 5, 6 };
+            yield return new object[] { s_invariantCompare, "-Testing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 1, 7 };
+            yield return new object[] { s_invariantCompare, "Test(ing)", "Testing", 0, 9, CompareOptions.IgnoreSymbols, 0, 8 };
+            yield return new object[] { s_invariantCompare, "Testing]", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 7 };
+            yield return new object[] { s_invariantCompare, "{Test}ing", "Testing", 0, 9, CompareOptions.IgnoreSymbols, 1, 8 };
+            yield return new object[] { s_invariantCompare, "\"Testing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 1, 7 };
+
+            // Ignore symbols - currency and math symbols
+            yield return new object[] { s_invariantCompare, "$Testing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 1, 7 };
+            yield return new object[] { s_invariantCompare, "Test€ing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 8 };
+            yield return new object[] { s_invariantCompare, "Testing¢", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 7 };
+            yield return new object[] { s_invariantCompare, "+Testing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 1, 7 };
+            yield return new object[] { s_invariantCompare, "Test=ing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 8 };
+            yield return new object[] { s_invariantCompare, "Testing%", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 7 };
+
+            // Ignore symbols - whitespace characters
+            yield return new object[] { s_invariantCompare, " Testing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 1, 7 };
+            yield return new object[] { s_invariantCompare, "Testing ", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 7 };
+            yield return new object[] { s_invariantCompare, "Test\u00A0ing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 8 }; // Non-breaking space
+            yield return new object[] { s_invariantCompare, "Testing\u2028", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 7 }; // Line separator
+            yield return new object[] { s_invariantCompare, "\u2029Testing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 1, 7 }; // Paragraph separator
+            yield return new object[] { s_invariantCompare, "Test\ting\n", "Testing", 0, 9, CompareOptions.IgnoreSymbols, 0, 8 }; // Tab and newline
+
+            // Ignore symbols - multiple whitespace and punctuation
+            yield return new object[] { s_invariantCompare, "  Testing,  ", "Testing", 0, 11, CompareOptions.IgnoreSymbols, 2, 7 };
+            yield return new object[] { s_invariantCompare, "'Te st  i ng!", "Testing", 0, 13, CompareOptions.IgnoreSymbols, 1, 11 };
+
+            // Ignore symbols - mixed categories
+            yield return new object[] { s_invariantCompare, "$Te%s t&ing+", "Testing", 0, 12, CompareOptions.IgnoreSymbols, 1, 10 };
+            yield return new object[] { s_invariantCompare, ", Hello World!", "HelloWorld", 0, 13, CompareOptions.IgnoreSymbols, 2, 11 };
+
+            // With symbols - should not match
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 0, 11, CompareOptions.None, -1, 0 };
+            yield return new object[] { s_invariantCompare, "Tes ting", "Testing", 0, 8, CompareOptions.None, -1, 0 };
+            yield return new object[] { s_invariantCompare, "'Te st  i ng!", "Testing", 0, 11, CompareOptions.IgnoreSymbols, -1, 0 };
+
             yield return new object[] { s_invariantCompare, "cbabababdbaba", "ab", 0, 13, CompareOptions.None, 2, 2 };
 
             // Ordinal should be case-sensitive

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -97,6 +97,7 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "+Testing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 1, 7 };
             yield return new object[] { s_invariantCompare, "Test=ing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 8 };
             yield return new object[] { s_invariantCompare, "Testing%", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 0, 7 };
+            yield return new object[] { s_invariantCompare, "x$test$xtest$x", "test", 0, 14, CompareOptions.IgnoreSymbols, 2, 4 };
 
             // Ignore symbols - whitespace characters
             yield return new object[] { s_invariantCompare, " Testing", "Testing", 0, 8, CompareOptions.IgnoreSymbols, 1, 7 };
@@ -113,6 +114,14 @@ namespace System.Globalization.Tests
             // Ignore symbols - mixed categories
             yield return new object[] { s_invariantCompare, "$Te%s t&ing+", "Testing", 0, 12, CompareOptions.IgnoreSymbols, 1, 10 };
             yield return new object[] { s_invariantCompare, ", Hello World!", "HelloWorld", 0, 13, CompareOptions.IgnoreSymbols, 2, 11 };
+
+            // Ignore symbols - source contains surrogates (to match) + symbols (to ignore)
+            yield return new object[] { s_invariantCompare, "$\U0001D7D8Testing!", "\U0001D7D8Testing", 0, 11, CompareOptions.IgnoreSymbols, 1, 9 }; 
+            yield return new object[] { s_invariantCompare, "Test$\U0001D7D8ing", "Test\U0001D7D8ing", 0, 10, CompareOptions.IgnoreSymbols, 0, 10 }; 
+            yield return new object[] { s_invariantCompare, "$Testing\U0001D7DA", "Testing\U0001D7DA", 0, 10, CompareOptions.IgnoreSymbols, 1, 9 }; 
+            yield return new object[] { s_invariantCompare, "$\U0001D7D8Test!\U0001D7D9ing", "\U0001D7D8Test\U0001D7D9ing", 0, 13, CompareOptions.IgnoreSymbols, 1, 12 }; 
+            yield return new object[] { s_invariantCompare, "\U0001D7D8 Test$ \U0001D7D9 ing!", "\U0001D7D8 Test \U0001D7D9 ing", 0, 15, CompareOptions.IgnoreSymbols, 0, 15 };
+            yield return new object[] { s_invariantCompare, "!$\U0001D7D8Test\U0001D7D9ing\U0001D7DA!", "\U0001D7D8Test\U0001D7D9ing\U0001D7DA", 0, 15, CompareOptions.IgnoreSymbols, 2, 13 };
 
             // With symbols - should not match
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 0, 11, CompareOptions.None, -1, 0 };

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -72,29 +72,23 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "\uD800\uD800", "\uD800\uD800", CompareOptions.None, true, 2 };
 
             // Ignore symbols
-            if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
-            {
-                yield return new object[] { s_invariantCompare, "Test's can be interesting", "Tests", CompareOptions.IgnoreSymbols, true, 6 };
-                yield return new object[] { s_invariantCompare, "Test's can be interesting", "Tests", CompareOptions.None, false, 0 };
-            }
+            yield return new object[] { s_invariantCompare, "Test's can be interesting", "Tests", CompareOptions.IgnoreSymbols, true, 6 };
+            yield return new object[] { s_invariantCompare, "Test's can be interesting", "Tests", CompareOptions.None, false, 0 };
 
             // Platform differences
             if (PlatformDetection.IsNlsGlobalization)
             {
-                if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
-                {
-                    yield return new object[] { s_hungarianCompare, "dzsdzsfoobar", "ddzsf", CompareOptions.None, true, 7 };
-                    yield return new object[] { s_invariantCompare, "''Tests", "Tests", CompareOptions.IgnoreSymbols, true, 7 };
-                    yield return new object[] { s_frenchCompare, "\u0153", "oe", CompareOptions.None, true, 1 };
-                }
+                yield return new object[] { s_hungarianCompare, "dzsdzsfoobar", "ddzsf", CompareOptions.None, true, 7 };
+                yield return new object[] { s_invariantCompare, "''Tests", "Tests", CompareOptions.IgnoreSymbols, true, 7 };
+                yield return new object[] { s_frenchCompare, "\u0153", "oe", CompareOptions.None, true, 1 };
                 yield return new object[] { s_invariantCompare, "\uD800\uDC00", "\uD800", CompareOptions.None, true, 1 };
                 yield return new object[] { s_invariantCompare, "\uD800\uDC00", "\uD800", CompareOptions.IgnoreCase, true, 1 };
             }
             else
             {
                 yield return new object[] { s_hungarianCompare, "dzsdzsfoobar", "ddzsf", CompareOptions.None, false, 0 };
-                if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
-                    yield return new object[] { s_invariantCompare, "''Tests", "Tests", CompareOptions.IgnoreSymbols, false, 0 };
+                // Bug in ICU (non-Apple) implementation, correct result should be true (https://github.com/dotnet/runtime/issues/118521)
+                yield return new object[] { s_invariantCompare, "''Tests", "Tests", CompareOptions.IgnoreSymbols, PlatformDetection.IsHybridGlobalizationOnApplePlatform ? true : false, 0 };
                 yield return new object[] { s_frenchCompare, "\u0153", "oe", CompareOptions.None, false, 0 };
                 if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
                 {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -80,11 +80,8 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "\uD800\uD800", "\uD800\uD800", CompareOptions.None, true, 2 };
 
             // Ignore symbols
-            if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
-            {
-                yield return new object[] { s_invariantCompare, "More Test's", "Tests", CompareOptions.IgnoreSymbols, true, 6 };
-                yield return new object[] { s_invariantCompare, "More Test's", "Tests", CompareOptions.None, false, 0 };
-            }
+            yield return new object[] { s_invariantCompare, "More Test's", "Tests", CompareOptions.IgnoreSymbols, true, 6 };
+            yield return new object[] { s_invariantCompare, "More Test's", "Tests", CompareOptions.None, false, 0 };
 
             // NULL character
             yield return new object[] { s_invariantCompare, "a\u0000b", "a\u0000b", CompareOptions.None, true, 3 };

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -101,8 +101,7 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "AA\u200DA", "\u200d", 3, 4, CompareOptions.None, 4, 0};
 
             // Ignore symbols
-            if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform) // IgnoreSymbols are not supported
-                yield return new object[] { s_invariantCompare, "More Test's", "Tests", 10, 11, CompareOptions.IgnoreSymbols, 5, 6 };
+            yield return new object[] { s_invariantCompare, "More Test's", "Tests", 10, 11, CompareOptions.IgnoreSymbols, 5, 6 };
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 10, 11, CompareOptions.None, -1, 0 };
             yield return new object[] { s_invariantCompare, "cbabababdbaba", "ab", 12, 13, CompareOptions.None, 10, 2 };
 

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -100,9 +100,46 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "\u0001F601", "\u200d", 1, 2, CompareOptions.None, 2, 0}; // \u0001F601 is GRINNING FACE WITH SMILING EYES surrogate character
             yield return new object[] { s_invariantCompare, "AA\u200DA", "\u200d", 3, 4, CompareOptions.None, 4, 0};
 
-            // Ignore symbols
+            // Ignore symbols - punctuation characters
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 10, 11, CompareOptions.IgnoreSymbols, 5, 6 };
+            yield return new object[] { s_invariantCompare, "-Testing", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 1, 7 };
+            yield return new object[] { s_invariantCompare, "Testing]", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 0, 7 };
+            yield return new object[] { s_invariantCompare, "\"Testing", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 1, 7 };
+
+            // Ignore symbols - currency and math symbols
+            yield return new object[] { s_invariantCompare, "$Testing", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 1, 7 };
+            yield return new object[] { s_invariantCompare, "Test€ing", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 0, 8 };
+            yield return new object[] { s_invariantCompare, "Testing¢", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 0, 7 };
+            yield return new object[] { s_invariantCompare, "Test=ing", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 0, 8 };
+
+            // Ignore symbols - whitespace characters
+            yield return new object[] { s_invariantCompare, " Testing", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 1, 7 };
+            yield return new object[] { s_invariantCompare, "Testing ", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 0, 7 };
+            yield return new object[] { s_invariantCompare, "Test\u00A0ing", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 0, 8 }; // Non-breaking space
+            yield return new object[] { s_invariantCompare, "Testing\u2028", "Testing", 7, 8, CompareOptions.IgnoreSymbols, 0, 7 }; // Line separator
+            yield return new object[] { s_invariantCompare, "Test\ting\n", "Testing", 8, 9, CompareOptions.IgnoreSymbols, 0, 8 }; // Tab and newline
+
+            // Ignore symbols - multiple whitespace and punctuation
+            yield return new object[] { s_invariantCompare, "  Testing,  ", "Testing", 10, 11, CompareOptions.IgnoreSymbols, 2, 7 };
+            yield return new object[] { s_invariantCompare, "'Te st  i ng!", "Testing", 12, 13, CompareOptions.IgnoreSymbols, 1, 11 };
+
+            // Ignore symbols - mixed categories
+            yield return new object[] { s_invariantCompare, "$Te%s t&ing+", "Testing", 11, 12, CompareOptions.IgnoreSymbols, 1, 10 };
+            yield return new object[] { s_invariantCompare, ", Hello World!", "HelloWorld", 13, 14, CompareOptions.IgnoreSymbols, 2, 11 };
+            yield return new object[] { s_invariantCompare, "x$test$xtest$x", "test", 13, 14, CompareOptions.IgnoreSymbols, 8, 4 };
+
+            // Ignore symbols - source contains surrogates (to match) + symbols (to ignore)
+            yield return new object[] { s_invariantCompare, "$\U0001D7D8Testing!", "\U0001D7D8Testing", 10, 11, CompareOptions.IgnoreSymbols, 1, 9 };
+            yield return new object[] { s_invariantCompare, "Test$\U0001D7D8ing", "Test\U0001D7D8ing", 9, 10, CompareOptions.IgnoreSymbols, 0, 10 };
+            yield return new object[] { s_invariantCompare, "$Testing\U0001D7DA", "Testing\U0001D7DA", 9, 10, CompareOptions.IgnoreSymbols, 1, 9 };
+            yield return new object[] { s_invariantCompare, "$\U0001D7D8Test!\U0001D7D9ing", "\U0001D7D8Test\U0001D7D9ing", 12, 13, CompareOptions.IgnoreSymbols, 1, 12 };
+            yield return new object[] { s_invariantCompare, "\U0001D7D8 Test$ \U0001D7D9 ing!", "\U0001D7D8 Test \U0001D7D9 ing", 14, 15, CompareOptions.IgnoreSymbols, 0, 15 };
+            yield return new object[] { s_invariantCompare, "!$\U0001D7D8Test\U0001D7D9ing\U0001D7DA!", "\U0001D7D8Test\U0001D7D9ing\U0001D7DA", 14, 15, CompareOptions.IgnoreSymbols, 2, 13 };
+
+            // With symbols - should not match
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 10, 11, CompareOptions.None, -1, 0 };
+            yield return new object[] { s_invariantCompare, "Tes ting", "Testing", 7, 8, CompareOptions.None, -1, 0 };
+
             yield return new object[] { s_invariantCompare, "cbabababdbaba", "ab", 12, 13, CompareOptions.None, 10, 2 };
 
             // Platform differences

--- a/src/native/libs/System.Globalization.Native/pal_collation.m
+++ b/src/native/libs/System.Globalization.Native/pal_collation.m
@@ -13,14 +13,14 @@
 
 #if defined(APPLE_HYBRID_GLOBALIZATION)
 // Enum that corresponds to C# CompareOptions
-typedef enum
+typedef enum : int32_t
 {
-    None = 0,
-    IgnoreCase = 1,
-    IgnoreNonSpace = 2,
-    IgnoreKanaType = 8,
-    IgnoreWidth = 16,
-    StringSort = 536870912,
+    None = 0x00000000,
+    IgnoreCase = 0x00000001,
+    IgnoreNonSpace = 0x00000002,
+    IgnoreKanaType = 0x00000008,
+    IgnoreWidth = 0x00000010,
+    StringSort = 0x20000000,
 } CompareOptions;
 
 typedef enum
@@ -45,7 +45,7 @@ static NSLocale* GetCurrentLocale(const uint16_t* localeName, int32_t lNameLengt
     return currentLocale;
 }
 
-static bool IsComparisonOptionSupported(int32_t comparisonOptions)
+static bool IsComparisonOptionSupported(CompareOptions comparisonOptions)
 {
     int32_t supportedOptions = None | IgnoreCase | IgnoreNonSpace | IgnoreWidth | StringSort | IgnoreKanaType;
     if ((comparisonOptions | supportedOptions) != supportedOptions)
@@ -53,7 +53,7 @@ static bool IsComparisonOptionSupported(int32_t comparisonOptions)
     return true;
 }
 
-static NSStringCompareOptions ConvertFromCompareOptionsToNSStringCompareOptions(int32_t comparisonOptions, bool isLiteralSearchSupported)
+static NSStringCompareOptions ConvertFromCompareOptionsToNSStringCompareOptions(CompareOptions comparisonOptions, bool isLiteralSearchSupported)
 {
     // To achieve an equivalent search behavior to the default in ICU,
     // NSLiteralSearch is employed as the default search option.


### PR DESCRIPTION
Supersedes https://github.com/dotnet/runtime/pull/118523.

Implementation of `CompareOptions.IgnoreSymbols` for `IndexOf`, `IsPrefix`, `IsSuffix`, `Compare` on iOS. Because ObjectiveC string APIs (https://developer.apple.com/documentation/foundation/nsstring/compareoptions?language=objc) don't provide a direct alternative to `IgnoreSymbols` option, we filter the symbols from the strings in the managed code and after returning from native, we re-calculate the original index and length.

The implementation works in a following:
1. Preprocess the source and search strings by removing the symbols.
2. Invoke the native API for comparison.
3. Map the range from preprocessed source string back to the original string to get the index and length.


---

Fixes https://github.com/dotnet/runtime/issues/111895