### PR TITLE
Fix interpreter compiler branch elimination

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -783,9 +783,9 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
         {
             *ip++ = ins->info.pTargetBB->nativeOffset - brBaseOffset;
         }
-        else if (opcode == INTOP_BR && ins->info.pTargetBB == m_pCBB->pNextBB)
+        else if (opcode == INTOP_BR && ins->info.pTargetBB == m_pCBB->pNextBB && ins->info.pTargetBB->overlappingEHClauseCount == m_pCBB->overlappingEHClauseCount)
         {
-            // Ignore branch to the next basic block. Revert the added INTOP_BR.
+            // Ignore branch to the next basic block if it is on the same clause depth. Revert the added INTOP_BR.
             isReverted = true;
             ip--;
         }


### PR DESCRIPTION
The code emission was eliminating branches at the end of a basic block going to the next basic block. This should only happen in case when both blocks are on the same overlapping clause depth though. It was breaking couple of EH tests where it let execution flow from the end of a try block to an unrelated block.