### PR TITLE
[release/10.0] Perf Infra: Fix perf iOS pipeline setup 

### DIFF
--- a/eng/pipelines/performance/templates/build-perf-sample-apps.yml
+++ b/eng/pipelines/performance/templates/build-perf-sample-apps.yml
@@ -4,10 +4,10 @@ parameters:
   nameSuffix: ''
 
 steps:
-# Build Android sample app
+  # Build Android sample app
   - ${{ if eq(parameters.osGroup, 'android') }}:
     - ${{ if eq(parameters.runtimeType, 'mono') }}:
-      # Mono JIT Build
+      # Mono JIT build
       - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=Mono
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=Mono
@@ -30,7 +30,7 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
         displayName: clean bindir
 
-      # Mono AOT Build
+      # Mono AOT build
       - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=Mono AOT=true
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=Mono AOT=true
@@ -54,7 +54,7 @@ steps:
         displayName: clean bindir
 
     - ${{ if eq(parameters.runtimeType, 'coreclr') }}:
-      # CoreCLR JIT Build
+      # CoreCLR JIT build
       - script: make run TARGET_ARCH=arm64 DEPLOY_AND_RUN=false RUNTIME_FLAVOR=CoreCLR
         workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/Android
         displayName: Build HelloAndroid sample app RUNTIME_FLAVOR=CoreCLR
@@ -123,132 +123,103 @@ steps:
         workingDirectory: $(Build.SourcesDirectory)/artifacts/bin
         displayName: clean bindir
 
-  - ${{ if and(eq(parameters.osGroup, 'ios'), eq(parameters.nameSuffix, 'iOSMono')) }}:
-    - script: make build-appbundle TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release AOT=True USE_LLVM=False DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=false
-      env:
-        DevTeamProvisioning: '-'
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
-      displayName: Build HelloiOS AOT sample app LLVM=False STRIP_SYMBOLS=False
-    - task: PublishBuildArtifacts@1
-      condition: succeededOrFailed()
-      displayName: 'Publish binlog'
-      inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-        artifactName:  iOSMonoArm64NoLLVMNoStripSymbolsBuildLog
-    - template: /eng/pipelines/common/upload-artifact-step.yml
-      parameters:
-        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
-        includeRootFolder: true
-        displayName: iOS Sample App NoLLVM
-        artifactName: iOSSampleAppNoLLVMSymbols
-        archiveExtension: '.zip'
-        archiveType: zip
-    - script: rm -r -f $(Build.SourcesDirectory)/src/mono/sample/iOS/bin
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
-      displayName: Clean bindir
-    - script: make build-appbundle TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release AOT=True USE_LLVM=False DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=true
-      env:
-        DevTeamProvisioning: '-'
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
-      displayName: Build HelloiOS AOT sample app LLVM=False STRIP_SYMBOLS=True
-    - task: PublishBuildArtifacts@1
-      condition: succeededOrFailed()
-      displayName: 'Publish binlog'
-      inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-        artifactName:  iOSMonoArm64NoLLVMStripSymbolsBuildLog
-    - template: /eng/pipelines/common/upload-artifact-step.yml
-      parameters:
-        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
-        includeRootFolder: true
-        displayName: iOS Sample App NoLLVM NoSymbols
-        artifactName: iOSSampleAppNoLLVMNoSymbols
-        archiveExtension: '.zip'
-        archiveType: zip
-    - script: rm -r -f $(Build.SourcesDirectory)/src/mono/sample/iOS/bin
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
-      displayName: Clean bindir
-    - script: make build-appbundle TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release AOT=True USE_LLVM=True DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=false
-      env:
-        DevTeamProvisioning: '-'
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
-      displayName: Build HelloiOS AOT sample app LLVM=True STRIP_SYMBOLS=False
-    - task: PublishBuildArtifacts@1
-      condition: succeededOrFailed()
-      displayName: 'Publish binlog'
-      inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-        artifactName:  iOSMonoArm64LLVMNoStripSymbolsBuildLog
-    - template: /eng/pipelines/common/upload-artifact-step.yml
-      parameters:
-        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
-        includeRootFolder: true
-        displayName: iOS Sample App LLVM
-        artifactName: iOSSampleAppLLVMSymbols
-        archiveExtension: '.zip'
-        archiveType: zip
-    - script: rm -r -f $(Build.SourcesDirectory)/src/mono/sample/iOS/bin
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
-      displayName: Clean bindir
-    - script: make build-appbundle TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release AOT=True USE_LLVM=True DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=true
-      env:
-        DevTeamProvisioning: '-'
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
-      displayName: Build HelloiOS AOT sample app LLVM=True STRIP_SYMBOLS=True
-    - task: PublishBuildArtifacts@1
-      condition: succeededOrFailed()
-      displayName: 'Publish binlog'
-      inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
-        artifactName: iOSMonoArm64LLVMStripSymbolsBuildLog
-    - template: /eng/pipelines/common/upload-artifact-step.yml
-      parameters:
-        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
-        includeRootFolder: true
-        displayName: iOS Sample App LLVM NoSymbols
-        artifactName: iOSSampleAppLLVMNoSymbols
-        archiveExtension: '.zip'
-        archiveType: zip
+  # Build iOS sample app
+  - ${{ if eq(parameters.osGroup, 'ios') }}:
+    - ${{ if eq(parameters.nameSuffix, 'iOSMono') }}:
+      # Mono FullAOT (no LLVM) build 
+      - script: make build-appbundle TARGET_OS=ios TARGET_ARCH=arm64 USE_MONO_RUNTIME=true BUILD_CONFIG=Release AOT=True INTERP=false USE_LLVM=False DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=true
+        env:
+          DevTeamProvisioning: '-'
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
+        displayName: Build HelloiOS Mono FullAOT sample app LLVM=False STRIP_SYMBOLS=True
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish binlog'
+        inputs:
+          pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
+          artifactName:  iOSMonoFullAOTArm64NoLLVMStripSymbolsBuildLog
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
+          includeRootFolder: true
+          displayName: iOS Sample App Mono FullAOT NoLLVM NoSymbols
+          artifactName: iOSSampleAppMonoFullAOTNoLLVMNoSymbols
+          archiveExtension: '.zip'
+          archiveType: zip
+      - script: rm -r -f $(Build.SourcesDirectory)/src/mono/sample/iOS/bin
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
+        displayName: Clean bindir
 
