### PR TITLE
Set DOTNET_CI environment variable for xharness command

### DIFF
--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -33,7 +33,7 @@
     <_AfterBuildCommands>
       mv $XHARNESS_OUT/AOTBuild.binlog &quot;$HELIX_WORKITEM_UPLOAD_ROOT&quot;
       $(_AppleSignCommand)
-      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=HELIX_WORKITEM_ROOT=&quot;$HELIX_WORKITEM_ROOT&quot; -- </_AfterBuildCommands>
+      xharness $(_AppleBuildCommand) --app &quot;$app&quot; --output-directory &quot;$output_directory&quot; --target &quot;$target&quot; --timeout &quot;$timeout&quot; --xcode &quot;$xcode_path&quot; -v --launch-timeout &quot;$launch_timeout&quot; $(_ResetSimulatorSwitch) $(_SignalAppEndSwitch) $(_AppleExpectedExitCode) --set-env=DOTNET_CI=true -- </_AfterBuildCommands>
 
     <RunScriptCommand>$(_AOTBuildCommand) $(_AfterBuildCommands)</RunScriptCommand>
   </PropertyGroup>


### PR DESCRIPTION
## Description

This PR updates the XHarness command to use the DOTNET_CI environment variable for the SkipOnCI attribute instead of HELIX_WORKITEM_ROOT. The HELIX_WORKITEM_ROOT path is only valid on the host machine. The attribute currently checks both variables to detect if the test is running in CI, but we consider DOTNET_CI to be the more appropriate and reliable.