### PR TITLE
[clr-interp] Fix switch statement stack slot handling

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -6181,7 +6181,7 @@ retry_emit:
                 });
 
                 // Setup so that we can safely branch to each target
-                uint32_t lastOffset = MAXUINT32;
+                uint32_t lastOffset = UINT32_MAX;
                 for (uint32_t i = 0; i < n; i++)
                 {
                     if (targetOffsets[i] != lastOffset)

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b44861/b44861_2.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b44861/b44861_2.il
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+
+
+
+.assembly extern mscorlib { }
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+.assembly 'b44861_2'// as "b"
+{
+
+
+  //                                                                                  bool) = ( 01 00 00 01 00 00 ) 
+  
+  
+}
+.assembly extern xunit.core {}
+// MVID: {0573B9C2-3980-4A83-9B01-889CCC1D6FBC}
+.namespace Test
+{
+  .class public auto ansi App
+         extends [mscorlib]System.Object
+  {
+    .method public hidebysig static int32
+            Main() il managed
+    {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    // Code size       31 (0x1f)
+    .maxstack  6
+            //init counter with -1
+            ldc.i4.m1
+        first_again:
+            ldc.i4.1
+            add
+            //print out counter
+            ldstr    "first_again value is "
+            call      void [System.Console]System.Console::Write(class [mscorlib]System.String)
+            dup
+            call      void [System.Console]System.Console::WriteLine(int32)
+            dup
+            brtrue do_switch
+            pop
+            ldc.i4.m1
+          again:
+            //increment counter
+            ldc.i4.1
+            add
+            //print out counter
+            ldstr    "value is "
+            call      void [System.Console]System.Console::Write(class [mscorlib]System.String)
+            dup
+            call      void [System.Console]System.Console::WriteLine(int32)
+        do_switch:
+              //make a switch
+            dup
+            switch     (first_again, first_again, first_again, again, again, again, stop)
+            //switch worked incorrectly
+            //throw an exception
+            newobj    instance void [mscorlib]System.Exception::.ctor()
+            throw
+          stop:
+              //check counter
+              //we should reach here when counter=6
+              ldc.i4 6
+              ceq
+              brfalse wrong
+              ldstr    "passed"
+              call      void [System.Console]System.Console::Write(class [mscorlib]System.String)
+              br done
+          wrong:
+              ldstr    "failed"
+              call      void [System.Console]System.Console::Write(class [mscorlib]System.String)
+          done:
+              ldc.i4 100
+        ret
+    } // end of method 'App::Main'
+
+    .method public hidebysig specialname rtspecialname 
+            instance void .ctor() il managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method 'App::.ctor'
+
+  } // end of class 'App'
+
+} // end of namespace 'Test'
+
+//*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b44861/b44861_2.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b44861/b44861_2.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix issue where switch instructions did not properly handle dispatch to blocks which already had defined their incoming stack slots
