### PR TITLE
[release/10.0] Add MetadataUpdateDeletedAttribute and Reflection Filtering

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1407,7 +1407,7 @@ namespace System.Reflection
             return IsCustomAttributeDefined(decoratedModule, decoratedMetadataToken, null, attributeCtorToken, false);
         }
 
-        private static bool IsCustomAttributeDefined(
+        internal static bool IsCustomAttributeDefined(
             RuntimeModule decoratedModule, int decoratedMetadataToken, RuntimeType? attributeFilterType)
         {
             return IsCustomAttributeDefined(decoratedModule, decoratedMetadataToken, attributeFilterType, 0, false);

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -1118,7 +1118,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int GetMethodDef(RuntimeMethodHandleInternal method);
+        internal static extern int GetMethodDef(RuntimeMethodHandleInternal method);
 
         internal static int GetMethodDef(IRuntimeMethodInfo method)
         {
@@ -1569,7 +1569,7 @@ namespace System
         private static unsafe partial void GetFieldDataReference(IntPtr fieldDesc, ObjectHandleOnStack target, ByteRefOnStack fieldDataRef);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int GetToken(IntPtr fieldDesc);
+        internal static extern int GetToken(IntPtr fieldDesc);
 
         internal static int GetToken(RtFieldInfo field)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.IO;
 using System.Reflection;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -605,6 +607,13 @@ namespace System
                                 continue;
                             #endregion
 
+                            if (MetadataUpdater.IsSupported &&
+                                RuntimeTypeMetadataUpdateHandler.FilterDeletedMembers &&
+                                RuntimeTypeMetadataUpdateHandler.IsMetadataUpdateDeleted(declaringType.GetRuntimeModule(), RuntimeMethodHandle.GetMethodDef(methodHandle)))
+                            {
+                                continue;
+                            }
+
                             #region Calculate Binding Flags
                             bool isPublic = (methodAttributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
                             bool isStatic = (methodAttributes & MethodAttributes.Static) != 0;
@@ -615,7 +624,7 @@ namespace System
                             RuntimeMethodHandleInternal instantiatedHandle = RuntimeMethodHandle.GetStubIfNeeded(methodHandle, declaringType, null);
 
                             RuntimeMethodInfo runtimeMethodInfo = new RuntimeMethodInfo(
-                            instantiatedHandle, declaringType, m_runtimeTypeCache, methodAttributes, bindingFlags, null);
+                                instantiatedHandle, declaringType, m_runtimeTypeCache, methodAttributes, bindingFlags, null);
 
                             list.Add(runtimeMethodInfo);
                             #endregion
@@ -685,6 +694,14 @@ namespace System
 
                                 #endregion
 
+                                // Filter out deleted method before setting override state, so that a deleted override in a subclass does not hide override in an ancestor.
+                                if (MetadataUpdater.IsSupported &&
+                                    RuntimeTypeMetadataUpdateHandler.FilterDeletedMembers &&
+                                    RuntimeTypeMetadataUpdateHandler.IsMetadataUpdateDeleted(declaringType.GetRuntimeModule(), RuntimeMethodHandle.GetMethodDef(methodHandle)))
+                                {
+                                    continue;
+                                }
+
                                 #region Continue if this is a virtual and is already overridden
                                 if (isVirtual)
                                 {
@@ -719,7 +736,7 @@ namespace System
                                 RuntimeMethodHandleInternal instantiatedHandle = RuntimeMethodHandle.GetStubIfNeeded(methodHandle, declaringType, null);
 
                                 RuntimeMethodInfo runtimeMethodInfo = new RuntimeMethodInfo(
-                                instantiatedHandle, declaringType, m_runtimeTypeCache, methodAttributes, bindingFlags, null);
+                                    instantiatedHandle, declaringType, m_runtimeTypeCache, methodAttributes, bindingFlags, null);
 
                                 list.Add(runtimeMethodInfo);
                                 #endregion
@@ -763,6 +780,13 @@ namespace System
                         Debug.Assert(
                             (methodAttributes & MethodAttributes.Abstract) == 0 &&
                             (methodAttributes & MethodAttributes.Virtual) == 0);
+
+                        if (MetadataUpdater.IsSupported &&
+                            RuntimeTypeMetadataUpdateHandler.FilterDeletedMembers &&
+                            RuntimeTypeMetadataUpdateHandler.IsMetadataUpdateDeleted(declaringType.GetRuntimeModule(), RuntimeMethodHandle.GetMethodDef(methodHandle)))
+                        {
+                            continue;
+                        }
 
                         #region Calculate Binding Flags
                         bool isPublic = (methodAttributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
@@ -875,6 +899,13 @@ namespace System
                                 continue;
                         }
 
+                        if (MetadataUpdater.IsSupported &&
+                            RuntimeTypeMetadataUpdateHandler.FilterDeletedMembers &&
+                            RuntimeTypeMetadataUpdateHandler.IsMetadataUpdateDeleted(declaringType.GetRuntimeModule(), RuntimeFieldHandle.GetToken(handle)))
+                        {
+                            continue;
+                        }
+
                         #region Calculate Binding Flags
                         bool isPublic = fieldAccess == FieldAttributes.Public;
                         bool isStatic = (fieldAttributes & FieldAttributes.Static) != 0;
@@ -885,8 +916,7 @@ namespace System
                         if (needsStaticFieldForGeneric && isStatic)
                             runtimeFieldHandle = RuntimeFieldHandle.GetStaticFieldForGenericType(runtimeFieldHandle, declaringType);
 
-                        RuntimeFieldInfo runtimeFieldInfo =
-                            new RtFieldInfo(runtimeFieldHandle, declaringType, m_runtimeTypeCache, bindingFlags);
+                        var runtimeFieldInfo = new RtFieldInfo(runtimeFieldHandle, declaringType, m_runtimeTypeCache, bindingFlags);
 
                         list.Add(runtimeFieldInfo);
                     }
@@ -903,8 +933,8 @@ namespace System
                     if (MdToken.IsNullToken(tkDeclaringType))
                         return;
 
-                    RuntimeModule module = declaringType.GetRuntimeModule();
-                    MetadataImport scope = module.MetadataImport;
+                    RuntimeModule declaringModule = declaringType.GetRuntimeModule();
+                    MetadataImport scope = declaringModule.MetadataImport;
 
                     scope.EnumFields(tkDeclaringType, out MetadataEnumResult tkFields);
 
@@ -936,6 +966,13 @@ namespace System
                                     continue;
                             }
 
+                            if (MetadataUpdater.IsSupported &&
+                                RuntimeTypeMetadataUpdateHandler.FilterDeletedMembers &&
+                                RuntimeTypeMetadataUpdateHandler.IsMetadataUpdateDeleted(declaringModule, tkField))
+                            {
+                                continue;
+                            }
+
                             #region Calculate Binding Flags
                             bool isPublic = fieldAccess == FieldAttributes.Public;
                             bool isStatic = (fieldAttributes & FieldAttributes.Static) != 0;
@@ -948,7 +985,7 @@ namespace System
                             list.Add(runtimeFieldInfo);
                         }
                     }
