### PR TITLE
Document API added in .NET 10.0

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
@@ -77,7 +77,7 @@ namespace System.Runtime.InteropServices.Java
         /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// The returned pointer is the exact value that was originally provided as
-        /// the <paramref name="context"/> parameter when the handle was created.
+        /// the context parameter when the handle was created.
         /// </remarks>
         public static unsafe void* GetContext(GCHandle obj)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
@@ -8,8 +8,32 @@ namespace System.Runtime.InteropServices.Java
 {
     [CLSCompliant(false)]
     [SupportedOSPlatform("android")]
+    /// <summary>
+    /// Provides helpers to create and manage GC handles used for tracking references
+    /// between the managed runtime and a Java VM. These APIs allow managed objects
+    /// to be referenced from native Java code so the runtime can participate in
+    /// cross-reference processing and correctly control object lifetime across
+    /// the managed/native boundary.
+    /// </summary>
     public static partial class JavaMarshal
     {
+        /// <summary>
+        /// Initializes the Java marshal subsystem with a callback used when the runtime
+        /// needs to mark managed objects that are referenced from Java during cross-
+        /// reference processing.
+        /// </summary>
+        /// <param name="markCrossReferences">A pointer to an unmanaged callback that
+        /// will be invoked to enumerate or mark managed objects referenced from Java
+        /// during a cross-reference sweep. The callback is expected to accept a
+        /// <see cref="MarkCrossReferencesArgs"/> pointer describing the objects to mark.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="markCrossReferences"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the subsystem cannot be initialized or is reinitialized.</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <remarks>
+        /// Only a single initialization is supported for the process. The runtime
+        /// stores the provided function pointer and will invoke it from internal
+        /// runtime code when cross-reference marking is required.
+        /// </remarks>
         public static unsafe void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences)
         {
             ArgumentNullException.ThrowIfNull(markCrossReferences);
@@ -20,6 +44,27 @@ namespace System.Runtime.InteropServices.Java
             }
         }
 
+        /// <summary>
+        /// Creates a GC handle that native Java code can hold to reference a managed
+        /// object. The handle prevents the object from being reclaimed while the
+        /// native side holds the reference, and an opaque <paramref name="context"/>
+        /// value can be associated with the handle for later retrieval.
+        /// </summary>
+        /// <param name="obj">The managed object to be referenced from native code.</param>
+        /// <param name="context">An opaque pointer-sized value that will be associated
+        /// with the handle and can be retrieved by the runtime via <see cref="GetContext(GCHandle)"/>.
+        /// Callers may use this to store native-side state or identifiers alongside
+        /// the handle.</param>
+        /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <remarks>
+        /// The CoreCLR implementation allocates the handle via an internal runtime
+        /// call and returns it as a <see cref="GCHandle"/>. Consumers must free or
+        /// otherwise release the handle as required by the runtime's handle management
+        /// policy on the native side (for example, when the corresponding Java reference
+        /// is released).
+        /// </remarks>
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             ArgumentNullException.ThrowIfNull(obj);
@@ -28,6 +73,18 @@ namespace System.Runtime.InteropServices.Java
             return GCHandle.FromIntPtr(handle);
         }
 
+        /// <summary>
+        /// Retrieves the opaque context pointer associated with a reference-tracking
+        /// GC handle previously created using <see cref="CreateReferenceTrackingHandle(object, void*)"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="GCHandle"/> whose context should be returned.</param>
+        /// <returns>The opaque context pointer associated with the handle.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the provided handle is invalid or does not represent a reference-tracking handle.</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <remarks>
+        /// The returned pointer is the exact value that was originally provided as
+        /// the <paramref name="context"/> parameter when the handle was created.
+        /// </remarks>
         public static unsafe void* GetContext(GCHandle obj)
         {
             IntPtr handle = GCHandle.ToIntPtr(obj);
@@ -40,6 +97,21 @@ namespace System.Runtime.InteropServices.Java
             return context;
         }
 
