### PR TITLE
[clr-interp] ret instructions are unconditional branches in control flow

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5296,6 +5296,7 @@ retry_emit:
                         CheckStackExact(0);
                     }
                     EmitLeave(ilOffset, target);
+                    linkBBlocks = false;
                     m_ip++;
                     break;
                 }
@@ -5322,6 +5323,7 @@ retry_emit:
                     m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
                 }
                 m_ip++;
+                linkBBlocks = false;
                 break;
             }
 


### PR DESCRIPTION
ret instructions are similar to unconditional branches in that they do not link to the next block