### PR TITLE
Fix docs link to Chrome C/C++ DevTools Support (DWARF) extension

### DIFF
--- a/docs/workflow/building/coreclr/wasm.md
+++ b/docs/workflow/building/coreclr/wasm.md
@@ -90,7 +90,7 @@ Note that paths to assemblies are in the `src/native/corehost/browserhost/sample
 For debugging CoreCLR WebAssembly code, the recommended approach is using Chrome browser with the **C/C++ DevTools Support (DWARF)** extension:
 
 1. **Install the Chrome extension:**
-   - [C/C++ DevTools Support (DWARF)](https://chrome.google.com/webstore/detail/cc-devtools-support-dwar/odljcjlcidgdhcjhoijagojpnjcgocgd)
+   - [C/C++ DevTools Support (DWARF)](https://goo.gle/wasm-debugging-extension)
 
 2. **Open Chrome DevTools** (F12) while running your WebAssembly application
 

--- a/src/mono/browser/debugger/debugger.md
+++ b/src/mono/browser/debugger/debugger.md
@@ -5,7 +5,7 @@
 It's possible to debug native code and managed code using the `BrowserDebugProxy` project.
 
 Steps:
-- Install [C/C++ DevTools Support (DWARF) extension](https://chrome.google.com/webstore/detail/cc%20%20-devtools-support-dwa/pdcpmagijalfljmkmjngeonclgbbannb) on chrome.
+- Install [C/C++ DevTools Support (DWARF) extension](https://goo.gle/wasm-debugging-extension) on chrome.
 - Enable DWARF support: Open DevTools, click on the settings, click on experiments and enable WebAssembly Debugging: Enable DWARF support.<br>
 ![image](https://user-images.githubusercontent.com/4503299/170745664-fc7d185c-469c-4443-9c57-545bd79588b8.png)
 - Start the WebAssembly App Without Debugging from VS, or `dotnet run` on command line.


### PR DESCRIPTION
The original URL no longer worked, replacing it with the short URL mentioned on https://developer.chrome.com/docs/devtools/wasm