### PR TITLE
[clr-interp] Fix cconv issue in InterpreterStub on linux-x64

### DIFF
--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -451,7 +451,7 @@ NESTED_ENTRY InterpreterStub, _TEXT, NoHandler
         jnz             LOCAL_LABEL(HaveInterpThreadContext)
 
 LOCAL_LABEL(NoManagedThread):
-        mov             rcx, r10
+        mov             rdi, r10
         call            C_FUNC(GetInterpThreadContextWithPossiblyMissingThread)
 
 LOCAL_LABEL(HaveInterpThreadContext):


### PR DESCRIPTION
It seems like this code was copied over from windows version, with minor oversight leading to passing first arg in rcx instead of rdi.