### PR TITLE
Host changes should trigger bootstrapped platforms

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -537,6 +537,7 @@ extends:
             condition: >-
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
       #


### PR DESCRIPTION
Since the bootstrapped pipelines are senstive to hosting changes, we trigger them for host changes.

Adding additional trigger as mentioned at https://github.com/dotnet/runtime/pull/120234#issuecomment-3434601039.