### PR TITLE
[release/10.0] JIT: Use r9,r10 for GS cookie check in Swift reverse pinvokes

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -115,6 +115,13 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
         // these cannot be a part of any kind of return
         regGSCheck                      = REG_R8;
         regNumber regGSCheckAlternative = REG_R9;
+
+		// except for swift, where R8 can be used for returns
+		if (compiler->info.compCallConv == CorInfoCallConvExtension::Swift)
+		{
+			regGSCheck            = REG_R9;
+			regGSCheckAlternative = REG_R10;
+		}
 #endif
 
         if (compiler->lvaKeepAliveAndReportThis() && compiler->lvaGetDesc(compiler->info.compThisArg)->lvIsInReg() &&


### PR DESCRIPTION
## Customer Impact

- [ ] Customer reported
- [X] Found internally

The JIT corrupts return values from x64 Swift reverse pinvokes when 4 registers are used to return in if the method simultaneously uses unsafe value types that induce a GS cookie check.

## Regression

- [x] Yes
- [ ] No

Introduced by #119864. 

## Testing

Internal stress testing (that forces GS cookie check) caught this in our existing Swift tests.

## Risk

Low. Change only affects Swift reverse pinvokes with GS cookie checks.