### PR TITLE
Fix TestReadyToRun to use the in-build crossgen

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -28,7 +28,6 @@
     <CoreCLRAotSdkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'aotsdk'))</CoreCLRAotSdkDir>
     <CoreCLRBuildIntegrationDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'build'))</CoreCLRBuildIntegrationDir>
 
-    <Crossgen2Dir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'crossgen2-published'))</Crossgen2Dir>
     <Crossgen2InBuildDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', '$(BuildArchitecture)', 'crossgen2'))</Crossgen2InBuildDir>
 
     <ToolsILLinkDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ILLink.Tasks', '$(ToolsConfiguration)'))</ToolsILLinkDir>

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -124,10 +124,10 @@
 
   <!-- Use local Crossgen2 pack for NetCoreAppCurrent. -->
   <Target Name="UpdateLocalCrossgen2Pack"
-          Condition="'$(UseLocalCrossgen2Pack)' == 'true' and '$(Crossgen2Dir)' != ''"
+          Condition="'$(UseLocalCrossgen2Pack)' == 'true' and '$(Crossgen2InBuildDir)' != ''"
           AfterTargets="ResolveFrameworkReferences">
     <ItemGroup>
-      <ResolvedCrossgen2Pack PackageDirectory="$(Crossgen2Dir)"
+      <ResolvedCrossgen2Pack PackageDirectory="$(Crossgen2InBuildDir)"
                              NuGetPackageVersion="$(ProductVersion)" />
     </ItemGroup>
   </Target>

--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -142,7 +142,6 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <Crossgen2Dir />
       <Crossgen2Dir Condition="('$(TargetArchitecture)' != 'x64' and '$(BuildArchitecture)' == 'x64') or '$(EnableNativeSanitizers)' != ''">$(CoreCLRArtifactsPath)x64/crossgen2</Crossgen2Dir>
     </PropertyGroup>
 


### PR DESCRIPTION
Fixes failures in runtime-coreclr crossgen2 pipeline and fixes `TestReadyToRun=true` builds.