### PR TITLE
Pass async flag to jit in aot tools

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3713,7 +3713,7 @@ namespace Internal.JitInterface
         private CORINFO_METHOD_STRUCT_* getAsyncResumptionStub()
 #pragma warning restore CA1822 // Mark members as static
         {
-            return null;
+            throw new NotImplementedException("Crossgen2 does not support runtime-async yet");
         }
 
         private byte[] _code;
@@ -4295,6 +4295,11 @@ namespace Internal.JitInterface
             if (this.MethodBeingCompiled.Context.Target.Abi == TargetAbi.NativeAotArmel)
             {
                 flags.Set(CorJitFlag.CORJIT_FLAG_SOFTFP_ABI);
+            }
+
+            if (this.MethodBeingCompiled.IsRuntimeAsync)
+            {
+                flags.Set(CorJitFlag.CORJIT_FLAG_ASYNC);
             }
 
             return (uint)sizeof(CORJIT_FLAGS);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -4297,7 +4297,7 @@ namespace Internal.JitInterface
                 flags.Set(CorJitFlag.CORJIT_FLAG_SOFTFP_ABI);
             }
 
-            if (this.MethodBeingCompiled.IsRuntimeAsync)
+            if (this.MethodBeingCompiled.IsAsync)
             {
                 flags.Set(CorJitFlag.CORJIT_FLAG_ASYNC);
             }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1414,6 +1414,7 @@ namespace Internal.JitInterface
         // ARM only
         CORJIT_FLAG_RELATIVE_CODE_RELOCS    = 29, // JIT should generate PC-relative address computations instead of EE relocation records
         CORJIT_FLAG_SOFTFP_ABI              = 30, // Enable armel calling convention
+        CORJIT_FLAG_ASYNC                   = 31,  // Generate code for use as an async function
     }
 
     public struct CORJIT_FLAGS

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
@@ -126,6 +126,15 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool IRuntimeAsync
+        {
+            get
+            {
+                return _methodDef.IsRuntimeAsync;
+            }
+        }
+
+
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
         {
             return _methodDef.HasCustomAttribute(attributeNamespace, attributeName);

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
@@ -126,11 +126,11 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override bool IsRuntimeAsync
+        public override bool IsAsync
         {
             get
             {
-                return _methodDef.IsRuntimeAsync;
+                return _methodDef.IsAsync;
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
@@ -126,7 +126,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override bool IRuntimeAsync
+        public override bool IsRuntimeAsync
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDelegator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDelegator.cs
@@ -38,6 +38,8 @@ namespace Internal.TypeSystem
 
         public override bool IsFinal => _wrappedMethod.IsFinal;
 
+        public override bool IsAsync => _wrappedMethod.IsAsync;
+
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
         {
             return _wrappedMethod.HasCustomAttribute(attributeNamespace, attributeName);

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -658,7 +658,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public virtual bool IsRuntimeAsync
+        public virtual bool IsAsync
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -658,6 +658,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public virtual bool IsRuntimeAsync
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public abstract bool HasCustomAttribute(string attributeNamespace, string attributeName);
 
         /// <summary>

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -119,6 +119,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool IsRuntimeAsync
+        {
+            get
+            {
+                return _typicalMethodDef.IsRuntimeAsync;
+            }
+        }
+
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
         {
             return _typicalMethodDef.HasCustomAttribute(attributeNamespace, attributeName);

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -119,11 +119,11 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override bool IsRuntimeAsync
+        public override bool IsAsync
         {
             get
             {
-                return _typicalMethodDef.IsRuntimeAsync;
+                return _typicalMethodDef.IsAsync;
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -32,6 +32,7 @@ namespace Internal.TypeSystem.Ecma
             public const int AttributeMetadataCache = 0x02000;
             public const int Intrinsic              = 0x04000;
             public const int UnmanagedCallersOnly   = 0x08000;
+            public const int Async                  = 0x10000;
         };
 
         private EcmaType _type;
@@ -166,6 +167,9 @@ namespace Internal.TypeSystem.Ecma
 
                 if ((methodImplAttributes & MethodImplAttributes.Synchronized) != 0)
                     flags |= MethodFlags.Synchronized;
+
+                if ((methodImplAttributes & MethodImplAttributes.Async) != 0)
+                    flags |= MethodFlags.Async;
 
                 flags |= MethodFlags.BasicMetadataCache;
             }
@@ -364,6 +368,14 @@ namespace Internal.TypeSystem.Ecma
             get
             {
                 return Attributes.IsRuntimeSpecialName() && Name.SequenceEqual(".cctor"u8);
+            }
+        }
+
+        public override bool IsRuntimeAsync
+        {
+            get
+            {
+                return (GetMethodFlags(MethodFlags.BasicMetadataCache | MethodFlags.Async) & MethodFlags.Async) != 0;
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -371,7 +371,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override bool IsRuntimeAsync
+        public override bool IsAsync
         {
             get
             {


### PR DESCRIPTION
- Adds CORJIT_FLAG_ASYNC to be passed to the JIT when compiling runtime-async methods for the aot tools.
- Adds IsRuntimeAsync property to MethodDesc to indicate when a method has the Async MethodImplAttribute.
- Replace null return for `getAsyncResumptionStub` to fail a compilation when it is called.

Previously, a crossgen compilation with a runtime-async method would succeed but fail at runtime. This change at least causes the compilation to fail.