-  - ${{ if and(eq(parameters.osGroup, 'ios'), eq(parameters.nameSuffix, 'iOSNativeAOT')) }}:
-    - script: make hello-app TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=false
-      env:
-        DevTeamProvisioning: '-'
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT
-      displayName: Build HelloiOS Native AOT sample app STRIP_SYMBOLS=False
-    - task: PublishBuildArtifacts@1
-      condition: succeededOrFailed()
-      displayName: 'Publish binlog'
-      inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/msbuild.binlog
-        artifactName: iOSNativeAOTArm64NoStripSymbolsBuildLog
-    - template: /eng/pipelines/common/upload-artifact-step.yml
-      parameters:
-        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
-        includeRootFolder: true
-        displayName: iOS Sample App Symbols
-        artifactName: iOSSampleAppSymbols
-        archiveExtension: '.zip'
-        archiveType: zip
-    - script: rm -r -f $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT
-      displayName: Clean bindir
-    - script: make hello-app TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=true
-      env:
-        DevTeamProvisioning: '-'
-      workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT
-      displayName: Build HelloiOS Native AOT sample app STRIP_SYMBOLS=True
-    - task: PublishBuildArtifacts@1
-      condition: succeededOrFailed()
-      displayName: 'Publish binlog'
-      inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/msbuild.binlog
-        artifactName: iOSNativeAOTArm64StripSymbolsBuildLog
-    - template: /eng/pipelines/common/upload-artifact-step.yml
-      parameters:
-        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
-        includeRootFolder: true
-        displayName: iOS Sample App NoSymbols
-        artifactName: iOSSampleAppNoSymbols
-        archiveExtension: '.zip'
-        archiveType: zip
+      # Mono FullAOT (with LLVM) build
+      - script: make build-appbundle TARGET_OS=ios TARGET_ARCH=arm64 USE_MONO_RUNTIME=true BUILD_CONFIG=Release AOT=True INTERP=false USE_LLVM=True DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=true
+        env:
+          DevTeamProvisioning: '-'
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
+        displayName: Build HelloiOS Mono FullAOT sample app LLVM=True STRIP_SYMBOLS=True
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish binlog'
+        inputs:
+          pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
+          artifactName: iOSMonoFullAOTArm64LLVMStripSymbolsBuildLog
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
+          includeRootFolder: true
+          displayName: iOS Sample App Mono FullAOT LLVM NoSymbols
+          artifactName: iOSSampleAppMonoFullAOTLLVMNoSymbols
+          archiveExtension: '.zip'
+          archiveType: zip
+      - script: rm -r -f $(Build.SourcesDirectory)/src/mono/sample/iOS/bin
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
+        displayName: Clean bindir
+
+    - ${{ if eq(parameters.runtimeType, 'coreclr') }}:
+      # CoreCLR Interpreter build
+      - script: make build-appbundle TARGET_OS=ios TARGET_ARCH=arm64 USE_MONO_RUNTIME=false BUILD_CONFIG=Checked AOT=false DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=true
+        env:
+          DevTeamProvisioning: '-'
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
+        displayName: Build HelloiOS CoreCLR Interpreter sample app STRIP_SYMBOLS=True
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish binlog'
+        inputs:
+          pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS/msbuild.binlog
+          artifactName:  iOSCoreCLRInterpreterArm64StripSymbolsBuildLog
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS/bin/ios-arm64/Bundle/HelloiOS/Debug-iphoneos/HelloiOS.app
+          includeRootFolder: true
+          displayName: iOS Sample App CoreCLR Interpreter NoSymbols
+          artifactName: iOSSampleAppCoreCLRInterpreterNoSymbols
+          archiveExtension: '.zip'
+          archiveType: zip
+      - script: rm -r -f $(Build.SourcesDirectory)/src/mono/sample/iOS/bin
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS
+        displayName: Clean bindir
+
+    - ${{ if eq(parameters.nameSuffix, 'iOSNativeAOT') }}:
+      # CoreCLR NativeAOT build
+      - script: make hello-app TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=true
+        env:
+          DevTeamProvisioning: '-'
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT
+        displayName: Build HelloiOS NativeAOT sample app STRIP_SYMBOLS=True
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: 'Publish binlog'
+        inputs:
+          pathtoPublish: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/msbuild.binlog
+          artifactName: iOSNativeAOTArm64StripSymbolsBuildLog
+      - template: /eng/pipelines/common/upload-artifact-step.yml
+        parameters:
+          rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/ios-arm64/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
+          includeRootFolder: true
+          displayName: iOS Sample App NativeAOT NoSymbols
+          artifactName: iOSSampleAppNativeAOTNoSymbols
+          archiveExtension: '.zip'
+          archiveType: zip
+      - script: rm -r -f $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin
+        workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT
+        displayName: Clean bindir

