### PR TITLE
Fix optImpliedByTypeOfAssertions to correctly find a non-null assertion

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_120792/Runtime_120792.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_120792/Runtime_120792.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Xunit;
+
+public class Runtime_120792
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        for (int i = 0; i < 300; i++)
+        {
+            Problem(42);
+            Thread.Sleep(16);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Problem(object value)
+    {
+        Type tt = value == null ? typeof(object) : value.GetType();
+        if (!tt.Equals(typeof(int)) || value == null)
+            throw new InvalidOperationException();
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_120792/Runtime_120792.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_120792/Runtime_120792.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_120792/Runtime_120792.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_120792/Runtime_120792.csproj
@@ -2,8 +2,12 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/120792

This looks like some very old bug that was exposed by an unrelated change in .NET 10.0

Basically, we have an assertion `obj->pMT == <cns_type>` we invoke `optImpliedByTypeOfAssertions` to see if we can find some existing assertion (anywhere) for `obj != null` so we can duplicate it into current `ASSERT_TP& activeAssertions`, because `obj->pMT` assertion implies obj is not null.

We do find such an assertion but for some reason we don't check that it's null on the right side (op2) -> obj != null. Instead, we pick up some random `obj != <frozen_object>` assertion which then is incorrectly used.

[No diffs.](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1180340&view=ms.vss-build-web.run-extensions-tab)
