### PR TITLE
Revert "Move hosting tests to XUnit 3"

### DIFF
--- a/src/installer/tests/AppHost.Bundle.Tests/AppHost.Bundle.Tests.csproj
+++ b/src/installer/tests/AppHost.Bundle.Tests/AppHost.Bundle.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <Description>Apphost Bundle Tests</Description>
-    <OutputType>Exe</OutputType>
-    <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
     <TargetFramework>$(TestInfraTargetFramework)</TargetFramework>
     <AssemblyName>AppHost.Bundle.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -11,8 +9,7 @@
     <TestsOutputName>ahb</TestsOutputName>
     <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
          This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
-    <NoWarn>$(NoWarn);NU1511;xUnit1004</NoWarn>
-    <TestRunnerName>XUnitV3</TestRunnerName>
+    <NoWarn>$(NoWarn);NU1511</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
@@ -27,7 +27,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(path)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(selfContained ? null : HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(selfContained ? null : TestContext.BuiltDotNet.BinPath)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World!");
@@ -75,9 +75,9 @@ namespace AppHost.Bundle.Tests
             if (OperatingSystem.IsWindows())
             {
                 // StandaloneApp sets FileVersion to NETCoreApp version. On Windows, this should be copied to singlefilehost resources.
-                string expectedVersion = HostTestContext.MicrosoftNETCoreAppVersion.Contains('-')
-                    ? HostTestContext.MicrosoftNETCoreAppVersion[..HostTestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
-                    : HostTestContext.MicrosoftNETCoreAppVersion;
+                string expectedVersion = TestContext.MicrosoftNETCoreAppVersion.Contains('-')
+                    ? TestContext.MicrosoftNETCoreAppVersion[..TestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
+                    : TestContext.MicrosoftNETCoreAppVersion;
                 Assert.Equal(expectedVersion, System.Diagnostics.FileVersionInfo.GetVersionInfo(singleFile).FileVersion);
             }
         }
@@ -103,17 +103,14 @@ namespace AppHost.Bundle.Tests
             if (OperatingSystem.IsWindows())
             {
                 // StandaloneApp sets FileVersion to NETCoreApp version. On Windows, this should be copied to singlefilehost resources.
-                string expectedVersion = HostTestContext.MicrosoftNETCoreAppVersion.Contains('-')
-                    ? HostTestContext.MicrosoftNETCoreAppVersion[..HostTestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
-                    : HostTestContext.MicrosoftNETCoreAppVersion;
+                string expectedVersion = TestContext.MicrosoftNETCoreAppVersion.Contains('-')
+                    ? TestContext.MicrosoftNETCoreAppVersion[..TestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
+                    : TestContext.MicrosoftNETCoreAppVersion;
                 Assert.Equal(expectedVersion, System.Diagnostics.FileVersionInfo.GetVersionInfo(singleFile).FileVersion);
             }
         }
 
-        [Theory(
-            SkipType = typeof(Binaries.CetCompat),
-            SkipUnless = nameof(Binaries.CetCompat.IsSupported),
-            Skip = "CET is not supported on this platform")]
+        [ConditionalTheory(typeof(Binaries.CetCompat), nameof(Binaries.CetCompat.IsSupported))]
         [InlineData(true)]
         [InlineData(false)]
         public void DisableCetCompat(bool selfContained)
@@ -127,12 +124,12 @@ namespace AppHost.Bundle.Tests
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath, HostTestContext.BuildArchitecture)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath, TestContext.BuildArchitecture)
                 .MultilevelLookup(false)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Theory]
@@ -161,7 +158,7 @@ namespace AppHost.Bundle.Tests
 
             using (var dotnetWithMockHostFxr = TestArtifact.Create("mockhostfxrFrameworkMissingFailure"))
             {
-                var dotnet = new DotNetBuilder(dotnetWithMockHostFxr.Location, HostTestContext.BuiltDotNet.BinPath, null)
+                var dotnet = new DotNetBuilder(dotnetWithMockHostFxr.Location, TestContext.BuiltDotNet.BinPath, null)
                     .RemoveHostFxr()
                     .AddMockHostFxr(new Version(2, 2, 0))
                     .Build();
@@ -180,7 +177,7 @@ namespace AppHost.Bundle.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [PlatformSpecific(TestPlatforms.Windows)] // GUI app host is only supported on Windows.
         public void FrameworkDependent_GUI_DownlevelHostFxr_ErrorDialog()
         {
             var singleFile = sharedTestState.FrameworkDependentApp.Bundle();
@@ -191,14 +188,14 @@ namespace AppHost.Bundle.Tests
             {
                 string expectedErrorCode = Constants.ErrorCode.BundleExtractionFailure.ToString("x");
 
-                var dotnet = new DotNetBuilder(dotnetWithMockHostFxr.Location, HostTestContext.BuiltDotNet.BinPath, null)
+                var dotnet = new DotNetBuilder(dotnetWithMockHostFxr.Location, TestContext.BuiltDotNet.BinPath, null)
                     .RemoveHostFxr()
                     .AddMockHostFxr(new Version(5, 0, 0))
                     .Build();
 
                 Command command = Command.Create(singleFile)
                     .EnableTracingAndCaptureOutputs()
-                    .DotNetRoot(dotnet.BinPath, HostTestContext.BuildArchitecture)
+                    .DotNetRoot(dotnet.BinPath, TestContext.BuildArchitecture)
                     .Start();
 
                 WindowsUtils.WaitForPopupFromProcess(command.Process);

--- a/src/installer/tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
@@ -24,7 +24,7 @@ namespace AppHost.Bundle.Tests
         {
             CommandResult result = Command.Create(path)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(selfContained ? null : HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(selfContained ? null : TestContext.BuiltDotNet.BinPath)
                 .MultilevelLookup(false)
                 .Execute();
             if (deleteApp)
@@ -142,7 +142,8 @@ namespace AppHost.Bundle.Tests
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/54234")]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/54234")]
         // NOTE: when enabling this test take a look at commented code marked by "ACTIVE ISSUE:" in SharedTestState
         public void SelfContained_R2R_Composite()
         {

--- a/src/installer/tests/AppHost.Bundle.Tests/NativeLibraries.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/NativeLibraries.cs
@@ -38,7 +38,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(app, "load_native_library_pinvoke")
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(selfContained ? null : HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(selfContained ? null : TestContext.BuiltDotNet.BinPath)
                 // Specify an extraction root that will get cleaned up by the test app artifact
                 .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, extractionRoot)
                 .Execute()
@@ -66,7 +66,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(app, "load_native_library_api")
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(selfContained ? null : HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(selfContained ? null : TestContext.BuiltDotNet.BinPath)
                 // Specify an extraction root that will get cleaned up by the test app artifact
                 .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, extractionRoot)
                 .Execute()

--- a/src/installer/tests/Directory.Build.props
+++ b/src/installer/tests/Directory.Build.props
@@ -4,11 +4,12 @@
   <PropertyGroup>
     <TestArtifactsOutputRoot>$(ArtifactsDir)tests\host\$(TargetOS).$(TargetArchitecture).$(Configuration)\</TestArtifactsOutputRoot>
     <TestInfraTargetFramework>$(NetCoreAppToolCurrent)</TestInfraTargetFramework>
-    <TestCaseFilter>/[category!=failing]</TestCaseFilter>
-    <TestRunnerAdditionalArguments>--filter-query $(TestCaseFilter)</TestRunnerAdditionalArguments>
+    <TestCaseFilter>category!=failing</TestCaseFilter>
+    <TestRunnerAdditionalArguments>--filter $(TestCaseFilter) -v detailed</TestRunnerAdditionalArguments>
     <!-- Enable crash and hang dumps -->
-    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --crashdump</TestRunnerAdditionalArguments>
-    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --hangdump --hangdump-timeout 5m --hangdump-type full</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --blame-crash-dump-type full</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --blame-hang-timeout 5m --blame-hang-dump-type full</TestRunnerAdditionalArguments>
+    <UseVSTestRunner>true</UseVSTestRunner>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 

--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -92,11 +92,6 @@
     <RunSettingsTestCaseFilter>$(TestCaseFilter)</RunSettingsTestCaseFilter>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Version="1.7.3" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="1.7.3" />
-  </ItemGroup>
-
   <Import Project="$(RepositoryEngineeringDir)testing\runsettings.targets"
           Condition="'$(IsTestProject)' == 'true'" />
 

--- a/src/installer/tests/HostActivation.Tests/Breadcrumbs.cs
+++ b/src/installer/tests/HostActivation.Tests/Breadcrumbs.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void BreadcrumbThreadFinishes()
         {
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll)
+            TestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll)
                 .EnvironmentVariable(Constants.Breadcrumbs.EnvironmentVariable, sharedTestState.BreadcrumbLocation)
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void UnhandledException_BreadcrumbThreadDoesNotFinish()
         {
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll, "throw_exception")
+            TestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll, "throw_exception")
                 .EnvironmentVariable(Constants.Breadcrumbs.EnvironmentVariable, sharedTestState.BreadcrumbLocation)
                 .EnableTracingAndCaptureOutputs()
                 .DisableDumps() // Expected to throw an exception

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalProbingPath.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalProbingPath.cs
@@ -111,24 +111,24 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             public SharedTestState()
             {
                 DotNetWithNetCoreApp = DotNet("WithNetCoreApp")
-                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(HostTestContext.MicrosoftNETCoreAppVersion)
+                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(TestContext.MicrosoftNETCoreAppVersion)
                     .Build();
 
-                string nativeDependencyRelPath = $"{HostTestContext.BuildRID}/{Binaries.GetSharedLibraryFileNameForCurrentPlatform("native")}";
-                FrameworkReferenceApp = CreateFrameworkReferenceApp(Constants.MicrosoftNETCoreApp, HostTestContext.MicrosoftNETCoreAppVersion, b => b
+                string nativeDependencyRelPath = $"{TestContext.BuildRID}/{Binaries.GetSharedLibraryFileNameForCurrentPlatform("native")}";
+                FrameworkReferenceApp = CreateFrameworkReferenceApp(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion, b => b
                     .WithProject(DependencyName, DependencyVersion, p => p
                         .WithAssemblyGroup(null, g => g
                             .WithAsset($"{DependencyName}.dll", f => f.NotOnDisk()))
-                        .WithNativeLibraryGroup(HostTestContext.BuildRID, g => g
+                        .WithNativeLibraryGroup(TestContext.BuildRID, g => g
                             .WithAsset(nativeDependencyRelPath, f => f.NotOnDisk()))));
                 RuntimeConfig.FromFile(FrameworkReferenceApp.RuntimeConfigJson)
-                    .WithTfm(HostTestContext.Tfm)
+                    .WithTfm(TestContext.Tfm)
                     .Save();
 
                 AdditionalProbingPath = Path.Combine(Location, "probe");
                 (DependencyPath, NativeDependencyDirectory) = AddDependencies(AdditionalProbingPath);
 
-                AdditionalProbingPath_ArchTfm = Path.Combine(AdditionalProbingPath, HostTestContext.BuildArchitecture, HostTestContext.Tfm);
+                AdditionalProbingPath_ArchTfm = Path.Combine(AdditionalProbingPath, TestContext.BuildArchitecture, TestContext.Tfm);
                 (DependencyPath_ArchTfm, NativeDependencyDirectory_ArchTfm) = AddDependencies(AdditionalProbingPath_ArchTfm);
 
                 (string, string) AddDependencies(string probeDir)

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DepsFile.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DepsFile.cs
@@ -92,10 +92,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             public SharedTestState()
             {
                 DotNetWithNetCoreApp = DotNet("WithNetCoreApp")
-                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(HostTestContext.MicrosoftNETCoreAppVersion)
+                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(TestContext.MicrosoftNETCoreAppVersion)
                     .Build();
 
-                FrameworkReferenceApp = CreateFrameworkReferenceApp(Constants.MicrosoftNETCoreApp, HostTestContext.MicrosoftNETCoreAppVersion, b => b
+                FrameworkReferenceApp = CreateFrameworkReferenceApp(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion, b => b
                     .WithProject(DependencyName, "1.0.0", p => p
                         .WithAssemblyGroup(null, g => g.WithAsset($"{DependencyName}.dll"))));
 

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/LocalPath.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/LocalPath.cs
@@ -66,8 +66,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                     {
                         // Add RID-specific assembly
                         (string ridPath, string localRidPath) = GetPaths(libraryType, true);
-                        b.WithRuntimeLibrary(libraryType, $"{library}-{HostTestContext.BuildRID}", "1.0.0", p => p
-                            .WithAssemblyGroup(HostTestContext.BuildRID, g => g
+                        b.WithRuntimeLibrary(libraryType, $"{library}-{TestContext.BuildRID}", "1.0.0", p => p
+                            .WithAssemblyGroup(TestContext.BuildRID, g => g
                                 .WithAsset(ridPath, useLocalPath ? f => f.WithLocalPath(localRidPath) : null)));
                     }
                 }
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             static (string Path, string LocalPath) GetPaths(RuntimeLibraryType libraryType, bool useRid)
             {
                 string library = $"Test{libraryType}";
-                string path = useRid ? $"lib/{HostTestContext.BuildRID}/{library}-{HostTestContext.BuildRID}.dll" : $"lib/{library}.dll";
+                string path = useRid ? $"lib/{TestContext.BuildRID}/{library}-{TestContext.BuildRID}.dll" : $"lib/{library}.dll";
                 return (path, $"{libraryType}/{path}");
             }
         }
@@ -137,9 +137,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                     {
                         // Add RID-specific native library
                         (string ridPath, string localRidPath) = GetPaths(libraryType, true);
-                        b.WithRuntimeLibrary(libraryType, $"{library}-{HostTestContext.BuildRID}", "1.0.0", p => p
-                            .WithNativeLibraryGroup(HostTestContext.BuildRID, g => g
-                                .WithAsset($"{ridPath}/{library}-{HostTestContext.BuildRID}.native", useLocalPath ? f => f.WithLocalPath($"{localRidPath}/{library}-{HostTestContext.BuildRID}.native") : null)));
+                        b.WithRuntimeLibrary(libraryType, $"{library}-{TestContext.BuildRID}", "1.0.0", p => p
+                            .WithNativeLibraryGroup(TestContext.BuildRID, g => g
+                                .WithAsset($"{ridPath}/{library}-{TestContext.BuildRID}.native", useLocalPath ? f => f.WithLocalPath($"{localRidPath}/{library}-{TestContext.BuildRID}.native") : null)));
                     }
                 }
 
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
             static (string Path, string LocalPath) GetPaths(NetCoreAppBuilder.RuntimeLibraryType libraryType, bool useRid)
             {
-                string path = useRid ? $"native/{HostTestContext.BuildRID}" : "native";
+                string path = useRid ? $"native/{TestContext.BuildRID}" : "native";
                 return (path, $"{libraryType}/{path}");
             }
         }
@@ -245,7 +245,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             }
             else
             {
-                app.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, HostTestContext.MicrosoftNETCoreAppVersion, customizer);
+                app.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion, customizer);
             }
             return app;
         }
@@ -257,7 +257,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             public SharedTestState()
             {
                 DotNetWithNetCoreApp = DotNet("WithNetCoreApp")
-                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(HostTestContext.MicrosoftNETCoreAppVersion)
+                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(TestContext.MicrosoftNETCoreAppVersion)
                     .Build();
             }
         }

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/PerAssemblyVersionResolutionMultipleFrameworks.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/PerAssemblyVersionResolutionMultipleFrameworks.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                     HighWare,
                     "1.1.1",
                     runtimeConfig => runtimeConfig.WithFramework(Constants.MicrosoftNETCoreApp, "4.0.0"),