+        /// <summary>
+        /// Completes processing of cross references after the runtime has invoked the
+        /// provided <c>markCrossReferences</c> callback. This notifies the runtime of
+        /// handles that are no longer reachable from native Java code so the runtime
+        /// can release or update them accordingly.
+        /// </summary>
+        /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
+        /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <remarks>
+        /// The runtime will process the list of unreachable handles and take appropriate
+        /// action (for example, releasing internal references). The overload that accepts
+        /// a <see cref="ReadOnlySpan{GCHandle}"/> is a convenience helper that pins the
+        /// span and forwards a pointer and length to the internal runtime bridge call.
+        /// </remarks>
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
@@ -6,8 +6,6 @@ using System.Runtime.Versioning;
 
 namespace System.Runtime.InteropServices.Java
 {
-    [CLSCompliant(false)]
-    [SupportedOSPlatform("android")]
     /// <summary>
     /// Provides helpers to create and manage GC handles used for tracking references
     /// between the managed runtime and a Java VM. These APIs allow managed objects
@@ -15,6 +13,8 @@ namespace System.Runtime.InteropServices.Java
     /// cross-reference processing and correctly control object lifetime across
     /// the managed/native boundary.
     /// </summary>
+    [CLSCompliant(false)]
+    [SupportedOSPlatform("android")]
     public static partial class JavaMarshal
     {
         /// <summary>
@@ -33,6 +33,7 @@ namespace System.Runtime.InteropServices.Java
         /// Only a single initialization is supported for the process. The runtime
         /// stores the provided function pointer and will invoke it from internal
         /// runtime code when cross-reference marking is required.
+        /// Additionally, this callback must be implemented in unmanaged code.
         /// </remarks>
         public static unsafe void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences)
         {
@@ -58,13 +59,6 @@ namespace System.Runtime.InteropServices.Java
         /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
-        /// <remarks>
-        /// The CoreCLR implementation allocates the handle via an internal runtime
-        /// call and returns it as a <see cref="GCHandle"/>. Consumers must free or
-        /// otherwise release the handle as required by the runtime's handle management
-        /// policy on the native side (for example, when the corresponding Java reference
-        /// is released).
-        /// </remarks>
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             ArgumentNullException.ThrowIfNull(obj);
@@ -79,7 +73,7 @@ namespace System.Runtime.InteropServices.Java
         /// </summary>
         /// <param name="obj">The <see cref="GCHandle"/> whose context should be returned.</param>
         /// <returns>The opaque context pointer associated with the handle.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the provided handle is invalid or does not represent a reference-tracking handle.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the provided handle is null or does not represent a reference-tracking handle.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// The returned pointer is the exact value that was originally provided as
@@ -99,19 +93,13 @@ namespace System.Runtime.InteropServices.Java
 
         /// <summary>
         /// Completes processing of cross references after the runtime has invoked the
-        /// provided <c>markCrossReferences</c> callback. This notifies the runtime of
+        /// callback provided to <see cref="Initialize" />. This notifies the runtime of
         /// handles that are no longer reachable from native Java code so the runtime
         /// can release or update them accordingly.
         /// </summary>
         /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
         /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
         /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
-        /// <remarks>
-        /// The runtime will process the list of unreachable handles and take appropriate
-        /// action (for example, releasing internal references). The overload that accepts
-        /// a <see cref="ReadOnlySpan{GCHandle}"/> is a convenience helper that pins the
-        /// span and forwards a pointer and length to the internal runtime bridge call.
-        /// </remarks>
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
@@ -8,11 +8,13 @@ namespace System.Runtime.InteropServices.Java
 {
     /// <summary>
     /// Provides helpers to create and manage GC handles used for tracking references
-    /// between the managed runtime and a Java VM. These APIs allow managed objects
-    /// to be referenced from native Java code so the runtime can participate in
-    /// cross-reference processing and correctly control object lifetime across
-    /// the managed/native boundary.
+    /// between the managed runtime and a Java VM.
     /// </summary>
+    /// <remarks>
+    /// The APIs provided by this type allow managed objects to be referenced from native
+    /// Java code so the runtime can participate in cross-reference processing and
+    /// correctly control object lifetime across the managed/native boundary.
+    /// </remarks>
     [CLSCompliant(false)]
     [SupportedOSPlatform("android")]
     public static partial class JavaMarshal
@@ -26,9 +28,9 @@ namespace System.Runtime.InteropServices.Java
         /// will be invoked to enumerate or mark managed objects referenced from Java
         /// during a cross-reference sweep. The callback is expected to accept a
         /// <see cref="MarkCrossReferencesArgs"/> pointer describing the objects to mark.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="markCrossReferences"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown when the subsystem cannot be initialized or is reinitialized.</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="markCrossReferences"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The subsystem cannot be initialized or is reinitialized.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// Only a single initialization is supported for the process. The runtime
         /// stores the provided function pointer and will invoke it from internal
@@ -54,11 +56,11 @@ namespace System.Runtime.InteropServices.Java
         /// <param name="obj">The managed object to be referenced from native code.</param>
         /// <param name="context">An opaque pointer-sized value that will be associated
         /// with the handle and can be retrieved by the runtime via <see cref="GetContext(GCHandle)"/>.
-        /// Callers may use this to store native-side state or identifiers alongside
+        /// Callers can use this to store native-side state or identifiers alongside
         /// the handle.</param>
         /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="obj"/> is null.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             ArgumentNullException.ThrowIfNull(obj);
@@ -73,8 +75,8 @@ namespace System.Runtime.InteropServices.Java
         /// </summary>
         /// <param name="obj">The <see cref="GCHandle"/> whose context should be returned.</param>
         /// <returns>The opaque context pointer associated with the handle.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the provided handle is null or does not represent a reference-tracking handle.</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="InvalidOperationException">The provided handle is null or does not represent a reference-tracking handle.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// The returned pointer is the exact value that was originally provided as
         /// the context parameter when the handle was created.
@@ -99,7 +101,7 @@ namespace System.Runtime.InteropServices.Java
         /// </summary>
         /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
         /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.NativeAot.cs
@@ -75,7 +75,7 @@ namespace System.Runtime.InteropServices.Java
         /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// The returned pointer is the exact value that was originally provided as
-        /// the <paramref name="context"/> parameter when the handle was created.
+        /// the context parameter when the handle was created.
         /// </remarks>
         public static unsafe void* GetContext(GCHandle obj)
         {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.NativeAot.cs
@@ -8,8 +8,32 @@ namespace System.Runtime.InteropServices.Java
 {
     [CLSCompliant(false)]
     [SupportedOSPlatform("android")]
+    /// <summary>
+    /// Provides helpers to create and manage GC handles used for tracking references
+    /// between the managed runtime and a Java VM. These APIs allow managed objects
+    /// to be referenced from native Java code so the runtime can participate in
+    /// cross-reference processing and correctly control object lifetime across
+    /// the managed/native boundary.
+    /// </summary>
     public static partial class JavaMarshal
     {
+        /// <summary>
+        /// Initializes the Java marshal subsystem with a callback used when the runtime
+        /// needs to mark managed objects that are referenced from Java during cross-
+        /// reference processing.
+        /// </summary>
+        /// <param name="markCrossReferences">A pointer to an unmanaged callback that
+        /// will be invoked to enumerate or mark managed objects referenced from Java
+        /// during a cross-reference sweep. The callback is expected to accept a
+        /// <see cref="MarkCrossReferencesArgs"/> pointer describing the objects to mark.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="markCrossReferences"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the subsystem cannot be initialized or is reinitialized.</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <remarks>
+        /// Only a single initialization is supported for the process. The runtime
+        /// stores the provided function pointer and will invoke it from internal
+        /// runtime code when cross-reference marking is required.
+        /// </remarks>
         public static unsafe void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences)
         {
             ArgumentNullException.ThrowIfNull(markCrossReferences);
@@ -20,12 +44,45 @@ namespace System.Runtime.InteropServices.Java
             }
         }
 
+        /// <summary>
+        /// Creates a GC handle that native Java code can hold to reference a managed
+        /// object. The handle prevents the object from being reclaimed while the
+        /// native side holds the reference, and an opaque <paramref name="context"/>
+        /// value can be associated with the handle for later retrieval.
+        /// </summary>
+        /// <param name="obj">The managed object to be referenced from native code.</param>
+        /// <param name="context">An opaque pointer-sized value that will be associated
+        /// with the handle and can be retrieved by the runtime via <see cref="GetContext(GCHandle)"/>.
+        /// Callers may use this to store native-side state or identifiers alongside
+        /// the handle.</param>
+        /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <remarks>
+        /// The CoreCLR implementation allocates the handle via an internal runtime
+        /// call and returns it as a <see cref="GCHandle"/>. Consumers must free or
+        /// otherwise release the handle as required by the runtime's handle management
+        /// policy on the native side (for example, when the corresponding Java reference
+        /// is released).
+        /// </remarks>
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             ArgumentNullException.ThrowIfNull(obj);
             return GCHandle.FromIntPtr(RuntimeImports.RhHandleAllocCrossReference(obj, (IntPtr)context));
         }
 
+        /// <summary>
+        /// Retrieves the opaque context pointer associated with a reference-tracking
+        /// GC handle previously created using <see cref="CreateReferenceTrackingHandle(object, void*)"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="GCHandle"/> whose context should be returned.</param>
+        /// <returns>The opaque context pointer associated with the handle.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the provided handle is invalid or does not represent a reference-tracking handle.</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <remarks>
+        /// The returned pointer is the exact value that was originally provided as
+        /// the <paramref name="context"/> parameter when the handle was created.
+        /// </remarks>
         public static unsafe void* GetContext(GCHandle obj)
         {
             IntPtr handle = GCHandle.ToIntPtr(obj);
@@ -37,6 +94,21 @@ namespace System.Runtime.InteropServices.Java
             return (void*)context;
         }
 
+        /// <summary>
+        /// Completes processing of cross references after the runtime has invoked the
+        /// provided <c>markCrossReferences</c> callback. This notifies the runtime of
+        /// handles that are no longer reachable from native Java code so the runtime
+        /// can release or update them accordingly.
+        /// </summary>
+        /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
+        /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <remarks>
+        /// The runtime will process the list of unreachable handles and take appropriate
+        /// action (for example, releasing internal references). The overload that accepts
+        /// a <see cref="ReadOnlySpan{GCHandle}"/> is a convenience helper that pins the
+        /// span and forwards a pointer and length to the internal runtime bridge call.
+        /// </remarks>
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.NativeAot.cs
@@ -8,11 +8,13 @@ namespace System.Runtime.InteropServices.Java
 {
     /// <summary>
     /// Provides helpers to create and manage GC handles used for tracking references
-    /// between the managed runtime and a Java VM. These APIs allow managed objects
-    /// to be referenced from native Java code so the runtime can participate in
-    /// cross-reference processing and correctly control object lifetime across
-    /// the managed/native boundary.
+    /// between the managed runtime and a Java VM.
     /// </summary>
+    /// <remarks>
+    /// The APIs provided by this type allow managed objects to be referenced from native
+    /// Java code so the runtime can participate in cross-reference processing and
+    /// correctly control object lifetime across the managed/native boundary.
+    /// </remarks>
     [CLSCompliant(false)]
     [SupportedOSPlatform("android")]
     public static partial class JavaMarshal
@@ -26,9 +28,9 @@ namespace System.Runtime.InteropServices.Java
         /// will be invoked to enumerate or mark managed objects referenced from Java
         /// during a cross-reference sweep. The callback is expected to accept a
         /// <see cref="MarkCrossReferencesArgs"/> pointer describing the objects to mark.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="markCrossReferences"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown when the subsystem cannot be initialized or is reinitialized.</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="markCrossReferences"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The subsystem cannot be initialized or is reinitialized.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// Only a single initialization is supported for the process. The runtime
         /// stores the provided function pointer and will invoke it from internal
@@ -54,11 +56,11 @@ namespace System.Runtime.InteropServices.Java
         /// <param name="obj">The managed object to be referenced from native code.</param>
         /// <param name="context">An opaque pointer-sized value that will be associated
         /// with the handle and can be retrieved by the runtime via <see cref="GetContext(GCHandle)"/>.
-        /// Callers may use this to store native-side state or identifiers alongside
+        /// Callers can use this to store native-side state or identifiers alongside
         /// the handle.</param>
         /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="obj"/> is null.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             ArgumentNullException.ThrowIfNull(obj);
@@ -71,8 +73,8 @@ namespace System.Runtime.InteropServices.Java
         /// </summary>
         /// <param name="obj">The <see cref="GCHandle"/> whose context should be returned.</param>
         /// <returns>The opaque context pointer associated with the handle.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the provided handle is null or does not represent a reference-tracking handle.</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="InvalidOperationException">The provided handle is null or does not represent a reference-tracking handle.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// The returned pointer is the exact value that was originally provided as
         /// the context parameter when the handle was created.
@@ -96,7 +98,7 @@ namespace System.Runtime.InteropServices.Java
         /// </summary>
         /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
         /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)

--- a/src/libraries/System.Console/src/System/Console.cs
+++ b/src/libraries/System.Console/src/System/Console.cs
@@ -813,6 +813,10 @@ namespace System
             Out.WriteLine(value);
         }
 
+        /// <summary>
+        /// Writes the specified read-only span of characters, followed by the current line terminator, to the standard output stream.
+        /// </summary>
+        /// <param name="value">The span of characters to write.</param>
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static void WriteLine(ReadOnlySpan<char> value)
         {
@@ -975,6 +979,10 @@ namespace System
             Out.Write(value);
         }
 
+        /// <summary>
+        /// Writes the specified read-only span of characters to the standard output stream.
+        /// </summary>
+        /// <param name="value">The span of characters to write.</param>
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static void Write(ReadOnlySpan<char> value)
         {

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.Async.cs
@@ -32,6 +32,7 @@ public static partial class ZipFile
     /// <param name="archiveFileName">A string specifying the path on the filesystem to open the archive on. The path is permitted
     /// to specify relative or absolute path information. Relative path information is interpreted as relative to the current working directory.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result is an opened <see cref="ZipArchive"/> in <see cref="ZipArchiveMode.Read"/> mode.</returns>
     public static Task<ZipArchive> OpenReadAsync(string archiveFileName, CancellationToken cancellationToken = default) => OpenAsync(archiveFileName, ZipArchiveMode.Read, cancellationToken);
 
     /// <summary>
@@ -71,6 +72,7 @@ public static partial class ZipFile
     /// If the file exists and is empty or does not exist, a new Zip file will be created.
     /// Note that creating a Zip file with the <code>ZipArchiveMode.Create</code> mode is more efficient when creating a new Zip file.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result is an opened <see cref="ZipArchive"/> in the requested <paramref name="mode"/>.</returns>
     public static Task<ZipArchive> OpenAsync(string archiveFileName, ZipArchiveMode mode, CancellationToken cancellationToken = default) => OpenAsync(archiveFileName, mode, entryNameEncoding: null, cancellationToken);
 
     /// <summary>
@@ -149,6 +151,7 @@ public static partial class ZipFile
     ///     otherwise an <see cref="ArgumentException"/> is thrown.</para>
     /// </param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result is an opened <see cref="ZipArchive"/> in the requested <paramref name="mode"/>.</returns>
     public static async Task<ZipArchive> OpenAsync(string archiveFileName, ZipArchiveMode mode, Encoding? entryNameEncoding, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -212,6 +215,7 @@ public static partial class ZipFile
     /// <param name="sourceDirectoryName">The path to the directory on the file system to be archived. </param>
     /// <param name="destinationArchiveFileName">The name of the archive to be created.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous create operation. The task completes when the archive has been written to disk.</returns>
     public static Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName, CancellationToken cancellationToken = default) =>
         DoCreateFromDirectoryAsync(sourceDirectoryName, destinationArchiveFileName, compressionLevel: null, includeBaseDirectory: false, entryNameEncoding: null, cancellationToken);
 

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Extract.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Extract.Async.cs
@@ -40,6 +40,7 @@ public static partial class ZipFile
     /// <param name="sourceArchiveFileName">The path to the archive on the file system that is to be extracted.</param>
     /// <param name="destinationDirectoryName">The path to the directory in which to place the extracted files, specified as a relative or absolute path. A relative path is interpreted as relative to the current working directory.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
     public static Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, CancellationToken cancellationToken = default) =>
         ExtractToDirectoryAsync(sourceArchiveFileName, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: false, cancellationToken);
 
@@ -75,6 +76,7 @@ public static partial class ZipFile
     /// <param name="destinationDirectoryName">The path to the directory in which to place the extracted files, specified as a relative or absolute path. A relative path is interpreted as relative to the current working directory.</param>
     /// <param name="overwriteFiles">True to indicate overwrite.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
     public static Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default) =>
         ExtractToDirectoryAsync(sourceArchiveFileName, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: overwriteFiles, cancellationToken);
 
@@ -188,6 +190,7 @@ public static partial class ZipFile
     ///     otherwise an <see cref="ArgumentException"/> is thrown.</para>
     /// </param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
     public static async Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, Encoding? entryNameEncoding, bool overwriteFiles, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.Async.cs
@@ -42,7 +42,7 @@ public static partial class ZipFileExtensions
     /// relative or absolute path information. Relative path information is interpreted as relative to the current working directory.</param>
     /// <param name="entryName">The name of the entry to be created.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
-    /// <returns>A wrapper for the newly created entry.</returns>
+    /// <returns>A task that represents the asynchronous operation. The value of the task is the newly created entry.</returns>
     public static Task<ZipArchiveEntry> CreateEntryFromFileAsync(this ZipArchive destination, string sourceFileName, string entryName, CancellationToken cancellationToken = default) =>
         DoCreateEntryFromFileAsync(destination, sourceFileName, entryName, null, cancellationToken);
 
@@ -75,7 +75,7 @@ public static partial class ZipFileExtensions
     /// <param name="entryName">The name of the entry to be created.</param>
     /// <param name="compressionLevel">The level of the compression (speed/memory vs. compressed size trade-off).</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
-    /// <returns>A wrapper for the newly created entry.</returns>
+    /// <returns>A task that represents the asynchronous operation. The value of the task is the newly created entry.</returns>
     public static Task<ZipArchiveEntry> CreateEntryFromFileAsync(this ZipArchive destination,
                                                       string sourceFileName, string entryName, CompressionLevel compressionLevel, CancellationToken cancellationToken = default) =>
         DoCreateEntryFromFileAsync(destination, sourceFileName, entryName, compressionLevel, cancellationToken);

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Extract.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Extract.Async.cs
@@ -36,6 +36,7 @@ public static partial class ZipFileExtensions
     /// The directory specified must not exist. The path is permitted to specify relative or absolute path information.
     /// Relative path information is interpreted as relative to the current working directory.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
     public static Task ExtractToDirectoryAsync(this ZipArchive source, string destinationDirectoryName, CancellationToken cancellationToken = default) =>
         ExtractToDirectoryAsync(source, destinationDirectoryName, overwriteFiles: false, cancellationToken);
 
@@ -68,6 +69,7 @@ public static partial class ZipFileExtensions
     /// Relative path information is interpreted as relative to the current working directory.</param>
     /// <param name="overwriteFiles">True to indicate overwrite.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
     public static async Task ExtractToDirectoryAsync(this ZipArchive source, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.Async.cs
@@ -33,7 +33,8 @@ public static partial class ZipFileExtensions
     /// <param name="destinationFileName">The name of the file that will hold the contents of the entry.
     /// The path is permitted to specify relative or absolute path information.
     /// Relative path information is interpreted as relative to the current working directory.</param>
-    /// /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous extract operation. The task completes when the entry contents have been written to the destination file.</returns>
     public static Task ExtractToFileAsync(this ZipArchiveEntry source, string destinationFileName, CancellationToken cancellationToken = default) =>
         ExtractToFileAsync(source, destinationFileName, false, cancellationToken);
 
@@ -65,6 +66,7 @@ public static partial class ZipFileExtensions
     /// Relative path information is interpreted as relative to the current working directory.</param>
     /// <param name="overwrite">True to indicate overwrite.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous extract operation. The task completes when the entry contents have been written to the destination file.</returns>
     public static async Task ExtractToFileAsync(this ZipArchiveEntry source, string destinationFileName, bool overwrite, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -62,6 +62,7 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
     /// <exception cref="ArgumentOutOfRangeException">mode specified an invalid value.</exception>
     /// <exception cref="InvalidDataException">The contents of the stream could not be interpreted as a Zip file. -or- mode is Update and an entry is missing from the archive or is corrupt and cannot be read. -or- mode is Update and an entry is too large to fit into memory.</exception>
     /// <exception cref="ArgumentException">If a Unicode encoding other than UTF-8 is specified for the <code>entryNameEncoding</code>.</exception>
+    /// <returns>A task that represents the asynchronous initialization. The task result is a <see cref="ZipArchive"/> instance opened on the provided stream.</returns>
     public static async Task<ZipArchive> CreateAsync(Stream stream, ZipArchiveMode mode, bool leaveOpen, Encoding? entryNameEncoding, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -125,6 +125,10 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Asynchronously releases the resources used by the <see cref="ZipArchive"/>.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> that represents the asynchronous dispose operation.</returns>
     public async ValueTask DisposeAsync() => await DisposeAsyncCore().ConfigureAwait(false);
 
     protected virtual async ValueTask DisposeAsyncCore()

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -45,7 +45,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("Where`1", typeof(Enumerable))]
-        public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
+    public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
@@ -58,7 +58,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("Where`1", typeof(Enumerable))]
-        public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int, bool>> predicate)
+    public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int, bool>> predicate)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
@@ -2178,6 +2178,12 @@ namespace System.Linq
         }
 
         [DynamicDependency("Shuffle`1", typeof(Enumerable))]
