### PR TITLE
Update TypeMap attribute handling

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -254,14 +254,7 @@ namespace Mono.Linker.Steps
         {
             InitializeCorelibAttributeXml();
             Context.Pipeline.InitializeMarkHandlers(Context, MarkContext);
-
-            if (Annotations.GetEntryPointAssembly() is AssemblyDefinition entryPoint)
-            {
-                _typeMapHandler = new TypeMapHandler(entryPoint);
-            }
-
-            _typeMapHandler.Initialize(Context, this);
-
+            _typeMapHandler.Initialize(Context, this, Annotations.GetEntryPointAssembly());
             ProcessMarkedPending();
         }
 
@@ -1458,7 +1451,7 @@ namespace Mono.Linker.Steps
             return !Annotations.SetProcessed(provider);
         }
 
-        protected virtual void MarkAssembly(AssemblyDefinition assembly, DependencyInfo reason, MessageOrigin origin)
+        public void MarkAssembly(AssemblyDefinition assembly, DependencyInfo reason, MessageOrigin origin)
         {
             Annotations.Mark(assembly, reason, origin);
             if (CheckProcessed(assembly))

--- a/src/tools/illink/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/SweepStep.cs
@@ -261,7 +261,7 @@ namespace Mono.Linker.Steps
 
         bool IsMarkedAssembly(AssemblyDefinition assembly)
         {
-            return Annotations.IsMarked(assembly.MainModule);
+            return Annotations.IsMarked(assembly) || Annotations.IsMarked(assembly.MainModule);
         }
 
         bool CanSweepNamesForMember(IMemberDefinition member, MetadataTrimming metadataTrimming)

--- a/src/tools/illink/src/linker/Linker/DependencyInfo.cs
+++ b/src/tools/illink/src/linker/Linker/DependencyInfo.cs
@@ -147,6 +147,7 @@ namespace Mono.Linker
         UnsafeAccessorTarget = 89, // the member is referenced via UnsafeAccessor attribute
 
         TypeMapEntry = 90, // external or proxy type map entry
+        TypeMapAssemblyTarget = 91, // TypeMapTargetAssembly for a used typeMapGroup
     }
 
     public readonly struct DependencyInfo : IEquatable<DependencyInfo>

--- a/src/tools/illink/src/linker/Linker/TypeMapHandler.cs
+++ b/src/tools/illink/src/linker/Linker/TypeMapHandler.cs
@@ -312,8 +312,7 @@ namespace Mono.Linker
                 return self.Attribute.AttributeType.Name switch
                 {
                     "TypeMapAttribute`1" =>
-                        sourceType is null || context.Annotations.IsRelevantToVariantCasting(sourceType)
-                        || context.Annotations.IsInstantiated(sourceType), // Or target of an IsInst instruction
+                        sourceType is null || context.Annotations.IsMarked(sourceType),
                     "TypeMapAssociationAttribute`1" =>
                         context.Annotations.IsInstantiated(sourceType),
                     _ => false,

--- a/src/tools/illink/src/linker/Linker/TypeMapHandler.cs
+++ b/src/tools/illink/src/linker/Linker/TypeMapHandler.cs
@@ -74,7 +74,8 @@ namespace Mono.Linker
             {
                 foreach (var entry in assemblyTargets)
                 {
-                    _markStep.MarkCustomAttribute(entry.Attribute, new DependencyInfo(DependencyKind.TypeMapEntry, callingMethod), new MessageOrigin(entry.Origin));
+                    var info = new DependencyInfo(DependencyKind.TypeMapEntry, callingMethod);
+                    _markStep.MarkCustomAttribute(entry.Attribute, info, new MessageOrigin(entry.Origin));
                     _markStep.MarkAssembly(entry.Origin, info, new MessageOrigin(entry.Origin));
                 }
             }
@@ -95,7 +96,8 @@ namespace Mono.Linker
             {
                 foreach (var entry in assemblyTargets)
                 {
-                    _markStep.MarkCustomAttribute(entry.Attribute, new DependencyInfo(DependencyKind.TypeMapEntry, callingMethod), new MessageOrigin(entry.Origin));
+                    var info = new DependencyInfo(DependencyKind.TypeMapEntry, callingMethod);
+                    _markStep.MarkCustomAttribute(entry.Attribute, info, new MessageOrigin(entry.Origin));
                     _markStep.MarkAssembly(entry.Origin, info, new MessageOrigin(entry.Origin));
                 }
             }

--- a/src/tools/illink/src/linker/Linker/TypeMapHandler.cs
+++ b/src/tools/illink/src/linker/Linker/TypeMapHandler.cs
@@ -290,13 +290,10 @@ namespace Mono.Linker
                                 var nextAssemblyName = AssemblyNameReference.Parse(str);
                                 if (context.TryResolve(nextAssemblyName) is AssemblyDefinition nextAssembly)
                                 {
-#pragma warning disable CA1868 // Unnecessary call to 'Contains(item)'
-                                    if (!seen.Contains(nextAssembly))
+                                    if (seen.Add(nextAssembly))
                                     {
-                                        seen.Add(nextAssembly);
                                         toVisit.Enqueue(nextAssembly);
                                     }
-#pragma warning restore CA1868 // Unnecessary call to 'Contains(item)'
                                 }
                             }
                         }