-                    path => NetCoreAppBuilder.ForNETCoreApp(HighWare, HostTestContext.BuildRID)
+                    path => NetCoreAppBuilder.ForNETCoreApp(HighWare, TestContext.BuildRID)
                         .WithProject(HighWare, "1.1.1", p => p
                             .WithAssemblyGroup(null, g => g
                             .WithAsset(TestAssemblyWithNoVersions + ".dll")

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
@@ -94,8 +94,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         // The fallback RID is a compile-time define for the host. On Windows, it is always win10 and on
         // other platforms, it matches the build RID (non-portable for source-builds, portable otherwise)
         private static string FallbackRid = OperatingSystem.IsWindows()
-            ? $"win10-{HostTestContext.BuildArchitecture}"
-            : HostTestContext.BuildRID;
+            ? $"win10-{TestContext.BuildArchitecture}"
+            : TestContext.BuildRID;
 
         protected const string UnknownRid = "unknown-rid";
 
@@ -332,15 +332,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         }
 
         // The build RID from the test context should match the build RID of the host under test
-        private static string CurrentRid = HostTestContext.BuildRID;
+        private static string CurrentRid = TestContext.BuildRID;
         private static string CurrentRidAsset = $"{CurrentRid}/{CurrentRid}Asset.dll";
 
         // Strip the -<arch> from the RID to get the OS
-        private static string CurrentOS = CurrentRid[..^(HostTestContext.BuildArchitecture.Length + 1)];
+        private static string CurrentOS = CurrentRid[..^(TestContext.BuildArchitecture.Length + 1)];
         private static string CurrentOSAsset = $"{CurrentOS}/{CurrentOS}Asset.dll";
 
         // Append a different architecture - arm64 if current architecture is x64, otherwise x64
-        private static string DifferentArch = $"{CurrentOS}-{(HostTestContext.BuildArchitecture == "x64" ? "arm64" : "x64")}";
+        private static string DifferentArch = $"{CurrentOS}-{(TestContext.BuildArchitecture == "x64" ? "arm64" : "x64")}";
         private static string DifferentArchAsset = $"{DifferentArch}/{DifferentArch}Asset.dll";
 
         [Theory]
@@ -603,7 +603,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         protected static void UseFallbacksFromBuiltDotNet(NetCoreAppBuilder builder)
         {
             IReadOnlyList<RuntimeFallbacks> fallbacks;
-            string depsJson = Path.Combine(HostTestContext.BuiltDotNet.GreatestVersionSharedFxPath, $"{Constants.MicrosoftNETCoreApp}.deps.json");
+            string depsJson = Path.Combine(TestContext.BuiltDotNet.GreatestVersionSharedFxPath, $"{Constants.MicrosoftNETCoreApp}.deps.json");
             using (FileStream fileStream = File.OpenRead(depsJson))
             using (DependencyContextJsonReader reader = new DependencyContextJsonReader())
             {

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/SharedTestStateBase.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/SharedTestStateBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
         public DotNetBuilder DotNet(string name)
         {
-            return new DotNetBuilder(_baseDirectory.Location, HostTestContext.BuiltDotNet.BinPath, name);
+            return new DotNetBuilder(_baseDirectory.Location, TestContext.BuiltDotNet.BinPath, name);
         }
 
         public TestApp CreateFrameworkReferenceApp(string fxName, string fxVersion, Action<NetCoreAppBuilder> customizer = null)

--- a/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
+++ b/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
@@ -22,7 +22,7 @@ namespace HostActivation.Tests
         public void MuxerExec_MissingAppAssembly_Fails()
         {
             string assemblyName = Path.Combine(GetNonexistentAndUnnormalizedPath(), "foo.dll");
-            HostTestContext.BuiltDotNet.Exec("exec", assemblyName)
+            TestContext.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -34,7 +34,7 @@ namespace HostActivation.Tests
         public void MuxerExec_MissingAppAssembly_BadExtension_Fails()
         {
             string assemblyName = Path.Combine(GetNonexistentAndUnnormalizedPath(), "foo.xzy");
-            HostTestContext.BuiltDotNet.Exec("exec", assemblyName)
+            TestContext.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -46,10 +46,10 @@ namespace HostActivation.Tests
         public void MuxerExec_BadExtension_Fails()
         {
             // Get a valid file name, but not exe or dll
-            string fxDir = HostTestContext.BuiltDotNet.GreatestVersionSharedFxPath;
+            string fxDir = TestContext.BuiltDotNet.GreatestVersionSharedFxPath;
             string assemblyName = Path.Combine(fxDir, "Microsoft.NETCore.App.deps.json");
 
-            HostTestContext.BuiltDotNet.Exec("exec", assemblyName)
+            TestContext.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -60,7 +60,7 @@ namespace HostActivation.Tests
         [Fact]
         public void MissingArgumentValue_Fails()
         {
-            HostTestContext.BuiltDotNet.Exec("--fx-version")
+            TestContext.BuiltDotNet.Exec("--fx-version")
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -72,7 +72,7 @@ namespace HostActivation.Tests
         public void InvalidFileOrCommand_NoSDK_ListsPossibleIssues()
         {
             string fileName = "NonExistent";
-            HostTestContext.BuiltDotNet.Exec(fileName)
+            TestContext.BuiltDotNet.Exec(fileName)
                 .WorkingDirectory(sharedTestState.BaseDirectory.Location)
                 .CaptureStdOut()
                 .CaptureStdErr()
@@ -85,7 +85,7 @@ namespace HostActivation.Tests
         // Return a non-existent path that contains a mix of / and \
         private string GetNonexistentAndUnnormalizedPath()
         {
-            return Path.Combine(HostTestContext.BuiltDotNet.BinPath, @"x\y/");
+            return Path.Combine(TestContext.BuiltDotNet.BinPath, @"x\y/");
         }
 
         public class SharedTestState : IDisposable

--- a/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkDependentAppLaunch.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void Muxer_Default()
         {
-            var dotnet = HostTestContext.BuiltDotNet;
+            var dotnet = TestContext.BuiltDotNet;
             var appDll = sharedTestState.App.AppDll;
 
             dotnet.Exec(appDll)
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             File.Copy(appDll, appOtherExt, true);
             File.Delete(appDll);
 
-            HostTestContext.BuiltDotNet.Exec(appOtherExt)
+            TestContext.BuiltDotNet.Exec(appOtherExt)
                 .CaptureStdErr()
                 .Execute()
                 .Should().Fail()
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 fileStream.SetLength(fileStream.Position);
             }
 
-            HostTestContext.BuiltDotNet.Exec(appExe)
+            TestContext.BuiltDotNet.Exec(appExe)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -141,7 +141,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             }
 
             // If the app being run is not actually a managed assembly, it should come through as a load failure.
-            HostTestContext.BuiltDotNet.Exec(appExe)
+            TestContext.BuiltDotNet.Exec(appExe)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .DisableDumps() // Expected to throw an exception
@@ -154,7 +154,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void Muxer_AltDirectorySeparatorChar()
         {
             var appDll = sharedTestState.App.AppDll.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            HostTestContext.BuiltDotNet.Exec(appDll)
+            TestContext.BuiltDotNet.Exec(appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
@@ -173,7 +173,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var runtimeConfig = Path.Combine(subdirectory, Path.GetFileName(app.RuntimeConfigJson));
             File.Move(app.RuntimeConfigJson, runtimeConfig, overwrite: true);
 
-            HostTestContext.BuiltDotNet.Exec("exec", "--runtimeconfig", runtimeConfig, app.AppDll)
+            TestContext.BuiltDotNet.Exec("exec", "--runtimeconfig", runtimeConfig, app.AppDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
@@ -191,12 +191,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath, HostTestContext.BuildArchitecture)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath, TestContext.BuildArchitecture)
                 .MultilevelLookup(false)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [ConditionalFact(typeof(Binaries.CetCompat), nameof(Binaries.CetCompat.IsSupported))]
@@ -209,12 +209,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Command.Create(app.AppExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath, HostTestContext.BuildArchitecture)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath, TestContext.BuildArchitecture)
                 .MultilevelLookup(false)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -223,25 +223,25 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             string appExe = sharedTestState.App.AppExe;
 
-            string dotnetPath = $@"\\?\{HostTestContext.BuiltDotNet.BinPath}";
+            string dotnetPath = $@"\\?\{TestContext.BuiltDotNet.BinPath}";
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(dotnetPath, HostTestContext.BuildArchitecture)
+                .DotNetRoot(dotnetPath, TestContext.BuildArchitecture)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
 
-            dotnetPath = $@"\\.\{HostTestContext.BuiltDotNet.BinPath}";
+            dotnetPath = $@"\\.\{TestContext.BuiltDotNet.BinPath}";
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(dotnetPath, HostTestContext.BuildArchitecture)
+                .DotNetRoot(dotnetPath, TestContext.BuildArchitecture)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -263,7 +263,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 File.Copy(file, Path.Combine(newDir, Path.GetFileName(file)), true);
 
             Command.Create(appExe)
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                 .EnableTracingAndCaptureOutputs()
                 .MultilevelLookup(false)
                 .Execute()
@@ -274,7 +274,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void ComputedTPA_NoTrailingPathSeparator()
         {
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll)
+            TestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll)
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -290,11 +290,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             if (useAppHost)
             {
                 command = Command.Create(sharedTestState.MockApp.AppExe)
-                    .DotNetRoot(HostTestContext.BuiltDotNet.BinPath, HostTestContext.BuildArchitecture);
+                    .DotNetRoot(TestContext.BuiltDotNet.BinPath, TestContext.BuildArchitecture);
             }
             else
             {
-                command = HostTestContext.BuiltDotNet.Exec(sharedTestState.MockApp.AppDll);
+                command = TestContext.BuiltDotNet.Exec(sharedTestState.MockApp.AppDll);
             }
 
             command.EnableTracingAndCaptureOutputs()
@@ -318,11 +318,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             if (useAppHost)
             {
                 command = Command.Create(app.AppExe)
-                    .DotNetRoot(HostTestContext.BuiltDotNet.BinPath, HostTestContext.BuildArchitecture);
+                    .DotNetRoot(TestContext.BuiltDotNet.BinPath, TestContext.BuildArchitecture);
             }
             else
             {
-                command = HostTestContext.BuiltDotNet.Exec(app.AppDll);
+                command = TestContext.BuiltDotNet.Exec(app.AppDll);
             }
 
             command.EnableTracingAndCaptureOutputs()
@@ -339,13 +339,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             TestApp app = sharedTestState.MockApp.Copy();
 
             // Create a runtimeconfig.json with a framework that has no name property
-            var framework = new RuntimeConfig.Framework(null, HostTestContext.MicrosoftNETCoreAppVersion);
+            var framework = new RuntimeConfig.Framework(null, TestContext.MicrosoftNETCoreAppVersion);
             new RuntimeConfig(app.RuntimeConfigJson)
                 .WithFramework(framework)
                 .Save();
 
             Command.Create(app.AppExe)
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Fail()
@@ -364,7 +364,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Save();
 
             Command.Create(app.AppExe)
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Fail()
@@ -385,18 +385,18 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 if (missingHostfxr)
                 {
                     expectedErrorCode = Constants.ErrorCode.CoreHostLibMissingFailure;
-                    expectedStdErr = $"&apphost_version={HostTestContext.MicrosoftNETCoreAppVersion}";
+                    expectedStdErr = $"&apphost_version={TestContext.MicrosoftNETCoreAppVersion}";
                     expectedUrlQuery = "missing_runtime=true&";
                 }
                 else
                 {
-                    new DotNetBuilder(invalidDotNet.Location, HostTestContext.BuiltDotNet.BinPath, null)
+                    new DotNetBuilder(invalidDotNet.Location, TestContext.BuiltDotNet.BinPath, null)
                         .Build();
 
                     expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure;
                     expectedStdErr = $"Framework: '{Constants.MicrosoftNETCoreApp}', " +
-                        $"version '{HostTestContext.MicrosoftNETCoreAppVersion}' ({HostTestContext.BuildArchitecture})";
-                    expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={HostTestContext.MicrosoftNETCoreAppVersion}";
+                        $"version '{TestContext.MicrosoftNETCoreAppVersion}' ({TestContext.BuildArchitecture})";
+                    expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={TestContext.MicrosoftNETCoreAppVersion}";
                 }
 
                 CommandResult result = Command.Create(sharedTestState.App.AppExe)
@@ -407,7 +407,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 result.Should().Fail()
                     .And.HaveStdErrContaining($"https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
-                    .And.HaveStdErrContaining($"&rid={HostTestContext.BuildRID}")
+                    .And.HaveStdErrContaining($"&rid={TestContext.BuildRID}")
                     .And.HaveStdErrContaining(expectedStdErr)
                     .And.ExitWith(expectedErrorCode);
             }
@@ -425,11 +425,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             {
                 string expectedErrorCode;
                 string expectedUrlQuery;
-                new DotNetBuilder(invalidDotNet.Location, HostTestContext.BuiltDotNet.BinPath, null)
+                new DotNetBuilder(invalidDotNet.Location, TestContext.BuiltDotNet.BinPath, null)
                     .Build();
 
                 expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure.ToString("x");
-                expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={HostTestContext.MicrosoftNETCoreAppVersion}";
+                expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={TestContext.MicrosoftNETCoreAppVersion}";
                 Command command = Command.Create(appExe)
                     .EnableTracingAndCaptureOutputs()
                     .DotNetRoot(invalidDotNet.Location)
@@ -439,13 +439,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 WindowsUtils.WaitForPopupFromProcess(command.Process);
                 command.Process.Kill();
 
-                string expectedMissingFramework = $"'{Constants.MicrosoftNETCoreApp}', version '{HostTestContext.MicrosoftNETCoreAppVersion}' ({HostTestContext.BuildArchitecture})";
+                string expectedMissingFramework = $"'{Constants.MicrosoftNETCoreApp}', version '{TestContext.MicrosoftNETCoreAppVersion}' ({TestContext.BuildArchitecture})";
                 var result = command.WaitForExit()
                     .Should().Fail()
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
                     .And.HaveStdErrContaining("&gui=true")
-                    .And.HaveStdErrContaining($"&rid={HostTestContext.BuildRID}")
+                    .And.HaveStdErrContaining($"&rid={TestContext.BuildRID}")
                     .And.HaveStdErrMatching($"details: (?>.|\\s)*{System.Text.RegularExpressions.Regex.Escape(expectedMissingFramework)}");
             }
         }
@@ -475,7 +475,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?missing_runtime=true")
                     .And.HaveStdErrContaining("gui=true")
-                    .And.HaveStdErrContaining($"&apphost_version={HostTestContext.MicrosoftNETCoreAppVersion}");
+                    .And.HaveStdErrContaining($"&apphost_version={TestContext.MicrosoftNETCoreAppVersion}");
             }
         }
 
@@ -490,14 +490,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // The mockhostfxrFrameworkMissingFailure folder name is used by mock hostfxr to return the appropriate error code
             using (var dotnetWithMockHostFxr = TestArtifact.Create("mockhostfxrFrameworkMissingFailure"))
             {
-                var dotnet = new DotNetBuilder(dotnetWithMockHostFxr.Location, HostTestContext.BuiltDotNet.BinPath, null)
+                var dotnet = new DotNetBuilder(dotnetWithMockHostFxr.Location, TestContext.BuiltDotNet.BinPath, null)
                     .RemoveHostFxr()
                     .AddMockHostFxr(new Version(2, 2, 0))
                     .Build();
 
                 Command command = Command.Create(appExe)
                     .EnableTracingAndCaptureOutputs()
-                    .DotNetRoot(dotnet.BinPath, HostTestContext.BuildArchitecture)
+                    .DotNetRoot(dotnet.BinPath, TestContext.BuildArchitecture)
                     .MultilevelLookup(false)
                     .Start();
 

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolution.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolution.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     string arch = otherArchs[i];
 
                     // Create a .NET install with Microsoft.NETCoreApp at the registered location
-                    var dotnet = new DotNetBuilder(otherArchArtifact.Location, HostTestContext.BuiltDotNet.BinPath, arch)
+                    var dotnet = new DotNetBuilder(otherArchArtifact.Location, TestContext.BuiltDotNet.BinPath, arch)
                         .AddMicrosoftNETCoreAppFrameworkMockHostPolicy(requestedVersion)
                         .Build();
                     installLocations[i] = (arch, dotnet.BinPath);
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 // Error message should list framework found for other architectures
                 foreach ((string arch, string path) in installLocations)
                 {
-                    if (arch == HostTestContext.BuildArchitecture)
+                    if (arch == TestContext.BuildArchitecture)
                         continue;
 
                     string expectedPath = System.Text.RegularExpressions.Regex.Escape(Path.Combine(path, "shared", MicrosoftNETCoreApp));
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                                   {value} at [{SharedState.InstalledDotNet.SharedFxPath}]
                                     Disabled via {Constants.DisableRuntimeVersions.EnvironmentVariable} environment variable
                                 """);
-
+                                
                         }
                     }
                 }

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 
             public DotNetBuilder DotNet(string name)
             {
-                return new DotNetBuilder(_baseDirArtifact.Location, HostTestContext.BuiltDotNet.BinPath, name);
+                return new DotNetBuilder(_baseDirArtifact.Location, TestContext.BuiltDotNet.BinPath, name);
             }
 
             public TestApp CreateFrameworkReferenceApp()

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         [Fact]
         public void MissingName()
         {
-            var framework = new RuntimeConfig.Framework(null, HostTestContext.MicrosoftNETCoreAppVersion);
+            var framework = new RuntimeConfig.Framework(null, TestContext.MicrosoftNETCoreAppVersion);
             RunSelfContainedTest(
                 new TestSettings()
                     .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultilevelLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultilevelLookup.cs
@@ -13,6 +13,8 @@ using static Microsoft.DotNet.CoreSetup.Test.Constants;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
+    // Multi-level lookup was only supported on Windows.
+    [PlatformSpecific(TestPlatforms.Windows)]
     public class MultilevelLookup :
         FrameworkResolutionBase,
         IClassFixture<MultilevelLookup.SharedTestState>
@@ -21,8 +23,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 
         public MultilevelLookup(SharedTestState sharedState)
         {
-            Assert.SkipUnless(OperatingSystem.IsWindows(), "Multi-level lookup is only supported on Windows");
-
             SharedState = sharedState;
         }
 

--- a/src/installer/tests/HostActivation.Tests/HostActivation.Tests.csproj
+++ b/src/installer/tests/HostActivation.Tests/HostActivation.Tests.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>$(TestInfraTargetFramework)</TargetFramework>
-    <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
     <AssemblyName>HostActivation.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <!-- Reduce the length of the test output dir to make it more reliable on Windows. -->
@@ -11,7 +9,6 @@
     <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
          This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
     <NoWarn>$(NoWarn);NU1511</NoWarn>
-    <TestRunnerName>XUnitV3</TestRunnerName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/installer/tests/HostActivation.Tests/HostCommands.cs
+++ b/src/installer/tests/HostActivation.Tests/HostCommands.cs
@@ -41,9 +41,9 @@ namespace HostActivation.Tests
                 .Should().Pass()
                 .And.HaveStdOutContaining(expectedSdksOutput)
                 .And.HaveStdOutContaining(expectedRuntimesOutput)
-                .And.HaveStdOutMatching($@"Architecture:\s*{HostTestContext.BuildArchitecture}")
+                .And.HaveStdOutMatching($@"Architecture:\s*{TestContext.BuildArchitecture}")
                 // If an SDK exists, we rely on it to print the RID. The host should not print it again.
-                .And.NotHaveStdOutMatching($@"RID:\s*{HostTestContext.BuildRID}");
+                .And.NotHaveStdOutMatching($@"RID:\s*{TestContext.BuildRID}");
         }
 
         [Fact]
@@ -57,23 +57,23 @@ namespace HostActivation.Tests
             string expectedRuntimesOutput =
                 $"""
                 .NET runtimes installed:
-                {GetListRuntimesOutput(HostTestContext.BuiltDotNet.BinPath, [HostTestContext.MicrosoftNETCoreAppVersion], "  ")}
+                {GetListRuntimesOutput(TestContext.BuiltDotNet.BinPath, [TestContext.MicrosoftNETCoreAppVersion], "  ")}
                 """;
-            HostTestContext.BuiltDotNet.Exec("--info")
+            TestContext.BuiltDotNet.Exec("--info")
                 .CaptureStdOut()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining(expectedSdksOutput)
                 .And.HaveStdOutContaining(expectedRuntimesOutput)
-                .And.HaveStdOutMatching($@"Architecture:\s*{HostTestContext.BuildArchitecture}")
-                .And.HaveStdOutMatching($@"RID:\s*{HostTestContext.BuildRID}");
+                .And.HaveStdOutMatching($@"Architecture:\s*{TestContext.BuildArchitecture}")
+                .And.HaveStdOutMatching($@"RID:\s*{TestContext.BuildRID}");
         }
 
         [Fact]
         public void Info_Utf8Path()
         {
             string installLocation = Encoding.UTF8.GetString("utf8-龯蝌灋齅ㄥ䶱"u8);
-            DotNetCli dotnet = new DotNetBuilder(SharedState.Artifact.Location, HostTestContext.BuiltDotNet.BinPath, installLocation)
+            DotNetCli dotnet = new DotNetBuilder(SharedState.Artifact.Location, TestContext.BuiltDotNet.BinPath, installLocation)
                 .Build();
 
             dotnet.Exec("--info")
@@ -87,7 +87,7 @@ namespace HostActivation.Tests
         [Fact]
         public void Info_ListEnvironment()
         {
-            var command = HostTestContext.BuiltDotNet.Exec("--info")
+            var command = TestContext.BuiltDotNet.Exec("--info")
                 .CaptureStdOut();
 
             // Add DOTNET_ROOT environment variables
@@ -159,7 +159,7 @@ namespace HostActivation.Tests
         public void Info_ListEnvironment_LegacyPrefixDetection()
         {
             string comPlusEnvVar = "COMPlus_ReadyToRun";
-            HostTestContext.BuiltDotNet.Exec("--info")
+            TestContext.BuiltDotNet.Exec("--info")
                 .EnvironmentVariable(comPlusEnvVar, "0")
                 .CaptureStdOut()
                 .Execute()
@@ -175,7 +175,7 @@ namespace HostActivation.Tests
             using (TestArtifact workingDir = TestArtifact.Create(nameof(Info_GlobalJson_InvalidJson)))
             {
                 string globalJsonPath = GlobalJson.Write(workingDir.Location, "{ \"sdk\": { }");
-                HostTestContext.BuiltDotNet.Exec("--info")
+                TestContext.BuiltDotNet.Exec("--info")
                     .WorkingDirectory(workingDir.Location)
                     .CaptureStdOut().CaptureStdErr()
                     .Execute()
@@ -196,7 +196,7 @@ namespace HostActivation.Tests
             using (TestArtifact workingDir = TestArtifact.Create(nameof(Info_GlobalJson_InvalidData)))
             {
                 string globalJsonPath = GlobalJson.CreateWithVersion(workingDir.Location, version);
-                HostTestContext.BuiltDotNet.Exec("--info")
+                TestContext.BuiltDotNet.Exec("--info")
                     .WorkingDirectory(workingDir.Location)
                     .CaptureStdOut().CaptureStdErr()
                     .Execute()
@@ -216,7 +216,7 @@ namespace HostActivation.Tests
             using (TestArtifact workingDir = TestArtifact.Create(nameof(Info_GlobalJson_NonExistentFeatureBand)))
             {
                 string globalJsonPath = GlobalJson.CreateWithVersion(workingDir.Location, version);
-                var result = HostTestContext.BuiltDotNet.Exec("--info")
+                var result = TestContext.BuiltDotNet.Exec("--info")
                     .WorkingDirectory(workingDir.Location)
                     .CaptureStdOut().CaptureStdErr()
                     .Execute()
@@ -289,7 +289,7 @@ namespace HostActivation.Tests
         public void ListRuntimes_OtherArchitecture_NoInstalls()
         {
             // Non-host architecture - arm64 if current architecture is x64, otherwise x64
-            string arch = HostTestContext.BuildArchitecture == "x64" ? "arm64" : "x64";
+            string arch = TestContext.BuildArchitecture == "x64" ? "arm64" : "x64";
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(SharedState.DotNet.GreatestVersionHostFxrFilePath))
             {
                 // Register a location that should have no runtimes installed
@@ -306,7 +306,7 @@ namespace HostActivation.Tests
         [Fact]
         public void ListRuntimes_UnknownArchitecture()
         {
-            HostTestContext.BuiltDotNet.Exec("--list-runtimes", "--arch", "invalid")
+            TestContext.BuiltDotNet.Exec("--list-runtimes", "--arch", "invalid")
                 .CaptureStdOut()
                 .Execute()
                 .Should().Fail()
@@ -358,7 +358,7 @@ namespace HostActivation.Tests
         public void ListSdks_OtherArchitecture_NoInstalls()
         {
             // Non-host architecture - arm64 if current architecture is x64, otherwise x64
-            string arch = HostTestContext.BuildArchitecture == "x64" ? "arm64" : "x64";
+            string arch = TestContext.BuildArchitecture == "x64" ? "arm64" : "x64";
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(SharedState.DotNet.GreatestVersionHostFxrFilePath))
             {
                 // Register a location that should have no SDKs installed
@@ -375,7 +375,7 @@ namespace HostActivation.Tests
         [Fact]
         public void ListSdks_UnknownArchitecture()
         {
-            HostTestContext.BuiltDotNet.Exec("--list-sdks", "--arch", "invalid")
+            TestContext.BuiltDotNet.Exec("--list-sdks", "--arch", "invalid")
                 .CaptureStdOut()
                 .Execute()
                 .Should().Fail()
@@ -409,7 +409,7 @@ namespace HostActivation.Tests
             {
                 Artifact = TestArtifact.Create(nameof(HostCommands));
 
-                var builder = new DotNetBuilder(Artifact.Location, HostTestContext.BuiltDotNet.BinPath, "exe");
+                var builder = new DotNetBuilder(Artifact.Location, TestContext.BuiltDotNet.BinPath, "exe");
                 foreach (string version in InstalledVersions)
                 {
                     builder.AddMicrosoftNETCoreAppFrameworkMockHostPolicy(version);
@@ -419,7 +419,7 @@ namespace HostActivation.Tests
                 DotNet = builder.Build();
 
                 // Add runtimes and SDKs for other architectures
-                string[] otherArchs = new[] { "arm64", "x64", "x86" }.Where(a => a != HostTestContext.BuildArchitecture).ToArray();
+                string[] otherArchs = new[] { "arm64", "x64", "x86" }.Where(a => a != TestContext.BuildArchitecture).ToArray();
                 OtherArchInstallLocations = new (string, string)[otherArchs.Length];
                 for (int i = 0; i < otherArchs.Length; i++)
                 {

--- a/src/installer/tests/HostActivation.Tests/HostVersionCompatibility.cs
+++ b/src/installer/tests/HostActivation.Tests/HostVersionCompatibility.cs
@@ -30,8 +30,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             string appExe = app.AppExe;
 
             RuntimeConfig appConfig = RuntimeConfig.FromFile(app.RuntimeConfigJson);
-            Assert.NotEqual(appConfig.Tfm, HostTestContext.Tfm);
-            Assert.NotEqual(appConfig.GetIncludedFramework(Constants.MicrosoftNETCoreApp).Version, HostTestContext.MicrosoftNETCoreAppVersion);
+            Assert.NotEqual(appConfig.Tfm, TestContext.Tfm);
+            Assert.NotEqual(appConfig.GetIncludedFramework(Constants.MicrosoftNETCoreApp).Version, TestContext.MicrosoftNETCoreAppVersion);
 
             // Use the newer apphost
             // This emulates the case when:
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdErrContaining($"--- Invoked apphost [version: {HostTestContext.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdErrContaining($"--- Invoked apphost [version: {TestContext.MicrosoftNETCoreAppVersion}");
 
             // Use the newer apphost and hostFxr
             // This emulates the case when:
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdErrContaining($"--- Invoked apphost [version: {HostTestContext.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdErrContaining($"--- Invoked apphost [version: {TestContext.MicrosoftNETCoreAppVersion}");
         }
 
         [Fact]
@@ -71,8 +71,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             RuntimeConfig previousAppConfig = RuntimeConfig.FromFile(previousVersionApp.RuntimeConfigJson);
             string previousVersion = previousAppConfig.GetIncludedFramework(Constants.MicrosoftNETCoreApp).Version;
-            Assert.NotEqual(HostTestContext.Tfm, previousAppConfig.Tfm);
-            Assert.NotEqual(HostTestContext.MicrosoftNETCoreAppVersion, previousVersion);
+            Assert.NotEqual(TestContext.Tfm, previousAppConfig.Tfm);
+            Assert.NotEqual(TestContext.MicrosoftNETCoreAppVersion, previousVersion);
 
             // Use the older apphost
             // This emulates the case when:

--- a/src/installer/tests/HostActivation.Tests/InstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/InstallLocation.cs
@@ -25,39 +25,39 @@ namespace HostActivation.Tests
         [Fact]
         public void EnvironmentVariable_CurrentArchitectureIsUsedIfEnvVarSet()
         {
-            var arch = HostTestContext.BuildArchitecture.ToUpper();
+            var arch = TestContext.BuildArchitecture.ToUpper();
             Command.Create(sharedTestState.App.AppExe)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath, arch)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath, arch)
                 .Execute()
                 .Should().Pass()
-                .And.HaveUsedDotNetRootInstallLocation(HostTestContext.BuiltDotNet.BinPath, HostTestContext.BuildRID, arch);
+                .And.HaveUsedDotNetRootInstallLocation(TestContext.BuiltDotNet.BinPath, TestContext.BuildRID, arch);
         }
 
         [Fact]
         public void EnvironmentVariable_IfNoArchSpecificEnvVarIsFoundDotnetRootIsUsed()
         {
-            var arch = HostTestContext.BuildArchitecture.ToUpper();
+            var arch = TestContext.BuildArchitecture.ToUpper();
             Command.Create(sharedTestState.App.AppExe)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                 .Execute()
                 .Should().Pass()
-                .And.HaveUsedDotNetRootInstallLocation(HostTestContext.BuiltDotNet.BinPath, HostTestContext.BuildRID);
+                .And.HaveUsedDotNetRootInstallLocation(TestContext.BuiltDotNet.BinPath, TestContext.BuildRID);
         }
 
         [Fact]
         public void EnvironmentVariable_ArchSpecificDotnetRootIsUsedOverDotnetRoot()
         {
-            var arch = HostTestContext.BuildArchitecture.ToUpper();
-            var dotnet = HostTestContext.BuiltDotNet.BinPath;
+            var arch = TestContext.BuildArchitecture.ToUpper();
+            var dotnet = TestContext.BuiltDotNet.BinPath;
             Command.Create(sharedTestState.App.AppExe)
                 .EnableTracingAndCaptureOutputs()
                 .DotNetRoot("non_existent_path")
                 .DotNetRoot(dotnet, arch)
                 .Execute()
                 .Should().Pass()
-                .And.HaveUsedDotNetRootInstallLocation(dotnet, HostTestContext.BuildRID, arch)
+                .And.HaveUsedDotNetRootInstallLocation(dotnet, TestContext.BuildRID, arch)
                 .And.NotHaveStdErrContaining("Using environment variable DOTNET_ROOT=");
         }
 
@@ -66,8 +66,8 @@ namespace HostActivation.Tests
         {
             var app = sharedTestState.TestBehaviourEnabledApp;
             var appExe = app.AppExe;
-            var arch = HostTestContext.BuildArchitecture.ToUpper();
-            var dotnet = HostTestContext.BuiltDotNet.BinPath;
+            var arch = TestContext.BuildArchitecture.ToUpper();
+            var dotnet = TestContext.BuiltDotNet.BinPath;
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(appExe))
             {
@@ -79,7 +79,7 @@ namespace HostActivation.Tests
                     .DotNetRoot(dotnet, arch)
                     .Execute()
                     .Should().Pass()
-                    .And.HaveUsedDotNetRootInstallLocation(dotnet, HostTestContext.BuildRID, arch)
+                    .And.HaveUsedDotNetRootInstallLocation(dotnet, TestContext.BuildRID, arch)
                     .And.NotHaveStdErrContaining("Using global install location");
             }
         }
@@ -94,12 +94,12 @@ namespace HostActivation.Tests
                 .MultilevelLookup(false)
                 .EnvironmentVariable(
                     Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath,
-                    HostTestContext.BuiltDotNet.BinPath)
+                    TestContext.BuiltDotNet.BinPath)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdErrContaining("Did not find [DOTNET_ROOT] directory [non_existent_path]")
                 // If DOTNET_ROOT points to a folder that does not exist, we fall back to the global install path.
-                .And.HaveUsedGlobalInstallLocation(HostTestContext.BuiltDotNet.BinPath)
+                .And.HaveUsedGlobalInstallLocation(TestContext.BuiltDotNet.BinPath)
                 .And.HaveStdOutContaining("Hello World");
         }
 
@@ -113,10 +113,10 @@ namespace HostActivation.Tests
                 .MultilevelLookup(false)
                 .EnvironmentVariable(
                     Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath,
-                    HostTestContext.BuiltDotNet.BinPath)
+                    TestContext.BuiltDotNet.BinPath)
                 .Execute()
                 .Should().Fail()
-                .And.HaveUsedDotNetRootInstallLocation(app.Location, HostTestContext.BuildRID)
+                .And.HaveUsedDotNetRootInstallLocation(app.Location, TestContext.BuildRID)
                 // If DOTNET_ROOT points to a folder that exists we assume that there's a dotnet installation in it
                 .And.HaveStdErrContaining($"The required library {Binaries.HostFxr.FileName} could not be found.");
         }
@@ -132,11 +132,11 @@ namespace HostActivation.Tests
                 Command.Create(app.AppExe)
                     .EnableTracingAndCaptureOutputs()
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
-                    .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, HostTestContext.BuiltDotNet.BinPath)
+                    .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, TestContext.BuiltDotNet.BinPath)
                     .DotNetRoot(null)
                     .Execute()
                     .Should().Pass()
-                    .And.HaveUsedGlobalInstallLocation(HostTestContext.BuiltDotNet.BinPath);
+                    .And.HaveUsedGlobalInstallLocation(TestContext.BuiltDotNet.BinPath);
             }
         }
 
@@ -147,7 +147,7 @@ namespace HostActivation.Tests
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(app.AppExe))
             {
                 registeredInstallLocationOverride.SetInstallLocation(
-                    (HostTestContext.BuildArchitecture, HostTestContext.BuiltDotNet.BinPath));
+                    (TestContext.BuildArchitecture, TestContext.BuiltDotNet.BinPath));
 
                 Command.Create(app.AppExe)
                     .EnableTracingAndCaptureOutputs()
@@ -155,8 +155,8 @@ namespace HostActivation.Tests
                     .DotNetRoot(null)
                     .Execute()
                     .Should().Pass()
-                    .And.HaveUsedRegisteredInstallLocation(HostTestContext.BuiltDotNet.BinPath)
-                    .And.HaveUsedGlobalInstallLocation(HostTestContext.BuiltDotNet.BinPath);
+                    .And.HaveUsedRegisteredInstallLocation(TestContext.BuiltDotNet.BinPath)
+                    .And.HaveUsedGlobalInstallLocation(TestContext.BuiltDotNet.BinPath);
             }
         }
 
@@ -166,7 +166,7 @@ namespace HostActivation.Tests
             var app = sharedTestState.TestBehaviourEnabledApp;
             var arch1 = "someArch";
             var path1 = "x/y/z";
-            var arch2 = HostTestContext.BuildArchitecture;
+            var arch2 = TestContext.BuildArchitecture;
             var path2 = "a/b/c";
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(app.AppExe))
@@ -248,7 +248,7 @@ namespace HostActivation.Tests
         {
             using (var testArtifact = TestArtifact.Create("listOtherArchs"))
             {
-                var dotnet = new DotNetBuilder(testArtifact.Location, HostTestContext.BuiltDotNet.BinPath, "exe").Build();
+                var dotnet = new DotNetBuilder(testArtifact.Location, TestContext.BuiltDotNet.BinPath, "exe").Build();
                 using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(dotnet.GreatestVersionHostFxrFilePath))
                 {
                     var installLocations = new (string, string)[] {
@@ -276,7 +276,7 @@ namespace HostActivation.Tests
                     pathOverride = System.Text.RegularExpressions.Regex.Escape(pathOverride);
                     foreach ((string arch, string path) in installLocations)
                     {
-                        if (arch == HostTestContext.BuildArchitecture)
+                        if (arch == TestContext.BuildArchitecture)
                             continue;
 
                         result.Should()
@@ -315,13 +315,13 @@ namespace HostActivation.Tests
                     .And.HaveStdErrContaining(
                         $"""
                           Environment variable:
-                            DOTNET_ROOT_{HostTestContext.BuildArchitecture.ToUpper()} = <not set>
+                            DOTNET_ROOT_{TestContext.BuildArchitecture.ToUpper()} = <not set>
                             DOTNET_ROOT = <not set>
                         """)
                     .And.HaveStdErrMatching(
                         $"""
                           Registered location:
-                            {System.Text.RegularExpressions.Regex.Escape(registeredLocationOverride)}.*{HostTestContext.BuildArchitecture}.* = <not set>
+                            {System.Text.RegularExpressions.Regex.Escape(registeredLocationOverride)}.*{TestContext.BuildArchitecture}.* = <not set>
                         """)
                     .And.HaveStdErrContaining(
                         $"""
@@ -360,7 +360,7 @@ namespace HostActivation.Tests
             CommandResult result;
             using (var installOverride = new RegisteredInstallLocationOverride(app.AppExe))
             {
-                installOverride.SetInstallLocation([(HostTestContext.BuildArchitecture, globalLocation)]);
+                installOverride.SetInstallLocation([(TestContext.BuildArchitecture, globalLocation)]);
                 result = Command.Create(app.AppExe)
                     .EnableTracingAndCaptureOutputs()
                     .ApplyRegisteredInstallLocationOverride(installOverride)
@@ -377,7 +377,7 @@ namespace HostActivation.Tests
                     result.Should().HaveUsedAppRelativeInstallLocation(appRelativeLocation);
                     break;
                 case SearchLocation.EnvironmentVariable:
-                    result.Should().HaveUsedDotNetRootInstallLocation(envLocation, HostTestContext.BuildRID);
+                    result.Should().HaveUsedDotNetRootInstallLocation(envLocation, TestContext.BuildRID);
                     break;
                 case SearchLocation.Global:
                     result.Should().HaveUsedGlobalInstallLocation(globalLocation);
@@ -463,7 +463,7 @@ namespace HostActivation.Tests
             CommandResult result;
             using (var installOverride = new RegisteredInstallLocationOverride(app.AppExe))
             {
-                installOverride.SetInstallLocation([(HostTestContext.BuildArchitecture, globalLocation)]);
+                installOverride.SetInstallLocation([(TestContext.BuildArchitecture, globalLocation)]);
                 result = Command.Create(app.AppExe)
                     .EnableTracingAndCaptureOutputs()
                     .ApplyRegisteredInstallLocationOverride(installOverride)
@@ -480,7 +480,7 @@ namespace HostActivation.Tests
                     result.Should().HaveUsedAppRelativeInstallLocation(appRelativeLocation);
                     break;
                 case SearchLocation.EnvironmentVariable:
-                    result.Should().HaveUsedDotNetRootInstallLocation(envLocation, HostTestContext.BuildRID);
+                    result.Should().HaveUsedDotNetRootInstallLocation(envLocation, TestContext.BuildRID);
                     break;
                 case SearchLocation.Global:
                     result.Should().HaveUsedGlobalInstallLocation(globalLocation);

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -109,7 +109,7 @@ namespace HostActivation.Tests
             string expectedList = string.Join(';', f.LocalSdkPaths);
 
             string api = ApiNames.hostfxr_get_available_sdks;
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -130,7 +130,7 @@ namespace HostActivation.Tests
             });
 
             string api = ApiNames.hostfxr_resolve_sdk2;
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, NoGlobalJson, "0")
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, NoGlobalJson, "0")
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -151,7 +151,7 @@ namespace HostActivation.Tests
             });
 
             string api = ApiNames.hostfxr_resolve_sdk2;
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, NoGlobalJson, "disallow_prerelease")
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, NoGlobalJson, "disallow_prerelease")
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -180,7 +180,7 @@ namespace HostActivation.Tests
                 });
 
                 string api = ApiNames.hostfxr_resolve_sdk2;
