### PR TITLE
Disable CoreCLR tests crashing merged test suites fully interpreted

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -51,6 +51,8 @@ namespace TestLibrary
 
         public static bool IsNonZeroLowerBoundArrayNotSupported => !IsNonZeroLowerBoundArraySupported;
 
+        public static bool IsExceptionInteropSupported => IsWindows && !Utilities.IsNativeAot && !Utilities.IsMonoRuntime && !Utilities.IsCoreClrInterpreter;
+
         public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;
 
         static string _variant = Environment.GetEnvironmentVariable("DOTNET_RUNTIME_VARIANT");

--- a/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
@@ -120,7 +120,6 @@ namespace TestLibrary
 #else
         public static bool IsReflectionEmitSupported => true;
 #endif
-        public static bool SupportsExceptionInterop => IsWindows && IsNotMonoRuntime && !IsNativeAot; // matches definitions in clr.featuredefines.props
         public static bool IsGCStress => (Environment.GetEnvironmentVariable("DOTNET_GCStress") != null);
 
         public static string ByteArrayToString(byte[] bytes)

--- a/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
+++ b/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
@@ -719,9 +719,8 @@ namespace System.Runtime.InteropServices.Tests
                 Parameter_CleanUpNativeDataMethodThrows_ThrowsActualException();
                 Field_ParentIsStruct_ThrowsTypeLoadException();
                 Parameter_DifferentCustomMarshalerType_MarshalsCorrectly();
-                if (SupportsExceptionInterop)
+                if (TestLibrary.PlatformDetection.IsExceptionInteropSupported)
                 {
-                    // EH interop is not supported for NativeAOT.
                     DelegateParameter_MarshalerOnRefInt_ThrowsMarshalDirectiveException();
                 }
             }

