### PR TITLE
[clr-interp] Fix additional iteration in Copy_Ref implementation on arm64

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -949,16 +949,15 @@ LEAF_END Load_Stack_Ref, _TEXT
 
 
 .macro Copy_Ref argReg
-    cmp x11, #16
+    subs x11, x11, #16
     blt LOCAL_LABEL(CopyBy8\argReg)
-    sub x11, x11, #16
 LOCAL_LABEL(RefCopyLoop16\argReg):
     ldp x13, x14, [\argReg], #16
     stp x13, x14, [x9], #16
     subs x11, x11, #16
     bge LOCAL_LABEL(RefCopyLoop16\argReg)
-    add x11, x11, #16
 LOCAL_LABEL(CopyBy8\argReg):
+    add x11, x11, #16
     cmp x11, #8
     blt LOCAL_LABEL(RefCopyLoop1\argReg)
     ldr x13, [\argReg], #8

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -961,13 +961,10 @@ LOCAL_LABEL(RefCopyLoop16\argReg):
 LOCAL_LABEL(CopyBy8\argReg):
     cmp x11, #8
     blt LOCAL_LABEL(RefCopyLoop1\argReg)
-LOCAL_LABEL(RefCopyLoop8\argReg):
     ldr x13, [\argReg], #8
     str x13, [x9], #8
     subs x11, x11, #8
-    bgt LOCAL_LABEL(RefCopyLoop8\argReg)
     beq LOCAL_LABEL(RefCopyDone\argReg)
-    add x11, x11, #8
 LOCAL_LABEL(RefCopyLoop1\argReg):
     ldrb w13, [\argReg], #1
     strb w13, [x9], #1

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -951,12 +951,12 @@ LEAF_END Load_Stack_Ref, _TEXT
 .macro Copy_Ref argReg
     cmp x11, #16
     blt LOCAL_LABEL(CopyBy8\argReg)
+    sub x11, x11, #16
 LOCAL_LABEL(RefCopyLoop16\argReg):
     ldp x13, x14, [\argReg], #16
     stp x13, x14, [x9], #16
     subs x11, x11, #16
-    bgt LOCAL_LABEL(RefCopyLoop16\argReg)
-    beq LOCAL_LABEL(RefCopyDone\argReg)
+    bge LOCAL_LABEL(RefCopyLoop16\argReg)
     add x11, x11, #16
 LOCAL_LABEL(CopyBy8\argReg):
     cmp x11, #8

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1300,16 +1300,15 @@ StoreCopyLoop
 
     MACRO
         Copy_Ref $argReg
-        cmp x11, #16
+        subs x11, x11, #16
         blt CopyBy8$argReg
-        sub x11, x11, #16
 RefCopyLoop16$argReg
         ldp x13, x14, [$argReg], #16
         stp x13, x14, [x9], #16
         subs x11, x11, #16
         bge RefCopyLoop16$argReg
-        add x11, x11, #16
 CopyBy8$argReg
+        add x11, x11, #16
         cmp x11, #8
         blt RefCopyLoop1$argReg
         ldr x13, [$argReg], #8

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1312,13 +1312,10 @@ RefCopyLoop16$argReg
 CopyBy8$argReg
         cmp x11, #8
         blt RefCopyLoop1$argReg
-RefCopyLoop8$argReg
         ldr x13, [$argReg], #8
         str x13, [x9], #8
         subs x11, x11, #8
-        bgt RefCopyLoop8$argReg
         beq RefCopyDone$argReg
-        add x11, x11, #8
 RefCopyLoop1$argReg
         ldrb w13, [$argReg], #1
         strb w13, [x9], #1

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1302,12 +1302,12 @@ StoreCopyLoop
         Copy_Ref $argReg
         cmp x11, #16
         blt CopyBy8$argReg
+        sub x11, x11, #16
 RefCopyLoop16$argReg
         ldp x13, x14, [$argReg], #16
         stp x13, x14, [x9], #16
         subs x11, x11, #16
-        bgt RefCopyLoop16$argReg
-        beq RefCopyDone$argReg
+        bge RefCopyLoop16$argReg
         add x11, x11, #16
 CopyBy8$argReg
         cmp x11, #8


### PR DESCRIPTION
After a loop iteration is done, the code is subtracting 16, obtaining the current remaining counter. If the remaining counter is bigger than 0 then we do another iteration. This is wrong, because we can only do another 16 byte copy iteration if the remaining counter is bigger or equal to 16. In order to be correct, the code would have to branch to the very beginning of the macro. In case of negative result, we would fallback to 8 byte copy, but, if the result is negative, it means we already overcopied, so this implementation is wrong.

The fix makes it such that when we subtract 16 after an iteration, we don't obtain the current remaining counter, rather the potential remaining counter, in case we did another copy iteration. If this counter is positive, then it is safe to do another iteration, if it is negative then we can't copy 16 bytes at a time, fallback to the next case.

The PR also removes redundant looping for 8 bytes copy scenario, which can be hit at most once.