-                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "disallow_prerelease")
+                TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "disallow_prerelease")
                     .EnableTracingAndCaptureOutputs()
                     .Execute()
                     .Should().Pass()
@@ -211,7 +211,7 @@ namespace HostActivation.Tests
                 });
 
                 string api = ApiNames.hostfxr_resolve_sdk2;
-                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "0")
+                TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "0")
                     .EnableTracingAndCaptureOutputs()
                     .Execute()
                     .Should().Pass()
@@ -237,7 +237,7 @@ namespace HostActivation.Tests
                 });
 
                 string api = ApiNames.hostfxr_resolve_sdk2;
-                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "0")
+                TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "0")
                     .EnableTracingAndCaptureOutputs()
                     .Execute()
                     .Should().Pass()
@@ -264,7 +264,7 @@ namespace HostActivation.Tests
                 });
 
                 string api = ApiNames.hostfxr_resolve_sdk2;
-                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "0")
+                TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "0")
                     .EnableTracingAndCaptureOutputs()
                     .Execute()
                     .Should().Pass()
@@ -292,7 +292,7 @@ namespace HostActivation.Tests
                 });
 
                 string api = ApiNames.hostfxr_resolve_sdk2;
-                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "0")
+                TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "0")
                     .EnableTracingAndCaptureOutputs()
                     .Execute()
                     .Should().Pass()