--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
@@ -46,6 +46,7 @@ namespace PInvokeTests
     public static class IEnumeratorTests
     {
         [Fact]
+        [SkipOnCoreClrAttribute("Assert thunkData with interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
         public static void TestNativeToManaged()
         {
             AssertExtensions.CollectionEqual(Enumerable.Range(1, 10), EnumeratorAsEnumerable(IEnumeratorNative.GetIntegerEnumerator(1, 10)));
@@ -53,6 +54,7 @@ namespace PInvokeTests
         }
 
         [Fact]
+        [SkipOnCoreClrAttribute("Assert thunkData with interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
         public static void TestManagedToNative()
         {
             IEnumeratorNative.VerifyIntegerEnumerator(Enumerable.Range(1, 10).GetEnumerator(), 1, 10);

--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
@@ -46,7 +46,7 @@ namespace PInvokeTests
     public static class IEnumeratorTests
     {
         [Fact]
-        [SkipOnCoreClrAttribute("Assert thunkData with interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static void TestNativeToManaged()
         {
             AssertExtensions.CollectionEqual(Enumerable.Range(1, 10), EnumeratorAsEnumerable(IEnumeratorNative.GetIntegerEnumerator(1, 10)));
@@ -54,7 +54,7 @@ namespace PInvokeTests
         }
 
         [Fact]
-        [SkipOnCoreClrAttribute("Assert thunkData with interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static void TestManagedToNative()
         {
             IEnumeratorNative.VerifyIntegerEnumerator(Enumerable.Range(1, 10).GetEnumerator(), 1, 10);

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
@@ -212,6 +212,7 @@ public class PassingByRefTest
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34196", TestRuntimes.Mono)]
     [ActiveIssue("https://github.com/dotnet/runtimelab/issues/167", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
+    [SkipOnCoreClrAttribute("Exception propagation through reverse pinvoke is not supported with interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
     public static int TestEntryPoint()
     {
         try{

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
@@ -212,7 +212,7 @@ public class PassingByRefTest
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34196", TestRuntimes.Mono)]
     [ActiveIssue("https://github.com/dotnet/runtimelab/issues/167", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-    [SkipOnCoreClrAttribute("Exception propagation through reverse pinvoke is not supported with interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClrAttribute("Exception propagation through reverse pinvoke is not supported with interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
     public static int TestEntryPoint()
     {
         try{

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
@@ -209,8 +209,6 @@ public class PassingByRefTest
     }
 
     [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/34196", TestRuntimes.Mono)]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/167", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
     public static int TestEntryPoint()
     {

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
@@ -208,11 +208,10 @@ public class PassingByRefTest
         }
     }
 
-    [Fact]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34196", TestRuntimes.Mono)]
     [ActiveIssue("https://github.com/dotnet/runtimelab/issues/167", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-    [SkipOnCoreClrAttribute("Exception propagation through reverse pinvoke is not supported with interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
     public static int TestEntryPoint()
     {
         try{

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
@@ -319,6 +319,7 @@ namespace FPBehaviorApp
         }
 
         [Fact]
+        [SkipOnCoreClr("This test runs forever with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
         public static int TestEntryPoint()
         {
             Program.ManagedConversionRule = FPtoIntegerConversionType.CONVERT_SATURATING;

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
@@ -319,7 +319,7 @@ namespace FPBehaviorApp
         }
 
         [Fact]
-        [SkipOnCoreClr("This test runs forever with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static int TestEntryPoint()
         {
             Program.ManagedConversionRule = FPtoIntegerConversionType.CONVERT_SATURATING;

--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.csproj
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.csproj
@@ -12,5 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="CMakeLists.txt" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/tailcall/reference_i.il
+++ b/src/tests/JIT/Methodical/tailcall/reference_i.il
@@ -9,6 +9,7 @@
 }
 .assembly extern xunit.core {}
 .assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
+.assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly ASSEMBLY_NAME { }
 .method public static class System.String 
         rems(int32& n,
@@ -77,9 +78,10 @@
   .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
       01 00 00 00
   )
-  .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = {
-      string('AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904')
-      int32(0x400) // InterpreterActive
+  .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
+    string('https://github.com/dotnet/runtime/issues/120904')
+    type([TestLibrary]TestLibrary.Utilities)
+    string[1] ('IsCoreClrInterpreter')
   }
   .entrypoint
   // Code size       66 (0x42)

--- a/src/tests/JIT/Methodical/tailcall/reference_i.il
+++ b/src/tests/JIT/Methodical/tailcall/reference_i.il
@@ -8,6 +8,7 @@
   .ver 4:0:0:0
 }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly ASSEMBLY_NAME { }
 .method public static class System.String 
         rems(int32& n,
@@ -76,6 +77,10 @@
   .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
       01 00 00 00
   )
+  .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = {
+      string('AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904')
+      int32(0x400) // InterpreterActive
+  }
   .entrypoint
   // Code size       66 (0x42)
   .maxstack  2

--- a/src/tests/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
+++ b/src/tests/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
@@ -65,6 +65,7 @@ namespace SIMD
         }
 
         [Fact]
+        [SkipOnCoreClrAttribute("The test runs forever when interpreted, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
         public static int TestEntryPoint()
         {
             Bench(0, -1);

--- a/src/tests/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
+++ b/src/tests/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
@@ -65,7 +65,7 @@ namespace SIMD
         }
 
         [Fact]
-        [SkipOnCoreClrAttribute("The test runs forever when interpreted, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static int TestEntryPoint()
         {
             Bench(0, -1);

--- a/src/tests/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.csproj
+++ b/src/tests/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.csproj
@@ -18,6 +18,9 @@
     <Compile Include="VectorFloatStrict.cs" />
     <Compile Include="VectorHelpers.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
   <PropertyGroup>
     <ProjectAssetsFile>$(JitPackagesConfigFileDirectory)benchmark\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/Desktop/b609988_Desktop.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/Desktop/b609988_Desktop.il
@@ -25,6 +25,7 @@
   .ver 0:0:0:0
 }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
@@ -1228,6 +1229,10 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = {
+        string('AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904')
+        int32(0x400) // InterpreterActive
+    }
     .entrypoint
     .maxstack  1
     IL_0000:  call       void Program::Test1()

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/Desktop/b609988_Desktop.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/Desktop/b609988_Desktop.il
@@ -26,6 +26,7 @@
 }
 .assembly extern xunit.core {}
 .assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
+.assembly extern TestLibrary { .ver 0:0:0:0 }
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
@@ -1229,9 +1230,10 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = {
-        string('AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904')
-        int32(0x400) // InterpreterActive
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
+      string('https://github.com/dotnet/runtime/issues/120904')
+      type([TestLibrary]TestLibrary.Utilities)
+      string[1] ('IsCoreClrInterpreter')
     }
     .entrypoint
     .maxstack  1

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/b609988.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/b609988.il
@@ -25,6 +25,7 @@
 }
 .assembly extern xunit.core {}
 .assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
+.assembly extern TestLibrary { .ver 0:0:0:0 }
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
@@ -1228,9 +1229,10 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = {
-        string('AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904')
-        int32(0x400) // InterpreterActive
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
+      string('https://github.com/dotnet/runtime/issues/120904')
+      type([TestLibrary]TestLibrary.Utilities)
+      string[1] ('IsCoreClrInterpreter')
     }
     .entrypoint
     .maxstack  1

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/b609988.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/b609988.il
@@ -24,6 +24,7 @@
   .ver 0:0:0:0
 }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .imagebase 0x00400000
 .file alignment 0x00000200
 .stackreserve 0x00100000
@@ -1227,6 +1228,10 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = {
+        string('AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904')
+        int32(0x400) // InterpreterActive
+    }
     .entrypoint
     .maxstack  1
     IL_0000:  call       void Program::Test1()

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.cs
@@ -65,7 +65,7 @@ namespace GitHub_19438
         }
 
         [Fact]
-        [SkipOnCoreClrAttribute("Test runs forever when interpreted, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static void TestEntryPoint()
         {
             const int iterationCount = 10;

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.cs
@@ -65,6 +65,7 @@ namespace GitHub_19438
         }
 
         [Fact]
+        [SkipOnCoreClrAttribute("Test runs forever when interpreted, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
         public static void TestEntryPoint()
         {
             const int iterationCount = 10;

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.csproj
@@ -5,4 +5,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/JIT/SIMD/Sums.cs
+++ b/src/tests/JIT/SIMD/Sums.cs
@@ -40,7 +40,7 @@ namespace VectorMathTests
         }
 
         [Fact]
-        [SkipOnCoreClrAttribute("Test runs forever when interpreted, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static void TestEntryPoint()
         {
             System.Diagnostics.Stopwatch clock = new System.Diagnostics.Stopwatch();

--- a/src/tests/JIT/SIMD/Sums.cs
+++ b/src/tests/JIT/SIMD/Sums.cs
@@ -40,6 +40,7 @@ namespace VectorMathTests
         }
 
         [Fact]
+        [SkipOnCoreClrAttribute("Test runs forever when interpreted, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
         public static void TestEntryPoint()
         {
             System.Diagnostics.Stopwatch clock = new System.Diagnostics.Stopwatch();

--- a/src/tests/JIT/SIMD/Sums_r.csproj
+++ b/src/tests/JIT/SIMD/Sums_r.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="Sums.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/JIT/SIMD/Sums_ro.csproj
+++ b/src/tests/JIT/SIMD/Sums_ro.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="Sums.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.cs
+++ b/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.cs
@@ -13,7 +13,7 @@ namespace SimpleArray_01
     public class Class1
     {
         [Fact]
-        [SkipOnCoreClrAttribute("Test runs forever when interpreted, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static int TestEntryPoint()
         {
             int retVal = 100;

--- a/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.cs
+++ b/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.cs
@@ -13,6 +13,7 @@ namespace SimpleArray_01
     public class Class1
     {
         [Fact]
+        [SkipOnCoreClrAttribute("Test runs forever when interpreted, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
         public static int TestEntryPoint()
         {
             int retVal = 100;

--- a/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.csproj
+++ b/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.csproj
@@ -9,4 +9,7 @@
   <ItemGroup>
     <Compile Include="RngchkStress3.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>  
 </Project>

--- a/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.csproj
+++ b/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.csproj
@@ -11,5 +11,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/src/tests/Regressions/coreclr/GitHub_111242/Test111242.cs
+++ b/src/tests/Regressions/coreclr/GitHub_111242/Test111242.cs
@@ -45,7 +45,7 @@ public static class Test111242
         Assert.Fail("Should not reach here");
     }
 
-    [Fact]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))] 
     public static unsafe void TestEntryPoint()
     {
         TestSetJmp(&ManagedCallback);

--- a/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
@@ -1,12 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CLRTestTargetUnsupported -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'windows'">true</CLRTestTargetUnsupported>
-    <!-- Testing a backwards compatibility quirk we don't officially support -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
@@ -7,6 +7,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'windows'">true</CLRTestTargetUnsupported>
     <!-- Testing a backwards compatibility quirk we don't officially support -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
+    <!-- SetJmp/LongJmp across interpreted frames is not supported -->
+    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
@@ -7,8 +7,6 @@
     <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'windows'">true</CLRTestTargetUnsupported>
     <!-- Testing a backwards compatibility quirk we don't officially support -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
-    <!-- SetJmp/LongJmp across interpreted frames is not supported -->
-    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
@@ -24,7 +24,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
     public static void ThrowNativeExceptionAndCatchInFrame()
     {
         bool caughtException = false;
@@ -45,7 +45,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
     public static void ThrowManagedExceptionThroughNativeAndCatchInFrame()
     {
         bool caughtException = false;
@@ -72,7 +72,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
     public static void ThrowNativeExceptionAndCatchInFrameWithFilter()
     {
         bool caughtException = false;
@@ -101,7 +101,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
     public static void ThrowNativeExceptionAndCatchInFrameWithFinally()
     {
         bool caughtException = false;
@@ -130,7 +130,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
     public static void ThrowNativeExceptionInFrameWithFinallyCatchInOuterFrame()
     {
         bool caughtException = false;
@@ -187,7 +187,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
     public static void PropagateAndRethrowCppException()
     {
         try
@@ -206,7 +206,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
     public static void PropagateAndCatchCppException()
     {
         bool reportedUnhandledException = false;

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
@@ -24,6 +24,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
     public static void ThrowNativeExceptionAndCatchInFrame()
     {
         bool caughtException = false;
@@ -44,6 +45,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
     public static void ThrowManagedExceptionThroughNativeAndCatchInFrame()
     {
         bool caughtException = false;
@@ -70,6 +72,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
     public static void ThrowNativeExceptionAndCatchInFrameWithFilter()
     {
         bool caughtException = false;
@@ -98,6 +101,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
     public static void ThrowNativeExceptionAndCatchInFrameWithFinally()
     {
         bool caughtException = false;
@@ -126,6 +130,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
     public static void ThrowNativeExceptionInFrameWithFinallyCatchInOuterFrame()
     {
         bool caughtException = false;
@@ -182,6 +187,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
     public static void PropagateAndRethrowCppException()
     {
         try
@@ -200,6 +206,7 @@ public unsafe static class ExceptionInterop
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
+    [SkipOnCoreClr("Exception interop not supported with the interpreter", RuntimeTestModes.InterpreterActive)]
     public static void PropagateAndCatchCppException()
     {
         bool reportedUnhandledException = false;

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
@@ -21,10 +21,7 @@ internal unsafe static class ExceptionInteropNative
 
 public unsafe static class ExceptionInterop
 {
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     public static void ThrowNativeExceptionAndCatchInFrame()
     {
         bool caughtException = false;
@@ -42,10 +39,7 @@ public unsafe static class ExceptionInterop
         Assert.True(caughtException);
     }
 
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     public static void ThrowManagedExceptionThroughNativeAndCatchInFrame()
     {
         bool caughtException = false;
@@ -69,10 +63,7 @@ public unsafe static class ExceptionInterop
         }
     }
 
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     public static void ThrowNativeExceptionAndCatchInFrameWithFilter()
     {
         bool caughtException = false;
@@ -98,10 +89,7 @@ public unsafe static class ExceptionInterop
         }
     }
 
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     public static void ThrowNativeExceptionAndCatchInFrameWithFinally()
     {
         bool caughtException = false;
@@ -127,10 +115,7 @@ public unsafe static class ExceptionInterop
         Assert.True(caughtException);
     }
 
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     public static void ThrowNativeExceptionInFrameWithFinallyCatchInOuterFrame()
     {
         bool caughtException = false;
@@ -184,10 +169,7 @@ public unsafe static class ExceptionInterop
         }
     }
 
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     public static void PropagateAndRethrowCppException()
     {
         try
@@ -203,10 +185,7 @@ public unsafe static class ExceptionInterop
     [DllImport(nameof(ExceptionInteropNative))]
     public static extern void InvokeCallbackOnNewThread(delegate*unmanaged<void> callBack);
 
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Windows)]
-    [SkipOnMono("Exception interop not supported on Mono.")]
-    [SkipOnCoreClr("Exception interop not supported with the interpreter, https://github.com/dotnet/runtime/issues/118965", RuntimeTestModes.InterpreterActive)]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsExceptionInteropSupported))]
     public static void PropagateAndCatchCppException()
     {
         bool reportedUnhandledException = false;

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.csproj
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.csproj
@@ -7,5 +7,8 @@
       <CMakeProjectReference Include="CMakeLists.txt" />
       <Compile Include="ExceptionInterop.cs" />
     </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    </ItemGroup>
   </Project>
   

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop_ro.csproj
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop_ro.csproj
@@ -11,5 +11,8 @@
       <CMakeProjectReference Include="CMakeLists.txt" />
       <Compile Include="ExceptionInterop.cs" />
     </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    </ItemGroup>
   </Project>
   

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread01.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread01.cs
@@ -55,6 +55,7 @@ public class Test_thread01
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread01.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread01.cs
@@ -55,7 +55,7 @@ public class Test_thread01
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread01_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread01_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread01.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread02.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread02.cs
@@ -55,7 +55,7 @@ public class Test_thread02
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread02.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread02.cs
@@ -55,6 +55,7 @@ public class Test_thread02
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread02_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread02_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread02.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread03.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread03.cs
@@ -57,6 +57,7 @@ public class Test_thread03
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread03.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread03.cs
@@ -57,7 +57,7 @@ public class Test_thread03
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread03_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread03_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread03.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread04.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread04.cs
@@ -57,6 +57,7 @@ public class Test_thread04
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread04.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread04.cs
@@ -57,7 +57,7 @@ public class Test_thread04
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread04_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread04_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread04.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread05.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread05.cs
@@ -57,6 +57,7 @@ public class Test_thread05
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread05.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread05.cs
@@ -57,7 +57,7 @@ public class Test_thread05
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread05_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread05_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread05.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread06.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread06.cs
@@ -57,7 +57,7 @@ public class Test_thread06
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread06.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread06.cs
@@ -57,6 +57,7 @@ public class Test_thread06
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread06_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread06_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread06.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread07.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread07.cs
@@ -55,7 +55,7 @@ public class Test_thread07
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread07.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread07.cs
@@ -55,6 +55,7 @@ public class Test_thread07
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread07_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread07_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread07.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread08.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread08.cs
@@ -57,7 +57,7 @@ public class Test_thread08
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread08.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread08.cs
@@ -57,6 +57,7 @@ public class Test_thread08
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread08_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread08_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread08.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread09.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread09.cs
@@ -57,7 +57,7 @@ public class Test_thread09
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread09.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread09.cs
@@ -57,6 +57,7 @@ public class Test_thread09
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread09_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread09_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread09.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread10.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread10.cs
@@ -65,6 +65,7 @@ public class Test_thread10
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread10.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread10.cs
@@ -65,7 +65,7 @@ public class Test_thread10
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread10_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread10_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread10.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread11.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread11.cs
@@ -65,6 +65,7 @@ public class Test_thread11
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread11.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread11.cs
@@ -65,7 +65,7 @@ public class Test_thread11
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread11_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread11_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread11.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread12.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread12.cs
@@ -65,7 +65,7 @@ public class Test_thread12
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread12.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread12.cs
@@ -65,6 +65,7 @@ public class Test_thread12
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread12_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread12_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread12.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread13.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread13.cs
@@ -212,7 +212,7 @@ public class Test_thread13
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread13.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread13.cs
@@ -212,6 +212,7 @@ public class Test_thread13
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread13_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread13_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread13.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread14.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread14.cs
@@ -212,7 +212,7 @@ public class Test_thread14
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread14.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread14.cs
@@ -212,6 +212,7 @@ public class Test_thread14
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread14_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread14_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread14.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread15.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread15.cs
@@ -212,6 +212,7 @@ public class Test_thread15
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread15.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread15.cs
@@ -212,7 +212,7 @@ public class Test_thread15
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread15_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread15_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread15.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread16.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread16.cs
@@ -62,7 +62,7 @@ public class Test_thread16
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread16.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread16.cs
@@ -62,6 +62,7 @@ public class Test_thread16
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread16_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread16_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread16.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread17.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread17.cs
@@ -62,7 +62,7 @@ public class Test_thread17
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread17.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread17.cs
@@ -62,6 +62,7 @@ public class Test_thread17
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread17_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread17_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread17.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread18.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread18.cs
@@ -62,6 +62,7 @@ public class Test_thread18
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread18.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread18.cs
@@ -62,7 +62,7 @@ public class Test_thread18
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread18_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread18_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread18.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread19.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread19.cs
@@ -66,7 +66,7 @@ public class Test_thread19
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread19.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread19.cs
@@ -66,6 +66,7 @@ public class Test_thread19
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread19_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread19_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread19.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread20.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread20.cs
@@ -66,6 +66,7 @@ public class Test_thread20
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread20.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread20.cs
@@ -66,7 +66,7 @@ public class Test_thread20
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread20_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread20_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread20.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread21.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread21.cs
@@ -66,6 +66,7 @@ public class Test_thread21
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread21.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread21.cs
@@ -66,7 +66,7 @@ public class Test_thread21
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread21_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread21_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread21.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread22.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread22.cs
@@ -222,6 +222,7 @@ public class Test_thread22
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread22.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread22.cs
@@ -222,7 +222,7 @@ public class Test_thread22
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread22_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread22_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread22.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread23.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread23.cs
@@ -220,6 +220,7 @@ public class Test_thread23
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread23.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread23.cs
@@ -220,7 +220,7 @@ public class Test_thread23
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread23_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread23_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread23.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread24.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread24.cs
@@ -218,6 +218,7 @@ public class Test_thread24
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread24.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread24.cs
@@ -218,7 +218,7 @@ public class Test_thread24
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 	

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread24_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread24_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread24.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread25.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread25.cs
@@ -55,6 +55,7 @@ public class Test_thread25
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread25.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread25.cs
@@ -55,7 +55,7 @@ public class Test_thread25
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread25_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread25_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread25.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
@@ -57,7 +57,7 @@ public class Test_thread26
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
@@ -57,6 +57,7 @@ public class Test_thread26
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
@@ -57,7 +57,7 @@ public class Test_thread26
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread26_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread26_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread26.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
@@ -57,6 +57,7 @@ public class Test_thread27
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
@@ -57,7 +57,7 @@ public class Test_thread27
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
@@ -57,7 +57,7 @@ public class Test_thread27
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread27_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread27_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread27.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread28.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread28.cs
@@ -57,6 +57,7 @@ public class Test_thread28
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread28.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread28.cs
@@ -57,7 +57,7 @@ public class Test_thread28
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread28_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread28_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread28.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread29.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread29.cs
@@ -55,7 +55,7 @@ public class Test_thread29
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread29.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread29.cs
@@ -55,6 +55,7 @@ public class Test_thread29
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread29_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread29_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread29.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
@@ -55,6 +55,7 @@ public class Test_thread30
 	}
 	
 	[Fact]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
@@ -55,7 +55,7 @@ public class Test_thread30
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter", RuntimeTestModes.InterpreterActive)]
+    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
@@ -55,7 +55,7 @@ public class Test_thread30
 	}
 	
 	[Fact]
-    [SkipOnCoreClrAttribute("Fails intermittently with AV when running with the interpreter, https://github.com/dotnet/runtime/issues/120904", RuntimeTestModes.InterpreterActive)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
 	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread30_WaitCallback.csproj
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread30_WaitCallback.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="thread30.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This change disables all coreclr tests that cause the merged coreclr test suites to crash and so preventing us from getting any test pass / fail information from those. This is with running the tests with InterpMode=3 (fully interpreted)

This was put together on Windows x64 checked build, we may need to add more for other targets in a separate PR.

The disabled tests comment includes basic info on the failure / crash.