### PR TITLE
Fix interpreted synchronized methods

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -2154,7 +2154,7 @@ void InterpCompiler::CreateBasicBlocks(CORINFO_METHOD_INFO* methodInfo)
             ip++;
             if (opcode == CEE_RET)
             {
-                if (m_isSynchronized && m_currentILOffset < m_ILCodeSizeFromILHeader)
+                if (m_isSynchronized && insOffset < m_ILCodeSizeFromILHeader)
                 {
                     // This is a ret instruction coming from the initial IL of a synchronized method.
                     CreateLeaveChainIslandBasicBlocks(methodInfo, insOffset, GetBB(m_synchronizedPostFinallyOffset));


### PR DESCRIPTION
The `InterpCompiler::CreateBasicBlocks` was comparing incorrect offset with `m_ILCodeSizeFromILHeader` when checking when to convert `CEE_RET` to `CEE_LEAVE`. The `m_currentILOffset` it was using was uninitialized, so sometimes the comparison passed, sometimes not based on the random value in the `m_currentILOffset`.