@@ -304,7 +304,7 @@ namespace HostActivation.Tests
         [Fact]
         public void Hostfxr_corehost_set_error_writer_test()
         {
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, "Test_hostfxr_set_error_writer")
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, "Test_hostfxr_set_error_writer")
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass();
@@ -323,7 +323,7 @@ namespace HostActivation.Tests
             string expectedFrameworkPaths = string.Join(';', frameworks.Select(fw => Path.Combine(f.LocalFrameworksDir, fw.Name)));
 
             string api = ApiNames.hostfxr_get_dotnet_environment_info;
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -352,7 +352,7 @@ namespace HostActivation.Tests
             string expectedFrameworkPaths = string.Join(';', frameworks.Select(fw => Path.Combine(f.LocalFrameworksDir, fw.Name)));
 
             string api = ApiNames.hostfxr_get_dotnet_environment_info;
-            var result = HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
+            var result = TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir)
                 .EnableTracingAndCaptureOutputs()
                 .EnvironmentVariable(Constants.DisableRuntimeVersions.EnvironmentVariable, string.Join(';', disabledVersions))
                 .Execute();
@@ -373,7 +373,7 @@ namespace HostActivation.Tests
         public void Hostfxr_get_dotnet_environment_info_global_install_path()
         {
             string api = ApiNames.hostfxr_get_dotnet_environment_info;
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api)
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api)
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -384,7 +384,7 @@ namespace HostActivation.Tests
         public void Hostfxr_get_dotnet_environment_info_result_is_nullptr_fails()
         {
             string api = ApiNames.hostfxr_get_dotnet_environment_info;
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, "test_invalid_result_ptr")
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, "test_invalid_result_ptr")
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -396,7 +396,7 @@ namespace HostActivation.Tests
         public void Hostfxr_get_dotnet_environment_info_reserved_is_not_nullptr_fails()
         {
             string api = ApiNames.hostfxr_get_dotnet_environment_info;
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, "test_invalid_reserved_ptr")
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, "test_invalid_reserved_ptr")
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -420,12 +420,12 @@ namespace HostActivation.Tests
                     .WithFramework(requested.Name, requested.Version)
                     .Save(withUtf8Bom);
 
