### PR TITLE
Use covariant returns in ILCompiler.TypeSystem

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Dataflow/EcmaExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/Dataflow/EcmaExtensions.cs
@@ -61,7 +61,7 @@ namespace ILCompiler.Dataflow
                 }
             }
 
-            mdType = mdType.MetadataBaseType;
+            mdType = mdType.BaseType;
             if (mdType != null)
                 return GetProperty(mdType, name, signature);
 

--- a/src/coreclr/tools/Common/Compiler/EventPseudoDesc.cs
+++ b/src/coreclr/tools/Common/Compiler/EventPseudoDesc.cs
@@ -25,7 +25,7 @@ namespace ILCompiler
             get
             {
                 MethodDefinitionHandle adder = Definition.GetAccessors().Adder;
-                return adder.IsNil ? null : _type.EcmaModule.GetMethod(adder);
+                return adder.IsNil ? null : _type.Module.GetMethod(adder);
             }
         }
 
@@ -34,7 +34,7 @@ namespace ILCompiler
             get
             {
                 MethodDefinitionHandle setter = Definition.GetAccessors().Remover;
-                return setter.IsNil ? null : _type.EcmaModule.GetMethod(setter);
+                return setter.IsNil ? null : _type.Module.GetMethod(setter);
             }
         }
 
@@ -43,7 +43,7 @@ namespace ILCompiler
             get
             {
                 MethodDefinitionHandle raiser = Definition.GetAccessors().Raiser;
-                return raiser.IsNil ? null : _type.EcmaModule.GetMethod(raiser);
+                return raiser.IsNil ? null : _type.Module.GetMethod(raiser);
             }
         }
 

--- a/src/coreclr/tools/Common/Compiler/EventPseudoDesc.cs
+++ b/src/coreclr/tools/Common/Compiler/EventPseudoDesc.cs
@@ -20,7 +20,7 @@ namespace ILCompiler
 
         private EventDefinition Definition => _type.MetadataReader.GetEventDefinition(_handle);
 
-        public MethodDesc AddMethod
+        public EcmaMethod AddMethod
         {
             get
             {
@@ -29,7 +29,7 @@ namespace ILCompiler
             }
         }
 
-        public MethodDesc RemoveMethod
+        public EcmaMethod RemoveMethod
         {
             get
             {
@@ -38,7 +38,7 @@ namespace ILCompiler
             }
         }
 
-        public MethodDesc RaiseMethod
+        public EcmaMethod RaiseMethod
         {
             get
             {
@@ -55,7 +55,7 @@ namespace ILCompiler
             }
         }
 
