### PR TITLE
Mark the special ABI primitive types as having stable layout

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Int128FieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/Int128FieldLayoutAlgorithm.cs
@@ -33,7 +33,7 @@ namespace ILCompiler
             // 32bit platforms use standard metadata layout engine
             if (defType.Context.Target.Architecture == TargetArchitecture.ARM)
             {
-                layoutFromMetadata.LayoutAbiStable = false; // Int128 parameter passing ABI is unstable at this time
+                layoutFromMetadata.LayoutAbiStable = true;
                 layoutFromMetadata.IsInt128OrHasInt128Fields = true;
                 return layoutFromMetadata;
             }
@@ -47,7 +47,7 @@ namespace ILCompiler
                 FieldAlignment = new LayoutInt(16),
                 FieldSize = layoutFromMetadata.FieldSize,
                 Offsets = layoutFromMetadata.Offsets,
-                LayoutAbiStable = false, // Int128 parameter passing ABI is unstable at this time
+                LayoutAbiStable = true,
                 IsInt128OrHasInt128Fields = true
             };
         }

--- a/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -15,11 +15,9 @@ namespace ILCompiler
     public class VectorFieldLayoutAlgorithm : FieldLayoutAlgorithm
     {
         private readonly FieldLayoutAlgorithm _fallbackAlgorithm;
-        private readonly bool _vectorAbiIsStable;
 
-        public VectorFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm, bool vectorAbiIsStable = true)
+        public VectorFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm)
         {
-            _vectorAbiIsStable = vectorAbiIsStable;
             _fallbackAlgorithm = fallbackAlgorithm;
         }
 
@@ -119,7 +117,7 @@ namespace ILCompiler
                 FieldAlignment = alignment,
                 FieldSize = layoutFromMetadata.FieldSize,
                 Offsets = layoutFromMetadata.Offsets,
-                LayoutAbiStable = _vectorAbiIsStable
+                LayoutAbiStable = true
             };
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -64,8 +64,14 @@ namespace ILCompiler
             _r2rFieldLayoutAlgorithm = new ReadyToRunMetadataFieldLayoutAlgorithm();
             _systemObjectFieldLayoutAlgorithm = new SystemObjectFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
 
-            // Only the Arm64 JIT respects the OS rules for vector type abi currently
-            _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm, (details.Architecture == TargetArchitecture.ARM64) ? true : bubbleIncludesCorelib);
+            // There are a few types which require special layout algorithms and which could change based on hardware
+            // or to better match the underlying native ABI in the future. However, these are also fairly core types
+            // which are used in many perf critical functions that exist on startup and which are often tied to an ISA.
+            //
+            // Given that, we treat them as ABI stable today to ensure that R2R works well. If we end up modifying the
+            // ABI handling in the future, we would need to take a major version bump to R2R, which is deemed worthwhile.
+
+            _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
 
             ReadOnlySpan<byte> matchingVectorType = "Unknown"u8;
             if (details.MaximumSimdVectorLength == SimdVectorLength.Vector128Bit)
@@ -75,10 +81,7 @@ namespace ILCompiler
             else if (details.MaximumSimdVectorLength == SimdVectorLength.Vector512Bit)
                 matchingVectorType = "Vector512`1"u8;
 
-            // No architecture has completely stable handling of Vector<T> in the abi (Arm64 may change to SVE)
-            _vectorOfTFieldLayoutAlgorithm = new VectorOfTFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm, _vectorFieldLayoutAlgorithm, matchingVectorType, bubbleIncludesCorelib);
-
-            // Int128 and UInt128 should be ABI stable on all currently supported platforms
+            _vectorOfTFieldLayoutAlgorithm = new VectorOfTFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm, _vectorFieldLayoutAlgorithm, matchingVectorType);
             _int128FieldLayoutAlgorithm = new Int128FieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
 
             _typeWithRepeatedFieldsFieldLayoutAlgorithm = new TypeWithRepeatedFieldsFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
@@ -198,14 +201,12 @@ namespace ILCompiler
         private FieldLayoutAlgorithm _vectorFallbackAlgorithm;
         private byte[] _similarVectorName;
         private DefType _similarVectorOpenType;
-        private bool _vectorAbiIsStable;
 
-        public VectorOfTFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm, FieldLayoutAlgorithm vectorFallbackAlgorithm, ReadOnlySpan<byte> similarVector, bool vectorAbiIsStable = true)
+        public VectorOfTFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm, FieldLayoutAlgorithm vectorFallbackAlgorithm, ReadOnlySpan<byte> similarVector)
         {
             _fallbackAlgorithm = fallbackAlgorithm;
             _vectorFallbackAlgorithm = vectorFallbackAlgorithm;
             _similarVectorName = similarVector.ToArray();
-            _vectorAbiIsStable = vectorAbiIsStable;
         }
 
         private DefType GetSimilarVector(DefType vectorOfTType)