-                var builder = new DotNetBuilder(artifact.Location, HostTestContext.BuiltDotNet.BinPath, "dotnet");
+                var builder = new DotNetBuilder(artifact.Location, TestContext.BuiltDotNet.BinPath, "dotnet");
                 if (!isMissing)
                     builder.AddFramework(requested.Name, requested.Version, c => { });
 
                 DotNetCli dotnet = builder.Build();
-                var result = HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
+                var result = TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
                     .CaptureStdOut()
                     .CaptureStdErr()
                     .Execute();
@@ -459,7 +459,7 @@ namespace HostActivation.Tests
 
                 config.Save();
 
-                var result = HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath)
+                var result = TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath)
                     .CaptureStdOut()
                     .CaptureStdErr()
                     .Execute();
@@ -527,11 +527,11 @@ namespace HostActivation.Tests
                 };
 
                 string actualVersion = version.ToString(3);
-                DotNetCli dotnet = new DotNetBuilder(artifact.Location, HostTestContext.BuiltDotNet.BinPath, "dotnet")
+                DotNetCli dotnet = new DotNetBuilder(artifact.Location, TestContext.BuiltDotNet.BinPath, "dotnet")
                     .AddFramework(requested.Name, actualVersion, c => { })
                     .Build();
 
-                var result = HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
+                var result = TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
                     .CaptureStdOut()
                     .CaptureStdErr()
                     .Execute();
@@ -561,16 +561,16 @@ namespace HostActivation.Tests
                 if (isMissing)
                 {
                     // Request a higher major framework version than the one available relative to the running hostfxr
-                    Version existingVersion = Version.Parse(HostTestContext.MicrosoftNETCoreAppVersion.Contains('-')
-                        ? HostTestContext.MicrosoftNETCoreAppVersion[..HostTestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
-                        : HostTestContext.MicrosoftNETCoreAppVersion);
+                    Version existingVersion = Version.Parse(TestContext.MicrosoftNETCoreAppVersion.Contains('-')
+                        ? TestContext.MicrosoftNETCoreAppVersion[..TestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
+                        : TestContext.MicrosoftNETCoreAppVersion);
                     Version newerVersion = new Version(existingVersion.Major + 1, existingVersion.Minor, existingVersion.Build);
                     requestedVersion = newerVersion.ToString(3);
                 }
                 else
                 {
                     // Request the framework version that is available relative to the running hostfxr
-                    requestedVersion = HostTestContext.MicrosoftNETCoreAppVersion;
+                    requestedVersion = TestContext.MicrosoftNETCoreAppVersion;
                 }
 
                 (string Name, string Version) requested = (Constants.MicrosoftNETCoreApp, requestedVersion);
@@ -582,7 +582,7 @@ namespace HostActivation.Tests
                     .Save();
 
                 // API should use the running hostfxr when dotnet root is not specified
-                var result = HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath)
+                var result = TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath)
                     .CaptureStdOut()
                     .CaptureStdErr()
                     .Execute();
@@ -595,7 +595,7 @@ namespace HostActivation.Tests
                 }
                 else
                 {
-                    result.Should().ReturnResolvedFramework(requested.Name, requested.Version, GetFrameworkPath(requested.Name, requested.Version, HostTestContext.BuiltDotNet.BinPath));
+                    result.Should().ReturnResolvedFramework(requested.Name, requested.Version, GetFrameworkPath(requested.Name, requested.Version, TestContext.BuiltDotNet.BinPath));
                 }
             }
         }
@@ -620,7 +620,7 @@ namespace HostActivation.Tests
 
                 config.Save();
 
-                var builder = new DotNetBuilder(artifact.Location, HostTestContext.BuiltDotNet.BinPath, "dotnet");
+                var builder = new DotNetBuilder(artifact.Location, TestContext.BuiltDotNet.BinPath, "dotnet");
                 foreach (var framework in expectedFrameworks)
                 {
                     builder.AddFramework(framework.Name, framework.Version, c => { });
@@ -628,7 +628,7 @@ namespace HostActivation.Tests
 
                 DotNetCli dotnet = builder.Build();
 
-                var result = HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
+                var result = TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
                     .CaptureStdOut()
                     .CaptureStdErr()
                     .Execute();
@@ -668,12 +668,12 @@ namespace HostActivation.Tests
                 config.Save();
 
                 var expectedFramework = requested[0];
-                DotNetCli dotnet = new DotNetBuilder(artifact.Location, HostTestContext.BuiltDotNet.BinPath, "dotnet")
+                DotNetCli dotnet = new DotNetBuilder(artifact.Location, TestContext.BuiltDotNet.BinPath, "dotnet")
                     .AddFramework(expectedFramework.Name, expectedFramework.Version,
                         c => c.WithFramework(incompatibleHigher.Name, incompatibleHigher.Version))
                     .Build();
 
-                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
+                TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
                     .CaptureStdOut()
                     .CaptureStdErr()
                     .Execute()
@@ -698,14 +698,14 @@ namespace HostActivation.Tests
                     .WithFramework(requested.Name, requested.Version)
                     .Save();
 
-                DotNetCli dotnet = new DotNetBuilder(artifact.Location, HostTestContext.BuiltDotNet.BinPath, "dotnet")
+                DotNetCli dotnet = new DotNetBuilder(artifact.Location, TestContext.BuiltDotNet.BinPath, "dotnet")
                     .AddFramework(requested.Name, requested.Version, c => { })
                     .Build();
 
                 string frameworkPath = Path.Combine(dotnet.BinPath, "shared", requested.Name, requested.Version);
                 File.WriteAllText(Path.Combine(frameworkPath, $"{requested.Name}.runtimeconfig.json"), "{}");
 
-                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
+                TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, dotnet.BinPath)
                     .CaptureStdOut()
                     .CaptureStdErr()
                     .Execute()
@@ -738,7 +738,7 @@ namespace HostActivation.Tests
 
                 config.Save();
 
-                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, HostTestContext.BuiltDotNet.BinPath)
+                TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, configPath, TestContext.BuiltDotNet.BinPath)
                     .CaptureStdOut()
                     .CaptureStdErr()
                     .Execute()
@@ -751,7 +751,7 @@ namespace HostActivation.Tests
         [Fact]
         public void Hostpolicy_corehost_set_error_writer_test()
         {
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, "Test_corehost_set_error_writer")
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, "Test_corehost_set_error_writer")
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass();
@@ -761,12 +761,12 @@ namespace HostActivation.Tests
         public void HostRuntimeContract_get_runtime_property()
         {
             TestApp app = sharedTestState.HostApiInvokerApp;
-            HostTestContext.BuiltDotNet.Exec(app.AppDll, "host_runtime_contract.get_runtime_property", "APP_CONTEXT_BASE_DIRECTORY", "RUNTIME_IDENTIFIER", "DOES_NOT_EXIST", "ENTRY_ASSEMBLY_NAME")
+            TestContext.BuiltDotNet.Exec(app.AppDll, "host_runtime_contract.get_runtime_property", "APP_CONTEXT_BASE_DIRECTORY", "RUNTIME_IDENTIFIER", "DOES_NOT_EXIST", "ENTRY_ASSEMBLY_NAME")
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining($"APP_CONTEXT_BASE_DIRECTORY = {Path.GetDirectoryName(app.AppDll)}")
-                .And.HaveStdOutContaining($"RUNTIME_IDENTIFIER = {HostTestContext.BuildRID}")
+                .And.HaveStdOutContaining($"RUNTIME_IDENTIFIER = {TestContext.BuildRID}")
                 .And.HaveStdOutContaining($"DOES_NOT_EXIST = <none>")
                 .And.HaveStdOutContaining($"ENTRY_ASSEMBLY_NAME = {app.AssemblyName}");
         }
@@ -774,7 +774,7 @@ namespace HostActivation.Tests
         [Fact]
         public void HostRuntimeContract_bundle_probe()
         {
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, "host_runtime_contract.bundle_probe", "APP_CONTEXT_BASE_DIRECTORY", "RUNTIME_IDENTIFIER", "DOES_NOT_EXIST", "ENTRY_ASSEMBLY_NAME")
+            TestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, "host_runtime_contract.bundle_probe", "APP_CONTEXT_BASE_DIRECTORY", "RUNTIME_IDENTIFIER", "DOES_NOT_EXIST", "ENTRY_ASSEMBLY_NAME")
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -797,7 +797,7 @@ namespace HostActivation.Tests
                 // On non-Windows, we can't just P/Invoke to already loaded hostfxr, so provide the app with
                 // paths to hostfxr so that it can handle resolving the library.
                 RuntimeConfig.FromFile(HostApiInvokerApp.RuntimeConfigJson)
-                    .WithProperty("HOSTFXR_PATH", HostTestContext.BuiltDotNet.GreatestVersionHostFxrFilePath)
+                    .WithProperty("HOSTFXR_PATH", TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath)
                     .Save();
 
                 SdkAndFrameworkFixture = new SdkAndFrameworkFixture();

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
@@ -69,8 +69,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                DotNetRoot = HostTestContext.BuiltDotNet.BinPath;
-                HostFxrPath = HostTestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
+                DotNetRoot = TestContext.BuiltDotNet.BinPath;
+                HostFxrPath = TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
 
                 App = TestApp.CreateFromBuiltAssets("HelloWorld");
             }

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
@@ -12,14 +12,13 @@ using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {
+    [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
     public class Comhost : IClassFixture<Comhost.SharedTestState>
     {
         private readonly SharedTestState sharedState;
 
         public Comhost(SharedTestState sharedTestState)
         {
-            Assert.SkipUnless(OperatingSystem.IsWindows(), "COM activation is only supported on Windows");
-
             sharedState = sharedTestState;
         }
 
@@ -36,7 +35,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 sharedState.ComHostPath,
                 sharedState.ClsidString
             };
-            CommandResult result = sharedState.CreateNativeHostCommand(args, HostTestContext.BuiltDotNet.BinPath)
+            CommandResult result = sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
                 .Execute();
 
             result.Should().Pass()
@@ -69,7 +68,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     comHost,
                     sharedState.ClsidString
                     };
-                CommandResult result = sharedState.CreateNativeHostCommand(args, HostTestContext.BuiltDotNet.BinPath)
+                CommandResult result = sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
                     .Execute();
 
                 result.Should().Pass()
@@ -102,7 +101,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     comHostWithAppLocalFxr,
                     sharedState.ClsidString
                 };
-                CommandResult result = sharedState.CreateNativeHostCommand(args, HostTestContext.BuiltDotNet.BinPath)
+                CommandResult result = sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
                     .Execute();
 
                 result.Should().Pass()
@@ -129,15 +128,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     sharedState.ComHostPath,
                     sharedState.ClsidString
                 };
-                sharedState.CreateNativeHostCommand(args, HostTestContext.BuiltDotNet.BinPath)
+                sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
                     .WorkingDirectory(cwd.Location)
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("New instance of Server created")
                     .And.HaveStdOutContaining($"Activation of {sharedState.ClsidString} succeeded.")
-                    .And.ResolveHostFxr(HostTestContext.BuiltDotNet)
-                    .And.ResolveHostPolicy(HostTestContext.BuiltDotNet)
-                    .And.ResolveCoreClr(HostTestContext.BuiltDotNet);
+                    .And.ResolveHostFxr(TestContext.BuiltDotNet)
+                    .And.ResolveHostPolicy(TestContext.BuiltDotNet)
+                    .And.ResolveCoreClr(TestContext.BuiltDotNet);
             }
         }
 
@@ -156,7 +155,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     comHost,
                     sharedState.ClsidString
                 };
-                CommandResult result = sharedState.CreateNativeHostCommand(args, HostTestContext.BuiltDotNet.BinPath)
+                CommandResult result = sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
                     .Execute();
 
                 result.Should().Pass()
@@ -174,7 +173,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 sharedState.ComHostPath,
                 sharedState.ClsidString
             };
