### PR TITLE
Use Dictionary with StringComparer to avoid string allocations in System.Data.Common

### DIFF
--- a/src/libraries/System.Data.Common/src/System/Data/Common/AdapterUtil.Common.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/AdapterUtil.Common.cs
@@ -825,8 +825,7 @@ namespace System.Data.Common
             for (; ; ++uniqueIndex)
             {
                 string uniqueName = columnName + uniqueIndex.ToString(CultureInfo.InvariantCulture);
-                string lowerName = uniqueName.ToLowerInvariant();
-                if (hash.TryAdd(lowerName, index))
+                if (hash.TryAdd(uniqueName, index))
                 {
                     columnName = uniqueName;
                     break;


### PR DESCRIPTION
**Issue**

`System.Data.Common.ADP` internal helper class has `BuildSchemaTableInfoTableNames` method that calls `ToLowerInvariant` on a `string` in a loop only to perform a dictionary lookup.

**Suggested fix**

 Using `Dictionary<K, V>` with `StringComparer.InvariantCultureIgnoreCase` can avoid multiple `string` allocations in that method.

**How issue was found**

I came up with an idea of an analyzer that would look for `Dictionary<string, TValue>` lookups and find cases when a string allocation is made only to perform a lookup. In such a case an analyzer could recommend using `Dictionary<K, V>.GetAlternateLookup<ReadOnlySpan<char>>` to avoid an allocation. I prototyped such an analyzer and ran it as a standalone analysis tool against projects that are part of `src/libraries/sfx.slnx` solution. This is how I found this code. And in this particular case, I actually realized it should be even easier to fix by using `StringComparer`. This could probably be a second rule in the same analyzer.

**Analyzer proposal**

I submitted [analyzer proposal](https://github.com/dotnet/sdk/issues/51221) in SDK repo.