### PR TITLE
[iOS] Fix `SkipOnCI` attribute support on Apple mobile devices

### DIFF
--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -30,13 +30,10 @@
     <_AppleBuildCommand Condition="'$(IncludesTestRunner)' != 'true'">apple run</_AppleBuildCommand>
 
     <_AppleExpectedExitCode Condition="'$(ExpectedExitCode)' != ''">--expected-exit-code $(ExpectedExitCode)</_AppleExpectedExitCode>
-    <_DotNetCIEnvSwitch>$${DOTNET_CI:+--set-env=DOTNET_CI=&quot;$DOTNET_CI&quot;}</_DotNetCIEnvSwitch>
-    <_HelixWorkItemRootEnvSwitch>$${HELIX_WORKITEM_ROOT:+--set-env=HELIX_WORKITEM_ROOT=&quot;$HELIX_WORKITEM_ROOT&quot;}</_HelixWorkItemRootEnvSwitch>
-    <_AgentOSEnvSwitch>$${AGENT_OS:+--set-env=AGENT_OS=&quot;$AGENT_OS&quot;}</_AgentOSEnvSwitch>
     <_AfterBuildCommands>
       mv $XHARNESS_OUT/AOTBuild.binlog &quot;$HELIX_WORKITEM_UPLOAD_ROOT&quot;
       $(_AppleSignCommand)
-      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) $(_DotNetCIEnvSwitch) $(_HelixWorkItemRootEnvSwitch) $(_AgentOSEnvSwitch) -- </_AfterBuildCommands>
+      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=DOTNET_CI=&quot;$DOTNET_CI&quot; --set-env=HELIX_WORKITEM_ROOT=&quot;$HELIX_WORKITEM_ROOT&quot; --set-env=AGENT_OS=&quot;$AGENT_OS&quot; -- </_AfterBuildCommands>
 
     <RunScriptCommand>$(_AOTBuildCommand) $(_AfterBuildCommands)</RunScriptCommand>
   </PropertyGroup>

--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -33,7 +33,7 @@
     <_AfterBuildCommands>
       mv $XHARNESS_OUT/AOTBuild.binlog &quot;$HELIX_WORKITEM_UPLOAD_ROOT&quot;
       $(_AppleSignCommand)
-      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) -- </_AfterBuildCommands>
+      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=DOTNET_CI=&quot;$DOTNET_CI&quot; -- </_AfterBuildCommands>
 
     <RunScriptCommand>$(_AOTBuildCommand) $(_AfterBuildCommands)</RunScriptCommand>
   </PropertyGroup>

--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -30,10 +30,13 @@
     <_AppleBuildCommand Condition="'$(IncludesTestRunner)' != 'true'">apple run</_AppleBuildCommand>
 
     <_AppleExpectedExitCode Condition="'$(ExpectedExitCode)' != ''">--expected-exit-code $(ExpectedExitCode)</_AppleExpectedExitCode>
+    <_DotNetCIEnvSwitch>$${DOTNET_CI:+--set-env=DOTNET_CI=&quot;$$DOTNET_CI&quot;}</_DotNetCIEnvSwitch>
+    <_HelixWorkItemRootEnvSwitch>$${HELIX_WORKITEM_ROOT:+--set-env=HELIX_WORKITEM_ROOT=&quot;$$HELIX_WORKITEM_ROOT&quot;}</_HelixWorkItemRootEnvSwitch>
+    <_AgentOSEnvSwitch>$${AGENT_OS:+--set-env=AGENT_OS=&quot;$$AGENT_OS&quot;}</_AgentOSEnvSwitch>
     <_AfterBuildCommands>
       mv $XHARNESS_OUT/AOTBuild.binlog &quot;$HELIX_WORKITEM_UPLOAD_ROOT&quot;
       $(_AppleSignCommand)
-      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=DOTNET_CI=&quot;true&quot; -- </_AfterBuildCommands>
+      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) $(_DotNetCIEnvSwitch) $(_HelixWorkItemRootEnvSwitch) $(_AgentOSEnvSwitch) -- </_AfterBuildCommands>
 
     <RunScriptCommand>$(_AOTBuildCommand) $(_AfterBuildCommands)</RunScriptCommand>
   </PropertyGroup>

--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -33,11 +33,7 @@
     <_AfterBuildCommands>
       mv $XHARNESS_OUT/AOTBuild.binlog &quot;$HELIX_WORKITEM_UPLOAD_ROOT&quot;
       $(_AppleSignCommand)