-            CommandResult result = sharedState.CreateNativeHostCommand(args, HostTestContext.BuiltDotNet.BinPath)
+            CommandResult result = sharedState.CreateNativeHostCommand(args, TestContext.BuiltDotNet.BinPath)
                 .Execute();
 
             result.Should().Pass()

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ComhostSideBySide.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ComhostSideBySide.cs
@@ -11,14 +11,13 @@ using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {
+    [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
     public class ComhostSideBySide : IClassFixture<ComhostSideBySide.SharedTestState>
     {
         private readonly SharedTestState sharedState;
 
         public ComhostSideBySide(SharedTestState sharedTestState)
         {
-            Assert.SkipUnless(OperatingSystem.IsWindows(), "COM activation is only supported on Windows");
-
             sharedState = sharedTestState;
         }
 
@@ -32,7 +31,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             CommandResult result = Command.Create(sharedState.ComSxsPath, args)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                 .MultilevelLookup(false)
                 .Execute();
 
@@ -50,7 +49,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             CommandResult result = Command.Create(sharedState.ComSxsPath, args)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                 .MultilevelLookup(false)
                 .Execute();
 
@@ -70,7 +69,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             TestApp app = selfContained ? sharedState.ManagedHost_SelfContained : sharedState.ManagedHost_FrameworkDependent;
             CommandResult result = Command.Create(app.AppExe, args)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                 .MultilevelLookup(false)
                 .Execute();
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
@@ -230,8 +230,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                DotNetRoot = HostTestContext.BuiltDotNet.BinPath;
-                HostFxrPath = HostTestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
+                DotNetRoot = TestContext.BuiltDotNet.BinPath;
+                HostFxrPath = TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
 
                 App = TestApp.CreateFromBuiltAssets("AppWithCustomEntryPoints");
                 Component = TestApp.CreateFromBuiltAssets("Component");

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetNativeSearchDirectories.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetNativeSearchDirectories.cs
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                DotNet = new DotNetBuilder(BaseDirectory, HostTestContext.BuiltDotNet.BinPath, "mockRuntime")
+                DotNet = new DotNetBuilder(BaseDirectory, TestContext.BuiltDotNet.BinPath, "mockRuntime")
                     .AddMicrosoftNETCoreAppFrameworkMockCoreClr(NetCoreAppVersion)
                     .Build();
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.FrameworkCompatibilityTestData.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.FrameworkCompatibilityTestData.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Xunit;
-using Xunit.Sdk;
+using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.PropertyCompatibilityTestData.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.PropertyCompatibilityTestData.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Xunit;
-using Xunit.Sdk;
+using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
@@ -327,10 +327,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [MemberData(nameof(GetFrameworkCompatibilityTestData), Scenario.ConfigMultiple)]
-        [MemberData(nameof(GetFrameworkCompatibilityTestData), Scenario.Mixed)]
-        [MemberData(nameof(GetFrameworkCompatibilityTestData), Scenario.NonContextMixedAppHost)]
-        [MemberData(nameof(GetFrameworkCompatibilityTestData), Scenario.NonContextMixedDotnet)]
+        [MemberData(nameof(GetFrameworkCompatibilityTestData), parameters: Scenario.ConfigMultiple)]
+        [MemberData(nameof(GetFrameworkCompatibilityTestData), parameters: Scenario.Mixed)]
+        [MemberData(nameof(GetFrameworkCompatibilityTestData), parameters: Scenario.NonContextMixedAppHost)]
+        [MemberData(nameof(GetFrameworkCompatibilityTestData), parameters: Scenario.NonContextMixedDotnet)]
         public void CompatibilityCheck_Frameworks(string scenario, FrameworkCompatibilityTestData testData)
         {
             if (scenario != Scenario.ConfigMultiple && scenario != Scenario.Mixed && scenario != Scenario.NonContextMixedAppHost && scenario != Scenario.NonContextMixedDotnet)
@@ -433,14 +433,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), arguments: new object[] { Scenario.ConfigMultiple, false })]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), arguments: new object[] { Scenario.ConfigMultiple, true })]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), arguments: new object[] { Scenario.Mixed, false })]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), arguments: new object[] { Scenario.Mixed, true })]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), arguments: new object[] { Scenario.NonContextMixedAppHost, false })]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), arguments: new object[] { Scenario.NonContextMixedAppHost, true })]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), arguments: new object[] { Scenario.NonContextMixedDotnet, false })]
-        [MemberData(nameof(GetPropertyCompatibilityTestData), arguments: new object[] { Scenario.NonContextMixedDotnet, true })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.ConfigMultiple, false })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.ConfigMultiple, true })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.Mixed, false })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.Mixed, true })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixedAppHost, false })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixedAppHost, true })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixedDotnet, false })]
+        [MemberData(nameof(GetPropertyCompatibilityTestData), parameters: new object[] { Scenario.NonContextMixedDotnet, true })]
         public void CompatibilityCheck_Properties(string scenario, bool hasMultipleProperties, PropertyTestData[] properties)
         {
             if (scenario != Scenario.ConfigMultiple && scenario != Scenario.Mixed && scenario != Scenario.NonContextMixedAppHost && scenario != Scenario.NonContextMixedDotnet)
@@ -683,7 +683,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                var dotNet = new DotNetBuilder(BaseDirectory, HostTestContext.BuiltDotNet.BinPath, "mockRuntime")
+                var dotNet = new DotNetBuilder(BaseDirectory, TestContext.BuiltDotNet.BinPath, "mockRuntime")
                     .AddMicrosoftNETCoreAppFrameworkMockCoreClr(NetCoreAppVersion)
                     .Build();
                 DotNetRoot = dotNet.BinPath;

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssembly.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssembly.cs
@@ -146,11 +146,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                DotNetRoot = HostTestContext.BuiltDotNet.BinPath;
-                HostFxrPath = HostTestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
+                DotNetRoot = TestContext.BuiltDotNet.BinPath;
+                HostFxrPath = TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
 
                 Application = TestApp.CreateEmpty("App");
-                Application.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, HostTestContext.MicrosoftNETCoreAppVersion);
+                Application.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion);
 
                 SelfContainedApplication = TestApp.CreateEmpty("SelfContainedApp");
                 SelfContainedApplication.PopulateSelfContained(TestApp.MockedComponent.None);

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
@@ -259,8 +259,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     .Should().Pass()
                     .And.InitializeContextForConfig(component.RuntimeConfigJson)
                     .And.ExecuteFunctionPointer(sharedState.ComponentEntryPoint1, 1, 1)
-                    .And.ResolveHostPolicy(HostTestContext.BuiltDotNet)
-                    .And.ResolveCoreClr(HostTestContext.BuiltDotNet);
+                    .And.ResolveHostPolicy(TestContext.BuiltDotNet)
+                    .And.ResolveCoreClr(TestContext.BuiltDotNet);
             }
         }
 
@@ -280,8 +280,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                DotNetRoot = HostTestContext.BuiltDotNet.BinPath;
-                HostFxrPath = HostTestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
+                DotNetRoot = TestContext.BuiltDotNet.BinPath;
+                HostFxrPath = TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
 
                 Component = TestApp.CreateFromBuiltAssets("Component");
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             {
                 if (useRegisteredLocation)
                 {
-                    registeredInstallLocationOverride.SetInstallLocation((HostTestContext.BuildArchitecture, installLocation));
+                    registeredInstallLocationOverride.SetInstallLocation((TestContext.BuildArchitecture, installLocation));
                 }
 
                 result = Command.Create(sharedState.NativeHostPath, $"{GetHostFxrPath} {explicitLoad} {(useAssemblyPath ? sharedState.TestAssemblyPath : string.Empty)}")
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
                 if (shouldUseArchSpecificInstallLocation)
-                    registeredInstallLocationOverride.SetInstallLocation((HostTestContext.BuildArchitecture, string.Format(value, installLocation)));
+                    registeredInstallLocationOverride.SetInstallLocation((TestContext.BuildArchitecture, string.Format(value, installLocation)));
                 else
                     registeredInstallLocationOverride.SetInstallLocation((string.Empty, string.Format(value, installLocation)));
 
@@ -223,7 +223,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 {
                     result.Should().HaveLookedForArchitectureSpecificInstallLocation(
                         registeredInstallLocationOverride.PathValueOverride,
-                        HostTestContext.BuildArchitecture);
+                        TestContext.BuildArchitecture);
                 }
                 else
                 {
@@ -254,7 +254,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
                 registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] {
-                    (HostTestContext.BuildArchitecture, installLocation),
+                    (TestContext.BuildArchitecture, installLocation),
                     ("someOtherArch", $"{installLocation}/invalid")
                 });
 
@@ -270,7 +270,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 result.Should().Pass()
                     .And.HaveLookedForArchitectureSpecificInstallLocation(
                         registeredInstallLocationOverride.PathValueOverride,
-                        HostTestContext.BuildArchitecture)
+                        TestContext.BuildArchitecture)
                     .And.HaveUsedRegisteredInstallLocation(installLocation)
                     .And.HaveStdOutContaining($"hostfxr_path: {sharedState.HostFxrPath}".ToLower());
             }
@@ -285,7 +285,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             {
                 registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] {
                     (string.Empty, $"{installLocation}/a/b/c"),
-                    (HostTestContext.BuildArchitecture, installLocation)
+                    (TestContext.BuildArchitecture, installLocation)
                 });
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
@@ -300,7 +300,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 result.Should().Pass()
                     .And.HaveLookedForArchitectureSpecificInstallLocation(
                         registeredInstallLocationOverride.PathValueOverride,
-                        HostTestContext.BuildArchitecture)
+                        TestContext.BuildArchitecture)
                     .And.HaveUsedRegisteredInstallLocation(installLocation)
                     .And.HaveStdOutContaining($"hostfxr_path: {sharedState.HostFxrPath}".ToLower());
             }

--- a/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
+++ b/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 // On Linux/macOS the install location is registered in a file which is normally
                 // located in /etc/dotnet/install_location
                 // So we need to redirect it to a different place here.
-                string directory = Path.Combine(HostTestContext.TestArtifactsPath, "installLocationOverride" + Process.GetCurrentProcess().Id.ToString());
+                string directory = Path.Combine(TestContext.TestArtifactsPath, "installLocationOverride" + Process.GetCurrentProcess().Id.ToString());
                 if (Directory.Exists(directory))
                     Directory.Delete(directory, true);
                 Directory.CreateDirectory(directory);

--- a/src/installer/tests/HostActivation.Tests/RuntimeProperties.cs
+++ b/src/installer/tests/HostActivation.Tests/RuntimeProperties.cs
@@ -131,9 +131,9 @@ namespace HostActivation.Tests
             public SharedTestState()
             {
                 // Make a copy of the built .NET, as we will update the framework's runtime config
-                copiedDotnet = TestArtifact.CreateFromCopy("runtimeProperties", HostTestContext.BuiltDotNet.BinPath);
+                copiedDotnet = TestArtifact.CreateFromCopy("runtimeProperties", TestContext.BuiltDotNet.BinPath);
 
-                MockSDK = new DotNetBuilder(copiedDotnet.Location, HostTestContext.BuiltDotNet.BinPath, "mocksdk")
+                MockSDK = new DotNetBuilder(copiedDotnet.Location, TestContext.BuiltDotNet.BinPath, "mocksdk")
                     .AddMicrosoftNETCoreAppFrameworkMockCoreClr("9999.0.0")
                     .AddMockSDK("9999.0.0-dev", "9999.0.0")
                     .Build();

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -26,7 +26,7 @@ namespace HostActivation.Tests
             SharedState = sharedState;
 
             string exeDotNetPath = sharedState.BaseArtifact.GetUniqueSubdirectory("exe");
-            ExecutableDotNetBuilder = new DotNetBuilder(exeDotNetPath, HostTestContext.BuiltDotNet.BinPath, null);
+            ExecutableDotNetBuilder = new DotNetBuilder(exeDotNetPath, TestContext.BuiltDotNet.BinPath, null);
             ExecutableDotNet = ExecutableDotNetBuilder
                 .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("9999.0.0")
                 .Build();
@@ -1224,7 +1224,7 @@ namespace HostActivation.Tests
                 // All dirs will be placed inside the base folder
                 // Executable location is created per test as each test adds a different set of SDK versions
 
-                var currentWorkingSdk = new DotNetBuilder(BaseArtifact.Location, HostTestContext.BuiltDotNet.BinPath, "current")
+                var currentWorkingSdk = new DotNetBuilder(BaseArtifact.Location, TestContext.BuiltDotNet.BinPath, "current")
                     .AddMockSDK("10000.0.0", "9999.0.0")
                     .Build();
                 CurrentWorkingDir = currentWorkingSdk.BinPath;

--- a/src/installer/tests/HostActivation.Tests/SelfContainedAppLaunch.cs
+++ b/src/installer/tests/HostActivation.Tests/SelfContainedAppLaunch.cs
@@ -37,23 +37,21 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
 
             if (OperatingSystem.IsWindows())
             {
                 // App sets FileVersion to NETCoreApp version. On Windows, this should be copied to app resources.
-                string expectedVersion = HostTestContext.MicrosoftNETCoreAppVersion.Contains('-')
-                    ? HostTestContext.MicrosoftNETCoreAppVersion[..HostTestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
-                    : HostTestContext.MicrosoftNETCoreAppVersion;
+                string expectedVersion = TestContext.MicrosoftNETCoreAppVersion.Contains('-')
+                    ? TestContext.MicrosoftNETCoreAppVersion[..TestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
+                    : TestContext.MicrosoftNETCoreAppVersion;
                 Assert.Equal(expectedVersion, System.Diagnostics.FileVersionInfo.GetVersionInfo(appExe).FileVersion);
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(Binaries.CetCompat), nameof(Binaries.CetCompat.IsSupported))]
         public void AppHost_DisableCetCompat()
         {
-            Assert.SkipUnless(Binaries.CetCompat.IsSupported, "CET not supported on this platform");
-
             TestApp app = sharedTestState.App.Copy();
             app.CreateAppHost(disableCetCompat: true);
             Assert.False(Binaries.CetCompat.IsMarkedCompatible(app.AppExe));
@@ -64,7 +62,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -82,7 +80,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 // Note that this is an exact match - we don't expect any output from the host itself
-                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {HostTestContext.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
+                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {TestContext.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
                 .And.NotHaveStdErr();
 
             // Make sure tracing indicates there is no runtime config and no deps json
@@ -90,7 +88,7 @@ namespace HostActivation.Tests
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {HostTestContext.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
+                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {TestContext.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
                 .And.HaveStdErrContaining($"Runtime config does not exist at [{app.RuntimeConfigJson}]")
                 .And.HaveStdErrContaining($"Dependencies manifest does not exist at [{app.DepsJson}]");
         }
@@ -109,7 +107,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -136,7 +134,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -158,13 +156,13 @@ namespace HostActivation.Tests
                 .DotNetRoot(app.Location)
                 .Execute()
                 .Should().Fail()
-                .And.HaveUsedDotNetRootInstallLocation(Path.GetFullPath(app.Location), HostTestContext.BuildRID)
+                .And.HaveUsedDotNetRootInstallLocation(Path.GetFullPath(app.Location), TestContext.BuildRID)
                 .And.HaveStdErrContaining($"The required library {Binaries.HostFxr.FileName} could not be found.");
         }
 
-                [Fact]
+        [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void Exe_activation_of_GUI_App()
+        public void DevicePath()
         {
             string appExe = $@"\\?\{sharedTestState.App.AppExe}";
             Command.Create(appExe)
@@ -173,7 +171,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
 
             appExe = $@"\\.\{sharedTestState.App.AppExe}";
             Command.Create(appExe)
@@ -182,7 +180,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -193,7 +191,7 @@ namespace HostActivation.Tests
             {
                 // Find the NETCoreApp runtime pack
                 RuntimeLibraryBuilder netCoreApp = b.RuntimeLibraries.First(
-                    r => r.Type == RuntimeLibraryType.runtimepack.ToString() && r.Name == $"runtimepack.{Constants.MicrosoftNETCoreApp}.Runtime.{HostTestContext.BuildRID}");
+                    r => r.Type == RuntimeLibraryType.runtimepack.ToString() && r.Name == $"runtimepack.{Constants.MicrosoftNETCoreApp}.Runtime.{TestContext.BuildRID}");
 
                 // Update all NETCoreApp asset paths to point to the subdirectory
                 RuntimeAssetGroupBuilder[] groups = [.. netCoreApp.AssemblyGroups, .. netCoreApp.NativeLibraryGroups];
@@ -226,7 +224,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(HostTestContext.MicrosoftNETCoreAppVersion)
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion)
                 .And.HaveStdErrContaining($"CoreCLR path = '{Path.Join(app.Location, subdirectory, Binaries.CoreClr.FileName)}'");
         }
 

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Save();
 
             // RuntimeConfig defined startup hook
-            HostTestContext.BuiltDotNet.Exec(app.AppDll)
+            TestContext.BuiltDotNet.Exec(app.AppDll)
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             const string wildcardPattern = @"[\r\n\s.]*";
 
             // RuntimeConfig and Environment startup hooks in expected order
-            HostTestContext.BuiltDotNet.Exec(app.AppDll)
+            TestContext.BuiltDotNet.Exec(app.AppDll)
                 .EnvironmentVariable(startupHookVarName, startupHook2Dll)
                 .CaptureStdOut()
                 .CaptureStdErr()
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void Muxer_activation_of_Empty_StartupHook_Variable_Succeeds()
         {
             var startupHookVar = "";
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll)
+            TestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll)
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .CaptureStdOut()
                 .CaptureStdErr()
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var startupHookDll = sharedTestState.StartupHookWithAssemblyResolver.AppDll;
 
             // Startup hook has a dependency not on the TPA list
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll)
+            TestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll)
                 .EnvironmentVariable(startupHookVarName, startupHookDll)
                 // Indicate that the startup hook should try to use a dependency
                 .EnvironmentVariable("TEST_STARTUPHOOK_USE_DEPENDENCY", true.ToString())
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var startupHookDll = sharedTestState.StartupHookWithAssemblyResolver.AppDll;
 
             // Startup hook with assembly resolver results in use of injected dependency
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll, "load_shared_library")
+            TestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll, "load_shared_library")
                 .EnvironmentVariable(startupHookVarName, startupHookDll)
                 // Indicate that the startup hook should add an assembly resolver
                 .EnvironmentVariable("TEST_STARTUPHOOK_ADD_RESOLVER", true.ToString())
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             // Startup hooks are not executed when the StartupHookSupport
             // feature switch is set to false.