@@ -256,7 +257,7 @@ namespace ILCompiler
                     ByteCountUnaligned = LayoutInt.Indeterminate,
                     ByteCountAlignment = LayoutInt.Indeterminate,
                     Offsets = fieldsAndOffsets.ToArray(),
-                    LayoutAbiStable = false,
+                    LayoutAbiStable = true,
                     IsVectorTOrHasVectorTFields = true,
                 };
                 return instanceLayout;
@@ -275,7 +276,7 @@ namespace ILCompiler
                     FieldAlignment = layoutFromSimilarIntrinsicVector.FieldAlignment,
                     FieldSize = layoutFromSimilarIntrinsicVector.FieldSize,
                     Offsets = layoutFromMetadata.Offsets,
-                    LayoutAbiStable = _vectorAbiIsStable,
+                    LayoutAbiStable = true,
                     IsVectorTOrHasVectorTFields = true,
                 };
 #else
@@ -286,7 +287,7 @@ namespace ILCompiler
                     FieldAlignment = layoutFromMetadata.FieldAlignment,
                     FieldSize = layoutFromSimilarIntrinsicVector.FieldSize,
                     Offsets = layoutFromMetadata.Offsets,
-                    LayoutAbiStable = _vectorAbiIsStable,
+                    LayoutAbiStable = true,
                     IsVectorTOrHasVectorTFields = true,
                 };
 #endif

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/TestTypeSystemContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/TestTypeSystemContext.cs
@@ -37,7 +37,7 @@ namespace TypeSystemTests
         public TestTypeSystemContext(TargetArchitecture arch, TargetOS targetOS = TargetOS.Unknown)
             : base(new TargetDetails(arch, targetOS, TargetAbi.Unknown))
         {
-            _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_metadataFieldLayout, true);
+            _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_metadataFieldLayout);
             _int128FieldLayoutAlgorithm = new Int128FieldLayoutAlgorithm(_metadataFieldLayout);
         }
 


### PR DESCRIPTION
This resolves #120367 and was tested using the following program:
```csharp
using System.Numerics;
using System.Runtime.Intrinsics;

TestV();
TestV64();
TestV128();
TestV256();
TestV512();

static ushort[] TestV()
{
    Console.WriteLine(Vector<byte>.Count);
    ushort[] numbers = new ushort[32];
    Vector<ushort>.Zero.CopyTo(numbers);
    return numbers;
}

static ushort[] TestV64()
{
    Console.WriteLine(Vector64<byte>.Count);
    ushort[] numbers = new ushort[4];
    Vector64<ushort>.Zero.CopyTo(numbers);
    return numbers;
}

static ushort[] TestV128()
{
    Console.WriteLine(Vector128<byte>.Count);
    ushort[] numbers = new ushort[8];
    Vector128<ushort>.Zero.CopyTo(numbers);
    return numbers;
}

static ushort[] TestV256()
{
    Console.WriteLine(Vector256<byte>.Count);
    ushort[] numbers = new ushort[16];
    Vector256<ushort>.Zero.CopyTo(numbers);
    return numbers;
}

static ushort[] TestV512()
{
    Console.WriteLine(Vector512<byte>.Count);
    ushort[] numbers = new ushort[32];
    Vector512<ushort>.Zero.CopyTo(numbers);
    return numbers;
}
```

## Results

