### PR TITLE
Fix incomplete message in installer

### DIFF
--- a/src/installer/pkg/sfx/bundle/theme/1033/bundle.wxl
+++ b/src/installer/pkg/sfx/bundle/theme/1033/bundle.wxl
@@ -66,7 +66,7 @@ Ready? Set? Let's go!" />
   <String Id="WelcomeHeaderMessage" Value=".NET Runtime" />
   <String Id="WelcomeDescription" Value="The .NET Runtime is used to run .NET applications, on your Windows computer. .NET is open source, cross platform, and supported by Microsoft. We hope you enjoy it!" />
   <String Id="LearnMoreTitle" Value="Learn more about .NET" />
-  <String Id="SuccessInstallLocation" Value="The following was installed at [DOTNETHOME]" />
+  <String Id="SuccessInstallLocation" Value="The following was installed:" />
   <String Id="SuccessInstallProductName" Value=" - [BUNDLEMONIKER] " />
   <String Id="ResourcesHeader" Value="Resources" />
   <String Id="DocumentationLink" Value="&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;" />


### PR DESCRIPTION
Fixes #120133

This aligns with other bundles (SDK, WindowsDesktop) which also omit the install location.