### PR TITLE
Don't assume all S_IFREG files are seekable

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -332,13 +332,11 @@ namespace Microsoft.Win32.SafeHandles
                     // we take advantage of the information provided by the fstat syscall
                     // and for regular files (most common case)
                     // avoid one extra sys call for determining whether file can be seeked
-                    // we exclude 0-length files because they may be actually pipes
+                    _canSeek = NullableBool.True;
+
+                    // we exclude 0-length files from the assert because those may may be pseudofiles
                     // (e.g. /proc/net/route) and these are not seekable on all systems
-                    if (status.Size > 0)
-                    {
-                        _canSeek = NullableBool.True;
-                        Debug.Assert(Interop.Sys.LSeek(this, 0, Interop.Sys.SeekWhence.SEEK_CUR) >= 0);
-                    }
+                    Debug.Assert(status.Size == 0 || Interop.Sys.LSeek(this, 0, Interop.Sys.SeekWhence.SEEK_CUR) >= 0);
                 }
 
                 fileLength = status.Size;

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -332,8 +332,13 @@ namespace Microsoft.Win32.SafeHandles
                     // we take advantage of the information provided by the fstat syscall
                     // and for regular files (most common case)
                     // avoid one extra sys call for determining whether file can be seeked
-                    _canSeek = NullableBool.True;
-                    Debug.Assert(Interop.Sys.LSeek(this, 0, Interop.Sys.SeekWhence.SEEK_CUR) >= 0);
+                    // we exclude 0-length files because they may be actually pipes
+                    // (e.g. /proc/net/route) and these are not seekable on all systems
+                    if (status.Size > 0)
+                    {
+                        _canSeek = NullableBool.True;
+                        Debug.Assert(Interop.Sys.LSeek(this, 0, Interop.Sys.SeekWhence.SEEK_CUR) >= 0);
+                    }
                 }
 
                 fileLength = status.Size;


### PR DESCRIPTION
Fixes #120577.

It seems that special files like /proc/net/route are not seekable on AzureLinux 3, which trips an assert in SafeFileHandle.Init. 
This PR excludes 0-length files (including all pseudofiles) from the assert to unblock CI.

<details>
<summary>Original outdated description</summary>

Since these files report 0 length in `fstat`, we can relax the seekabilit assumption to only files with Size > 0.

In practice, most file reads are done via `RandomAccess.ReadAtOffset` and we keep our own seek offset in the SafeFileHandle internally, so seekability does not matter much (the affected unit tests don't fail in release builds), but it breaks in e.g. following scenario where access to SafeFileHandle property would attempt to synchronize the position with the underlying OS handle:

```cs
FileStream file = new FileStream("/proc/net/route", FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 10);

System.Console.WriteLine($"Position: {file.Position}, CanSeek: {file.CanSeek}, Length: {file.Length}");

file.Position = 1;

System.Console.WriteLine($"SafeFileHandle: {file.SafeFileHandle}");
```

This would produce:

```
Position: 0, CanSeek: True, Length: 0

      System.IO.IOException : Illegal seek : '/proc/net/route'
      Stack Trace:
        /_/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs(104,0): at System.IO.Strategies.OSFileStreamStrategy.get_SafeFileHandle()
...
```

</details>