## Before
```
BEFORE
   1: JIT compiled Program:<Main>$(System.String[]) [Tier0, IL size=31, code size=51]
   2: JIT compiled Program:<<Main>$>g__TestV|0_0() [Tier0, IL size=34, code size=92]
   3: JIT compiled System.Threading.Thread:GetThreadStaticsBase() [Tier0, IL size=18, code size=34]
   4: JIT compiled System.Numerics.Vector`1[ushort]:CopyTo(ushort[]) [Tier0, IL size=39, code size=79]
   5: JIT compiled Program:<<Main>$>g__TestV64|0_1() [Tier0, IL size=30, code size=85]
   6: JIT compiled System.Runtime.Intrinsics.Vector64:CopyTo[ushort](System.Runtime.Intrinsics.Vector64`1[ushort],ushort[]) [Tier0, IL size=34, code size=71]
   7: JIT compiled Program:<<Main>$>g__TestV128|0_2() [Tier0, IL size=30, code size=84]
   8: JIT compiled Program:<<Main>$>g__TestV256|0_3() [Tier0, IL size=31, code size=84]
   9: JIT compiled System.Runtime.Intrinsics.Vector256:CopyTo[ushort](System.Runtime.Intrinsics.Vector256`1[ushort],ushort[]) [Tier0, IL size=34, code size=79]
  10: JIT compiled Program:<<Main>$>g__TestV512|0_4() [Tier0, IL size=31, code size=98]
  11: JIT compiled System.Runtime.Intrinsics.Vector512:CopyTo[ushort](System.Runtime.Intrinsics.Vector512`1[ushort],ushort[]) [Tier0, IL size=34, code size=83]
```

## After - .NET 10

### AVX512 Capable Machine
```
1: JIT compiled System.Threading.Thread:GetThreadStaticsBase() [Tier0, IL size=18, code size=34]
   2: JIT compiled System.Numerics.Vector`1[ushort]:CopyTo(ushort[]) [Tier0, IL size=39, code size=79]
   3: JIT compiled System.Runtime.Intrinsics.Vector64:CopyTo[ushort](System.Runtime.Intrinsics.Vector64`1[ushort],ushort[]) [Tier0, IL size=34, code size=71]
   4: JIT compiled System.Runtime.Intrinsics.Vector256:CopyTo[ushort](System.Runtime.Intrinsics.Vector256`1[ushort],ushort[]) [Tier0, IL size=34, code size=79]
   5: JIT compiled Program:<<Main>$>g__TestV512|0_4() [Tier0, IL size=31, code size=98]
   6: JIT compiled System.Runtime.Intrinsics.Vector512:CopyTo[ushort](System.Runtime.Intrinsics.Vector512`1[ushort],ushort[]) [Tier0, IL size=34, code size=83]
```

### AVX512=0
```
   1: JIT compiled System.Threading.Thread:GetThreadStaticsBase() [Tier0, IL size=18, code size=34]
   2: JIT compiled System.Numerics.Vector`1[ushort]:CopyTo(ushort[]) [Tier0, IL size=39, code size=79]
   3: JIT compiled System.Runtime.Intrinsics.Vector64:CopyTo[ushort](System.Runtime.Intrinsics.Vector64`1[ushort],ushort[]) [Tier0, IL size=34, code size=71]
   4: JIT compiled System.Runtime.Intrinsics.Vector256:CopyTo[ushort](System.Runtime.Intrinsics.Vector256`1[ushort],ushort[]) [Tier0, IL size=34, code size=79]
   5: JIT compiled System.Runtime.Intrinsics.Vector512:CopyTo[ushort](System.Runtime.Intrinsics.Vector512`1[ushort],ushort[]) [Tier0, IL size=34, code size=100]
```

### AVX2=0
```
   1: JIT compiled Program:<Main>$(System.String[]) [Tier0, IL size=31, code size=51]
   2: JIT compiled Program:<<Main>$>g__TestV|0_0() [Tier0, IL size=34, code size=87]
   3: JIT compiled System.Threading.Thread:GetThreadStaticsBase() [Tier0, IL size=18, code size=34]
   4: JIT compiled Program:<<Main>$>g__TestV64|0_1() [Tier0, IL size=30, code size=85]
   5: JIT compiled System.Runtime.Intrinsics.Vector64:CopyTo[ushort](System.Runtime.Intrinsics.Vector64`1[ushort],ushort[]) [Tier0, IL size=34, code size=71]
   6: JIT compiled Program:<<Main>$>g__TestV128|0_2() [Tier0, IL size=30, code size=84]
   7: JIT compiled Program:<<Main>$>g__TestV256|0_3() [Tier0, IL size=31, code size=84]
   8: JIT compiled System.Runtime.Intrinsics.Vector256:CopyTo[ushort](System.Runtime.Intrinsics.Vector256`1[ushort],ushort[]) [Tier0, IL size=34, code size=79]
   9: JIT compiled Program:<<Main>$>g__TestV512|0_4() [Tier0, IL size=31, code size=126]
  10: JIT compiled System.Runtime.Intrinsics.Vector512:CopyTo[ushort](System.Runtime.Intrinsics.Vector512`1[ushort],ushort[]) [Tier0, IL size=34, code size=100]
```

### SSE42=0
```
   1: JIT compiled System.SpanHelpers:IndexOfNullCharacter(ptr) [Instrumented Tier0, IL size=1148, code size=926]
   2: JIT compiled System.SpanHelpers:GetCharVector128SpanLength(nint,nint) [Tier0, IL size=14, code size=26]
   3: JIT compiled System.SpanHelpers:NonPackedIndexOfValueType[short,System.SpanHelpers+DontNegate`1[short]](byref,short,int) [Instrumented Tier0, IL size=1204, code size=1761]
   4: JIT compiled System.Text.Unicode.Utf16Utility:GetPointerToFirstInvalidChar(ptr,int,byref,byref) [Instrumented Tier0, IL size=946, code size=1280]
   5: JIT compiled System.Text.Ascii:GetIndexOfFirstNonAsciiChar_Intrinsified(ptr,nuint) [Instrumented Tier0, IL size=473, code size=1390]
   6: JIT compiled System.Text.Ascii:VectorContainsNonAsciiChar(System.Runtime.Intrinsics.Vector128`1[ushort]) [Tier0, IL size=109, code size=63]
   7: JIT compiled System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ptr,int,ptr,int,byref,byref) [Instrumented Tier0, IL size=1494, code size=2856]
   8: JIT compiled System.Text.Ascii:NarrowUtf16ToAscii(ptr,ptr,nuint) [Instrumented Tier0, IL size=380, code size=755]
   9: JIT compiled Program:<Main>$(System.String[]) [Tier0, IL size=31, code size=51]
  10: JIT compiled Program:<<Main>$>g__TestV|0_0() [Tier0, IL size=34, code size=87]
  11: JIT compiled System.Threading.Thread:GetThreadStaticsBase() [Tier0, IL size=18, code size=34]
  12: JIT compiled System.PackedSpanHelpers:IndexOfAnyInRange[System.SpanHelpers+DontNegate`1[short]](byref,short,short,int) [Instrumented Tier0, IL size=861, code size=1316]
  13: JIT compiled Program:<<Main>$>g__TestV64|0_1() [Tier0, IL size=30, code size=85]
  14: JIT compiled System.Runtime.Intrinsics.Vector64:CopyTo[ushort](System.Runtime.Intrinsics.Vector64`1[ushort],ushort[]) [Tier0, IL size=34, code size=71]
  15: JIT compiled Program:<<Main>$>g__TestV128|0_2() [Tier0, IL size=30, code size=82]
  16: JIT compiled Program:<<Main>$>g__TestV256|0_3() [Tier0, IL size=31, code size=104]
  17: JIT compiled System.Runtime.Intrinsics.Vector256:CopyTo[ushort](System.Runtime.Intrinsics.Vector256`1[ushort],ushort[]) [Tier0, IL size=34, code size=93]
  18: JIT compiled Program:<<Main>$>g__TestV512|0_4() [Tier0, IL size=31, code size=135]
  19: JIT compiled System.Runtime.Intrinsics.Vector512:CopyTo[ushort](System.Runtime.Intrinsics.Vector512`1[ushort],ushort[]) [Tier0, IL size=34, code size=109]
```

### HWIntrinsics=0
```
   A LOT - Not actually going to list the several hundred APIs, this is expected since the "baseline" ISA is disabled
```

## After - .NET 11

### AVX512 Capable Machine
```
  1: JIT compiled System.Runtime.Intrinsics.Vector64:CopyTo[ushort](System.Runtime.Intrinsics.Vector64`1[ushort],ushort[]) [Tier0, IL size=34, code size=71]
  2: JIT compiled System.Runtime.Intrinsics.Vector256:CopyTo[ushort](System.Runtime.Intrinsics.Vector256`1[ushort],ushort[]) [Tier0, IL size=34, code size=79]
  3: JIT compiled Program:<<Main>$>g__TestV512|0_4() [Tier0, IL size=31, code size=98]
  4: JIT compiled System.Runtime.Intrinsics.Vector512:CopyTo[ushort](System.Runtime.Intrinsics.Vector512`1[ushort],ushort[]) [Tier0, IL size=34, code size=83]
```
  
### AVX512=0
```
  1: JIT compiled System.Runtime.Intrinsics.Vector64:CopyTo[ushort](System.Runtime.Intrinsics.Vector64`1[ushort],ushort[]) [Tier0, IL size=34, code size=71]
  2: JIT compiled System.Runtime.Intrinsics.Vector256:CopyTo[ushort](System.Runtime.Intrinsics.Vector256`1[ushort],ushort[]) [Tier0, IL size=34, code size=79]
  3: JIT compiled System.Runtime.Intrinsics.Vector512:CopyTo[ushort](System.Runtime.Intrinsics.Vector512`1[ushort],ushort[]) [Tier0, IL size=34, code size=100]
```

### AVX2=0
```
  A LOT - This is also expected since we bumped the R2R baseline to AVX2 for .NET 11
```