### PR TITLE
Don't trigger ICU loading in string.ToUpperInvariant

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -263,7 +263,7 @@ namespace System.Globalization
             if (GlobalizationMode.Invariant)
             {
                 // We could have just checked instance for being null instead of GlobalizationMode.Invariant, but:
-                // 1) GlobalizationMode.Invariant is substitable by ILLink (so the other branch can be trimmed away when true)
+                // 1) GlobalizationMode.Invariant is substitutable by ILLink (so the other branch can be trimmed away when true)
                 // 2) GlobalizationMode.Invariant triggers ICU load if it was not already loaded.
                 Debug.Assert(instance == null);
 
@@ -375,7 +375,7 @@ namespace System.Globalization
                     if (GlobalizationMode.Invariant)
                     {
                         // We could have just checked instance for being null instead of GlobalizationMode.Invariant, but:
-                        // 1) GlobalizationMode.Invariant is substitable by ILLink (so the other branch can be trimmed away when true)
+                        // 1) GlobalizationMode.Invariant is substitutable by ILLink (so the other branch can be trimmed away when true)
                         // 2) GlobalizationMode.Invariant triggers ICU load if it was not already loaded.
                         Debug.Assert(instance == null);
                         return toUpper ? InvariantModeCasing.ToUpper(source) : InvariantModeCasing.ToLower(source);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -368,7 +368,6 @@ namespace System.Globalization
                 {
                     if (GlobalizationMode.Invariant)
                     {
-                        Debug.Assert(instance == null);
                         return toUpper ? InvariantModeCasing.ToUpper(source) : InvariantModeCasing.ToLower(source);
                     }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -269,6 +269,7 @@ namespace System.Globalization
                 {
                     InvariantModeCasing.ToLower(source, destination);
                 }
+                return;
             }
 
             // instance being null means it's Invariant
@@ -277,7 +278,7 @@ namespace System.Globalization
             fixed (char* pSource = &MemoryMarshal.GetReference(source))
             fixed (char* pDestination = &MemoryMarshal.GetReference(destination))
             {
-                instance!.ChangeCaseCore(pSource + charsConsumed, source.Length - charsConsumed,
+                instance.ChangeCaseCore(pSource + charsConsumed, source.Length - charsConsumed,
                     pDestination + charsConsumed, destination.Length - charsConsumed, toUpper);
             }
         }
@@ -389,7 +390,7 @@ namespace System.Globalization
                     // and run the culture-aware logic over the remainder of the data
                     fixed (char* pResult = result)
                     {
-                        instance!.ChangeCaseCore(pSource + currIdx, source.Length - (int)currIdx, pResult + currIdx, result.Length - (int)currIdx, toUpper);
+                        instance.ChangeCaseCore(pSource + currIdx, source.Length - (int)currIdx, pResult + currIdx, result.Length - (int)currIdx, toUpper);
                     }
                     return result;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -235,7 +235,6 @@ namespace System.Globalization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void ChangeCaseCommon<TConversion>(TextInfo? instance, ReadOnlySpan<char> source, Span<char> destination) where TConversion : struct
         {
-            Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(typeof(TConversion) == typeof(ToUpperConversion) || typeof(TConversion) == typeof(ToLowerConversion));
 
             if (source.IsEmpty)
@@ -288,7 +287,6 @@ namespace System.Globalization
             Debug.Assert(typeof(TConversion) == typeof(ToUpperConversion) || typeof(TConversion) == typeof(ToLowerConversion));
             bool toUpper = typeof(TConversion) == typeof(ToUpperConversion); // JIT will treat this as a constant in release builds
 
-            Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(source != null);
 
             // If the string is empty, we're done.

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -171,19 +171,12 @@ namespace System.Globalization
         public string ToLower(string str)
         {
             ArgumentNullException.ThrowIfNull(str);
-
-            if (GlobalizationMode.Invariant)
-            {
-                return InvariantModeCasing.ToLower(str);
-            }
-
             return ChangeCaseCommon<ToLowerConversion>(this, str);
         }
 
         internal static string ToLowerInvariant(string str)
         {
             ArgumentNullException.ThrowIfNull(str);
-
             return ChangeCaseCommon<ToLowerConversion>(null, str);
         }
 
@@ -480,14 +473,12 @@ namespace System.Globalization
         public string ToUpper(string str)
         {
             ArgumentNullException.ThrowIfNull(str);
-
             return ChangeCaseCommon<ToUpperConversion>(this, str);
         }
 
         internal static string ToUpperInvariant(string str)
         {
             ArgumentNullException.ThrowIfNull(str);
-
             return ChangeCaseCommon<ToUpperConversion>(null, str);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -2365,7 +2365,7 @@ namespace System
         // Creates a copy of this string in lower case based on invariant culture.
         public string ToLowerInvariant()
         {
-            return TextInfo.Invariant.ToLower(this);
+            return TextInfo.ToLowerInvariant(this);
         }
 
         public string ToUpper() => ToUpper(null);
@@ -2380,7 +2380,7 @@ namespace System
         // Creates a copy of this string in upper case based on invariant culture.
         public string ToUpperInvariant()
         {
-            return TextInfo.Invariant.ToUpper(this);
+            return TextInfo.ToUpperInvariant(this);
         }
 
         // Trims the whitespace from both ends of the string.  Whitespace is defined by

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/TrimmingTests/InvariantGlobalizationTrue.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/TrimmingTests/InvariantGlobalizationTrue.cs
@@ -11,9 +11,30 @@ using System.Runtime.CompilerServices;
 /// </summary>
 class Program
 {
+    private static string Str1 = "aaaaBBBB";
+    private static string Str2 = "ccccDDDD";
+    private static string Str3;
+
     static int Main(string[] args)
     {
         const BindingFlags allStatics = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
+        Str3 = Str1.ToLowerInvariant() + Str2.ToUpperInvariant();
+
+        Type textInfo = GetCoreLibType("System.Globalization.TextInfo");
+        if (textInfo != null)
+        {
+            string[] methodsShouldBeGone = ["NlsChangeCase", "ChangeCaseCore", "ChangeCaseNative", "IcuChangeCase"];
+
+            foreach (MethodInfo method in textInfo.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (methodsShouldBeGone.Contains(method.Name))
+                {
+                    Console.WriteLine($"Member '{method.Name}' was not trimmed from GlobalizationMode, but should have been.");
+                    return -2;
+                }
+            }
+        }
 
         try
         {
@@ -40,7 +61,7 @@ class Program
 
             return 100;
         }
-        
+
         // Ensure the internal GlobalizationMode class is trimmed correctly.
         Type globalizationMode = GetCoreLibType("System.Globalization.GlobalizationMode");
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/TrimmingTests/InvariantGlobalizationTrue.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/TrimmingTests/InvariantGlobalizationTrue.cs
@@ -26,7 +26,7 @@ class Program
         {
             string[] methodsShouldBeGone = ["NlsChangeCase", "ChangeCaseCore", "ChangeCaseNative", "IcuChangeCase"];
 
-            foreach (MethodInfo method in textInfo.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+            foreach (MethodInfo method in textInfo.GetMethods(BindingFlags.Instance | allStatics))
             {
                 if (methodsShouldBeGone.Contains(method.Name))
                 {


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/120407

It looks like even a simple
```cs
System.Console("Hello world");
```
may trigger ICU load unnecessarily via `string.ToUpperInvariant` calls:

<img width="1058" height="756" alt="image" src="https://github.com/user-attachments/assets/808a0f2f-2f36-4efe-b89b-63f8a7bc9833" />

Another source of these `string.ToUpperInvariant`s are EventSource (over EventSources' names to generate guids) - we plan to remove those, though.

For most app the ICU most likely will be loaded anyway, but IMO if it doesn't take too much of efforts, we should delay/avoid it. In this PR it is achieved by introducing a few extra null check.


Perf-traces for a hello world:

- [Main](https://www.speedscope.app/#profileURL=https://egorbot2.blob.core.windows.net/telegafiles/main_b56e384598.speedscope)
- [PR](https://www.speedscope.app/#profileURL=https://egorbot2.blob.core.windows.net/telegafiles/PR_b8977a145a.speedscope)

Also, perf improvements for the InvariantGlobalization mode: https://github.com/EgorBot/runtime-utils/issues/521