### PR TITLE
[cDAC] fix extant APIs

### DIFF
--- a/src/native/managed/cdac/mscordaccore_universal/Legacy/ClrDataModule.cs
+++ b/src/native/managed/cdac/mscordaccore_universal/Legacy/ClrDataModule.cs
@@ -243,10 +243,10 @@ internal sealed unsafe partial class ClrDataModule : ICustomQueryInterface, IXCL
                     }
                     _extentsSet = true;
                 }
-
-                *handle = 1;
-                hr = _extents[0].baseAddress != 0 ? HResults.S_OK : HResults.S_FALSE;
             }
+
+            *handle = 1;
+            hr = _extents[0].baseAddress != 0 ? HResults.S_OK : HResults.S_FALSE;
         }
         catch (System.Exception ex)
         {
@@ -303,10 +303,13 @@ internal sealed unsafe partial class ClrDataModule : ICustomQueryInterface, IXCL
             int hrLocal = _legacyModule.EnumExtent(&handleLocal, &dataModuleExtentLocal);
             legacyExtentHandle = handleLocal;
             Debug.Assert(hr == hrLocal, $"cDAC: {hr}, DAC: {hrLocal}");
-            CLRDataModuleExtent* dataModuleExtent = (CLRDataModuleExtent*)extent;
-            Debug.Assert(dataModuleExtent->baseAddress == dataModuleExtentLocal.baseAddress, $"cDAC: {dataModuleExtent->baseAddress}, DAC: {dataModuleExtentLocal.baseAddress}");
-            Debug.Assert(dataModuleExtent->length == dataModuleExtentLocal.length, $"cDAC: {dataModuleExtent->length}, DAC: {dataModuleExtentLocal.length}");
-            Debug.Assert(dataModuleExtent->type == dataModuleExtentLocal.type, $"cDAC: {dataModuleExtent->type}, DAC: {dataModuleExtentLocal.type}");
+            if (hr == HResults.S_OK)
+            {
+                CLRDataModuleExtent* dataModuleExtent = (CLRDataModuleExtent*)extent;
+                Debug.Assert(dataModuleExtent->baseAddress == dataModuleExtentLocal.baseAddress, $"cDAC: {dataModuleExtent->baseAddress}, DAC: {dataModuleExtentLocal.baseAddress}");
+                Debug.Assert(dataModuleExtent->length == dataModuleExtentLocal.length, $"cDAC: {dataModuleExtent->length}, DAC: {dataModuleExtentLocal.length}");
+                Debug.Assert(dataModuleExtent->type == dataModuleExtentLocal.type, $"cDAC: {dataModuleExtent->type}, DAC: {dataModuleExtentLocal.type}");
+            }
         }
 #endif
 


### PR DESCRIPTION
Previously, if `StartEnumExtents` was called on `ClrDataModule` multiple times, the `handle` would not be reset so the results were incorrect. 