### PR TITLE
Replace signed comparisons with unsigned comparisons in bounds checking `ImmutableArray<T>.Builder`

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -139,7 +139,7 @@ namespace System.Collections.Immutable
             {
                 get
                 {
-                    if (index >= this.Count)
+                    if ((uint)index >= (uint)this.Count)
                     {
                         ThrowIndexOutOfRangeException();
                     }
@@ -149,7 +149,7 @@ namespace System.Collections.Immutable
 
                 set
                 {
-                    if (index >= this.Count)
+                    if ((uint)index >= (uint)this.Count)
                     {
                         ThrowIndexOutOfRangeException();
                     }
@@ -167,7 +167,7 @@ namespace System.Collections.Immutable
             /// </exception>
             public ref readonly T ItemRef(int index)
             {
-                if (index >= this.Count)
+                if ((uint)index >= (uint)this.Count)
                 {
                     ThrowIndexOutOfRangeException();
                 }


### PR DESCRIPTION
This PR replaces signed comparisons with unsigned comparisons in bounds checking for `ImmutableArray<T>.Builder` indexer and `ItemRef` method. Change bounds check from `if (index >= this.Count)` to `if ((uint)index >= (uint)this.Count)`.