### PR TITLE
Enable continuing after assert in interpreter on macOS

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -8734,6 +8734,10 @@ extern "C" void assertAbort(const char* why, const char* file, unsigned line)
 #ifdef _MSC_VER
     __debugbreak();
 #else // _MSC_VER
+#ifdef TARGET_APPLE
+    __builtin_debugtrap();
+#else // TARGET_APPLE
     __builtin_trap();
+#endif // TARGET_APPLE
 #endif // _MSC_VER
 }


### PR DESCRIPTION
This change changes __builtin_trap() that we use to break into the debugger on assert to __builtin_debugtrap() on macOS. The former doesn't allow continuing after the assert while the latter does.