### PR TITLE
Add missing interpreter HFA helpers

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -906,6 +906,48 @@ NESTED_ENTRY InterpreterStubRetVector64, _TEXT, NoHandler
     EPILOG_RETURN
 NESTED_END InterpreterStubRetVector64, _TEXT
 
+NESTED_ENTRY InterpreterStubRet2Vector64, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
+    // The +16 is for the fp, lr above
+    add x0, sp, #__PWTB_TransitionBlock + 16
+    mov x1, x19 // the IR bytecode pointer
+    mov x2, xzr
+    bl C_FUNC(ExecuteInterpretedMethod)
+    ldr d0, [x0], #8
+    ldr d1, [x0]
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr,   16
+    EPILOG_RETURN
+NESTED_END InterpreterStubRet2Vector64, _TEXT
+
+NESTED_ENTRY InterpreterStubRet3Vector64, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
+    // The +16 is for the fp, lr above
+    add x0, sp, #__PWTB_TransitionBlock + 16
+    mov x1, x19 // the IR bytecode pointer
+    mov x2, xzr
+    bl C_FUNC(ExecuteInterpretedMethod)
+    ldr d0, [x0], #8
+    ldr d1, [x0], #8
+    ldr d2, [x0]
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr,   16
+    EPILOG_RETURN
+NESTED_END InterpreterStubRet3Vector64, _TEXT
+
+NESTED_ENTRY InterpreterStubRet4Vector64, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
+    // The +16 is for the fp, lr above
+    add x0, sp, #__PWTB_TransitionBlock + 16
+    mov x1, x19 // the IR bytecode pointer
+    mov x2, xzr
+    bl C_FUNC(ExecuteInterpretedMethod)
+    ldr d0, [x0], #8
+    ldr d1, [x0], #8
+    ldr d2, [x0], #8
+    ldr d3, [x0]
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr,   16
+    EPILOG_RETURN
+NESTED_END InterpreterStubRet4Vector64, _TEXT
+
 NESTED_ENTRY InterpreterStubRetVector128, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
     // The +16 is for the fp, lr above
@@ -917,6 +959,48 @@ NESTED_ENTRY InterpreterStubRetVector128, _TEXT, NoHandler
     EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr,   16
     EPILOG_RETURN
 NESTED_END InterpreterStubRetVector128, _TEXT
+
+NESTED_ENTRY InterpreterStubRet2Vector128, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
+    // The +16 is for the fp, lr above
+    add x0, sp, #__PWTB_TransitionBlock + 16
+    mov x1, x19 // the IR bytecode pointer
+    mov x2, xzr
+    bl C_FUNC(ExecuteInterpretedMethod)
+    ldr q0, [x0], #16
+    ldr q1, [x0]
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr,   16
+    EPILOG_RETURN
+NESTED_END InterpreterStubRet2Vector128, _TEXT
+
+NESTED_ENTRY InterpreterStubRet3Vector128, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
+    // The +16 is for the fp, lr above
+    add x0, sp, #__PWTB_TransitionBlock + 16
+    mov x1, x19 // the IR bytecode pointer
+    mov x2, xzr
+    bl C_FUNC(ExecuteInterpretedMethod)
+    ldr q0, [x0], #16
+    ldr q1, [x0], #16
+    ldr q2, [x0]
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr,   16
+    EPILOG_RETURN
+NESTED_END InterpreterStubRet3Vector128, _TEXT
+
+NESTED_ENTRY InterpreterStubRet4Vector128, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
+    // The +16 is for the fp, lr above
+    add x0, sp, #__PWTB_TransitionBlock + 16
+    mov x1, x19 // the IR bytecode pointer
+    mov x2, xzr
+    bl C_FUNC(ExecuteInterpretedMethod)
+    ldr q0, [x0], #16
+    ldr q1, [x0], #16
+    ldr q2, [x0], #16
+    ldr q3, [x0]
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr,   16
+    EPILOG_RETURN
+NESTED_END InterpreterStubRet4Vector128, _TEXT
 
 // Copy arguments from the processor stack to the interpreter stack
 // The CPU stack slots are aligned to pointer size.
