### PR TITLE
Fix interpreter EH when exception escapes filter funclet

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -59,8 +59,8 @@ class AsmOffsets
 #if TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x8;
 #if FEATURE_INTERPRETER
-    public const int SIZEOF__StackFrameIterator = 0x170;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x168;
+    public const int SIZEOF__StackFrameIterator = 0x178;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x170;
 #else
     public const int SIZEOF__StackFrameIterator = 0x150;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x148;
@@ -74,8 +74,8 @@ class AsmOffsets
 #else // TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
 #if FEATURE_INTERPRETER
-    public const int SIZEOF__StackFrameIterator = 0xd8;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xd4;
+    public const int SIZEOF__StackFrameIterator = 0xdc;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xd8;
 #else
     public const int SIZEOF__StackFrameIterator = 0xc8;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xc4;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -79,8 +79,8 @@ class AsmOffsets
 #else // TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
 #if FEATURE_INTERPRETER
-    public const int SIZEOF__StackFrameIterator = 0xdc;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xd8;
+    public const int SIZEOF__StackFrameIterator = 0xd8;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xd4;
 #else
     public const int SIZEOF__StackFrameIterator = 0xc8;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xc4;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -59,8 +59,13 @@ class AsmOffsets
 #if TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x8;
 #if FEATURE_INTERPRETER
+#if TARGET_AMD64 && !TARGET_UNIX
     public const int SIZEOF__StackFrameIterator = 0x178;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x170;
+#else
+    public const int SIZEOF__StackFrameIterator = 0x170;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x168;
+#endif    
 #else
     public const int SIZEOF__StackFrameIterator = 0x150;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x148;

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2812,7 +2812,9 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                     m_interpExecMethodSP = GetSP(pRD->pCurrentContext);
                     m_interpExecMethodFP = GetFP(pRD->pCurrentContext);
                     m_interpExecMethodFirstArgReg = GetFirstArgReg(pRD->pCurrentContext);
-
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
+                    m_interpExecMethodSSP = pRD->SSP;
+#endif
                     ((PTR_InterpreterFrame)m_crawl.pFrame)->SetContextToInterpMethodContextFrame(pRD->pCurrentContext);
                     if (pRD->pCurrentContext->ContextFlags & CONTEXT_EXCEPTION_ACTIVE)
                     {
@@ -2833,6 +2835,9 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                     SetSP(pRD->pCurrentContext, m_interpExecMethodSP);
                     SetFP(pRD->pCurrentContext, m_interpExecMethodFP);
                     SetFirstArgReg(pRD->pCurrentContext, m_interpExecMethodFirstArgReg);
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
+                    pRD->SSP = m_interpExecMethodSSP;
+#endif
                     SyncRegDisplayToCurrentContext(pRD);
                 }
             }
@@ -2844,6 +2849,9 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                 m_interpExecMethodSP = GetSP(pRD->pCurrentContext);
                 m_interpExecMethodFP = GetFP(pRD->pCurrentContext);
                 m_interpExecMethodFirstArgReg = GetFirstArgReg(pRD->pCurrentContext);
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
+                m_interpExecMethodSSP = pRD->SSP;
+#endif
             }
         }
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/stackwalk.h
+++ b/src/coreclr/vm/stackwalk.h
@@ -744,6 +744,9 @@ private:
     TADDR         m_interpExecMethodSP;
     TADDR         m_interpExecMethodFP;
     TADDR         m_interpExecMethodFirstArgReg;
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
+    TADDR         m_interpExecMethodSSP;
+#endif // TARGET_AMD64 && TARGET_WINDOWS
 #endif // FEATURE_INTERPRETER
 
 #if defined(RECORD_RESUMABLE_FRAME_SP)


### PR DESCRIPTION
The EH was crashing with interpreter when there was an unhandled exception in a filter funclet. It was asserting on x64 windows due to SSP not being correct, but the actual issue was more involved than just ensuring the SSP was correct.
The problem happens due to the way the stack walking handles unwinding from the first interpreted frame. To better explain what was wrong, let me describe hat mechanism. That transition sets the IP to a special value InterpreterFrame::DummyCallerIP and SP to the address of the InterpreterFrame. The frame state is SFITER_NATIVE_MARKER_FRAME. When the stack frame iterator moves to the next frame, the state is SFITER_FRAME_FUNCTION, the explicit frame is the InterpreterFrame and the REGDISPLAY is set to the native context that was in REGDISPLAY before we switched to iterating over the interpreter frames.

The SfiNext in the EH needs to handle the case when it gets the SFITER_NATIVE_MARKER_FRAME described above. It can either be transitioning to a managed caller of the interpreted core or it could have been a call to a funclet that doesn't have transition frame stored in the intepreter frame, so it doesn't have any context to move to. This doesn't cause any problem for catch or finally funclets, as that means a collided unwind that is detected and the REGDISPLAY is overwritten by the REGDISPLAY from the stack frame iterator of the exception that we've collided with.
The only problem is for filter funclet, where we need to return that frame from the SfiNext and the EH uses its SP in the second pass to know when the 2nd pass is finished.
The bug was that we have moved the stack frame iterator from the SFITER_NATIVE_MARKER_FRAME, which got REGDISPLAY with SP that was actually smaller than the SP of the last reported interpreted frame. That caused the 2nd pass to terminate prematurely on the very first frame, thinking it found the target frame. Thus finallys were not called and also the context was wrong. That lead to the assert in CallCatchFunclet.

There was also a secondary problem that we were not saving and restoring SSP when the state moved from the special state with IP set to InterpreterFrame::DummyCallerIP and the SSP was the SSP in the InterpExecMethod, instead of the SSP in the DispatchManagedException that the rest of the context was pointing to.

This change fixes both these issues and unhandled exceptions in filter funclets are correctly swallowed now.