### PR TITLE
Fix ARM64 interpreter asm helpers

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -959,22 +959,18 @@ LOCAL_LABEL(RefCopyLoop16\argReg):
     bge LOCAL_LABEL(RefCopyLoop16\argReg)
 LOCAL_LABEL(CopyBy8\argReg):
     add x11, x11, #16
-    subs x11, x11, #8
+    cmp x11, #8
     blt LOCAL_LABEL(CopyBy1\argReg)
-LOCAL_LABEL(RefCopyLoop8\argReg):
     ldr x13, [\argReg], #8
     str x13, [x9], #8
     subs x11, x11, #8
-    bge LOCAL_LABEL(RefCopyDone\argReg)
 LOCAL_LABEL(CopyBy1\argReg):
-    add x11, x11, #8
-    subs x11, x11, #1
-    blt LOCAL_LABEL(RefCopyDone\argReg)
+    cbz x11, LOCAL_LABEL(RefCopyDone\argReg)
 LOCAL_LABEL(RefCopyLoop1\argReg):
     ldrb w13, [\argReg], #1
     strb w13, [x9], #1
     subs x11, x11, #1
-    bge  LOCAL_LABEL(RefCopyLoop1\argReg)
+    bne  LOCAL_LABEL(RefCopyLoop1\argReg)
 LOCAL_LABEL(RefCopyDone\argReg):
     // Align x9 to the stack slot size
     add x9, x9, 7

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -787,8 +787,7 @@ NESTED_ENTRY InterpreterStubRetBuff, _TEXT, NoHandler
     add x0, sp, #__PWTB_TransitionBlock + 16
     mov x1, x19 // the IR bytecode pointer
     // Load the return buffer address