-            HostTestContext.BuiltDotNet.Exec(app.AppDll)
+            TestContext.BuiltDotNet.Exec(app.AppDll)
                 .EnvironmentVariable(startupHookVarName, startupHookDll)
                 .CaptureStdOut()
                 .CaptureStdErr()

--- a/src/installer/tests/HostActivation.Tests/SymbolicLinks.cs
+++ b/src/installer/tests/HostActivation.Tests/SymbolicLinks.cs
@@ -46,7 +46,7 @@ namespace HostActivation.Tests
                 var result = Command.Create(Path.Combine(testDir.Location, symlinkRelativePath, Path.GetFileName(sharedTestState.FrameworkDependentApp.AppExe)))
                     .CaptureStdErr()
                     .CaptureStdOut()
-                    .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                    .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                     .Execute();
 
                 // This should succeed on all platforms, but for different reasons:
@@ -113,7 +113,7 @@ namespace HostActivation.Tests
                 var result = Command.Create(Path.Combine(targetPath, appHostName))
                     .CaptureStdErr()
                     .CaptureStdOut()
-                    .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                    .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                     .Execute();
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -163,7 +163,7 @@ namespace HostActivation.Tests
                 var result = Command.Create(Path.Combine(testDir.Location, symlinkRelativePath, Path.GetFileName(sharedTestState.FrameworkDependentApp.AppExe)))
                     .CaptureStdErr()
                     .CaptureStdOut()
-                    .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                    .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                     .Execute();
 
                 // This should succeed on all platforms, but for different reasons:
@@ -272,7 +272,7 @@ namespace HostActivation.Tests
                 var result = Command.Create(symlink.SrcPath)
                     .CaptureStdErr()
                     .CaptureStdOut()