--- a/src/tools/illink/src/linker/Linker/TypeMapHandler.cs
+++ b/src/tools/illink/src/linker/Linker/TypeMapHandler.cs
@@ -314,7 +314,7 @@ namespace Mono.Linker
                     "TypeMapAttribute`1" =>
                         sourceType is null || context.Annotations.IsMarked(sourceType),
                     "TypeMapAssociationAttribute`1" =>
-                        context.Annotations.IsInstantiated(sourceType),
+                        context.Annotations.IsMarked(sourceType),
                     _ => false,
                 };
             }

--- a/src/tools/illink/src/linker/Linker/TypeReferenceEqualityComparer.cs
+++ b/src/tools/illink/src/linker/Linker/TypeReferenceEqualityComparer.cs
@@ -11,6 +11,9 @@ namespace Mono.Linker
     // Copied from https://github.com/jbevain/cecil/blob/master/Mono.Cecil/TypeReferenceComparer.cs
     internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeReference>
     {
+        [Obsolete("Default will point to default object equality comparer. Use the constructor to create an instance with a resolver.")]
+        public static new object Default => throw new InvalidOperationException();
+
         public readonly ITryResolveMetadata _resolver;
 
         public TypeReferenceEqualityComparer(ITryResolveMetadata resolver)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapReferencedAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapReferencedAssembly.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Reflection.Dependencies;
+using Mono.Linker.Tests.Cases.Reflection.Dependencies.Library;
+
+[assembly: TypeMap<UsedTypeMapUniverse>("UnimportantString", typeof(TargetTypeUnconditional1))]
+[assembly: TypeMap<UsedTypeMapUniverse>("UnimportantString", typeof(TargetTypeConditional1), typeof(TrimTarget1))]
+[assembly: TypeMapAssociation<UsedTypeMapUniverse>(typeof(ProxySource1), typeof(ProxyTarget1))]
+
+[assembly: TypeMap<UnusedTypeMapUniverse>("UnimportantString", typeof(TargetTypeUnconditional2))]
+[assembly: TypeMap<UnusedTypeMapUniverse>("UnimportantString", typeof(TargetTypeConditional2), typeof(TrimTarget2))]
+[assembly: TypeMapAssociation<UnusedTypeMapUniverse>(typeof(ProxySource2), typeof(ProxyTarget2))]
+[assembly: TypeMapAssemblyTarget<UsedTypeMapUniverse>("library2")]
+
+namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
+{
+    public class TypeMapReferencedAssembly
+    {
+        public static void Main()
+        {
+            // Mark expected trim targets
+            _ = new TrimTarget1();
+            _ = new ProxySource1();
+            _ = new TrimTarget2();
+            _ = new ProxySource2();
+
+            // Mark expected type map universe
+            _ = TypeMapping.GetOrCreateExternalTypeMapping<UsedTypeMapUniverse>();
+            _ = TypeMapping.GetOrCreateProxyTypeMapping<UsedTypeMapUniverse>();
+        }
+    }
+
+    public class UsedTypeMapUniverse;
+    public class UnusedTypeMapUniverse;
+}
+
+namespace Mono.Linker.Tests.Cases.Reflection.Dependencies.Library
+{
+    public class TargetTypeUnconditional1;
+    public class TargetTypeConditional1;
+    public class ProxySource1;
+    public class ProxyTarget1;
+    public class TargetTypeUnconditional2;
+    public class TargetTypeConditional2;
+    public class ProxySource2;
+    public class ProxyTarget2;
+    public class TrimTarget1;
+    public class TrimTarget2;
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapSecondOrderReference.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapSecondOrderReference.cs
@@ -1,0 +1,43 @@
+
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Reflection.Dependencies;
+using Mono.Linker.Tests.Cases.Reflection.Dependencies.Library2;
+
+// Nothing in this assembly should be referenced or rooted directly
+// This should validate the if only the type map attributes are kept, the assembly is still preserved
+[assembly: TypeMap<string>("UnimportantString", typeof(long))]
+[assembly: TypeMap<string>("UnimportantString", typeof(uint), typeof(string))]
+[assembly: TypeMapAssociation<string>(typeof(int), typeof(uint))]
+
+[assembly: TypeMap<UnusedTypeMapUniverse2>("UnimportantString", typeof(TargetTypeUnconditional2))]
+[assembly: TypeMap<UnusedTypeMapUniverse2>("UnimportantString", typeof(TargetTypeConditional2), typeof(TrimTarget2))]
+[assembly: TypeMapAssociation<UnusedTypeMapUniverse2>(typeof(ProxySource2), typeof(ProxyTarget2))]
+
+[assembly: TypeMapAssemblyTarget<string>("library")] // Circular reference
+
+namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
+{
+    public class TypeMapReferencedAssembly2
+    {
+    }
+
+    public class UsedTypeMapUniverse2;
+    public class UnusedTypeMapUniverse2;
+}
+
+namespace Mono.Linker.Tests.Cases.Reflection.Dependencies.Library2
+{
+    public class TargetTypeUnconditional1;
+    public class TargetTypeConditional1;
+    public class ProxySource1;
+    public class ProxyTarget1;
+    public class TargetTypeUnconditional2;
+    public class TargetTypeConditional2;
+    public class ProxySource2;
+    public class ProxyTarget2;
+    public class TrimTarget1;
+    public class TrimTarget2;
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
@@ -113,7 +113,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
     {
         [Kept]
         [ExpectedWarning("IL2057", "Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'")]
-        [ExpectBodyModified] // Bug
         public static void Main(string[] args)
         {
             object t = Activator.CreateInstance(Type.GetType(args[1]));
@@ -191,10 +190,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
             _ = TypeMapping.GetOrCreateProxyTypeMapping<UsedProxyTypeMap>();
             _ = new UsedProxySource();
             _ = new UsedProxySource2();
-            object obj = null!;
-            // Rewritten as if these types are removed
-            if (obj is UsedTrimTarget) ;
-            if (obj is UsedTrimTarget2) ;
+
+            UseTrimTargets();
 
             // For the second order reference, instantiate int and string as the dependency source types to root the TypeMap attributes
             // Do not directly root anything in the assembly to validate the assembly is kept even in only the typemap attributes are marked.
@@ -202,7 +199,18 @@ namespace Mono.Linker.Tests.Cases.Reflection
             _ = new int();
             _ = TypeMapping.GetOrCreateExternalTypeMapping<string>();
             _ = TypeMapping.GetOrCreateProxyTypeMapping<string>();
+        }
 
+        [ExpectBodyModified]
+        [Kept]
+        static void UseTrimTargets()
+        {
+            object obj = null!;
+            // Rewritten as if these types are removed
+            if (obj is UsedTrimTarget)
+                obj = 1;
+            if (obj is UsedTrimTarget2)
+                obj = 2;
         }
 
         [Kept]
@@ -504,7 +512,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
     class UsedProxySource2;
     [Kept]
     class UsedTrimTarget;
-    [Kept(By=Tool.NativeAot)]
+    [Kept(By=Tool.NativeAot)] // Associated attribute not kept
     class UsedTrimTarget2;
 
     [Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
@@ -98,7 +98,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
     // No types kept in library2, just TypeMap attributes
     [RemovedTypeInAssembly("library2.dll", typeof(TypeMapReferencedAssembly2))]
     [RemovedTypeInAssembly("library2.dll", typeof(UsedTypeMapUniverse2))]
-    [RemovedTypeInAssembly("library2.dll", typeof(UsedTypeMapUniverse2))]
     [RemovedTypeInAssembly("library2.dll", typeof(Mono.Linker.Tests.Cases.Reflection.Dependencies.Library2.ProxySource1))]
     [RemovedTypeInAssembly("library2.dll", typeof(Mono.Linker.Tests.Cases.Reflection.Dependencies.Library2.ProxySource2))]
     [RemovedTypeInAssembly("library2.dll", typeof(Mono.Linker.Tests.Cases.Reflection.Dependencies.Library2.ProxyTarget1))]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/120394

- Mark TypeMapAssemblyTargetAttributes when its TypeMapUniverse is marked
- Recurse through TypeMapAssemblyTarget assemblies to find all TypeMapAttributes
- Refactor TypeMapHandler construction and initialization
- Use TypeReferenceEqualityComparer for Dictionaries
- Mark TypeMap attribute origin / assembly when a TypeMap attribute is marked. Otherwise, assemblies with only TypeMapAttributes will not be kept.
- Add more test coverage