### PR TITLE
[clr-interp] Access checks and callouts

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1673,8 +1673,7 @@ InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
     m_compHnd = compHnd;
     m_methodInfo = methodInfo;
     m_classHnd   = compHnd->getMethodClass(m_methodHnd);
-#ifdef DEBUG
-#endif
+
 #ifdef DEBUG
     m_methodName = ::PrintMethodName(compHnd, m_classHnd, m_methodHnd, &m_methodInfo->args,
                             /* includeAssembly */ false,

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -6383,6 +6383,12 @@ retry_emit:
                 ResolveToken(token, CORINFO_TOKENKIND_Field, &resolvedToken);
                 m_compHnd->getFieldInfo(&resolvedToken, m_methodHnd, CORINFO_ACCESS_ADDRESS, &fieldInfo);
 
+                if (fieldInfo.accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&fieldInfo.accessCalloutHelper);
+                }
+
                 bool isStatic = !!(fieldInfo.fieldFlags & CORINFO_FLG_FIELD_STATIC);
 
                 if (isStatic)
@@ -6413,6 +6419,12 @@ retry_emit:
                 uint32_t token = getU4LittleEndian(m_ip + 1);
                 ResolveToken(token, CORINFO_TOKENKIND_Field, &resolvedToken);
                 m_compHnd->getFieldInfo(&resolvedToken, m_methodHnd, CORINFO_ACCESS_GET, &fieldInfo);
+
+                if (fieldInfo.accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&fieldInfo.accessCalloutHelper);
+                }
 
                 CorInfoType fieldType = fieldInfo.fieldType;
                 bool isStatic = !!(fieldInfo.fieldFlags & CORINFO_FLG_FIELD_STATIC);
@@ -6474,6 +6486,12 @@ retry_emit:
                 ResolveToken(token, CORINFO_TOKENKIND_Field, &resolvedToken);
                 m_compHnd->getFieldInfo(&resolvedToken, m_methodHnd, CORINFO_ACCESS_GET, &fieldInfo);
 
+                if (fieldInfo.accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&fieldInfo.accessCalloutHelper);
+                }
+
                 CorInfoType fieldType = fieldInfo.fieldType;
                 bool isStatic = !!(fieldInfo.fieldFlags & CORINFO_FLG_FIELD_STATIC);
                 InterpType interpFieldType = GetInterpType(fieldType);
@@ -6508,6 +6526,12 @@ retry_emit:
                 ResolveToken(token, CORINFO_TOKENKIND_Field, &resolvedToken);
                 m_compHnd->getFieldInfo(&resolvedToken, m_methodHnd, CORINFO_ACCESS_ADDRESS, &fieldInfo);
 
+                if (fieldInfo.accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&fieldInfo.accessCalloutHelper);
+                }
+
                 EmitStaticFieldAddress(&fieldInfo, &resolvedToken);
 
                 m_ip += 5;
@@ -6520,6 +6544,12 @@ retry_emit:
                 uint32_t token = getU4LittleEndian(m_ip + 1);
                 ResolveToken(token, CORINFO_TOKENKIND_Field, &resolvedToken);
                 m_compHnd->getFieldInfo(&resolvedToken, m_methodHnd, CORINFO_ACCESS_GET, &fieldInfo);
+
+                if (fieldInfo.accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&fieldInfo.accessCalloutHelper);
+                }
 
                 CorInfoType fieldType = fieldInfo.fieldType;
                 InterpType interpFieldType = GetInterpType(fieldType);
@@ -6543,6 +6573,12 @@ retry_emit:
                 uint32_t token = getU4LittleEndian(m_ip + 1);
                 ResolveToken(token, CORINFO_TOKENKIND_Field, &resolvedToken);
                 m_compHnd->getFieldInfo(&resolvedToken, m_methodHnd, CORINFO_ACCESS_GET, &fieldInfo);
+
+                if (fieldInfo.accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&fieldInfo.accessCalloutHelper);
+                }
 
                 CorInfoType fieldType = fieldInfo.fieldType;
                 InterpType interpFieldType = GetInterpType(fieldType);
@@ -6674,6 +6710,16 @@ retry_emit:
 
                 CORINFO_RESOLVED_TOKEN resolvedToken;
                 ResolveToken(token, CORINFO_TOKENKIND_Class, &resolvedToken);
+
+                CORINFO_HELPER_DESC calloutHelper;
+                CorInfoIsAccessAllowedResult accessAllowed =
+                    m_compHnd->canAccessClass(&resolvedToken, m_methodHnd, &calloutHelper);
+                if (accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&calloutHelper);
+                }
+
                 CORINFO_GENERICHANDLE_RESULT embedInfo;
                 m_compHnd->embedGenericHandle(&resolvedToken, true, m_methodInfo->ftn, &embedInfo);
                 assert(embedInfo.compileTimeHandle != NULL);
@@ -6960,6 +7006,12 @@ retry_emit:
                             NO_WAY("Currently do not support LDFTN of Parameterized functions");
                         }
 
