### PR TITLE
[RISC-V] Optimize redundant sext.w generation in GT_JCMP codegen

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3188,7 +3188,6 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
                     regOp1 = tmpRegOp1;
                 }
             }
- 
             if (tree->OperIs(GT_EQ, GT_NE))
             {
                 if ((imm != 0) || (cmpSize == EA_4BYTE))

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3454,13 +3454,13 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
             // But due to the safety reason, only a peephole optimization is done now.
             bool signExtOp1 = !(emit->isRedundantSignExtend(INS_sext_w, EA_8BYTE, tmpRegOp1, regOp1));
             bool signExtOp2 = !(emit->isRedundantSignExtend(INS_sext_w, EA_8BYTE, tmpRegOp2, regOp2));
-            
+
             if (signExtOp1)
             {
                 emit->emitIns_R_R(INS_sext_w, EA_8BYTE, tmpRegOp1, regOp1);
                 regOp1 = tmpRegOp1;
             }
-            
+
             if (signExtOp2)
             {
                 emit->emitIns_R_R(INS_sext_w, EA_8BYTE, tmpRegOp2, regOp2);

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -651,7 +651,7 @@ bool emitter::emitInsIsSignExtend(instruction ins)
     switch (ins)
     {
         case INS_sext_w: // R_R
-        case INS_lui: // R_I
+        case INS_lui:    // R_I
 
         // R_R_I
         case INS_lb:
@@ -717,15 +717,15 @@ bool emitter::isRedundantSignExtend(instruction ins, emitAttr size, regNumber ds
         return false;
     }
 
-    regNumber prevDst = emitLastIns->idReg1();
-    regNumber prevSrc = emitLastIns->idReg2();
+    regNumber prevDst  = emitLastIns->idReg1();
+    regNumber prevSrc  = emitLastIns->idReg2();
     emitAttr  prevSize = emitLastIns->idOpSize();
 
     bool isPrevInsSignExtend = emitInsIsSignExtend(emitLastIns->idIns());
 
     if (isPrevInsSignExtend && (prevDst == src))
     {
-        JITDUMP("\n -- suppressing 'sext.w reg%u, reg%u' as previous instruction already sign-extended " 
+        JITDUMP("\n -- suppressing 'sext.w reg%u, reg%u' as previous instruction already sign-extended "
                 "the register reg%u.\n",
                 dst, src, prevDst);
 

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -648,7 +648,7 @@ void emitter::emitIns_Mov(emitAttr attr, regNumber dstReg, regNumber srcReg, boo
 //
 bool emitter::emitInsIsSignExtend(instruction ins)
 {
-    switch(ins)
+    switch (ins)
     {
         case INS_sext_w: // R_R
         case INS_lui: // R_I

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -19,6 +19,8 @@ struct CnsVal
     bool    cnsReloc;
 };
 
+bool isRedundantSignExtend(instruction ins, emitAttr size, regNumber reg1, regNumber reg2);
+
 #ifdef DEBUG
 
 /************************************************************************/
@@ -61,6 +63,7 @@ private:
 bool emitInsIsLoad(instruction ins);
 bool emitInsIsStore(instruction ins);
 bool emitInsIsLoadOrStore(instruction ins);
+bool emitInsIsSignExtend(instruction ins);
 
 void emitDispInsName(
     code_t code, const BYTE* addr, bool doffs, unsigned insOffset, const instrDesc* id, const insGroup* ig);

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -19,7 +19,7 @@ struct CnsVal
     bool    cnsReloc;
 };
 
-bool isRedundantSignExtend(instruction ins, emitAttr size, regNumber reg1, regNumber reg2);
+bool isRedundantSignExtend(instruction ins, emitAttr size, regNumber dst, regNumber src);
 
 #ifdef DEBUG
 


### PR DESCRIPTION
There was an issue when emitting instructions for GT_JCMP nodes: 4-byte operands are always sign-extended before the comparison.

The commit suppresses emitting the 'sext.w' if the last instruction has already sign-extended the operands of JCMP. It cannot optimize out the sign-extension if a previously sign-extending instruction is not emitted right before the emission of the JCMP instruction, as it is implemented as a peephole optimization to conservatively preserve type safety.

The optimization slightly improves the performance of loop-intensive benchmark by reducing the instruction count of hot code, while not affecting the jit workload time.

@clamp03 @tomeksowi @SkyShield, @credo-quia-absurdum
part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung