### PR TITLE
Convert pointers to span in System.Net.Primitives

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IriHelper.cs
@@ -113,8 +113,7 @@ namespace System
                         {
                             // possibly utf8 encoded sequence of unicode
                             int charactersRead = PercentEncodingHelper.UnescapePercentEncodedUTF8Sequence(
-                                pInput + i,
-                                end - i,
+                                new ReadOnlySpan<char>(pInput + i, end - i),
                                 ref dest,
                                 isQuery,
                                 iriParsing: true);

--- a/src/libraries/System.Private.Uri/src/System/PercentEncodingHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/PercentEncodingHelper.cs
@@ -3,14 +3,16 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System
 {
     internal static class PercentEncodingHelper
     {
-        public static unsafe int UnescapePercentEncodedUTF8Sequence(char* input, int length, ref ValueStringBuilder dest, bool isQuery, bool iriParsing)
+        public static int UnescapePercentEncodedUTF8Sequence(ReadOnlySpan<char> input, ref ValueStringBuilder dest, bool isQuery, bool iriParsing)
         {
+            int length = input.Length;
             // The following assertions rely on the input not mutating mid-operation, as is the case currently since callers are working with strings
             // If we start accepting input such as spans, this method must be audited to ensure no buffer overruns/infinite loops could occur
 
@@ -85,7 +87,10 @@ namespace System
             Debug.Assert(bytesLeftInBuffer < 4 || (fourByteBuffer & (BitConverter.IsLittleEndian ? 0x80000000 : 0x00000080)) != 0);
 
             uint temp = fourByteBuffer; // make a copy so that the *copy* (not the original) is marked address-taken
-            if (Rune.DecodeFromUtf8(new ReadOnlySpan<byte>(&temp, bytesLeftInBuffer), out Rune rune, out bytesConsumed) == OperationStatus.Done)
+
+
+
+            if (Rune.DecodeFromUtf8(MemoryMarshal.AsBytes(new ReadOnlySpan<uint>(ref temp))[..bytesLeftInBuffer], out Rune rune, out bytesConsumed) == OperationStatus.Done)
             {
                 Debug.Assert(bytesConsumed >= 2, $"Rune.DecodeFromUtf8 consumed {bytesConsumed} bytes, likely indicating input was modified concurrently during UnescapePercentEncodedUTF8Sequence's execution");
 
@@ -93,7 +98,7 @@ namespace System
                 {
                     if (charsToCopy != 0)
                     {
-                        dest.Append(new ReadOnlySpan<char>(input + totalCharsConsumed - charsToCopy, charsToCopy));
+                        dest.Append(input.Slice(totalCharsConsumed - charsToCopy, charsToCopy));
                         charsToCopy = 0;
                     }
 
@@ -167,7 +172,8 @@ namespace System
                 return totalCharsConsumed;
 
             bytesLeftInBuffer *= 3;
-            dest.Append(new ReadOnlySpan<char>(input + totalCharsConsumed - charsToCopy, charsToCopy + bytesLeftInBuffer));
+
+            dest.Append(input.Slice(totalCharsConsumed - charsToCopy, charsToCopy + bytesLeftInBuffer));
             return totalCharsConsumed + bytesLeftInBuffer;
         }
     }

--- a/src/libraries/System.Private.Uri/src/System/PercentEncodingHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/PercentEncodingHelper.cs
@@ -13,6 +13,7 @@ namespace System
         public static int UnescapePercentEncodedUTF8Sequence(ReadOnlySpan<char> input, ref ValueStringBuilder dest, bool isQuery, bool iriParsing)
         {
             int length = input.Length;
+
             // The following assertions rely on the input not mutating mid-operation, as is the case currently since callers are working with strings
             // If we start accepting input such as spans, this method must be audited to ensure no buffer overruns/infinite loops could occur
 
@@ -87,8 +88,6 @@ namespace System
             Debug.Assert(bytesLeftInBuffer < 4 || (fourByteBuffer & (BitConverter.IsLittleEndian ? 0x80000000 : 0x00000080)) != 0);
 
             uint temp = fourByteBuffer; // make a copy so that the *copy* (not the original) is marked address-taken
-
-
 
             if (Rune.DecodeFromUtf8(MemoryMarshal.AsBytes(new ReadOnlySpan<uint>(ref temp))[..bytesLeftInBuffer], out Rune rune, out bytesConsumed) == OperationStatus.Done)
             {

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -1027,17 +1027,7 @@ namespace System
             string self = GetParts(ComponentsToCompare, UriFormat.SafeUnescaped);
             string other = uriLink.GetParts(ComponentsToCompare, UriFormat.SafeUnescaped);
 
-            unsafe
-            {
-                fixed (char* selfPtr = self)
-                {
-                    fixed (char* otherPtr = other)
-                    {
-                        return UriHelper.TestForSubPath(selfPtr, self.Length, otherPtr, other.Length,
-                            IsUncOrDosPath || uriLink.IsUncOrDosPath);
-                    }
-                }
-            }
+            return UriHelper.TestForSubPath(self, other, IsUncOrDosPath || uriLink.IsUncOrDosPath);
         }
 
         //

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -56,8 +56,7 @@ namespace System
         // ASSUMES that strings like http://host/Path/Path/MoreDir/../../  have been canonicalized before going to this method.
         // ASSUMES that back slashes already have been converted if applicable.
         //
-        internal static unsafe bool TestForSubPath(char* selfPtr, int selfLength, char* otherPtr, int otherLength,
-            bool ignoreCase)
+        internal static bool TestForSubPath(ReadOnlySpan<char> self, ReadOnlySpan<char> other, bool ignoreCase)
         {
             int i = 0;
             char chSelf;
@@ -65,10 +64,10 @@ namespace System
 
             bool AllSameBeforeSlash = true;
 
-            for (; i < selfLength && i < otherLength; ++i)
+            for (; i < self.Length && i < other.Length; ++i)
             {
-                chSelf = *(selfPtr + i);
-                chOther = *(otherPtr + i);
+                chSelf = self[i];
+                chOther = other[i];
 
                 if (chSelf == '?' || chSelf == '#')
                 {
@@ -118,9 +117,9 @@ namespace System
             }
 
             // If self is longer then it must not have any more path segments
-            for (; i < selfLength; ++i)
+            for (; i < self.Length; ++i)
             {
-                if ((chSelf = *(selfPtr + i)) == '?' || chSelf == '#')
+                if ((chSelf = self[i]) == '?' || chSelf == '#')
                 {
                     return true;
                 }
@@ -507,8 +506,7 @@ namespace System
                     {
                         // Unicode
                         int charactersRead = PercentEncodingHelper.UnescapePercentEncodedUTF8Sequence(
-                            pStr + next,
-                            end - next,
+                            new ReadOnlySpan<char>(pStr + next, end - next),
                             ref dest,
                             isQuery,
                             iriParsing);


### PR DESCRIPTION
IPAddress and Uri parsing are heavily relying on raw pointers making code extremely difficult to validate we never go out of bounds. I wonder what is the performance impact if we convert them all to Span.. Obviously, in most cases it will lead to redundant bounds checks that JIT is unlikely to remove due to complex loop shapes, implicit/IPA assumptions, etc..