-                    GC.KeepAlive(module);
+                    GC.KeepAlive(declaringModule);
                 }
 
                 private void AddSpecialInterface(
@@ -1144,8 +1181,8 @@ namespace System
                     if (MdToken.IsNullToken(tkDeclaringType))
                         return;
 
-                    RuntimeModule module = declaringType.GetRuntimeModule();
-                    MetadataImport scope = module.MetadataImport;
+                    RuntimeModule declaringModule = declaringType.GetRuntimeModule();
+                    MetadataImport scope = declaringModule.MetadataImport;
 
                     scope.EnumEvents(tkDeclaringType, out MetadataEnumResult tkEvents);
 
@@ -1162,6 +1199,13 @@ namespace System
 
                             if (!filter.Match(name))
                                 continue;
+                        }
+
+                        if (MetadataUpdater.IsSupported &&
+                            RuntimeTypeMetadataUpdateHandler.FilterDeletedMembers &&
+                            RuntimeTypeMetadataUpdateHandler.IsMetadataUpdateDeleted(declaringModule, tkEvent))
+                        {
+                            continue;
                         }
 
                         RuntimeEventInfo eventInfo = new RuntimeEventInfo(
@@ -1191,7 +1235,7 @@ namespace System
 
                         list.Add(eventInfo);
                     }
