### PR TITLE
Include the chain status flags on assertion failure

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -117,7 +117,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     chain2.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                     valid = chain2.Build(microsoftDotCom);
-                    Assert.True(valid, $"Chain built validly but failed with '{chain.AllStatusFlags()}'.");
+                    Assert.True(valid, $"Chain built validly but failed with '{chain2.AllStatusFlags()}'.");
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 bool valid = chain.Build(microsoftDotCom);
-                Assert.True(valid, "Chain built validly");
+                Assert.True(valid, $"Chain built validly but failed with '{chain.AllStatusFlags()}'.");
 
                 // The chain should have 3 members
                 Assert.Equal(3, chain.ChainElements.Count);
@@ -86,7 +86,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 bool valid = chain.Build(microsoftDotCom);
-                Assert.True(valid, "Source chain built validly");
+                Assert.True(valid, $"Chain built validly but failed with '{chain.AllStatusFlags()}'.");
                 Assert.Equal(3, chain.ChainElements.Count);
 
                 using (var chainHolder2 = new ChainHolder(chain.ChainContext))
@@ -117,7 +117,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     chain2.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                     valid = chain2.Build(microsoftDotCom);
-                    Assert.True(valid, "Cloned chain built validly");
+                    Assert.True(valid, $"Chain built validly but failed with '{chain.AllStatusFlags()}'.");
                 }
             }
         }
@@ -191,7 +191,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 valid = chain.Build(sampleCert);
-                Assert.True(valid, "Chain built validly");
+                Assert.True(valid, $"Chain built validly but failed with '{chain.AllStatusFlags()}'.");
 
                 Assert.Equal(1, chain.ChainElements.Count);
                 chainHolder.DisposeChainElements();
@@ -539,7 +539,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 bool valid = chain.Build(cert);
-                Assert.True(valid, "Chain built validly");
+                Assert.True(valid, $"Chain built validly but failed with '{chain.AllStatusFlags()}'.");
             }
         }
 
@@ -588,7 +588,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 bool valid = chain.Build(cert);
-                Assert.True(valid, "Chain built validly");
+                Assert.True(valid, $"Chain built validly but failed with '{chain.AllStatusFlags()}'.");
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CollectionTests.cs
@@ -907,7 +907,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.VerificationTime = new DateTime(2021, 02, 26, 12, 01, 01, DateTimeKind.Local);
 
                 bool valid = chain.Build(microsoftDotCom);
-                Assert.True(valid, "Precondition: Chain built validly");
+                Assert.True(valid, $"Precondition: Chain built validly but failed with '{chain.AllStatusFlags()}'.");
 
                 ICollection collection = chain.ChainElements;
                 Array array = Array.CreateInstance(typeof(object), new int[] { 10 }, new int[] { 10 });
@@ -1322,7 +1322,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 bool valid = chain.Build(microsoftDotCom);
-                Assert.True(valid, "Precondition: Chain built validly");
+                Assert.True(valid, $"Precondition: Chain built validly but failed with '{chain.AllStatusFlags()}'.");
 
                 int position = 0;
 


### PR DESCRIPTION
We have some intermittent chain building failures in CI, but the assertion is an "true but was false". Let's include the chain status flags so we have a better idea of why the tests are failing, since the failures do not reproduce locally for me.

Contributes to #120527 and #102232.