### PR TITLE
[release/10.0] Revert generic number tricks

### DIFF
--- a/src/libraries/Common/src/System/Net/IPv4AddressHelper.Common.cs
+++ b/src/libraries/Common/src/System/Net/IPv4AddressHelper.Common.cs
@@ -19,23 +19,13 @@ namespace System.Net
 
         private const int NumberOfLabels = 4;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static ushort ToUShort<TChar>(TChar value)
-            where TChar : unmanaged, IBinaryInteger<TChar>
-        {
-            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
-
-            return typeof(TChar) == typeof(char)
-                ? (char)(object)value
-                : (byte)(object)value;
-        }
+        //
+        // Char parsing
+        //
 
         // Only called from the IPv6Helper, only parse the canonical format
-        internal static int ParseHostNumber<TChar>(ReadOnlySpan<TChar> str, int start, int end)
-            where TChar : unmanaged, IBinaryInteger<TChar>
+        internal static int ParseHostNumber(ReadOnlySpan<char> str, int start, int end)
         {
-            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
-
             Span<byte> numbers = stackalloc byte[NumberOfLabels];
 
             for (int i = 0; i < numbers.Length; ++i)
@@ -43,7 +33,7 @@ namespace System.Net
                 int b = 0;
                 int ch;
 
-                for (; (start < end) && (ch = ToUShort(str[start])) != '.' && ch != ':'; ++start)
+                for (; (start < end) && (ch = (ushort)(str[start])) != '.' && ch != ':'; ++start)
                 {
                     b = (b * 10) + ch - '0';
                 }
@@ -97,8 +87,7 @@ namespace System.Net
         //
 
         //Remark: MUST NOT be used unless all input indexes are verified and trusted.
-        internal static unsafe bool IsValid<TChar>(TChar* name, int start, ref int end, bool allowIPv6, bool notImplicitFile, bool unknownScheme)
-            where TChar : unmanaged, IBinaryInteger<TChar>
+        internal static unsafe bool IsValid(char* name, int start, ref int end, bool allowIPv6, bool notImplicitFile, bool unknownScheme)
         {
             // IPv6 can only have canonical IPv4 embedded. Unknown schemes will not attempt parsing of non-canonical IPv4 addresses.
             if (allowIPv6 || unknownScheme)
@@ -124,11 +113,8 @@ namespace System.Net
         //                 / "2" %x30-34 DIGIT     ; 200-249
         //                 / "25" %x30-35          ; 250-255
         //
-        internal static unsafe bool IsValidCanonical<TChar>(TChar* name, int start, ref int end, bool allowIPv6, bool notImplicitFile)
-            where TChar : unmanaged, IBinaryInteger<TChar>
+        internal static unsafe bool IsValidCanonical(char* name, int start, ref int end, bool allowIPv6, bool notImplicitFile)
         {
-            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
-
             int dots = 0;
             long number = 0;
             bool haveNumber = false;
@@ -136,7 +122,7 @@ namespace System.Net
 
             while (start < end)
             {
-                int ch = ToUShort(name[start]);
+                int ch = (ushort)(name[start]);
 
                 if (allowIPv6)
                 {
@@ -162,7 +148,7 @@ namespace System.Net
                     // A number starting with zero should be interpreted in base 8 / octal
                     if (!haveNumber && parsedCharacter == 0)
                     {
-                        if ((start + 1 < end) && name[start + 1] == TChar.CreateTruncating('0'))
+                        if ((start + 1 < end) && name[start + 1] == '0')
                         {
                             // 00 is not allowed as a prefix.
                             return false;
@@ -210,11 +196,8 @@ namespace System.Net
         // Return Invalid (-1) for failures.
         // If the address has less than three dots, only the rightmost section is assumed to contain the combined value for
         // the missing sections: 0xFF00FFFF == 0xFF.0x00.0xFF.0xFF == 0xFF.0xFFFF
-        internal static unsafe long ParseNonCanonical<TChar>(TChar* name, int start, ref int end, bool notImplicitFile)
-            where TChar : unmanaged, IBinaryInteger<TChar>
+        internal static unsafe long ParseNonCanonical(char* name, int start, ref int end, bool notImplicitFile)
         {
-            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
-
             int numberBase = IPv4AddressHelper.Decimal;
             int ch = 0;
             Span<long> parts = stackalloc long[3]; // One part per octet. Final octet doesn't have a terminator, so is stored in currentValue.
@@ -227,7 +210,7 @@ namespace System.Net
 
             for (; current < end; current++)
             {
-                ch = ToUShort(name[current]);
+                ch = (ushort)(name[current]);
                 currentValue = 0;
 
                 // Figure out what base this section is in, default to base 10.
@@ -241,7 +224,7 @@ namespace System.Net
                     atLeastOneChar = true;
                     if (current < end)
                     {
-                        ch = ToUShort(name[current]);
+                        ch = (ushort)(name[current]);
 
                         if (ch == 'x' || ch == 'X')
                         {
@@ -260,7 +243,322 @@ namespace System.Net
                 // Parse this section
                 for (; current < end; current++)
                 {
-                    ch = ToUShort(name[current]);
+                    ch = (ushort)(name[current]);
+                    int digitValue = HexConverter.FromChar(ch);
+
+                    if (digitValue >= numberBase)
+                    {
+                        break; // Invalid/terminator
+                    }
+                    currentValue = (currentValue * numberBase) + digitValue;
+
+                    if (currentValue > MaxIPv4Value) // Overflow
+                    {
+                        return Invalid;
+                    }
+
+                    atLeastOneChar = true;
+                }
+
+                if (current < end && ch == '.')
+                {
+                    if (dotCount >= 3 // Max of 3 dots and 4 segments
+                        || !atLeastOneChar // No empty segments: 1...1
+                                           // Only the last segment can be more than 255 (if there are less than 3 dots)
+                        || currentValue > 0xFF)
+                    {
+                        return Invalid;
+                    }
+                    parts[dotCount] = currentValue;
+                    dotCount++;
+                    atLeastOneChar = false;
+                    continue;
+                }
+                // We don't get here unless we find an invalid character or a terminator
+                break;
+            }
+
+            // Terminators
+            if (!atLeastOneChar)
+            {
+                return Invalid;  // Empty trailing segment: 1.1.1.
+            }
+            else if (current >= end)
+            {
+                // end of string, allowed
+            }
+            else if (ch == '/' || ch == '\\' || (notImplicitFile && (ch == ':' || ch == '?' || ch == '#')))
+            {
+                // For a normal IPv4 address, the terminator is the prefix ('/' or its counterpart, '\'). If notImplicitFile is set, the terminator
+                // is one of the characters which signify the start of the rest of the URI - the port number (':'), query string ('?') or fragment ('#')
+
+                end = current;
+            }
+            else
+            {
+                // not a valid terminating character
+                return Invalid;
+            }
+
+            // Parsed, reassemble and check for overflows in the last part. Previous parts have already been checked in the loop
+            switch (dotCount)
+            {
+                case 0: // 0xFFFFFFFF
+                    return currentValue;
+                case 1: // 0xFF.0xFFFFFF
+                    Debug.Assert(parts[0] <= 0xFF);
+                    if (currentValue > 0xffffff)
+                    {
+                        return Invalid;
+                    }
+                    return (parts[0] << 24) | currentValue;
+                case 2: // 0xFF.0xFF.0xFFFF
+                    Debug.Assert(parts[0] <= 0xFF);
+                    Debug.Assert(parts[1] <= 0xFF);
+                    if (currentValue > 0xffff)
+                    {
+                        return Invalid;
+                    }
+                    return (parts[0] << 24) | (parts[1] << 16) | currentValue;
+                case 3: // 0xFF.0xFF.0xFF.0xFF
+                    Debug.Assert(parts[0] <= 0xFF);
+                    Debug.Assert(parts[1] <= 0xFF);
+                    Debug.Assert(parts[2] <= 0xFF);
+                    if (currentValue > 0xff)
+                    {
+                        return Invalid;
+                    }
+                    return (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | currentValue;
+                default:
+                    return Invalid;
+            }
+        }
+
+        //
+        // Byte parsing
+        //
+
+        // Only called from the IPv6Helper, only parse the canonical format
+        internal static int ParseHostNumber(ReadOnlySpan<byte> str, int start, int end)
+        {
+            Span<byte> numbers = stackalloc byte[NumberOfLabels];
+
+            for (int i = 0; i < numbers.Length; ++i)
+            {
+                int b = 0;
+                int ch;
+
+                for (; (start < end) && (ch = (ushort)(str[start])) != '.' && ch != ':'; ++start)
+                {
+                    b = (b * 10) + ch - '0';
+                }
+
+                numbers[i] = (byte)b;
+                ++start;
+            }
+
+            return BinaryPrimitives.ReadInt32BigEndian(numbers);
+        }
+
+        //
+        // IsValid
+        //
+        //  Performs IsValid on a substring. Updates the index to where we
+        //  believe the IPv4 address ends
+        //
+        // Inputs:
+        //  <argument>  name
+        //      string containing possible IPv4 address
+        //
+        //  <argument>  start
+        //      offset in <name> to start checking for IPv4 address
+        //
+        //  <argument>  end
+        //      offset in <name> of the last character we can touch in the check
+        //
+        // Outputs:
+        //  <argument>  end
+        //      index of last character in <name> we checked
+        //
+        //  <argument>  allowIPv6
+        //      enables parsing IPv4 addresses embedded in IPv6 address literals
+        //
+        //  <argument>  notImplicitFile
+        //      do not consider this URI holding an implicit filename
+        //
+        //  <argument>  unknownScheme
+        //      the check is made on an unknown scheme (suppress IPv4 canonicalization)
+        //
+        // Assumes:
+        // The address string is terminated by either
+        // end of the string, characters ':' '/' '\' '?'
+        //
+        //
+        // Returns:
+        //  bool
+        //
+        // Throws:
+        //  Nothing
+        //
+
+        //Remark: MUST NOT be used unless all input indexes are verified and trusted.
+        internal static unsafe bool IsValid(byte* name, int start, ref int end, bool allowIPv6, bool notImplicitFile, bool unknownScheme)
+        {
+            // IPv6 can only have canonical IPv4 embedded. Unknown schemes will not attempt parsing of non-canonical IPv4 addresses.
+            if (allowIPv6 || unknownScheme)
+            {
+                return IsValidCanonical(name, start, ref end, allowIPv6, notImplicitFile);
+            }
+            else
+            {
+                return ParseNonCanonical(name, start, ref end, notImplicitFile) != Invalid;
+            }
+        }
+
+        //
+        // IsValidCanonical
+        //
+        //  Checks if the substring is a valid canonical IPv4 address or an IPv4 address embedded in an IPv6 literal
+        //  This is an attempt to parse ABNF productions from RFC3986, Section 3.2.2:
+        //     IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
+        //     IPv4address = dec-octet "." dec-octet "." dec-octet "." dec-octet
+        //     dec-octet   = DIGIT                 ; 0-9
+        //                 / %x31-39 DIGIT         ; 10-99
+        //                 / "1" 2DIGIT            ; 100-199
+        //                 / "2" %x30-34 DIGIT     ; 200-249
+        //                 / "25" %x30-35          ; 250-255
+        //
+        internal static unsafe bool IsValidCanonical(byte* name, int start, ref int end, bool allowIPv6, bool notImplicitFile)
+        {
+            int dots = 0;
+            long number = 0;
+            bool haveNumber = false;
+            bool firstCharIsZero = false;
+
+            while (start < end)
+            {
+                int ch = (ushort)(name[start]);
+
+                if (allowIPv6)
+                {
+                    // For an IPv4 address nested inside an IPv6 address, the terminator is either the IPv6 address terminator (']'), prefix ('/') or ScopeId ('%')
+                    if (ch == ']' || ch == '/' || ch == '%')
+                    {
+                        break;
+                    }
+                }
+                else if (ch == '/' || ch == '\\' || (notImplicitFile && (ch == ':' || ch == '?' || ch == '#')))
+                {
+                    // For a normal IPv4 address, the terminator is the prefix ('/' or its counterpart, '\'). If notImplicitFile is set, the terminator
+                    // is one of the characters which signify the start of the rest of the URI - the port number (':'), query string ('?') or fragment ('#')
+
+                    break;
+                }
+
+                // An explicit cast to an unsigned integer forces character values preceding '0' to underflow, eliminating one comparison below.
+                uint parsedCharacter = (uint)(ch - '0');
+
+                if (parsedCharacter < IPv4AddressHelper.Decimal)
+                {
+                    // A number starting with zero should be interpreted in base 8 / octal
+                    if (!haveNumber && parsedCharacter == 0)
+                    {
+                        if ((start + 1 < end) && name[start + 1] == (byte)('0'))
+                        {
+                            // 00 is not allowed as a prefix.
+                            return false;
+                        }
+
+                        firstCharIsZero = true;
+                    }
+
+                    haveNumber = true;
+                    number = number * IPv4AddressHelper.Decimal + parsedCharacter;
+                    if (number > byte.MaxValue)
+                    {
+                        return false;
+                    }
+                }
+                else if (ch == '.')
+                {
+                    // If the current character is not an integer, it may be the IPv4 component separator ('.')
+
+                    if (!haveNumber || (number > 0 && firstCharIsZero))
+                    {
+                        // 0 is not allowed to prefix a number.
+                        return false;
+                    }
+                    ++dots;
+                    haveNumber = false;
+                    number = 0;
+                    firstCharIsZero = false;
+                }
+                else
+                {
+                    return false;
+                }
+                ++start;
+            }
+            bool res = (dots == 3) && haveNumber;
+            if (res)
+            {
+                end = start;
+            }
+            return res;
+        }
+
+        // Parse any canonical or noncanonical IPv4 formats and return a long between 0 and MaxIPv4Value.
+        // Return Invalid (-1) for failures.
+        // If the address has less than three dots, only the rightmost section is assumed to contain the combined value for
+        // the missing sections: 0xFF00FFFF == 0xFF.0x00.0xFF.0xFF == 0xFF.0xFFFF
+        internal static unsafe long ParseNonCanonical(byte* name, int start, ref int end, bool notImplicitFile)
+        {
+            int numberBase = IPv4AddressHelper.Decimal;
+            int ch = 0;
+            Span<long> parts = stackalloc long[3]; // One part per octet. Final octet doesn't have a terminator, so is stored in currentValue.
+            long currentValue = 0;
+            bool atLeastOneChar = false;
+
+            // Parse one dotted section at a time
+            int dotCount = 0; // Limit 3
+            int current = start;
+
+            for (; current < end; current++)
+            {
+                ch = (ushort)(name[current]);
+                currentValue = 0;
+
+                // Figure out what base this section is in, default to base 10.
+                // A number starting with zero should be interpreted in base 8 / octal
+                // If the number starts with 0x, it should be interpreted in base 16 / hex
+                numberBase = IPv4AddressHelper.Decimal;
+
+                if (ch == '0')
+                {
+                    current++;
+                    atLeastOneChar = true;
+                    if (current < end)
+                    {
+                        ch = (ushort)(name[current]);
+
+                        if (ch == 'x' || ch == 'X')
+                        {
+                            numberBase = IPv4AddressHelper.Hex;
+
+                            current++;
+                            atLeastOneChar = false;
+                        }
+                        else
+                        {
+                            numberBase = IPv4AddressHelper.Octal;
+                        }
+                    }
+                }
+
+                // Parse this section
+                for (; current < end; current++)
+                {
+                    ch = (ushort)(name[current]);
                     int digitValue = HexConverter.FromChar(ch);
 
                     if (digitValue >= numberBase)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeaders.cs
@@ -125,14 +125,272 @@ namespace System.Net.Http.Headers
         /// Matching is case-insensitive. Because of this, we do not preserve the case of the original header,
         /// whether from the wire or from the user explicitly setting a known header using a header name string.
         /// </remarks>
-        private static KnownHeader? GetCandidate<T>(ReadOnlySpan<T> key)
-            where T : struct, INumberBase<T>
+        private static KnownHeader? GetCandidate(ReadOnlySpan<char> key)
         {
             // Lookup is performed by first switching on the header name's length, and then switching
             // on the most unique position in that length's string.
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static int GetLower(T value) => int.CreateTruncating(value) | 0x20;
+            static int GetLower(char value) => value | 0x20;
+
+            switch (key.Length)
+            {
+                case 2:
+                    return TE; // TE
+
+                case 3:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'a': return Age; // [A]ge
+                        case 'p': return P3P; // [P]3P
+                        case 't': return TSV; // [T]SV
+                        case 'v': return Via; // [V]ia
+                    }
+                    break;
+
+                case 4:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'd': return Date; // [D]ate
+                        case 'e': return ETag; // [E]Tag
+                        case 'f': return From; // [F]rom
+                        case 'h': return Host; // [H]ost
+                        case 'l': return Link; // [L]ink
+                        case 'v': return Vary; // [V]ary
+                    }
+                    break;
+
+                case 5:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'a': return Allow; // [A]llow
+                        case 'r': return Range; // [R]ange
+                    }
+                    break;
+
+                case 6:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'a': return Accept; // [A]ccept
+                        case 'c': return Cookie; // [C]ookie
+                        case 'e': return Expect; // [E]xpect
+                        case 'o': return Origin; // [O]rigin
+                        case 'p': return Pragma; // [P]ragma
+                        case 's': return Server; // [S]erver
+                    }
+                    break;
+
+                case 7:
+                    switch (GetLower(key[0]))
+                    {
+                        case ':': return PseudoStatus; // [:]status
+                        case 'a': return AltSvc;  // [A]lt-Svc
+                        case 'c': return Cookie2; // [C]ookie2
+                        case 'e': return Expires; // [E]xpires
+                        case 'r':
+                            switch (GetLower(key[3]))
+                            {
+                                case 'e': return Referer; // [R]ef[e]rer
+                                case 'r': return Refresh; // [R]ef[r]esh
+                            }
+                            break;
+                        case 't': return Trailer; // [T]railer
+                        case 'u': return Upgrade; // [U]pgrade
+                        case 'w': return Warning; // [W]arning
+                        case 'x': return XCache;  // [X]-Cache
+                    }
+                    break;
+
+                case 8:
+                    switch (GetLower(key[3]))
+                    {
+                        case '-': return AltUsed;  // Alt[-]Used
+                        case 'a': return Location; // Loc[a]tion
+                        case 'm': return IfMatch;  // If-[M]atch
+                        case 'r': return IfRange;  // If-[R]ange
+                    }
+                    break;
+
+                case 9:
+                    return ExpectCT; // Expect-CT
+
+                case 10:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'c': return Connection; // [C]onnection
+                        case 'k': return KeepAlive;  // [K]eep-Alive
+                        case 's': return SetCookie;  // [S]et-Cookie
+                        case 'u': return UserAgent;  // [U]ser-Agent
+                    }
+                    break;
+
+                case 11:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'c': return ContentMD5; // [C]ontent-MD5
+                        case 'g': return GrpcStatus; // [g]rpc-status
+                        case 'r': return RetryAfter; // [R]etry-After
+                        case 's': return SetCookie2; // [S]et-Cookie2
+                        case 'x': return XServedBy;  // [X]-Served-By
+                    }
+                    break;
+
+                case 12:
+                    switch (GetLower(key[5]))
+                    {
+                        case 'd': return XMSEdgeRef;  // X-MSE[d]ge-Ref
+                        case 'e': return XPoweredBy;  // X-Pow[e]red-By
+                        case 'm': return GrpcMessage; // grpc-[m]essage
+                        case 'n': return ContentType; // Conte[n]t-Type
+                        case 'o': return MaxForwards; // Max-F[o]rwards
+                        case 't': return AcceptPatch; // Accep[t]-Patch
+                        case 'u': return XRequestID;  // X-Req[u]est-ID
+                    }
+                    break;
+
+                case 13:
+                    switch (GetLower(key[12]))
+                    {
+                        case 'd': return LastModified;  // Last-Modifie[d]
+                        case 'e': return ContentRange;  // Content-Rang[e]
+                        case 'g':
+                            switch (GetLower(key[0]))
+                            {
+                                case 's': return ServerTiming;  // [S]erver-Timin[g]
+                                case 'g': return GrpcEncoding;  // [g]rpc-encodin[g]
+                            }
+                            break;
+                        case 'h': return IfNoneMatch;   // If-None-Matc[h]
+                        case 'l': return CacheControl;  // Cache-Contro[l]
+                        case 'n': return Authorization; // Authorizatio[n]
+                        case 's': return AcceptRanges;  // Accept-Range[s]
+                        case 't': return ProxySupport;  // Proxy-Suppor[t]
+                    }
+                    break;
+
+                case 14:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'a': return AcceptCharset; // [A]ccept-Charset
+                        case 'c': return ContentLength; // [C]ontent-Length
+                    }
+                    break;
+
+                case 15:
+                    switch (GetLower(key[7]))
+                    {
+                        case '-': return XFrameOptions;  // X-Frame[-]Options
+                        case 'e': return AcceptEncoding; // Accept-[E]ncoding
+                        case 'k': return PublicKeyPins;  // Public-[K]ey-Pins
+                        case 'l': return AcceptLanguage; // Accept-[L]anguage
+                        case 'm': return XUACompatible;  // X-UA-Co[m]patible
+                        case 'r': return ReferrerPolicy; // Referre[r]-Policy
+                    }
+                    break;
+
+                case 16:
+                    switch (GetLower(key[11]))
+                    {
+                        case 'a': return ContentLocation; // Content-Loc[a]tion
+                        case 'c':
+                            switch (GetLower(key[0]))
+                            {
+                                case 'p': return ProxyConnection; // [P]roxy-Conne[c]tion
+                                case 'x': return XXssProtection;  // [X]-XSS-Prote[c]tion
+                            }
+                            break;
+                        case 'g': return ContentLanguage; // Content-Lan[g]uage
+                        case 'i': return WWWAuthenticate; // WWW-Authent[i]cate
+                        case 'o': return ContentEncoding; // Content-Enc[o]ding
+                        case 'r': return XAspNetVersion;  // X-AspNet-Ve[r]sion
+                    }
+                    break;
+
+                case 17:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'i': return IfModifiedSince;  // [I]f-Modified-Since
+                        case 's': return SecWebSocketKey;  // [S]ec-WebSocket-Key
+                        case 't': return TransferEncoding; // [T]ransfer-Encoding
+                    }
+                    break;
+
+                case 18:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'p': return ProxyAuthenticate; // [P]roxy-Authenticate
+                        case 'x': return XContentDuration;  // [X]-Content-Duration
+                    }
+                    break;
+
+                case 19:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'c': return ContentDisposition; // [C]ontent-Disposition
+                        case 'i': return IfUnmodifiedSince;  // [I]f-Unmodified-Since
+                        case 'p': return ProxyAuthorization; // [P]roxy-Authorization
+                        case 't': return TimingAllowOrigin;  // [T]iming-Allow-Origin
+                    }
+                    break;
+
+                case 20:
+                    return SecWebSocketAccept; // Sec-WebSocket-Accept
+
+                case 21:
+                    return SecWebSocketVersion; // Sec-WebSocket-Version
+
+                case 22:
+                    switch (GetLower(key[0]))
+                    {
+                        case 'a': return AccessControlMaxAge;  // [A]ccess-Control-Max-Age
+                        case 's': return SecWebSocketProtocol; // [S]ec-WebSocket-Protocol
+                        case 'x': return XContentTypeOptions;  // [X]-Content-Type-Options
+                    }
+                    break;
+
+                case 23:
+                    return ContentSecurityPolicy; // Content-Security-Policy
+
+                case 24:
+                    return SecWebSocketExtensions; // Sec-WebSocket-Extensions
+
+                case 25:
+                    switch (GetLower(key[0]))
+                    {
+                        case 's': return StrictTransportSecurity; // [S]trict-Transport-Security
+                        case 'u': return UpgradeInsecureRequests; // [U]pgrade-Insecure-Requests
+                    }
+                    break;
+
+                case 27:
+                    return AccessControlAllowOrigin; // Access-Control-Allow-Origin
+
+                case 28:
+                    switch (GetLower(key[21]))
+                    {
+                        case 'h': return AccessControlAllowHeaders; // Access-Control-Allow-[H]eaders
+                        case 'm': return AccessControlAllowMethods; // Access-Control-Allow-[M]ethods
+                        case '-': return CrossOriginResourcePolicy; // Cross-Origin-Resource[-]Policy
+                    }
+                    break;
+
+                case 29:
+                    return AccessControlExposeHeaders; // Access-Control-Expose-Headers
+
+                case 32:
+                    return AccessControlAllowCredentials; // Access-Control-Allow-Credentials
+            }
+
+            return null;
+        }
+
+        private static KnownHeader? GetCandidate(ReadOnlySpan<byte> key)
+        {
+            // Lookup is performed by first switching on the header name's length, and then switching
+            // on the most unique position in that length's string.
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static int GetLower(byte value) => value | 0x20;
 
             switch (key.Length)
             {
@@ -387,7 +645,7 @@ namespace System.Net.Http.Headers
 
         public static KnownHeader? TryGetKnownHeader(string name)
         {
-            KnownHeader? candidate = GetCandidate<char>(name);
+            KnownHeader? candidate = GetCandidate(name);
             if (candidate != null && StringComparer.OrdinalIgnoreCase.Equals(name, candidate.Name))
             {
                 return candidate;

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -470,7 +470,12 @@ namespace System
                 return false;
             }
         }
-        private static bool TryParseGuid<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
+
+        //
+        // Char parsing
+        //
+
+        private static bool TryParseGuid(ReadOnlySpan<char> guidString, ref GuidResult result)
         {
             guidString = Number.SpanTrim(guidString); // Remove whitespace from beginning and end
 
@@ -480,23 +485,23 @@ namespace System
                 return false;
             }
 
-            return TChar.CastToUInt32(guidString[0]) switch
+            return guidString[0] switch
             {
                 '(' => TryParseExactP(guidString, ref result),
-                '{' => guidString[9] == TChar.CastFrom('-') ?
+                '{' => guidString[9] == '-' ?
                         TryParseExactB(guidString, ref result) :
                         TryParseExactX(guidString, ref result),
-                _ => guidString[8] == TChar.CastFrom('-') ?
+                _ => guidString[8] == '-' ?
                         TryParseExactD(guidString, ref result) :
                         TryParseExactN(guidString, ref result),
             };
         }
 
-        private static bool TryParseExactB<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
+        private static bool TryParseExactB(ReadOnlySpan<char> guidString, ref GuidResult result)
         {
             // e.g. "{d85b1407-351d-4694-9392-03acc5870eb1}"
 
-            if (guidString.Length != 38 || guidString[0] != TChar.CastFrom('{') || guidString[37] != TChar.CastFrom('}'))
+            if (guidString.Length != 38 || guidString[0] != '{' || guidString[37] != '}')
             {
                 result.SetFailure(ParseFailure.Format_GuidInvLen);
                 return false;
@@ -505,11 +510,11 @@ namespace System
             return TryParseExactD(guidString.Slice(1, 36), ref result);
         }
 
-        private static bool TryParseExactD<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
+        private static bool TryParseExactD(ReadOnlySpan<char> guidString, ref GuidResult result)
         {
             // e.g. "d85b1407-351d-4694-9392-03acc5870eb1"
 
-            if (guidString.Length != 36 || guidString[8] != TChar.CastFrom('-') || guidString[13] != TChar.CastFrom('-') || guidString[18] != TChar.CastFrom('-') || guidString[23] != TChar.CastFrom('-'))
+            if (guidString.Length != 36 || guidString[8] != '-' || guidString[13] != '-' || guidString[18] != '-' || guidString[23] != '-')
             {
                 result.SetFailure(guidString.Length != 36 ? ParseFailure.Format_GuidInvLen : ParseFailure.Format_GuidDashes);
                 return false;
@@ -517,16 +522,16 @@ namespace System
 
             Span<byte> bytes = MemoryMarshal.AsBytes(new Span<GuidResult>(ref result));
             int invalidIfNegative = 0;
-            bytes[0] = DecodeByte(guidString[6],   guidString[7],  ref invalidIfNegative);
-            bytes[1] = DecodeByte(guidString[4],   guidString[5],  ref invalidIfNegative);
-            bytes[2] = DecodeByte(guidString[2],   guidString[3],  ref invalidIfNegative);
-            bytes[3] = DecodeByte(guidString[0],   guidString[1],  ref invalidIfNegative);
-            bytes[4] = DecodeByte(guidString[11],  guidString[12], ref invalidIfNegative);
-            bytes[5] = DecodeByte(guidString[9],   guidString[10], ref invalidIfNegative);
-            bytes[6] = DecodeByte(guidString[16],  guidString[17], ref invalidIfNegative);
-            bytes[7] = DecodeByte(guidString[14],  guidString[15], ref invalidIfNegative);
-            bytes[8] = DecodeByte(guidString[19],  guidString[20], ref invalidIfNegative);
-            bytes[9] = DecodeByte(guidString[21],  guidString[22], ref invalidIfNegative);
+            bytes[0] = DecodeByte(guidString[6], guidString[7], ref invalidIfNegative);
+            bytes[1] = DecodeByte(guidString[4], guidString[5], ref invalidIfNegative);
+            bytes[2] = DecodeByte(guidString[2], guidString[3], ref invalidIfNegative);
+            bytes[3] = DecodeByte(guidString[0], guidString[1], ref invalidIfNegative);
+            bytes[4] = DecodeByte(guidString[11], guidString[12], ref invalidIfNegative);
+            bytes[5] = DecodeByte(guidString[9], guidString[10], ref invalidIfNegative);
+            bytes[6] = DecodeByte(guidString[16], guidString[17], ref invalidIfNegative);
+            bytes[7] = DecodeByte(guidString[14], guidString[15], ref invalidIfNegative);
+            bytes[8] = DecodeByte(guidString[19], guidString[20], ref invalidIfNegative);
+            bytes[9] = DecodeByte(guidString[21], guidString[22], ref invalidIfNegative);
             bytes[10] = DecodeByte(guidString[24], guidString[25], ref invalidIfNegative);
             bytes[11] = DecodeByte(guidString[26], guidString[27], ref invalidIfNegative);
             bytes[12] = DecodeByte(guidString[28], guidString[29], ref invalidIfNegative);
@@ -552,7 +557,7 @@ namespace System
             // We continue to support these but expect them to be incredibly rare.  As such, we
             // optimize for correctly formed strings where all the digits are valid hex, and only
             // fall back to supporting these other forms if parsing fails.
-            if (guidString.ContainsAny(TChar.CastFrom('X'), TChar.CastFrom('x'), TChar.CastFrom('+')) && TryCompatParsing(guidString, ref result))
+            if (guidString.ContainsAny('X', 'x', '+') && TryCompatParsing(guidString, ref result))
             {
                 return true;
             }
@@ -560,7 +565,7 @@ namespace System
             result.SetFailure(ParseFailure.Format_GuidInvalidChar);
             return false;
 
-            static bool TryCompatParsing(ReadOnlySpan<TChar> guidString, ref GuidResult result)
+            static bool TryCompatParsing(ReadOnlySpan<char> guidString, ref GuidResult result)
             {
                 if (TryParseHex(guidString.Slice(0, 8), out result._a) && // _a
                     TryParseHex(guidString.Slice(9, 4), out uint uintTmp)) // _b
@@ -591,7 +596,7 @@ namespace System
             }
         }
 
-        private static bool TryParseExactN<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
+        private static bool TryParseExactN(ReadOnlySpan<char> guidString, ref GuidResult result)
         {
             // e.g. "d85b1407351d4694939203acc5870eb1"
 
@@ -634,11 +639,11 @@ namespace System
             return false;
         }
 
-        private static bool TryParseExactP<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
+        private static bool TryParseExactP(ReadOnlySpan<char> guidString, ref GuidResult result)
         {
             // e.g. "(d85b1407-351d-4694-9392-03acc5870eb1)"
 
-            if (guidString.Length != 38 || guidString[0] != TChar.CastFrom('(') || guidString[37] != TChar.CastFrom(')'))
+            if (guidString.Length != 38 || guidString[0] != '(' || guidString[37] != ')')
             {
                 result.SetFailure(ParseFailure.Format_GuidInvLen);
                 return false;
@@ -647,7 +652,7 @@ namespace System
             return TryParseExactD(guidString.Slice(1, 36), ref result);
         }
 
-        private static bool TryParseExactX<TChar>(ReadOnlySpan<TChar> guidString, ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
+        private static bool TryParseExactX(ReadOnlySpan<char> guidString, ref GuidResult result)
         {
             // e.g. "{0xd85b1407,0x351d,0x4694,{0x93,0x92,0x03,0xac,0xc5,0x87,0x0e,0xb1}}"
 
@@ -662,10 +667,10 @@ namespace System
 
             // Eat all of the whitespace.  Unlike the other forms, X allows for any amount of whitespace
             // anywhere, not just at the beginning and end.
-            guidString = EatAllWhitespace(guidString, ref result);
+            guidString = EatAllWhitespace(guidString);
 
             // Check for leading '{'
-            if (guidString.Length == 0 || guidString[0] != TChar.CastFrom('{'))
+            if (guidString.Length == 0 || guidString[0] != '{')
             {
                 result.SetFailure(ParseFailure.Format_GuidBrace);
                 return false;
@@ -680,7 +685,7 @@ namespace System
 
             // Find the end of this hex number (since it is not fixed length)
             int numStart = 3;
-            int numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom(','));
+            int numLen = guidString.Slice(numStart).IndexOf(',');
             if (numLen <= 0)
             {
                 result.SetFailure(ParseFailure.Format_GuidComma);
@@ -702,7 +707,7 @@ namespace System
             }
             // +3 to get by ',0x'
             numStart = numStart + numLen + 3;
-            numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom(','));
+            numLen = guidString.Slice(numStart).IndexOf(',');
             if (numLen <= 0)
             {
                 result.SetFailure(ParseFailure.Format_GuidComma);
@@ -724,7 +729,7 @@ namespace System
             }
             // +3 to get by ',0x'
             numStart = numStart + numLen + 3;
-            numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom(','));
+            numLen = guidString.Slice(numStart).IndexOf(',');
             if (numLen <= 0)
             {
                 result.SetFailure(ParseFailure.Format_GuidComma);
@@ -739,7 +744,7 @@ namespace System
             }
 
             // Check for '{'
-            if ((uint)guidString.Length <= (uint)(numStart + numLen + 1) || guidString[numStart + numLen + 1] != TChar.CastFrom('{'))
+            if ((uint)guidString.Length <= (uint)(numStart + numLen + 1) || guidString[numStart + numLen + 1] != '{')
             {
                 result.SetFailure(ParseFailure.Format_GuidBrace);
                 return false;
@@ -762,7 +767,7 @@ namespace System
                 // Calculate number length
                 if (i < 7)  // first 7 cases
                 {
-                    numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom(','));
+                    numLen = guidString.Slice(numStart).IndexOf(',');
                     if (numLen <= 0)
                     {
                         result.SetFailure(ParseFailure.Format_GuidComma);
@@ -771,7 +776,7 @@ namespace System
                 }
                 else // last case ends with '}', not ','
                 {
-                    numLen = guidString.Slice(numStart).IndexOf(TChar.CastFrom('}'));
+                    numLen = guidString.Slice(numStart).IndexOf('}');
                     if (numLen <= 0)
                     {
                         result.SetFailure(ParseFailure.Format_GuidBraceAfterLastNumber);
@@ -796,7 +801,7 @@ namespace System
             }
 
             // Check for last '}'
-            if (numStart + numLen + 1 >= guidString.Length || guidString[numStart + numLen + 1] != TChar.CastFrom('}'))
+            if (numStart + numLen + 1 >= guidString.Length || guidString[numStart + numLen + 1] != '}')
             {
                 result.SetFailure(ParseFailure.Format_GuidEndBrace);
                 return false;
@@ -813,7 +818,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static byte DecodeByte<TChar>(TChar ch1, TChar ch2, ref int invalidIfNegative) where TChar : unmanaged, IUtfChar<TChar>
+        private static byte DecodeByte(char ch1, char ch2, ref int invalidIfNegative)
         {
             ReadOnlySpan<byte> lookup = HexConverter.CharToHexLookup;
             Debug.Assert(lookup.Length == 256);
@@ -821,37 +826,37 @@ namespace System
             int lower = (sbyte)lookup[byte.CreateTruncating(ch2)];
             int result = (upper << 4) | lower;
 
-            uint c1 = TChar.CastToUInt32(ch1);
-            uint c2 = TChar.CastToUInt32(ch2);
+            uint c1 = (uint)ch1;
+            uint c2 = (uint)ch2;
             // Result will be negative if ch1 or/and ch2 are greater than 0xFF
             result = (c1 | c2) >> 8 == 0 ? result : -1;
             invalidIfNegative |= result;
             return (byte)result;
         }
 
-        private static bool TryParseHex<TChar>(ReadOnlySpan<TChar> guidString, out ushort result, ref bool overflow) where TChar : unmanaged, IUtfChar<TChar>
+        private static bool TryParseHex(ReadOnlySpan<char> guidString, out ushort result, ref bool overflow)
         {
             bool success = TryParseHex(guidString, out uint tmp, ref overflow);
             result = (ushort)tmp;
             return success;
         }
 
-        private static bool TryParseHex<TChar>(ReadOnlySpan<TChar> guidString, out uint result) where TChar : unmanaged, IUtfChar<TChar>
+        private static bool TryParseHex(ReadOnlySpan<char> guidString, out uint result)
         {
             bool overflowIgnored = false;
             return TryParseHex(guidString, out result, ref overflowIgnored);
         }
 
-        private static bool TryParseHex<TChar>(ReadOnlySpan<TChar> guidString, out uint result, ref bool overflow) where TChar : unmanaged, IUtfChar<TChar>
+        private static bool TryParseHex(ReadOnlySpan<char> guidString, out uint result, ref bool overflow)
         {
             if (guidString.Length > 0)
             {
-                if (guidString[0] == TChar.CastFrom('+'))
+                if (guidString[0] == '+')
                 {
                     guidString = guidString.Slice(1);
                 }
 
-                if (guidString.Length > 1 && guidString[0] == TChar.CastFrom('0') && (guidString[1] | TChar.CastFrom(0x20)) == TChar.CastFrom('x'))
+                if (guidString.Length > 1 && guidString[0] == '0' && (guidString[1] | 0x20) == 'x')
                 {
                     guidString = guidString.Slice(2);
                 }
@@ -859,7 +864,7 @@ namespace System
 
             // Skip past leading 0s.
             int i = 0;
-            for (; i < guidString.Length && guidString[i] == TChar.CastFrom('0'); i++) ;
+            for (; i < guidString.Length && guidString[i] == '0'; i++) ;
 
             int processedDigits = 0;
             uint tmp = 0;
@@ -882,106 +887,525 @@ namespace System
             return true;
         }
 
-        private static ReadOnlySpan<TChar> EatAllWhitespace<TChar>(ReadOnlySpan<TChar> str, scoped ref GuidResult result) where TChar : unmanaged, IUtfChar<TChar>
+        private static ReadOnlySpan<char> EatAllWhitespace(ReadOnlySpan<char> str)
         {
-            if (typeof(TChar) == typeof(char))
+            ReadOnlySpan<char> charSpan = Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<char>>(str);
+            // Find the first whitespace character. If there is none, just return the input.
+            int i;
+            for (i = 0; i < charSpan.Length && !char.IsWhiteSpace(charSpan[i]); i++) ;
+            if (i == charSpan.Length)
             {
-                ReadOnlySpan<char> charSpan = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(str);
-                // Find the first whitespace character. If there is none, just return the input.
-                int i;
-                for (i = 0; i < charSpan.Length && !char.IsWhiteSpace(charSpan[i]); i++) ;
-                if (i == charSpan.Length)
-                {
-                    return str;
-                }
-
-                // There was at least one whitespace. Copy over everything prior to it to a new array.
-                var chArr = new char[charSpan.Length];
-                int newLength = 0;
-                if (i > 0)
-                {
-                    newLength = i;
-                    charSpan.Slice(0, i).CopyTo(chArr);
-                }
-
-                // Loop through the remaining chars, copying over non-whitespace.
-                for (; i < charSpan.Length; i++)
-                {
-                    char c = charSpan[i];
-                    if (!char.IsWhiteSpace(c))
-                    {
-                        chArr[newLength++] = c;
-                    }
-                }
-
-                // Return the string with the whitespace removed.
-                return Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(new ReadOnlySpan<char>(chArr, 0, newLength));
+                return str;
             }
-            else
+
+            // There was at least one whitespace. Copy over everything prior to it to a new array.
+            var chArr = new char[charSpan.Length];
+            int newLength = 0;
+            if (i > 0)
             {
-                Debug.Assert(typeof(TChar) == typeof(byte));
+                newLength = i;
+                charSpan.Slice(0, i).CopyTo(chArr);
+            }
 
-                ReadOnlySpan<byte> srcUtf8Span = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(str);
-
-                // Find the first whitespace character.  If there is none, just return the input.
-                int i = 0;
-                while (i < srcUtf8Span.Length)
+            // Loop through the remaining chars, copying over non-whitespace.
+            for (; i < charSpan.Length; i++)
+            {
+                char c = charSpan[i];
+                if (!char.IsWhiteSpace(c))
                 {
-                    if (Rune.DecodeFromUtf8(srcUtf8Span.Slice(i), out Rune current, out int bytesConsumed) != Buffers.OperationStatus.Done)
-                    {
-                        result.SetFailure(ParseFailure.Format_GuidInvalidChar);
-                        return ReadOnlySpan<TChar>.Empty;
-                    }
+                    chArr[newLength++] = c;
+                }
+            }
 
-                    if (!Rune.IsWhiteSpace(current))
-                    {
-                        break;
-                    }
+            // Return the string with the whitespace removed.
+            return new ReadOnlySpan<char>(chArr, 0, newLength);
+        }
 
-                    i += bytesConsumed;
+        private static bool IsHexPrefix(ReadOnlySpan<char> str, int i) =>
+            i + 1 < str.Length &&
+            str[i] == '0' &&
+            (str[i + 1] | 0x20) == 'x';
+
+        //
+        // Byte parsing
+        //
+
+        private static bool TryParseGuid(ReadOnlySpan<byte> guidString, ref GuidResult result)
+        {
+            guidString = Number.SpanTrim(guidString); // Remove whitespace from beginning and end
+
+            if (guidString.Length < 32) // Minimal length we can parse ('N' format)
+            {
+                result.SetFailure(ParseFailure.Format_GuidUnrecognized);
+                return false;
+            }
+
+            return guidString[0] switch
+            {
+                (byte)('(') => TryParseExactP(guidString, ref result),
+                (byte)('{') => guidString[9] == (byte)('-') ?
+                        TryParseExactB(guidString, ref result) :
+                        TryParseExactX(guidString, ref result),
+                _ => guidString[8] == (byte)('-') ?
+                        TryParseExactD(guidString, ref result) :
+                        TryParseExactN(guidString, ref result),
+            };
+        }
+
+        private static bool TryParseExactB(ReadOnlySpan<byte> guidString, ref GuidResult result)
+        {
+            // e.g. "{d85b1407-351d-4694-9392-03acc5870eb1}"
+
+            if (guidString.Length != 38 || guidString[0] != (byte)('{') || guidString[37] != (byte)('}'))
+            {
+                result.SetFailure(ParseFailure.Format_GuidInvLen);
+                return false;
+            }
+
+            return TryParseExactD(guidString.Slice(1, 36), ref result);
+        }
+
+        private static bool TryParseExactD(ReadOnlySpan<byte> guidString, ref GuidResult result)
+        {
+            // e.g. "d85b1407-351d-4694-9392-03acc5870eb1"
+
+            if (guidString.Length != 36 || guidString[8] != (byte)('-') || guidString[13] != (byte)('-') || guidString[18] != (byte)('-') || guidString[23] != (byte)('-'))
+            {
+                result.SetFailure(guidString.Length != 36 ? ParseFailure.Format_GuidInvLen : ParseFailure.Format_GuidDashes);
+                return false;
+            }
+
+            Span<byte> bytes = MemoryMarshal.AsBytes(new Span<GuidResult>(ref result));
+            int invalidIfNegative = 0;
+            bytes[0] = DecodeByte(guidString[6], guidString[7], ref invalidIfNegative);
+            bytes[1] = DecodeByte(guidString[4], guidString[5], ref invalidIfNegative);
+            bytes[2] = DecodeByte(guidString[2], guidString[3], ref invalidIfNegative);
+            bytes[3] = DecodeByte(guidString[0], guidString[1], ref invalidIfNegative);
+            bytes[4] = DecodeByte(guidString[11], guidString[12], ref invalidIfNegative);
+            bytes[5] = DecodeByte(guidString[9], guidString[10], ref invalidIfNegative);
+            bytes[6] = DecodeByte(guidString[16], guidString[17], ref invalidIfNegative);
+            bytes[7] = DecodeByte(guidString[14], guidString[15], ref invalidIfNegative);
+            bytes[8] = DecodeByte(guidString[19], guidString[20], ref invalidIfNegative);
+            bytes[9] = DecodeByte(guidString[21], guidString[22], ref invalidIfNegative);
+            bytes[10] = DecodeByte(guidString[24], guidString[25], ref invalidIfNegative);
+            bytes[11] = DecodeByte(guidString[26], guidString[27], ref invalidIfNegative);
+            bytes[12] = DecodeByte(guidString[28], guidString[29], ref invalidIfNegative);
+            bytes[13] = DecodeByte(guidString[30], guidString[31], ref invalidIfNegative);
+            bytes[14] = DecodeByte(guidString[32], guidString[33], ref invalidIfNegative);
+            bytes[15] = DecodeByte(guidString[34], guidString[35], ref invalidIfNegative);
+
+            if (invalidIfNegative >= 0)
+            {
+                if (!BitConverter.IsLittleEndian)
+                {
+                    result.ReverseAbcEndianness();
                 }
 
-                if (i == srcUtf8Span.Length)
-                {
-                    return str;
-                }
+                return true;
+            }
 
-                // There was at least one whitespace. Copy over everything prior to it to a new array.
-                Span<byte> destUtf8Span = new byte[srcUtf8Span.Length];
-                int newLength = 0;
-                if (i > 0)
-                {
-                    newLength = i;
-                    srcUtf8Span.Slice(0, i).CopyTo(destUtf8Span);
-                }
+            // The 'D' format has some undesirable behavior leftover from its original implementation:
+            // - Components may begin with "0x" and/or "+", but the expected length of each component
+            //   needs to include those prefixes, e.g. a four digit component could be "1234" or
+            //   "0x34" or "+0x4" or "+234", but not "0x1234" nor "+1234" nor "+0x1234".
+            // - "0X" is valid instead of "0x"
+            // We continue to support these but expect them to be incredibly rare.  As such, we
+            // optimize for correctly formed strings where all the digits are valid hex, and only
+            // fall back to supporting these other forms if parsing fails.
+            if (guidString.ContainsAny((byte)('X'), (byte)('x'), (byte)('+')) && TryCompatParsing(guidString, ref result))
+            {
+                return true;
+            }
 
-                // Loop through the remaining chars, copying over non-whitespace.
-                while (i < srcUtf8Span.Length)
+            result.SetFailure(ParseFailure.Format_GuidInvalidChar);
+            return false;
+
+            static bool TryCompatParsing(ReadOnlySpan<byte> guidString, ref GuidResult result)
+            {
+                guidString = guidString.Slice(0, 36);
+
+                if (TryParseHex(guidString.Slice(0, 8), out result._a) && // _a
+                    TryParseHex(guidString.Slice(9, 4), out uint uintTmp)) // _b
                 {
-                    if (Rune.DecodeFromUtf8(srcUtf8Span.Slice(i), out Rune current, out int bytesConsumed) != Buffers.OperationStatus.Done)
+                    result._b = (ushort)uintTmp;
+                    if (TryParseHex(guidString.Slice(14, 4), out uintTmp)) // _c
                     {
-                        result.SetFailure(ParseFailure.Format_GuidInvalidChar);
-                        return ReadOnlySpan<TChar>.Empty;
-                    }
+                        result._c = (ushort)uintTmp;
+                        if (TryParseHex(guidString.Slice(19, 4), out uintTmp)) // _d, _e
+                        {
+                            result._de = BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness((ushort)uintTmp) : (ushort)uintTmp;
+                            if (TryParseHex(guidString.Slice(24, 4), out uintTmp)) // _f, _g
+                            {
+                                result._fg = BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness((ushort)uintTmp) : (ushort)uintTmp;
 
-                    if (!Rune.IsWhiteSpace(current))
-                    {
-                        srcUtf8Span.Slice(i, bytesConsumed).CopyTo(destUtf8Span.Slice(newLength));
-                        newLength += bytesConsumed;
+                                // Unlike the other components, this one never allowed 0x or +, so we can parse it as straight hex.
+                                if (Number.TryParseBinaryIntegerHexNumberStyle(guidString.Slice(28, 8), NumberStyles.AllowHexSpecifier, out uintTmp) == Number.ParsingStatus.OK) // _h, _i, _j, _k
+                                {
+                                    result._hijk = BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(uintTmp) : uintTmp;
+                                    return true;
+                                }
+                            }
+                        }
                     }
-
-                    i += bytesConsumed;
                 }
 
-                // Return the string with the whitespace removed.
-                return Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(destUtf8Span.Slice(0, newLength));
+                return false;
             }
         }
 
-        private static bool IsHexPrefix<TChar>(ReadOnlySpan<TChar> str, int i) where TChar : unmanaged, IUtfChar<TChar> =>
+        private static bool TryParseExactN(ReadOnlySpan<byte> guidString, ref GuidResult result)
+        {
+            // e.g. "d85b1407351d4694939203acc5870eb1"
+
+            if (guidString.Length != 32)
+            {
+                result.SetFailure(ParseFailure.Format_GuidInvLen);
+                return false;
+            }
+
+            Span<byte> bytes = MemoryMarshal.AsBytes(new Span<GuidResult>(ref result));
+            int invalidIfNegative = 0;
+            bytes[0] = DecodeByte(guidString[6], guidString[7], ref invalidIfNegative);
+            bytes[1] = DecodeByte(guidString[4], guidString[5], ref invalidIfNegative);
+            bytes[2] = DecodeByte(guidString[2], guidString[3], ref invalidIfNegative);
+            bytes[3] = DecodeByte(guidString[0], guidString[1], ref invalidIfNegative);
+            bytes[4] = DecodeByte(guidString[10], guidString[11], ref invalidIfNegative);
+            bytes[5] = DecodeByte(guidString[8], guidString[9], ref invalidIfNegative);
+            bytes[6] = DecodeByte(guidString[14], guidString[15], ref invalidIfNegative);
+            bytes[7] = DecodeByte(guidString[12], guidString[13], ref invalidIfNegative);
+            bytes[8] = DecodeByte(guidString[16], guidString[17], ref invalidIfNegative);
+            bytes[9] = DecodeByte(guidString[18], guidString[19], ref invalidIfNegative);
+            bytes[10] = DecodeByte(guidString[20], guidString[21], ref invalidIfNegative);
+            bytes[11] = DecodeByte(guidString[22], guidString[23], ref invalidIfNegative);
+            bytes[12] = DecodeByte(guidString[24], guidString[25], ref invalidIfNegative);
+            bytes[13] = DecodeByte(guidString[26], guidString[27], ref invalidIfNegative);
+            bytes[14] = DecodeByte(guidString[28], guidString[29], ref invalidIfNegative);
+            bytes[15] = DecodeByte(guidString[30], guidString[31], ref invalidIfNegative);
+
+            if (invalidIfNegative >= 0)
+            {
+                if (!BitConverter.IsLittleEndian)
+                {
+                    result.ReverseAbcEndianness();
+                }
+
+                return true;
+            }
+
+            result.SetFailure(ParseFailure.Format_GuidInvalidChar);
+            return false;
+        }
+
+        private static bool TryParseExactP(ReadOnlySpan<byte> guidString, ref GuidResult result)
+        {
+            // e.g. "(d85b1407-351d-4694-9392-03acc5870eb1)"
+
+            if (guidString.Length != 38 || guidString[0] != (byte)('(') || guidString[37] != (byte)(')'))
+            {
+                result.SetFailure(ParseFailure.Format_GuidInvLen);
+                return false;
+            }
+
+            return TryParseExactD(guidString.Slice(1, 36), ref result);
+        }
+
+        private static bool TryParseExactX(ReadOnlySpan<byte> guidString, ref GuidResult result)
+        {
+            // e.g. "{0xd85b1407,0x351d,0x4694,{0x93,0x92,0x03,0xac,0xc5,0x87,0x0e,0xb1}}"
+
+            // Compat notes due to the previous implementation's implementation details.
+            // - Each component need not be the full expected number of digits.
+            // - Each component may contain any number of leading 0s
+            // - The "short" components are parsed as 32-bits and only considered to overflow if they'd overflow 32 bits.
+            // - The "byte" components are parsed as 32-bits and are considered to overflow if they'd overflow 8 bits,
+            //   but for the Guid ctor, whether they overflow 8 bits or 32 bits results in differing exceptions.
+            // - Components may begin with "0x", "0x+", even "0x+0x".
+            // - "0X" is valid instead of "0x"
+
+            // Eat all of the whitespace.  Unlike the other forms, X allows for any amount of whitespace
+            // anywhere, not just at the beginning and end.
+            guidString = EatAllWhitespace(guidString, ref result);
+
+            // Check for leading '{'
+            if (guidString.Length == 0 || guidString[0] != (byte)('{'))
+            {
+                result.SetFailure(ParseFailure.Format_GuidBrace);
+                return false;
+            }
+
+            // Check for '0x'
+            if (!IsHexPrefix(guidString, 1))
+            {
+                result.SetFailure(ParseFailure.Format_GuidHexPrefix);
+                return false;
+            }
+
+            // Find the end of this hex number (since it is not fixed length)
+            int numStart = 3;
+            int numLen = guidString.Slice(numStart).IndexOf((byte)(','));
+            if (numLen <= 0)
+            {
+                result.SetFailure(ParseFailure.Format_GuidComma);
+                return false;
+            }
+
+            bool overflow = false;
+            if (!TryParseHex(guidString.Slice(numStart, numLen), out result._a, ref overflow) || overflow)
+            {
+                result.SetFailure(overflow ? ParseFailure.Overflow_UInt32 : ParseFailure.Format_GuidInvalidChar);
+                return false;
+            }
+
+            // Check for '0x'
+            if (!IsHexPrefix(guidString, numStart + numLen + 1))
+            {
+                result.SetFailure(ParseFailure.Format_GuidHexPrefix);
+                return false;
+            }
+            // +3 to get by ',0x'
+            numStart = numStart + numLen + 3;
+            numLen = guidString.Slice(numStart).IndexOf((byte)(','));
+            if (numLen <= 0)
+            {
+                result.SetFailure(ParseFailure.Format_GuidComma);
+                return false;
+            }
+
+            // Read in the number
+            if (!TryParseHex(guidString.Slice(numStart, numLen), out result._b, ref overflow) || overflow)
+            {
+                result.SetFailure(overflow ? ParseFailure.Overflow_UInt32 : ParseFailure.Format_GuidInvalidChar);
+                return false;
+            }
+
+            // Check for '0x'
+            if (!IsHexPrefix(guidString, numStart + numLen + 1))
+            {
+                result.SetFailure(ParseFailure.Format_GuidHexPrefix);
+                return false;
+            }
+            // +3 to get by ',0x'
+            numStart = numStart + numLen + 3;
+            numLen = guidString.Slice(numStart).IndexOf((byte)(','));
+            if (numLen <= 0)
+            {
+                result.SetFailure(ParseFailure.Format_GuidComma);
+                return false;
+            }
+
+            // Read in the number
+            if (!TryParseHex(guidString.Slice(numStart, numLen), out result._c, ref overflow) || overflow)
+            {
+                result.SetFailure(overflow ? ParseFailure.Overflow_UInt32 : ParseFailure.Format_GuidInvalidChar);
+                return false;
+            }
+
+            // Check for '{'
+            if ((uint)guidString.Length <= (uint)(numStart + numLen + 1) || guidString[numStart + numLen + 1] != (byte)('{'))
+            {
+                result.SetFailure(ParseFailure.Format_GuidBrace);
+                return false;
+            }
+
+            // Prepare for loop
+            numLen++;
+            for (int i = 0; i < 8; i++)
+            {
+                // Check for '0x'
+                if (!IsHexPrefix(guidString, numStart + numLen + 1))
+                {
+                    result.SetFailure(ParseFailure.Format_GuidHexPrefix);
+                    return false;
+                }
+
+                // +3 to get by ',0x' or '{0x' for first case
+                numStart = numStart + numLen + 3;
+
+                // Calculate number length
+                if (i < 7)  // first 7 cases
+                {
+                    numLen = guidString.Slice(numStart).IndexOf((byte)(','));
+                    if (numLen <= 0)
+                    {
+                        result.SetFailure(ParseFailure.Format_GuidComma);
+                        return false;
+                    }
+                }
+                else // last case ends with '}', not ','
+                {
+                    numLen = guidString.Slice(numStart).IndexOf((byte)('}'));
+                    if (numLen <= 0)
+                    {
+                        result.SetFailure(ParseFailure.Format_GuidBraceAfterLastNumber);
+                        return false;
+                    }
+                }
+
+                // Read in the number
+                if (!TryParseHex(guidString.Slice(numStart, numLen), out uint byteVal, ref overflow) || overflow || byteVal > byte.MaxValue)
+                {
+                    // The previous implementation had some odd inconsistencies, which are carried forward here.
+                    // The byte values in the X format are treated as integers with regards to overflow, so
+                    // a "byte" value like 0xddd in Guid's ctor results in a FormatException but 0xddddddddd results
+                    // in OverflowException.
+                    result.SetFailure(
+                        overflow ? ParseFailure.Overflow_UInt32 :
+                        byteVal > byte.MaxValue ? ParseFailure.Overflow_Byte :
+                        ParseFailure.Format_GuidInvalidChar);
+                    return false;
+                }
+                Unsafe.Add(ref result._d, i) = (byte)byteVal;
+            }
+
+            // Check for last '}'
+            if (numStart + numLen + 1 >= guidString.Length || guidString[numStart + numLen + 1] != (byte)('}'))
+            {
+                result.SetFailure(ParseFailure.Format_GuidEndBrace);
+                return false;
+            }
+
+            // Check if we have extra characters at the end
+            if (numStart + numLen + 1 != guidString.Length - 1)
+            {
+                result.SetFailure(ParseFailure.Format_ExtraJunkAtEnd);
+                return false;
+            }
+
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static byte DecodeByte(byte ch1, byte ch2, ref int invalidIfNegative)
+        {
+            ReadOnlySpan<byte> lookup = HexConverter.CharToHexLookup;
+            Debug.Assert(lookup.Length == 256);
+            int upper = (sbyte)lookup[byte.CreateTruncating(ch1)];
+            int lower = (sbyte)lookup[byte.CreateTruncating(ch2)];
+            int result = (upper << 4) | lower;
+
+            uint c1 = (uint)ch1;
+            uint c2 = (uint)ch2;
+            // Result will be negative if ch1 or/and ch2 are greater than 0xFF
+            result = (c1 | c2) >> 8 == 0 ? result : -1;
+            invalidIfNegative |= result;
+            return (byte)result;
+        }
+
+        private static bool TryParseHex(ReadOnlySpan<byte> guidString, out ushort result, ref bool overflow)
+        {
+            bool success = TryParseHex(guidString, out uint tmp, ref overflow);
+            result = (ushort)tmp;
+            return success;
+        }
+
+        private static bool TryParseHex(ReadOnlySpan<byte> guidString, out uint result)
+        {
+            bool overflowIgnored = false;
+            return TryParseHex(guidString, out result, ref overflowIgnored);
+        }
+
+        private static bool TryParseHex(ReadOnlySpan<byte> guidString, out uint result, ref bool overflow)
+        {
+            if (guidString.Length > 0)
+            {
+                if (guidString[0] == (byte)('+'))
+                {
+                    guidString = guidString.Slice(1);
+                }
+
+                if (guidString.Length > 1 && guidString[0] == (byte)('0') && (guidString[1] | (byte)(0x20)) == (byte)('x'))
+                {
+                    guidString = guidString.Slice(2);
+                }
+            }
+
+            // Skip past leading 0s.
+            int i = 0;
+            for (; i < guidString.Length && guidString[i] == (byte)('0'); i++) ;
+
+            int processedDigits = 0;
+            uint tmp = 0;
+            for (; i < guidString.Length; i++)
+            {
+                int c = int.CreateTruncating(guidString[i]);
+                int numValue = HexConverter.FromChar(c);
+                if (numValue == 0xFF)
+                {
+                    if (processedDigits > 8) overflow = true;
+                    result = 0;
+                    return false;
+                }
+                tmp = (tmp * 16) + (uint)numValue;
+                processedDigits++;
+            }
+
+            if (processedDigits > 8) overflow = true;
+            result = tmp;
+            return true;
+        }
+
+        private static ReadOnlySpan<byte> EatAllWhitespace(ReadOnlySpan<byte> str, scoped ref GuidResult result)
+        {
+            ReadOnlySpan<byte> srcUtf8Span = Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<byte>>(str);
+
+            // Find the first whitespace character.  If there is none, just return the input.
+            int i = 0;
+            while (i < srcUtf8Span.Length)
+            {
+                if (Rune.DecodeFromUtf8(srcUtf8Span.Slice(i), out Rune current, out int bytesConsumed) != Buffers.OperationStatus.Done)
+                {
+                    result.SetFailure(ParseFailure.Format_GuidInvalidChar);
+                    return ReadOnlySpan<byte>.Empty;
+                }
+
+                if (!Rune.IsWhiteSpace(current))
+                {
+                    break;
+                }
+
+                i += bytesConsumed;
+            }
+
+            if (i == srcUtf8Span.Length)
+            {
+                return str;
+            }
+
+            // There was at least one whitespace. Copy over everything prior to it to a new array.
+            Span<byte> destUtf8Span = new byte[srcUtf8Span.Length];
+            int newLength = 0;
+            if (i > 0)
+            {
+                newLength = i;
+                srcUtf8Span.Slice(0, i).CopyTo(destUtf8Span);
+            }
+
+            // Loop through the remaining chars, copying over non-whitespace.
+            while (i < srcUtf8Span.Length)
+            {
+                if (Rune.DecodeFromUtf8(srcUtf8Span.Slice(i), out Rune current, out int bytesConsumed) != Buffers.OperationStatus.Done)
+                {
+                    result.SetFailure(ParseFailure.Format_GuidInvalidChar);
+                    return ReadOnlySpan<byte>.Empty;
+                }
+
+                if (!Rune.IsWhiteSpace(current))
+                {
+                    srcUtf8Span.Slice(i, bytesConsumed).CopyTo(destUtf8Span.Slice(newLength));
+                    newLength += bytesConsumed;
+                }
+
+                i += bytesConsumed;
+            }
+
+            // Return the string with the whitespace removed.
+            return destUtf8Span.Slice(0, newLength);
+        }
+
+        private static bool IsHexPrefix(ReadOnlySpan<byte> str, int i) =>
             i + 1 < str.Length &&
-            str[i] == TChar.CastFrom('0') &&
-            (str[i + 1] | TChar.CastFrom(0x20)) == TChar.CastFrom('x');
+            str[i] == (byte)('0') &&
+            (str[i + 1] | (byte)(0x20)) == (byte)('x');
 
         // Returns an unsigned byte array containing the GUID.
         public byte[] ToByteArray()


### PR DESCRIPTION
Unroll code sharing strategy to avoid generic interface loading issues.

Fixes Issue https://github.com/dotnet/runtime/issues/120288

main PR https://github.com/dotnet/runtime/pull/120549

# Description

This PR avoids the perf penalty of the generic instantiation of a large number of interfaces startup by unrolling the code for all primitive types manually. This way the loading is pay for play.  

# Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

# Testing

<!-- What kind of testing has been done with the fix. -->

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

# Package authoring no longer needed in .NET 9

IMPORTANT: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.