### PR TITLE
Fix install-dependencies.sh for Amazon Linux 2023

### DIFF
--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -30,6 +30,8 @@ case "$os" in
         elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ] || [ "$ID" = "azurelinux" ]; then
             pkg_mgr="$(command -v tdnf 2>/dev/null || command -v dnf)"
             $pkg_mgr install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio
+        elif [ "$ID" = "amzn" ]; then
+            dnf install -y cmake llvm lld lldb clang python libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio
         elif [ "$ID" = "alpine" ]; then
             apk add build-base cmake bash curl clang llvm-dev lld lldb krb5-dev lttng-ust-dev icu-dev openssl-dev pigz cpio
         else


### PR DESCRIPTION
install-dependencies.sh used to be no-op on Amazon Linux 2023.

also, it doesn't need curl dependency, it comes with `curl-minimal` preinstalled (which is mutually exclusive with just `curl`).