### PR TITLE
Add missing project reference

### DIFF
--- a/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
@@ -11,6 +11,7 @@
     <Compile Include="Test111242.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_111242/Test111242.csproj
@@ -11,7 +11,7 @@
     <Compile Include="Test111242.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes failures in main for runtime-coreclr outerloop (for reference: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1182310&view=logs&j=3725811e-4a8b-5f6a-b03b-a353ee894148&t=d59fccfb-2b13-5841-75bf-bfec705ee16a&l=13592)