### PR TITLE
Ensure EH native helpers are not on the stack trace

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/InternalCalls.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/InternalCalls.cs
@@ -5,6 +5,7 @@
 // This is where we group together all the internal calls.
 //
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,27 +13,33 @@ namespace System.Runtime.ExceptionServices
 {
     internal static partial class InternalCalls
     {
+        [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "SfiInit")]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpSfiInit(ref StackFrameIterator pThis, void* pStackwalkCtx, [MarshalAs(UnmanagedType.U1)] bool instructionFault, bool* fIsExceptionIntercepted);
 
+        [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "SfiNext")]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpSfiNext(ref StackFrameIterator pThis, uint* uExCollideClauseIdx, bool* fUnwoundReversePInvoke, bool* fIsExceptionIntercepted);
 
+        [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "CallFilterFunclet")]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpCallFilterFunclet(
             ObjectHandleOnStack exceptionObj, byte* pFilterIP, void* pvRegDisplay);
 
+        [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AppendExceptionStackFrame")]
         internal static unsafe partial void RhpAppendExceptionStackFrame(ObjectHandleOnStack exceptionObj, IntPtr ip, UIntPtr sp, int flags, EH.ExInfo* exInfo);
 
+        [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EHEnumInitFromStackFrameIterator")]
         [SuppressGCTransition]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpEHEnumInitFromStackFrameIterator(ref StackFrameIterator pFrameIter, out EH.MethodRegionInfo pMethodRegionInfo, void* pEHEnum);
 
+        [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EHEnumNext")]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpEHEnumNext(void* pEHEnum, void* pEHClause);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubEnvironment.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubEnvironment.cs
@@ -87,5 +87,19 @@ namespace Microsoft.Interop
                 return _wasmImportLinkageAttrType.Value;
             }
         }
+
+        private Optional<INamedTypeSymbol?> _stackTraceHiddenAttrType;
+        public INamedTypeSymbol? StackTraceHiddenAttrType
+        {
+            get
+            {
+                if (_stackTraceHiddenAttrType.HasValue)
+                {
+                    return _stackTraceHiddenAttrType.Value;
+                }
+                _stackTraceHiddenAttrType = new Optional<INamedTypeSymbol?>(Compilation.GetTypeByMetadataName(TypeNames.System_Diagnostics_StackTraceHiddenAttribute));
+                return _stackTraceHiddenAttrType.Value;
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Interop
 
         private static NameSyntax? _System_Runtime_InteropServices_StructLayoutAttribute;
         public static NameSyntax System_Runtime_InteropServices_StructLayoutAttribute => _System_Runtime_InteropServices_StructLayoutAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_StructLayoutAttribute);
+        private static NameSyntax? _System_Diagnostics_StackTraceHiddenAttribute;
+        public static NameSyntax System_Diagnostics_StackTraceHiddenAttribute => _System_Diagnostics_StackTraceHiddenAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.System_Diagnostics_StackTraceHiddenAttribute);
     }
 
     public static class TypeSyntaxes
@@ -225,6 +227,8 @@ namespace Microsoft.Interop
         public const string System_Runtime_InteropServices_Marshal = "System.Runtime.InteropServices.Marshal";
 
         private const string System_Runtime_InteropServices_MarshalEx = "System.Runtime.InteropServices.MarshalEx";
+
+        public const string System_Diagnostics_StackTraceHiddenAttribute = "System.Diagnostics.StackTraceHiddenAttribute";
 
         public static string MarshalEx(InteropGenerationOptions options)
         {


### PR DESCRIPTION
Currently, the EH native helpers, like `RhpSfiNext`, that are library imports, are visible on the stack trace in case JIT / R2R doesn't inline the IL stubs for those pinvokes. That's due to two issues
* The library imports are not marked by the `[StackTraceHidden]` attribute
* Even if they were, the `LibraryImportGenerator` doesn't propagate this attribute to the target pinvoke

This change fixes both of these issues.

Close #120436