### PR TITLE
[release/10.0] Set PRERELEASE to 0

### DIFF
--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -2,7 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
 
 # If set, indicates that this is not an officially supported release.
 # Release branches should set this to false.
-set(PRERELEASE 1)
+set(PRERELEASE 0)
 
 #----------------------------------------
 # Detect and set platform variable names


### PR DESCRIPTION
This is necessary to disable extraneous C/C++ compiler warnings in new release branches.

Context https://github.com/dotnet/runtime/pull/120644#issuecomment-3401967453