@@ -1906,6 +1990,69 @@ NESTED_END CallJittedMethodRetVector64, _TEXT
 // X1 - interpreter stack args location
 // X2 - interpreter stack return value location
 // X3 - stack arguments size (properly aligned)
+NESTED_ENTRY CallJittedMethodRet2Vector64, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+    str x2, [fp, #16]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    ldr x2, [fp, #16]
+    str d0, [x2], #8
+    str d1, [x2]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRet2Vector64, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+NESTED_ENTRY CallJittedMethodRet3Vector64, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+    str x2, [fp, #16]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    ldr x2, [fp, #16]
+    str d0, [x2], #8
+    str d1, [x2], #8
+    str d2, [x2]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRet3Vector64, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+NESTED_ENTRY CallJittedMethodRet4Vector64, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+    str x2, [fp, #16]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    ldr x2, [fp, #16]
+    str d0, [x2], #8
+    str d1, [x2], #8
+    str d2, [x2], #8
+    str d3, [x2]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRet4Vector64, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
 NESTED_ENTRY CallJittedMethodRetVector128, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
     str x2, [fp, #16]
@@ -1920,5 +2067,69 @@ NESTED_ENTRY CallJittedMethodRetVector128, _TEXT, NoHandler
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
     EPILOG_RETURN
 NESTED_END CallJittedMethodRetVector128, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+NESTED_ENTRY CallJittedMethodRet2Vector128, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+    str x2, [fp, #16]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    ldr x2, [fp, #16]
+    str q0, [x2], #16
+    str q1, [x2]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRet2Vector128, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+NESTED_ENTRY CallJittedMethodRet3Vector128, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+    str x2, [fp, #16]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    ldr x2, [fp, #16]
+    str q0, [x2], #16
+    str q1, [x2], #16
+    str q2, [x2]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRet3Vector128, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+NESTED_ENTRY CallJittedMethodRet4Vector128, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+    str x2, [fp, #16]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    ldr x2, [fp, #16]
+    str q0, [x2], #16
+    str q1, [x2], #16
+    str q2, [x2], #16
+    str q3, [x2]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRet4Vector128, _TEXT
+
 
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1242,7 +1242,7 @@ HaveInterpThreadContext
         EPILOG_RETURN
     NESTED_END InterpreterStubRet4Float
 
-     NESTED_ENTRY InterpreterStubRetVector64
+    NESTED_ENTRY InterpreterStubRetVector64
         PROLOG_SAVE_REG_PAIR   fp, lr, #-16!
         ; The +16 is for the fp, lr above
         add x0, sp, #__PWTB_TransitionBlock + 16
@@ -1253,6 +1253,48 @@ HaveInterpThreadContext
         EPILOG_RESTORE_REG_PAIR fp, lr, #16!
         EPILOG_RETURN
     NESTED_END InterpreterStubRetVector64
+
+    NESTED_ENTRY InterpreterStubRet2Vector64
+        PROLOG_SAVE_REG_PAIR   fp, lr, #-16!
+        ; The +16 is for the fp, lr above
+        add x0, sp, #__PWTB_TransitionBlock + 16
+        mov x1, x19 ; the IR bytecode pointer
+        mov x2, xzr
+        bl C_FUNC(ExecuteInterpretedMethod)
+        ldr d0, [x0], #8
+        ldr d1, [x0]
+        EPILOG_RESTORE_REG_PAIR fp, lr, #16!
+        EPILOG_RETURN
+    NESTED_END InterpreterStubRet2Vector64
+
+    NESTED_ENTRY InterpreterStubRet3Vector64
+        PROLOG_SAVE_REG_PAIR   fp, lr, #-16!
+        ; The +16 is for the fp, lr above
+        add x0, sp, #__PWTB_TransitionBlock + 16
+        mov x1, x19 ; the IR bytecode pointer
+        mov x2, xzr
+        bl C_FUNC(ExecuteInterpretedMethod)
+        ldr d0, [x0], #8
+        ldr d1, [x0], #8
+        ldr d2, [x0]
+        EPILOG_RESTORE_REG_PAIR fp, lr, #16!
+        EPILOG_RETURN
+    NESTED_END InterpreterStubRet3Vector64
+
+    NESTED_ENTRY InterpreterStubRet4Vector64
+        PROLOG_SAVE_REG_PAIR   fp, lr, #-16!
+        ; The +16 is for the fp, lr above
+        add x0, sp, #__PWTB_TransitionBlock + 16
+        mov x1, x19 ; the IR bytecode pointer
+        mov x2, xzr
+        bl C_FUNC(ExecuteInterpretedMethod)
+        ldr d0, [x0], #8
+        ldr d1, [x0], #8
+        ldr d2, [x0], #8
+        ldr d3, [x0]
+        EPILOG_RESTORE_REG_PAIR fp, lr, #16!
+        EPILOG_RETURN
+    NESTED_END InterpreterStubRet4Vector64
 
     NESTED_ENTRY InterpreterStubRetVector128
         PROLOG_SAVE_REG_PAIR   fp, lr, #-16!
@@ -1265,6 +1307,48 @@ HaveInterpThreadContext
         EPILOG_RESTORE_REG_PAIR fp, lr, #16!
         EPILOG_RETURN
     NESTED_END InterpreterStubRetVector128
+
+    NESTED_ENTRY InterpreterStubRet2Vector128
+        PROLOG_SAVE_REG_PAIR   fp, lr, #-16!
+        ; The +16 is for the fp, lr above
+        add x0, sp, #__PWTB_TransitionBlock + 16
+        mov x1, x19 ; the IR bytecode pointer
+        mov x2, xzr
+        bl C_FUNC(ExecuteInterpretedMethod)
+        ldr q0, [x0], #16
+        ldr q1, [x0]
+        EPILOG_RESTORE_REG_PAIR fp, lr, #16!
+        EPILOG_RETURN
+    NESTED_END InterpreterStubRet2Vector128
+
+    NESTED_ENTRY InterpreterStubRet3Vector128
+        PROLOG_SAVE_REG_PAIR   fp, lr, #-16!
+        ; The +16 is for the fp, lr above
+        add x0, sp, #__PWTB_TransitionBlock + 16
+        mov x1, x19 ; the IR bytecode pointer
+        mov x2, xzr
+        bl C_FUNC(ExecuteInterpretedMethod)
+        ldr q0, [x0], #16
+        ldr q1, [x0], #16
+        ldr q2, [x0]
+        EPILOG_RESTORE_REG_PAIR fp, lr, #16!
+        EPILOG_RETURN
+    NESTED_END InterpreterStubRet3Vector128
+
+    NESTED_ENTRY InterpreterStubRet4Vector128
+        PROLOG_SAVE_REG_PAIR   fp, lr, #-16!
+        ; The +16 is for the fp, lr above
+        add x0, sp, #__PWTB_TransitionBlock + 16
+        mov x1, x19 ; the IR bytecode pointer
+        mov x2, xzr
+        bl C_FUNC(ExecuteInterpretedMethod)
+        ldr q0, [x0], #16
+        ldr q1, [x0], #16
+        ldr q2, [x0], #16
+        ldr q3, [x0]
+        EPILOG_RESTORE_REG_PAIR fp, lr, #16!
+        EPILOG_RETURN
+    NESTED_END InterpreterStubRet4Vector128
 
     ; Routines for passing value type arguments by reference in general purpose registers X0..X7
     ; from native code to the interpreter
@@ -2169,6 +2253,69 @@ CopyLoop
     ; X1 - interpreter stack args location
     ; X2 - interpreter stack return value location
     ; X3 - stack arguments size (properly aligned)
+    NESTED_ENTRY CallJittedMethodRet2Vector64
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
+        str x2, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        ldr x2, [fp, #16]
+        str d0, [x2], #8
+        str d1, [x2]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRet2Vector64
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    NESTED_ENTRY CallJittedMethodRet3Vector64
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
+        str x2, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        ldr x2, [fp, #16]
+        str d0, [x2], #8
+        str d1, [x2], #8
+        str d2, [x2]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRet3Vector64
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    NESTED_ENTRY CallJittedMethodRet4Vector64
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
+        str x2, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        ldr x2, [fp, #16]
+        str d0, [x2], #8
+        str d1, [x2], #8
+        str d2, [x2], #8
+        str d3, [x2]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRet4Vector64
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRetVector128
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
         str x2, [fp, #16]
@@ -2183,6 +2330,70 @@ CopyLoop
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
         EPILOG_RETURN
     NESTED_END CallJittedMethodRetVector128
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    NESTED_ENTRY CallJittedMethodRet2Vector128
+        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+        str x2, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        ldr x2, [fp, #16]
+        str q0, [x2], #16
+        str q1, [x2]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRet2Vector128
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    NESTED_ENTRY CallJittedMethodRet3Vector128
+        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+        str x2, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        ldr x2, [fp, #16]
+        str q0, [x2], #16
+        str q1, [x2], #16
+        str q2, [x2]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRet3Vector128
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    NESTED_ENTRY CallJittedMethodRet4Vector128
+        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+        str x2, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        ldr x2, [fp, #16]
+        str q0, [x2], #16
+        str q1, [x2], #16
+        str q2, [x2], #16
+        str q3, [x2]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRet4Vector128
+
 
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1260,7 +1260,7 @@ HaveInterpThreadContext
         add x0, sp, #__PWTB_TransitionBlock + 16
         mov x1, x19 ; the IR bytecode pointer
         mov x2, xzr
-        bl C_FUNC(ExecuteInterpretedMethod)
+        bl ExecuteInterpretedMethod
         ldr d0, [x0], #8
         ldr d1, [x0]
         EPILOG_RESTORE_REG_PAIR fp, lr, #16!
@@ -1273,7 +1273,7 @@ HaveInterpThreadContext
         add x0, sp, #__PWTB_TransitionBlock + 16
         mov x1, x19 ; the IR bytecode pointer
         mov x2, xzr
-        bl C_FUNC(ExecuteInterpretedMethod)
+        bl ExecuteInterpretedMethod
         ldr d0, [x0], #8
         ldr d1, [x0], #8
         ldr d2, [x0]
@@ -1287,7 +1287,7 @@ HaveInterpThreadContext
         add x0, sp, #__PWTB_TransitionBlock + 16
         mov x1, x19 ; the IR bytecode pointer
         mov x2, xzr
-        bl C_FUNC(ExecuteInterpretedMethod)
+        bl ExecuteInterpretedMethod
         ldr d0, [x0], #8
         ldr d1, [x0], #8
         ldr d2, [x0], #8
@@ -1314,7 +1314,7 @@ HaveInterpThreadContext
         add x0, sp, #__PWTB_TransitionBlock + 16
         mov x1, x19 ; the IR bytecode pointer
         mov x2, xzr
-        bl C_FUNC(ExecuteInterpretedMethod)
+        bl ExecuteInterpretedMethod
         ldr q0, [x0], #16
         ldr q1, [x0]
         EPILOG_RESTORE_REG_PAIR fp, lr, #16!
@@ -1327,7 +1327,7 @@ HaveInterpThreadContext
         add x0, sp, #__PWTB_TransitionBlock + 16
         mov x1, x19 ; the IR bytecode pointer
         mov x2, xzr
-        bl C_FUNC(ExecuteInterpretedMethod)
+        bl ExecuteInterpretedMethod
         ldr q0, [x0], #16
         ldr q1, [x0], #16
         ldr q2, [x0]
@@ -1341,7 +1341,7 @@ HaveInterpThreadContext
         add x0, sp, #__PWTB_TransitionBlock + 16
         mov x1, x19 ; the IR bytecode pointer
         mov x2, xzr
-        bl C_FUNC(ExecuteInterpretedMethod)
+        bl ExecuteInterpretedMethod
         ldr q0, [x0], #16
         ldr q1, [x0], #16
         ldr q2, [x0], #16

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -2336,7 +2336,7 @@ CopyLoop
     ; X2 - interpreter stack return value location
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet2Vector128
-        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
         str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
@@ -2347,7 +2347,7 @@ CopyLoop
         str q0, [x2], #16
         str q1, [x2]
         EPILOG_STACK_RESTORE
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
         EPILOG_RETURN
     NESTED_END CallJittedMethodRet2Vector128
 
@@ -2356,7 +2356,7 @@ CopyLoop
     ; X2 - interpreter stack return value location
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet3Vector128
-        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
         str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
@@ -2368,7 +2368,7 @@ CopyLoop
         str q1, [x2], #16
         str q2, [x2]
         EPILOG_STACK_RESTORE
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
         EPILOG_RETURN
     NESTED_END CallJittedMethodRet3Vector128
 
@@ -2377,7 +2377,7 @@ CopyLoop
     ; X2 - interpreter stack return value location
     ; X3 - stack arguments size (properly aligned)
     NESTED_ENTRY CallJittedMethodRet4Vector128
-        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
         str x2, [fp, #16]
         sub sp, sp, x3
         mov x10, x0
@@ -2390,7 +2390,7 @@ CopyLoop
         str q2, [x2], #16
         str q3, [x2]
         EPILOG_STACK_RESTORE
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
         EPILOG_RETURN
     NESTED_END CallJittedMethodRet4Vector128
 

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1092,7 +1092,13 @@ extern "C" void CallJittedMethodRet2Float(PCODE *routines, int8_t*pArgs, int8_t*
 extern "C" void CallJittedMethodRet3Float(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize);
 extern "C" void CallJittedMethodRet4Float(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize);
 extern "C" void CallJittedMethodRetVector64(PCODE *routines, int8_t *pArgs, int8_t *pRet, int totalStackSize);
+extern "C" void CallJittedMethodRet2Vector64(PCODE *routines, int8_t *pArgs, int8_t *pRet, int totalStackSize);
+extern "C" void CallJittedMethodRet3Vector64(PCODE *routines, int8_t *pArgs, int8_t *pRet, int totalStackSize);
+extern "C" void CallJittedMethodRet4Vector64(PCODE *routines, int8_t *pArgs, int8_t *pRet, int totalStackSize);
 extern "C" void CallJittedMethodRetVector128(PCODE *routines, int8_t *pArgs, int8_t *pRet, int totalStackSize);
+extern "C" void CallJittedMethodRet2Vector128(PCODE *routines, int8_t *pArgs, int8_t *pRet, int totalStackSize);
+extern "C" void CallJittedMethodRet3Vector128(PCODE *routines, int8_t *pArgs, int8_t *pRet, int totalStackSize);
+extern "C" void CallJittedMethodRet4Vector128(PCODE *routines, int8_t *pArgs, int8_t *pRet, int totalStackSize);
 extern "C" void InterpreterStubRet2I8();
 extern "C" void InterpreterStubRet2Double();
 extern "C" void InterpreterStubRet3Double();
@@ -1102,7 +1108,13 @@ extern "C" void InterpreterStubRet2Float();
 extern "C" void InterpreterStubRet3Float();
 extern "C" void InterpreterStubRet4Float();
 extern "C" void InterpreterStubRetVector64();
+extern "C" void InterpreterStubRet2Vector64();
+extern "C" void InterpreterStubRet3Vector64();
+extern "C" void InterpreterStubRet4Vector64();
 extern "C" void InterpreterStubRetVector128();
+extern "C" void InterpreterStubRet2Vector128();
+extern "C" void InterpreterStubRet3Vector128();
+extern "C" void InterpreterStubRet4Vector128();
 #endif // TARGET_ARM64
 
 #if LOG_COMPUTE_CALL_STUB
@@ -1161,8 +1173,16 @@ CallStubHeader::InvokeFunctionPtr CallStubGenerator::GetInvokeFunctionPtr(CallSt
             INVOKE_FUNCTION_PTR(CallJittedMethodRet4Float);
         case ReturnTypeVector64:
             INVOKE_FUNCTION_PTR(CallJittedMethodRetVector64);
+        case ReturnType2Vector64:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRet2Vector64);
+        case ReturnType4Vector64:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRet4Vector64);
         case ReturnTypeVector128:
             INVOKE_FUNCTION_PTR(CallJittedMethodRetVector128);
+        case ReturnType2Vector128:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRet2Vector128);
+        case ReturnType4Vector128:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRet4Vector128);
 #endif // TARGET_ARM64
         default:
             _ASSERTE(!"Unexpected return type for interpreter stub");
@@ -1226,8 +1246,20 @@ PCODE CallStubGenerator::GetInterpreterReturnTypeHandler(CallStubGenerator::Retu
             RETURN_TYPE_HANDLER(InterpreterStubRet4Float);
         case ReturnTypeVector64:
             RETURN_TYPE_HANDLER(InterpreterStubRetVector64);
+        case ReturnType2Vector64:
+            RETURN_TYPE_HANDLER(InterpreterStubRet2Vector64);
+        case ReturnType3Vector64:
+            RETURN_TYPE_HANDLER(InterpreterStubRet3Vector64);
+        case ReturnType4Vector64:
+            RETURN_TYPE_HANDLER(InterpreterStubRet4Vector64);
         case ReturnTypeVector128:
             RETURN_TYPE_HANDLER(InterpreterStubRetVector128);
+        case ReturnType2Vector128:
+            RETURN_TYPE_HANDLER(InterpreterStubRet2Vector128);
+        case ReturnType3Vector128:
+            RETURN_TYPE_HANDLER(InterpreterStubRet3Vector128);
+        case ReturnType4Vector128:
+            RETURN_TYPE_HANDLER(InterpreterStubRet4Vector128);
 #endif // TARGET_ARM64
         default:
             _ASSERTE(!"Unexpected return type for interpreter stub");
@@ -1883,6 +1915,12 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIterator *pArg
                                 {
                                     case 8:
                                         return ReturnTypeVector64;
+                                    case 16:
+                                        return ReturnType2Vector64;
+                                    case 24:
+                                        return ReturnType3Vector64;
+                                    case 32:
+                                        return ReturnType4Vector64;
                                     default:
                                         _ASSERTE(!"Unsupported Vector64 HFA size");
                                         break;
@@ -1893,6 +1931,12 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIterator *pArg
                                 {
                                     case 16:
                                         return ReturnTypeVector128;
+                                    case 32:
+                                        return ReturnType2Vector128;
+                                    case 48:
+                                        return ReturnType3Vector128;
+                                    case 64:
+                                        return ReturnType4Vector128;
                                     default:
                                         _ASSERTE(!"Unsupported Vector128 HFA size");
                                         break;

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1175,12 +1175,16 @@ CallStubHeader::InvokeFunctionPtr CallStubGenerator::GetInvokeFunctionPtr(CallSt
             INVOKE_FUNCTION_PTR(CallJittedMethodRetVector64);
         case ReturnType2Vector64:
             INVOKE_FUNCTION_PTR(CallJittedMethodRet2Vector64);
+        case ReturnType3Vector64:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRet3Vector64);
         case ReturnType4Vector64:
             INVOKE_FUNCTION_PTR(CallJittedMethodRet4Vector64);
         case ReturnTypeVector128:
             INVOKE_FUNCTION_PTR(CallJittedMethodRetVector128);
         case ReturnType2Vector128:
             INVOKE_FUNCTION_PTR(CallJittedMethodRet2Vector128);
+        case ReturnType3Vector128:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRet3Vector128);
         case ReturnType4Vector128:
             INVOKE_FUNCTION_PTR(CallJittedMethodRet4Vector128);
 #endif // TARGET_ARM64

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -92,7 +92,13 @@ class CallStubGenerator
         ReturnType3Float,
         ReturnType4Float,
         ReturnTypeVector64,
-        ReturnTypeVector128
+        ReturnType2Vector64,
+        ReturnType3Vector64,
+        ReturnType4Vector64,
+        ReturnTypeVector128,
+        ReturnType2Vector128,
+        ReturnType3Vector128,
+        ReturnType4Vector128
 #endif // TARGET_ARM64
     };
 


### PR DESCRIPTION
There are missing helpers for 2, 3 and 4 vector64 and vector128 HFA in the interpreter call stubs.

This change implements them.