### PR TITLE
Disable `ExtendedLayout` tests when using Mono AOT

### DIFF
--- a/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
+++ b/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/120529 -->
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExtendedLayout.cs" />

--- a/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
+++ b/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/120529 -->
+    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/119948 -->
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
   </PropertyGroup>


### PR DESCRIPTION
## Description

This PR disables failing tests on extra-platforms.