### PR TITLE
Fix "same try" in interpreter compiler

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1625,11 +1625,11 @@ void InterpCompiler::BuildEHInfo()
         {
             INTERP_DUMP("filter IR_%04x(%x), handler [IR_%04x(%x), IR_%04x(%x))%s\n", pFilterStartBB->nativeOffset, clause.FilterOffset, handlerStartNativeOffset, clause.HandlerOffset, handlerEndNativeOffset, clause.HandlerOffset + clause.HandlerLength, ((int)nativeClause.Flags & COR_ILEXCEPTION_CLAUSE_SAMETRY) ? " (same try)" : "");
         }
-        else if (nativeClause.Flags == CORINFO_EH_CLAUSE_FINALLY)
+        else if (clause.Flags == CORINFO_EH_CLAUSE_FINALLY)
         {
             INTERP_DUMP("finally handler [IR_%04x(%x), IR_%04x(%x))\n", handlerStartNativeOffset, clause.HandlerOffset, handlerEndNativeOffset, clause.HandlerOffset + clause.HandlerLength);
         }
-        else if (nativeClause.Flags == CORINFO_EH_CLAUSE_FAULT)
+        else if (clause.Flags == CORINFO_EH_CLAUSE_FAULT)
         {
             INTERP_DUMP("fault handler [IR_%04x(%x), IR_%04x(%x))\n", handlerStartNativeOffset, clause.HandlerOffset, handlerEndNativeOffset, clause.HandlerOffset + clause.HandlerLength);
         }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1615,6 +1615,9 @@ void InterpCompiler::BuildEHInfo()
             nativeClause.Flags = (CORINFO_EH_CLAUSE_FLAGS)((int)nativeClause.Flags | COR_ILEXCEPTION_CLAUSE_SAMETRY);
         }
 
+        lastTryILOffset = clause.TryOffset;
+        lastTryILLength = clause.TryLength;
+
         m_compHnd->setEHinfo(nativeEHIndex++, &nativeClause);
 
         INTERP_DUMP("  try [IR_%04x(%x), IR_%04x(%x)) ", tryStartNativeOffset, clause.TryOffset, tryEndNativeOffset, clause.TryOffset + clause.TryLength);
@@ -1625,6 +1628,10 @@ void InterpCompiler::BuildEHInfo()
         else if (nativeClause.Flags == CORINFO_EH_CLAUSE_FINALLY)
         {
             INTERP_DUMP("finally handler [IR_%04x(%x), IR_%04x(%x))\n", handlerStartNativeOffset, clause.HandlerOffset, handlerEndNativeOffset, clause.HandlerOffset + clause.HandlerLength);
+        }
+        else if (nativeClause.Flags == CORINFO_EH_CLAUSE_FAULT)
+        {
+            INTERP_DUMP("fault handler [IR_%04x(%x), IR_%04x(%x))\n", handlerStartNativeOffset, clause.HandlerOffset, handlerEndNativeOffset, clause.HandlerOffset + clause.HandlerLength);
         }
         else
         {


### PR DESCRIPTION
The COR_ILEXCEPTION_CLAUSE_SAMETRY was never set in the generated EH info due to a bug.
I've also fixed a minor debug logging issue - fault clauses were missing in the dumped EH clauses