### PR TITLE
Avoid referencing types of JsonIgnore'd properties.

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Primitives;
 
@@ -332,7 +333,17 @@ namespace System.Text.Json.SourceGeneration.Tests
         public string FieldWithCustomName;
 
         public new int ShadowProperty { get; set; }
+
+#pragma warning disable EXP0001
+        [JsonIgnore]
+        public ExperimentalClass ExperimentalProperty { get; set; }
+#pragma warning restore EXP0001
     }
+
+#if NET
+    [Experimental("EXP0001")]
+#endif
+    public class ExperimentalClass;
 
     public sealed class ClassWithConflictingIgnoredProperties
     {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
@@ -889,11 +889,11 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
                 if (value.EndsWith("\r\n", StringComparison.Ordinal))
                 {
-                    WriteLine(value.Substring(0, value.Length - 2));
+                    WriteLine(value[..^2]);
                 }
                 else if (value.EndsWith("\n", StringComparison.Ordinal))
                 {
-                    WriteLine(value.Substring(0, value.Length - 1));
+                    WriteLine(value[..^1]);
                 }
                 else
                 {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Text.Json.SourceGeneration.UnitTests
 {
@@ -133,7 +134,10 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 #endif
         }
 
-        public static JsonSourceGeneratorResult RunJsonSourceGenerator(Compilation compilation, bool disableDiagnosticValidation = false)
+        public static JsonSourceGeneratorResult RunJsonSourceGenerator(
+            Compilation compilation,
+            bool disableDiagnosticValidation = false,
+            ITestOutputHelper? logger = null)
         {
             var generatedSpecs = ImmutableArray<ContextGenerationSpec>.Empty;
             var generator = new JsonSourceGenerator
@@ -143,6 +147,19 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             CSharpGeneratorDriver driver = CreateJsonSourceGeneratorDriver(compilation, generator);
             driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outCompilation, out ImmutableArray<Diagnostic> diagnostics);
+
+            if (logger is not null)
+            {
+                foreach (Diagnostic diagnostic in outCompilation.GetDiagnostics().Concat(diagnostics))
+                {
+                    logger.WriteLine(diagnostic.ToString());
+                }
+
+                foreach (var tree in outCompilation.SyntaxTrees)
+                {
+                    LogGeneratedCode(tree, logger);
+                }
+            }
 
             if (!disableDiagnosticValidation)
             {
@@ -830,6 +847,59 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         internal static void AssertMaxSeverity(this IEnumerable<Diagnostic> diagnostics, DiagnosticSeverity maxSeverity)
         {
             Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Severity > maxSeverity);
+        }
+
+        private static void LogGeneratedCode(SyntaxTree tree, ITestOutputHelper logger)
+        {
+            logger.WriteLine(FileSeparator);
+            logger.WriteLine($"{tree.FilePath} content:");
+            logger.WriteLine(FileSeparator);
+            using NumberedSourceFileWriter lineWriter = new(logger);
+            tree.GetRoot().WriteTo(lineWriter);
+            lineWriter.WriteLine(string.Empty);
+        }
+
+        private static readonly string FileSeparator = new string('=', 140);
+
+        private sealed class NumberedSourceFileWriter : TextWriter
+        {
+            private readonly ITestOutputHelper _logger;
+            private readonly StringBuilder _lineBuilder = new StringBuilder();
+            private int _lineNumber;
+
+            internal NumberedSourceFileWriter(ITestOutputHelper logger)
+            {
+                _logger = logger;
+            }
+
+            public override Encoding Encoding => Encoding.Unicode;
+
+            public override void WriteLine(string? value)
+            {
+                _logger.WriteLine($"{++_lineNumber,6}: {_lineBuilder}{value}");
+                _lineBuilder.Clear();
+            }
+
+            public override void Write(string? value)
+            {
+                if (value is null)
+                {
+                    return;
+                }
+
+                if (value.EndsWith("\r\n", StringComparison.Ordinal))
+                {
+                    WriteLine(value.Substring(0, value.Length - 2));
+                }
+                else if (value.EndsWith("\n", StringComparison.Ordinal))
+                {
+                    WriteLine(value.Substring(0, value.Length - 1));
+                }
+                else
+                {
+                    _lineBuilder.Append(value);
+                }
+            }
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
@@ -889,11 +889,11 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
                 if (value.EndsWith("\r\n", StringComparison.Ordinal))
                 {
-                    WriteLine(value[..^2]);
+                    WriteLine(value.Substring(0, value.Length - 2));
                 }
                 else if (value.EndsWith("\n", StringComparison.Ordinal))
                 {
-                    WriteLine(value[..^1]);
+                    WriteLine(value.Substring(0, value.Length - 1));
                 }
                 else
                 {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Text.Json.SourceGeneration.UnitTests
 {
@@ -12,7 +13,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
     [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/71962", ~RuntimeConfiguration.Release)]
     [SkipOnMono("https://github.com/dotnet/runtime/issues/92467")]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotX86Process))] // https://github.com/dotnet/runtime/issues/71962
-    public class GeneratorTests
+    public class GeneratorTests(ITestOutputHelper logger)
     {
         [Fact]
         public void TypeDiscoveryPrimitivePOCO()
@@ -54,7 +55,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             Assert.Equal(5, result.AllGeneratedTypes.Count());
             result.AssertContainsType("global::HelloWorld.MyType");
@@ -109,7 +110,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             Compilation compilation = CompilationHelper.CreateCompilation(source, additionalReferences);
 
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             Assert.Equal(6, result.AllGeneratedTypes.Count());
             result.AssertContainsType("global::HelloWorld.MyType");
@@ -169,7 +170,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             Compilation compilation = CompilationHelper.CreateCompilation(source, additionalReferences);
 
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             Assert.Equal(6, result.AllGeneratedTypes.Count());
             result.AssertContainsType("global::HelloWorld.MyType");
@@ -271,7 +272,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             MetadataReference[] additionalReferences = { MetadataReference.CreateFromImage(referencedImage) };
 
             Compilation compilation = CompilationHelper.CreateCompilation(source, additionalReferences);
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
 
         [Fact]
@@ -312,7 +313,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
 
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             Assert.Equal(5, result.AllGeneratedTypes.Count());
             result.AssertContainsType("global::MyType");
@@ -362,7 +363,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
 
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             Assert.Equal(3, result.AllGeneratedTypes.Count());
             result.AssertContainsType("global::HelloWorld.AppRecord");
@@ -396,7 +397,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             MetadataReference[] additionalReferences = { MetadataReference.CreateFromImage(referencedImage) };
 
             Compilation compilation = CompilationHelper.CreateCompilation(source, additionalReferences);
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             Assert.Equal(3, result.AllGeneratedTypes.Count());
             result.AssertContainsType("global::ReferencedAssembly.LibRecord");
@@ -435,7 +436,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             Compilation compilation = CompilationHelper.CreateCompilation(source, additionalReferences);
 
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             Assert.Equal(3, result.AllGeneratedTypes.Count());
             result.AssertContainsType("global::HelloWorld.AppRecord");
@@ -486,7 +487,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             MetadataReference[] additionalReferences = { MetadataReference.CreateFromImage(referencedImage) };
             Compilation compilation = CompilationHelper.CreateCompilation(source, additionalReferences);
 
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             // Should find the generated type.
             Assert.Equal(2, result.AllGeneratedTypes.Count());
@@ -495,7 +496,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         }
 
         [Fact]
-        public static void NoWarningsDueToObsoleteMembers()
+        public void NoWarningsDueToObsoleteMembers()
         {
             string source = """
                 using System;
@@ -518,11 +519,11 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
 
         [Fact]
-        public static void NoErrorsWhenUsingReservedCSharpKeywords()
+        public void NoErrorsWhenUsingReservedCSharpKeywords()
         {
             string source = """
                 using System.Text.Json.Serialization;
@@ -541,7 +542,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
 
         [Fact]
@@ -564,7 +565,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
 
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             // Should find the generated type.
             Assert.Equal(3, result.AllGeneratedTypes.Count());
@@ -574,7 +575,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         }
 
         [Fact]
-        public static void NoErrorsWhenUsingTypesWithMultipleEqualsOperators()
+        public void NoErrorsWhenUsingTypesWithMultipleEqualsOperators()
         {
             // Regression test for https://github.com/dotnet/runtime/issues/103515
             string source = """
@@ -604,11 +605,11 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
 
         [Fact]
-        public static void NoErrorsWhenUsingIgnoredReservedCSharpKeywords()
+        public void NoErrorsWhenUsingIgnoredReservedCSharpKeywords()
         {
             string source = """
                 using System.Text.Json.Serialization;
@@ -627,7 +628,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
 
         [Fact]
@@ -678,7 +679,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             Compilation compilation = CompilationHelper.CreateCompilation(source, additionalReferences);
 
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             Assert.Equal(3, result.AllGeneratedTypes.Count());
             result.AssertContainsType("global::Test.Sample");
@@ -724,7 +725,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
 
-            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
 
             Assert.Equal(5, result.AllGeneratedTypes.Count());
             result.AssertContainsType("global::System.Collections.Generic.Dictionary<string, string>");
@@ -771,7 +772,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source, parseOptions: CompilationHelper.CreateParseOptions(languageVersion));
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
 
         [Fact]
@@ -802,7 +803,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
 
 #if ROSLYN4_4_OR_GREATER && NET
@@ -828,7 +829,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source, parseOptions: CompilationHelper.CreateParseOptions(LanguageVersion.CSharp11));
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
 #endif
 
@@ -856,7 +857,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
 
         [Fact]
@@ -881,7 +882,63 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 """;
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
-            CompilationHelper.RunJsonSourceGenerator(compilation);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
         }
+
+#if ROSLYN4_4_OR_GREATER
+        [Fact]
+        public void PropertyWithExperimentalType_JsonIgnore_CompilesSuccessfully()
+        {
+            string source = """
+                using System.Diagnostics.CodeAnalysis;
+                using System.Text.Json.Serialization;
+
+                [Experimental("EXP001")]
+                public class ExperimentalType
+                {
+                    public int Value { get; set; }
+                }
+
+                public class MyPoco
+                {
+                    [JsonIgnore]
+                #pragma warning disable EXP001
+                    public ExperimentalType ExpType { get; set; }
+                #pragma warning restore EXP001
+                }
+
+                [JsonSerializable(typeof(MyPoco))]
+                public partial class MyContext : JsonSerializerContext
+                {
+                }
+                """;
+
+            Compilation compilation = CompilationHelper.CreateCompilation(source);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
+        }
+
+        [Fact]
+        public void PocoWithExperimentalProperty_JsonIgnore_CompilesSuccessfully()
+        {
+            string source = """
+                using System.Diagnostics.CodeAnalysis;
+                using System.Text.Json.Serialization;
+
+                public class MyPoco
+                {
+                    [Experimental("EXP001"), JsonIgnore]
+                    public int ExperimentalProperty { get; set; }
+                }
+
+                [JsonSerializable(typeof(MyPoco))]
+                public partial class MyContext : JsonSerializerContext
+                {
+                }
+                """;
+
+            Compilation compilation = CompilationHelper.CreateCompilation(source);
+            CompilationHelper.RunJsonSourceGenerator(compilation, logger: logger);
+        }
+#endif
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/System.Text.Json.SourceGeneration.Roslyn4.4.Unit.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/System.Text.Json.SourceGeneration.Roslyn4.4.Unit.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RoslynApiVersion>$(MicrosoftCodeAnalysisVersion_4_4)</RoslynApiVersion>
+    <RoslynApiVersion>$(MicrosoftCodeAnalysisVersion_4_8)</RoslynApiVersion>
     <DefineConstants>$(DefineConstants);ROSLYN4_0_OR_GREATER;ROSLYN4_4_OR_GREATER</DefineConstants>
     <IsHighAotMemoryUsageTest>true</IsHighAotMemoryUsageTest>
   </PropertyGroup>


### PR DESCRIPTION
Updates the source generator so that generated code does not reference types of JsonIgnore'd properties unless the type is already present elsewhere in the type graph. Instead, it replaces the ignored property with a stub `JsonPropertyInfo<object>` instance which is necessary for certain runtime validations performed by the serializer. This prevents inadvertent referencing of types marked as experimental in the source generator.