### PR TITLE
[RuntimeAsync] make a test compatible with runtime async.

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
@@ -651,14 +651,22 @@ namespace System.Threading.Tasks.Tests
             }).Dispose();
         }
 
+        // NOTE: This depends on private implementation details generally only used by the debugger.
+        // If those ever change, this test will need to be updated as well.
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name = "s_asyncDebuggingEnabled")]
+        private extern static ref bool AsyncDebuggingEnabled(Task t);
+
+        // NOTE: This depends on private implementation details generally only used by the debugger.
+        // If those ever change, this test will need to be updated as well.
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name = "s_currentActiveTasks")]
+        private extern static ref Dictionary<int, Task>? CurrentActiveTasks(Task t);
+
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void AsyncTaskMethodBuilder_Completed_RemovedFromTracking()
         {
             RemoteExecutor.Invoke(() =>
             {
-                // NOTE: This depends on private implementation details generally only used by the debugger.
-                // If those ever change, this test will need to be updated as well.
-                typeof(Task).GetField("s_asyncDebuggingEnabled", BindingFlags.NonPublic | BindingFlags.Static).SetValue(null, true);
+                AsyncDebuggingEnabled(null) = true;
 
                 for (int i = 0; i < 1000; i++)
                 {
@@ -670,12 +678,10 @@ namespace System.Threading.Tasks.Tests
                     t.Wait();
                 }
 
-                object activeTasks = typeof(Task).GetField("s_currentActiveTasks", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
-                if (activeTasks is not null)
-                {
-                    int activeCount = ((dynamic)activeTasks).Count;
-                    Assert.InRange(activeCount, 0, 10); // some other tasks may be created by the runtime, so this is just using a reasonably small upper bound
-                }
+                Dictionary<int, Task>? activeTasks = CurrentActiveTasks(null);
+                int activeCount = activeTasks?.Count ?? 0;
+                Assert.InRange(activeCount, 0, 10); // some other tasks may be created by the runtime, so this is just using a reasonably small upper bound
+
             }).Dispose();
         }
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
@@ -670,8 +670,12 @@ namespace System.Threading.Tasks.Tests
                     t.Wait();
                 }
 
-                int activeCount = ((dynamic)typeof(Task).GetField("s_currentActiveTasks", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null)).Count;
-                Assert.InRange(activeCount, 0, 10); // some other tasks may be created by the runtime, so this is just using a reasonably small upper bound
+                object activeTasks = typeof(Task).GetField("s_currentActiveTasks", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+                if (activeTasks is not null)
+                {
+                    int activeCount = ((dynamic)activeTasks).Count;
+                    Assert.InRange(activeCount, 0, 10); // some other tasks may be created by the runtime, so this is just using a reasonably small upper bound
+                }
             }).Dispose();
         }
 


### PR DESCRIPTION
This is a test-only change.

The particular testcase looks into implementation details of active task tracking like `s_currentActiveTasks`

Runtime async does not have task tracking on synchronous/fast path since no tasks are created, so assumption that as long as we have async code, `s_currentActiveTasks` will be initialized to something is no longer true. 

Test expects "fewer than 10 active tasks" at the end of the scenario. 
I changed the test to handle a case if no active tasks were tracked at all. This keeps the test checking for the same thing - that not a lot of active tasks may hang around unexpectedly, but avoids a crash if `s_currentActiveTasks` is `null`.