+        /// <summary>
+        /// Returns an <see cref="IQueryable{TSource}"/> whose ordering of elements is randomized.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The sequence to shuffle.</param>
+        /// <returns>An <see cref="IQueryable{TSource}"/> representing a randomized ordering of <paramref name="source"/>.</returns>
         public static IQueryable<TSource> Shuffle<TSource>(this IQueryable<TSource> source)
         {
             ArgumentNullException.ThrowIfNull(source);

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -45,7 +45,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("Where`1", typeof(Enumerable))]
-    public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
+        public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
@@ -58,7 +58,7 @@ namespace System.Linq
         }
 
         [DynamicDependency("Where`1", typeof(Enumerable))]
-    public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int, bool>> predicate)
+        public static IQueryable<TSource> Where<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, int, bool>> predicate)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/Queryable.cs
@@ -2177,13 +2177,13 @@ namespace System.Linq
                     Expression.Constant(comparer, typeof(IEqualityComparer<TSource>))));
         }
 
-        [DynamicDependency("Shuffle`1", typeof(Enumerable))]
         /// <summary>
         /// Returns an <see cref="IQueryable{TSource}"/> whose ordering of elements is randomized.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The sequence to shuffle.</param>
         /// <returns>An <see cref="IQueryable{TSource}"/> representing a randomized ordering of <paramref name="source"/>.</returns>
