### PR TITLE
[CodeOwners] Add EventPipe paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@
 /src/mono/dlls @thaystg @steveisok @vitek-karas
 
 /src/native/public/mono @steveisok @vitek-karas
+/src/native/eventpipe @noahfalk @lateralusX @mdh1418
 /src/native/external/libunwind @janvorli @AaronRobinsonMSFT @dotnet/dotnet-diag
 /src/native/external/libunwind_extras @janvorli @AaronRobinsonMSFT @dotnet/dotnet-diag
 


### PR DESCRIPTION
Adding us as code owners so we are informed of any changes to eventpipe, which should help catch any breaking changes while native tests are not yet stood up.