### PR TITLE
Fix issue with return / goto from catch inside catch that exits the outer catch

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5028,7 +5028,6 @@ retry_emit:
                 INTERP_DUMP("Chaining generated BB%d -> BB%d\n" , pPrevBB->index, pNewBB->index);
                 pPrevBB->pNextBB = pNewBB;
                 assert(!linkBBlocks);
-                linkBBlocks = false;
             }
 
             m_pCBB = pPrevBB;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2027,12 +2027,12 @@ void InterpCompiler::CreateNextLocalVar(int iArgToSet, CORINFO_CLASS_HANDLE argC
 // Create finally call island basic blocks for all try regions with finally clauses that the leave exits.
 // That means when the leaveOffset is inside the try region and the target is outside of it.
 // These finally call island blocks are used for non-exceptional finally execution.
-// The linked list of finally and catch call island blocks is stored in the pFinallyCallIslandBB field of the finally / catch basic block.
-// The pFinallyCallIslandBB in the actual island block points to the outer try region's finally call island block / outer catch region's catch call island block.
-void InterpCompiler::CreateFinallyCallIslandBasicBlocks(CORINFO_METHOD_INFO* methodInfo, int32_t leaveOffset, InterpBasicBlock* pLeaveTargetBB)
+// The linked list of finally and catch call island blocks is stored in the pLeaveChainIslandBB field of the finally / catch basic block.
+// The pLeaveChainIslandBB in the actual island block points to the outer try region's finally call island block / outer catch region's catch call island block.
+void InterpCompiler::CreateLeaveChainIslandBasicBlocks(CORINFO_METHOD_INFO* methodInfo, int32_t leaveOffset, InterpBasicBlock* pLeaveTargetBB)
 {
-    bool firstFinallyCallIsland = true;
-    InterpBasicBlock* pInnerFinallyCallIslandBB = NULL;
+    bool firstLeaveChainIsland = true;
+    InterpBasicBlock* pInnerLeaveChainIslandBB = NULL;
     for (unsigned int i = 0; i < getEHcount(methodInfo); i++)
     {
         bool isFinallyCallIsland = false;
@@ -2088,43 +2088,43 @@ void InterpCompiler::CreateFinallyCallIslandBasicBlocks(CORINFO_METHOD_INFO* met
         // We have found a leave that goes out of a try region with a finally or out of a catch handler
 
         InterpBasicBlock* pHandlerBB = GetBB(clause.HandlerOffset);
-        InterpBasicBlock* pFinallyCallIslandBB = NULL;
+        InterpBasicBlock* pLeaveChainIslandBB = NULL;
 
-        InterpBasicBlock** ppLastBBNext = &pHandlerBB->pFinallyCallIslandBB;
+        InterpBasicBlock** ppLastBBNext = &pHandlerBB->pLeaveChainIslandBB;
         while (*ppLastBBNext != NULL)
         {
             if ((*ppLastBBNext)->pLeaveTargetBB == pLeaveTargetBB)
             {
                 // We already have finally call island block for the leave target
-                pFinallyCallIslandBB = (*ppLastBBNext);
+                pLeaveChainIslandBB = (*ppLastBBNext);
                 break;
             }
             ppLastBBNext = &((*ppLastBBNext)->pNextBB);
         }
 
-        if (pFinallyCallIslandBB == NULL)
+        if (pLeaveChainIslandBB == NULL)
         {
-            pFinallyCallIslandBB = AllocBB(clause.HandlerOffset + clause.HandlerLength);
-            pFinallyCallIslandBB->pLeaveTargetBB = pLeaveTargetBB;
-            *ppLastBBNext = pFinallyCallIslandBB;
+            pLeaveChainIslandBB = AllocBB(clause.HandlerOffset + clause.HandlerLength);
+            pLeaveChainIslandBB->pLeaveTargetBB = pLeaveTargetBB;
+            *ppLastBBNext = pLeaveChainIslandBB;
         }
 
-        pFinallyCallIslandBB->isFinallyCallIsland = isFinallyCallIsland;
+        pLeaveChainIslandBB->isFinallyCallIsland = isFinallyCallIsland;
 
-        if (pInnerFinallyCallIslandBB != NULL)
+        if (pInnerLeaveChainIslandBB != NULL)
         {
-            pInnerFinallyCallIslandBB->pFinallyCallIslandBB = pFinallyCallIslandBB;
+            pInnerLeaveChainIslandBB->pLeaveChainIslandBB = pLeaveChainIslandBB;
         }
-        pInnerFinallyCallIslandBB = pFinallyCallIslandBB;
+        pInnerLeaveChainIslandBB = pLeaveChainIslandBB;
 
-        if (firstFinallyCallIsland)
+        if (firstLeaveChainIsland)
         {
             // The leaves table entry points to the first finally call island block
-            firstFinallyCallIsland = false;
+            firstLeaveChainIsland = false;
 
             LeavesTableEntry leavesEntry;
             leavesEntry.ilOffset = leaveOffset;
-            leavesEntry.pFinallyCallIslandBB = pFinallyCallIslandBB;
+            leavesEntry.pLeaveChainIslandBB = pLeaveChainIslandBB;
             m_leavesTable.Add(leavesEntry);
         }
     }
@@ -2157,7 +2157,7 @@ void InterpCompiler::CreateBasicBlocks(CORINFO_METHOD_INFO* methodInfo)
                 if (m_isSynchronized && m_currentILOffset < m_ILCodeSizeFromILHeader)
                 {
                     // This is a ret instruction coming from the initial IL of a synchronized method.
-                    CreateFinallyCallIslandBasicBlocks(methodInfo, insOffset, GetBB(m_synchronizedPostFinallyOffset));
+                    CreateLeaveChainIslandBasicBlocks(methodInfo, insOffset, GetBB(m_synchronizedPostFinallyOffset));
                 }
             }
             break;
@@ -2185,7 +2185,7 @@ void InterpCompiler::CreateBasicBlocks(CORINFO_METHOD_INFO* methodInfo)
             pTargetBB = GetBB(target);
             if (opcode == CEE_LEAVE_S)
             {
-                CreateFinallyCallIslandBasicBlocks(methodInfo, insOffset, pTargetBB);
+                CreateLeaveChainIslandBasicBlocks(methodInfo, insOffset, pTargetBB);
             }
             ip += 2;
             GetBB((int32_t)(ip - codeStart));
@@ -2197,7 +2197,7 @@ void InterpCompiler::CreateBasicBlocks(CORINFO_METHOD_INFO* methodInfo)
             pTargetBB = GetBB(target);
             if (opcode == CEE_LEAVE)
             {
-                CreateFinallyCallIslandBasicBlocks(methodInfo, insOffset, pTargetBB);
+                CreateLeaveChainIslandBasicBlocks(methodInfo, insOffset, pTargetBB);
             }
             ip += 5;
             GetBB((int32_t)(ip - codeStart));
@@ -2344,13 +2344,13 @@ void InterpCompiler::InitializeClauseBuildingBlocks(CORINFO_METHOD_INFO* methodI
 
         InterpBasicBlock* pFinallyBB = GetBB(clause.HandlerOffset);
 
-        InterpBasicBlock* pFinallyCallIslandBB = pFinallyBB->pFinallyCallIslandBB;
-        while (pFinallyCallIslandBB != NULL)
+        InterpBasicBlock* pLeaveChainIslandBB = pFinallyBB->pLeaveChainIslandBB;
+        while (pLeaveChainIslandBB != NULL)
         {
             InterpBasicBlock* pAfterFinallyBB = m_ppOffsetToBB[clause.HandlerOffset + clause.HandlerLength];
             assert(pAfterFinallyBB != NULL);
-            pFinallyCallIslandBB->clauseType = pAfterFinallyBB->clauseType;
-            pFinallyCallIslandBB = pFinallyCallIslandBB->pNextBB;
+            pLeaveChainIslandBB->clauseType = pAfterFinallyBB->clauseType;
+            pLeaveChainIslandBB = pLeaveChainIslandBB->pNextBB;
         }
     }
 }
@@ -2538,7 +2538,7 @@ void InterpCompiler::EmitLeave(int32_t ilOffset, int32_t target)
             // from the building block, because the finally call islands share the same IL
             // offset with another block of original code in front of which it is injected.
             // The EmitBranch would to that block instead of the finally call island.
-            pTargetBB = m_leavesTable.Get(i).pFinallyCallIslandBB;
+            pTargetBB = m_leavesTable.Get(i).pLeaveChainIslandBB;
             break;
         }
     }
