### PR TITLE
Emit a file that lists which packages don't use ///-source-of-truth

### DIFF
--- a/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
@@ -36,6 +36,7 @@
       <TfmSpecificPackageFile Include="@(ReferenceAssemblyFile);
                                        @(CompilerGeneratedXmlDocFile)"
                               PackagePath="ref\$(NetCoreAppCurrent)\" />
+      <NoDocPackages Include="@(ProjectReferenceCopyLocalPathNonPrivate->WithoutMetadataValue('UseCompilerGeneratedDocXmlFile', 'true')->WithMetadataValue('IsPackable', 'true')->'%(PackageId)'->Distinct())" />
     </ItemGroup>
 
     <ItemGroup>
@@ -44,6 +45,13 @@
       <PlatformNotSupportedCompilerGeneratedXmlDocFile Include="@(CompilerGeneratedXmlDocFile->WithMetadataValue('IsPlatformNotSupportedAssembly', 'true'))" />
       <!-- Allow libraries to temporarily suppress the PNSE error. -->
       <PlatformNotSupportedCompilerGeneratedXmlDocFile Remove="@(PlatformNotSupportedCompilerGeneratedXmlDocFile->WithMetadataValue('SuppressPlatformNotSupportedAssemblyDocXmlError', 'true'))" />
+    </ItemGroup>
+
+    <WriteLinesToFile Lines="@(NoDocPackages)"
+                      File="$(OutputPath)NoDocPackages.txt"
+                      Overwrite="true" />
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)NoDocPackages.txt" PackagePath="ref\$(NetCoreAppCurrent)\" />
     </ItemGroup>
 
     <Error Text="Compiler generated XML documentation files are missing data because partial facade assemblies aren't supported by the repo infrastructure. Consider removing the partial facade feature. Assemblies: @(PartialFacadeCompilerGeneratedXmlDocFile->Metadata('Filename'), ', ')."

--- a/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
@@ -36,7 +36,7 @@
       <TfmSpecificPackageFile Include="@(ReferenceAssemblyFile);
                                        @(CompilerGeneratedXmlDocFile)"
                               PackagePath="ref\$(NetCoreAppCurrent)\" />
-      <NoDocPackages Include="@(ProjectReferenceCopyLocalPathNonPrivate->WithoutMetadataValue('UseCompilerGeneratedDocXmlFile', 'true')->WithMetadataValue('IsPackable', 'true')->'%(PackageId)'->Distinct())" />
+      <NoDocPackages Include="@(ReferencePath->WithoutMetadataValue('UseCompilerGeneratedDocXmlFile', 'true')->WithMetadataValue('IsPackable', 'true')->'%(PackageId)'->Distinct())" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Here's a sample that adds a file that catalogs which libraries do not use ///-source-of-truth.

This could be used by the docs process to understand which packages to exclude from ingestion into dotnet-api-docs.

I just dumped a text file with each package on a new line.  Let me know if you'd prefer some different format.