-                    GC.KeepAlive(module);
+                    GC.KeepAlive(declaringModule);
                 }
 
                 private RuntimePropertyInfo[] PopulateProperties(Filter filter)
@@ -1251,8 +1295,8 @@ namespace System
                     if (MdToken.IsNullToken(tkDeclaringType))
                         return;
 
-                    RuntimeModule module = declaringType.GetRuntimeModule();
-                    MetadataImport scope = module.MetadataImport;
+                    RuntimeModule declaringModule = declaringType.GetRuntimeModule();
+                    MetadataImport scope = declaringModule.MetadataImport;
 
                     scope.EnumProperties(tkDeclaringType, out MetadataEnumResult tkProperties);
 
@@ -1274,6 +1318,14 @@ namespace System
 
                             if (!filter.Match(name))
                                 continue;
+                        }
+
+                        // Filter out deleted property before updating usedSlots, so that a deleted override in a subclass does not hide override in an ancestor.
+                        if (MetadataUpdater.IsSupported &&
+                            RuntimeTypeMetadataUpdateHandler.FilterDeletedMembers &&
+                            RuntimeTypeMetadataUpdateHandler.IsMetadataUpdateDeleted(declaringModule, tkProperty))
+                        {
+                            continue;
                         }
 
                         RuntimePropertyInfo propertyInfo =
@@ -1365,7 +1417,7 @@ namespace System
 
                         list.Add(propertyInfo);
                     }
-                    GC.KeepAlive(module);
+                    GC.KeepAlive(declaringModule);
                 }
                 #endregion
 
@@ -1458,6 +1510,7 @@ namespace System
 
                 return existingCache;
             }
+
             #endregion
 
             #region Internal Members

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -881,6 +881,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\MethodImplAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\MethodImplOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ModuleInitializerAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\MetadataUpdateDeletedAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\MetadataUpdateOriginalTypeAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\NullableAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\NullableContextAttribute.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/MetadataUpdateDeletedAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/MetadataUpdateDeletedAttribute.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// This attribute is emitted by the compiler when a metadata entity is deleted during a
+/// Hot Reload session.
+/// </summary>
+[AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = false)]
+public sealed class MetadataUpdateDeletedAttribute : Attribute;

--- a/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.cs
+++ b/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.cs
@@ -33,9 +33,13 @@ namespace System.Runtime.CompilerServices
     public sealed class CreateNewOnMetadataUpdateAttribute : System.Attribute
     {
     }
