### PR TITLE
[RuntimeAsync] Remove no longer needed workarounds for Roslyn NYIs

### DIFF
--- a/src/tests/async/struct/struct.cs
+++ b/src/tests/async/struct/struct.cs
@@ -47,28 +47,22 @@ public class Async2Struct
 
         public async Task Test()
         {
-            // TODO: C# compiler is expected to do this, but not in the prototype.
-            S @this = this;
+            AssertEqual(100, this.Value);
+            this.Value++;
+            await this.InstanceCall();
+            AssertEqual(101, this.Value);
 
-            AssertEqual(100, @this.Value);
-            @this.Value++;
-            await @this.InstanceCall();
-            AssertEqual(101, @this.Value);
-
-            await @this.TaskButNotAsync();
-            AssertEqual(102, @this.Value);
+            await this.TaskButNotAsync();
+            AssertEqual(102, this.Value);
         }
 
         private async Task InstanceCall()
         {
-            // TODO: C# compiler is expected to do this, but not in the prototype.
-            S @this = this;
-
-            AssertEqual(101, @this.Value);
-            @this.Value++;
-            AssertEqual(102, @this.Value);
+            AssertEqual(101, this.Value);
+            this.Value++;
+            AssertEqual(102, this.Value);
             await Task.Yield();
-            AssertEqual(102, @this.Value);
+            AssertEqual(102, this.Value);
         }
 
         private Task TaskButNotAsync()


### PR DESCRIPTION

Async methods in structs can compile and work correctly now.

This is a test-only change that removes workarounds.