@@ -5021,7 +5021,7 @@ retry_emit:
             InterpBasicBlock *pPrevBB = m_pCBB;
             InterpBasicBlock *pPrevBB2 = m_pCBB;
 
-            pPrevBB = GenerateCodeForFinallyCallIslands(pNewBB, pPrevBB);
+            pPrevBB = GenerateCodeForLeaveChainIslands(pNewBB, pPrevBB);
 
             if (pPrevBB != pPrevBB2 && !pPrevBB->pNextBB)
             {
@@ -7754,47 +7754,46 @@ DO_LDFTN:
     UnlinkUnreachableBBlocks();
 }
 
-InterpBasicBlock *InterpCompiler::GenerateCodeForFinallyCallIslands(InterpBasicBlock *pNewBB, InterpBasicBlock *pPrevBB)
+InterpBasicBlock *InterpCompiler::GenerateCodeForLeaveChainIslands(InterpBasicBlock *pNewBB, InterpBasicBlock *pPrevBB)
 {
-    InterpBasicBlock *pFinallyCallIslandBB = pNewBB->pFinallyCallIslandBB;
+    InterpBasicBlock *pLeaveChainIslandBB = pNewBB->pLeaveChainIslandBB;
 
-    while (pFinallyCallIslandBB != NULL)
+    while (pLeaveChainIslandBB != NULL)
     {
-        INTERP_DUMP("Injecting %s island BB%d\n", pFinallyCallIslandBB->isFinallyCallIsland ? "finally call" : "catch leave", pFinallyCallIslandBB->index);
-        if (pFinallyCallIslandBB->emitState != BBStateEmitted)
+        INTERP_DUMP("Injecting %s island BB%d\n", pLeaveChainIslandBB->isFinallyCallIsland ? "finally call" : "catch leave", pLeaveChainIslandBB->index);
+        if (pLeaveChainIslandBB->emitState != BBStateEmitted)
         {
             // Set the finally call island BB as current so that the instructions are emitted into it
-            m_pCBB = pFinallyCallIslandBB;
-            // TODO: is this still needed?
+            m_pCBB = pLeaveChainIslandBB;
             m_pStackPointer = m_pStackBase;
             InitBBStackState(m_pCBB);
-            if (pFinallyCallIslandBB->isFinallyCallIsland)
+            if (pLeaveChainIslandBB->isFinallyCallIsland)
             {
                 EmitBranchToBB(INTOP_CALL_FINALLY, pNewBB); // The pNewBB is the finally BB
                 m_pLastNewIns->ilOffset = -1;
             }
 
-            InterpOpcode branchOpcode = pFinallyCallIslandBB->isFinallyCallIsland ? INTOP_BR : INTOP_LEAVE_CATCH;
+            InterpOpcode branchOpcode = pLeaveChainIslandBB->isFinallyCallIsland ? INTOP_BR : INTOP_LEAVE_CATCH;
 
             // Try to get the next finally call (for an outer try's finally) / catch leave island block (for an outer catch)
-            if (pFinallyCallIslandBB->pFinallyCallIslandBB)
+            if (pLeaveChainIslandBB->pLeaveChainIslandBB)
             {
                 // Branch to the next finally call island (at an outer try block)
-                EmitBranchToBB(branchOpcode, pFinallyCallIslandBB->pFinallyCallIslandBB);
+                EmitBranchToBB(branchOpcode, pLeaveChainIslandBB->pLeaveChainIslandBB);
             }
             else
             {
                 // This is the last finally call / catch leave island, so we need to emit a branch to the leave target
-                EmitBranchToBB(branchOpcode, pFinallyCallIslandBB->pLeaveTargetBB);
+                EmitBranchToBB(branchOpcode, pLeaveChainIslandBB->pLeaveTargetBB);
             }
             m_pLastNewIns->ilOffset = -1;
             m_pCBB->emitState = BBStateEmitted;
-            INTERP_DUMP("Chaining BB%d -> BB%d\n", pPrevBB->index, pFinallyCallIslandBB->index);
+            INTERP_DUMP("Chaining BB%d -> BB%d\n", pPrevBB->index, pLeaveChainIslandBB->index);
         }
-        assert(pPrevBB->pNextBB == NULL || pPrevBB->pNextBB == pFinallyCallIslandBB);
-        pPrevBB->pNextBB = pFinallyCallIslandBB;
-        pPrevBB = pFinallyCallIslandBB;
-        pFinallyCallIslandBB = pFinallyCallIslandBB->pNextBB;
+        assert(pPrevBB->pNextBB == NULL || pPrevBB->pNextBB == pLeaveChainIslandBB);
+        pPrevBB->pNextBB = pLeaveChainIslandBB;
+        pPrevBB = pLeaveChainIslandBB;
+        pLeaveChainIslandBB = pLeaveChainIslandBB->pNextBB;
     }
 
     return pPrevBB;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1475,7 +1475,7 @@ void InterpCompiler::GetNativeRangeForClause(uint32_t startILOffset, uint32_t en
     InterpBasicBlock* pEndBB = pStartBB;
     for (InterpBasicBlock* pBB = pStartBB->pNextBB; (pBB != NULL) && ((uint32_t)pBB->ilOffset < endILOffset); pBB = pBB->pNextBB)
     {
-        if ((pBB->clauseType == pStartBB->clauseType) && (pBB->overlappingEHClauseCount == pStartBB->overlappingEHClauseCount))
+        if (pBB->overlappingEHClauseCount == pStartBB->overlappingEHClauseCount)
         {
             pEndBB = pBB;
         }
@@ -2027,32 +2027,65 @@ void InterpCompiler::CreateNextLocalVar(int iArgToSet, CORINFO_CLASS_HANDLE argC
 // Create finally call island basic blocks for all try regions with finally clauses that the leave exits.
 // That means when the leaveOffset is inside the try region and the target is outside of it.
 // These finally call island blocks are used for non-exceptional finally execution.
-// The linked list of finally call island blocks is stored in the pFinallyCallIslandBB field of the finally basic block.
-// The pFinallyCallIslandBB in the actual finally call island block points to the outer try region's finally call island block.
+// The linked list of finally and catch call island blocks is stored in the pFinallyCallIslandBB field of the finally / catch basic block.
+// The pFinallyCallIslandBB in the actual island block points to the outer try region's finally call island block / outer catch region's catch call island block.
 void InterpCompiler::CreateFinallyCallIslandBasicBlocks(CORINFO_METHOD_INFO* methodInfo, int32_t leaveOffset, InterpBasicBlock* pLeaveTargetBB)
 {
     bool firstFinallyCallIsland = true;
     InterpBasicBlock* pInnerFinallyCallIslandBB = NULL;
     for (unsigned int i = 0; i < getEHcount(methodInfo); i++)
     {
+        bool isFinallyCallIsland = false;
         CORINFO_EH_CLAUSE clause;
         getEHinfo(methodInfo, i, &clause);
-        if (clause.Flags != CORINFO_EH_CLAUSE_FINALLY)
+
+        // Check IL correctness for filter clauses
+        if (clause.Flags == CORINFO_EH_CLAUSE_FILTER && (uint32_t)leaveOffset >= clause.FilterOffset && (uint32_t)leaveOffset < clause.HandlerOffset)
         {
+            if ((uint32_t)pLeaveTargetBB->ilOffset < clause.FilterOffset || (uint32_t)pLeaveTargetBB->ilOffset >= clause.HandlerOffset)
+            {
+                BADCODE("Leave out of filter clause is not allowed");
+            }
+        }
+
+        if (clause.Flags == CORINFO_EH_CLAUSE_FINALLY)
+        {
+            // Only try regions in which the leave instruction is located are considered.
+            if ((uint32_t)leaveOffset < clause.TryOffset || (uint32_t)leaveOffset >= (clause.TryOffset + clause.TryLength))
+            {
+                continue;
+            }
+
+            // If the leave target is inside the try region, we don't need to create a finally call island block.
+            if ((uint32_t)pLeaveTargetBB->ilOffset >= clause.TryOffset && (uint32_t)pLeaveTargetBB->ilOffset < (clause.TryOffset + clause.TryLength))
+            {
+                continue;
+            }
+
+            isFinallyCallIsland = true;
+        }
+        else if ((clause.Flags == CORINFO_EH_CLAUSE_NONE) || (clause.Flags & CORINFO_EH_CLAUSE_FILTER) != 0)
+        {
+            // This is a catch
+            // If the leave instruction is outside of this catch handler, there is nothing to do for this catch
+            if ((uint32_t)leaveOffset < clause.HandlerOffset || (uint32_t)leaveOffset >= (clause.HandlerOffset + clause.HandlerLength))
+            {
+                continue;
+            }
+
+            // If the leave target is inside the catch region, there is nothing more to do for this catch
+            if ((uint32_t)pLeaveTargetBB->ilOffset >= clause.HandlerOffset && (uint32_t)pLeaveTargetBB->ilOffset < (clause.HandlerOffset + clause.HandlerLength))
+            {
+                continue;
+            }
+        }
+        else
+        {
+            assert(clause.Flags == CORINFO_EH_CLAUSE_FAULT);
             continue;
         }
 
-        // Only try regions in which the leave instruction is located are considered.
-        if ((uint32_t)leaveOffset < clause.TryOffset || (uint32_t)leaveOffset >= (clause.TryOffset + clause.TryLength))
-        {
-            continue;
-        }
-
-        // If the leave target is inside the try region, we don't need to create a finally call island block.
-        if ((uint32_t)pLeaveTargetBB->ilOffset >= clause.TryOffset && (uint32_t)pLeaveTargetBB->ilOffset < (clause.TryOffset + clause.TryLength))
-        {
-            continue;
-        }
+        // We have found a leave that goes out of a try region with a finally or out of a catch handler
 
         InterpBasicBlock* pHandlerBB = GetBB(clause.HandlerOffset);
         InterpBasicBlock* pFinallyCallIslandBB = NULL;
@@ -2075,6 +2108,8 @@ void InterpCompiler::CreateFinallyCallIslandBasicBlocks(CORINFO_METHOD_INFO* met
             pFinallyCallIslandBB->pLeaveTargetBB = pLeaveTargetBB;
             *ppLastBBNext = pFinallyCallIslandBB;
         }
+
+        pFinallyCallIslandBB->isFinallyCallIsland = isFinallyCallIsland;
 
         if (pInnerFinallyCallIslandBB != NULL)
         {
@@ -2300,17 +2335,12 @@ void InterpCompiler::InitializeClauseBuildingBlocks(CORINFO_METHOD_INFO* methodI
         }
     }
 
-    // Now that we have classified all the basic blocks, we can set the clause type for the finally call island blocks.
-    // We set it to the same type as the basic block after the finally handler.
+    // Now that we have classified all the basic blocks, we can set the clause type for the finally call / catch leave island blocks.
+    // We set it to the same type as the basic block after the finally / catch handler.
     for (unsigned int i = 0; i < getEHcount(methodInfo); i++)
     {
         CORINFO_EH_CLAUSE clause;
         getEHinfo(methodInfo, i, &clause);
-
-        if (clause.Flags != CORINFO_EH_CLAUSE_FINALLY)
-        {
-            continue;
-        }
 
         InterpBasicBlock* pFinallyBB = GetBB(clause.HandlerOffset);
 
@@ -2520,17 +2550,7 @@ void InterpCompiler::EmitLeave(int32_t ilOffset, int32_t target)
 
     // The leave doesn't jump out of any try region with finally, so we can just emit a branch
     // to the target.
-    if (m_pCBB->clauseType == BBClauseCatch)
-    {
-        // leave out of catch is different from a leave out of finally. It
-        // exits the catch handler and returns the address of the finally
-        // call island as the continuation address to the EH code.
-        EmitBranchToBB(INTOP_LEAVE_CATCH, pTargetBB);
-    }
-    else
-    {
-        EmitBranchToBB(INTOP_BR, pTargetBB);
-    }
+    EmitBranchToBB(INTOP_BR, pTargetBB);
 }
 
 void InterpCompiler::EmitBinaryArithmeticOp(int32_t opBase)
@@ -4998,6 +5018,21 @@ retry_emit:
                 assert (pNewBB->emitState == BBStateNotEmitted);
             }
 
+            InterpBasicBlock *pPrevBB = m_pCBB;
+            InterpBasicBlock *pPrevBB2 = m_pCBB;
+
+            pPrevBB = GenerateCodeForFinallyCallIslands(pNewBB, pPrevBB);
+
+            if (pPrevBB != pPrevBB2 && !pPrevBB->pNextBB)
+            {
+                INTERP_DUMP("Chaining generated BB%d -> BB%d\n" , pPrevBB->index, pNewBB->index);
+                pPrevBB->pNextBB = pNewBB;
+                assert(!linkBBlocks);
+                linkBBlocks = false;
+            }
+
+            m_pCBB = pPrevBB;
+
             // We are starting a new basic block. Change cbb and link them together
             if (linkBBlocks)
             {
@@ -5045,14 +5080,10 @@ retry_emit:
                 }
             }
 
-            InterpBasicBlock *pPrevBB = m_pCBB;
-
-            pPrevBB = GenerateCodeForFinallyCallIslands(pNewBB, pPrevBB);
-
-            if (!pPrevBB->pNextBB)
+            if (!m_pCBB->pNextBB)
             {
-                INTERP_DUMP("Chaining BB%d -> BB%d\n" , pPrevBB->index, pNewBB->index);
-                pPrevBB->pNextBB = pNewBB;
+                INTERP_DUMP("Chaining BB%d -> BB%d\n" , m_pCBB->index, pNewBB->index);
+                m_pCBB->pNextBB = pNewBB;
             }
 
             m_pCBB = pNewBB;
@@ -7729,24 +7760,32 @@ InterpBasicBlock *InterpCompiler::GenerateCodeForFinallyCallIslands(InterpBasicB
 
     while (pFinallyCallIslandBB != NULL)
     {
-        INTERP_DUMP("Injecting finally call island BB%d\n", pFinallyCallIslandBB->index);
+        INTERP_DUMP("Injecting %s island BB%d\n", pFinallyCallIslandBB->isFinallyCallIsland ? "finally call" : "catch leave", pFinallyCallIslandBB->index);
         if (pFinallyCallIslandBB->emitState != BBStateEmitted)
         {
             // Set the finally call island BB as current so that the instructions are emitted into it
             m_pCBB = pFinallyCallIslandBB;
+            // TODO: is this still needed?
+            m_pStackPointer = m_pStackBase;
             InitBBStackState(m_pCBB);
-            EmitBranchToBB(INTOP_CALL_FINALLY, pNewBB); // The pNewBB is the finally BB
-            m_pLastNewIns->ilOffset = -1;
-            // Try to get the next finally call island block (for an outer try's finally)
+            if (pFinallyCallIslandBB->isFinallyCallIsland)
+            {
+                EmitBranchToBB(INTOP_CALL_FINALLY, pNewBB); // The pNewBB is the finally BB
+                m_pLastNewIns->ilOffset = -1;
+            }
+
+            InterpOpcode branchOpcode = pFinallyCallIslandBB->isFinallyCallIsland ? INTOP_BR : INTOP_LEAVE_CATCH;
+
+            // Try to get the next finally call (for an outer try's finally) / catch leave island block (for an outer catch)
             if (pFinallyCallIslandBB->pFinallyCallIslandBB)
             {
                 // Branch to the next finally call island (at an outer try block)
-                EmitBranchToBB(INTOP_BR, pFinallyCallIslandBB->pFinallyCallIslandBB);
+                EmitBranchToBB(branchOpcode, pFinallyCallIslandBB->pFinallyCallIslandBB);
             }
             else
             {
-                // This is the last finally call island, so we need to emit a branch to the leave target
-                EmitBranchToBB(INTOP_BR, pFinallyCallIslandBB->pLeaveTargetBB);
+                // This is the last finally call / catch leave island, so we need to emit a branch to the leave target
+                EmitBranchToBB(branchOpcode, pFinallyCallIslandBB->pLeaveTargetBB);
             }
             m_pLastNewIns->ilOffset = -1;
             m_pCBB->emitState = BBStateEmitted;

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -312,7 +312,9 @@ struct InterpBasicBlock
 
     // * If this basic block is a finally, this points to a finally call island that is located where the finally
     //   was before all funclets were moved to the end of the method.
-    // * If this basic block is a call island, this points to the next finally call island basic block.
+    // * If this basic block is a catch, this points to a catch leave island that is located where the catch
+    //   was before all funclets were moved to the end of the method.
+    // * If this basic block is a call island, this points to the next finally call / catch leave island basic block.
     // * Otherwise, this is NULL.
     InterpBasicBlock *pFinallyCallIslandBB;
     // Target of a leave instruction that is located in this basic block. NULL if there is none.
@@ -329,6 +331,9 @@ struct InterpBasicBlock
 
     // True indicates that this basic block is the first block of a filter, catch or filtered handler funclet.
     bool isFilterOrCatchFuncletEntry;
+
+    // Valid only for BBs of call islands. It is set to true if it is a finally call island, false if is is a catch leave island.
+    bool isFinallyCallIsland;
 
     // If this basic block is a catch or filter funclet entry, this is the index of the variable
     // that holds the exception object.
@@ -359,6 +364,7 @@ struct InterpBasicBlock
 
         clauseType = BBClauseNone;
         isFilterOrCatchFuncletEntry = false;
+        isFinallyCallIsland = false;
         clauseVarIndex = -1;
         overlappingEHClauseCount = 0;
     }

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -316,7 +316,7 @@ struct InterpBasicBlock
     //   was before all funclets were moved to the end of the method.
     // * If this basic block is a call island, this points to the next finally call / catch leave island basic block.
     // * Otherwise, this is NULL.
-    InterpBasicBlock *pFinallyCallIslandBB;
+    InterpBasicBlock *pLeaveChainIslandBB;
     // Target of a leave instruction that is located in this basic block. NULL if there is none.
     InterpBasicBlock *pLeaveTargetBB;
 
@@ -354,7 +354,7 @@ struct InterpBasicBlock
 
         pFirstIns = pLastIns = NULL;
         pNextBB = NULL;
-        pFinallyCallIslandBB = NULL;
+        pLeaveChainIslandBB = NULL;
         pLeaveTargetBB = NULL;
 
         inCount = 0;
@@ -464,7 +464,7 @@ struct LeavesTableEntry
     int32_t ilOffset;
     // The BB of the call island BB that will be the first to call when the leave
     // instruction is executed.
-    InterpBasicBlock *pFinallyCallIslandBB;
+    InterpBasicBlock *pLeaveChainIslandBB;
 };
 
 class InterpCompiler
@@ -555,7 +555,7 @@ private:
     int32_t GetDataForHelperFtn(CorInfoHelpFunc ftn);
 
     void GenerateCode(CORINFO_METHOD_INFO* methodInfo);
-    InterpBasicBlock* GenerateCodeForFinallyCallIslands(InterpBasicBlock *pNewBB, InterpBasicBlock *pPrevBB);
+    InterpBasicBlock* GenerateCodeForLeaveChainIslands(InterpBasicBlock *pNewBB, InterpBasicBlock *pPrevBB);
     void PatchInitLocals(CORINFO_METHOD_INFO* methodInfo);
 
     void                    ResolveToken(uint32_t token, CorInfoTokenKind tokenKind, CORINFO_RESOLVED_TOKEN *pResolvedToken);
@@ -783,7 +783,7 @@ private:
     InterpMethod* CreateInterpMethod();
     void CreateBasicBlocks(CORINFO_METHOD_INFO* methodInfo);
     void InitializeClauseBuildingBlocks(CORINFO_METHOD_INFO* methodInfo);
-    void CreateFinallyCallIslandBasicBlocks(CORINFO_METHOD_INFO* methodInfo, int32_t leaveOffset, InterpBasicBlock* pLeaveTargetBB);
+    void CreateLeaveChainIslandBasicBlocks(CORINFO_METHOD_INFO* methodInfo, int32_t leaveOffset, InterpBasicBlock* pLeaveTargetBB);
     void GetNativeRangeForClause(uint32_t startILOffset, uint32_t endILOffset, int32_t *nativeStartOffset, int32_t* nativeEndOffset);
     void getEHinfo(CORINFO_METHOD_INFO* methodInfo, unsigned int index, CORINFO_EH_CLAUSE* ehClause);
     unsigned int getEHcount(CORINFO_METHOD_INFO* methodInfo);


### PR DESCRIPTION
When there is a try/catch inside a catch handler and there is a return
in the inner catch or goto going out of the outer catch handler, we were
resuming after the inner catch at the end of the method / goto target,
so we were not returning from the call to the outer catch.
We need to inject a catch leave island that the inner catch returns as
its resume after catch location and that island can then return from the
outer catch.
This mechanism needs to be part of the finally call islands chain so that
returns from catches / calls to finallys happen correctly and in the
right order.
This change extends the finally call islands chain to implement that.

This change also fixes a problem with ordering of emission of the code
for these islands and the basic blocks linking in the `GenerateCode`
method.
It also fixes a bug in `GetNativeRangeForClause` that was in some edge
cases getting incorrectly shorter range.

To make reviewing a bit easier, I've split this PR into two commits. The
first adds the actual functionality and the second just renames things
to match the fact that the islands are no longer finally call islands
only.