-    // 16 is the size of the pushed registers above
-    ldr x2, [sp, #__PWTB_ArgumentRegisters + 16]
+    mov x2, x8
     bl C_FUNC(ExecuteInterpretedMethod)
     EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr,   16
     EPILOG_RETURN
@@ -960,17 +959,22 @@ LOCAL_LABEL(RefCopyLoop16\argReg):
     bge LOCAL_LABEL(RefCopyLoop16\argReg)
 LOCAL_LABEL(CopyBy8\argReg):
     add x11, x11, #16
-    cmp x11, #8
-    blt LOCAL_LABEL(RefCopyLoop1\argReg)
+    subs x11, x11, #8
+    blt LOCAL_LABEL(CopyBy1\argReg)
+LOCAL_LABEL(RefCopyLoop8\argReg):
     ldr x13, [\argReg], #8
     str x13, [x9], #8
     subs x11, x11, #8
-    beq LOCAL_LABEL(RefCopyDone\argReg)
+    bge LOCAL_LABEL(RefCopyDone\argReg)
+LOCAL_LABEL(CopyBy1\argReg):
+    add x11, x11, #8
+    subs x11, x11, #1
+    blt LOCAL_LABEL(RefCopyDone\argReg)
 LOCAL_LABEL(RefCopyLoop1\argReg):
     ldrb w13, [\argReg], #1
     strb w13, [x9], #1
     subs x11, x11, #1
-    bne  LOCAL_LABEL(RefCopyLoop1\argReg)
+    bge  LOCAL_LABEL(RefCopyLoop1\argReg)
 LOCAL_LABEL(RefCopyDone\argReg):
     // Align x9 to the stack slot size
     add x9, x9, 7
@@ -1322,11 +1326,26 @@ LEAF_ENTRY Load_Stack
     ldr w14, [x10], #4 // SP offset
     ldr w12, [x10], #4 // number of stack slots
     add x14, sp, x14
+    subs x12, x12, #8
+    blt LOCAL_LABEL(CopyBy1)
 LOCAL_LABEL(CopyLoop):
     ldr x13, [x9], #8
     str x13, [x14], #8
     subs x12, x12, #8
-    bne LOCAL_LABEL(CopyLoop)
+    bge LOCAL_LABEL(CopyLoop)
+LOCAL_LABEL(CopyBy1):
+    add x12, x12, #8
+    subs x12, x12, #1
+    blt LOCAL_LABEL(Done)
+LOCAL_LABEL(CopyLoop1):
+    ldrb w13, [x9], #1
+    strb w13, [x14], #1
+    subs x12, x12, #1
+    bge LOCAL_LABEL(CopyLoop1)
+LOCAL_LABEL(Done):
+    // Align x9 to the stack slot size
+    add x9, x9, 7
+    and x9, x9, 0xfffffffffffffff8
     ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
 LEAF_END Load_Stack
@@ -1680,13 +1699,13 @@ NESTED_END CallJittedMethodRetBuff, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     str x0, [x2]
     EPILOG_STACK_RESTORE
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
@@ -1699,13 +1718,13 @@ NESTED_END CallJittedMethodRetI8, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRet2I8, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     stp x0, x1, [x2]
     EPILOG_STACK_RESTORE
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
@@ -1718,13 +1737,13 @@ NESTED_END CallJittedMethodRet2I8, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRetDouble, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     str d0, [x2]
     EPILOG_STACK_RESTORE
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
@@ -1737,13 +1756,13 @@ NESTED_END CallJittedMethodRetDouble, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRet2Double, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     stp d0, d1, [x2]
     EPILOG_STACK_RESTORE
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
@@ -1756,13 +1775,13 @@ NESTED_END CallJittedMethodRet2Double, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRet3Double, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     stp d0, d1, [x2], #16
     str d2, [x2]
     EPILOG_STACK_RESTORE
@@ -1776,13 +1795,13 @@ NESTED_END CallJittedMethodRet3Double, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRet4Double, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     stp d0, d1, [x2], #16
     stp d2, d3, [x2]
     EPILOG_STACK_RESTORE
@@ -1796,13 +1815,13 @@ NESTED_END CallJittedMethodRet4Double, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRetFloat, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     str s0, [x2]
     EPILOG_STACK_RESTORE
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
@@ -1815,13 +1834,13 @@ NESTED_END CallJittedMethodRetFloat, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRet2Float, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     stp s0, s1, [x2]
     EPILOG_STACK_RESTORE
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
@@ -1834,13 +1853,13 @@ NESTED_END CallJittedMethodRet2Float, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRet3Float, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     stp s0, s1, [x2], #8
     str s2, [x2]
     EPILOG_STACK_RESTORE
@@ -1854,13 +1873,13 @@ NESTED_END CallJittedMethodRet3Float, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRet4Float, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     stp s0, s1, [x2], #8
     stp s2, s3, [x2]
     EPILOG_STACK_RESTORE
@@ -1874,13 +1893,13 @@ NESTED_END CallJittedMethodRet4Float, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRetVector64, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     str d0, [x2]
     EPILOG_STACK_RESTORE
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
@@ -1893,13 +1912,13 @@ NESTED_END CallJittedMethodRetVector64, _TEXT
 // X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRetVector128, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
-    str x2, [sp, #16]
+    str x2, [fp, #16]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
-    ldr x2, [sp, #16]
+    ldr x2, [fp, #16]
     str q0, [x2]
     EPILOG_STACK_RESTORE
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1135,8 +1135,7 @@ HaveInterpThreadContext
         add x0, sp, #__PWTB_TransitionBlock + 16
         mov x1, x19 ; the IR bytecode pointer
         ; Load the return buffer address
-        ; 16 is the size of the pushed registers above
-        ldr x2, [sp, #__PWTB_ArgumentRegisters + 16]
+        mov x2, x8
         bl ExecuteInterpretedMethod
         EPILOG_RESTORE_REG_PAIR fp, lr, #16!
         EPILOG_RETURN
@@ -1311,17 +1310,22 @@ RefCopyLoop16$argReg
         bge RefCopyLoop16$argReg
 CopyBy8$argReg
         add x11, x11, #16
-        cmp x11, #8
-        blt RefCopyLoop1$argReg
+        subs x11, x11, #8
+        blt CopyBy1$argReg
+RefCopyLoop8$argReg
         ldr x13, [$argReg], #8
         str x13, [x9], #8
         subs x11, x11, #8
-        beq RefCopyDone$argReg
+        bge RefCopyLoop8$argReg
+CopyBy1$argReg
+        add x11, x11, #8
+        subs x11, x11, #1
+        blt RefCopyDone$argReg
 RefCopyLoop1$argReg
         ldrb w13, [$argReg], #1
         strb w13, [x9], #1
         subs x11, x11, #1
-        bne  RefCopyLoop1$argReg
+        bge  RefCopyLoop1$argReg
 RefCopyDone$argReg
         ; Align x9 to the stack slot size
         add x9, x9, 7
@@ -1958,13 +1962,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRetI8
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         str x0, [x2]
         EPILOG_STACK_RESTORE
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
@@ -1977,13 +1981,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet2I8
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         stp x0, x1, [x2]
         EPILOG_STACK_RESTORE
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
@@ -1996,13 +2000,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRetDouble
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         str d0, [x2]
         EPILOG_STACK_RESTORE
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
@@ -2015,13 +2019,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet2Double
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         stp d0, d1, [x2]
         EPILOG_STACK_RESTORE
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
@@ -2034,13 +2038,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet3Double
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         stp d0, d1, [x2], #16
         str d2, [x2]
         EPILOG_STACK_RESTORE
@@ -2054,13 +2058,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet4Double
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         stp d0, d1, [x2], #16
         stp d2, d3, [x2]
         EPILOG_STACK_RESTORE
@@ -2074,13 +2078,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRetFloat
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         str s0, [x2]
         EPILOG_STACK_RESTORE
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
@@ -2093,13 +2097,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet2Float
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         stp s0, s1, [x2]
         EPILOG_STACK_RESTORE
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
@@ -2112,13 +2116,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet3Float
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         stp s0, s1, [x2], #8
         str s2, [x2]
         EPILOG_STACK_RESTORE
@@ -2132,13 +2136,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet4Float
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         stp s0, s1, [x2], #8
         stp s2, s3, [x2]
         EPILOG_STACK_RESTORE
@@ -2152,13 +2156,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRetVector64
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         str d0, [x2]
         EPILOG_STACK_RESTORE
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
@@ -2171,13 +2175,13 @@ CopyLoop
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRetVector128
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        str x2, [sp, #16]
+        str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
         mov x9, x1
         ldr x11, [x10], #8
         blr x11
-        ldr x2, [sp, #16]
+        ldr x2, [fp, #16]
         str q0, [x2]
         EPILOG_STACK_RESTORE
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1310,22 +1310,18 @@ RefCopyLoop16$argReg
         bge RefCopyLoop16$argReg
 CopyBy8$argReg
         add x11, x11, #16
-        subs x11, x11, #8
+        cmp x11, #8
         blt CopyBy1$argReg
-RefCopyLoop8$argReg
         ldr x13, [$argReg], #8
         str x13, [x9], #8
         subs x11, x11, #8
-        bge RefCopyLoop8$argReg
 CopyBy1$argReg
-        add x11, x11, #8
-        subs x11, x11, #1
-        blt RefCopyDone$argReg
+        cbz x11, RefCopyDone$argReg
 RefCopyLoop1$argReg
         ldrb w13, [$argReg], #1
         strb w13, [x9], #1
         subs x11, x11, #1
-        bge  RefCopyLoop1$argReg
+        bne  RefCopyLoop1$argReg
 RefCopyDone$argReg
         ; Align x9 to the stack slot size
         add x9, x9, 7


### PR DESCRIPTION
Running the CoreCLR tests fully interpreted on macOS arm64 has revealed a number of bugs in the assembler helper routines for call stubs.
* Load_Stack on macOS arm64 can get size that's not a multiple of 8
* InterpreterStubRetBuff was loading the return buffer address from a slot that is usually not initialized by the x8. And the x8 is actually valid at that place, so we can get the value from it.
* The Copy_Ref was fixed in another PR recently, but the same bug that was fixed for the copying by 16 bytes was there for copying by 8 and 1 byte.
* The CallJittedMethodRetXXX functions were restoring the x2 from a SP relative address, but SP was modified after the x2 was stored there. The FP relative offset is stable, so I've switched to that one.

This change fixes all of these.