-                    .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                    .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                     .Execute();
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -299,7 +299,7 @@ namespace HostActivation.Tests
             {
                 var dotnetSymlink = Path.Combine(testDir.Location, Binaries.GetExeName("dotnet"));
 
-                using var symlink = new SymLink(dotnetSymlink, HostTestContext.BuiltDotNet.BinPath);
+                using var symlink = new SymLink(dotnetSymlink, TestContext.BuiltDotNet.BinPath);
                 Command.Create(sharedTestState.FrameworkDependentApp.AppExe)
                     .EnvironmentVariable("DOTNET_ROOT", symlink.SrcPath)
                     .CaptureStdErr()
@@ -337,7 +337,7 @@ namespace HostActivation.Tests
             {
                 var dotnetSymlink = Path.Combine(testDir.Location, Binaries.DotNet.FileName);
 
-                using var symlink = new SymLink(dotnetSymlink, HostTestContext.BuiltDotNet.DotnetExecutablePath);
+                using var symlink = new SymLink(dotnetSymlink, TestContext.BuiltDotNet.DotnetExecutablePath);
                 var result = Command.Create(symlink.SrcPath, sharedTestState.SelfContainedApp.AppDll)
                     .CaptureStdErr()
                     .CaptureStdOut()
@@ -369,7 +369,7 @@ namespace HostActivation.Tests
                 Directory.Move(app.Location, newAppDir.Location);
 
                 using var symlink = new SymLink(app.Location, newAppDir.Location);
-                HostTestContext.BuiltDotNet.Exec(app.AppDll)
+                TestContext.BuiltDotNet.Exec(app.AppDll)
                     .CaptureStdErr()
                     .CaptureStdOut()
                     .Execute()

--- a/src/installer/tests/HostActivation.Tests/Tracing.cs
+++ b/src/installer/tests/HostActivation.Tests/Tracing.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void TracingOff()
         {
-            HostTestContext.BuiltDotNet.Exec("--list-runtimes")
+            TestContext.BuiltDotNet.Exec("--list-runtimes")
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void TracingOnDefault()
         {
-            HostTestContext.BuiltDotNet.Exec("--list-runtimes")
+            TestContext.BuiltDotNet.Exec("--list-runtimes")
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void TracingOnVerbose()
         {
-            HostTestContext.BuiltDotNet.Exec("--list-runtimes")
+            TestContext.BuiltDotNet.Exec("--list-runtimes")
                 .EnableTracingAndCaptureOutputs()
                 .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "4")
                 .Execute()
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void TracingOnInfo()
         {
-            HostTestContext.BuiltDotNet.Exec("--list-runtimes")
+            TestContext.BuiltDotNet.Exec("--list-runtimes")
                 .EnableTracingAndCaptureOutputs()
                 .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "3")
                 .Execute()
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void TracingOnWarning()
         {
-            HostTestContext.BuiltDotNet.Exec("--list-runtimes")
+            TestContext.BuiltDotNet.Exec("--list-runtimes")
                 .EnableTracingAndCaptureOutputs()
                 .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "2")
                 .Execute()
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void TracingOnToFileDefault()
         {
             string traceFilePath;
-            HostTestContext.BuiltDotNet.Exec("--list-runtimes")
+            TestContext.BuiltDotNet.Exec("--list-runtimes")
                 .EnableHostTracingToFile(out traceFilePath)
                 .CaptureStdOut()
                 .CaptureStdErr()
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void TracingOnToFileBadPathDefault()
         {
-            HostTestContext.BuiltDotNet.Exec("--list-runtimes")
+            TestContext.BuiltDotNet.Exec("--list-runtimes")
                 .EnableTracingAndCaptureOutputs()
                 .EnvironmentVariable(Constants.HostTracing.TraceFileEnvironmentVariable, "badpath/TracingOnToFileBadPathDefault.log")
                 .Execute()
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             using (TestArtifact directory = TestArtifact.Create("trace"))
             {
-                var result = HostTestContext.BuiltDotNet.Exec("--list-runtimes")
+                var result = TestContext.BuiltDotNet.Exec("--list-runtimes")
                     .EnableHostTracingToPath(directory.Location)
                     .CaptureStdOut()
                     .CaptureStdErr()
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void LegacyVariableName()
         {
-            HostTestContext.BuiltDotNet.Exec("--list-runtimes")
+            TestContext.BuiltDotNet.Exec("--list-runtimes")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdErr()
                 .Execute()

--- a/src/installer/tests/HostActivation.Tests/WindowsSpecificBehavior.cs
+++ b/src/installer/tests/HostActivation.Tests/WindowsSpecificBehavior.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Runtime.InteropServices;
+
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.Win32;
 using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 {
+    [PlatformSpecific(TestPlatforms.Windows)]
     public class WindowsSpecificBehavior : IClassFixture<WindowsSpecificBehavior.SharedTestState>
     {
         private SharedTestState sharedTestState;
@@ -16,14 +17,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public WindowsSpecificBehavior(SharedTestState fixture)
         {
             sharedTestState = fixture;
-
-            Assert.SkipUnless(OperatingSystem.IsWindows(), "Test only runs on Windows");
         }
 
         [Fact]
         public void DotNet_NoCompatShims()
         {
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll, "compat_shims")
+            TestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll, "compat_shims")
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
@@ -37,7 +36,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Command.Create(sharedTestState.App.AppExe, "compat_shims")
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(HostTestContext.BuiltDotNet.BinPath)
+                .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Reported OS version is lower than the true OS version - shims in use.");
@@ -59,7 +58,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [ConditionalFact(nameof(LongPathsEnabled))]
         public void DotNet_LongPath_Succeeds()
         {
-            HostTestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll, "long_path", sharedTestState.App.Location)
+            TestContext.BuiltDotNet.Exec(sharedTestState.App.AppDll, "long_path", sharedTestState.App.Location)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()

--- a/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
+++ b/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
@@ -2,14 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>$(TestInfraTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
-    <!-- Package tests run on the host, not the target -->
-    <RuntimeIdentifier>$(HostRid)</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
          This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
     <NoWarn>$(NoWarn);NU1511</NoWarn>
-    <TestRunnerName>XUnitV3</TestRunnerName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
+++ b/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             using (var tester = NuGetArtifactTester.Open(
                 dirs,
                 "Microsoft.NETCore.App.Host",
-                $"Microsoft.NETCore.App.Host.{HostTestContext.BuildRID}"))
+                $"Microsoft.NETCore.App.Host.{TestContext.BuildRID}"))
             {
                 tester.IsAppHostPack();
             }
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             using (var tester = NuGetArtifactTester.Open(
                 dirs,
                 "Microsoft.NETCore.App.Runtime",
-                $"Microsoft.NETCore.App.Runtime.{HostTestContext.BuildRID}"))
+                $"Microsoft.NETCore.App.Runtime.{TestContext.BuildRID}"))
             {
                 tester.IsRuntimePack();
             }

--- a/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
+++ b/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
@@ -37,9 +37,9 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             string nupkgPath = Path.Combine(
                 dirs.BaseArtifactsFolder,
                 "packages",
-                HostTestContext.Configuration,
+                TestContext.Configuration,
                 "Shipping",
-                $"{id}.{HostTestContext.MicrosoftNETCoreAppVersion}.nupkg");
+                $"{id}.{TestContext.MicrosoftNETCoreAppVersion}.nupkg");
 
             // If the nuspec exists, the nupkg should exist.
             Assert.True(File.Exists(nupkgPath));

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
@@ -262,9 +262,9 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         }
 
         [Theory]
-        [PlatformSpecific(TestPlatforms.OSX)]
         [InlineData("")]
         [InlineData("dir with spaces")]
+        [PlatformSpecific(TestPlatforms.OSX)]
         public void CodeSignMachOAppHost(string subdir)
         {
             using (TestArtifact artifact = CreateTestDirectory())
@@ -287,9 +287,9 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         }
 
         [Theory]
-        [PlatformSpecific(TestPlatforms.OSX)]
         [InlineData("")]
         [InlineData("dir with spaces")]
+        [PlatformSpecific(TestPlatforms.OSX)]
         public void SigningExistingAppHostCreatesNewInode(string subdir)
         {
             using (TestArtifact artifact = CreateTestDirectory())

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
@@ -245,7 +245,7 @@ namespace Microsoft.NET.HostModel.Bundle.Tests
             // work correctly in the presence of "."s in the hostName.
             using (var app = TestApp.CreateEmpty("App.With.Periods"))
             {
-                app.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, HostTestContext.MicrosoftNETCoreAppVersion);
+                app.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion);
 
                 string hostName = Path.GetFileName(app.AppExe);
                 string depsJsonName = Path.GetFileName(app.DepsJson);
@@ -415,7 +415,7 @@ namespace Microsoft.NET.HostModel.Bundle.Tests
                 App = TestApp.CreateFromBuiltAssets(AppName);
                 NonAsciiApp = TestApp.CreateFromBuiltAssets("HelloWorld_中文");
 
-                SystemDll = Path.Combine(HostTestContext.BuiltDotNet.GreatestVersionSharedFxPath, "System.dll");
+                SystemDll = Path.Combine(TestContext.BuiltDotNet.GreatestVersionSharedFxPath, "System.dll");
             }
 
             public void Dispose()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/MachObjectTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/MachObjectTests.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.CoreSetup.Test;
 using Microsoft.NET.HostModel.MachO;
 using Microsoft.NET.HostModel.MachO.CodeSign.Tests;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.NET.HostModel.Tests;
 
@@ -149,8 +150,8 @@ public class MachObjectTests
 
     // test all the binaries compared to codesinginfo from codesign output
     [Theory]
-    [PlatformSpecific(TestPlatforms.OSX)]
     [MemberData(nameof(GetTestFilePaths), nameof(EmbeddedSignatureBlobMatchesCodesignInfo))]
+    [PlatformSpecific(TestPlatforms.OSX)]
     public void EmbeddedSignatureBlobMatchesCodesignInfo(string filePath, TestArtifact _)
     {
         if (!SigningTests.IsSigned(filePath))

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/SigningTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/MachObjectSigning/SigningTests.cs
@@ -78,9 +78,9 @@ namespace Microsoft.NET.HostModel.MachO.CodeSign.Tests
         }
 
         [Theory]
-        [PlatformSpecific(TestPlatforms.OSX)]
         [MemberData(nameof(GetTestFilePaths), nameof(MatchesCodesignOutput))]
-        public void MatchesCodesignOutput(string filePath, TestArtifact _)
+        [PlatformSpecific(TestPlatforms.OSX)]
+        void MatchesCodesignOutput(string filePath, TestArtifact _)
         {
             string fileName = Path.GetFileName(filePath);
             string originalFilePath = filePath;

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Tests.csproj
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>$(TestInfraTargetFramework)</TargetFramework>
-    <OutputType>Exe</OutputType>
-    <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
     <AssemblyName>Microsoft.NET.HostModel.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <!-- Reduce the length of the test output dir to make it more reliable on Windows. -->
@@ -11,7 +9,6 @@
     <!-- NuGet warns about a transitive P2P to System.Text.Json that can't be pruned.
          This is a false positive: https://github.com/NuGet/Home/issues/14103 -->
     <NoWarn>$(NoWarn);NU1511</NoWarn>
-    <TestRunnerName>XUnitV3</TestRunnerName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Microsoft.NET.HostModel.TestData" Version="$(MicrosoftNETHostModelTestDataVersion)" />
   </ItemGroup>
 

--- a/src/installer/tests/TestUtils/Binaries.cs
+++ b/src/installer/tests/TestUtils/Binaries.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public static class CoreClr
         {
             public static string FileName = GetSharedLibraryFileNameForCurrentPlatform("coreclr");
-            public static string FilePath = Path.Combine(HostTestContext.BuiltDotNet.GreatestVersionSharedFxPath, FileName);
+            public static string FilePath = Path.Combine(TestContext.BuiltDotNet.GreatestVersionSharedFxPath, FileName);
 
             public static string MockName = GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr");
             public static string MockPath = Path.Combine(RepoDirectoriesProvider.Default.HostTestArtifacts, MockName);
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public static (IEnumerable<string> Assemblies, IEnumerable<string> NativeLibraries) GetRuntimeFiles()
         {
-            var runtimePackDir = HostTestContext.BuiltDotNet.GreatestVersionSharedFxPath;
+            var runtimePackDir = TestContext.BuiltDotNet.GreatestVersionSharedFxPath;
             var assemblies = Directory.GetFiles(runtimePackDir, "*.dll").Where(f => IsAssembly(f));
 
             (string prefix, string suffix) = Binaries.GetSharedLibraryPrefixSuffix();
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public static class CetCompat
         {
             // We only support CET shadow stack compatibility for Windows x64 currently
-            public static bool IsSupported => OperatingSystem.IsWindows() && HostTestContext.BuildArchitecture == "x64";
+            public static bool IsSupported => OperatingSystem.IsWindows() && TestContext.BuildArchitecture == "x64";
 
             // https://learn.microsoft.com/windows/win32/debug/pe-format#debug-type
             private const int IMAGE_DEBUG_TYPE_EX_DLLCHARACTERISTICS = 20;

--- a/src/installer/tests/TestUtils/CommandExtensions.cs
+++ b/src/installer/tests/TestUtils/CommandExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public static Command EnableHostTracingToFile(this Command command, out string filePath)
         {
-            filePath = Path.Combine(HostTestContext.TestArtifactsPath, "trace" + Guid.NewGuid().ToString() + ".log");
+            filePath = Path.Combine(TestContext.TestArtifactsPath, "trace" + Guid.NewGuid().ToString() + ".log");
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             // If we are clearing out the variable, make sure we clear out any architecture-specific one too
             if (string.IsNullOrEmpty(dotNetRoot))
-                command = command.EnvironmentVariable($"{Constants.DotnetRoot.ArchitectureEnvironmentVariablePrefix}{HostTestContext.BuildArchitecture.ToUpperInvariant()}", dotNetRoot);
+                command = command.EnvironmentVariable($"{Constants.DotnetRoot.ArchitectureEnvironmentVariablePrefix}{TestContext.BuildArchitecture.ToUpperInvariant()}", dotNetRoot);
 
             return command
                     .EnvironmentVariable(Constants.DotnetRoot.EnvironmentVariable, dotNetRoot)

--- a/src/installer/tests/TestUtils/DotNetBuilder.cs
+++ b/src/installer/tests/TestUtils/DotNetBuilder.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             // ./shared/Microsoft.NETCore.App/<version> - create a mock of the root framework
             string netCoreAppPath = AddFramework(Constants.MicrosoftNETCoreApp, version);
 
-            string currentRid = HostTestContext.BuildRID;
+            string currentRid = TestContext.BuildRID;
 
             NetCoreAppBuilder.ForNETCoreApp(Constants.MicrosoftNETCoreApp, currentRid)
                 .WithStandardRuntimeFallbacks()

--- a/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
+++ b/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 string repoRoot = GetRepoRootDirectory();
                 BaseArtifactsFolder = Path.Combine(repoRoot, "artifacts");
 
-                string osPlatformConfig = $"{HostTestContext.BuildRID}.{HostTestContext.Configuration}";
+                string osPlatformConfig = $"{TestContext.BuildRID}.{TestContext.Configuration}";
                 string artifacts = Path.Combine(BaseArtifactsFolder, "bin", osPlatformConfig);
                 HostArtifacts = Path.Combine(artifacts, "corehost");
                 HostTestArtifacts = Path.Combine(artifacts, "corehost_test");

--- a/src/installer/tests/TestUtils/SingleFileTestApp.cs
+++ b/src/installer/tests/TestUtils/SingleFileTestApp.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         /// </summary>
         /// <param name="appName">Name of pre-built app</param>
         /// <returns>
-        /// The <paramref name="appName"/> is expected to be in <see cref="HostTestContext.TestAssetsOutput"/>
+        /// The <paramref name="appName"/> is expected to be in <see cref="TestContext.TestAssetsOutput"/>
         /// and have been built as framework-dependent
         /// </returns>
         public static SingleFileTestApp CreateFrameworkDependent(string appName)
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         /// </summary>
         /// <param name="appName">Name of pre-built app</param>
         /// <returns>
-        /// The <paramref name="appName"/> is expected to be in <see cref="HostTestContext.TestAssetsOutput"/>
+        /// The <paramref name="appName"/> is expected to be in <see cref="TestContext.TestAssetsOutput"/>
         /// and have been built as framework-dependent
         /// </returns>
         public static SingleFileTestApp CreateSelfContained(string appName)
@@ -177,23 +177,23 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             // Copy the compiled app output - the app is expected to have been built as framework-dependent
             TestArtifact.CopyRecursive(
-                Path.Combine(HostTestContext.TestAssetsOutput, AppName),
+                Path.Combine(TestContext.TestAssetsOutput, AppName),
                 builtApp.Location);
 
             // Remove any runtimeconfig.json or deps.json - we will be creating new ones
             File.Delete(builtApp.RuntimeConfigJson);
             File.Delete(builtApp.DepsJson);
 
-            var shortVersion = HostTestContext.Tfm[3..]; // trim "net" from beginning
-            var builder = NetCoreAppBuilder.ForNETCoreApp(AppName, HostTestContext.BuildRID, shortVersion);
+            var shortVersion = TestContext.Tfm[3..]; // trim "net" from beginning
+            var builder = NetCoreAppBuilder.ForNETCoreApp(AppName, TestContext.BuildRID, shortVersion);
 
             // Update the .runtimeconfig.json
             builder.WithRuntimeConfig(c =>
             {
-                c.WithTfm(HostTestContext.Tfm);
+                c.WithTfm(TestContext.Tfm);
                 c = selfContained
-                    ? c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, HostTestContext.MicrosoftNETCoreAppVersion)
-                    : c.WithFramework(Constants.MicrosoftNETCoreApp, HostTestContext.MicrosoftNETCoreAppVersion);
+                    ? c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion)
+                    : c.WithFramework(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion);
             });
 
             // Add runtime libraries and assets for generating the .deps.json.
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     .WithAsset(Path.GetFileName(builtApp.AppDll), f => f.NotOnDisk())));
             if (selfContained)
             {
-                builder.WithRuntimePack($"{Constants.MicrosoftNETCoreApp}.Runtime.{HostTestContext.BuildRID}", HostTestContext.MicrosoftNETCoreAppVersion, l => l
+                builder.WithRuntimePack($"{Constants.MicrosoftNETCoreApp}.Runtime.{TestContext.BuildRID}", TestContext.MicrosoftNETCoreAppVersion, l => l
                     .WithAssemblyGroup(string.Empty, g =>
                     {
                         foreach (var file in Binaries.GetRuntimeFiles().Assemblies)

--- a/src/installer/tests/TestUtils/TestApp.cs
+++ b/src/installer/tests/TestUtils/TestApp.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             assetRelativePath = assetRelativePath ?? appName;
             TestApp app = CreateEmpty(appName);
             TestArtifact.CopyRecursive(
-                Path.Combine(HostTestContext.TestAssetsOutput, assetRelativePath),
+                Path.Combine(TestContext.TestAssetsOutput, assetRelativePath),
                 app.Location);
             return app;
         }
@@ -107,18 +107,18 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public void PopulateSelfContained(MockedComponent mock, Action<NetCoreAppBuilder> customizer = null)
         {
-            var builder = NetCoreAppBuilder.ForNETCoreApp(Name, HostTestContext.BuildRID);
+            var builder = NetCoreAppBuilder.ForNETCoreApp(Name, TestContext.BuildRID);
 
             // Update the .runtimeconfig.json - add included framework and remove any existing NETCoreApp framework
             builder.WithRuntimeConfig(c =>
-                c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, HostTestContext.MicrosoftNETCoreAppVersion)
+                c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion)
                     .RemoveFramework(Constants.MicrosoftNETCoreApp));
 
             // Add main project assembly
             builder.WithProject(p => p.WithAssemblyGroup(null, g => g.WithMainAssembly()));
 
             // Add runtime libraries and assets
-            builder.WithRuntimePack($"{Constants.MicrosoftNETCoreApp}.Runtime.{HostTestContext.BuildRID}", HostTestContext.MicrosoftNETCoreAppVersion, l =>
+            builder.WithRuntimePack($"{Constants.MicrosoftNETCoreApp}.Runtime.{TestContext.BuildRID}", TestContext.MicrosoftNETCoreAppVersion, l =>
             {
                 if (mock == MockedComponent.None)
                 {

--- a/src/installer/tests/TestUtils/TestArtifact.cs
+++ b/src/installer/tests/TestUtils/TestArtifact.cs
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             Exception? lastException = null;
             for (int i = 0; i < 10; i++)
             {
-                var parentPath = Path.Combine(HostTestContext.TestArtifactsPath, Path.GetRandomFileName());
+                var parentPath = Path.Combine(TestContext.TestArtifactsPath, Path.GetRandomFileName());
                 // Create a lock file next to the target folder
                 var lockPath = parentPath + ".lock";
                 var artifactPath = Path.Combine(parentPath, artifactName);

--- a/src/installer/tests/TestUtils/TestContext.cs
+++ b/src/installer/tests/TestUtils/TestContext.cs
@@ -6,7 +6,7 @@ using Microsoft.DotNet.TestUtils;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
-    public sealed class HostTestContext
+    public sealed class TestContext
     {
         public static string BuildArchitecture { get; }
         public static string BuildRID { get; }
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         private static string _testContextVariableFilePath { get; }
         private static ImmutableDictionary<string, string> _testContextVariables { get; }
 
-        static HostTestContext()
+        static TestContext()
         {
             _testContextVariableFilePath = Path.Combine(
                 Directory.GetCurrentDirectory(),

--- a/src/installer/tests/TestUtils/TestUtils.csproj
+++ b/src/installer/tests/TestUtils/TestUtils.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="$(AwesomeAssertionsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="$(XUnitV3Version)" ExcludeAssets="build" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
+    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" ExcludeAssets="build" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 

--- a/src/installer/tests/helixpublish.proj
+++ b/src/installer/tests/helixpublish.proj
@@ -10,7 +10,6 @@
 
     <IncludeDotNetCli>true</IncludeDotNetCli>
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
-    <DotNetCliRuntime>$(TargetRid)</DotNetCliRuntime>
   </PropertyGroup>
 
   <ItemGroup>
@@ -46,16 +45,9 @@
     <MSBuild Projects="%(HostTestProject.Identity)" Targets="GetTargetPath">
       <Output TaskParameter="TargetOutputs" PropertyName="_TargetPath" />
     </MSBuild>
-
-    <PropertyGroup>
-      <_TestExePath>$([System.IO.Path]::GetFileNameWithoutExtension($(_TargetPath)))$(ExeSuffix)</_TestExePath>
-    </PropertyGroup>
-
     <ItemGroup>
       <HostTestProject>
-        <Command Condition="'$(TargetOS)' == 'windows'">$(_TestExePath) $(TestRunnerAdditionalArguments) --report-trx --results-directory .</Command>
-        <Command Condition="'$(TargetOS)' != 'windows'">./$(_TestExePath) $(TestRunnerAdditionalArguments) --report-trx --results-directory .</Command>
-        <PreCommands Condition="'$(TargetOS)' != 'windows'">chmod +x $(_TestExePath)</PreCommands>
+        <Command>dotnet test $([System.IO.Path]::GetFileName($(_TargetPath))) $(TestRunnerAdditionalArguments) --logger trx --results-directory .</Command>
         <PayloadDirectory>$(_PayloadDirectory)</PayloadDirectory>
       </HostTestProject>
     </ItemGroup>
@@ -66,7 +58,7 @@
       <HelixWorkItem Include="$([System.IO.Path]::GetFileNameWithoutExtension(%(HostTestProject.Identity)))">
         <PayloadDirectory>%(HostTestProject.PayloadDirectory)</PayloadDirectory>
         <Command>%(HostTestProject.Command)</Command>
-        <PreCommands>@(_HelixPreCommands);%(HostTestProject.PreCommands)</PreCommands>
+        <PreCommands>@(_HelixPreCommands)</PreCommands>
         <Timeout>00:30:00</Timeout>
       </HelixWorkItem>
     </ItemGroup>


### PR DESCRIPTION
Reverts dotnet/runtime#120234

This change appears to have broken the boot strapped community builds.