### PR TITLE
Make `BundledAppWithSubDirs` clean up bundled apps after each test case instead of after all tests in the class

### DIFF
--- a/src/installer/tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -224,6 +224,9 @@ namespace AppHost.Bundle.Tests
             DirectoryInfo expectedExtractDir = sharedTestState.SelfContainedApp.GetExtractionDir(Path.Combine(home, ".net"), bundledApp.Manifest);
             var extractedFiles = GetExpectedExtractedFiles(bundledApp.Manifest, bundledApp.Options);
             expectedExtractDir.Should().HaveFiles(extractedFiles);
+
+            // Extraction directory for this test is not associated with the SingleFileTestApp, so we need to explicitly delete it.
+            Directory.Delete(expectedExtractDir.FullName, recursive: true);
         }
 
         private static List<string> GetExpectedExtractedFiles(Manifest manifest, BundleOptions bundleOptions)

--- a/src/installer/tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
@@ -20,16 +20,20 @@ namespace AppHost.Bundle.Tests
             sharedTestState = fixture;
         }
 
-        private FluentAssertions.AndConstraint<CommandResultAssertions> RunTheApp(string path, bool selfContained, bool deleteExtracted = true)
+        private FluentAssertions.AndConstraint<CommandResultAssertions> RunTheApp(string path, bool selfContained, bool deleteApp = true)
         {
             CommandResult result = Command.Create(path)
                 .EnableTracingAndCaptureOutputs()
                 .DotNetRoot(selfContained ? null : TestContext.BuiltDotNet.BinPath)
                 .MultilevelLookup(false)
                 .Execute();
-            if (deleteExtracted)
+            if (deleteApp)
             {
                 DeleteExtractionDirectory(result);
+
+                // Delete the bundled app itself. It would already be cleaned up after all tests in this class run, but
+                // we do this early for test environments that may not have enough space for all the bundled apps at once.
+                FileUtils.DeleteFileIfPossible(path);
             }
 
             return result.Should().Pass()
@@ -65,7 +69,7 @@ namespace AppHost.Bundle.Tests
 
             // Run the bundled app
             bool shouldExtract = options.HasFlag(BundleOptions.BundleAllContent);
-            RunTheApp(singleFile, selfContained: false, deleteExtracted: !shouldExtract)
+            RunTheApp(singleFile, selfContained: false, deleteApp: !shouldExtract)
                 .And.CreateExtraction(shouldExtract);
 
             if (shouldExtract)
@@ -87,7 +91,7 @@ namespace AppHost.Bundle.Tests
 
             // Run the bundled app
             bool shouldExtract = options.HasFlag(BundleOptions.BundleAllContent);
-            RunTheApp(singleFile, selfContained: true, deleteExtracted: !shouldExtract)
+            RunTheApp(singleFile, selfContained: true, deleteApp: !shouldExtract)
                 .And.CreateExtraction(shouldExtract);
 
             if (shouldExtract)
@@ -107,7 +111,7 @@ namespace AppHost.Bundle.Tests
 
             // Run the bundled app
             bool shouldExtract = options.HasFlag(BundleOptions.BundleAllContent);
-            RunTheApp(singleFile, selfContained: true, deleteExtracted: !shouldExtract)
+            RunTheApp(singleFile, selfContained: true, deleteApp: !shouldExtract)
                 .And.CreateExtraction(shouldExtract);
 
             if (shouldExtract)
@@ -127,7 +131,7 @@ namespace AppHost.Bundle.Tests
 
             // Run the bundled app
             bool shouldExtract = options.HasFlag(BundleOptions.BundleAllContent);
-            RunTheApp(singleFile, selfContained: false, deleteExtracted: !shouldExtract)
+            RunTheApp(singleFile, selfContained: false, deleteApp: !shouldExtract)
                 .And.CreateExtraction(shouldExtract);
 
             if (shouldExtract)


### PR DESCRIPTION
The `BundledAppWithSubDirs` tests intermittently hit out of space issues in CI. They do clean up the bundled apps they create, but only after all tests in the class have run. This change makes those tests clean up earlier for environments that may not have the space for all the bundled apps at the same time. This also fixes the one case where we were leaving an extracted file (`mockcoreclr`) behind on non-Windows.

Fixes #119249 

cc @dotnet/appmodel @AaronRobinsonMSFT 