+        [DynamicDependency("Shuffle`1", typeof(Enumerable))]
         public static IQueryable<TSource> Shuffle<TSource>(this IQueryable<TSource> source)
         {
             ArgumentNullException.ThrowIfNull(source);

--- a/src/libraries/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Reverse.cs
@@ -8,6 +8,12 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
+        /// <summary>
+        /// Returns a sequence with the elements of <paramref name="source"/> in reverse order.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The sequence whose elements should be reversed.</param>
+        /// <returns>An <see cref="IEnumerable{TSource}"/> that enumerates the elements of <paramref name="source"/> in reverse.</returns>
         public static IEnumerable<TSource> Reverse<TSource>(this IEnumerable<TSource> source)
         {
             if (source is null)
@@ -23,6 +29,12 @@ namespace System.Linq
             return new ReverseIterator<TSource>(source);
         }
 
+        /// <summary>
+        /// Returns a sequence with the elements of <paramref name="source"/> in reverse order.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The array whose elements should be reversed.</param>
+        /// <returns>An <see cref="IEnumerable{TSource}"/> that enumerates the elements of <paramref name="source"/> in reverse.</returns>
         public static IEnumerable<TSource> Reverse<TSource>(this TSource[] source)
         {
             if (source is null)

--- a/src/libraries/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Reverse.cs
@@ -34,7 +34,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The array whose elements should be reversed.</param>
-        /// <returns>An <see cref="IEnumerable{TSource}"/> that enumerates the elements of <paramref name="source"/> in reverse.</returns>
+        /// <returns>A sequence whose elements correspond to those of the input sequence in reverse order.</returns>
         public static IEnumerable<TSource> Reverse<TSource>(this TSource[] source)
         {
             if (source is null)

--- a/src/libraries/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Reverse.cs
@@ -13,7 +13,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The sequence whose elements should be reversed.</param>
-        /// <returns>An <see cref="IEnumerable{TSource}"/> that enumerates the elements of <paramref name="source"/> in reverse.</returns>
+        /// <returns>A sequence that enumerates the elements of <paramref name="source"/> in reverse.</returns>
         public static IEnumerable<TSource> Reverse<TSource>(this IEnumerable<TSource> source)
         {
             if (source is null)

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -230,6 +230,7 @@ namespace System.Net
 
         /// <summary>Determines whether the provided span contains a valid <see cref="IPAddress"/>.</summary>
         /// <param name="utf8Text">The text to parse.</param>
+        /// <returns><see langword="true"/> if <paramref name="utf8Text"/> contains a valid IP address; otherwise, <see langword="false"/>.</returns>
         public static bool IsValidUtf8(ReadOnlySpan<byte> utf8Text) => IPAddressParser.IsValid(utf8Text);
 
         /// <devdoc>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -776,6 +776,7 @@ namespace System.Net.Security
             return bytesRead == 1 ? oneByte : -1;
         }
 
+        /// <inheritdoc />
         public override unsafe int Read(Span<byte> buffer)
         {
             ThrowIfExceptionalOrNotAuthenticated();
@@ -797,6 +798,7 @@ namespace System.Net.Security
             }
         }
 
+        /// <inheritdoc />
         public override int Read(byte[] buffer, int offset, int count)
         {
             ThrowIfExceptionalOrNotAuthenticated();
@@ -806,8 +808,10 @@ namespace System.Net.Security
             return vt.GetAwaiter().GetResult();
         }
 
+        /// <inheritdoc />
         public override void WriteByte(byte value) => Write(new ReadOnlySpan<byte>(ref value));
 
+        /// <inheritdoc />
         public override unsafe void Write(ReadOnlySpan<byte> buffer)
         {
             ThrowIfExceptionalOrNotAuthenticated();
@@ -831,6 +835,7 @@ namespace System.Net.Security
 
         public void Write(byte[] buffer) => Write(buffer, 0, buffer.Length);
 
+        /// <inheritdoc />
         public override void Write(byte[] buffer, int offset, int count)
         {
             ThrowIfExceptionalOrNotAuthenticated();

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -345,6 +345,11 @@ namespace System
             return result.ToGuid();
         }
 
+        /// <summary>
+        /// Parses the specified sequence of UTF-8 encoded bytes and returns a new <see cref="Guid"/>.
+        /// </summary>
+        /// <param name="utf8Text">A span containing the UTF-8 encoded representation of the GUID to parse.</param>
+        /// <returns>The parsed <see cref="Guid"/>.</returns>
         public static Guid Parse(ReadOnlySpan<byte> utf8Text)
         {
             var result = new GuidResult(GuidParseThrowStyle.AllButOverflow);
@@ -380,6 +385,12 @@ namespace System
             }
         }
 
+        /// <summary>
+        /// Tries to parse the specified sequence of UTF-8 encoded bytes as a GUID.
+        /// </summary>
+        /// <param name="utf8Text">A span containing the UTF-8 encoded representation of the GUID to parse.</param>
+        /// <param name="result">When this method returns, contains the parsed <see cref="Guid"/>, if the parse succeeded; otherwise, the default value.</param>
+        /// <returns><see langword="true"/> if the parse operation succeeded; otherwise, <see langword="false"/>.</returns>
         public static bool TryParse(ReadOnlySpan<byte> utf8Text, out Guid result)
         {
             var parseResult = new GuidResult(GuidParseThrowStyle.None);

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -3632,17 +3632,10 @@ namespace System
         /// <param name="comparer">An optional comparer to use for element equality checks.</param>
         /// <typeparam name="T">The type of elements in the span and value.</typeparam>
         /// <returns><see langword="true"/> if <paramref name="span"/> ends with <paramref name="value"/>; otherwise, <see langword="false"/>.</returns>
-        public static bool EndsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value, IEqualityComparer<T>? comparer = null)
-        {
-            comparer ??= EqualityComparer<T>.Default;
-            if (value.Length > span.Length) return false;
-            int offset = span.Length - value.Length;
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (!comparer.Equals(span[offset + i], value[i])) return false;
-            }
-            return true;
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool EndsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value, IEqualityComparer<T>? comparer = null) =>
+            value.Length <= span.Length &&
+            SequenceEqual(span.Slice(span.Length - value.Length), value, comparer);
 
         /// <summary>
         /// Determines whether the specified value appears at the start of the span.

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -365,7 +365,7 @@ namespace System
         /// <summary>
         /// Searches for the specified value and returns true if found. If not found, returns false.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="T">The type of the elements in the span.</typeparam>
         /// <param name="span">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to use the default <see cref="IEqualityComparer{T}"/> for the type of an element.</param>
@@ -448,6 +448,7 @@ namespace System
         /// <summary>
         /// Searches for any occurrence of the specified <paramref name="value0"/> or <paramref name="value1"/>, and returns true if found. If not found, returns false.
         /// </summary>
+        /// <typeparam name="T">The type of the elements in the span.</typeparam>
         /// <param name="span">The span to search.</param>
         /// <param name="value0">One of the values to search for.</param>
         /// <param name="value1">One of the values to search for.</param>
@@ -458,6 +459,7 @@ namespace System
         /// <summary>
         /// Searches for any occurrence of the specified <paramref name="value0"/> or <paramref name="value1"/>, and returns true if found. If not found, returns false.
         /// </summary>
+        /// <typeparam name="T">The type of the elements in the span.</typeparam>
         /// <param name="span">The span to search.</param>
         /// <param name="value0">One of the values to search for.</param>
         /// <param name="value1">One of the values to search for.</param>
@@ -492,6 +494,7 @@ namespace System
         /// <summary>
         /// Searches for any occurrence of any of the specified <paramref name="values"/> and returns true if found. If not found, returns false.
         /// </summary>
+        /// <typeparam name="T">The type of the elements in the span.</typeparam>
         /// <param name="span">The span to search.</param>
         /// <param name="values">The set of values to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -501,6 +504,7 @@ namespace System
         /// <summary>
         /// Searches for any occurrence of any of the specified <paramref name="values"/> and returns true if found. If not found, returns false.
         /// </summary>
+        /// <typeparam name="T">The type of the elements in the span.</typeparam>
         /// <param name="span">The span to search.</param>
         /// <param name="values">The set of values to search for.</param>
         /// <param name="comparer">The comparer to use. If <see langword="null"/>, <see cref="EqualityComparer{T}.Default"/> is used.</param>
@@ -3574,11 +3578,13 @@ namespace System
         }
 
         /// <summary>
-        /// Determines whether a specified sequence appears at the start of a read-only span.
+        /// Determines whether the beginning of this span matches the specified sequence.
         /// </summary>
-        /// <param name="span">The source span.</param>
+        /// <param name="span">The span to search.</param>
         /// <param name="value">The sequence to compare to the start of <paramref name="span"/>.</param>
-        /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to use the default <see cref="IEqualityComparer{T}"/> for the type of an element.</param>
+        /// <param name="comparer">An optional comparer to use for element equality checks.</param>
+        /// <typeparam name="T">The type of elements in the span and value.</typeparam>
+        /// <returns><see langword="true"/> if <paramref name="span"/> starts with <paramref name="value"/>; otherwise, <see langword="false"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool StartsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value, IEqualityComparer<T>? comparer = null) =>
             value.Length <= span.Length &&
@@ -3619,15 +3625,24 @@ namespace System
         }
 
         /// <summary>
-        /// Determines whether the specified sequence appears at the end of the read-only span.
+        /// Determines whether the end of this span matches the specified sequence.
         /// </summary>
-        /// <param name="span">The source span.</param>
+        /// <param name="span">The span to search.</param>
         /// <param name="value">The sequence to compare to the end of <paramref name="span"/>.</param>
-        /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to use the default <see cref="IEqualityComparer{T}"/> for the type of an element.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EndsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value, IEqualityComparer<T>? comparer = null) =>
-            value.Length <= span.Length &&
-            SequenceEqual(span.Slice(span.Length - value.Length), value, comparer);
+        /// <param name="comparer">An optional comparer to use for element equality checks.</param>
+        /// <typeparam name="T">The type of elements in the span and value.</typeparam>
+        /// <returns><see langword="true"/> if <paramref name="span"/> ends with <paramref name="value"/>; otherwise, <see langword="false"/>.</returns>
+        public static bool EndsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value, IEqualityComparer<T>? comparer = null)
+        {
+            comparer ??= EqualityComparer<T>.Default;
+            if (value.Length > span.Length) return false;
+            int offset = span.Length - value.Length;
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (!comparer.Equals(span[offset + i], value[i])) return false;
+            }
+            return true;
+        }
 
         /// <summary>
         /// Determines whether the specified value appears at the start of the span.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
