### PR TITLE
Validate that an IPv6 Uri host is followed by expected delimiters

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3888,6 +3888,14 @@ namespace System
             if (ch == '[' && syntax.InFact(UriSyntaxFlags.AllowIPv6Host) &&
                 IPv6AddressHelper.IsValid(pString, start + 1, ref end))
             {
+                if (end < length && pString[end] is not (':' or '/' or '?' or '#'))
+                {
+                    // A valid IPv6 address wasn't followed by a valid delimiter (e.g. http://[::]extra).
+                    flags |= Flags.UnknownHostType;
+                    err = ParsingError.BadHostName;
+                    return idx;
+                }
+
                 flags |= Flags.IPv6HostType;
 
                 if (hasUnicode)


### PR DESCRIPTION
For an input like `http://[::]extra`, we would previously hallucinate a slash after the `]`, so parsing would succeed and `AbsolutePath` would return `/extra`.

This change enforces that the `]` is followed by a delimiter, same as we do for all other host types.