### PR TITLE
Address upcoming breaking change for span-valued collection expressions

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorShape.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorShape.cs
@@ -68,10 +68,10 @@ namespace System.Numerics.Tensors
         private TensorShape(nint linearLength, scoped ReadOnlySpan<nint> lengths, scoped ReadOnlySpan<nint> strides, TensorFlags flags)
         {
             int rank = lengths.Length;
-
+            ReadOnlySpan<nint> rank0Lengths = [0];
             if (rank == 0)
             {
-                lengths = [0];
+                lengths = rank0Lengths;
                 rank = 1;
             }
             Debug.Assert(rank >= 1);


### PR DESCRIPTION
[Doc for upcoming breaking change](https://github.com/dotnet/roslyn/blob/copilot/fix-safecontext-of-span-collection/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%2011.md#the-safe-context-of-a-collection-expression-of-spanreadonlyspan-type-is-now-declaration-block)

See dotnet/roslyn#80684. TensorShape's constructor was the only break I found when compiling the libraries. I fixed this by extracting the collection-expression to the top level.