--- a/eng/pipelines/performance/templates/perf-ios-scenarios-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-ios-scenarios-build-jobs.yml
@@ -1,11 +1,11 @@
 parameters:
-  hybridGlobalization: true
   mono: false
+  coreclr: false
   nativeAot: false
 
 jobs:
   - ${{ if eq(parameters.mono, true) }}:
-    # build mono iOS scenarios HybridGlobalization
+    # build mono iOS scenarios
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
         jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -19,11 +19,27 @@ jobs:
           isOfficialBuild: false
           postBuildSteps:
             - template: /eng/pipelines/performance/templates/build-perf-sample-apps.yml
+
+  - ${{ if eq(parameters.coreclr, true) }}:
+    # build CoreCLR iOS scenarios
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: checked
+        runtimeFlavor: coreclr
+        platforms:
+        - ios_arm64
+        jobParameters:
+          buildArgs: -s clr+clr.runtime+libs+packs -c $(_BuildConfig)
+          nameSuffix: iOSCoreCLR
+          isOfficialBuild: false
+          postBuildSteps:
+            - template: /eng/pipelines/performance/templates/build-perf-sample-apps.yml
               parameters:
-                hybridGlobalization: ${{ parameters.hybridGlobalization }}
+                runtimeType: coreclr
 
   - ${{ if eq(parameters.nativeAot, true) }}:
-    # build NativeAOT iOS scenarios HybridGlobalization
+    # build NativeAOT iOS scenarios
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
         jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -37,5 +53,3 @@ jobs:
           isOfficialBuild: false
           postBuildSteps:
             - template: /eng/pipelines/performance/templates/build-perf-sample-apps.yml
-              parameters:
-                hybridGlobalization: ${{ parameters.hybridGlobalization }}

