### PR TITLE
[mono] Disable failing tests on Mono AOT linux-x64

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_101731/Runtime_101731.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_101731/Runtime_101731.cs
@@ -35,7 +35,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(float.MaxValue)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557", TestRuntimes.Mono)]
     public static void TestConvertToInt64NativeSingle(float value)
     {
         Func<float, long> func = float.ConvertToIntegerNative<long>;
@@ -45,7 +45,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(double.MaxValue)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557", TestRuntimes.Mono)]
     public static void TestConvertToUInt32NativeDouble(double value)
     {
         Func<double, uint> func = double.ConvertToIntegerNative<uint>;
@@ -55,7 +55,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(float.MaxValue)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557", TestRuntimes.Mono)]
     public static void TestConvertToUInt32NativeSingle(float value)
     {
         Func<float, uint> func = float.ConvertToIntegerNative<uint>;
@@ -65,7 +65,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(double.MaxValue)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557", TestRuntimes.Mono)]
     public static void TestConvertToUInt64NativeDouble(double value)
     {
         Func<double, ulong> func = double.ConvertToIntegerNative<ulong>;
@@ -75,7 +75,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(float.MaxValue)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557", TestRuntimes.Mono)]
     public static void TestConvertToUInt64NativeSingle(float value)
     {
         Func<float, ulong> func = float.ConvertToIntegerNative<ulong>;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_101731/Runtime_101731.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_101731/Runtime_101731.cs
@@ -35,6 +35,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(float.MaxValue)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
     public static void TestConvertToInt64NativeSingle(float value)
     {
         Func<float, long> func = float.ConvertToIntegerNative<long>;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_101731/Runtime_101731.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_101731/Runtime_101731.cs
@@ -45,6 +45,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(double.MaxValue)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
     public static void TestConvertToUInt32NativeDouble(double value)
     {
         Func<double, uint> func = double.ConvertToIntegerNative<uint>;
@@ -54,6 +55,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(float.MaxValue)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
     public static void TestConvertToUInt32NativeSingle(float value)
     {
         Func<float, uint> func = float.ConvertToIntegerNative<uint>;
@@ -63,6 +65,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(double.MaxValue)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
     public static void TestConvertToUInt64NativeDouble(double value)
     {
         Func<double, ulong> func = double.ConvertToIntegerNative<ulong>;
@@ -72,6 +75,7 @@ public static class Runtime_101731
 
     [Theory]
     [InlineData(float.MaxValue)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
     public static void TestConvertToUInt64NativeSingle(float value)
     {
         Func<float, ulong> func = float.ConvertToIntegerNative<ulong>;

--- a/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
+++ b/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/119948 -->
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExtendedLayout.cs" />

--- a/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
+++ b/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
@@ -4,7 +4,7 @@
 
     <!-- Tracking issue: https://github.com/dotnet/runtime/issues/119948 -->
     <MonoAotIncompatible>true</MonoAotIncompatible>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'minifullaot'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExtendedLayout.cs" />

--- a/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
+++ b/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayout.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
-    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/119948 -->
-    <MonoAotIncompatible>true</MonoAotIncompatible>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExtendedLayout.cs" />

--- a/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayoutTypes.ilproj
+++ b/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayoutTypes.ilproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <!-- Tracking issue: https://github.com/dotnet/runtime/issues/119948 -->
     <MonoAotIncompatible>true</MonoAotIncompatible>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'minifullaot'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExtendedLayoutTypes.il" />

--- a/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayoutTypes.ilproj
+++ b/src/tests/Loader/classloader/ExtendedLayout/ExtendedLayoutTypes.ilproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/119948 -->
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExtendedLayoutTypes.il" />

--- a/src/tests/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case13.cs
+++ b/src/tests/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case13.cs
@@ -155,6 +155,7 @@ public class Test
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
     public static void Validate_Explicit5_Invalid()
     {
         if (Environment.Is64BitProcess)

--- a/src/tests/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case13.cs
+++ b/src/tests/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case13.cs
@@ -155,7 +155,7 @@ public class Test
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557")]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/112557", TestRuntimes.Mono)]
     public static void Validate_Explicit5_Invalid()
     {
         if (Environment.Is64BitProcess)

--- a/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
@@ -5,6 +5,7 @@
     <!-- This test removes one of its dependencies at runtime, so it is not compatible with AOT  -->
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <NativeAotIncompatible>true</NativeAotIncompatible>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test76531.cs" />

--- a/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_76531/test76531.csproj
@@ -5,7 +5,7 @@
     <!-- This test removes one of its dependencies at runtime, so it is not compatible with AOT  -->
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <NativeAotIncompatible>true</NativeAotIncompatible>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'minifullaot'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test76531.cs" />


### PR DESCRIPTION
## Description

This PR disables tests that are failing on Mono FullAOT linux-x64. These are known issues and not new regressions.