-    [AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct,
-                    AllowMultiple=false, Inherited=false)]
-    public class MetadataUpdateOriginalTypeAttribute : Attribute
+    [System.AttributeUsageAttribute(System.AttributeTargets.All, AllowMultiple=false, Inherited=false)]
+    public sealed partial class MetadataUpdateDeletedAttribute : System.Attribute
+    {
+        public MetadataUpdateDeletedAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Struct, AllowMultiple=false, Inherited=false)]
+    public partial class MetadataUpdateOriginalTypeAttribute : System.Attribute
     {
 	public MetadataUpdateOriginalTypeAttribute(Type originalType) { throw null; }
 	public Type OriginalType { get { throw null; } }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember/ReflectionDeleteMember.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember/ReflectionDeleteMember.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class ReflectionDeleteMember
+    {
+        public int F1;
+
+        public ReflectionDeleteMember() { }
+        public ReflectionDeleteMember(int arg) { F1 = arg; }
+
+        public virtual int P1 { get; set; }
+        public virtual void M1() { }
+
+        public virtual int P2 { get; }
+        public virtual void M2() { }
+
+        public int P3 { get; set; }
+        public void M3() { }
+        public event Action E1 { add { } remove { } }
+    }
+
+    public class ReflectionDeleteMember_Derived : ReflectionDeleteMember
+    {
+        public new int F1;
+
+        public override int P1 { get; set; }
+        public override void M1() { }
+
+        public override int P2 { get; }
+        public override void M2() { }
+
+        public new int P3 { get; set; }
+        public new void M3() { }
+        public new event Action E1 { add { } remove { } }
+    }
+
+    public class ReflectionDeleteMember_Derived2 : ReflectionDeleteMember_Derived
+    {
+        public override int P1 { get; set; }
+        public override void M1() { }
+
+        public override int P2 { get; }
+        public override void M2() { }
+    }
+
+    public interface IReflectionDeleteMember
+    {
+        int P1 { get; set; }
+        int P2 { get; }
+        void M1();
+        void M2();
+        event Action E1;
+        event Action E2;
+    }
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember/ReflectionDeleteMember_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember/ReflectionDeleteMember_v1.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class ReflectionDeleteMember
+    {
+        public int F1; // delete: not supported by Roslyn
+
+        public ReflectionDeleteMember() { }
+        // delete: public ReflectionDeleteMember(int arg) { F1 = arg; }
+
+        public virtual int P1 { get; set; }
+        public virtual void M1() { }
+
+        public virtual int P2 { get; }
+        public virtual void M2() { }
+
+        public int P3 { get; set; }
+        public void M3() { }
+        public event Action E1 { add { } remove { } }
+    }
+
+    public class ReflectionDeleteMember_Derived : ReflectionDeleteMember
+    {
+        public new int F1;
+
+        public override int P1 { get; set; } // delete: not supported by Roslyn
+        public override void M1() { }        // delete: not supported by Roslyn
+
+        public override int P2 { get; }
+        public override void M2() { }
+
+        // delete: public new int P3 { get; set; }
+        // delete: public new void M3() { }
+        // delete: public new event Action E1 { add { } remove { } }
+    }
+
+    public class ReflectionDeleteMember_Derived2 : ReflectionDeleteMember_Derived
+    {
+        public override int P1 { get; set; }
+        public override void M1() { }
+
+        public override int P2 { get; } // delete: not supported by Roslyn
+        public override void M2() { }   // delete: not supported by Roslyn
+    }
+
+    public interface IReflectionDeleteMember
+    {
+        int P1 { get; set; }
+        int P2 { get; }   // delete: not supported by Roslyn
+        void M1();
+        void M2();        // delete: not supported by Roslyn
+        event Action E1;
+        event Action E2;  // delete: not supported by Roslyn
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ReflectionDeleteMember.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember/deltascript.json
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember/deltascript.json
@@ -1,0 +1,6 @@
+{
+    "changes": [
+        {"document": "ReflectionDeleteMember.cs", "update": "ReflectionDeleteMember_v1.cs"}
+    ]
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -19,6 +21,119 @@ namespace System.Reflection.Metadata
     [Collection(nameof(DisableParallelization))]
     public class ApplyUpdateTest
     {
+
+        [ConditionalFact(typeof(ApplyUpdateUtil), nameof (ApplyUpdateUtil.IsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120547", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime))]
+        void DeleteMemberTest()
+        {
+            ApplyUpdateUtil.TestCase(static () =>
+            {
+                var assm = typeof (ApplyUpdate.Test.ReflectionDeleteMember).Assembly;
+
+                var type_ReflectionDeleteMember = assm.GetType("System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember");
+                var type_ReflectionDeleteMember_Derived = assm.GetType("System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember_Derived");
+                var type_ReflectionDeleteMember_Derived2 = assm.GetType("System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember_Derived2");
+                var type_IReflectionDeleteMember = assm.GetType("System.Reflection.Metadata.ApplyUpdate.Test.IReflectionDeleteMember");
+
+                ApplyUpdateUtil.ApplyUpdate(assm);
+                ApplyUpdateUtil.ClearAllReflectionCaches();
+
+                Assert.Equal(
+                [
+                    "get_P1 : ReflectionDeleteMember",
+                    "set_P1 : ReflectionDeleteMember",
+                    "M1 : ReflectionDeleteMember",
+                    "get_P2 : ReflectionDeleteMember",
+                    "M2 : ReflectionDeleteMember",
+                    "get_P3 : ReflectionDeleteMember",
+                    "set_P3 : ReflectionDeleteMember",
+                    "M3 : ReflectionDeleteMember",
+                    "add_E1 : ReflectionDeleteMember",
+                    "remove_E1 : ReflectionDeleteMember",
+                    "GetType : Object",
+                    "ToString : Object",
+                    "Equals : Object",
+                    "GetHashCode : Object",
+                    ".ctor(0) : ReflectionDeleteMember",
+                    "P1 : ReflectionDeleteMember",
+                    "P2 : ReflectionDeleteMember",
+                    "P3 : ReflectionDeleteMember",
+                    "E1 : ReflectionDeleteMember",
+                    "F1 : ReflectionDeleteMember",
+                ], Inspect(type_ReflectionDeleteMember));
+
+                Assert.Equal(
+                [
+                    "get_P1 : ReflectionDeleteMember_Derived",
+                    "set_P1 : ReflectionDeleteMember_Derived",
+                    "M1 : ReflectionDeleteMember_Derived",
+                    "get_P2 : ReflectionDeleteMember_Derived",
+                    "M2 : ReflectionDeleteMember_Derived",
+                    "get_P3 : ReflectionDeleteMember",
+                    "set_P3 : ReflectionDeleteMember",
+                    "M3 : ReflectionDeleteMember",
+                    "add_E1 : ReflectionDeleteMember",
+                    "remove_E1 : ReflectionDeleteMember",
+                    "GetType : Object",
+                    "ToString : Object",
+                    "Equals : Object",
+                    "GetHashCode : Object",
+                    ".ctor(0) : ReflectionDeleteMember_Derived",
+                    "P1 : ReflectionDeleteMember_Derived",
+                    "P2 : ReflectionDeleteMember_Derived",
+                    "P3 : ReflectionDeleteMember",
+                    "E1 : ReflectionDeleteMember",
+                    "F1 : ReflectionDeleteMember_Derived",
+                    "F1 : ReflectionDeleteMember",
+                ], Inspect(type_ReflectionDeleteMember_Derived));
+
+                Assert.Equal(
+                [
+                    "get_P1 : ReflectionDeleteMember_Derived2",
+                    "set_P1 : ReflectionDeleteMember_Derived2",
+                    "M1 : ReflectionDeleteMember_Derived2",
+                    "get_P2 : ReflectionDeleteMember_Derived2",
+                    "M2 : ReflectionDeleteMember_Derived2",
+                    "get_P3 : ReflectionDeleteMember",
+                    "set_P3 : ReflectionDeleteMember",
+                    "M3 : ReflectionDeleteMember",
+                    "add_E1 : ReflectionDeleteMember",
+                    "remove_E1 : ReflectionDeleteMember",
+                    "GetType : Object",
+                    "ToString : Object",
+                    "Equals : Object",
+                    "GetHashCode : Object",
+                    ".ctor(0) : ReflectionDeleteMember_Derived2",
+                    "P1 : ReflectionDeleteMember_Derived2",
+                    "P2 : ReflectionDeleteMember_Derived2",
+                    "P3 : ReflectionDeleteMember",
+                    "E1 : ReflectionDeleteMember",
+                    "F1 : ReflectionDeleteMember_Derived",
+                    "F1 : ReflectionDeleteMember",
+                ], Inspect(type_ReflectionDeleteMember_Derived2));
+
+                Assert.Equal(
+                [
+                    "get_P1 : IReflectionDeleteMember",
+                    "set_P1 : IReflectionDeleteMember",
+                    "get_P2 : IReflectionDeleteMember",
+                    "M1 : IReflectionDeleteMember",
+                    "M2 : IReflectionDeleteMember",
+                    "add_E1 : IReflectionDeleteMember",
+                    "remove_E1 : IReflectionDeleteMember",
+                    "add_E2 : IReflectionDeleteMember",
+                    "remove_E2 : IReflectionDeleteMember",
+                    "P1 : IReflectionDeleteMember",
+                    "P2 : IReflectionDeleteMember",
+                    "E1 : IReflectionDeleteMember",
+                    "E2 : IReflectionDeleteMember",
+                ], Inspect(type_IReflectionDeleteMember));
+            });
+
+            static IEnumerable<string> Inspect(Type type)
+                => type.GetMembers().Select(m => (m is ConstructorInfo ctor ? $"{ctor.Name}({ctor.GetParameters().Length})" : m.Name) + " : " + m.DeclaringType!.Name);
+        }
+
         [ConditionalFact(typeof(ApplyUpdateUtil), nameof (ApplyUpdateUtil.IsSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/54617", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         void StaticMethodBodyUpdate()
@@ -626,7 +741,7 @@ namespace System.Reflection.Metadata
             if (nestedIdx != -1)
                 comparisonName = typeName.Substring(nestedIdx+1);
             Assert.True(comparisonName == ty.Name, $"{callerFilePath}:{callerLineNumber}: returned type has unexpected name '{ty.Name}' (expected: '{comparisonName}') in {callerMemberName}");
-            Assert.True(ContainsTypeWithName (allTypes, fullName), $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetTypes to contain '{fullName}', but it didn't in {callerMemberName}");
+            Assert.True(ContainsTypeWithName (allTypes, fullName), $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetTypes to contain '{fullName}', but it didn'type_ReflectionDeleteMember in {callerMemberName}");
             if (moreChecks != null)
                 moreChecks(ty);
             return ty;

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -741,7 +741,7 @@ namespace System.Reflection.Metadata
             if (nestedIdx != -1)
                 comparisonName = typeName.Substring(nestedIdx+1);
             Assert.True(comparisonName == ty.Name, $"{callerFilePath}:{callerLineNumber}: returned type has unexpected name '{ty.Name}' (expected: '{comparisonName}') in {callerMemberName}");
-            Assert.True(ContainsTypeWithName (allTypes, fullName), $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetTypes to contain '{fullName}', but it didn'type_ReflectionDeleteMember in {callerMemberName}");
+            Assert.True(ContainsTypeWithName (allTypes, fullName), $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetTypes to contain '{fullName}', but it didn't in {callerMemberName}");
             if (moreChecks != null)
                 moreChecks(ty);
             return ty;

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -41,6 +41,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember\ReflectionDeleteMember.cs" />
+    <None Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember\ReflectionDeleteMember_v1.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- iOS & tvOS are aot workloads and loading an embedded assembly results in some dynamic codegen, which is not allowed -->
     <ProjectReference Condition="'$(TargetOS)' != 'ios' and '$(TargetOS)' != 'tvos'" Include="System.Runtime.Loader.Test.Assembly\System.Runtime.Loader.Test.Assembly.csproj" ReferenceOutputAssembly="false" OutputItemType="EmbeddedResource" />
     <ProjectReference Condition="'$(TargetOS)' != 'ios' and '$(TargetOS)' != 'tvos'" Include="System.Runtime.Loader.Test.Assembly2\System.Runtime.Loader.Test.Assembly2.csproj" ReferenceOutputAssembly="false" OutputItemType="EmbeddedResource" />
@@ -74,6 +79,7 @@
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.StaticLambdaRegression\System.Reflection.Metadata.ApplyUpdate.Test.StaticLambdaRegression.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod.csproj" />
+    <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionDeleteMember.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.GenericAddStaticField\System.Reflection.Metadata.ApplyUpdate.Test.GenericAddStaticField.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.GenericAddInstanceField\System.Reflection.Metadata.ApplyUpdate.Test.GenericAddInstanceField.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows\System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows.csproj" />


### PR DESCRIPTION
Backport of #119584 to release/10.0

/cc @jeffhandley @steveisok @lewing 

## Customer Impact

- [x] Customer reported
- [x] Found internally

Hot Reload needs to mark metadata entities with an attribute or flag that instructs Reflection to not return them when enumerating types or type members. With this new attribute, Reflection filters out all types and members marked with this attribute if any Hot Reload change has been applied to the containing module/type.

Related issues and PRs:

* https://github.com/dotnet/runtime/issues/118903
* https://github.com/dotnet/runtime/issues/75154
* https://github.com/dotnet/roslyn/pull/80125
* https://github.com/dotnet/hotreload-utils/pull/619
* https://github.com/dotnet/runtime/pull/120299
* https://github.com/dotnet/runtime/issues/120547
* https://github.com/dotnet/aspnetcore/issues/50579
* https://github.com/dotnet/aspnetcore/issues/44857

## Regression

- [ ] Yes
- [x] No

## Testing

New tests were added to exercise this scenario, simulating a hot reload update that deletes a member, verifying the member is no longer visible through Reflection.

## Risk

Medium to High. This adds new API surface, alters the `RuntimeType` code paths with surgical changes that rely on `MetadataUpdater.IsSupported` conditions to be performant/trimmed out, and integrates with Roslyn to emit the attribute while also raising diagnostics if customers apply the attribute to user code.

It's anticipated there will be hot reload cases that escape this logic, but this targets the most common scenarios.