--- a/src/mono/sample/iOS/Makefile
+++ b/src/mono/sample/iOS/Makefile
@@ -9,7 +9,8 @@ USE_LLVM=true
 DEPLOY_AND_RUN?=true
 APP_SANDBOX?=false
 STRIP_DEBUG_SYMBOLS?=false # only used when measuring SOD via build-appbundle make target
-HYBRID_GLOBALIZATION?=true
+USE_MONO_RUNTIME?=true
+AOT?=true
 
 #If DIAGNOSTIC_PORTS is enabled, @(RuntimeComponents) must also include 'diagnostics_tracing'.
 #If @(RuntimeComponents) includes 'diagnostics_tracing', DIAGNOSTIC_PORTS is optional.
@@ -41,7 +42,8 @@ build-appbundle: clean appbuilder
 	/p:MonoEnableLLVM=$(USE_LLVM) \
 	/p:StripDebugSymbols=$(STRIP_DEBUG_SYMBOLS) \
 	/p:DeployAndRun=false \
-	/p:HybridGlobalization=$(HYBRID_GLOBALIZATION) \
+	/p:RunAOTCompilation=$(AOT) \
+	/p:UseMonoRuntime=$(USE_MONO_RUNTIME) \
 	/bl
 
 run: clean appbuilder

--- a/src/mono/sample/iOS/Program.cs
+++ b/src/mono/sample/iOS/Program.cs
@@ -21,8 +21,8 @@ public static class Program
     private static void SetText(string txt)
     {
         byte[] ascii = ASCIIEncoding.ASCII.GetBytes(txt);
-        
-        unsafe 
+
+        unsafe
         {
             fixed (byte* asciiPtr = ascii)
             {
@@ -37,7 +37,14 @@ public static class Program
     {
         SetText("OnButtonClick! #" + counter++);
     }
-
+#if CORECLR_TEST
+    public static int Main(string[] args)
+    {
+        Console.WriteLine("Done!");
+        Thread.Sleep(Timeout.Infinite);
+        return 42;
+    }
+#else
 #if CI_TEST
     public static async Task<int> Main(string[] args)
 #else
@@ -63,6 +70,7 @@ public static class Program
         return 42;
 #else
         await Task.Delay(-1);
-#endif 
+#endif
     }
+#endif
 }

--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -6,6 +6,7 @@
     <TargetOS Condition="'$(TargetOS)' == ''">iossimulator</TargetOS>
     <RuntimeIdentifier>$(TargetOS)-$(TargetArchitecture)</RuntimeIdentifier>
     <DefineConstants Condition="'$(ArchiveTests)' == 'true'">$(DefineConstants);CI_TEST</DefineConstants>
+    <DefineConstants Condition="'$(UseMonoRuntime)' != 'true'">$(DefineConstants);CORECLR_TEST</DefineConstants>
     <AppName>HelloiOS</AppName>
     <MainLibraryFileName>$(AssemblyName).dll</MainLibraryFileName>
     <SelfContained>true</SelfContained>
@@ -28,6 +29,9 @@
 
   <ItemGroup>
     <RuntimeComponents Condition="'$(DiagnosticPorts)' != ''" Include="diagnostics_tracing" />
+    <EnvironmentVariables Condition="'$(UseMonoRuntime)' != 'true'" Include="DOTNET_InterpMode=3" />
+    <EnvironmentVariables Condition="'$(UseMonoRuntime)' != 'true'" Include="DOTNET_ReadyToRun=0" />
+    <EnvironmentVariables Condition="'$(UseMonoRuntime)' != 'true'" Include="DOTNET_InterpDump=*!*" />
   </ItemGroup>
 
   <Import Project="$(MonoProjectRoot)\msbuild\apple\build\AppleBuild.props" />


### PR DESCRIPTION
Essentially backporting these commits from main:
* 206103050346de885ffdab74043d3f0f6e6e78cc
* ae2104904921c9466c35c2422800346f21b8e919
* 64c0dfbe02c7678f7294ffceb5f0f77f18ffa187

Fixes error we are hitting (ex. https://dev.azure.com/dnceng/internal/_build/results?buildId=2816773&view=results) due to a job depending on an unknown job. 

Test run to verify pipeline now starts: https://dev.azure.com/dnceng/internal/_build/results?buildId=2817118&view=results.