### PR TITLE
Revert "Change Brotli CompressionLevel.Fastest to use quality 2 instead of 1"

### DIFF
--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliUtils.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliUtils.cs
@@ -16,11 +16,7 @@ namespace System.IO.Compression
             compressionLevel switch
             {
                 CompressionLevel.NoCompression => Quality_Min,
-                // We use quality 2 for Fastest instead of 0 or 1 because qualities 0 and 1 produce very poor
-                // compression for incremental writes (e.g., line-by-line), often resulting in output larger
-                // than the uncompressed input. Quality 2 provides much better compression for such scenarios
-                // while still maintaining fast compression speed.
-                CompressionLevel.Fastest => 2,
+                CompressionLevel.Fastest => 1,
                 CompressionLevel.Optimal => Quality_Default,
                 CompressionLevel.SmallestSize => Quality_Max,
                 _ => throw new ArgumentException(SR.ArgumentOutOfRange_Enum, nameof(compressionLevel))


### PR DESCRIPTION
Reverts dotnet/runtime#120433
Closes https://github.com/dotnet/runtime/issues/120711

Unfortunately, increasing the quality decreases performance when batching the input (as is the expected usage). And the large (in some benchmarks up to 80% slowdown) performance hit does not justify fixing the small writes scenario this way.

