### PR TITLE
Fix longstanding regex interpreter bug around lazy loops with empty matches

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -329,6 +329,23 @@ namespace System.Text.RegularExpressions.Tests
             yield return (@"(b|a|aa)((?:aa)+?)+?$", "aaaaaaaa", RegexOptions.None, 0, 8, true, "aaaaaaaa");
             yield return (@"(|a|aa)(((?:aa)+?)+?|aaaaab)\w$", "aaaaaabc", RegexOptions.None, 0, 8, true, "aaaaaabc");
 
+            // Lazy loops with empty matches
+            if (!PlatformDetection.IsNetFramework)
+            {
+                // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/111051
+                yield return (@"(.)+()+?b", "xyzb", RegexOptions.None, 0, 4, true, "xyzb");
+                yield return (@"^(.)+()+?b", "xyzb", RegexOptions.None, 0, 4, true, "xyzb");
+
+                if (!RegexHelpers.IsNonBacktracking(engine))
+                {
+                    // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/58786
+                    yield return (@"(?<!a*(?:a?)+?)", @"x", RegexOptions.None, 0, 1, false, "");
+
+                    // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/114626
+                    yield return (@"(?>(-*)+?-*)$", "abc", RegexOptions.None, 0, 3, true, "");
+                }
+            }
+
             // Nested loops
             yield return (@"(abcd*)+e", "abcde", RegexOptions.None, 0, 5, true, "abcde");
             yield return (@"(abcd*?)+e", "abcde", RegexOptions.None, 0, 5, true, "abcde");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -343,6 +343,9 @@ namespace System.Text.RegularExpressions.Tests
 
                     // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/114626
                     yield return (@"(?>(-*)+?-*)$", "abc", RegexOptions.None, 0, 3, true, "");
+
+                    // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/63385
+                    yield return (@"(^+?)?()", "1", RegexOptions.None, 0, 1, true, "");
                 }
             }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
@@ -452,15 +452,34 @@ namespace System.Text.RegularExpressions.Tests
                             new CaptureData("x", 3, 1),
                         }
                     };
+
+                    // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/111051
+                    yield return new object[]
+                    {
+                        engine, @"anyexpress1(?<=(.(any express|(any express)*)+?)anyexpress1)", "anystring anyexpress1", RegexOptions.None, new[]
+                        {
+                            new CaptureData("anyexpress1", 10, 11),
+                        }
+                    };
                 }
 
-                // Fails on .NET Framework: [ActiveIssue("https://github.com/dotnet/runtime/issues/62094")]
+                // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/62094
                 yield return new object[]
                 {
                     engine, @"(?:){93}", "x", RegexOptions.None, new[]
                     {
                         new CaptureData("", 0, 0),
                         new CaptureData("", 1, 0)
+                    }
+                };
+
+                // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/43314
+                yield return new object[]
+                {
+                    engine, @"(?:(?:0?)+?(?:a?)+?)?", "0a", RegexOptions.None, new[]
+                    {
+                        new CaptureData("0a", 0, 2),
+                        new CaptureData("", 2, 0),
                     }
                 };
 #endif


### PR DESCRIPTION
This has been an issue in the interpreter forever, as far as I can tell. We've had multiple issues over the years all flagging problems with different symptoms that stem from the same core problem.

Fixes https://github.com/dotnet/runtime/issues/43314
Fixes https://github.com/dotnet/runtime/issues/58786
Fixes https://github.com/dotnet/runtime/issues/63385
Fixes https://github.com/dotnet/runtime/issues/111051
Fixes https://github.com/dotnet/runtime/issues/114626

The problem came down to how the regex interpreter handled lazy quantifiers over expressions that can match the empty string. When the interpreter reaches one of these lazy loops, it uses an internal instruction called `Lazybranchmark` to manage entering and potentially looping the subexpression. To keep track of loop state and capture boundaries, the interpreter uses two internal stacks, a grouping stack, that tracks positions relevant to capturing groups (e.g. where a group started), and a backtracking stack, that tracks states that are needed if the engine has to go back and try a different match. The bug occurred in the case when the subpattern inside the lazy loop matches nothing. In this case, the interpreter unconditionally pushed a placeholder onto the grouping stack. If the rest of the pattern then succeeded without backtracking through this loop, that extra placeholder remained on the grouping stack. This polluted the capture bookkeeping: later parts of the pattern popped that placeholder, treating it as a real start position, and shifted captures to the wrong place.

The fix is to stop pushing onto the grouping stack when the loop matches empty. Instead, the interpreter records two things on the backtracking stack: the old group boundary and a flag indicating whether the grouping stack needs to be popped later. If the interpreter ends up backtracking through this lazy loop, it checks the flag: if a grouping stack entry was added earlier, it pops it; if not, it leaves the grouping stack untouched. This keeps the grouping stack and backtracking stack in sync in both forward and backtracking paths. As a result, empty lazy loops no longer leave stray entries on the grouping stack. This also prevents the unbounded stack growth that previously caused overflows or hangs on some patterns involving nested lazy quantifiers.