-      if [ -n &quot;$DOTNET_CI&quot; ]; then
-        xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=DOTNET_CI=&quot;$DOTNET_CI&quot; --
-      else
-        xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --
-      fi </_AfterBuildCommands>
+      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=DOTNET_CI=&quot;true&quot; -- </_AfterBuildCommands>
 
     <RunScriptCommand>$(_AOTBuildCommand) $(_AfterBuildCommands)</RunScriptCommand>
   </PropertyGroup>

--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -33,7 +33,11 @@
     <_AfterBuildCommands>
       mv $XHARNESS_OUT/AOTBuild.binlog &quot;$HELIX_WORKITEM_UPLOAD_ROOT&quot;
       $(_AppleSignCommand)
-      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=DOTNET_CI=&quot;$DOTNET_CI&quot; -- </_AfterBuildCommands>
+      if [ -n &quot;$DOTNET_CI&quot; ]; then
+        xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=DOTNET_CI=&quot;$DOTNET_CI&quot; --
+      else
+        xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --
+      fi </_AfterBuildCommands>
 
     <RunScriptCommand>$(_AOTBuildCommand) $(_AfterBuildCommands)</RunScriptCommand>
   </PropertyGroup>

--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -33,7 +33,7 @@
     <_AfterBuildCommands>
       mv $XHARNESS_OUT/AOTBuild.binlog &quot;$HELIX_WORKITEM_UPLOAD_ROOT&quot;
       $(_AppleSignCommand)
-      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=DOTNET_CI=&quot;$DOTNET_CI&quot; --set-env=HELIX_WORKITEM_ROOT=&quot;$HELIX_WORKITEM_ROOT&quot; --set-env=AGENT_OS=&quot;$AGENT_OS&quot; -- </_AfterBuildCommands>
+      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=HELIX_WORKITEM_ROOT=&quot;$HELIX_WORKITEM_ROOT&quot; -- </_AfterBuildCommands>
 
     <RunScriptCommand>$(_AOTBuildCommand) $(_AfterBuildCommands)</RunScriptCommand>
   </PropertyGroup>

--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -30,9 +30,9 @@
     <_AppleBuildCommand Condition="'$(IncludesTestRunner)' != 'true'">apple run</_AppleBuildCommand>
 
     <_AppleExpectedExitCode Condition="'$(ExpectedExitCode)' != ''">--expected-exit-code $(ExpectedExitCode)</_AppleExpectedExitCode>
-    <_DotNetCIEnvSwitch>$${DOTNET_CI:+--set-env=DOTNET_CI=&quot;$$DOTNET_CI&quot;}</_DotNetCIEnvSwitch>
-    <_HelixWorkItemRootEnvSwitch>$${HELIX_WORKITEM_ROOT:+--set-env=HELIX_WORKITEM_ROOT=&quot;$$HELIX_WORKITEM_ROOT&quot;}</_HelixWorkItemRootEnvSwitch>
-    <_AgentOSEnvSwitch>$${AGENT_OS:+--set-env=AGENT_OS=&quot;$$AGENT_OS&quot;}</_AgentOSEnvSwitch>
+    <_DotNetCIEnvSwitch>$${DOTNET_CI:+--set-env=DOTNET_CI=&quot;$DOTNET_CI&quot;}</_DotNetCIEnvSwitch>
+    <_HelixWorkItemRootEnvSwitch>$${HELIX_WORKITEM_ROOT:+--set-env=HELIX_WORKITEM_ROOT=&quot;$HELIX_WORKITEM_ROOT&quot;}</_HelixWorkItemRootEnvSwitch>
+    <_AgentOSEnvSwitch>$${AGENT_OS:+--set-env=AGENT_OS=&quot;$AGENT_OS&quot;}</_AgentOSEnvSwitch>
     <_AfterBuildCommands>
       mv $XHARNESS_OUT/AOTBuild.binlog &quot;$HELIX_WORKITEM_UPLOAD_ROOT&quot;
       $(_AppleSignCommand)


### PR DESCRIPTION
## Description

Sets the environment variable used by xUnit to detect if a test is running in a CI environment. This enables the `SkipOnCI` attribute to work correctly on Apple mobile devices.

Contributes to https://github.com/dotnet/xharness/issues/1473