@@ -18,14 +18,15 @@ namespace System.Runtime.CompilerServices
         // "BypassReadyToRun" is until AOT/R2R typesystem has support for MethodImpl.Async
         // Must be NoInlining because we use AsyncSuspend to manufacture an explicit suspension point.
         // It will not capture/restore any local state that is live across it.
-        [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
-        [RequiresPreviewFeatures]
+
         /// <summary>
         /// Awaits the specified awaiter and returns when the awaiter has completed.
         /// </summary>
         /// <typeparam name="TAwaiter">The awaiter type.</typeparam>
         /// <param name="awaiter">The awaiter to await.</param>
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
+        [RequiresPreviewFeatures]
         public static void AwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
@@ -39,14 +40,15 @@ namespace System.Runtime.CompilerServices
 
         // Must be NoInlining because we use AsyncSuspend to manufacture an explicit suspension point.
         // It will not capture/restore any local state that is live across it.
-        [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
-        [RequiresPreviewFeatures]
+
         /// <summary>
         /// Awaits the specified awaiter without capturing the execution context and returns when the awaiter has completed.
         /// </summary>
         /// <typeparam name="TAwaiter">The awaiter type.</typeparam>
         /// <param name="awaiter">The awaiter to await.</param>
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
+        [RequiresPreviewFeatures]
         public static void UnsafeAwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
@@ -118,14 +120,14 @@ namespace System.Runtime.CompilerServices
             return awaiter.GetResult();
         }
 
-        [Intrinsic]
-        [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.Async)]
-        [RequiresPreviewFeatures]
         /// <summary>
         /// Awaits the specified <see cref="Task"/> and throws any exception produced by the task.
         /// </summary>
         /// <param name="task">The task to await.</param>
+        [Intrinsic]
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.Async)]
+        [RequiresPreviewFeatures]
         public static void Await(ValueTask task)
         {
             ValueTaskAwaiter awaiter = task.GetAwaiter();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
@@ -21,6 +21,11 @@ namespace System.Runtime.CompilerServices
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         [RequiresPreviewFeatures]
+        /// <summary>
+        /// Awaits the specified awaiter and returns when the awaiter has completed.
+        /// </summary>
+        /// <typeparam name="TAwaiter">The awaiter type.</typeparam>
+        /// <param name="awaiter">The awaiter to await.</param>
         public static void AwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
@@ -37,6 +42,11 @@ namespace System.Runtime.CompilerServices
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         [RequiresPreviewFeatures]
+        /// <summary>
+        /// Awaits the specified awaiter without capturing the execution context and returns when the awaiter has completed.
+        /// </summary>
+        /// <typeparam name="TAwaiter">The awaiter type.</typeparam>
+        /// <param name="awaiter">The awaiter to await.</param>
         public static void UnsafeAwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
@@ -48,6 +58,12 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(sentinelContinuation);
         }
 
+
+        /// <summary>
+        /// Awaits the specified <see cref="Task{T}"/> and returns its result, throwing any exception produced by the task.
+        /// </summary>
+        /// <typeparam name="T">The result type produced by the task.</typeparam>
+        /// <param name="task">The task to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -63,6 +79,10 @@ namespace System.Runtime.CompilerServices
             return awaiter.GetResult();
         }
 
+        /// <summary>
+        /// Awaits the specified <see cref="ValueTask"/> and throws any exception produced by the operation.
+        /// </summary>
+        /// <param name="task">The value task to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -78,6 +98,11 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
+        /// <summary>
+        /// Awaits the specified <see cref="ValueTask{T}"/> and returns its result, throwing any exception produced by the operation.
+        /// </summary>
+        /// <typeparam name="T">The result type produced by the value task.</typeparam>
+        /// <param name="task">The value task to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -97,6 +122,10 @@ namespace System.Runtime.CompilerServices
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
         [RequiresPreviewFeatures]
+        /// <summary>
+        /// Awaits the specified <see cref="Task"/> and throws any exception produced by the task.
+        /// </summary>
+        /// <param name="task">The task to await.</param>
         public static void Await(ValueTask task)
         {
             ValueTaskAwaiter awaiter = task.GetAwaiter();
@@ -108,6 +137,10 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
+        /// <summary>
+        /// Awaits the specified configured task awaitable without capturing the execution context and throws any exception produced by the operation.
+        /// </summary>
+        /// <param name="configuredAwaitable">The configured awaitable to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -123,6 +156,10 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
+        /// <summary>
+        /// Awaits the specified configured value task awaitable without capturing the execution context and throws any exception produced by the operation.
+        /// </summary>
+        /// <param name="configuredAwaitable">The configured value task awaitable to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -138,6 +175,11 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
+        /// <summary>
+        /// Awaits the specified configured task awaitable and returns its result, throwing any exception produced by the operation.
+        /// </summary>
+        /// <typeparam name="T">The result type produced by the awaitable.</typeparam>
+        /// <param name="configuredAwaitable">The configured awaitable to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -153,6 +195,11 @@ namespace System.Runtime.CompilerServices
             return awaiter.GetResult();
         }
 
+        /// <summary>
+        /// Awaits the specified configured value task awaitable and returns its result, throwing any exception produced by the operation.
+        /// </summary>
+        /// <typeparam name="T">The result type produced by the awaitable.</typeparam>
+        /// <param name="configuredAwaitable">The configured awaitable to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -19,6 +19,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Returns a pointer to the given by-ref parameter.
         /// </summary>
+        /// <typeparam name="T">The type referenced by the byref parameter.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__AS_POINTER
         // AOT:AsPointer
@@ -39,6 +40,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Returns the size of an object of the given type parameter.
         /// </summary>
+        /// <typeparam name="T">The type whose size is returned.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__SIZEOF
         // AOT:SizeOf
@@ -54,6 +56,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Casts the given object to the specified type, performs no dynamic type checking.
         /// </summary>
+        /// <typeparam name="T">The target reference type. The return value will be of this type.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__OBJECT_AS
         // AOT:As
@@ -72,6 +75,8 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Reinterprets the given reference as a reference to a value of type <typeparamref name="TTo"/>.
         /// </summary>
+        /// <typeparam name="TFrom">The source type of the reference to reinterpret.</typeparam>
+        /// <typeparam name="TTo">The destination type to reinterpret the reference as.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_AS
         // AOT:As
@@ -91,6 +96,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Adds an element offset to the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by <paramref name="source"/>.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_ADD
         // AOT:Add
@@ -118,6 +124,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Adds an element offset to the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by <paramref name="source"/>.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_INTPTR_ADD
         // AOT:Add
@@ -145,6 +152,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Adds an element offset to the given pointer.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by the pointer.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__PTR_ADD
         // AOT:Add
@@ -174,6 +182,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Adds an element offset to the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by <paramref name="source"/>.</typeparam>
         [Intrinsic]
         // CoreCLR:
         [NonVersionable]
@@ -200,6 +209,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Adds an byte offset to the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by the source.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_ADD_BYTE_OFFSET_UINTPTR
         // AOT:AddByteOffset
@@ -226,6 +236,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Determines whether the specified references point to the same location.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by the inputs.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_ARE_SAME
         // AOT:AreSame
@@ -652,6 +663,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Adds an byte offset to the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by the source.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_ADD_BYTE_OFFSET_INTPTR
         // AOT:AddByteOffset
@@ -809,6 +821,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Subtracts an element offset from the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by <paramref name="source"/>.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_INT_SUBTRACT
         [NonVersionable]
@@ -835,6 +848,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Subtracts an element offset from the given void pointer.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by the pointer.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__PTR_INT_SUBTRACT
         [NonVersionable]
@@ -862,6 +876,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Subtracts an element offset from the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by <paramref name="source"/>.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_INTPTR_SUBTRACT
         [NonVersionable]
@@ -887,6 +902,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Subtracts an element offset from the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by <paramref name="source"/>.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_UINTPTR_SUBTRACT
         [NonVersionable]
@@ -913,6 +929,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Subtracts a byte offset from the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by the source.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_INTPTR_SUBTRACT_BYTE_OFFSET
         [NonVersionable]
@@ -931,6 +948,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Subtracts a byte offset from the given reference.
         /// </summary>
+        /// <typeparam name="T">The element type referenced by the source.</typeparam>
         [Intrinsic]
         // CoreCLR:METHOD__UNSAFE__BYREF_UINTPTR_SUBTRACT_BYTE_OFFSET
         [NonVersionable]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionHandling.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionHandling.cs
@@ -17,12 +17,12 @@ namespace System.Runtime.ExceptionServices
             return s_handler?.Invoke(ex) == true;
         }
 