+                        if (callInfo.accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                        {
+                            // Inject call to callsite callout helper
+                            EmitCallsiteCallout(&callInfo.callsiteCalloutHelper);
+                        }
+
 DO_LDFTN:
                         if (callInfo.kind == CORINFO_CALL)
                         {
@@ -7057,6 +7109,17 @@ DO_LDFTN:
                 CHECK_STACK(1);
                 CORINFO_RESOLVED_TOKEN resolvedToken;
                 ResolveToken(token, CORINFO_TOKENKIND_Box, &resolvedToken);
+
+                CORINFO_HELPER_DESC calloutHelper;
+                CorInfoIsAccessAllowedResult accessAllowed =
+                    m_compHnd->canAccessClass(&resolvedToken, m_methodHnd, &calloutHelper);
+                if (accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&calloutHelper);
+                }
+
+
                 if (m_compHnd->isValueClass(resolvedToken.hClass))
                 {
                     CORINFO_GENERICHANDLE_RESULT embedInfo;
@@ -7076,6 +7139,16 @@ DO_LDFTN:
                 CHECK_STACK(1);
                 CORINFO_RESOLVED_TOKEN resolvedToken;
                 ResolveToken(token, CORINFO_TOKENKIND_Class, &resolvedToken);
+
+                CORINFO_HELPER_DESC calloutHelper;
+                CorInfoIsAccessAllowedResult accessAllowed =
+                    m_compHnd->canAccessClass(&resolvedToken, m_methodHnd, &calloutHelper);
+                if (accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&calloutHelper);
+                }
+
                 CORINFO_GENERICHANDLE_RESULT embedInfo;
                 m_compHnd->embedGenericHandle(&resolvedToken, false, m_methodInfo->ftn, &embedInfo);
                 DeclarePointerIsClass((CORINFO_CLASS_HANDLE)embedInfo.compileTimeHandle);
@@ -7162,6 +7235,15 @@ DO_LDFTN:
 
                 CORINFO_RESOLVED_TOKEN resolvedToken;
                 ResolveToken(token, CORINFO_TOKENKIND_Newarr, &resolvedToken);
+
+                CORINFO_HELPER_DESC calloutHelper;
+                CorInfoIsAccessAllowedResult accessAllowed =
+                    m_compHnd->canAccessClass(&resolvedToken, m_methodHnd, &calloutHelper);
+                if (accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&calloutHelper);
+                }
 
                 CORINFO_CLASS_HANDLE arrayClsHnd = resolvedToken.hClass;
                 CorInfoHelpFunc helpFunc = m_compHnd->getNewArrHelper(arrayClsHnd);
@@ -7560,6 +7642,15 @@ DO_LDFTN:
                 CHECK_STACK(1);
                 CORINFO_RESOLVED_TOKEN resolvedToken;
                 ResolveToken(getU4LittleEndian(m_ip + 1), CORINFO_TOKENKIND_Casting, &resolvedToken);
+
+                CORINFO_HELPER_DESC calloutHelper;
+                CorInfoIsAccessAllowedResult accessAllowed =
+                    m_compHnd->canAccessClass(&resolvedToken, m_methodHnd, &calloutHelper);
+                if (accessAllowed == CORINFO_ACCESS_ILLEGAL)
+                {
+                    // Inject call to callsite callout helper
+                    EmitCallsiteCallout(&calloutHelper);
+                }
 
                 CorInfoHelpFunc castingHelper = m_compHnd->getCastingHelper(&resolvedToken, *m_ip == CEE_CASTCLASS /* throwing */);
 

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -746,6 +746,7 @@ private:
     void    EmitBox(StackInfo* pStackInfo, const CORINFO_GENERICHANDLE_RESULT &boxType, bool argByRef);
     void    EmitLeave(int32_t ilOffset, int32_t target);
     void    EmitPushSyncObject();
+    void    EmitCallsiteCallout(CORINFO_HELPER_DESC* calloutDesc);
 
     // Var Offset allocator
     TArray<InterpInst*, MemPoolAllocator> *m_pActiveCalls;

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -746,7 +746,8 @@ private:
     void    EmitBox(StackInfo* pStackInfo, const CORINFO_GENERICHANDLE_RESULT &boxType, bool argByRef);
     void    EmitLeave(int32_t ilOffset, int32_t target);
     void    EmitPushSyncObject();