-        public MetadataType OwningType
+        public EcmaType OwningType
         {
             get
             {

--- a/src/coreclr/tools/Common/Compiler/GenericCycleDetection/GraphBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/GenericCycleDetection/GraphBuilder.cs
@@ -174,7 +174,7 @@ namespace ILCompiler
                     {
                         try
                         {
-                            var ecmaType = (EcmaType)assembly.GetObject(typeHandle);
+                            var ecmaType = assembly.GetType(typeHandle);
                             WalkAncestorTypes(ecmaType);
                         }
                         catch (TypeSystemException)
@@ -198,7 +198,7 @@ namespace ILCompiler
                         {
                             try
                             {
-                                var ecmaMethod = (EcmaMethod)assembly.GetObject(methodHandle);
+                                var ecmaMethod = assembly.GetMethod(methodHandle);
                                 WalkMethod(ecmaMethod);
 
                                 if (ecmaMethod.IsVirtual)
@@ -218,7 +218,7 @@ namespace ILCompiler
                         {
                             try
                             {
-                                var ecmaField = (EcmaField)assembly.GetObject(fieldHandle);
+                                var ecmaField = assembly.GetField(fieldHandle);
 
                                 if (typeContext.IsNull)
                                 {

--- a/src/coreclr/tools/Common/Compiler/GenericCycleDetection/ModuleCycleInfo.cs
+++ b/src/coreclr/tools/Common/Compiler/GenericCycleDetection/ModuleCycleInfo.cs
@@ -217,7 +217,7 @@ namespace ILCompiler
 
             private bool FormsCycle(TypeSystemEntity entity, out ModuleCycleInfo cycleInfo)
             {
-                EcmaModule ownerModule = (entity as EcmaType)?.EcmaModule ?? (entity as EcmaMethod)?.Module;
+                EcmaModule ownerModule = (entity as EcmaType)?.Module ?? (entity as EcmaMethod)?.Module;
                 if (ownerModule != null)
                 {
                     cycleInfo = _hashtable.GetOrCreateValue(ownerModule);

--- a/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
+++ b/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
@@ -64,7 +64,7 @@ namespace ILCompiler
             if (potentialType.Name.SequenceEqual("X64"u8) || potentialType.Name.SequenceEqual("Arm64"u8))
             {
                 if (architecture is TargetArchitecture.X64 or TargetArchitecture.ARM64)
-                    potentialType = (MetadataType)potentialType.ContainingType;
+                    potentialType = potentialType.ContainingType;
                 else
                     return "";
             }

--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -170,7 +170,7 @@ namespace ILCompiler
         {
             if (type is EcmaType ecmaType)
             {
-                string assemblyName = ((EcmaAssembly)ecmaType.EcmaModule).GetName().Name;
+                string assemblyName = ((EcmaAssembly)ecmaType.Module).GetName().Name;
                 bool isSystemPrivate = assemblyName.StartsWith("System.Private.");
 
                 // Abbreviate System.Private to S.P. This might conflict with user defined assembly names,
@@ -190,7 +190,7 @@ namespace ILCompiler
 
                     if (!_mangledTypeNames.ContainsKey(type))
                     {
-                        foreach (MetadataType t in ecmaType.EcmaModule.GetAllTypes())
+                        foreach (MetadataType t in ecmaType.Module.GetAllTypes())
                         {
                             string name = t.GetFullName();
 

--- a/src/coreclr/tools/Common/Compiler/PropertyPseudoDesc.cs
+++ b/src/coreclr/tools/Common/Compiler/PropertyPseudoDesc.cs
@@ -24,7 +24,7 @@ namespace ILCompiler
             new EcmaSignatureParser(_type.Module, _type.MetadataReader.GetBlobReader(Definition.Signature), NotFoundBehavior.Throw)
             .ParsePropertySignature();
 
-        public MethodDesc GetMethod
+        public EcmaMethod GetMethod
         {
             get
             {
@@ -33,7 +33,7 @@ namespace ILCompiler
             }
         }
 
-        public MethodDesc SetMethod
+        public EcmaMethod SetMethod
         {
             get
             {
@@ -50,7 +50,7 @@ namespace ILCompiler
             }
         }
 
-        public MetadataType OwningType
+        public EcmaType OwningType
         {
             get
             {

--- a/src/coreclr/tools/Common/Compiler/PropertyPseudoDesc.cs
+++ b/src/coreclr/tools/Common/Compiler/PropertyPseudoDesc.cs
@@ -21,7 +21,7 @@ namespace ILCompiler
         private PropertyDefinition Definition => _type.MetadataReader.GetPropertyDefinition(_handle);
 
         public PropertySignature Signature =>
-            new EcmaSignatureParser(_type.EcmaModule, _type.MetadataReader.GetBlobReader(Definition.Signature), NotFoundBehavior.Throw)
+            new EcmaSignatureParser(_type.Module, _type.MetadataReader.GetBlobReader(Definition.Signature), NotFoundBehavior.Throw)
             .ParsePropertySignature();
 
         public MethodDesc GetMethod
@@ -29,7 +29,7 @@ namespace ILCompiler
             get
             {
                 MethodDefinitionHandle getter = Definition.GetAccessors().Getter;
-                return getter.IsNil ? null : _type.EcmaModule.GetMethod(getter);
+                return getter.IsNil ? null : _type.Module.GetMethod(getter);
             }
         }
 
@@ -38,7 +38,7 @@ namespace ILCompiler
             get
             {
                 MethodDefinitionHandle setter = Definition.GetAccessors().Setter;
-                return setter.IsNil ? null : _type.EcmaModule.GetMethod(setter);
+                return setter.IsNil ? null : _type.Module.GetMethod(setter);
             }
         }
 

--- a/src/coreclr/tools/Common/Compiler/PseudoDescExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/PseudoDescExtensions.cs
@@ -15,7 +15,7 @@ namespace ILCompiler
             if (!accessor.IsSpecialName || accessor.GetTypicalMethodDefinition() is not EcmaMethod ecmaAccessor)
                 return null;
 
-            var type = (EcmaType)ecmaAccessor.OwningType;
+            var type = ecmaAccessor.OwningType;
             var reader = type.MetadataReader;
             foreach (var propertyHandle in reader.GetTypeDefinition(type.Handle).GetProperties())
             {
@@ -35,7 +35,7 @@ namespace ILCompiler
             if (!accessor.IsSpecialName || accessor.GetTypicalMethodDefinition() is not EcmaMethod ecmaAccessor)
                 return null;
 
-            var type = (EcmaType)ecmaAccessor.OwningType;
+            var type = ecmaAccessor.OwningType;
             var reader = type.MetadataReader;
             foreach (var eventHandle in reader.GetTypeDefinition(type.Handle).GetEvents())
             {

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3443,7 +3443,7 @@ namespace Internal.JitInterface
 
             if (method.GetTypicalMethodDefinition() is EcmaMethod ecmaMethod)
             {
-                EcmaType owningType = (EcmaType)ecmaMethod.OwningType;
+                EcmaType owningType = ecmaMethod.OwningType;
                 var reader = owningType.MetadataReader;
 
                 if (className != null)
@@ -3456,7 +3456,7 @@ namespace Internal.JitInterface
                 EcmaType containingType = owningType;
                 for (nuint i = 0; i < maxEnclosingClassNames; i++)
                 {
-                    containingType = containingType.ContainingType as EcmaType;
+                    containingType = containingType.ContainingType;
                     if (containingType == null)
                         break;
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2334,7 +2334,7 @@ namespace Internal.JitInterface
         {
             int result = 0;
 
-            if (type.MetadataBaseType is { ContainsGCPointers: true } baseType)
+            if (type.BaseType is { ContainsGCPointers: true } baseType)
                 result += GatherClassGCLayout(baseType, gcPtrs);
 
             bool isInlineArray = type.IsInlineArray;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
@@ -1311,7 +1311,7 @@ namespace Internal.JitInterface
             string nestedTypeName = null;
             while (metadataType.ContainingType != null)
             {
-                var enclosingType = (MetadataType)metadataType.ContainingType;
+                var enclosingType = metadataType.ContainingType;
                 namespaceName = enclosingType.GetNamespace();
                 nestedTypeName = nestedTypeName is null ? metadataType.GetName() : $"{metadataType.GetName()}_{nestedTypeName}";
                 typeName = enclosingType.GetName();

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetGenerator.cs
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetGenerator.cs
@@ -808,7 +808,7 @@ namespace Internal.JitInterface
             string nestedTypeName = null;
             while (metadataType.ContainingType != null)
             {
-                var enclosingType = (MetadataType)metadataType.ContainingType;
+                var enclosingType = metadataType.ContainingType;
                 namespaceName = enclosingType.GetNamespace();
                 nestedTypeName = nestedTypeName is null ? metadataType.GetName() : $""{metadataType.GetName()}_{nestedTypeName}"";
                 typeName = enclosingType.GetName();

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.Metadata.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.Metadata.cs
@@ -17,8 +17,6 @@ namespace Internal.TypeSystem
             return Array.Empty<MethodImplRecord>();
         }
 
-        public override MetadataType MetadataBaseType => (MetadataType)BaseType;
-
         public override DefType[] ExplicitlyImplementedInterfaces => Array.Empty<DefType>();
 
         public override bool IsAbstract => false;

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
@@ -87,11 +87,11 @@ namespace Internal.TypeSystem
         // consumer-specific initialization.
         partial void Initialize();
 
-        public override DefType BaseType
+        public override MetadataType BaseType
         {
             get
             {
-                return Context.GetWellKnownType(WellKnownType.Object);
+                return (MetadataType)Context.GetWellKnownType(WellKnownType.Object);
             }
         }
 
@@ -171,12 +171,12 @@ namespace Internal.TypeSystem
         // consumer-specific initialization.
         partial void Initialize();
 
-        public override DefType BaseType
+        public override MetadataType BaseType
         {
             get
             {
                 // UniversalCanon is "a struct of indeterminate size and GC layout"
-                return Context.GetWellKnownType(WellKnownType.ValueType);
+                return (MetadataType)Context.GetWellKnownType(WellKnownType.ValueType);
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
@@ -51,7 +51,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override DefType ContainingType => null;
+        public override MetadataType ContainingType => null;
     }
 
     /// <summary>

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
@@ -8,6 +8,10 @@ using Internal.NativeFormat;
 
 using Debug = System.Diagnostics.Debug;
 
+#if TYPE_LOADER_IMPLEMENTATION
+using MetadataType = Internal.TypeSystem.DefType;
+#endif
+
 namespace Internal.TypeSystem
 {
     /// <summary>

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
@@ -45,7 +45,7 @@ namespace Internal.TypeSystem
                 );
         }
 
-        public abstract DefType OwningType
+        public abstract MetadataType OwningType
         {
             get;
         }

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
@@ -6,6 +6,10 @@ using System.Runtime.CompilerServices;
 
 using Debug = System.Diagnostics.Debug;
 
+#if TYPE_LOADER_IMPLEMENTATION
+using MetadataType = Internal.TypeSystem.DefType;
+#endif
+
 namespace Internal.TypeSystem
 {
     public abstract partial class FieldDesc : TypeSystemEntity

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
@@ -4,6 +4,10 @@
 using System;
 using Debug = System.Diagnostics.Debug;
 
+#if TYPE_LOADER_IMPLEMENTATION
+using MetadataType = Internal.TypeSystem.DefType;
+#endif
+
 namespace Internal.TypeSystem
 {
     public sealed partial class FieldForInstantiatedType : FieldDesc

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
@@ -26,7 +26,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override DefType OwningType
+        public override MetadataType OwningType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/ImpliedRepeatedFieldDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ImpliedRepeatedFieldDesc.cs
@@ -9,14 +9,14 @@ namespace Internal.TypeSystem
     {
         private readonly FieldDesc _underlyingFieldDesc;
 
-        public ImpliedRepeatedFieldDesc(DefType owningType, FieldDesc underlyingFieldDesc, int fieldIndex)
+        public ImpliedRepeatedFieldDesc(MetadataType owningType, FieldDesc underlyingFieldDesc, int fieldIndex)
         {
             OwningType = owningType;
             _underlyingFieldDesc = underlyingFieldDesc;
             FieldIndex = fieldIndex;
         }
 
-        public override DefType OwningType { get; }
+        public override MetadataType OwningType { get; }
 
         public override TypeDesc FieldType => _underlyingFieldDesc.FieldType;
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.Metadata.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.Metadata.cs
@@ -8,16 +8,6 @@ namespace Internal.TypeSystem
 {
     public sealed partial class InstantiatedType : MetadataType
     {
-        public override MetadataType MetadataBaseType
-        {
-            get
-            {
-                if (_baseType == this)
-                    return InitializeBaseType();
-                return _baseType;
-            }
-        }
-
         // Properties that are passed through from the type definition
         public override ClassLayoutMetadata GetClassLayout()
         {

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
@@ -297,7 +297,7 @@ namespace Internal.TypeSystem
             return _typeDef;
         }
 
-        public override DefType ContainingType
+        public override MetadataType ContainingType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
@@ -69,7 +69,7 @@ namespace Internal.TypeSystem
             return (_baseType = (uninst != null) ? (MetadataType)uninst.InstantiateSignature(_instantiation, default(Instantiation)) : null);
         }
 
-        public override DefType BaseType
+        public override MetadataType BaseType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -72,7 +72,7 @@ namespace Internal.TypeSystem
                     ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadBadFormat, type);
                 }
 
-                MetadataType baseType = type.MetadataBaseType;
+                MetadataType baseType = type.BaseType;
                 if (!baseType.IsObject && baseType.IsAutoLayout)
                 {
                     ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadBadFormat, type);

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
@@ -69,13 +69,8 @@ namespace Internal.TypeSystem
         /// </summary>
         public abstract ModuleDesc Module { get; }
 
-        /// <summary>
-        /// Same as <see cref="TypeDesc.BaseType"/>, but the result is a MetadataType (avoids casting).
-        /// </summary>
-        public abstract MetadataType MetadataBaseType { get; }
-
-        // Make sure children remember to override both MetadataBaseType and BaseType.
-        public abstract override DefType BaseType { get; }
+        /// <inheritdoc />
+        public abstract override MetadataType BaseType { get; }
 
         /// <summary>
         /// If true, the type cannot be used as a base type of any other type.

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
@@ -87,7 +87,7 @@ namespace Internal.TypeSystem
         /// </summary>
         public abstract bool HasCustomAttribute(string attributeNamespace, string attributeName);
 
-        public abstract override DefType ContainingType { get; }
+        public abstract override MetadataType ContainingType { get; }
 
         /// <summary>
         /// Get all of the types nested in this type.

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -425,7 +425,7 @@ namespace Internal.TypeSystem
                     return nameSigOverride;
                 }
 
-                currentType = currentType.MetadataBaseType;
+                currentType = currentType.BaseType;
             }
 
             return null;
@@ -506,7 +506,7 @@ namespace Internal.TypeSystem
             }
 
             MethodDesc nameSigMatchMethod = FindMatchingVirtualMethodOnTypeByNameAndSigWithSlotCheck(unificationGroup.DefiningMethod, currentType, reverseMethodSearch: true);
-            MetadataType baseType = currentType.MetadataBaseType;
+            MetadataType baseType = currentType.BaseType;
 
             // Unless the current type has a name/sig match for the group, look to the base type to define the unification group further
             if ((nameSigMatchMethod == null) && (baseType != null))
@@ -707,7 +707,7 @@ namespace Internal.TypeSystem
 
             // If interface is explicitly defined on a type, search for a name/sig match.
             bool foundExplicitInterface = IsInterfaceExplicitlyImplementedOnType(currentType, interfaceType);
-            MetadataType baseType = currentType.MetadataBaseType;
+            MetadataType baseType = currentType.BaseType;
 
             if (foundExplicitInterface)
             {
@@ -813,7 +813,7 @@ namespace Internal.TypeSystem
                 if (currentTypeInterfaceResolution != null)
                     return currentTypeInterfaceResolution;
 
-                currentType = currentType.MetadataBaseType;
+                currentType = currentType.BaseType;
             }
         }
 
@@ -834,7 +834,7 @@ namespace Internal.TypeSystem
                     return FindSlotDefiningMethodForVirtualMethod(nameSigOverride);
                 }
 
-                currentType = currentType.MetadataBaseType;
+                currentType = currentType.BaseType;
             }
         }
 
@@ -988,7 +988,7 @@ namespace Internal.TypeSystem
                         }
                     }
 
-                    type = type.MetadataBaseType;
+                    type = type.BaseType;
                 } while (type != null);
             }
         }
@@ -1007,7 +1007,7 @@ namespace Internal.TypeSystem
                 return null;
 
             // Search for match on a per-level in the type hierarchy
-            for (MetadataType typeToCheck = currentType; typeToCheck != null; typeToCheck = typeToCheck.MetadataBaseType)
+            for (MetadataType typeToCheck = currentType; typeToCheck != null; typeToCheck = typeToCheck.BaseType)
             {
                 MethodDesc resolvedMethodOnType = TryResolveVirtualStaticMethodOnThisType(typeToCheck, interfaceMethod);
                 if (resolvedMethodOnType != null)
@@ -1029,7 +1029,7 @@ namespace Internal.TypeSystem
             TypeDesc interfaceType = interfaceMethod.OwningType;
 
             // Search for match on a per-level in the type hierarchy
-            for (MetadataType typeToCheck = currentType; typeToCheck != null; typeToCheck = typeToCheck.MetadataBaseType)
+            for (MetadataType typeToCheck = currentType; typeToCheck != null; typeToCheck = typeToCheck.BaseType)
             {
                 MethodDesc resolvedMethodOnType = TryResolveVirtualStaticMethodOnThisType(typeToCheck, interfaceMethod);
                 if (resolvedMethodOnType != null)

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFields.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFields.cs
@@ -115,7 +115,7 @@ namespace Internal.TypeSystem
 
         public override bool IsAbstract => false;
 
-        public override DefType ContainingType => MetadataType.ContainingType;
+        public override MetadataType ContainingType => MetadataType.ContainingType;
 
         public override PInvokeStringFormat PInvokeStringFormat => MetadataType.PInvokeStringFormat;
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFields.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFields.cs
@@ -109,9 +109,7 @@ namespace Internal.TypeSystem
 
         public override ModuleDesc Module => MetadataType.Module;
 
-        public override MetadataType MetadataBaseType => MetadataType.MetadataBaseType;
-
-        public override DefType BaseType => MetadataType.BaseType;
+        public override MetadataType BaseType => MetadataType.BaseType;
 
         public override bool IsSealed => true;
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.Sorting.cs
@@ -14,8 +14,8 @@ namespace Internal.TypeSystem.Ecma
         {
             var otherField = (EcmaField)other;
 
-            EcmaModule module = _type.EcmaModule;
-            EcmaModule otherModule = otherField._type.EcmaModule;
+            EcmaModule module = _type.Module;
+            EcmaModule otherModule = otherField._type.Module;
 
             int result = module.MetadataReader.GetToken(_handle) - otherModule.MetadataReader.GetToken(otherField._handle);
             if (result != 0)

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
@@ -73,7 +73,7 @@ namespace Internal.TypeSystem.Ecma
         {
             get
             {
-                return _type.EcmaModule;
+                return _type.Module;
             }
         }
 
@@ -293,7 +293,7 @@ namespace Internal.TypeSystem.Ecma
             if ((definition.Attributes & FieldAttributes.HasFieldMarshal) != 0)
             {
                 BlobReader marshalAsReader = reader.GetBlobReader(definition.GetMarshallingDescriptor());
-                EcmaSignatureParser parser = new EcmaSignatureParser(_type.EcmaModule, marshalAsReader, NotFoundBehavior.Throw);
+                EcmaSignatureParser parser = new EcmaSignatureParser(_type.Module, marshalAsReader, NotFoundBehavior.Throw);
                 return parser.ParseMarshalAsDescriptor();
             }
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
@@ -61,7 +61,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override DefType OwningType
+        public override EcmaType OwningType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.Sorting.cs
@@ -14,8 +14,8 @@ namespace Internal.TypeSystem.Ecma
         {
             var otherMethod = (EcmaMethod)other;
 
-            EcmaModule module = _type.EcmaModule;
-            EcmaModule otherModule = otherMethod._type.EcmaModule;
+            EcmaModule module = _type.Module;
+            EcmaModule otherModule = otherMethod._type.Module;
 
             // Sort by module in preference to by token. This will place methods of the same type near each other
             // even when working with several modules

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -98,7 +98,7 @@ namespace Internal.TypeSystem.Ecma
         {
             get
             {
-                return _type.EcmaModule;
+                return _type.Module;
             }
         }
 
@@ -517,7 +517,7 @@ namespace Internal.TypeSystem.Ecma
             {
                 CustomAttribute attribute = reader.GetCustomAttribute(attributeHandle);
                 CustomAttributeValue<TypeDesc> decoded = attribute.DecodeValue(
-                    new CustomAttributeTypeProvider(_type.EcmaModule));
+                    new CustomAttributeTypeProvider(_type.Module));
 
                 if (decoded.FixedArguments.Length != 1 || !(decoded.FixedArguments[0].Value is bool))
                     ThrowHelper.ThrowBadImageFormatException();

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -66,7 +66,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override TypeDesc OwningType
+        public override EcmaType OwningType
         {
             get
             {
@@ -581,5 +581,9 @@ namespace Internal.TypeSystem.Ecma
             }
             return null;
         }
+
+        public override EcmaMethod GetMethodDefinition() => this;
+
+        public override EcmaMethod GetTypicalMethodDefinition() => this;
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -101,7 +101,7 @@ namespace Internal.TypeSystem.Ecma
                         {
                             MethodDefinitionHandle methodDefinitionHandle = (MethodDefinitionHandle)handle;
                             TypeDefinitionHandle typeDefinitionHandle = _module._metadataReader.GetMethodDefinition(methodDefinitionHandle).GetDeclaringType();
-                            EcmaType type = (EcmaType)_module.GetObject(typeDefinitionHandle, NotFoundBehavior.Throw);
+                            EcmaType type = _module.GetType(typeDefinitionHandle);
                             item = new EcmaMethod(type, methodDefinitionHandle);
                         }
                         break;
@@ -110,7 +110,7 @@ namespace Internal.TypeSystem.Ecma
                         {
                             FieldDefinitionHandle fieldDefinitionHandle = (FieldDefinitionHandle)handle;
                             TypeDefinitionHandle typeDefinitionHandle = _module._metadataReader.GetFieldDefinition(fieldDefinitionHandle).GetDeclaringType();
-                            EcmaType type = (EcmaType)_module.GetObject(typeDefinitionHandle, NotFoundBehavior.Throw);
+                            EcmaType type = _module.GetType(typeDefinitionHandle);
                             item = new EcmaField(type, fieldDefinitionHandle);
                         }
                         break;
@@ -458,6 +458,11 @@ namespace Internal.TypeSystem.Ecma
             return type;
         }
 
+        public EcmaType GetType(TypeDefinitionHandle handle)
+        {
+            return (EcmaType)GetType((EntityHandle)handle);
+        }
+
         public MethodDesc GetMethod(EntityHandle handle)
         {
             MethodDesc method = GetObject(handle, NotFoundBehavior.Throw) as MethodDesc;
@@ -466,12 +471,22 @@ namespace Internal.TypeSystem.Ecma
             return method;
         }
 
+        public EcmaMethod GetMethod(MethodDefinitionHandle handle)
+        {
+            return (EcmaMethod)GetMethod((EntityHandle)handle);
+        }
+
         public FieldDesc GetField(EntityHandle handle)
         {
             FieldDesc field = GetObject(handle, NotFoundBehavior.Throw) as FieldDesc;
             if (field == null)
                 ThrowHelper.ThrowBadImageFormatException();
             return field;
+        }
+
+        public EcmaField GetField(FieldDefinitionHandle handle)
+        {
+            return (EcmaField)GetField((EntityHandle)handle);
         }
 
         internal EcmaField GetField(FieldDefinitionHandle handle, EcmaType owningType)
@@ -738,21 +753,21 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public sealed override IEnumerable<MetadataType> GetAllTypes()
+        public sealed override IEnumerable<EcmaType> GetAllTypes()
         {
             foreach (var typeDefinitionHandle in _metadataReader.TypeDefinitions)
             {
-                yield return (MetadataType)GetType(typeDefinitionHandle);
+                yield return GetType(typeDefinitionHandle);
             }
         }
 
-        public sealed override MetadataType GetGlobalModuleType()
+        public sealed override EcmaType GetGlobalModuleType()
         {
             int typeDefinitionsCount = _metadataReader.TypeDefinitions.Count;
             if (typeDefinitionsCount == 0)
                 return null;
 
-            return (MetadataType)GetType(MetadataTokens.EntityHandle(0x02000001 /* COR_GLOBAL_PARENT_TOKEN */));
+            return (EcmaType)GetType(MetadataTokens.EntityHandle(0x02000001 /* COR_GLOBAL_PARENT_TOKEN */));
         }
 
         public string GetUserString(UserStringHandle userStringHandle)

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.TypeEquivalence.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.TypeEquivalence.cs
@@ -28,7 +28,7 @@ namespace Internal.TypeSystem.Ecma
                 if (attributeHandle.IsNil)
                     return null;
 
-                guidAttribute = this.MetadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(this.EcmaModule));
+                guidAttribute = this.MetadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(this.Module));
             }
 
             if (!guidAttribute.HasValue)

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
@@ -109,15 +109,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override ModuleDesc Module
-        {
-            get
-            {
-                return _module;
-            }
-        }
-
-        public EcmaModule EcmaModule
+        public override EcmaModule Module
         {
             get
             {
@@ -160,17 +152,7 @@ namespace Internal.TypeSystem.Ecma
             return type;
         }
 
-        public override DefType BaseType
-        {
-            get
-            {
-                if (_baseType == this)
-                    return InitializeBaseType();
-                return _baseType;
-            }
-        }
-
-        public override MetadataType MetadataBaseType
+        public override MetadataType BaseType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
@@ -288,7 +288,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override IEnumerable<MethodDesc> GetMethods()
+        public override IEnumerable<EcmaMethod> GetMethods()
         {
             foreach (var handle in _typeDefinition.GetMethods())
             {
@@ -296,7 +296,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override IEnumerable<MethodDesc> GetVirtualMethods()
+        public override IEnumerable<EcmaMethod> GetVirtualMethods()
         {
             MetadataReader reader = _module.MetadataReader;
             foreach (var handle in _typeDefinition.GetMethods())
@@ -307,7 +307,18 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override MethodDesc GetMethod(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        /// <summary>
+        /// Gets a named method on the type. This method only looks at methods defined
+        /// in type's metadata. The <paramref name="signature"/> parameter can be null.
+        /// If signature is not specified and there are multiple matches, the first one
+        /// is returned. Returns null if method not found.
+        /// </summary>
+        public new EcmaMethod GetMethod(ReadOnlySpan<byte> name, MethodSignature signature)
+        {
+            return GetMethod(name, signature, default(Instantiation));
+        }
+
+        public override EcmaMethod GetMethod(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
         {
             var metadataReader = this.MetadataReader;
 
@@ -324,7 +335,7 @@ namespace Internal.TypeSystem.Ecma
             return null;
         }
 
-        public override MethodDesc GetMethodWithEquivalentSignature(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        public override EcmaMethod GetMethodWithEquivalentSignature(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
         {
             var metadataReader = this.MetadataReader;
 
@@ -341,7 +352,7 @@ namespace Internal.TypeSystem.Ecma
             return null;
         }
 
-        public override MethodDesc GetStaticConstructor()
+        public override EcmaMethod GetStaticConstructor()
         {
             var metadataReader = this.MetadataReader;
             var stringComparer = metadataReader.StringComparer;
@@ -360,7 +371,7 @@ namespace Internal.TypeSystem.Ecma
             return null;
         }
 
-        public override MethodDesc GetDefaultConstructor()
+        public override EcmaMethod GetDefaultConstructor()
         {
             if (IsAbstract)
                 return null;
@@ -423,7 +434,7 @@ namespace Internal.TypeSystem.Ecma
             return null;
         }
 
-        public override IEnumerable<FieldDesc> GetFields()
+        public override IEnumerable<EcmaField> GetFields()
         {
             foreach (var handle in _typeDefinition.GetFields())
             {
@@ -450,7 +461,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override FieldDesc GetField(ReadOnlySpan<byte> name)
+        public override EcmaField GetField(ReadOnlySpan<byte> name)
         {
             var metadataReader = this.MetadataReader;
 
@@ -466,7 +477,7 @@ namespace Internal.TypeSystem.Ecma
             return null;
         }
 
-        public override IEnumerable<MetadataType> GetNestedTypes()
+        public override IEnumerable<EcmaType> GetNestedTypes()
         {
             foreach (var handle in _typeDefinition.GetNestedTypes())
             {
@@ -474,7 +485,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override MetadataType GetNestedType(string name)
+        public override EcmaType GetNestedType(string name)
         {
             var metadataReader = this.MetadataReader;
             var stringComparer = metadataReader.StringComparer;
@@ -495,7 +506,7 @@ namespace Internal.TypeSystem.Ecma
                 }
 
                 if (nameMatched)
-                    return (EcmaType)_module.GetObject(handle);
+                    return _module.GetType(handle);
             }
 
             return null;
@@ -509,7 +520,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override DefType ContainingType
+        public override EcmaType ContainingType
         {
             get
             {
@@ -517,7 +528,7 @@ namespace Internal.TypeSystem.Ecma
                     return null;
 
                 var handle = _typeDefinition.GetDeclaringType();
-                return (DefType)_module.GetType(handle);
+                return _module.GetType(handle);
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EffectiveVisibility.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EffectiveVisibility.cs
@@ -119,7 +119,7 @@ namespace Internal.TypeSystem
         {
             EffectiveVisibility visibility = method.Attributes.ToEffectiveVisibility();
 
-            for (EcmaType type = (EcmaType)method.OwningType; type is not null; type = (EcmaType)type.ContainingType)
+            for (EcmaType type = method.OwningType; type is not null; type = type.ContainingType)
             {
                 visibility = visibility.ConstrainToVisibility(type.Attributes.ToEffectiveVisibility());
             }
@@ -129,8 +129,8 @@ namespace Internal.TypeSystem
         public static EffectiveVisibility GetEffectiveVisibility(this EcmaType type)
         {
             EffectiveVisibility visibility = type.Attributes.ToEffectiveVisibility();
-            type = (EcmaType)type.ContainingType;
-            for (; type is not null; type = (EcmaType)type.ContainingType)
+            type = type.ContainingType;
+            for (; type is not null; type = type.ContainingType)
             {
                 visibility = visibility.ConstrainToVisibility(type.Attributes.ToEffectiveVisibility());
             }
@@ -159,7 +159,7 @@ namespace Internal.TypeSystem
             // Treat all non-Ecma fields as always having public visibility
             EffectiveVisibility visibility = field.Attributes.ToEffectiveVisibility();
 
-            for (EcmaType type = (EcmaType)field.OwningType; type is not null; type = (EcmaType)type.ContainingType)
+            for (EcmaType type = field.OwningType; type is not null; type = type.ContainingType)
             {
                 visibility = visibility.ConstrainToVisibility(type.Attributes.ToEffectiveVisibility());
             }

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/MetadataExtensions.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/MetadataExtensions.cs
@@ -23,7 +23,7 @@ namespace Internal.TypeSystem.Ecma
             if (attributeHandle.IsNil)
                 return null;
 
-            return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(This.EcmaModule));
+            return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(This.Module));
         }
 
         public static IEnumerable<CustomAttributeValue<TypeDesc>> GetDecodedCustomAttributes(this EcmaType This,
@@ -35,7 +35,7 @@ namespace Internal.TypeSystem.Ecma
             {
                 if (IsEqualCustomAttributeName(attributeHandle, metadataReader, attributeNamespace, attributeName))
                 {
-                    yield return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(This.EcmaModule));
+                    yield return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(This.Module));
                 }
             }
         }

--- a/src/coreclr/tools/Common/TypeSystem/IL/EcmaMethodIL.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/EcmaMethodIL.cs
@@ -45,7 +45,7 @@ namespace Internal.IL
             }
         }
 
-        public override MethodDesc OwningMethod
+        public override EcmaMethod OwningMethod
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
@@ -15,11 +15,11 @@ namespace Internal.IL.Stubs
     /// </summary>
     public sealed partial class PInvokeLazyFixupField : FieldDesc
     {
-        private readonly DefType _owningType;
+        private readonly MetadataType _owningType;
         private readonly MethodDesc _targetMethod;
         private readonly MethodSignature _nativeSignature;
 
-        public PInvokeLazyFixupField(DefType owningType, MethodDesc targetMethod, MethodSignature nativeSignature)
+        public PInvokeLazyFixupField(MetadataType owningType, MethodDesc targetMethod, MethodSignature nativeSignature)
         {
             Debug.Assert(targetMethod.IsPInvoke);
             _owningType = owningType;
@@ -111,7 +111,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override DefType OwningType
+        public override MetadataType OwningType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
@@ -480,7 +480,7 @@ namespace Internal.TypeSystem.Interop
                 }
             }
 
-            public override DefType OwningType
+            public override MetadataType OwningType
             {
                 get
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
@@ -139,7 +139,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override DefType ContainingType
+        public override MetadataType ContainingType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
@@ -115,15 +115,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override DefType BaseType
-        {
-            get
-            {
-                return (DefType)Context.GetWellKnownType(WellKnownType.ValueType);
-            }
-        }
-
-        public override MetadataType MetadataBaseType
+        public override MetadataType BaseType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
@@ -125,7 +125,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override DefType ContainingType
+        public override MetadataType ContainingType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
@@ -101,15 +101,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override DefType BaseType
-        {
-            get
-            {
-                return (DefType)Context.GetWellKnownType(WellKnownType.ValueType);
-            }
-        }
-
-        public override MetadataType MetadataBaseType
+        public override MetadataType BaseType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
@@ -381,7 +381,7 @@ namespace Internal.TypeSystem.Interop
                 }
             }
 
-            public override DefType OwningType
+            public override MetadataType OwningType
             {
                 get
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
@@ -130,7 +130,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override DefType ContainingType
+        public override MetadataType ContainingType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
@@ -106,15 +106,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override MetadataType MetadataBaseType
-        {
-            get
-            {
-                return InteropTypes.GetNativeFunctionPointerWrapper(Context);
-            }
-        }
-
-        public override DefType BaseType
+        public override MetadataType BaseType
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/InteropStateManager.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/InteropStateManager.cs
@@ -481,9 +481,9 @@ namespace Internal.TypeSystem
                 return new PInvokeLazyFixupField(_owningType, key.Method, key.NativeSignature);
             }
 
-            private readonly DefType _owningType;
+            private readonly MetadataType _owningType;
 
-            public PInvokeLazyFixupFieldHashtable(DefType owningType)
+            public PInvokeLazyFixupFieldHashtable(MetadataType owningType)
             {
                 _owningType = owningType;
             }

--- a/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
@@ -225,7 +225,7 @@ namespace Internal.TypeSystem
                 else
                 {
                     // nested type
-                    resolutionScope = GetTypeRef((MetadataType)metadataType.ContainingType);
+                    resolutionScope = GetTypeRef(metadataType.ContainingType);
                 }
 
                 typeHandle = _metadataBuilder.AddTypeReference(resolutionScope, typeNamespace, typeName);

--- a/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
@@ -336,7 +336,7 @@ namespace Internal.TypeSystem
 
             EntityHandle fieldHandle;
 
-            EntityHandle typeHandle = GetTypeRef((MetadataType)field.OwningType);
+            EntityHandle typeHandle = GetTypeRef(field.OwningType);
             StringHandle fieldName = _metadataBuilder.GetOrAddString(field.GetName());
 
             var sigBlob = GetFieldSignatureBlobHandle(field.GetTypicalFieldDefinition());

--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/FieldDesc.RuntimeDetermined.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/FieldDesc.RuntimeDetermined.cs
@@ -7,7 +7,7 @@ namespace Internal.TypeSystem
     {
         public FieldDesc GetNonRuntimeDeterminedFieldFromRuntimeDeterminedFieldViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
-            DefType owningType = OwningType;
+            MetadataType owningType = OwningType;
             TypeDesc owningTypeInstantiated = owningType.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
             if (owningTypeInstantiated != owningType)
             {

--- a/src/coreclr/tools/ILVerification/TypeVerifier.cs
+++ b/src/coreclr/tools/ILVerification/TypeVerifier.cs
@@ -45,7 +45,7 @@ namespace Internal.TypeVerifier
         public void VerifyInterfaces()
         {
             TypeDefinition typeDefinition = _module.MetadataReader.GetTypeDefinition(_typeDefinitionHandle);
-            EcmaType type = (EcmaType)_module.GetType(_typeDefinitionHandle);
+            EcmaType type = _module.GetType(_typeDefinitionHandle);
 
             if (type.IsInterface)
             {
@@ -59,7 +59,7 @@ namespace Internal.TypeVerifier
                 return;
             }
 
-            // Look for duplicates and prepare distinct list of implemented interfaces to avoid 
+            // Look for duplicates and prepare distinct list of implemented interfaces to avoid
             // subsequent error duplication
             List<InterfaceMetadataObjects> implementedInterfaces = new List<InterfaceMetadataObjects>();
             foreach (InterfaceImplementationHandle interfaceHandle in interfaceHandles)

--- a/src/coreclr/tools/ILVerification/Verifier.cs
+++ b/src/coreclr/tools/ILVerification/Verifier.cs
@@ -158,7 +158,7 @@ namespace ILVerify
         {
             foreach (var methodHandle in methodHandles)
             {
-                var method = (EcmaMethod)module.GetMethod(methodHandle);
+                var method = module.GetMethod(methodHandle);
                 var methodIL = EcmaMethodIL.Create(method);
 
                 if (methodIL != null)

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -156,7 +156,7 @@ namespace ILVerify
             Write(fullClassName);
 
             Write("::");
-            var method = (EcmaMethod)module.GetMethod(result.Method);
+            var method = module.GetMethod(result.Method);
             PrintMethod(method);
             Write("]");
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -267,8 +267,7 @@ namespace ILCompiler
             public override bool IsExtendedLayout => true;
             public override bool IsAutoLayout => false;
             public override bool IsBeforeFieldInit => false;
-            public override MetadataType MetadataBaseType => (MetadataType)Context.GetWellKnownType(WellKnownType.Object);
-            public override DefType BaseType => MetadataBaseType;
+            public override MetadataType BaseType => (MetadataType)Context.GetWellKnownType(WellKnownType.Object);
             public override bool IsSealed => true;
             public override bool IsAbstract => false;
             public override DefType ContainingType => null;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -270,7 +270,7 @@ namespace ILCompiler
             public override MetadataType BaseType => (MetadataType)Context.GetWellKnownType(WellKnownType.Object);
             public override bool IsSealed => true;
             public override bool IsAbstract => false;
-            public override DefType ContainingType => null;
+            public override MetadataType ContainingType => null;
             public override DefType[] ExplicitlyImplementedInterfaces => Array.Empty<DefType>();
             public override TypeSystemContext Context => ValueTypeRepresented.Context;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
@@ -230,16 +230,7 @@ namespace ILCompiler
                 }
             }
 
-            public override DefType BaseType
-            {
-                get
-                {
-                    // See below
-                    return null;
-                }
-            }
-
-            public override MetadataType MetadataBaseType
+            public override MetadataType BaseType
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
@@ -256,7 +256,7 @@ namespace ILCompiler
                 }
             }
 
-            public override DefType ContainingType
+            public override MetadataType ContainingType
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CustomAttributeExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CustomAttributeExtensions.cs
@@ -12,7 +12,7 @@ namespace ILCompiler
     {
         public static CustomAttributeValue<TypeDesc>? GetDecodedCustomAttribute(this PropertyPseudoDesc prop, string attributeNamespace, string attributeName)
         {
-            var ecmaType = prop.OwningType as EcmaType;
+            var ecmaType = prop.OwningType;
             var metadataReader = ecmaType.MetadataReader;
 
             var attributeHandle = metadataReader.GetCustomAttributeHandle(prop.GetCustomAttributes,
@@ -26,7 +26,7 @@ namespace ILCompiler
 
         public static IEnumerable<CustomAttributeValue<TypeDesc>> GetDecodedCustomAttributes(this PropertyPseudoDesc prop, string attributeNamespace, string attributeName)
         {
-            var ecmaType = prop.OwningType as EcmaType;
+            var ecmaType = prop.OwningType;
             var metadataReader = ecmaType.MetadataReader;
 
             var attributeHandles = prop.GetCustomAttributes;
@@ -41,7 +41,7 @@ namespace ILCompiler
 
         public static CustomAttributeValue<TypeDesc>? GetDecodedCustomAttribute(this EventPseudoDesc @event, string attributeNamespace, string attributeName)
         {
-            var ecmaType = @event.OwningType as EcmaType;
+            var ecmaType = @event.OwningType;
             var metadataReader = ecmaType.MetadataReader;
 
             var attributeHandle = metadataReader.GetCustomAttributeHandle(@event.GetCustomAttributes,
@@ -55,7 +55,7 @@ namespace ILCompiler
 
         public static IEnumerable<CustomAttributeValue<TypeDesc>> GetDecodedCustomAttributes(this EventPseudoDesc @event, string attributeNamespace, string attributeName)
         {
-            var ecmaType = @event.OwningType as EcmaType;
+            var ecmaType = @event.OwningType;
             var metadataReader = ecmaType.MetadataReader;
 
             var attributeHandles = @event.GetCustomAttributes;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CustomAttributeExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CustomAttributeExtensions.cs
@@ -21,7 +21,7 @@ namespace ILCompiler
             if (attributeHandle.IsNil)
                 return null;
 
-            return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(ecmaType.EcmaModule));
+            return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(ecmaType.Module));
         }
 
         public static IEnumerable<CustomAttributeValue<TypeDesc>> GetDecodedCustomAttributes(this PropertyPseudoDesc prop, string attributeNamespace, string attributeName)
@@ -34,7 +34,7 @@ namespace ILCompiler
             {
                 if (MetadataExtensions.IsEqualCustomAttributeName(attributeHandle, metadataReader, attributeNamespace, attributeName))
                 {
-                    yield return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(ecmaType.EcmaModule));
+                    yield return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(ecmaType.Module));
                 }
             }
         }
@@ -50,7 +50,7 @@ namespace ILCompiler
             if (attributeHandle.IsNil)
                 return null;
 
-            return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(ecmaType.EcmaModule));
+            return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(ecmaType.Module));
         }
 
         public static IEnumerable<CustomAttributeValue<TypeDesc>> GetDecodedCustomAttributes(this EventPseudoDesc @event, string attributeNamespace, string attributeName)
@@ -63,7 +63,7 @@ namespace ILCompiler
             {
                 if (MetadataExtensions.IsEqualCustomAttributeName(attributeHandle, metadataReader, attributeNamespace, attributeName))
                 {
-                    yield return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(ecmaType.EcmaModule));
+                    yield return metadataReader.GetCustomAttribute(attributeHandle).DecodeValue(new CustomAttributeTypeProvider(ecmaType.Module));
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -282,7 +282,7 @@ namespace ILLink.Shared.TrimAnalysis
             {
                 if (metadataType.Name.SequenceEqual("Type"u8) && metadataType.Namespace.SequenceEqual("System"u8))
                     return true;
-            } while ((metadataType = metadataType.MetadataBaseType) != null);
+            } while ((metadataType = metadataType.BaseType) != null);
 
             return false;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
@@ -72,7 +72,7 @@ namespace ILCompiler.DependencyAnalysis
                     PropertyAccessors accessors = property.GetAccessors();
 
                     if (accessors.Getter == methodHandle || accessors.Setter == methodHandle)
-                        AddDependenciesDueToCustomAttributes(ref dependencies, propertyCondition, factory, method.Module, property.GetCustomAttributes(), new PropertyPseudoDesc((EcmaType)method.OwningType, propertyHandle));
+                        AddDependenciesDueToCustomAttributes(ref dependencies, propertyCondition, factory, method.Module, property.GetCustomAttributes(), new PropertyPseudoDesc(method.OwningType, propertyHandle));
                 }
 
                 object eventCondition = GetMetadataApiDependency(factory, "Event"u8);
@@ -82,7 +82,7 @@ namespace ILCompiler.DependencyAnalysis
                     EventAccessors accessors = @event.GetAccessors();
 
                     if (accessors.Adder == methodHandle || accessors.Remover == methodHandle || accessors.Raiser == methodHandle)
-                        AddDependenciesDueToCustomAttributes(ref dependencies, eventCondition, factory, method.Module, @event.GetCustomAttributes(), new EventPseudoDesc((EcmaType)method.OwningType, eventHandle));
+                        AddDependenciesDueToCustomAttributes(ref dependencies, eventCondition, factory, method.Module, @event.GetCustomAttributes(), new EventPseudoDesc(method.OwningType, eventHandle));
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
@@ -91,14 +91,14 @@ namespace ILCompiler.DependencyAnalysis
         {
             MetadataReader reader = type.MetadataReader;
             TypeDefinition typeDef = reader.GetTypeDefinition(type.Handle);
-            AddDependenciesDueToCustomAttributes(ref dependencies, GetMetadataApiDependency(factory, "TypeDefinition"u8), factory, type.EcmaModule, typeDef.GetCustomAttributes(), type);
+            AddDependenciesDueToCustomAttributes(ref dependencies, GetMetadataApiDependency(factory, "TypeDefinition"u8), factory, type.Module, typeDef.GetCustomAttributes(), type);
 
             // Handle custom attributes on generic type parameters
             object genericParameterCondition = GetMetadataApiDependency(factory, "GenericParameter"u8);
             foreach (GenericParameterHandle genericParameterHandle in typeDef.GetGenericParameters())
             {
                 GenericParameter parameter = reader.GetGenericParameter(genericParameterHandle);
-                AddDependenciesDueToCustomAttributes(ref dependencies, genericParameterCondition, factory, type.EcmaModule, parameter.GetCustomAttributes(), type);
+                AddDependenciesDueToCustomAttributes(ref dependencies, genericParameterCondition, factory, type.Module, parameter.GetCustomAttributes(), type);
             }
         }
 
@@ -250,7 +250,7 @@ namespace ILCompiler.DependencyAnalysis
 
                     if (!accessors.Setter.IsNil)
                     {
-                        MethodDesc setterMethod = (MethodDesc)attributeTypeDefinition.EcmaModule.GetObject(accessors.Setter);
+                        MethodDesc setterMethod = (MethodDesc)attributeTypeDefinition.Module.GetObject(accessors.Setter);
                         if (factory.MetadataManager.IsReflectionBlocked(setterMethod))
                             return false;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldMetadataNode.cs
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             DependencyList dependencies = new DependencyList();
-            dependencies.Add(factory.TypeMetadata((MetadataType)_field.OwningType), "Owning type metadata");
+            dependencies.Add(factory.TypeMetadata(_field.OwningType), "Owning type metadata");
 
             if (_field is EcmaField ecmaField)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectGetTypeFlowDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectGetTypeFlowDependenciesNode.cs
@@ -37,7 +37,7 @@ namespace ILCompiler.DependencyAnalysis
 
             DependencyList result = Dataflow.ReflectionMethodBodyScanner.ProcessTypeGetTypeDataflow(factory, mdManager.FlowAnnotations, mdManager.Logger, _type);
 
-            MetadataType baseType = _type.MetadataBaseType;
+            MetadataType baseType = _type.BaseType;
             if (baseType != null && flowAnnotations.GetTypeAnnotation(baseType) != default)
             {
                 result.Add(factory.ObjectGetTypeFlowDependencies(baseType), "Apply annotations to bases");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
@@ -71,28 +71,28 @@ namespace ILCompiler.DependencyAnalysis
                 }
                 else if (_field.IsThreadStatic)
                 {
-                    dependencies.Add(factory.TypeThreadStaticIndex((MetadataType)_field.OwningType), "Threadstatic base of a reflectable field");
+                    dependencies.Add(factory.TypeThreadStaticIndex(_field.OwningType), "Threadstatic base of a reflectable field");
                 }
                 else if (_field.HasGCStaticBase)
                 {
-                    dependencies.Add(factory.TypeGCStaticsSymbol((MetadataType)_field.OwningType), "GC static base of a reflectable field");
+                    dependencies.Add(factory.TypeGCStaticsSymbol(_field.OwningType), "GC static base of a reflectable field");
                 }
                 else
                 {
-                    dependencies.Add(factory.TypeNonGCStaticsSymbol((MetadataType)_field.OwningType), "NonGC static base of a reflectable field");
+                    dependencies.Add(factory.TypeNonGCStaticsSymbol(_field.OwningType), "NonGC static base of a reflectable field");
                     needsNonGcStaticBase = false;
                 }
 
                 if (needsNonGcStaticBase)
                 {
-                    dependencies.Add(factory.TypeNonGCStaticsSymbol((MetadataType)_field.OwningType), "CCtor context");
+                    dependencies.Add(factory.TypeNonGCStaticsSymbol(_field.OwningType), "CCtor context");
                 }
 
                 // For generic types, the reflection mapping table only keeps track of information about offsets
                 // from the static bases. To locate the static base, we need the GenericStaticBaseInfo hashtable.
                 if (_field.OwningType.HasInstantiation)
                 {
-                    dependencies.Add(factory.GenericStaticBaseInfo((MetadataType)_field.OwningType), "Field on a generic type");
+                    dependencies.Add(factory.GenericStaticBaseInfo(_field.OwningType), "Field on a generic type");
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -37,9 +37,9 @@ namespace ILCompiler.DependencyAnalysis
         {
             DependencyList dependencies = new DependencyList();
 
-            DefType containingType = _type.ContainingType;
+            MetadataType containingType = _type.ContainingType;
             if (containingType != null)
-                dependencies.Add(factory.TypeMetadata((MetadataType)containingType), "Containing type of a reflectable type");
+                dependencies.Add(factory.TypeMetadata(containingType), "Containing type of a reflectable type");
             else
                 dependencies.Add(factory.ModuleMetadata(_type.Module), "Containing module of a reflectable type");
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -43,7 +43,7 @@ namespace ILCompiler.DependencyAnalysis
             else
                 dependencies.Add(factory.ModuleMetadata(_type.Module), "Containing module of a reflectable type");
 
-            MetadataType baseType = _type.MetadataBaseType;
+            MetadataType baseType = _type.BaseType;
             if (baseType != null)
                 GetMetadataDependencies(ref dependencies, factory, baseType, "Base type of a reflectable type");
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExternSymbolMappedField.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExternSymbolMappedField.cs
@@ -24,7 +24,7 @@ namespace ILCompiler
 
         public string SymbolName => _symbolName;
 
-        public override DefType OwningType => _fieldType.Context.SystemModule.GetGlobalModuleType();
+        public override MetadataType OwningType => _fieldType.Context.SystemModule.GetGlobalModuleType();
 
         public override TypeDesc FieldType => _fieldType;
         public override EmbeddedSignatureData[] GetEmbeddedSignatureData() => null;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MultiFileCompilationModuleGroup.cs
@@ -29,7 +29,7 @@ namespace ILCompiler
             if (ecmaType == null)
                 return true;
 
-            if (!IsModuleInCompilationGroup(ecmaType.EcmaModule))
+            if (!IsModuleInCompilationGroup(ecmaType.Module))
             {
                 return false;
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -427,7 +427,7 @@ namespace ILCompiler
                             && field.OwningType.HasStaticConstructor
                             && _policy.CanPreinitialize(field.OwningType))
                         {
-                            if (!TryGetNestedPreinitResult(methodIL.OwningMethod, (MetadataType)field.OwningType, recursionProtect, ref instructionCounter, out NestedPreinitResult nestedPreinitResult))
+                            if (!TryGetNestedPreinitResult(methodIL.OwningMethod, field.OwningType, recursionProtect, ref instructionCounter, out NestedPreinitResult nestedPreinitResult))
                             {
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Nested cctor failed to preinit");
                             }
@@ -2476,7 +2476,7 @@ namespace ILCompiler
                     else
                     {
                         Debug.Assert(targetField.IsStatic && !targetField.HasGCStaticBase && !targetField.IsThreadStatic && !targetField.HasRva);
-                        ISymbolNode nonGcStaticBase = factory.TypeNonGCStaticsSymbol((MetadataType)targetField.OwningType);
+                        ISymbolNode nonGcStaticBase = factory.TypeNonGCStaticsSymbol(targetField.OwningType);
                         builder.EmitPointerReloc(nonGcStaticBase, targetField.Offset.AsInt);
                     }
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnmanagedEntryPointsRootProvider.cs
@@ -36,13 +36,15 @@ namespace ILCompiler
                     if (ca.Parent.Kind != HandleKind.MethodDefinition)
                         continue;
 
+                    var parent = (MethodDefinitionHandle)ca.Parent;
+
                     if (!reader.GetAttributeNamespaceAndName(caHandle, out StringHandle nsHandle, out StringHandle nameHandle))
                         continue;
 
                     if (comparer.Equals(nameHandle, "RuntimeExportAttribute")
                         && comparer.Equals(nsHandle, "System.Runtime"))
                     {
-                        var method = (EcmaMethod)_module.GetMethod(ca.Parent);
+                        EcmaMethod method = _module.GetMethod(parent);
                         if (method.GetRuntimeExportName() != null)
                             yield return method;
                     }
@@ -50,7 +52,7 @@ namespace ILCompiler
                     if (comparer.Equals(nameHandle, "UnmanagedCallersOnlyAttribute")
                         && comparer.Equals(nsHandle, "System.Runtime.InteropServices"))
                     {
-                        var method = (EcmaMethod)_module.GetMethod(ca.Parent);
+                        EcmaMethod method = _module.GetMethod(parent);
                         if (method.GetUnmanagedCallersOnlyExportName() != null)
                             yield return method;
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -788,7 +788,7 @@ namespace ILCompiler
             var ecmaType = attributeType.GetTypeDefinition() as EcmaType;
             if (ecmaType != null)
             {
-                var moduleInfo = _linkAttributesHashTable.GetOrCreateValue(ecmaType.EcmaModule);
+                var moduleInfo = _linkAttributesHashTable.GetOrCreateValue(ecmaType.Module);
                 return !moduleInfo.RemovedAttributes.Contains(ecmaType);
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Type.cs
@@ -336,14 +336,14 @@ namespace ILCompiler.Metadata
 
                 foreach (var e in ecmaRecord.GetEvents())
                 {
-                    Event evt = HandleEvent(ecmaEntity.EcmaModule, e);
+                    Event evt = HandleEvent(ecmaEntity.Module, e);
                     if (evt != null)
                         record.Events.Add(evt);
                 }
 
                 foreach (var property in ecmaRecord.GetProperties())
                 {
-                    Property prop = HandleProperty(ecmaEntity.EcmaModule, property);
+                    Property prop = HandleProperty(ecmaEntity.Module, property);
                     if (prop != null)
                         record.Properties.Add(prop);
                 }
@@ -351,21 +351,21 @@ namespace ILCompiler.Metadata
                 Ecma.CustomAttributeHandleCollection customAttributes = ecmaRecord.GetCustomAttributes();
                 if (customAttributes.Count > 0)
                 {
-                    record.CustomAttributes = HandleCustomAttributes(ecmaEntity.EcmaModule, customAttributes);
+                    record.CustomAttributes = HandleCustomAttributes(ecmaEntity.Module, customAttributes);
                 }
 
                 /* COMPLETENESS
                 foreach (var miHandle in ecmaRecord.GetMethodImplementations())
                 {
-                    Ecma.MetadataReader reader = ecmaEntity.EcmaModule.MetadataReader;
+                    Ecma.MetadataReader reader = ecmaEntity.Module.MetadataReader;
 
                     Ecma.MethodImplementation miDef = reader.GetMethodImplementation(miHandle);
 
-                    Cts.MethodDesc methodBody = (Cts.MethodDesc)ecmaEntity.EcmaModule.GetObject(miDef.MethodBody);
+                    Cts.MethodDesc methodBody = (Cts.MethodDesc)ecmaEntity.Module.GetObject(miDef.MethodBody);
                     if (_policy.IsBlocked(methodBody))
                         continue;
 
-                    Cts.MethodDesc methodDecl = (Cts.MethodDesc)ecmaEntity.EcmaModule.GetObject(miDef.MethodDeclaration);
+                    Cts.MethodDesc methodDecl = (Cts.MethodDesc)ecmaEntity.Module.GetObject(miDef.MethodDeclaration);
                     if (_policy.IsBlocked(methodDecl.GetTypicalMethodDefinition()))
                         continue;
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedFieldRvaNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedFieldRvaNode.cs
@@ -62,7 +62,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             BlobReader metadataBlob = new BlobReader(_module.PEReader.GetMetadata().Pointer, _module.PEReader.GetMetadata().Length);
             metadataBlob.Offset = metadataReader.GetTableMetadataOffset(TableIndex.FieldRva);
             bool compressedFieldRef = 6 == metadataReader.GetTableRowSize(TableIndex.FieldRva);
-            
+
             for (int i = 1; i <= metadataReader.GetTableRowCount(TableIndex.FieldRva); i++)
             {
                 int currentFieldRva = metadataBlob.ReadInt32();
@@ -78,7 +78,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 if (currentFieldRva != _rva)
                     continue;
 
-                EcmaField field = (EcmaField)_module.GetField(MetadataTokens.FieldDefinitionHandle(currentFieldRid));
+                EcmaField field = _module.GetField(MetadataTokens.FieldDefinitionHandle(currentFieldRid));
                 Debug.Assert(field.HasRva);
 
                 int currentSize = field.FieldType.GetElementSize().AsInt;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMetadataBlobNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMetadataBlobNode.cs
@@ -13,13 +13,13 @@ using Debug = System.Diagnostics.Debug;
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     /// <summary>
-    /// Copies the metadata blob from input MSIL assembly to output ready-to-run image, fixing up Rvas to 
+    /// Copies the metadata blob from input MSIL assembly to output ready-to-run image, fixing up Rvas to
     /// method IL bodies and FieldRvas.
     /// </summary>
     public class CopiedMetadataBlobNode : ObjectNode, ISymbolDefinitionNode
     {
         EcmaModule _sourceModule;
-        
+
         public CopiedMetadataBlobNode(EcmaModule sourceModule)
         {
             _sourceModule = sourceModule;
@@ -73,7 +73,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             var tableIndex = TableIndex.FieldRva;
             int rowCount = metadataReader.GetTableRowCount(tableIndex);
             bool compressedFieldRef = 6 == metadataReader.GetTableRowSize(TableIndex.FieldRva);
-            
+
             for (int i = 1; i <= rowCount; i++)
             {
                 Debug.Assert(builder.CountBytes == reader.Offset);
@@ -91,7 +91,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     fieldToken = reader.ReadInt32();
                 }
                 EntityHandle fieldHandle = MetadataTokens.EntityHandle(TableIndex.Field, fieldToken);
-                EcmaField fieldDesc = (EcmaField)_sourceModule.GetField(fieldHandle);
+                EcmaField fieldDesc = _sourceModule.GetField((FieldDefinitionHandle)fieldHandle);
                 Debug.Assert(fieldDesc.HasRva);
 
                 builder.EmitReloc(factory.CopiedFieldRva(fieldDesc), RelocType.IMAGE_REL_BASED_ADDR32NB);
@@ -121,7 +121,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             int methodDefTableOffset = metadataReader.GetTableMetadataOffset(TableIndex.MethodDef);
             builder.EmitBytes(metadataBlob.ReadBytes(methodDefTableOffset));
-            
+
             WriteMethodTableRvas(factory, ref builder, ref metadataBlob);
 
             //

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             Debug.Assert(!method.IsAbstract);
 
-            _method = (EcmaMethod)method.GetTypicalMethodDefinition();
+            _method = method.GetTypicalMethodDefinition();
         }
 
         public override ObjectNodeSection GetSection(NodeFactory factory) => ObjectNodeSection.TextSection;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -56,7 +56,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             if (_compilationModuleGroup.VersionsWithType(type))
             {
-                return new ModuleToken(type.EcmaModule, (mdToken)MetadataTokens.GetToken(type.Handle));
+                return new ModuleToken(type.Module, (mdToken)MetadataTokens.GetToken(type.Handle));
             }
 
             ModuleToken token;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
@@ -253,7 +253,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         }
                     }
                     // validate that the global class cannot have instance methods
-                    if (type.EcmaModule.GetGlobalModuleType() == type && !methodDef.Attributes.HasFlag(MethodAttributes.Static))
+                    if (type.Module.GetGlobalModuleType() == type && !methodDef.Attributes.HasFlag(MethodAttributes.Static))
                     {
                         AddTypeValidationError(type, $"'{method}' is an instance method defined on the global <module> type");
                         return false;
@@ -310,8 +310,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 foreach (var methodImplHandle in typeDef.GetMethodImplementations())
                 {
                     var methodImpl = type.MetadataReader.GetMethodImplementation(methodImplHandle);
-                    var methodBody = type.EcmaModule.GetMethod(methodImpl.MethodBody);
-                    var methodDecl = type.EcmaModule.GetMethod(methodImpl.MethodDeclaration);
+                    var methodBody = type.Module.GetMethod(methodImpl.MethodBody);
+                    var methodDecl = type.Module.GetMethod(methodImpl.MethodDeclaration);
 
                     // Validate that all MethodImpls actually match signatures closely enough
                     if (!methodBody.Signature.ApplySubstitution(type.Instantiation).EquivalentWithCovariantReturnType(methodDecl.Signature.ApplySubstitution(type.Instantiation)))

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
@@ -57,7 +57,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 if (type is EcmaType ecmaType)
                     _tasksThatMustFinish.Enqueue(ValidateType(this, ecmaType));
             }
-            _tasksThatMustFinish.Enqueue(ValidateType(this, (EcmaType)module.GetGlobalModuleType()));
+            _tasksThatMustFinish.Enqueue(ValidateType(this, module.GetGlobalModuleType()));
 
             bool failAtEnd = false;
             while (_tasksThatMustFinish.TryDequeue(out var taskToComplete))
@@ -151,7 +151,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 // Per method rules
                 foreach (var methodDesc in type.GetMethods())
                 {
-                    var method = (EcmaMethod)methodDesc;
+                    var method = methodDesc;
                     var methodDef = method.MetadataReader.GetMethodDefinition(method.Handle);
                     // Validate that the validateTokenSig algorithm on all methods defined on the type
                     // The validateTokenSig algorithm simply validates the phyical structure of the signature. Getting a MethodSignature object is a more complete check

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -619,7 +619,7 @@ namespace ILCompiler
                                     return false;
                                 if (field.IsStatic)
                                     return false;
-                                MetadataType owningMetadataType = (MetadataType)field.OwningType;
+                                MetadataType owningMetadataType = field.OwningType;
                                 if (!owningMetadataType.IsNonVersionable())
                                     return false;
                                 break;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -110,7 +110,7 @@ namespace ILCompiler
 
         public sealed override bool ContainsType(TypeDesc type)
         {
-            return type.GetTypeDefinition() is EcmaType ecmaType && IsModuleInCompilationGroup(ecmaType.EcmaModule);
+            return type.GetTypeDefinition() is EcmaType ecmaType && IsModuleInCompilationGroup(ecmaType.Module);
         }
 
         public bool IsModuleInCompilationGroup(EcmaModule module)
@@ -508,7 +508,7 @@ namespace ILCompiler
         {
             if (!_crossModuleInlining)
                 return false;
-            
+
             return CrossModuleInlineableInternal(method);
         }
 
@@ -568,7 +568,7 @@ namespace ILCompiler
             {
 
                 // Validate that there are no tokens in the IL other than tokens associated with the following
-                // instructions with the 
+                // instructions with the
                 // 1. ldfld, ldflda, and stfld to instance fields of NonVersionable structs and NonVersionable classes
                 // 2. cpobj, initobj, ldobj, stobj, ldelem, ldelema or sizeof, to NonVersionable structures, signature variables, pointers, function pointers, byrefs, classes, or arrays
                 // 3. stelem, to NonVersionable structures
@@ -689,7 +689,7 @@ namespace ILCompiler
                             return false;
 
                         default:
-                            // Unless its a opcode known to be permitted with a 
+                            // Unless its a opcode known to be permitted with a
                             ilReader.Skip(opcode);
                             break;
                     }
@@ -768,7 +768,7 @@ namespace ILCompiler
             {
                 return false;
             }
-            
+
             if (type.IsCanonicalDefinitionType(CanonicalFormKind.Any))
                 return true;
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -56,7 +56,7 @@ namespace ILCompiler
             if (defType.GetTypeDefinition() is EcmaType ecmaType)
             {
                 // ECMA types are the only ones that can have statics
-                ModuleFieldLayout moduleFieldLayout = _moduleFieldLayoutMap.GetOrCreateValue(ecmaType.EcmaModule);
+                ModuleFieldLayout moduleFieldLayout = _moduleFieldLayoutMap.GetOrCreateValue(ecmaType.Module);
                 layout.Offsets = _moduleFieldLayoutMap.GetOrAddDynamicLayout(defType, moduleFieldLayout);
             }
             return layout;
@@ -114,7 +114,7 @@ namespace ILCompiler
                     {
                         ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, fieldDesc.OwningType);
                     }
-                    if (moduleLayout && fieldType.GetTypeDefinition() is EcmaType ecmaType && ecmaType.EcmaModule != module)
+                    if (moduleLayout && fieldType.GetTypeDefinition() is EcmaType ecmaType && ecmaType.Module != module)
                     {
                         // Allocate pessimistic non-GC area for cross-module fields as that's what CoreCLR does
                         // <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/ceeload.cpp#L1006">here</a>
@@ -215,7 +215,7 @@ namespace ILCompiler
                         {
                             ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, fieldDesc.OwningType);
                         }
-                        if (moduleLayout && fieldDesc.FieldType.GetTypeDefinition() is EcmaType ecmaType && ecmaType.EcmaModule != module)
+                        if (moduleLayout && fieldDesc.FieldType.GetTypeDefinition() is EcmaType ecmaType && ecmaType.Module != module)
                         {
                             // Allocate pessimistic non-GC area for cross-module fields as that's what CoreCLR does
                             // <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/ceeload.cpp#L1006">here</a>
@@ -614,7 +614,7 @@ namespace ILCompiler
                     return ComputeCStructFieldLayout(type, numInstanceFields);
                 case MetadataLayoutKind.Explicit:
                     // Works around https://github.com/dotnet/runtime/issues/102868
-                    if (type is { IsValueType: false, MetadataBaseType.IsSequentialLayout: true })
+                    if (type is { IsValueType: false, BaseType.IsSequentialLayout: true })
                     {
                         ThrowHelper.ThrowTypeLoadException(type);
                     }
@@ -622,7 +622,7 @@ namespace ILCompiler
                     return ComputeExplicitFieldLayout(type, numInstanceFields, layoutMetadata);
                 case MetadataLayoutKind.Sequential when !type.ContainsGCPointers:
                     // Works around https://github.com/dotnet/runtime/issues/102868
-                    if (type is { IsValueType: false, MetadataBaseType.IsExplicitLayout: true })
+                    if (type is { IsValueType: false, BaseType.IsExplicitLayout: true })
                     {
                         ThrowHelper.ThrowTypeLoadException(type);
                     }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
@@ -356,7 +356,7 @@ namespace ILCompiler.IBC
                         foundType = (EcmaType)m.GetType(typeNamespace, typeName, NotFoundBehavior.ReturnNull);
                         if (foundType != null)
                         {
-                            externalModule = foundType.EcmaModule;
+                            externalModule = foundType.Module;
                             break;
                         }
                     }
@@ -403,7 +403,7 @@ namespace ILCompiler.IBC
 
             var ecmaType = (EcmaType)methodMetadataType.GetTypeDefinition();
 
-            EcmaModule ecmaModule = ecmaType.EcmaModule;
+            EcmaModule ecmaModule = ecmaType.Module;
             var lookupClassTokenTypeDef = (int)LookupIbcTypeToken(ref ecmaModule, methodEntry.ClassToken, blobs);
             if (lookupClassTokenTypeDef != ecmaType.MetadataReader.GetToken(ecmaType.Handle))
                 throw new Exception($"Ibc MethodToken {ibcToken:x} incosistent classToken '{ibcToken:x}' with specified exact type '{ecmaType}'");
@@ -475,9 +475,9 @@ namespace ILCompiler.IBC
                     return context.GetWellKnownType(WellKnownType.Boolean);
                 case CorElementType.ELEMENT_TYPE_CHAR:
                     return context.GetWellKnownType(WellKnownType.Char);
-                case CorElementType.ELEMENT_TYPE_I: 
-                    return context.GetWellKnownType(WellKnownType.IntPtr); 
-                case CorElementType.ELEMENT_TYPE_U: 
+                case CorElementType.ELEMENT_TYPE_I:
+                    return context.GetWellKnownType(WellKnownType.IntPtr);
+                case CorElementType.ELEMENT_TYPE_U:
                     return context.GetWellKnownType(WellKnownType.UIntPtr);
                 case CorElementType.ELEMENT_TYPE_I1:
                     return context.GetWellKnownType(WellKnownType.SByte);
@@ -737,7 +737,7 @@ namespace ILCompiler.IBC
                     }
                 }
 
-                EcmaModule ecmaModuleOfMethod = ((EcmaType)methodMetadataType.GetTypeDefinition()).EcmaModule;
+                EcmaModule ecmaModuleOfMethod = ((EcmaType)methodMetadataType.GetTypeDefinition()).Module;
                 MethodDesc ecmaMethod = ecmaModuleOfMethod.GetMethod(MetadataTokens.EntityHandle((int)methodToken));
                 MethodDesc methodOnType = methodType.FindMethodOnTypeWithMatchingTypicalMethod(ecmaMethod);
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
@@ -185,7 +185,7 @@ namespace ILCompiler.IBC
 
             var mibcModule = EcmaModule.Create(tsc, peReader, null, null, new CustomCanonResolver(tsc));
 
-            var assemblyDictionary = (EcmaMethod)mibcModule.GetGlobalModuleType().GetMethod("AssemblyDictionary"u8, null);
+            EcmaMethod assemblyDictionary = mibcModule.GetGlobalModuleType().GetMethod("AssemblyDictionary"u8, null);
             IEnumerable<MethodProfileData> loadedMethodProfileData = Enumerable.Empty<MethodProfileData>();
 
             EcmaMethodIL ilBody = EcmaMethodIL.Create(assemblyDictionary);
@@ -267,7 +267,7 @@ namespace ILCompiler.IBC
         public static MibcConfig ParseMibcConfig(TypeSystemContext tsc, PEReader pEReader)
         {
             EcmaModule mibcModule = EcmaModule.Create(tsc, pEReader, null);
-            EcmaMethod mibcConfigMth = (EcmaMethod)mibcModule.GetGlobalModuleType().GetMethod("MibcConfig"u8, null);
+            EcmaMethod mibcConfigMth = mibcModule.GetGlobalModuleType().GetMethod("MibcConfig"u8, null);
 
             if (mibcConfigMth == null)
                 return null;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
@@ -211,7 +211,7 @@ namespace Internal.IL
         {
             int _maxStack;
             bool _isInitLocals;
-            MethodDesc _owningMethod;
+            EcmaMethod _owningMethod;
             ILExceptionRegion[] _exceptionRegions;
             byte[] _ilBytes;
             LocalVariableDefinition[] _locals;
@@ -226,7 +226,7 @@ namespace Internal.IL
                 try
                 {
                     Debug.Assert(mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences == null);
-                    mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences = ((EcmaMethod)wrappedMethod.OwningMethod).Module;
+                    mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences = wrappedMethod.OwningMethod.Module;
                     var owningMethodHandle = mutableModule.TryGetEntityHandle(wrappedMethod.OwningMethod);
                     if (!owningMethodHandle.HasValue)
                         return false;
@@ -254,7 +254,7 @@ namespace Internal.IL
 
                     ILTokenReplacer.Replace(_ilBytes, GetMutableModuleToken);
 #if DEBUG
-                    Debug.Assert(ReadyToRunStandaloneMethodMetadata.Compute((EcmaMethod)_owningMethod) != null);
+                    Debug.Assert(ReadyToRunStandaloneMethodMetadata.Compute(_owningMethod) != null);
 #endif // DEBUG
                 }
                 finally

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1429,7 +1429,7 @@ namespace Internal.JitInterface
                     {
                         Debug.Assert(_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(ecmaType));
                         token = (mdToken)MetadataTokens.GetToken(ecmaType.Handle);
-                        module = ecmaType.EcmaModule;
+                        module = ecmaType.Module;
                     }
                     else
                     {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1419,7 +1419,7 @@ namespace Internal.JitInterface
                     resultField = resultField.GetTypicalFieldDefinition();
 
                     Debug.Assert(resultField is EcmaField);
-                    Debug.Assert(_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(((EcmaField)resultField).OwningType) || ((MetadataType)resultField.OwningType).IsNonVersionable());
+                    Debug.Assert(_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(resultField.OwningType) || resultField.OwningType.IsNonVersionable());
                     token = (mdToken)MetadataTokens.GetToken(((EcmaField)resultField).Handle);
                     module = ((EcmaField)resultField).Module;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2173,7 +2173,7 @@ namespace Internal.JitInterface
                             ((target.OperatingSystem == TargetOS.Linux) &&
                             (target.Architecture is TargetArchitecture.X64 or TargetArchitecture.ARM64)))
                         {
-                            ISortableSymbolNode index = _compilation.NodeFactory.TypeThreadStaticIndex((MetadataType)field.OwningType);
+                            ISortableSymbolNode index = _compilation.NodeFactory.TypeThreadStaticIndex(field.OwningType);
                             if (index is TypeThreadStaticIndexNode ti)
                             {
                                 if (ti.IsInlined)
@@ -2197,12 +2197,12 @@ namespace Internal.JitInterface
                         if (field.HasGCStaticBase)
                         {
                             pResult->fieldLookup.accessType = InfoAccessType.IAT_PVALUE;
-                            baseAddr = _compilation.NodeFactory.TypeGCStaticsSymbol((MetadataType)field.OwningType);
+                            baseAddr = _compilation.NodeFactory.TypeGCStaticsSymbol(field.OwningType);
                         }
                         else
                         {
                             pResult->fieldLookup.accessType = InfoAccessType.IAT_VALUE;
-                            baseAddr = _compilation.NodeFactory.TypeNonGCStaticsSymbol((MetadataType)field.OwningType);
+                            baseAddr = _compilation.NodeFactory.TypeNonGCStaticsSymbol(field.OwningType);
                         }
                         pResult->fieldLookup.addr = (void*)ObjectToHandle(baseAddr);
                     }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -829,7 +829,7 @@ namespace Internal.JitInterface
                 MethodDesc caller = HandleToObject(callerHnd);
 
                 if (caller.OwningType is EcmaType ecmaOwningType
-                    && ecmaOwningType.EcmaModule.EntryPoint == caller)
+                    && ecmaOwningType.Module.EntryPoint == caller)
                 {
                     // Do not tailcall from the application entrypoint.
                     // We want Main to be visible in stack traces.

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/AssemblyQualifiedToken.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/AssemblyQualifiedToken.cs
@@ -29,8 +29,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
                 EcmaType type => (type.Module.Assembly.GetName().Name, MetadataTokens.GetToken(type.Handle)),
                 EcmaMethod method => (method.Module.Assembly.GetName().Name, MetadataTokens.GetToken(method.Handle)),
                 EcmaField field => (field.Module.Assembly.GetName().Name, MetadataTokens.GetToken(field.Handle)),
-                PropertyPseudoDesc property => (((EcmaType)property.OwningType).Module.Assembly.GetName().Name, MetadataTokens.GetToken(property.Handle)),
-                EventPseudoDesc @event => (((EcmaType)@event.OwningType).Module.Assembly.GetName().Name, MetadataTokens.GetToken(@event.Handle)),
+                PropertyPseudoDesc property => (property.OwningType.Module.Assembly.GetName().Name, MetadataTokens.GetToken(property.Handle)),
+                EventPseudoDesc @event => (@event.OwningType.Module.Assembly.GetName().Name, MetadataTokens.GetToken(@event.Handle)),
                 ILStubMethod => (null, 0), // Ignore compiler generated methods
                 MetadataType mt when mt.GetType().Name == "BoxedValueType" => (null, 0),
                 _ => throw new NotSupportedException($"The infra doesn't support getting a token for {entity} yet.")

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/MemberAssertionsCollector.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/MemberAssertionsCollector.cs
@@ -89,7 +89,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
                 if (t.GetName() == nameof(BaseMemberAssertionAttribute))
                     return true;
 
-                t = t.MetadataBaseType;
+                t = t.BaseType;
             }
 
             return false;
@@ -164,7 +164,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
         private static IEnumerable<CustomAttribute> GetCustomAttributes(EcmaType type)
         {
             var metadataReader = type.MetadataReader;
-            return GetCustomAttributes(metadataReader.GetTypeDefinition(type.Handle).GetCustomAttributes(), metadataReader, type.EcmaModule);
+            return GetCustomAttributes(metadataReader.GetTypeDefinition(type.Handle).GetCustomAttributes(), metadataReader, type.Module);
         }
 
         private static IEnumerable<CustomAttribute> GetCustomAttributes(EcmaMethod method)
@@ -181,12 +181,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
         private static IEnumerable<CustomAttribute> GetCustomAttributes(EcmaType type, PropertyPseudoDesc prop)
         {
-            return GetCustomAttributes(prop.GetCustomAttributes, type.MetadataReader, type.EcmaModule);
+            return GetCustomAttributes(prop.GetCustomAttributes, type.MetadataReader, type.Module);
         }
 
         private static IEnumerable<CustomAttribute> GetCustomAttributes(EcmaType type, EventPseudoDesc @event)
         {
-            return GetCustomAttributes(@event.GetCustomAttributes, type.MetadataReader, type.EcmaModule);
+            return GetCustomAttributes(@event.GetCustomAttributes, type.MetadataReader, type.Module);
         }
 
         private static IEnumerable<CustomAttribute> GetCustomAttributes(CustomAttributeHandleCollection attributeHandles, MetadataReader metadataReader, EcmaModule module)

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/Tests/DocumentationSignatureParserTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/Tests/DocumentationSignatureParserTests.cs
@@ -105,7 +105,7 @@ namespace Mono.Linker.Tests
             return entity switch
             {
                 MethodDesc method => (method.OwningType as MetadataType)?.Module,
-                FieldDesc field => (field.OwningType as MetadataType)?.Module,
+                FieldDesc field => field.OwningType?.Module,
                 MetadataType type => type.Module,
                 PropertyPseudoDesc property => property.OwningType.Module,
                 EventPseudoDesc @event => @event.OwningType.Module,

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemField.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemField.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
         }
 
         public override ReadOnlySpan<byte> Name => _name;
-        public override DefType OwningType => _type;
+        public override MetadataType OwningType => _type;
 
         public override TypeDesc FieldType => _fieldType;
 

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         public override bool IsAbstract => throw new NotImplementedException();
 
-        public override DefType ContainingType => _containingType;
+        public override TypeRefTypeSystemType ContainingType => _containingType;
 
         public override DefType[] ExplicitlyImplementedInterfaces => Array.Empty<DefType>();
 

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
@@ -156,9 +156,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         public override ModuleDesc Module => _module;
 
-        public override DefType BaseType => MetadataBaseType;
-
-        public override MetadataType MetadataBaseType
+        public override MetadataType BaseType
         {
             get
             {

--- a/src/tests/ilverify/ILMethodTester.cs
+++ b/src/tests/ilverify/ILMethodTester.cs
@@ -58,7 +58,7 @@ namespace ILVerification.Tests
         {
             EcmaModule module = TestDataLoader.GetModuleForTestAssembly(testCase.ModuleName);
             var methodHandle = (MethodDefinitionHandle) MetadataTokens.EntityHandle(testCase.MetadataToken);
-            var method = (EcmaMethod)module.GetMethod(methodHandle);
+            var method = module.GetMethod(methodHandle);
             var verifier = new Verifier((ILVerifyTypeSystemContext)method.Context, new VerifierOptions
             {
                 IncludeMetadataTokensInErrorMessages = true,

--- a/src/tests/ilverify/ILTypeVerificationTester.cs
+++ b/src/tests/ilverify/ILTypeVerificationTester.cs
@@ -58,7 +58,7 @@ namespace ILVerification.Tests
         {
             EcmaModule module = TestDataLoader.GetModuleForTestAssembly(testCase.ModuleName);
             var typeHandle = (TypeDefinitionHandle)MetadataTokens.EntityHandle(testCase.MetadataToken);
-            var type = (EcmaType)module.GetType(typeHandle);
+            EcmaType type = module.GetType(typeHandle);
             var verifier = new Verifier((ILVerifyTypeSystemContext)type.Context, new VerifierOptions
             {
                 IncludeMetadataTokensInErrorMessages = true,

--- a/src/tests/ilverify/TestDataLoader.cs
+++ b/src/tests/ilverify/TestDataLoader.cs
@@ -173,7 +173,7 @@ namespace ILVerification.Tests
 
                 foreach (var methodHandle in testModule.MetadataReader.MethodDefinitions)
                 {
-                    var method = (EcmaMethod)testModule.GetMethod(methodHandle);
+                    EcmaMethod method = testModule.GetMethod(methodHandle);
                     var methodName = method.GetName();
 
                     if (!methodName.Contains('_', StringComparison.Ordinal))
@@ -232,7 +232,7 @@ namespace ILVerification.Tests
             // Substitute method parameters with friendly name
             methodParams[0] = friendlyName;
 
-            var specialMethodHandle = (EcmaMethod)method.OwningType.GetMethod(Encoding.UTF8.GetBytes(specialName), method.Signature);
+            EcmaMethod specialMethodHandle = method.OwningType.GetMethod(Encoding.UTF8.GetBytes(specialName), method.Signature);
             return specialMethodHandle == null ? method.Handle : specialMethodHandle.Handle;
         }
 


### PR DESCRIPTION
Now that all usages of this code use `$(NetCoreAppToolCurrent)`, we can use more modern C# language features that require runtime support.

This PR changes a number of the return types of various properties and methods to help narrow the result types and avoid having to add "known to succeed" casts and instead rely on the type system to give correct answers by design.

This PR also removes `MetadataType.MetadataBaseType` and replaces it with `MetadataType.BaseType` with `MetadataType` as the return type (as the comments on it and all implementations effectively described it as such).

This should make it easier for us to avoid adding hard casts and instead represent constraints via the type system.