### PR TITLE
[browser][mono][perf] partial revert 119307 119800

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/NativeRebuildTests/FlagsChangeRebuildTest.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NativeRebuildTests/FlagsChangeRebuildTest.cs
@@ -39,9 +39,6 @@ namespace Wasm.Build.NativeRebuild.Tests
             if (!dotnetNativeFilesUnchanged)
                 pathsDict.UpdateTo(unchanged: false, "dotnet.native.wasm", "dotnet.native.js");
 
-            if (extraCFlags.Length != 0)
-                pathsDict.UpdateTo(unchanged: false, "driver.o", "runtime.o", "corebindings.o", "pinvoke.o");
-
             var originalStat = StatFiles(pathsDict);
 
             // Rebuild

--- a/src/mono/wasm/Wasm.Build.Tests/NativeRebuildTests/FlagsChangeRebuildTest.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NativeRebuildTests/FlagsChangeRebuildTest.cs
@@ -35,7 +35,7 @@ namespace Wasm.Build.NativeRebuild.Tests
             ProjectInfo info = CopyTestAsset(config, aot, TestAsset.WasmBasicTestApp, "rebuild_flags");
             BuildPaths paths = await FirstNativeBuildAndRun(info, config, aot, requestNativeRelink: true, invariant: false);
             var pathsDict = GetFilesTable(info.ProjectName, aot, paths, unchanged: true);
-            bool dotnetNativeFilesUnchanged = extraLDFlags.Length == 0 && extraCFlags.Length == 0;
+            bool dotnetNativeFilesUnchanged = extraLDFlags.Length == 0;
             if (!dotnetNativeFilesUnchanged)
                 pathsDict.UpdateTo(unchanged: false, "dotnet.native.wasm", "dotnet.native.js");
 
@@ -53,9 +53,8 @@ namespace Wasm.Build.NativeRebuild.Tests
             // and thus doesn't cause relinking
             TestUtils.AssertSubstring("pinvoke.c -> pinvoke.o", output, contains: extraCFlags.Length > 0);
 
-            // ldflags or cflags: link step args change, so it should trigger relink
+            // ldflags: link step args change, so it should trigger relink
             TestUtils.AssertSubstring("Linking with emcc", output, contains: !dotnetNativeFilesUnchanged);
-
             if (aot)
             {
                 // ExtraEmccLDFlags does not affect .bc files

--- a/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
@@ -144,7 +144,7 @@ namespace Wasm.Build.Tests
             CheckPropertyValues(line,
                                 wasmBuildNative: expectedWasmBuildNativeValue,
                                 wasmNativeStrip: expectedWasmNativeStripValue,
-                                wasmNativeDebugSymbols: config == Configuration.Debug && !expectedWasmNativeStripValue,
+                                wasmNativeDebugSymbols: true,
                                 wasmBuildingForNestedPublish: null);
         }
 
@@ -158,7 +158,7 @@ namespace Wasm.Build.Tests
             CheckPropertyValues(line,
                                 wasmBuildNative: expectedWasmBuildNativeValue,
                                 wasmNativeStrip: expectedWasmNativeStripValue,
-                                wasmNativeDebugSymbols: false,
+                                wasmNativeDebugSymbols: true,
                                 wasmBuildingForNestedPublish: true);
         }
 

--- a/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
@@ -233,7 +233,7 @@ namespace Wasm.Build.Tests
             }
             else
             {
-                expectedWasmNativeDebugSymbols = false;
+                expectedWasmNativeDebugSymbols = true;
                 expectedWasmNativeStripValue = true;
             }
 

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -911,7 +911,7 @@
   <Target Name="_RunWasmOptPostLink" Condition="'$(WasmRunWasmOpt)' == 'true'">
     <Error Condition="'$(_WasmOutputFileName)' == ''" Text="Could not determine %24(_WasmOutputFileName)" />
 
-    <Message Text="Running wasm-opt with--enable-simd --enable-exception-handling --enable-bulk-memory @(WasmOptConfigurationFlags, ' ')" Importance="High" />
+    <Message Text="Running wasm-opt with --enable-simd --enable-exception-handling --enable-bulk-memory @(WasmOptConfigurationFlags, ' ')" Importance="High" />
     <Exec Command="wasm-opt$(_ExeExt) --enable-simd --enable-exception-handling --enable-bulk-memory @(WasmOptConfigurationFlags, ' ') &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot; -o &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot;"
           IgnoreStandardErrorWarningFormat="true"
           EnvironmentVariables="@(WasmToolchainEnvVars)" />

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -537,7 +537,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <WasmNativeDebugSymbols Condition="'$(WasmNativeDebugSymbols)' == ''">false</WasmNativeDebugSymbols>
+      <WasmNativeDebugSymbols Condition="'$(WasmNativeDebugSymbols)' == ''">true</WasmNativeDebugSymbols>
       <WasmNativeStrip Condition="'$(WasmNativeStrip)' == ''">true</WasmNativeStrip>
     </PropertyGroup>
   </Target>
@@ -911,8 +911,8 @@
   <Target Name="_RunWasmOptPostLink" Condition="'$(WasmRunWasmOpt)' == 'true'">
     <Error Condition="'$(_WasmOutputFileName)' == ''" Text="Could not determine %24(_WasmOutputFileName)" />
 
-    <Message Text="Running wasm-opt with --strip-target-features --post-emscripten -O2 --low-memory-unused --zero-filled-memory --pass-arg=directize-initial-contents-immutable --mvp-features --enable-multivalue --enable-mutable-globals --enable-reference-types --enable-sign-ext --enable-simd --enable-exception-handling --enable-bulk-memory @(WasmOptConfigurationFlags, ' ')" Importance="High" />
-    <Exec Command="wasm-opt$(_ExeExt) --strip-target-features --post-emscripten -O2 --low-memory-unused --zero-filled-memory --pass-arg=directize-initial-contents-immutable --mvp-features --enable-multivalue --enable-mutable-globals --enable-reference-types --enable-sign-ext --enable-simd --enable-exception-handling --enable-bulk-memory @(WasmOptConfigurationFlags, ' ') &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot; -o &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot;"
+    <Message Text="Running wasm-opt with--enable-simd --enable-exception-handling --enable-bulk-memory @(WasmOptConfigurationFlags, ' ')" Importance="High" />
+    <Exec Command="wasm-opt$(_ExeExt) --enable-simd --enable-exception-handling --enable-bulk-memory @(WasmOptConfigurationFlags, ' ') &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot; -o &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot;"
           IgnoreStandardErrorWarningFormat="true"
           EnvironmentVariables="@(WasmToolchainEnvVars)" />
   </Target>


### PR DESCRIPTION
- [revert](https://github.com/dotnet/runtime/pull/119307) `WasmNativeDebugSymbols` default to previous `true`
- [revert](https://github.com/dotnet/runtime/pull/119800) `wasm-opt` to previous  `--enable-simd --enable-exception-handling --enable-bulk-memory`

Contributes to https://github.com/dotnet/perf-autofiling-issues/issues/62390