### PR TITLE
Do not set -warnings-as-errors for Swift unless PRERELEASE

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -83,9 +83,14 @@ if (CMAKE_OSX_SYSROOT)
     set(SWIFT_SDK_FLAG -sdk ${CMAKE_OSX_SYSROOT})
 endif()
 
+set(SWIFT_COMPILER_ERRORS_FLAG "")
+if (PRERELEASE)
+    set(SWIFT_COMPILER_ERRORS_FLAG "-warnings-as-errors")
+endif()
+
 add_custom_command(
     OUTPUT pal_swiftbindings.o
-    COMMAND xcrun swiftc -emit-object -static -parse-as-library -enable-library-evolution -warnings-as-errors -g ${SWIFT_OPTIMIZATION_FLAG} -runtime-compatibility-version none ${SWIFT_SDK_FLAG} -target ${SWIFT_COMPILER_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift -o pal_swiftbindings.o
+    COMMAND xcrun swiftc -emit-object -static -parse-as-library -enable-library-evolution ${SWIFT_COMPILER_ERRORS_FLAG} -g ${SWIFT_OPTIMIZATION_FLAG} -runtime-compatibility-version none ${SWIFT_SDK_FLAG} -target ${SWIFT_COMPILER_TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift -o pal_swiftbindings.o
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/pal_swiftbindings.swift
     COMMENT "Compiling Swift file pal_swiftbindings.swift"
 )


### PR DESCRIPTION
Addresses feedback https://github.com/dotnet/runtime/pull/120448#issuecomment-3384440978

I tested this out by

1. Introducing a compiler warning. As expected, it failed with:
    
    ```plain
    /Users/vcsjones/Projects/runtime/src/native/libs/System.Security.Cryptography.Native.Apple/pal_swiftbindings.swift:323:14: error: Potato!
      321 |     let key = SymmetricKey(data: ikm)
      322 | 
      323 |     #warning("Potato!")
          |              `- error: Potato!
      324 | 
      ```
2. Flipped PRERELEASE to 0 here

    https://github.com/dotnet/runtime/blob/8d3c4013b7e7c6d603b08a1fbf563d51e2c2e00c/eng/native/configureplatform.cmake#L5
    
3. Warning stayed being treated as a warning, and compilation succeeded.

    ```plain
      /Users/vcsjones/Projects/runtime/src/native/libs/System.Security.Cryptography.Native.Apple/pal_swiftbindings.swift:323:14: warning: Potato!
      321 |     let key = SymmetricKey(data: ikm)
      322 | 
      323 |     #warning("Potato!")
          |              `- warning: Potato!
      ```