### PR TITLE
Expose general purpose bit flag to detect encoding

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -565,12 +565,12 @@ namespace System.IO.Compression.Tests
         public static IEnumerable<object[]> Utf8_Encoded_Test_Pairs()
         {
             yield return new object[] { "ascii.txt", Encoding.Latin1, "Latin1 comment", false };
-            yield return new object[] { "üñîçødë.txt", Encoding.UTF8, "utf8 comment", true };
+            yield return new object[] { UnicodeFileName, Encoding.UTF8, "utf8 comment", true };
             yield return new object[] { "file.txt", Encoding.Latin1, "plain ascii", false };
             yield return new object[] { "file.txt", Encoding.UTF8, "üñîçødë comment", true };
             yield return new object[] { "ascii.txt", Encoding.ASCII, "ASCII comment", false };
-            yield return new object[] { "üñîçødë.txt", Encoding.ASCII, "ASCII comment", false }; // Will lose data, but encoding is not UTF8
-            yield return new object[] { "üñîçødë.txt", null, "utf8 comment", true }; // Default encoding (null) for runtime is UTF8 for non-ASCII
+            yield return new object[] { UnicodeFileName, Encoding.ASCII, "ASCII comment", false }; // Will lose data, but encoding is not UTF8
+            yield return new object[] { UnicodeFileName, null, "utf8 comment", true }; // Default encoding (null) for runtime is UTF8 for non-ASCII
             yield return new object[] { "ascii.txt", null, "ascii comment", false };
         }
 

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -562,6 +562,18 @@ namespace System.IO.Compression.Tests
         }
         public static IEnumerable<object[]> Get_Booleans_Data() => _bools.Select(b => new object[] { b });
 
+        public static IEnumerable<object[]> Utf8_Encoded_Test_Pairs()
+        {
+            yield return new object[] { "ascii.txt", Encoding.Latin1, "Latin1 comment", false };
+            yield return new object[] { "üñîçødë.txt", Encoding.UTF8, "utf8 comment", true };
+            yield return new object[] { "file.txt", Encoding.Latin1, "plain ascii", false };
+            yield return new object[] { "file.txt", Encoding.UTF8, "üñîçødë comment", true };
+            yield return new object[] { "ascii.txt", Encoding.ASCII, "ASCII comment", false };
+            yield return new object[] { "üñîçødë.txt", Encoding.ASCII, "ASCII comment", false }; // Will lose data, but encoding is not UTF8
+            yield return new object[] { "üñîçødë.txt", null, "utf8 comment", true }; // Default encoding (null) for runtime is UTF8 for non-ASCII
+            yield return new object[] { "ascii.txt", null, "ascii comment", false };
+        }
+
         // Returns pairs that are returned the same way by Utf8 and Latin1
         // Returns: originalComment, expectedComment
         private static IEnumerable<object[]> SharedComment_Data()

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -567,7 +567,7 @@ namespace System.IO.Compression.Tests
             yield return new object[] { "ascii.txt", Encoding.Latin1, "Latin1 comment", false };
             yield return new object[] { UnicodeFileName, Encoding.UTF8, "utf8 comment", true };
             yield return new object[] { "file.txt", Encoding.Latin1, "plain ascii", false };
-            yield return new object[] { "file.txt", Encoding.UTF8, "üñîçødë comment", true };
+            yield return new object[] { "file.txt", Encoding.UTF8, Utf8SmileyEmoji, true };
             yield return new object[] { "ascii.txt", Encoding.ASCII, "ASCII comment", false };
             yield return new object[] { UnicodeFileName, Encoding.ASCII, "ASCII comment", false }; // Will lose data, but encoding is not UTF8
             yield return new object[] { UnicodeFileName, null, "utf8 comment", true }; // Default encoding (null) for runtime is UTF8 for non-ASCII

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
@@ -153,5 +153,23 @@ namespace System.IO.Compression.Tests
 
             await DisposeZipArchive(async, archive);
         }
+
+        [Theory]
+        [MemberData(nameof(Utf8_Encoded_Test_Pairs))]
+        public void CheckUtf8Encoding(string entryName, Encoding? encoding, string comment, bool expected)
+        {
+            using var ms = new MemoryStream();
+            ZipArchive archive = encoding is null
+                ? new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true)
+                : new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding: encoding);
+
+            using (archive)
+            {
+                var entry = archive.CreateEntry(entryName);
+                if (comment is not null)
+                    entry.Comment = comment;
+                Assert.Equal(expected, entry.IsUtf8Encoded);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
+++ b/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
@@ -115,6 +115,7 @@ namespace System.IO.Compression
         public System.IO.Compression.ZipArchive Archive { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Comment { get { throw null; } set { } }
+        public bool IsUtf8Encoded { get { throw null; } }
         public long CompressedLength { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
         public uint Crc32 { get { throw null; } }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -225,6 +225,14 @@ namespace System.IO.Compression
         }
 
         /// <summary>
+        /// Returns true if the entry's general purpose bit flag indicates UTF-8 encoding is used for the entry name and comment.
+        /// </summary>
+        public bool IsUtf8Encoded
+        {
+            get => (_generalPurposeBitFlag & BitFlagValues.UnicodeFileNameAndComment) != 0;
+        }
+
+        /// <summary>
         /// The relative path of the entry as stored in the Zip archive. Note that Zip archives allow any string to be the path of the entry, including invalid and absolute paths.
         /// </summary>
         public string FullName


### PR DESCRIPTION
Introduced a new property IsUtf8Encoded on ZipArchiveEntry that indicates whether the entry name and comment are encoded in UTF-8, based on the ZIP specification’s General Purpose Bit Flag (bit 11).
Added unit tests to validate behaviour.
Fixes #43231