-    void    EmitCallsiteCallout(CORINFO_HELPER_DESC* calloutDesc);
+    void    EmitCallsiteCallout(CorInfoIsAccessAllowedResult accessAllowed, CORINFO_HELPER_DESC* calloutDesc);
+    void    EmitCanAccessCallout(CORINFO_RESOLVED_TOKEN *pResolvedToken);
 
     // Var Offset allocator
     TArray<InterpInst*, MemPoolAllocator> *m_pActiveCalls;

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -403,6 +403,10 @@ OPDEF(INTOP_CALL_HELPER_V_AGS, "call.helper.v.ags", 6, 1, 2, InterpOpGenericHelp
 // Call a helper function with a signature of void helper(SVar1, AddrOfSVar2)
 OPDEF(INTOP_CALL_HELPER_V_SA, "call.helper.v.sa", 4, 0, 2, InterpOpHelperFtnNoArgs)
 
+// Call a helper function with a signature of void helper(Pointer,Pointer,Pointer)
+OPDEF(INTOP_CALL_HELPER_V_SS, "call.helper.v.ss", 4, 0, 2, InterpOpHelperFtnNoArgs)
+OPDEF(INTOP_CALL_HELPER_V_SSS, "call.helper.v.sss", 5, 0, 3, InterpOpHelperFtnNoArgs)
+
 OPDEF(INTOP_GENERICLOOKUP, "generic", 4, 1, 1, InterpOpGenericLookup)
 
 OPDEF(INTOP_CALL_FINALLY, "call.finally", 2, 0, 0, InterpOpBranch)

--- a/src/coreclr/interpreter/interpconfigvalues.h
+++ b/src/coreclr/interpreter/interpconfigvalues.h
@@ -22,6 +22,7 @@
 RELEASE_CONFIG_METHODSET(Interpreter, "Interpreter")
 CONFIG_METHODSET(InterpHaltOnCall, "InterpHaltOnCall"); // Assert in the compiler when compiling a call to these method(s)
 CONFIG_METHODSET(InterpHalt, "InterpHalt");
+CONFIG_METHODSET(InterpBreak, "InterpBreak"); // Break into the debugger when compiling this method
 CONFIG_METHODSET(InterpDump, "InterpDump");
 CONFIG_INTEGER(InterpList, "InterpList", 0); // List the methods which are compiled by the interpreter JIT
 RELEASE_CONFIG_INTEGER(InterpMode, "InterpMode", 0); // Interpreter mode, one of the following:

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2333,6 +2333,59 @@ MAIN_LOOP:
                     ip += 4;
                     break;
                 }
+                case INTOP_CALL_HELPER_V_SS:
+                {
+                    void* helperArg1 = LOCAL_VAR(ip[1], void*);
+                    void* helperArg2 = LOCAL_VAR(ip[2], void*);
+                    MethodDesc *pILTargetMethod = NULL;
+                    HELPER_FTN_V_PP helperFtn = GetPossiblyIndirectHelper<HELPER_FTN_V_PP>(pMethod, ip[3], &pILTargetMethod);
+                    if (pILTargetMethod != NULL)
+                    {
+                        returnOffset = pMethod->allocaSize;
+                        callArgsOffset = pMethod->allocaSize;
+
+                        // Pass arguments to the target method
+                        LOCAL_VAR(callArgsOffset, void*) = helperArg1;
+                        LOCAL_VAR(callArgsOffset + INTERP_STACK_SLOT_SIZE, void*) = helperArg2;
+
+                        targetMethod = pILTargetMethod;
+                        ip += 4;
+                        goto CALL_INTERP_METHOD;
+                    }
+
+                    _ASSERTE(helperFtn != NULL);
+                    helperFtn(helperArg1, helperArg2);
+                    ip += 4;
+                    break;
+                }
+
+                case INTOP_CALL_HELPER_V_SSS:
+                {
+                    void* helperArg1 = LOCAL_VAR(ip[1], void*);
+                    void* helperArg2 = LOCAL_VAR(ip[2], void*);
+                    void* helperArg3 = LOCAL_VAR(ip[3], void*);
+                    MethodDesc *pILTargetMethod = NULL;
+                    HELPER_FTN_V_PPP helperFtn = GetPossiblyIndirectHelper<HELPER_FTN_V_PPP>(pMethod, ip[4], &pILTargetMethod);
+                    if (pILTargetMethod != NULL)
+                    {
+                        returnOffset = pMethod->allocaSize;
+                        callArgsOffset = pMethod->allocaSize;
+
+                        // Pass arguments to the target method
+                        LOCAL_VAR(callArgsOffset, void*) = helperArg1;
+                        LOCAL_VAR(callArgsOffset + INTERP_STACK_SLOT_SIZE, void*) = helperArg2;
+                        LOCAL_VAR(callArgsOffset + 2 * INTERP_STACK_SLOT_SIZE, void*) = helperArg3;
+
+                        targetMethod = pILTargetMethod;
+                        ip += 5;
+                        goto CALL_INTERP_METHOD;
+                    }
+
+                    _ASSERTE(helperFtn != NULL);
+                    helperFtn(helperArg1, helperArg2, helperArg3);
+                    ip += 5;
+                    break;
+                }
 
                 case INTOP_CALLVIRT_TAIL:
                 case INTOP_CALLVIRT:


### PR DESCRIPTION
Add support for visibility and access checks, as well as ambiguous function identification
- Utilize the jit interface driven scheme where certain jit interface calls will inform the jit that it should inject a call to a helper function.

As a drive-by feature, add support for DOTNET_InterpBreak which works like DOTNET_JitBreak in that it will cause the interpreter compiler to assert when a function is about to go through the interpreter compiler. This is useful to make it easy to debug the interpreter compiler compiling a specific method.