-    /// <summary>
-    /// Sets a handler for unhandled exceptions.
-    /// </summary>
-    /// <param name="handler">A callback that will be invoked for unhandled exceptions. Return <see langword="true"/> if the exception was handled; otherwise <see langword="false"/>.</param>
-    /// <exception cref="ArgumentNullException">If handler is null.</exception>
-    /// <exception cref="InvalidOperationException">If a handler is already set.</exception>
+        /// <summary>
+        /// Sets a handler for unhandled exceptions.
+        /// </summary>
+        /// <param name="handler">A callback that will be invoked for unhandled exceptions. Return <see langword="true"/> if the exception was handled; otherwise <see langword="false"/>.</param>
+        /// <exception cref="ArgumentNullException">If handler is null.</exception>
+        /// <exception cref="InvalidOperationException">If a handler is already set.</exception>
         /// <remarks>
         /// The handler will be called when an unhandled exception occurs.
         /// The handler should return true if the exception was handled, or false if it was not.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionHandling.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionHandling.cs
@@ -5,6 +5,9 @@ using System.Threading;
 
 namespace System.Runtime.ExceptionServices
 {
+    /// <summary>
+    /// Provides helpers for configuring and raising global unhandled exception handlers.
+    /// </summary>
     public static class ExceptionHandling
     {
         private static Func<Exception, bool>? s_handler;
@@ -14,11 +17,12 @@ namespace System.Runtime.ExceptionServices
             return s_handler?.Invoke(ex) == true;
         }
 
-        /// <summary>
-        /// Sets a handler for unhandled exceptions.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">If handler is null</exception>
-        /// <exception cref="InvalidOperationException">If a handler is already set</exception>
+    /// <summary>
+    /// Sets a handler for unhandled exceptions.
+    /// </summary>
+    /// <param name="handler">A callback that will be invoked for unhandled exceptions. Return <see langword="true"/> if the exception was handled; otherwise <see langword="false"/>.</param>
+    /// <exception cref="ArgumentNullException">If handler is null.</exception>
+    /// <exception cref="InvalidOperationException">If a handler is already set.</exception>
         /// <remarks>
         /// The handler will be called when an unhandled exception occurs.
         /// The handler should return true if the exception was handled, or false if it was not.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionHandling.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/ExceptionHandling.cs
@@ -21,11 +21,11 @@ namespace System.Runtime.ExceptionServices
         /// Sets a handler for unhandled exceptions.
         /// </summary>
         /// <param name="handler">A callback that will be invoked for unhandled exceptions. Return <see langword="true"/> if the exception was handled; otherwise <see langword="false"/>.</param>
-        /// <exception cref="ArgumentNullException">If handler is null.</exception>
-        /// <exception cref="InvalidOperationException">If a handler is already set.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="handler" /> is null.</exception>
+        /// <exception cref="InvalidOperationException">A handler is already set.</exception>
         /// <remarks>
-        /// The handler will be called when an unhandled exception occurs.
-        /// The handler should return true if the exception was handled, or false if it was not.
+        /// The handler is called when an unhandled exception occurs.
+        /// The handler should return <see langword="true" /> if the exception was handled, or <see langword="false" /> if it was not.
         /// If the handler returns false, the exception will continue to propagate as unhandled.
         ///
         /// The intent of this handler is to allow the user to handle unhandled exceptions

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
@@ -46,6 +46,10 @@ namespace System.Runtime.InteropServices
         /// Get a <see cref="Span{Byte}"/> view over a <see cref="BitArray"/>'s data.
         /// </summary>
         /// <param name="array">The <see cref="BitArray"/> whose backing storage should be viewed.</param>
+        /// <returns>
+        /// A <see cref="Span{Byte}"/> representing the underlying byte storage for the given <paramref name="array"/>,
+        /// or an empty span if <paramref name="array"/> is <see langword="null"/>.
+        /// </returns>
         /// <remarks>
         /// <para>
         /// The <see cref="BitArray"/> may have more capacity than is required to store the number of bits represented by

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandleExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandleExtensions.cs
@@ -22,6 +22,7 @@ namespace System.Runtime.InteropServices
         /// or <see langword="null"/> if the handle doesn't point to any object.
         /// </returns>
         /// <exception cref="NullReferenceException">If the handle is not initialized or already disposed.</exception>
+        /// <typeparam name="T">The element type of the pinned array.</typeparam>
         [CLSCompliant(false)]
         public static unsafe T* GetAddressOfArrayData<T>(
 #nullable disable // Nullable oblivious because no covariance between PinnedGCHandle<T> and PinnedGCHandle<T?>
@@ -45,6 +46,7 @@ namespace System.Runtime.InteropServices
         /// or <see langword="null"/> if the handle doesn't point to any object.
         /// </returns>
         /// <exception cref="NullReferenceException">If the handle is not initialized or already disposed.</exception>
+        /// <typeparam name="T">The element type of the string data (char).</typeparam>
         [CLSCompliant(false)]
         public static unsafe char* GetAddressOfStringData(
 #nullable disable // Nullable oblivious because no covariance between PinnedGCHandle<T> and PinnedGCHandle<T?>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandleExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandleExtensions.cs
@@ -46,7 +46,6 @@ namespace System.Runtime.InteropServices
         /// or <see langword="null"/> if the handle doesn't point to any object.
         /// </returns>
         /// <exception cref="NullReferenceException">If the handle is not initialized or already disposed.</exception>
-        /// <typeparam name="T">The element type of the string data (char).</typeparam>
         [CLSCompliant(false)]
         public static unsafe char* GetAddressOfStringData(
 #nullable disable // Nullable oblivious because no covariance between PinnedGCHandle<T> and PinnedGCHandle<T?>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.Unsupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.Unsupported.cs
@@ -6,8 +6,6 @@ using System.Runtime.Versioning;
 
 namespace System.Runtime.InteropServices.Java
 {
-    [CLSCompliant(false)]
-    [SupportedOSPlatform("android")]
     /// <summary>
     /// Provides helpers to create and manage GC handles used for tracking references
     /// between the managed runtime and a Java VM. These APIs allow managed objects
@@ -15,6 +13,8 @@ namespace System.Runtime.InteropServices.Java
     /// cross-reference processing and correctly control object lifetime across
     /// the managed/native boundary.
     /// </summary>
+    [CLSCompliant(false)]
+    [SupportedOSPlatform("android")]
     public static partial class JavaMarshal
     {
         /// <summary>
@@ -33,6 +33,7 @@ namespace System.Runtime.InteropServices.Java
         /// Only a single initialization is supported for the process. The runtime
         /// stores the provided function pointer and will invoke it from internal
         /// runtime code when cross-reference marking is required.
+        /// Additionally, this callback must be implemented in unmanaged code.
         /// </remarks>
         public static unsafe void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences)
         {
@@ -53,13 +54,6 @@ namespace System.Runtime.InteropServices.Java
         /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
-        /// <remarks>
-        /// The CoreCLR implementation allocates the handle via an internal runtime
-        /// call and returns it as a <see cref="GCHandle"/>. Consumers must free or
-        /// otherwise release the handle as required by the runtime's handle management
-        /// policy on the native side (for example, when the corresponding Java reference
-        /// is released).
-        /// </remarks>
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             throw new PlatformNotSupportedException();
@@ -71,7 +65,7 @@ namespace System.Runtime.InteropServices.Java
         /// </summary>
         /// <param name="obj">The <see cref="GCHandle"/> whose context should be returned.</param>
         /// <returns>The opaque context pointer associated with the handle.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the provided handle is invalid or does not represent a reference-tracking handle.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the provided handle is null or does not represent a reference-tracking handle.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// The returned pointer is the exact value that was originally provided as
@@ -84,19 +78,13 @@ namespace System.Runtime.InteropServices.Java
 
         /// <summary>
         /// Completes processing of cross references after the runtime has invoked the
-        /// provided <c>markCrossReferences</c> callback. This notifies the runtime of
+        /// callback provided to <see cref="Initialize" />. This notifies the runtime of
         /// handles that are no longer reachable from native Java code so the runtime
         /// can release or update them accordingly.
         /// </summary>
         /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
         /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
         /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
-        /// <remarks>
-        /// The runtime will process the list of unreachable handles and take appropriate
-        /// action (for example, releasing internal references). The overload that accepts
-        /// a <see cref="ReadOnlySpan{GCHandle}"/> is a convenience helper that pins the
-        /// span and forwards a pointer and length to the internal runtime bridge call.
-        /// </remarks>
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.Unsupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.Unsupported.cs
@@ -69,7 +69,7 @@ namespace System.Runtime.InteropServices.Java
         /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// The returned pointer is the exact value that was originally provided as
-        /// the <paramref name="context"/> parameter when the handle was created.
+        /// the context parameter when the handle was created.
         /// </remarks>
         public static unsafe void* GetContext(GCHandle obj)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.Unsupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.Unsupported.cs
@@ -8,11 +8,13 @@ namespace System.Runtime.InteropServices.Java
 {
     /// <summary>
     /// Provides helpers to create and manage GC handles used for tracking references
-    /// between the managed runtime and a Java VM. These APIs allow managed objects
-    /// to be referenced from native Java code so the runtime can participate in
-    /// cross-reference processing and correctly control object lifetime across
-    /// the managed/native boundary.
+    /// between the managed runtime and a Java VM.
     /// </summary>
+    /// <remarks>
+    /// The APIs provided by this type allow managed objects to be referenced from native
+    /// Java code so the runtime can participate in cross-reference processing and
+    /// correctly control object lifetime across the managed/native boundary.
+    /// </remarks>
     [CLSCompliant(false)]
     [SupportedOSPlatform("android")]
     public static partial class JavaMarshal
@@ -26,9 +28,9 @@ namespace System.Runtime.InteropServices.Java
         /// will be invoked to enumerate or mark managed objects referenced from Java
         /// during a cross-reference sweep. The callback is expected to accept a
         /// <see cref="MarkCrossReferencesArgs"/> pointer describing the objects to mark.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="markCrossReferences"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown when the subsystem cannot be initialized or is reinitialized.</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="markCrossReferences"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The subsystem cannot be initialized or is reinitialized.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// Only a single initialization is supported for the process. The runtime
         /// stores the provided function pointer and will invoke it from internal
@@ -49,11 +51,11 @@ namespace System.Runtime.InteropServices.Java
         /// <param name="obj">The managed object to be referenced from native code.</param>
         /// <param name="context">An opaque pointer-sized value that will be associated
         /// with the handle and can be retrieved by the runtime via <see cref="GetContext(GCHandle)"/>.
-        /// Callers may use this to store native-side state or identifiers alongside
+        /// Callers can use this to store native-side state or identifiers alongside
         /// the handle.</param>
         /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="obj"/> is null.</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="obj"/> is null.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             throw new PlatformNotSupportedException();
@@ -65,8 +67,8 @@ namespace System.Runtime.InteropServices.Java
         /// </summary>
         /// <param name="obj">The <see cref="GCHandle"/> whose context should be returned.</param>
         /// <returns>The opaque context pointer associated with the handle.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the provided handle is null or does not represent a reference-tracking handle.</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="InvalidOperationException">The provided handle is null or does not represent a reference-tracking handle.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         /// <remarks>
         /// The returned pointer is the exact value that was originally provided as
         /// the context parameter when the handle was created.
@@ -84,7 +86,7 @@ namespace System.Runtime.InteropServices.Java
         /// </summary>
         /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
         /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
-        /// <exception cref="PlatformNotSupportedException">Thrown when the runtime or platform does not support Java cross-reference marshalling.</exception>
+        /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -634,26 +634,26 @@ namespace System.Runtime.InteropServices
         }
 #endif
 
-    /// <summary>
-    /// Converts an HRESULT value to a corresponding CLR <see cref="Exception"/>.
-    /// </summary>
-    /// <param name="errorCode">The HRESULT value to convert.</param>
-    /// <returns>
-    /// An <see cref="Exception"/> that represents the supplied HRESULT, or
-    /// <see langword="null"/> if <paramref name="errorCode"/> indicates success (non-negative HRESULT).
-    /// </returns>
-    public static Exception? GetExceptionForHR(int errorCode) => GetExceptionForHR(errorCode, IntPtr.Zero);
+        /// <summary>
+        /// Converts an HRESULT value to a corresponding CLR <see cref="Exception"/>.
+        /// </summary>
+        /// <param name="errorCode">The HRESULT value to convert.</param>
+        /// <returns>
+        /// An <see cref="Exception"/> that represents the supplied HRESULT, or
+        /// <see langword="null"/> if <paramref name="errorCode"/> indicates success (non-negative HRESULT).
+        /// </returns>
+        public static Exception? GetExceptionForHR(int errorCode) => GetExceptionForHR(errorCode, IntPtr.Zero);
 
-    /// <summary>
-    /// Converts an HRESULT value and optional error information into a CLR <see cref="Exception"/>.
-    /// </summary>
-    /// <param name="errorCode">The HRESULT value to convert.</param>
-    /// <param name="errorInfo">Optional platform-specific error information (for example IErrorInfo on COM platforms), or <see cref="IntPtr.Zero"/> when not provided.</param>
-    /// <returns>
-    /// An <see cref="Exception"/> that represents the supplied HRESULT and error information, or
-    /// <see langword="null"/> if <paramref name="errorCode"/> indicates success (non-negative HRESULT).
-    /// </returns>
-    public static Exception? GetExceptionForHR(int errorCode, IntPtr errorInfo)
+        /// <summary>
+        /// Converts an HRESULT value and optional error information into a CLR <see cref="Exception"/>.
+        /// </summary>
+        /// <param name="errorCode">The HRESULT value to convert.</param>
+        /// <param name="errorInfo">Optional platform-specific error information (for example IErrorInfo on COM platforms), or <see cref="IntPtr.Zero"/> when not provided.</param>
+        /// <returns>
+        /// An <see cref="Exception"/> that represents the supplied HRESULT and error information, or
+        /// <see langword="null"/> if <paramref name="errorCode"/> indicates success (non-negative HRESULT).
+        /// </returns>
+        public static Exception? GetExceptionForHR(int errorCode, IntPtr errorInfo)
         {
             if (errorCode >= 0)
             {
@@ -663,17 +663,17 @@ namespace System.Runtime.InteropServices
             return GetExceptionForHRInternal(errorCode, errorInfo);
         }
 
-    /// <summary>
-    /// Converts an HRESULT value that is associated with a COM interface call into a CLR <see cref="Exception"/>.
-    /// </summary>
-    /// <param name="errorCode">The HRESULT value to convert.</param>
-    /// <param name="iid">The interface ID that was involved in the failing call. This may be used when probing for additional error info.</param>
-    /// <param name="pUnk">A pointer to the COM object involved in the failing call, or <see cref="IntPtr.Zero"/> if unavailable.</param>
-    /// <returns>
-    /// An <see cref="Exception"/> that represents the supplied HRESULT and COM context, or
-    /// <see langword="null"/> if <paramref name="errorCode"/> indicates success (non-negative HRESULT).
-    /// </returns>
-    public static Exception? GetExceptionForHR(int errorCode, in Guid iid, IntPtr pUnk)
+        /// <summary>
+        /// Converts an HRESULT value that is associated with a COM interface call into a CLR <see cref="Exception"/>.
+        /// </summary>
+        /// <param name="errorCode">The HRESULT value to convert.</param>
+        /// <param name="iid">The interface ID that was involved in the failing call. This may be used when probing for additional error info.</param>
+        /// <param name="pUnk">A pointer to the COM object involved in the failing call, or <see cref="IntPtr.Zero"/> if unavailable.</param>
+        /// <returns>
+        /// An <see cref="Exception"/> that represents the supplied HRESULT and COM context, or
+        /// <see langword="null"/> if <paramref name="errorCode"/> indicates success (non-negative HRESULT).
+        /// </returns>
+        public static Exception? GetExceptionForHR(int errorCode, in Guid iid, IntPtr pUnk)
         {
             if (errorCode >= 0)
             {
@@ -923,12 +923,12 @@ namespace System.Runtime.InteropServices
 #pragma warning restore IDE0060
 #endif
 
-    /// <summary>
-    /// Throws a CLR exception that corresponds to the given HRESULT if it represents a failure.
-    /// </summary>
-    /// <param name="errorCode">The HRESULT value to evaluate.</param>
-    /// <exception cref="Exception">An exception corresponding to <paramref name="errorCode"/> when it is a failure (negative HRESULT).</exception>
-    public static void ThrowExceptionForHR(int errorCode)
+        /// <summary>
+        /// Throws a CLR exception that corresponds to the given HRESULT if it represents a failure.
+        /// </summary>
+        /// <param name="errorCode">The HRESULT value to evaluate.</param>
+        /// <exception cref="Exception">An exception corresponding to <paramref name="errorCode"/> when it is a failure (negative HRESULT).</exception>
+        public static void ThrowExceptionForHR(int errorCode)
         {
             if (errorCode < 0)
             {
@@ -936,13 +936,13 @@ namespace System.Runtime.InteropServices
             }
         }
 
-    /// <summary>
-    /// Throws a CLR exception that corresponds to the given HRESULT and error information if it represents a failure.
-    /// </summary>
-    /// <param name="errorCode">The HRESULT value to evaluate.</param>
-    /// <param name="errorInfo">Optional platform-specific error information to be used when constructing the exception.</param>
-    /// <exception cref="Exception">An exception corresponding to <paramref name="errorCode"/> when it is a failure (negative HRESULT).</exception>
-    public static void ThrowExceptionForHR(int errorCode, IntPtr errorInfo)
+        /// <summary>
+        /// Throws a CLR exception that corresponds to the given HRESULT and error information if it represents a failure.
+        /// </summary>
+        /// <param name="errorCode">The HRESULT value to evaluate.</param>
+        /// <param name="errorInfo">Optional platform-specific error information to be used when constructing the exception.</param>
+        /// <exception cref="Exception">An exception corresponding to <paramref name="errorCode"/> when it is a failure (negative HRESULT).</exception>
+        public static void ThrowExceptionForHR(int errorCode, IntPtr errorInfo)
         {
             if (errorCode < 0)
             {
@@ -950,14 +950,14 @@ namespace System.Runtime.InteropServices
             }
         }
 
-    /// <summary>
-    /// Throws a CLR exception that corresponds to the given HRESULT and COM context if it represents a failure.
-    /// </summary>
-    /// <param name="errorCode">The HRESULT value to evaluate.</param>
-    /// <param name="iid">The interface ID that was involved in the failing call.</param>
-    /// <param name="pUnk">A pointer to the COM object involved in the failing call, or <see cref="IntPtr.Zero"/> if unavailable.</param>
-    /// <exception cref="Exception">An exception corresponding to <paramref name="errorCode"/> when it is a failure (negative HRESULT).</exception>
-    public static void ThrowExceptionForHR(int errorCode, in Guid iid, IntPtr pUnk)
+        /// <summary>
+        /// Throws a CLR exception that corresponds to the given HRESULT and COM context if it represents a failure.
+        /// </summary>
+        /// <param name="errorCode">The HRESULT value to evaluate.</param>
+        /// <param name="iid">The interface ID that was involved in the failing call.</param>
+        /// <param name="pUnk">A pointer to the COM object involved in the failing call, or <see cref="IntPtr.Zero"/> if unavailable.</param>
+        /// <exception cref="Exception">An exception corresponding to <paramref name="errorCode"/> when it is a failure (negative HRESULT).</exception>
+        public static void ThrowExceptionForHR(int errorCode, in Guid iid, IntPtr pUnk)
         {
             if (errorCode < 0)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -634,12 +634,26 @@ namespace System.Runtime.InteropServices
         }
 #endif
 
-        /// <summary>
-        /// Converts the HRESULT to a CLR exception.
-        /// </summary>
-        public static Exception? GetExceptionForHR(int errorCode) => GetExceptionForHR(errorCode, IntPtr.Zero);
+    /// <summary>
+    /// Converts an HRESULT value to a corresponding CLR <see cref="Exception"/>.
+    /// </summary>
+    /// <param name="errorCode">The HRESULT value to convert.</param>
+    /// <returns>
+    /// An <see cref="Exception"/> that represents the supplied HRESULT, or
+    /// <see langword="null"/> if <paramref name="errorCode"/> indicates success (non-negative HRESULT).
+    /// </returns>
+    public static Exception? GetExceptionForHR(int errorCode) => GetExceptionForHR(errorCode, IntPtr.Zero);
 
-        public static Exception? GetExceptionForHR(int errorCode, IntPtr errorInfo)
+    /// <summary>
+    /// Converts an HRESULT value and optional error information into a CLR <see cref="Exception"/>.
+    /// </summary>
+    /// <param name="errorCode">The HRESULT value to convert.</param>
+    /// <param name="errorInfo">Optional platform-specific error information (for example IErrorInfo on COM platforms), or <see cref="IntPtr.Zero"/> when not provided.</param>
+    /// <returns>
+    /// An <see cref="Exception"/> that represents the supplied HRESULT and error information, or
+    /// <see langword="null"/> if <paramref name="errorCode"/> indicates success (non-negative HRESULT).
+    /// </returns>
+    public static Exception? GetExceptionForHR(int errorCode, IntPtr errorInfo)
         {
             if (errorCode >= 0)
             {
@@ -649,7 +663,17 @@ namespace System.Runtime.InteropServices
             return GetExceptionForHRInternal(errorCode, errorInfo);
         }
 
-        public static Exception? GetExceptionForHR(int errorCode, in Guid iid, IntPtr pUnk)
+    /// <summary>
+    /// Converts an HRESULT value that is associated with a COM interface call into a CLR <see cref="Exception"/>.
+    /// </summary>
+    /// <param name="errorCode">The HRESULT value to convert.</param>
+    /// <param name="iid">The interface ID that was involved in the failing call. This may be used when probing for additional error info.</param>
+    /// <param name="pUnk">A pointer to the COM object involved in the failing call, or <see cref="IntPtr.Zero"/> if unavailable.</param>
+    /// <returns>
+    /// An <see cref="Exception"/> that represents the supplied HRESULT and COM context, or
+    /// <see langword="null"/> if <paramref name="errorCode"/> indicates success (non-negative HRESULT).
+    /// </returns>
+    public static Exception? GetExceptionForHR(int errorCode, in Guid iid, IntPtr pUnk)
         {
             if (errorCode >= 0)
             {
@@ -899,10 +923,12 @@ namespace System.Runtime.InteropServices
 #pragma warning restore IDE0060
 #endif
 
-        /// <summary>
-        /// Throws a CLR exception based on the HRESULT.
-        /// </summary>
-        public static void ThrowExceptionForHR(int errorCode)
+    /// <summary>
+    /// Throws a CLR exception that corresponds to the given HRESULT if it represents a failure.
+    /// </summary>
+    /// <param name="errorCode">The HRESULT value to evaluate.</param>
+    /// <exception cref="Exception">An exception corresponding to <paramref name="errorCode"/> when it is a failure (negative HRESULT).</exception>
+    public static void ThrowExceptionForHR(int errorCode)
         {
             if (errorCode < 0)
             {
@@ -910,7 +936,13 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        public static void ThrowExceptionForHR(int errorCode, IntPtr errorInfo)
+    /// <summary>
+    /// Throws a CLR exception that corresponds to the given HRESULT and error information if it represents a failure.
+    /// </summary>
+    /// <param name="errorCode">The HRESULT value to evaluate.</param>
+    /// <param name="errorInfo">Optional platform-specific error information to be used when constructing the exception.</param>
+    /// <exception cref="Exception">An exception corresponding to <paramref name="errorCode"/> when it is a failure (negative HRESULT).</exception>
+    public static void ThrowExceptionForHR(int errorCode, IntPtr errorInfo)
         {
             if (errorCode < 0)
             {
@@ -918,7 +950,14 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        public static void ThrowExceptionForHR(int errorCode, in Guid iid, IntPtr pUnk)
+    /// <summary>
+    /// Throws a CLR exception that corresponds to the given HRESULT and COM context if it represents a failure.
+    /// </summary>
+    /// <param name="errorCode">The HRESULT value to evaluate.</param>
+    /// <param name="iid">The interface ID that was involved in the failing call.</param>
+    /// <param name="pUnk">A pointer to the COM object involved in the failing call, or <see cref="IntPtr.Zero"/> if unavailable.</param>
+    /// <exception cref="Exception">An exception corresponding to <paramref name="errorCode"/> when it is a failure (negative HRESULT).</exception>
+    public static void ThrowExceptionForHR(int errorCode, in Guid iid, IntPtr pUnk)
         {
             if (errorCode < 0)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -664,7 +664,7 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>
-        /// Converts an HRESULT value that is associated with a COM interface call into a CLR <see cref="Exception"/>.
+        /// Converts an HRESULT value that is associated with a COM interface call into a CLR <see cref="Exception"/>, using extended COM error information if the provided COM object supports it.
         /// </summary>
         /// <param name="errorCode">The HRESULT value to convert.</param>
         /// <param name="iid">The interface ID that was involved in the failing call. This may be used when probing for additional error info.</param>
@@ -951,7 +951,7 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>
-        /// Throws a CLR exception that corresponds to the given HRESULT and COM context if it represents a failure.
+        /// Throws a CLR exception that corresponds to the given HRESULT and COM context if it represents a failure, using extended COM error information if the provided COM object supports it.
         /// </summary>
         /// <param name="errorCode">The HRESULT value to evaluate.</param>
         /// <param name="iid">The interface ID that was involved in the failing call.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -667,7 +667,7 @@ namespace System.Runtime.InteropServices
         /// Converts an HRESULT value that is associated with a COM interface call into a CLR <see cref="Exception"/>, using extended COM error information if the provided COM object supports it.
         /// </summary>
         /// <param name="errorCode">The HRESULT value to convert.</param>
-        /// <param name="iid">The interface ID that was involved in the failing call. This may be used when probing for additional error info.</param>
+        /// <param name="iid">The interface ID that was involved in the failing call. This ID can be used when probing for additional error information.</param>
         /// <param name="pUnk">A pointer to the COM object involved in the failing call, or <see cref="IntPtr.Zero"/> if unavailable.</param>
         /// <returns>
         /// An <see cref="Exception"/> that represents the supplied HRESULT and COM context, or

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/WeakGCHandle.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/WeakGCHandle.T.cs
@@ -59,6 +59,7 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>Sets the object this handle represents.</summary>
+        /// <param name="target">The object to assign to this handle.</param>
         /// <exception cref="NullReferenceException">If the handle is not initialized or already disposed.</exception>
         public readonly void SetTarget(T target)
         {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -2090,6 +2090,7 @@ namespace System.Runtime.Serialization.DataContracts
             ImportKnownTypeAttributes(type, typesChecked, ref nameToDataContractTable);
         }
 
+        /// <inheritdoc/>
         public sealed override bool Equals(object? obj)
         {
             if ((object)this == obj)
@@ -2125,6 +2126,7 @@ namespace System.Runtime.Serialization.DataContracts
             return false;
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return base.GetHashCode();

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/DeserializationEventHandler.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/DeserializationEventHandler.cs
@@ -5,5 +5,6 @@ namespace System.Runtime.Serialization
 {
     internal delegate void DeserializationEventHandler(object? sender);
 
+    /// <forInternalUseOnly />
     public delegate void SerializationEventHandler(StreamingContext context);
 }

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
@@ -1611,6 +1611,7 @@ namespace System.Runtime.Serialization
         }
     }
 
+    /// <forInternalUseOnly />
     public sealed class TypeLoadExceptionHolder
     {
         internal TypeLoadExceptionHolder(string? typeName)


### PR DESCRIPTION
Related #120483, #120512, #120495, #120496, #120499, #120497, #120498, #120501, #120502, #120503, #120505, #120504, #120509, #120510

This was the result of a copilot agent being asked to document all undocumented API mentioned in #120483, with the exception of Numerics and Intrinsics.  It did OK, but I had to clean a lot up.

Most of these will still need to be ported over, but I figured we might as well do it in source and review in runtime first, then I'll do a batch port.

Please review for accuracy 
- [x] @jkoritzinsky - Interop
- [x] @rzikm - Compression
- [ ] @VSadov - Async