### PR TITLE
Fix assert message with errant text pasted in

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -741,7 +741,7 @@ namespace System.Reflection.Metadata
             if (nestedIdx != -1)
                 comparisonName = typeName.Substring(nestedIdx+1);
             Assert.True(comparisonName == ty.Name, $"{callerFilePath}:{callerLineNumber}: returned type has unexpected name '{ty.Name}' (expected: '{comparisonName}') in {callerMemberName}");
-            Assert.True(ContainsTypeWithName (allTypes, fullName), $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetTypes to contain '{fullName}', but it didn'type_ReflectionDeleteMember in {callerMemberName}");
+            Assert.True(ContainsTypeWithName (allTypes, fullName), $"{callerFilePath}:{callerLineNumber}: expected Assembly.GetTypes to contain '{fullName}', but it didn't in {callerMemberName}");
             if (moreChecks != null)
                 moreChecks(ty);
             return ty;


### PR DESCRIPTION
This errant text snuck in with [(#119584) Add MetadataUpdateDeletedAttribute](https://github.com/dotnet/runtime/pull/119584/files#diff-5f16c1afd8beef4ef1699f4c91d537c33f528440ab83172c64bcdc21e2bd41c4R744).