### PR TITLE
Remove audit sources from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -24,10 +24,6 @@
     <!-- Need for prototype Roslyn compiler for runtime-async -->
     <add key="general-testing" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json" />
   </packageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>


### PR DESCRIPTION
The api.nuget.org source will clash with the CFSClean network isolation policy and the same data is provided by AzDO now.
