### PR TITLE
JIT: fix AV caused by JIT

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -701,20 +701,21 @@ private:
             // we may be able to sharpen the type for the local.
             if (tree->TypeIs(TYP_REF))
             {
-                LclVarDsc* lcl = m_compiler->lvaGetDesc(lclNum);
+                LclVarDsc* const lcl = m_compiler->lvaGetDesc(lclNum);
 
                 if (lcl->lvSingleDef)
                 {
-                    bool                 isExact;
-                    bool                 isNonNull;
-                    CORINFO_CLASS_HANDLE newClass = m_compiler->gtGetClassHandle(value, &isExact, &isNonNull);
-
-                    if (newClass != NO_CLASS_HANDLE)
+                    if (lcl->lvClassHnd == NO_CLASS_HANDLE)
                     {
-                        m_compiler->lvaUpdateClass(lclNum, newClass, isExact);
-                        m_madeChanges                    = true;
-                        m_compiler->hasUpdatedTypeLocals = true;
+                        m_compiler->lvaSetClass(lclNum, value);
                     }
+                    else
+                    {
+                        m_compiler->lvaUpdateClass(lclNum, value);
+                    }
+
+                    m_madeChanges                    = true;
+                    m_compiler->hasUpdatedTypeLocals = true;
                 }
             }
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -6967,6 +6967,10 @@ private:
             {
                 comp->lvaSetClass(tmp, retClsHnd, isExact);
             }
+            else
+            {
+                JITDUMP("Could not deduce class from [%06u]", comp->dspTreeID(retExpr));
+            }
         }
     }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_120522/Runtime_120522.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_120522/Runtime_120522.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Xunit;
+
+public class Runtime_120522
+{
+    static System.Collections.ArrayList array = [];
+
+    static void Problem(ref object[]? a)
+    {
+        a = new object[1];
+        array.Add(a.Clone());
+    }
+
+    [Fact]
+    [MethodImpl(MethodImplOptions.NoOptimization)]
+    public static int Test()
+    {
+        int i = 0;
+        while (i < 200_000)
+        {
+            object[]? a = null;
+            Problem(ref a);
+            i++;
+
+            if (i % 10_000 == 0)
+            {
+                Thread.Sleep(200);
+            }
+        }
+        
+        return i / 2000;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_120522/Runtime_120522.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_120522/Runtime_120522.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The JIT attempts to deduce a class handle for the return type of TYP_REF calls, and almost always succeeds. However System.Array.Clone is special cased to return the type of its argument, and this argument may be a byref indir without a known managed type, so this deduction may fail.

This causes the JIT to pass a null handle into the VM.

Cope with this by setting the type instead of updating the type, if we discover it later via inlining.

Closes #120522.