### PR TITLE
[release/10.0] Fix localization of links in runtime bundle

### DIFF
--- a/src/installer/pkg/sfx/bundle/bundle.thm
+++ b/src/installer/pkg/sfx/bundle/bundle.thm
@@ -44,8 +44,8 @@
       <Label Name="LicenseAssent" X="148" Y="288" Width="-12" Height="32" FontId="DefaultFont" HexStyle="000000">#(loc.LicenseAssent)</Label>
 
       <!-- These controls have larger vertical spacing to improve readability (20 instead of 16). -->
-      <Hypertext Name="PrivacyStatementLink" X="172" Y="320" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</Hypertext>
-      <Hypertext Name="EulaLink" X="172" Y="340" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Licensing Information for .NET&lt;/A&gt;</Hypertext>
+      <Hypertext Name="PrivacyStatementLink" X="172" Y="320" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">#(loc.PrivacyStatementLink)</Hypertext>
+      <Hypertext Name="EulaLink" X="172" Y="340" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">#(loc.EulaLink)</Hypertext>
 
       <Button Name="InstallButton" X="-124" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">#(loc.InstallInstallButton)</Button>
       <Button Name="InstallCancelButton" X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">


### PR DESCRIPTION
## Customer Impact

- [ ] Customer reported
- [x] Found internally

Links in the installer have English text instead of localized text. See #120109 for screenshots. Found by CTI.

## Regression

- [x] Yes
- [ ] No

Installers moved to WiX 5 in RC2 and we intentionally took a regression to localization because string weren't localized in time for the release. Now for GA we have all the strings.

## Testing

I validated this locally by running the installer using `/lang 3082` and verifying that the link is localized.

## Risk

Low. Localization was already missing.

Fixes #120109